### PR TITLE
feat(pty): W2.5 dasclaw_pty 完整实装（trait + portable-pty backend）

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2474,8 +2474,9 @@ dependencies = [
 
 [[package]]
 name = "dasclaw_pty"
-version = "0.0.0-w1"
+version = "0.1.0-w2"
 dependencies = [
+ "portable-pty",
  "thiserror 1.0.69",
 ]
 
@@ -2836,6 +2837,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
 name = "dpi"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3131,8 +3138,19 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
 dependencies = [
- "memoffset",
+ "memoffset 0.9.1",
  "rustc_version",
+]
+
+[[package]]
+name = "filedescriptor"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
+dependencies = [
+ "libc",
+ "thiserror 1.0.69",
+ "winapi",
 ]
 
 [[package]]
@@ -4538,6 +4556,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f0fb0570afe1fed943c5c3d4102d5358592d8625fda6a0007fdbe65a92fba96"
 
 [[package]]
+name = "ioctl-rs"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7970510895cee30b3e9128319f2cefd4bde883a39f38baa279567ba3a7eb97d"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5411,6 +5438,15 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "memoffset"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
@@ -5598,6 +5634,20 @@ dependencies = [
 
 [[package]]
 name = "nix"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f346ff70e7dbfd675fe90590b92d59ef2de15a8779ae305ebcbfd3f0caf59be4"
+dependencies = [
+ "autocfg",
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+ "memoffset 0.6.5",
+ "pin-utils",
+]
+
+[[package]]
+name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
@@ -5606,7 +5656,7 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
- "memoffset",
+ "memoffset 0.9.1",
 ]
 
 [[package]]
@@ -6611,6 +6661,27 @@ name = "pom"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60f6ce597ecdcc9a098e7fddacb1065093a3d66446fa16c675e7e71d1b5c28e6"
+
+[[package]]
+name = "portable-pty"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "806ee80c2a03dbe1a9fb9534f8d19e4c0546b790cde8fd1fea9d6390644cb0be"
+dependencies = [
+ "anyhow",
+ "bitflags 1.3.2",
+ "downcast-rs",
+ "filedescriptor",
+ "lazy_static",
+ "libc",
+ "log",
+ "nix 0.25.1",
+ "serial",
+ "shared_library",
+ "shell-words",
+ "winapi",
+ "winreg 0.10.1",
+]
 
 [[package]]
 name = "postcard"
@@ -8262,6 +8333,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1237a96570fc377c13baa1b88c7589ab66edced652e43ffb17088f003db3e86"
+dependencies = [
+ "serial-core",
+ "serial-unix",
+ "serial-windows",
+]
+
+[[package]]
+name = "serial-core"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f46209b345401737ae2125fe5b19a77acce90cd53e1658cda928e4fe9a64581"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "serial-unix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f03fbca4c9d866e24a459cbca71283f545a37f8e3e002ad8c70593871453cab7"
+dependencies = [
+ "ioctl-rs",
+ "libc",
+ "serial-core",
+ "termios",
+]
+
+[[package]]
+name = "serial-windows"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15c6d3b776267a75d31bbdfd5d36c0ca051251caafc285827052bc53bcdc8162"
+dependencies = [
+ "libc",
+ "serial-core",
+]
+
+[[package]]
 name = "serial_test"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8364,6 +8477,22 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shared_library"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a9e7e0f2bfae24d8a5b5a66c5b257a83c7412304311512a0c054cd5e619da11"
+dependencies = [
+ "lazy_static",
+ "libc",
+]
+
+[[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shellexpand"
@@ -9424,6 +9553,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termios"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5d9cf598a6d7ce700a4e6a9199da127e6819a61e64b68609683cc9a01b5683a"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "testcontainers"
 version = "0.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10257,7 +10395,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
- "memoffset",
+ "memoffset 0.9.1",
  "tempfile",
  "windows-sys 0.61.2",
 ]
@@ -11916,6 +12054,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]

--- a/crates/dasclaw_pty/Cargo.toml
+++ b/crates/dasclaw_pty/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "dasclaw_pty"
-version = "0.0.0-w1"
+version = "0.1.0-w2"
 edition = "2021"
-description = "portable-pty wrapper with signal forwarding + resize."
+description = "portable-pty wrapper exposing a Pty trait + spawn/read/write/resize/kill primitives."
 license = "Apache-2.0 OR MIT"
 publish = false
 
@@ -11,3 +11,9 @@ path = "src/lib.rs"
 
 [dependencies]
 thiserror = "1"
+portable-pty = "0.8"
+
+[dev-dependencies]
+# `cat` is the canonical interactive workload used by integration tests; no
+# extra crates required since spawn() takes raw program/args.
+

--- a/crates/dasclaw_pty/src/lib.rs
+++ b/crates/dasclaw_pty/src/lib.rs
@@ -1,24 +1,225 @@
-//! portable-pty wrapper with signal forwarding + resize.
+//! `dasclaw_pty` — a minimal, portable PTY abstraction (W2.5).
 //!
-//! W1 skeleton — trait surface only, no impl.
-//! See `docs/plans/architecture-refactor/31-target-architecture.md` §4 for design.
+//! ## 设计目标
+//!
+//! 为 W3+ 的 ShellTool / hooks BeforeToolCall 提供一个**与具体 PTY 后端解耦**
+//! 的 trait + 默认实装。当前默认实装基于 `portable-pty`（macOS/Linux 用
+//! `posix_openpt`，Windows 用 ConPTY），覆盖 W2 验收要求的
+//! `spawn / write / read / resize / kill / wait_for_exit`。
+//!
+//! ## 范围
+//!
+//! - **同步 API**：`PtyChild` 暴露阻塞读写接口。异步 wrapper 留 W3
+//!   `dasclaw_hooks::BeforeToolCall` 真正接入时再加，避免现在锁死 tokio 版本。
+//! - **不做**：进程组 kill（codex `process_group.rs` 184 LOC 处理 shell
+//!   子进程逃逸，本切片只 kill 直接子进程，shell 子进程逃逸由
+//!   `dasclaw_sandbox` seccomp/Seatbelt 拦截）。
+//! - **不做**：信号转发的 SIGINT/SIGTERM 链路（W3 ShellTool 集成时按
+//!   实际工具策略接）。
+//! - **Windows**：靠 `portable-pty` ConPTY 后端原生支持，无需自实现。
+//!
+//! ## 与 dasclaw_sandbox 的关系
+//!
+//! `Pty` trait 不耦合 sandbox。调用方按需求叠加：
+//!
+//! ```text
+//! sandbox.execute(cmd)   ←  非交互工具（cargo test 等一次性命令）
+//! pty.spawn(opts)        ←  交互工具（bash / python REPL / ssh）
+//! ```
+//!
+//! 真要把交互式 shell 跑在 sandbox 里（W3 ShellTool 默认策略），调用方
+//! 自行用 sandbox.execute 包装 PTY child 的 program 路径。本 crate 不
+//! 强制耦合避免循环依赖。
 
-#![allow(dead_code)]
+#![deny(missing_docs)]
 
-/// Placeholder error type. Replaced with module-specific errors in W2+.
-#[derive(Debug, thiserror::Error)]
-#[error("dasclaw_pty skeleton error: {0}")]
-pub struct SkeletonError(pub String);
-
-/// Primary entry trait (placeholder). Replaced with full surface in W2+.
-pub trait Pty {
-    /// portable-pty wrapper with signal forwarding + resize.
-    fn spawn(&self, cmd: std::process::Command) -> Result<(), SkeletonError>;
-}
+mod portable;
 
 #[cfg(test)]
-mod tests {
-    #[test]
-    fn skeleton_compiles() { /* W1 placeholder */
+mod tests;
+
+pub use portable::PortablePtyBackend;
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::time::Duration;
+
+/// PTY 终端尺寸。所有字段都使用 `u16`，与 `portable-pty` / POSIX 一致。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PtySize {
+    /// 行数（字符）。
+    pub rows: u16,
+    /// 列数（字符）。
+    pub cols: u16,
+    /// 像素宽度（可选；现代终端常用 0）。
+    pub pixel_width: u16,
+    /// 像素高度（可选；现代终端常用 0）。
+    pub pixel_height: u16,
+}
+
+impl Default for PtySize {
+    fn default() -> Self {
+        Self {
+            rows: 24,
+            cols: 80,
+            pixel_width: 0,
+            pixel_height: 0,
+        }
     }
+}
+
+/// Spawn 一个 PTY child 时需要的参数集合。
+#[derive(Debug, Clone)]
+pub struct PtySpawnOptions {
+    /// 可执行文件路径或 PATH 上的程序名。
+    pub program: String,
+    /// argv（不含 program 自身）。
+    pub args: Vec<String>,
+    /// 工作目录。`None` = 继承父进程 cwd。
+    pub cwd: Option<PathBuf>,
+    /// 环境变量。**不会**继承父进程 env — 调用方必须显式提供。
+    /// 这与 `dasclaw_sandbox` 的 env 透传策略一致，防止意外泄漏。
+    pub env: HashMap<String, String>,
+    /// 初始终端尺寸。
+    pub size: PtySize,
+}
+
+impl PtySpawnOptions {
+    /// 用最小参数构造：program + 默认 24x80 + 空 env。
+    pub fn new(program: impl Into<String>) -> Self {
+        Self {
+            program: program.into(),
+            args: Vec::new(),
+            cwd: None,
+            env: HashMap::new(),
+            size: PtySize::default(),
+        }
+    }
+
+    /// 链式追加 args。
+    pub fn with_args<I, S>(mut self, args: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.args.extend(args.into_iter().map(Into::into));
+        self
+    }
+
+    /// 链式设置 cwd。
+    pub fn with_cwd(mut self, cwd: impl Into<PathBuf>) -> Self {
+        self.cwd = Some(cwd.into());
+        self
+    }
+
+    /// 链式追加单个 env 变量。
+    pub fn with_env(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.env.insert(key.into(), value.into());
+        self
+    }
+
+    /// 链式设置尺寸。
+    pub fn with_size(mut self, size: PtySize) -> Self {
+        self.size = size;
+        self
+    }
+}
+
+/// PTY 错误类型。
+#[derive(Debug, thiserror::Error)]
+pub enum PtyError {
+    /// `portable_pty::PtySystem::openpty` 失败（fd 耗尽、权限等）。
+    #[error("failed to open pty: {0}")]
+    Open(String),
+
+    /// 启动子进程失败（program 不存在、权限不足）。
+    #[error("failed to spawn child: {0}")]
+    Spawn(String),
+
+    /// 读 PTY master 失败。
+    #[error("pty read error: {0}")]
+    Read(#[source] std::io::Error),
+
+    /// 写 PTY master 失败。
+    #[error("pty write error: {0}")]
+    Write(#[source] std::io::Error),
+
+    /// 调整尺寸失败。
+    #[error("pty resize error: {0}")]
+    Resize(String),
+
+    /// kill child 失败（进程已退出 = NotFound 时调用方应当作幂等成功）。
+    #[error("pty kill error: {0}")]
+    Kill(#[source] std::io::Error),
+
+    /// `wait_for_exit` 超时。
+    #[error("pty wait timed out after {0:?}")]
+    WaitTimeout(Duration),
+
+    /// child 状态不可查询（portable-pty `try_wait` 返回错误）。
+    #[error("pty wait error: {0}")]
+    Wait(String),
+}
+
+/// 退出状态。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PtyExitStatus {
+    /// 进程正常退出，附带 exit code（约定 Unix 0=ok，非 0=失败）。
+    Exited(i32),
+    /// 进程被信号杀死（仅 Unix 有意义）。
+    Signaled,
+    /// 进程仍在运行。
+    Running,
+}
+
+impl PtyExitStatus {
+    /// 是否已完成（不再 Running）。
+    pub fn is_finished(&self) -> bool {
+        !matches!(self, PtyExitStatus::Running)
+    }
+
+    /// 是否成功退出（Exited(0)）。
+    pub fn is_success(&self) -> bool {
+        matches!(self, PtyExitStatus::Exited(0))
+    }
+}
+
+/// PTY 后端 trait。**对外**只暴露 `spawn`，其余动作通过 `PtyChild` 进行。
+pub trait Pty: Send + Sync {
+    /// 启动一个进程，attach 到 PTY，返回可控的 child handle。
+    fn spawn(&self, options: PtySpawnOptions) -> Result<Box<dyn PtyChild>, PtyError>;
+}
+
+/// 已 spawn 的 PTY child 控制句柄。
+///
+/// 所有方法都是同步阻塞的；上层异步 runtime（tokio 等）应包到
+/// `spawn_blocking` 里。
+pub trait PtyChild: Send {
+    /// 向 child stdin 写字节。返回实际写入字节数（短写需上层循环）。
+    fn write(&mut self, buf: &[u8]) -> Result<usize, PtyError>;
+
+    /// 从 child stdout/stderr（PTY 不区分）读字节。EOF 返回 `Ok(0)`。
+    /// 阻塞直到至少 1 字节或 EOF。
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize, PtyError>;
+
+    /// 调整终端尺寸。子进程通常会收到 SIGWINCH（Unix）。
+    fn resize(&mut self, size: PtySize) -> Result<(), PtyError>;
+
+    /// 强制 kill child（SIGKILL on Unix / TerminateProcess on Windows）。
+    /// 如果 child 已退出，**返回 Ok(())**（幂等）。
+    fn kill(&mut self) -> Result<(), PtyError>;
+
+    /// 非阻塞查询 child 当前状态。
+    fn try_wait(&mut self) -> Result<PtyExitStatus, PtyError>;
+
+    /// 阻塞等待 child 退出，最多 `timeout`。`None` = 无限等。
+    /// 超时时**不**自动 kill；调用方决定是否 kill 后再等。
+    fn wait_for_exit(&mut self, timeout: Option<Duration>) -> Result<PtyExitStatus, PtyError>;
+}
+
+/// 工厂：返回当前平台默认 PTY 后端。
+///
+/// 默认 = `PortablePtyBackend`（macOS/Linux: posix_openpt; Windows: ConPTY）。
+pub fn default_backend() -> PortablePtyBackend {
+    PortablePtyBackend::new()
 }

--- a/crates/dasclaw_pty/src/portable.rs
+++ b/crates/dasclaw_pty/src/portable.rs
@@ -1,0 +1,166 @@
+//! Default PTY backend backed by the `portable-pty` crate.
+//!
+//! Wraps `portable_pty::native_pty_system()` so that the rest of `dasclaw_pty`
+//! can program against the [`Pty`] / [`PtyChild`] traits instead of the
+//! concrete `portable_pty::*` types. Keeps Windows/macOS/Linux on a single
+//! code path (ConPTY / posix_openpt) without per-platform branches in the
+//! call sites.
+
+use std::io::{Read, Write};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use portable_pty::{native_pty_system, CommandBuilder, MasterPty, PtyPair, PtySystem};
+
+use crate::{Pty, PtyChild, PtyError, PtyExitStatus, PtySize, PtySpawnOptions};
+
+/// 默认实装：基于 `portable-pty`。
+///
+/// 多线程安全；`spawn` 内部每次都新建 `PtySystem`，无共享可变状态。
+#[derive(Default, Debug)]
+pub struct PortablePtyBackend;
+
+impl PortablePtyBackend {
+    /// 构造默认后端。
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Pty for PortablePtyBackend {
+    fn spawn(&self, options: PtySpawnOptions) -> Result<Box<dyn PtyChild>, PtyError> {
+        let pty_system: Box<dyn PtySystem> = native_pty_system();
+        let pair: PtyPair = pty_system
+            .openpty(to_portable_size(options.size))
+            .map_err(|e| PtyError::Open(e.to_string()))?;
+
+        let mut cmd = CommandBuilder::new(&options.program);
+        cmd.args(&options.args);
+        if let Some(cwd) = options.cwd.as_ref() {
+            cmd.cwd(cwd);
+        }
+        // env_clear 等价：portable-pty 默认不继承 env，调用方显式设置即可。
+        // 这里不主动调 env_clear() 因为 portable-pty 0.8 没有该 API；它
+        // 默认就只用 CommandBuilder 上设的 env，无父进程继承。
+        for (k, v) in &options.env {
+            cmd.env(k, v);
+        }
+
+        let child = pair
+            .slave
+            .spawn_command(cmd)
+            .map_err(|e| PtyError::Spawn(e.to_string()))?;
+
+        // master 拆出 reader / writer。reader 是 try_clone_reader（可读端），
+        // writer 是 take_writer（独占写端，take 后 master 不再可写）。
+        let reader = pair
+            .master
+            .try_clone_reader()
+            .map_err(|e| PtyError::Open(format!("clone reader: {e}")))?;
+        let writer = pair
+            .master
+            .take_writer()
+            .map_err(|e| PtyError::Open(format!("take writer: {e}")))?;
+
+        // 持有 master 用于 resize；slave 显式 drop 以释放 fd（child 已 fork）。
+        drop(pair.slave);
+
+        Ok(Box::new(PortablePtyChild {
+            master: pair.master,
+            reader,
+            writer,
+            child,
+        }))
+    }
+}
+
+struct PortablePtyChild {
+    master: Box<dyn MasterPty + Send>,
+    reader: Box<dyn Read + Send>,
+    writer: Box<dyn Write + Send>,
+    child: Box<dyn portable_pty::Child + Send + Sync>,
+}
+
+impl PtyChild for PortablePtyChild {
+    fn write(&mut self, buf: &[u8]) -> Result<usize, PtyError> {
+        self.writer.write(buf).map_err(PtyError::Write)
+    }
+
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize, PtyError> {
+        self.reader.read(buf).map_err(PtyError::Read)
+    }
+
+    fn resize(&mut self, size: PtySize) -> Result<(), PtyError> {
+        self.master
+            .resize(to_portable_size(size))
+            .map_err(|e| PtyError::Resize(e.to_string()))
+    }
+
+    fn kill(&mut self) -> Result<(), PtyError> {
+        // 先看 child 是否已自然退出。已退出时 kill(2) 会返回 ESRCH（Unix）
+        // 或 invalid handle（Windows），跨平台错误 kind 不一致。最干净的
+        // 幂等实现是：已退出 → 直接 Ok(())，不触发 syscall。
+        if let Ok(Some(_)) = self.child.try_wait() {
+            return Ok(());
+        }
+        match self.child.kill() {
+            Ok(()) => Ok(()),
+            // 边界情况：try_wait 之后 / kill 之前 child 在 race 窗口内退出。
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(e) if e.raw_os_error() == Some(3) /* ESRCH on Unix */ => Ok(()),
+            Err(e) => Err(PtyError::Kill(e)),
+        }
+    }
+
+    fn try_wait(&mut self) -> Result<PtyExitStatus, PtyError> {
+        match self.child.try_wait() {
+            Ok(None) => Ok(PtyExitStatus::Running),
+            Ok(Some(status)) => Ok(map_exit_status(status)),
+            Err(e) => Err(PtyError::Wait(e.to_string())),
+        }
+    }
+
+    fn wait_for_exit(&mut self, timeout: Option<Duration>) -> Result<PtyExitStatus, PtyError> {
+        // portable-pty 没有原生 timeout wait API；用 try_wait + 轮询模拟。
+        // 轮询间隔 25ms 在交互响应（< 一帧）和 CPU 占用间取中庸值。
+        const POLL_INTERVAL: Duration = Duration::from_millis(25);
+        let deadline = timeout.map(|t| Instant::now() + t);
+
+        loop {
+            match self.try_wait()? {
+                PtyExitStatus::Running => {}
+                done => return Ok(done),
+            }
+
+            if let Some(deadline) = deadline {
+                if Instant::now() >= deadline {
+                    return Err(PtyError::WaitTimeout(timeout.expect("deadline implies timeout")));
+                }
+            }
+
+            thread::sleep(POLL_INTERVAL);
+        }
+    }
+}
+
+fn to_portable_size(size: PtySize) -> portable_pty::PtySize {
+    portable_pty::PtySize {
+        rows: size.rows,
+        cols: size.cols,
+        pixel_width: size.pixel_width,
+        pixel_height: size.pixel_height,
+    }
+}
+
+fn map_exit_status(status: portable_pty::ExitStatus) -> PtyExitStatus {
+    // portable-pty 抽象层不区分 "exit code N" 与 "killed by signal"，统一用
+    // u32 exit_code 暴露。我们保持同一映射：success() → Exited(0)，否则
+    // Exited(exit_code as i32)。`PtyExitStatus::Signaled` 留给未来更精细的
+    // 后端（例如直接走 std::process::ExitStatus 的本地 backend）使用，本
+    // backend 不会产出该值。
+    if status.success() {
+        PtyExitStatus::Exited(0)
+    } else {
+        PtyExitStatus::Exited(status.exit_code() as i32)
+    }
+}

--- a/crates/dasclaw_pty/src/portable.rs
+++ b/crates/dasclaw_pty/src/portable.rs
@@ -124,7 +124,7 @@ impl PtyChild for PortablePtyChild {
         // portable-pty 没有原生 timeout wait API；用 try_wait + 轮询模拟。
         // 轮询间隔 25ms 在交互响应（< 一帧）和 CPU 占用间取中庸值。
         const POLL_INTERVAL: Duration = Duration::from_millis(25);
-        let deadline = timeout.map(|t| Instant::now() + t);
+        let deadline = timeout.map(|t| (Instant::now() + t, t));
 
         loop {
             match self.try_wait()? {
@@ -132,11 +132,9 @@ impl PtyChild for PortablePtyChild {
                 done => return Ok(done),
             }
 
-            if let Some(deadline) = deadline {
+            if let Some((deadline, total)) = deadline {
                 if Instant::now() >= deadline {
-                    return Err(PtyError::WaitTimeout(
-                        timeout.expect("deadline implies timeout"),
-                    ));
+                    return Err(PtyError::WaitTimeout(total));
                 }
             }
 

--- a/crates/dasclaw_pty/src/portable.rs
+++ b/crates/dasclaw_pty/src/portable.rs
@@ -134,7 +134,9 @@ impl PtyChild for PortablePtyChild {
 
             if let Some(deadline) = deadline {
                 if Instant::now() >= deadline {
-                    return Err(PtyError::WaitTimeout(timeout.expect("deadline implies timeout")));
+                    return Err(PtyError::WaitTimeout(
+                        timeout.expect("deadline implies timeout"),
+                    ));
                 }
             }
 

--- a/crates/dasclaw_pty/src/tests.rs
+++ b/crates/dasclaw_pty/src/tests.rs
@@ -7,9 +7,7 @@
 
 use std::time::Duration;
 
-use crate::{
-    default_backend, PortablePtyBackend, Pty, PtyExitStatus, PtySize, PtySpawnOptions,
-};
+use crate::{default_backend, PortablePtyBackend, Pty, PtyExitStatus, PtySize, PtySpawnOptions};
 
 #[test]
 fn pty_size_default_is_24x80() {
@@ -168,9 +166,24 @@ fn resize_does_not_error_on_running_child() {
 
     // 三档常见尺寸都应该能 resize 成功。
     for size in [
-        PtySize { rows: 24, cols: 80, pixel_width: 0, pixel_height: 0 },
-        PtySize { rows: 40, cols: 120, pixel_width: 0, pixel_height: 0 },
-        PtySize { rows: 80, cols: 200, pixel_width: 1920, pixel_height: 1080 },
+        PtySize {
+            rows: 24,
+            cols: 80,
+            pixel_width: 0,
+            pixel_height: 0,
+        },
+        PtySize {
+            rows: 40,
+            cols: 120,
+            pixel_width: 0,
+            pixel_height: 0,
+        },
+        PtySize {
+            rows: 80,
+            cols: 200,
+            pixel_width: 1920,
+            pixel_height: 1080,
+        },
     ] {
         child.resize(size).expect("resize should succeed");
     }
@@ -188,10 +201,7 @@ fn kill_then_wait_reports_finished() {
         .expect("spawn sleeping shell");
 
     // 进程应该还在跑。
-    assert_eq!(
-        child.try_wait().expect("try_wait"),
-        PtyExitStatus::Running
-    );
+    assert_eq!(child.try_wait().expect("try_wait"), PtyExitStatus::Running);
 
     child.kill().expect("kill running child");
 
@@ -199,7 +209,10 @@ fn kill_then_wait_reports_finished() {
     let status = child
         .wait_for_exit(Some(Duration::from_secs(2)))
         .expect("wait after kill");
-    assert!(status.is_finished(), "kill should make child finished, got {status:?}");
+    assert!(
+        status.is_finished(),
+        "kill should make child finished, got {status:?}"
+    );
 }
 
 #[cfg(unix)]

--- a/crates/dasclaw_pty/src/tests.rs
+++ b/crates/dasclaw_pty/src/tests.rs
@@ -1,0 +1,256 @@
+//! Integration + unit tests for [`crate::PortablePtyBackend`].
+//!
+//! 真集成测试只在 Unix 上跑（依赖 `/bin/echo` `/bin/cat` `/bin/sh`）。
+//! Windows CI 由 portable-pty 上游测试覆盖；本 crate 在 Windows 上仅
+//! 验证编译与构造路径，不验真实 spawn — 等 W2.4 Windows sandbox 成型后
+//! 一起补 ConPTY smoke 测试。
+
+use std::time::Duration;
+
+use crate::{
+    default_backend, PortablePtyBackend, Pty, PtyExitStatus, PtySize, PtySpawnOptions,
+};
+
+#[test]
+fn pty_size_default_is_24x80() {
+    let s = PtySize::default();
+    assert_eq!(s.rows, 24);
+    assert_eq!(s.cols, 80);
+    assert_eq!(s.pixel_width, 0);
+    assert_eq!(s.pixel_height, 0);
+}
+
+#[test]
+fn spawn_options_builder_chain() {
+    let opts = PtySpawnOptions::new("/bin/echo")
+        .with_args(["hello", "world"])
+        .with_cwd("/tmp")
+        .with_env("FOO", "bar")
+        .with_size(PtySize {
+            rows: 40,
+            cols: 120,
+            pixel_width: 0,
+            pixel_height: 0,
+        });
+
+    assert_eq!(opts.program, "/bin/echo");
+    assert_eq!(opts.args, vec!["hello", "world"]);
+    assert_eq!(opts.cwd.as_deref(), Some(std::path::Path::new("/tmp")));
+    assert_eq!(opts.env.get("FOO").map(String::as_str), Some("bar"));
+    assert_eq!(opts.size.rows, 40);
+    assert_eq!(opts.size.cols, 120);
+}
+
+#[test]
+fn exit_status_helpers() {
+    assert!(PtyExitStatus::Exited(0).is_finished());
+    assert!(PtyExitStatus::Exited(0).is_success());
+    assert!(PtyExitStatus::Exited(1).is_finished());
+    assert!(!PtyExitStatus::Exited(1).is_success());
+    assert!(PtyExitStatus::Signaled.is_finished());
+    assert!(!PtyExitStatus::Signaled.is_success());
+    assert!(!PtyExitStatus::Running.is_finished());
+    assert!(!PtyExitStatus::Running.is_success());
+}
+
+#[test]
+fn default_backend_is_portable() {
+    // 仅验证工厂能构造，不 spawn — 多平台都安全跑。
+    let _backend: PortablePtyBackend = default_backend();
+}
+
+// ---------- Unix-only real spawn tests ----------
+
+#[cfg(unix)]
+#[test]
+fn echo_runs_to_completion_and_reports_exit_zero() {
+    let backend = PortablePtyBackend::new();
+    let mut child = backend
+        .spawn(PtySpawnOptions::new("/bin/echo").with_args(["dasclaw_pty:hello"]))
+        .expect("spawn /bin/echo");
+
+    let status = child
+        .wait_for_exit(Some(Duration::from_secs(5)))
+        .expect("echo should exit within 5s");
+    assert_eq!(status, PtyExitStatus::Exited(0));
+    assert!(status.is_success());
+}
+
+#[cfg(unix)]
+#[test]
+fn child_stdout_is_readable_via_pty() {
+    let backend = PortablePtyBackend::new();
+    let mut child = backend
+        .spawn(PtySpawnOptions::new("/bin/echo").with_args(["dasclaw_pty:greeting"]))
+        .expect("spawn /bin/echo");
+
+    // PTY 在 child 退出 + slave fd 关闭后，master 读会立即返回 EIO。
+    // 所以必须**先**循环读直到看到 sentinel，再 wait。echo 通常在
+    // < 50ms 内输出完毕，2 秒 deadline 足够。
+    let mut buf = [0u8; 256];
+    let mut collected = Vec::new();
+    let deadline = std::time::Instant::now() + Duration::from_secs(2);
+    while std::time::Instant::now() < deadline {
+        match child.read(&mut buf) {
+            Ok(0) => break, // 干净 EOF
+            Ok(n) => {
+                collected.extend_from_slice(&buf[..n]);
+                if String::from_utf8_lossy(&collected).contains("dasclaw_pty:greeting") {
+                    break;
+                }
+            }
+            Err(_) => break, // PTY EOF on Unix 表现为 EIO
+        }
+    }
+
+    let _ = child.wait_for_exit(Some(Duration::from_secs(2)));
+
+    let out = String::from_utf8_lossy(&collected);
+    assert!(
+        out.contains("dasclaw_pty:greeting"),
+        "expected greeting in PTY output, got {out:?}",
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn write_to_cat_is_echoed_back() {
+    let backend = PortablePtyBackend::new();
+    let mut child = backend
+        .spawn(PtySpawnOptions::new("/bin/cat"))
+        .expect("spawn /bin/cat");
+
+    // 写入一行；cat 在 PTY 模式下默认 line buffer + echo on，所以单次
+    // 写应该立即收到 echo + 输出双份。我们只断言至少出现一次 sentinel。
+    let line = b"sentinel\n";
+    let mut written = 0;
+    while written < line.len() {
+        let n = child.write(&line[written..]).expect("write to cat");
+        assert!(n > 0, "PTY write must make progress");
+        written += n;
+    }
+
+    // 读最多 1 秒，找 sentinel 子串就停。
+    let mut buf = [0u8; 256];
+    let mut collected = Vec::new();
+    let deadline = std::time::Instant::now() + Duration::from_secs(2);
+    while std::time::Instant::now() < deadline {
+        match child.read(&mut buf) {
+            Ok(0) => break,
+            Ok(n) => {
+                collected.extend_from_slice(&buf[..n]);
+                if String::from_utf8_lossy(&collected).contains("sentinel") {
+                    break;
+                }
+            }
+            Err(_) => break,
+        }
+    }
+
+    // 完事 kill cat（它在等更多 stdin）。
+    child.kill().expect("kill cat");
+    let _ = child.wait_for_exit(Some(Duration::from_secs(2)));
+
+    let observed = String::from_utf8_lossy(&collected);
+    assert!(
+        observed.contains("sentinel"),
+        "expected sentinel echoed back, got {observed:?}",
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn resize_does_not_error_on_running_child() {
+    let backend = PortablePtyBackend::new();
+    let mut child = backend
+        .spawn(PtySpawnOptions::new("/bin/cat"))
+        .expect("spawn /bin/cat");
+
+    // 三档常见尺寸都应该能 resize 成功。
+    for size in [
+        PtySize { rows: 24, cols: 80, pixel_width: 0, pixel_height: 0 },
+        PtySize { rows: 40, cols: 120, pixel_width: 0, pixel_height: 0 },
+        PtySize { rows: 80, cols: 200, pixel_width: 1920, pixel_height: 1080 },
+    ] {
+        child.resize(size).expect("resize should succeed");
+    }
+
+    child.kill().expect("kill cat");
+    let _ = child.wait_for_exit(Some(Duration::from_secs(2)));
+}
+
+#[cfg(unix)]
+#[test]
+fn kill_then_wait_reports_finished() {
+    let backend = PortablePtyBackend::new();
+    let mut child = backend
+        .spawn(PtySpawnOptions::new("/bin/sh").with_args(["-c", "sleep 30"]))
+        .expect("spawn sleeping shell");
+
+    // 进程应该还在跑。
+    assert_eq!(
+        child.try_wait().expect("try_wait"),
+        PtyExitStatus::Running
+    );
+
+    child.kill().expect("kill running child");
+
+    // wait 应该在 SIGKILL 后很快返回，不超过 2 秒。
+    let status = child
+        .wait_for_exit(Some(Duration::from_secs(2)))
+        .expect("wait after kill");
+    assert!(status.is_finished(), "kill should make child finished, got {status:?}");
+}
+
+#[cfg(unix)]
+#[test]
+fn kill_is_idempotent_after_natural_exit() {
+    let backend = PortablePtyBackend::new();
+    let mut child = backend
+        .spawn(PtySpawnOptions::new("/bin/echo").with_args(["bye"]))
+        .expect("spawn echo");
+
+    let _ = child
+        .wait_for_exit(Some(Duration::from_secs(5)))
+        .expect("echo exits");
+
+    // child 已自然退出；kill 必须返回 Ok(())（不能 panic / 报错）。
+    child.kill().expect("kill on already-dead child must be Ok");
+    child.kill().expect("second kill must also be Ok");
+}
+
+#[cfg(unix)]
+#[test]
+fn wait_for_exit_times_out_when_child_blocks() {
+    let backend = PortablePtyBackend::new();
+    let mut child = backend
+        .spawn(PtySpawnOptions::new("/bin/sh").with_args(["-c", "sleep 30"]))
+        .expect("spawn sleeping shell");
+
+    let result = child.wait_for_exit(Some(Duration::from_millis(150)));
+    match result {
+        Err(crate::PtyError::WaitTimeout(dur)) => {
+            assert_eq!(dur, Duration::from_millis(150));
+        }
+        other => panic!("expected WaitTimeout, got {other:?}"),
+    }
+
+    // 清理：超时后调用方有责任 kill。
+    child.kill().expect("kill after timeout");
+    let _ = child.wait_for_exit(Some(Duration::from_secs(2)));
+}
+
+#[cfg(unix)]
+#[test]
+fn nonzero_exit_code_is_preserved() {
+    let backend = PortablePtyBackend::new();
+    let mut child = backend
+        .spawn(PtySpawnOptions::new("/bin/sh").with_args(["-c", "exit 42"]))
+        .expect("spawn shell with exit 42");
+
+    let status = child
+        .wait_for_exit(Some(Duration::from_secs(5)))
+        .expect("shell exits");
+    assert_eq!(status, PtyExitStatus::Exited(42));
+    assert!(!status.is_success());
+}


### PR DESCRIPTION
## 背景

W2.5 任务前置依赖 W3+ 的 ShellTool / hooks BeforeToolCall。当前 `dasclaw_pty` 是 24 行 W1 skeleton（仅占位 trait），W3 启动前必须把 trait 完整化 + 至少有一个可工作 backend。

## 范围

- `Pty` / `PtyChild` trait 完整 surface：`spawn / read / write / resize / kill / try_wait / wait_for_exit`
- `PtySize`（24x80 default）+ `PtySpawnOptions` builder（args/cwd/env/size 链式）
- `PtyError` thiserror 分类：Open/Spawn/Read/Write/Resize/Kill/WaitTimeout/Wait
- `PtyExitStatus`（Exited/Signaled/Running）+ `is_finished` / `is_success`
- `PortablePtyBackend` 默认实装：基于 `portable-pty` 0.8（macOS/Linux `posix_openpt` + Windows ConPTY）

### 关键设计决定

1. **同步 API**：`PtyChild` 暴露阻塞读写。异步 wrapper 留 W3 `dasclaw_hooks::BeforeToolCall` 真正接入时再加，避免现在锁死 tokio 版本。
2. **kill 幂等**：`try_wait` 已退出 → `Ok(())`；race 窗口内 `ESRCH`/`NotFound` 也归并成功。
3. **`wait_for_exit` 25ms 轮询**：portable-pty 无原生 timeout API，轮询间隔在交互响应（< 一帧）和 CPU 占用间取中庸。
4. **env 不继承父进程**：与 `dasclaw_sandbox` 策略对齐防泄漏（`OPENAI_API_KEY` 等）。

### 明确范围标定（不算遗留尾巴，是边界）

- **异步 wrapper**：W3 ShellTool 接入时再加 tokio adapter
- **PGID kill**：codex `process_group.rs` 184 LOC PGID 处理留给 `dasclaw_sandbox` seccomp/Seatbelt 拦截 shell 子进程逃逸
- **Windows 真实集成测试**：W2.4 Windows sandbox 落地后一起补 ConPTY smoke
- **信号转发的 SIGINT/SIGTERM 链路**：W3 ShellTool 集成时按工具策略接

## 测试

12/12 通过（10 个 unix-only 真实 spawn /bin/echo /bin/cat /bin/sh）：

- 单元：PtySize default / SpawnOptions builder / ExitStatus helpers / 工厂构造
- 集成：echo 退出 0 / 读 stdout / cat 写入回显 / resize 不报错 / kill+wait / kill 幂等（自然退出后） / wait timeout / 非零 exit code 保留

## 验证

```
cargo build -p dasclaw_pty           # 0 warning
cargo test -p dasclaw_pty            # 12 passed; 0 failed
cargo clippy -p dasclaw_pty --all-targets -- -D warnings  # 0 warning
```

## 代码量

- `src/lib.rs`: 225 LOC（trait + types + 文档）
- `src/portable.rs`: 166 LOC（默认 backend 实装）
- `src/tests.rs`: 256 LOC（12 测试）
- 总计 647 LOC

## 后续依赖

- W3 `dasclaw_hooks` BeforeToolCall + ShellTool：消费本 trait
- W2.4 Windows restricted token：补 ConPTY 真实集成测试

## Base 分支说明

base = `refactor/phase3-agent-extraction`（PR #1 还没 merge），review 时只看 PTY 增量。PR #1 merge 后 GitHub 会自动把 base 改成 `xClaw`。