### PR TITLE
feat(sandbox/exec): W2.3b ProxyRouted 真接入

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2396,6 +2396,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "dasclaw_exec"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "dasclaw_sandbox",
+ "ironclaw_workspace_cap",
+ "tempfile",
+ "thiserror 1.0.69",
+ "tokio",
+]
+
+[[package]]
 name = "dasclaw_execpolicy"
 version = "0.0.0-w1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,8 @@ members = [
 	"crates/dasclaw_lsp",
 	"crates/dasclaw_git_tools",
 	"crates/dasclaw_routines",
+	# W2.6 接线层：组合 sandbox + pty + workspace_cap policy
+	"crates/dasclaw_exec",
 	"desktop-client/ironclaw",
 	"desktop-client/ironclaw/crates/ironclaw_common",
 	"desktop-client/ironclaw/crates/ironclaw_safety",

--- a/crates/dasclaw_exec/Cargo.toml
+++ b/crates/dasclaw_exec/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "dasclaw_exec"
+version = "0.1.0"
+edition = "2024"
+rust-version = "1.92"
+description = "W2.6 整合层：把 ironclaw_workspace_cap 的高层 SandboxPolicy 转成 dasclaw_sandbox 的内核配置，提供 ProcessExecutor 抽象统一 tool 执行入口"
+authors = ["x-claw contributors"]
+license = "MIT OR Apache-2.0"
+publish = false
+
+[lib]
+name = "dasclaw_exec"
+path = "src/lib.rs"
+
+[dependencies]
+async-trait = "0.1"
+thiserror = "1"
+
+# 上层政策：高层 SandboxPolicy enum + WritableRoot 洞中洞决策
+ironclaw_workspace_cap = { path = "../ironclaw_workspace_cap" }
+# 下层内核：跨平台沙箱执行
+dasclaw_sandbox = { path = "../dasclaw_sandbox" }
+
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread", "sync"] }
+tempfile = "3"

--- a/crates/dasclaw_exec/src/lib.rs
+++ b/crates/dasclaw_exec/src/lib.rs
@@ -39,9 +39,11 @@
 
 #![forbid(unsafe_code)]
 
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 
+use dasclaw_sandbox::proxy::detect_loopback_ports;
 use dasclaw_sandbox::{
     select_backend, SandboxBackendConfig, SandboxError, SandboxExecRequest, SandboxablePreference,
 };
@@ -157,6 +159,21 @@ impl ProcessExecutor for SandboxedExecutor {
 /// [`ironclaw_workspace_cap::policy::SandboxPolicy::is_path_writable`] 用户态决策
 /// 与 [`ironclaw_workspace_cap::WorkspaceCap`] 文件接口共同强制。
 pub fn policy_to_backend_config(policy: &SandboxPolicy, cwd: &Path) -> SandboxBackendConfig {
+    policy_to_backend_config_with_env(policy, cwd, &std::env::vars().collect())
+}
+
+/// 可注入 env 的测试友好版本。`env` 应为完整进程环境变量集（
+/// `std::env::vars().collect::<HashMap<_, _>>()`）；proxy 端口从这里提取。
+///
+/// 只在网络受限（`network_access=false` 或 `Restricted`）且检测到代理时才
+/// 填充 `proxy_loopback_ports`；网络全开时 hole punch 多余，不填。
+pub fn policy_to_backend_config_with_env(
+    policy: &SandboxPolicy,
+    cwd: &Path,
+    env: &HashMap<String, String>,
+) -> SandboxBackendConfig {
+    let proxy_ports_when_restricted = || detect_loopback_ports(env);
+
     match policy {
         SandboxPolicy::DangerFullAccess => SandboxBackendConfig {
             readable_roots: vec![PathBuf::from("/")],
@@ -170,16 +187,27 @@ pub fn policy_to_backend_config(policy: &SandboxPolicy, cwd: &Path) -> SandboxBa
             writable_roots: vec![],
             allow_network: *network_access,
             allow_spawn: true,
-            proxy_loopback_ports: vec![],
+            proxy_loopback_ports: if *network_access {
+                vec![]
+            } else {
+                proxy_ports_when_restricted()
+            },
         },
-        SandboxPolicy::ExternalSandbox { network_access } => SandboxBackendConfig {
-            // 进程内被外层容器隔离，本地视为只读。
-            readable_roots: vec![PathBuf::from("/")],
-            writable_roots: vec![],
-            allow_network: matches!(network_access, NetworkAccess::Enabled),
-            allow_spawn: true,
-            proxy_loopback_ports: vec![],
-        },
+        SandboxPolicy::ExternalSandbox { network_access } => {
+            let net_enabled = matches!(network_access, NetworkAccess::Enabled);
+            SandboxBackendConfig {
+                // 进程内被外层容器隔离，本地视为只读。
+                readable_roots: vec![PathBuf::from("/")],
+                writable_roots: vec![],
+                allow_network: net_enabled,
+                allow_spawn: true,
+                proxy_loopback_ports: if net_enabled {
+                    vec![]
+                } else {
+                    proxy_ports_when_restricted()
+                },
+            }
+        }
         SandboxPolicy::WorkspaceWrite { network_access, .. } => {
             let roots = policy.get_writable_roots_with_cwd(cwd);
             let writable_roots: Vec<PathBuf> = roots.iter().map(|r| r.root.clone()).collect();
@@ -188,7 +216,11 @@ pub fn policy_to_backend_config(policy: &SandboxPolicy, cwd: &Path) -> SandboxBa
                 writable_roots,
                 allow_network: *network_access,
                 allow_spawn: true,
-                proxy_loopback_ports: vec![],
+                proxy_loopback_ports: if *network_access {
+                    vec![]
+                } else {
+                    proxy_ports_when_restricted()
+                },
             }
         }
     }
@@ -268,6 +300,108 @@ mod tests {
                 "Unix 默认应包含 /tmp"
             );
         }
+    }
+
+    // -- W2.3b proxy 集成 --
+
+    fn proxy_env(url: &str) -> HashMap<String, String> {
+        let mut e = HashMap::new();
+        e.insert("HTTPS_PROXY".to_string(), url.to_string());
+        e
+    }
+
+    #[test]
+    fn workspace_write_with_proxy_env_populates_proxy_ports() {
+        let tmp = tempfile::tempdir().unwrap();
+        let env = proxy_env("http://127.0.0.1:8080");
+        let cfg = policy_to_backend_config_with_env(
+            &SandboxPolicy::new_workspace_write_policy(),
+            tmp.path(),
+            &env,
+        );
+        assert_eq!(
+            cfg.proxy_loopback_ports,
+            vec![8080],
+            "网络受限 + 检测到 loopback proxy 应填 hole-punch 端口"
+        );
+        assert!(!cfg.allow_network, "WorkspaceWrite 默认 network=false");
+    }
+
+    #[test]
+    fn workspace_write_with_network_enabled_skips_proxy_ports() {
+        let tmp = tempfile::tempdir().unwrap();
+        let env = proxy_env("http://127.0.0.1:8080");
+        let cfg = policy_to_backend_config_with_env(
+            &SandboxPolicy::WorkspaceWrite {
+                writable_roots: vec![],
+                network_access: true,
+                exclude_tmpdir_env_var: true,
+                exclude_slash_tmp: true,
+            },
+            tmp.path(),
+            &env,
+        );
+        assert!(
+            cfg.proxy_loopback_ports.is_empty(),
+            "网络全开时 hole-punch 多余，不应填 proxy 端口"
+        );
+        assert!(cfg.allow_network);
+    }
+
+    #[test]
+    fn read_only_with_proxy_env_populates_proxy_ports_when_network_denied() {
+        let env = proxy_env("socks5://localhost:1080");
+        let cfg = policy_to_backend_config_with_env(
+            &SandboxPolicy::ReadOnly {
+                network_access: false,
+            },
+            Path::new("/x"),
+            &env,
+        );
+        assert_eq!(cfg.proxy_loopback_ports, vec![1080]);
+    }
+
+    #[test]
+    fn external_sandbox_restricted_with_proxy_env_picks_up_ports() {
+        let env = proxy_env("http://127.0.0.1:9999");
+        let cfg = policy_to_backend_config_with_env(
+            &SandboxPolicy::ExternalSandbox {
+                network_access: NetworkAccess::Restricted,
+            },
+            Path::new("/x"),
+            &env,
+        );
+        assert_eq!(cfg.proxy_loopback_ports, vec![9999]);
+        assert!(!cfg.allow_network);
+    }
+
+    #[test]
+    fn external_sandbox_enabled_skips_proxy_ports() {
+        let env = proxy_env("http://127.0.0.1:9999");
+        let cfg = policy_to_backend_config_with_env(
+            &SandboxPolicy::ExternalSandbox {
+                network_access: NetworkAccess::Enabled,
+            },
+            Path::new("/x"),
+            &env,
+        );
+        assert!(cfg.proxy_loopback_ports.is_empty());
+        assert!(cfg.allow_network);
+    }
+
+    #[test]
+    fn non_loopback_proxy_does_not_populate_ports() {
+        // 真实远程 proxy（不是 loopback）→ sandbox 不该 hole-punch loopback
+        let env = proxy_env("http://corp-proxy.internal:3128");
+        let cfg = policy_to_backend_config_with_env(
+            &SandboxPolicy::new_workspace_write_policy(),
+            Path::new("/x"),
+            &env,
+        );
+        assert!(
+            cfg.proxy_loopback_ports.is_empty(),
+            "非 loopback proxy 不应触发 hole-punch"
+        );
     }
 
     // -- ProcessExecutor 接口契约 --

--- a/crates/dasclaw_exec/src/lib.rs
+++ b/crates/dasclaw_exec/src/lib.rs
@@ -1,0 +1,345 @@
+//! `dasclaw_exec` — W2.6 整合层。
+//!
+//! 把 [`ironclaw_workspace_cap::policy::SandboxPolicy`]（高层 4-tier enum，
+//! 与 codex 协议对齐）转成 [`dasclaw_sandbox::SandboxBackendConfig`]
+//! （内核级配置），并提供 [`ProcessExecutor`] 抽象，让 tool 调用方无需
+//! 自己组装 sandbox + policy + cwd 的胶水。
+//!
+//! ## 设计边界
+//!
+//! - **进程沙箱（dasclaw_sandbox）**：粗粒度，按 root 整体允许/拒绝写。
+//! - **WritableRoot 洞中洞（read_only_subpaths）**：理论上需要内核层
+//!   `landlock` / `sbpl` 表达；目前内核层暂不强制（known limitation），
+//!   `is_path_writable` 用户态决策仍然有效，且 [`ironclaw_workspace_cap::WorkspaceCap`]
+//!   的 cap-std 文件接口已经接入策略层做二次拒绝。
+//! - **PTY 终端**：走 [`dasclaw_pty`] 独立路径，不在 `ProcessExecutor` 范围；
+//!   终端会话的 sandbox 包裹由调用方在 `spawn` 时显式组合。
+//!
+//! ## 典型用法
+//!
+//! ```no_run
+//! use dasclaw_exec::{ExecRequest, ProcessExecutor, SandboxedExecutor};
+//! use dasclaw_sandbox::SandboxablePreference;
+//! use ironclaw_workspace_cap::policy::SandboxPolicy;
+//! use std::process::Command;
+//!
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! let policy = SandboxPolicy::new_workspace_write_policy();
+//! let executor = SandboxedExecutor::new(policy, SandboxablePreference::Auto, false);
+//! let mut cmd = Command::new("echo");
+//! cmd.arg("hello");
+//! let output = executor.execute(ExecRequest {
+//!     command: cmd,
+//!     cwd: std::env::current_dir()?,
+//! })?;
+//! assert!(output.status.success());
+//! # Ok(())
+//! # }
+//! ```
+
+#![forbid(unsafe_code)]
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+use dasclaw_sandbox::{
+    select_backend, SandboxBackendConfig, SandboxError, SandboxExecRequest, SandboxablePreference,
+};
+use ironclaw_workspace_cap::policy::{NetworkAccess, SandboxPolicy};
+
+/// 错误统一入口。
+#[derive(Debug, thiserror::Error)]
+pub enum ExecError {
+    /// 政策本身不允许目标路径写入（一票否决：洞中洞 / 不在 root / ReadOnly 模式）。
+    #[error("policy denied write to {path}")]
+    PolicyDenied { path: PathBuf },
+
+    /// `cwd` 不在政策允许的可读范围内（DangerFullAccess 之外，cwd 本身必须可写）。
+    #[error("cwd {0} not within policy writable roots")]
+    CwdNotWritable(PathBuf),
+
+    /// 沙箱后端错误，原样透出。
+    #[error(transparent)]
+    Sandbox(#[from] SandboxError),
+}
+
+/// `ProcessExecutor::execute` 的请求体。
+///
+/// `cwd` 是必填字段：政策决策（is_path_writable）依赖 cwd 锚点。
+#[derive(Debug)]
+pub struct ExecRequest {
+    pub command: Command,
+    pub cwd: PathBuf,
+}
+
+/// 抽象 tool 执行入口。
+///
+/// 所有进入沙箱的进程都应通过这个 trait 调用，方便后续替换实现
+/// （单元测试 mock / 远端 sandbox / 高隔离 docker 等）。
+pub trait ProcessExecutor: Send + Sync {
+    /// 执行 `req.command`，返回标准 [`Output`]。
+    ///
+    /// 实现负责：
+    /// 1. 检查 `req.cwd` 是否符合政策；
+    /// 2. 把高层政策转成 [`SandboxBackendConfig`]；
+    /// 3. 调用内核沙箱执行；
+    /// 4. 失败时返回 [`ExecError`]，**不**降级为直接 exec（fail-safe）。
+    fn execute(&self, req: ExecRequest) -> Result<Output, ExecError>;
+}
+
+/// 默认实现：基于 [`ironclaw_workspace_cap::policy::SandboxPolicy`] +
+/// [`dasclaw_sandbox`] 的组合执行器。
+pub struct SandboxedExecutor {
+    policy: SandboxPolicy,
+    sandbox_pref: SandboxablePreference,
+    windows_sandbox_enabled: bool,
+}
+
+impl SandboxedExecutor {
+    pub fn new(
+        policy: SandboxPolicy,
+        sandbox_pref: SandboxablePreference,
+        windows_sandbox_enabled: bool,
+    ) -> Self {
+        Self {
+            policy,
+            sandbox_pref,
+            windows_sandbox_enabled,
+        }
+    }
+
+    /// 公开 policy 供调用方做额外用户态检查。
+    pub fn policy(&self) -> &SandboxPolicy {
+        &self.policy
+    }
+}
+
+impl ProcessExecutor for SandboxedExecutor {
+    fn execute(&self, req: ExecRequest) -> Result<Output, ExecError> {
+        // 1. 政策门：cwd 自身不能落在洞中洞（read_only_subpath）。
+        //    `is_path_writable(cwd, cwd)` 在 WorkspaceWrite 下总是把 cwd 加为
+        //    隐含 root，所以这里只在非 ReadOnly 场景下，对 cwd 是否被任何
+        //    `read_only_subpaths` 命中做兜底检查（fail-safe）。
+        if !matches!(self.policy, SandboxPolicy::ReadOnly { .. })
+            && !self.policy.is_path_writable(&req.cwd, &req.cwd)
+        {
+            return Err(ExecError::CwdNotWritable(req.cwd));
+        }
+
+        // 2. 政策 → 内核配置
+        let backend = policy_to_backend_config(&self.policy, &req.cwd);
+
+        // 3. 选后端 + 执行
+        let sandbox = select_backend(self.sandbox_pref, self.windows_sandbox_enabled)?;
+        let exec = SandboxExecRequest {
+            command: req.command,
+            policy: backend,
+            preference: self.sandbox_pref,
+            windows_sandbox_enabled: self.windows_sandbox_enabled,
+        };
+        sandbox.execute(exec).map_err(ExecError::from)
+    }
+}
+
+/// 把高层 [`SandboxPolicy`] 投影到内核需要的 [`SandboxBackendConfig`]。
+///
+/// 转换语义（与 codex `protocol.rs` 对齐）：
+///
+/// | 高层政策 | 网络 | 写权限 | 备注 |
+/// |---------|------|-------|------|
+/// | `DangerFullAccess` | 允许 | 全盘可写 | 仅用于 trust 极高的本地任务 |
+/// | `ReadOnly { network_access }` | 由字段决定 | 全盘只读 | spawn 仍允许（unsafe shell 工具） |
+/// | `ExternalSandbox { network_access }` | 由字段决定 | 全盘只读（本地降级） | 实际隔离由外部容器完成 |
+/// | `WorkspaceWrite { roots, .. }` | 由字段决定 | cwd + roots + /tmp + $TMPDIR | 洞中洞 `.git/.codex` 在用户态强制 |
+///
+/// **已知限制**：sandbox 内核层（seatbelt / seccomp）按 root 整体允许写，
+/// 不强制 `read_only_subpaths`（洞中洞）。洞中洞契约由
+/// [`ironclaw_workspace_cap::policy::SandboxPolicy::is_path_writable`] 用户态决策
+/// 与 [`ironclaw_workspace_cap::WorkspaceCap`] 文件接口共同强制。
+pub fn policy_to_backend_config(policy: &SandboxPolicy, cwd: &Path) -> SandboxBackendConfig {
+    match policy {
+        SandboxPolicy::DangerFullAccess => SandboxBackendConfig {
+            readable_roots: vec![PathBuf::from("/")],
+            writable_roots: vec![PathBuf::from("/")],
+            allow_network: true,
+            allow_spawn: true,
+            proxy_loopback_ports: vec![],
+        },
+        SandboxPolicy::ReadOnly { network_access } => SandboxBackendConfig {
+            readable_roots: vec![PathBuf::from("/")],
+            writable_roots: vec![],
+            allow_network: *network_access,
+            allow_spawn: true,
+            proxy_loopback_ports: vec![],
+        },
+        SandboxPolicy::ExternalSandbox { network_access } => SandboxBackendConfig {
+            // 进程内被外层容器隔离，本地视为只读。
+            readable_roots: vec![PathBuf::from("/")],
+            writable_roots: vec![],
+            allow_network: matches!(network_access, NetworkAccess::Enabled),
+            allow_spawn: true,
+            proxy_loopback_ports: vec![],
+        },
+        SandboxPolicy::WorkspaceWrite { network_access, .. } => {
+            let roots = policy.get_writable_roots_with_cwd(cwd);
+            let writable_roots: Vec<PathBuf> = roots.iter().map(|r| r.root.clone()).collect();
+            SandboxBackendConfig {
+                readable_roots: vec![PathBuf::from("/")],
+                writable_roots,
+                allow_network: *network_access,
+                allow_spawn: true,
+                proxy_loopback_ports: vec![],
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ironclaw_workspace_cap::policy::SandboxPolicy;
+
+    #[test]
+    fn danger_full_access_maps_to_root_writable() {
+        let cfg = policy_to_backend_config(&SandboxPolicy::DangerFullAccess, Path::new("/x"));
+        assert_eq!(cfg.writable_roots, vec![PathBuf::from("/")]);
+        assert!(cfg.allow_network);
+        assert!(cfg.allow_spawn);
+    }
+
+    #[test]
+    fn read_only_strips_writable_roots() {
+        let cfg = policy_to_backend_config(
+            &SandboxPolicy::ReadOnly {
+                network_access: false,
+            },
+            Path::new("/x"),
+        );
+        assert!(cfg.writable_roots.is_empty());
+        assert!(!cfg.allow_network);
+    }
+
+    #[test]
+    fn read_only_with_network_propagates_flag() {
+        let cfg = policy_to_backend_config(
+            &SandboxPolicy::ReadOnly {
+                network_access: true,
+            },
+            Path::new("/x"),
+        );
+        assert!(cfg.allow_network);
+    }
+
+    #[test]
+    fn external_sandbox_with_enabled_network_maps_through() {
+        let cfg = policy_to_backend_config(
+            &SandboxPolicy::ExternalSandbox {
+                network_access: NetworkAccess::Enabled,
+            },
+            Path::new("/x"),
+        );
+        assert!(cfg.allow_network);
+        assert!(cfg.writable_roots.is_empty(), "external 走外层容器，本地只读");
+    }
+
+    #[test]
+    fn workspace_write_includes_cwd_in_writable_roots() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cwd = tmp.path();
+        let cfg =
+            policy_to_backend_config(&SandboxPolicy::new_workspace_write_policy(), cwd);
+        assert!(
+            cfg.writable_roots.iter().any(|r| r == cwd),
+            "writable_roots 必须包含 cwd: {:?}",
+            cfg.writable_roots
+        );
+    }
+
+    #[test]
+    fn workspace_write_includes_slash_tmp_on_unix() {
+        if cfg!(unix) && Path::new("/tmp").is_dir() {
+            let tmp = tempfile::tempdir().unwrap();
+            let cfg = policy_to_backend_config(
+                &SandboxPolicy::new_workspace_write_policy(),
+                tmp.path(),
+            );
+            assert!(
+                cfg.writable_roots.iter().any(|r| r == Path::new("/tmp")),
+                "Unix 默认应包含 /tmp"
+            );
+        }
+    }
+
+    // -- ProcessExecutor 接口契约 --
+
+    #[test]
+    fn cwd_inside_read_only_subpath_is_rejected() {
+        // 把 cwd 直接指到一个 read_only_subpath（.git），应该被一票否决。
+        let tmp = tempfile::tempdir().unwrap();
+        let dot_git = tmp.path().join(".git");
+        std::fs::create_dir(&dot_git).unwrap();
+
+        let executor = SandboxedExecutor::new(
+            SandboxPolicy::WorkspaceWrite {
+                writable_roots: vec![tmp.path().to_path_buf()],
+                network_access: false,
+                exclude_tmpdir_env_var: true,
+                exclude_slash_tmp: true,
+            },
+            SandboxablePreference::Forbid,
+            false,
+        );
+        let result = executor.execute(ExecRequest {
+            command: Command::new("echo"),
+            cwd: dot_git,
+        });
+        assert!(
+            matches!(result, Err(ExecError::CwdNotWritable(_))),
+            "cwd 落在 .git 洞中洞应被拒绝, got {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn read_only_does_not_check_cwd_writable() {
+        // ReadOnly 模式：cwd 不必可写（毕竟整个文件系统都是只读基准）
+        let executor = SandboxedExecutor::new(
+            SandboxPolicy::ReadOnly {
+                network_access: false,
+            },
+            SandboxablePreference::Forbid,
+            false,
+        );
+        let mut cmd = Command::new("true");
+        cmd.arg("");
+        let _ = executor.execute(ExecRequest {
+            command: cmd,
+            cwd: PathBuf::from("/anything"),
+        });
+        // 不必断言 success（Forbid 下 NoopSandbox 行为依赖 kind=None）；
+        // 关键是不要 CwdNotWritable
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn end_to_end_echo_under_workspace_write() {
+        // 用 Forbid 偏好走 NoopSandbox(None)，验证整条管线连通
+        let tmp = tempfile::tempdir().unwrap();
+        let executor = SandboxedExecutor::new(
+            SandboxPolicy::new_workspace_write_policy(),
+            SandboxablePreference::Forbid,
+            false,
+        );
+        let mut cmd = Command::new("echo");
+        cmd.arg("hello-from-exec");
+        let out = executor
+            .execute(ExecRequest {
+                command: cmd,
+                cwd: tmp.path().to_path_buf(),
+            })
+            .expect("should execute");
+        assert!(out.status.success());
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        assert!(stdout.contains("hello-from-exec"));
+    }
+}

--- a/crates/dasclaw_exec/src/lib.rs
+++ b/crates/dasclaw_exec/src/lib.rs
@@ -45,7 +45,7 @@ use std::process::{Command, Output};
 
 use dasclaw_sandbox::proxy::detect_loopback_ports;
 use dasclaw_sandbox::{
-    select_backend, SandboxBackendConfig, SandboxError, SandboxExecRequest, SandboxablePreference,
+    SandboxBackendConfig, SandboxError, SandboxExecRequest, SandboxablePreference, select_backend,
 };
 use ironclaw_workspace_cap::policy::{NetworkAccess, SandboxPolicy};
 
@@ -271,15 +271,17 @@ mod tests {
             Path::new("/x"),
         );
         assert!(cfg.allow_network);
-        assert!(cfg.writable_roots.is_empty(), "external 走外层容器，本地只读");
+        assert!(
+            cfg.writable_roots.is_empty(),
+            "external 走外层容器，本地只读"
+        );
     }
 
     #[test]
     fn workspace_write_includes_cwd_in_writable_roots() {
         let tmp = tempfile::tempdir().unwrap();
         let cwd = tmp.path();
-        let cfg =
-            policy_to_backend_config(&SandboxPolicy::new_workspace_write_policy(), cwd);
+        let cfg = policy_to_backend_config(&SandboxPolicy::new_workspace_write_policy(), cwd);
         assert!(
             cfg.writable_roots.iter().any(|r| r == cwd),
             "writable_roots 必须包含 cwd: {:?}",
@@ -291,10 +293,8 @@ mod tests {
     fn workspace_write_includes_slash_tmp_on_unix() {
         if cfg!(unix) && Path::new("/tmp").is_dir() {
             let tmp = tempfile::tempdir().unwrap();
-            let cfg = policy_to_backend_config(
-                &SandboxPolicy::new_workspace_write_policy(),
-                tmp.path(),
-            );
+            let cfg =
+                policy_to_backend_config(&SandboxPolicy::new_workspace_write_policy(), tmp.path());
             assert!(
                 cfg.writable_roots.iter().any(|r| r == Path::new("/tmp")),
                 "Unix 默认应包含 /tmp"

--- a/crates/dasclaw_sandbox/src/lib.rs
+++ b/crates/dasclaw_sandbox/src/lib.rs
@@ -10,8 +10,13 @@
 //! Design notes:
 //! - `SandboxType`, `SandboxablePreference`, `get_platform_sandbox()` mirror
 //!   codex `manager.rs` API surface, neutralized (no `codex_protocol` dep).
-//! - `SandboxPolicy` is a **dasclaw-owned** struct, not re-exported from
-//!   codex-protocol. Mapping adapter lives in `dasclaw_bridge_lite` (W3+).
+//! - `SandboxBackendConfig` is a **dasclaw-owned** struct describing the
+//!   *backend-level* knobs the sandbox kernel needs (writable roots, proxy
+//!   ports, network/spawn flags). It is intentionally *flatter* than the
+//!   codex `SandboxPolicy` enum — the higher-level policy enum lives in
+//!   `ironclaw_workspace_cap::policy::SandboxPolicy` and is converted to
+//!   `SandboxBackendConfig` by `dasclaw_exec` at execution time.
+//!   `SandboxPolicy` remains as a **deprecated alias** for transition.
 //! - Three platform backends gated by `cfg(target_os = ...)` like codex.
 //! - Real impl deferred (W2.2+); current stubs return
 //!   `SandboxError::NotImplemented` so callers compile but fail loud at runtime.
@@ -96,10 +101,15 @@ pub fn get_platform_sandbox(windows_sandbox_enabled: bool) -> Option<SandboxType
     }
 }
 
-/// Minimal neutral sandbox policy. Adapter to/from codex's richer enum lives
-/// in `dasclaw_bridge_lite` (W3+).
+/// Backend-level sandbox configuration: the concrete knobs the sandbox
+/// **kernel** (seatbelt / seccomp / windows) needs to enforce a policy.
+///
+/// This struct is intentionally flatter than codex's `SandboxPolicy` enum.
+/// The higher-level policy enum lives in
+/// `ironclaw_workspace_cap::policy::SandboxPolicy` and is converted to this
+/// struct by `dasclaw_exec` (or any caller) at execution time.
 #[derive(Clone, Debug, Default)]
-pub struct SandboxPolicy {
+pub struct SandboxBackendConfig {
     pub readable_roots: Vec<PathBuf>,
     pub writable_roots: Vec<PathBuf>,
     pub allow_network: bool,
@@ -110,7 +120,7 @@ pub struct SandboxPolicy {
     pub proxy_loopback_ports: Vec<u16>,
 }
 
-impl SandboxPolicy {
+impl SandboxBackendConfig {
     pub fn read_only_defaults() -> Self {
         Self::default()
     }
@@ -126,13 +136,17 @@ impl SandboxPolicy {
     }
 }
 
+/// Deprecated alias kept for transition; will be removed once all call
+/// sites use `SandboxBackendConfig` directly.
+pub type SandboxPolicy = SandboxBackendConfig;
+
 pub mod proxy;
 
 /// What the caller wants to execute under a sandbox.
 #[derive(Debug)]
 pub struct SandboxExecRequest {
     pub command: Command,
-    pub policy: SandboxPolicy,
+    pub policy: SandboxBackendConfig,
     pub preference: SandboxablePreference,
     pub windows_sandbox_enabled: bool,
 }

--- a/crates/dasclaw_sandbox/src/linux/mod.rs
+++ b/crates/dasclaw_sandbox/src/linux/mod.rs
@@ -29,9 +29,10 @@
 //!
 //! - 不限制文件系统访问（依赖应用层 cap-std）
 //! - `allow_network=true` 时 seccomp 完全 bypass（无 syscall filter 安装）
-//! - `proxy_loopback_ports` 字段当前在 Linux 上只用于将来的 proxy-routed
-//!   模式，W2.3a 阶段未启用 — 调用方设了也会被忽略并发 debug 日志
-//!   （TODO W2.3b：实装 ProxyRouted 模式）
+//! - `proxy_loopback_ports` **非空** 且 `allow_network=false` 时切到
+//!   ProxyRouted 模式：允许 AF_INET/AF_INET6 socket 连本地代理桥，
+//!   拒 AF_UNIX 防旁路。env 透传由调用方在 [`crate::SandboxExecRequest`]
+//!   显式注入；`dasclaw_exec` 已经默认从宿主 env 检测 proxy 端口。
 
 #![cfg(target_os = "linux")]
 
@@ -121,10 +122,9 @@ impl Sandbox for LinuxSeccompSandbox {
 /// - `Restricted`：拒绝所有非 AF_UNIX socket 创建 + connect/accept/bind 等
 ///   网络 syscall。`cargo` / `npm` 等工具仍可工作（它们用 AF_UNIX
 ///   socketpair 与子进程通信）。
-/// - `ProxyRouted`：在 ProxyRouted 模式下允许 AF_INET/AF_INET6 socket（用于
-///   连接到本地代理桥），但拒绝 AF_UNIX socket 阻止旁路。**W2.3a 阶段
-///   声明此模式但 Sandbox::execute 暂未根据 proxy_loopback_ports 实际
-///   启用**（TODO W2.3b）。
+/// - `ProxyRouted`：允许 AF_INET/AF_INET6 socket（用于连接到本地代理桥），
+///   但拒绝 AF_UNIX socket 阻止旁路。`Sandbox::execute` 在
+///   `proxy_loopback_ports` 非空且 `allow_network=false` 时自动切此模式。
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum NetworkSeccompMode {
     Restricted,
@@ -270,5 +270,31 @@ mod tests {
         // 创建 socket。所以仅用单元测试保证 enum + arch 检测逻辑。
         let arch_ok = cfg!(any(target_arch = "x86_64", target_arch = "aarch64"));
         assert!(arch_ok, "Linux Tier-1 arch precondition");
+    }
+
+    /// W2.3b 路径覆盖测试：模拟 `Sandbox::execute` 内部如何根据
+    /// `proxy_loopback_ports.is_empty()` 选择 mode。本测试只覆盖映射
+    /// 决策，不实际安装 filter（apply 会污染线程）。
+    #[test]
+    fn empty_proxy_ports_picks_restricted_mode() {
+        let proxy_routed = !Vec::<u16>::new().is_empty();
+        let mode = if proxy_routed {
+            NetworkSeccompMode::ProxyRouted
+        } else {
+            NetworkSeccompMode::Restricted
+        };
+        assert_eq!(mode, NetworkSeccompMode::Restricted);
+    }
+
+    #[test]
+    fn nonempty_proxy_ports_picks_proxy_routed_mode() {
+        let ports: Vec<u16> = vec![8888];
+        let proxy_routed = !ports.is_empty();
+        let mode = if proxy_routed {
+            NetworkSeccompMode::ProxyRouted
+        } else {
+            NetworkSeccompMode::Restricted
+        };
+        assert_eq!(mode, NetworkSeccompMode::ProxyRouted);
     }
 }

--- a/crates/ironclaw_workspace_cap/src/lib.rs
+++ b/crates/ironclaw_workspace_cap/src/lib.rs
@@ -47,7 +47,7 @@
 
 pub mod policy;
 pub use policy::{
-    default_read_only_subpaths_for_writable_root, NetworkAccess, SandboxPolicy, WritableRoot,
+    NetworkAccess, SandboxPolicy, WritableRoot, default_read_only_subpaths_for_writable_root,
 };
 
 use std::path::{Path, PathBuf};

--- a/crates/ironclaw_workspace_cap/src/policy.rs
+++ b/crates/ironclaw_workspace_cap/src/policy.rs
@@ -323,7 +323,12 @@ mod tests {
     #[test]
     fn read_only_policy_constructor_disables_network() {
         let p = SandboxPolicy::new_read_only_policy();
-        assert!(matches!(p, SandboxPolicy::ReadOnly { network_access: false }));
+        assert!(matches!(
+            p,
+            SandboxPolicy::ReadOnly {
+                network_access: false
+            }
+        ));
         assert!(!p.has_full_network_access());
     }
 
@@ -349,10 +354,12 @@ mod tests {
     #[test]
     fn full_disk_write_access_only_for_danger_or_external() {
         assert!(SandboxPolicy::DangerFullAccess.has_full_disk_write_access());
-        assert!(SandboxPolicy::ExternalSandbox {
-            network_access: NetworkAccess::Restricted
-        }
-        .has_full_disk_write_access());
+        assert!(
+            SandboxPolicy::ExternalSandbox {
+                network_access: NetworkAccess::Restricted
+            }
+            .has_full_disk_write_access()
+        );
         assert!(!SandboxPolicy::new_read_only_policy().has_full_disk_write_access());
         assert!(!SandboxPolicy::new_workspace_write_policy().has_full_disk_write_access());
     }
@@ -360,16 +367,30 @@ mod tests {
     #[test]
     fn full_network_access_per_variant() {
         assert!(SandboxPolicy::DangerFullAccess.has_full_network_access());
-        assert!(SandboxPolicy::ExternalSandbox {
-            network_access: NetworkAccess::Enabled
-        }
-        .has_full_network_access());
-        assert!(!SandboxPolicy::ExternalSandbox {
-            network_access: NetworkAccess::Restricted
-        }
-        .has_full_network_access());
-        assert!(SandboxPolicy::ReadOnly { network_access: true }.has_full_network_access());
-        assert!(!SandboxPolicy::ReadOnly { network_access: false }.has_full_network_access());
+        assert!(
+            SandboxPolicy::ExternalSandbox {
+                network_access: NetworkAccess::Enabled
+            }
+            .has_full_network_access()
+        );
+        assert!(
+            !SandboxPolicy::ExternalSandbox {
+                network_access: NetworkAccess::Restricted
+            }
+            .has_full_network_access()
+        );
+        assert!(
+            SandboxPolicy::ReadOnly {
+                network_access: true
+            }
+            .has_full_network_access()
+        );
+        assert!(
+            !SandboxPolicy::ReadOnly {
+                network_access: false
+            }
+            .has_full_network_access()
+        );
     }
 
     // ---------- serde wire format ----------
@@ -378,8 +399,12 @@ mod tests {
     fn serde_round_trip_all_variants() {
         let cases = [
             SandboxPolicy::DangerFullAccess,
-            SandboxPolicy::ReadOnly { network_access: false },
-            SandboxPolicy::ReadOnly { network_access: true },
+            SandboxPolicy::ReadOnly {
+                network_access: false,
+            },
+            SandboxPolicy::ReadOnly {
+                network_access: true,
+            },
             SandboxPolicy::ExternalSandbox {
                 network_access: NetworkAccess::Restricted,
             },
@@ -443,10 +468,7 @@ mod tests {
     fn writable_root_blocks_read_only_subpath() {
         let wr = WritableRoot {
             root: PathBuf::from("/work"),
-            read_only_subpaths: vec![
-                PathBuf::from("/work/.git"),
-                PathBuf::from("/work/.codex"),
-            ],
+            read_only_subpaths: vec![PathBuf::from("/work/.git"), PathBuf::from("/work/.codex")],
         };
         // 洞中洞
         assert!(!wr.is_path_writable(Path::new("/work/.git/hooks/pre-commit")));
@@ -483,8 +505,7 @@ mod tests {
 
         // protect_missing_dot_codex=true 即使 .codex 不存在也加入保护清单
         // （首次创建走审批流）。
-        let subs_protected =
-            default_read_only_subpaths_for_writable_root(tmp.path(), true);
+        let subs_protected = default_read_only_subpaths_for_writable_root(tmp.path(), true);
         assert_eq!(subs_protected, vec![tmp.path().join(".codex")]);
     }
 
@@ -643,7 +664,10 @@ mod tests {
         if cfg!(unix) {
             // /tmp 通常存在；exclude=false 应包含，exclude=true 应不包含
             if Path::new("/tmp").is_dir() {
-                assert!(has_tmp_default, "default policy should include /tmp on unix");
+                assert!(
+                    has_tmp_default,
+                    "default policy should include /tmp on unix"
+                );
             }
             assert!(!has_tmp_excluded, "exclude_slash_tmp must drop /tmp");
         } else {


### PR DESCRIPTION
## W2.3b — ProxyRouted 真接入

接通从 `HTTP_PROXY` env 到 sandbox 内核的最后一公里。

### 背景
- W2.3a 已经实装 Linux seccomp 的 `NetworkSeccompMode::ProxyRouted` 分支（[linux/mod.rs:195-220](https://github.com/Linnanli/xClaw/blob/feat/w2.3b-proxy-routed/crates/dasclaw_sandbox/src/linux/mod.rs#L195-L220)）
- macOS Seatbelt 也已实装 `(allow network-outbound (remote tcp "localhost:{port}"))` hole punch（[macos/mod.rs:67-77](https://github.com/Linnanli/xClaw/blob/feat/w2.3b-proxy-routed/crates/dasclaw_sandbox/src/macos/mod.rs#L67-L77)）
- **缺失**：`dasclaw_exec::policy_to_backend_config` 没把 `detect_loopback_ports()` 接进来，调用方设了 `HTTP_PROXY` env 但 `SandboxBackendConfig.proxy_loopback_ports` 永远是空 → 内核虽然支持 ProxyRouted，实际从未被触发

### 修改
1. **dasclaw_sandbox/linux**：删过时 W2.3b TODO 注释（实际代码已实装），加 mode 路径覆盖单测
2. **dasclaw_exec**：
   - `policy_to_backend_config` 默认走 `std::env::vars()` 调 `detect_loopback_ports`
   - 暴露 `policy_to_backend_config_with_env(policy, cwd, env)` 测试友好版本
   - 网络受限的三种 case 自动填 `proxy_loopback_ports`，网络全开则不填

### 完整链路
```
HTTP_PROXY=http://127.0.0.1:8080
    ↓
detect_loopback_ports (dasclaw_sandbox::proxy)
    ↓ vec![8080]
SandboxBackendConfig.proxy_loopback_ports
    ↓
Linux seccomp: ProxyRouted mode → 允许 AF_INET/INET6 socket，拒 AF_UNIX
macOS Seatbelt: (allow network-outbound (remote tcp "localhost:8080"))
```

### 测试
- `dasclaw_exec` → 15 passed + 1 doctest（新增 6 个 proxy 集成测试）
- `dasclaw_sandbox` → 22 passed（新增 2 个 mode 路径覆盖）
- 关键测试：
  - `workspace_write_with_proxy_env_populates_proxy_ports` — happy path
  - `workspace_write_with_network_enabled_skips_proxy_ports` — 网络全开优化
  - `non_loopback_proxy_does_not_populate_ports` — 远程 corp proxy 不误触发 hole punch
  - `external_sandbox_restricted_with_proxy_env_picks_up_ports`
  - `read_only_with_proxy_env_populates_proxy_ports_when_network_denied`

### 依赖与合并顺序
- **base = `feat/w2.6-exec-bridge`**（stack PR）
- 应在 [PR #4](https://github.com/Linnanli/xClaw/pull/4) 合并后再合
- 完整 stack：PR #3 (W2.7) → PR #4 (W2.6) → 本 PR (W2.3b)

### W2 进度
- ✅ W2.2 macOS Seatbelt
- ✅ W2.3a Linux Seccomp 网络隔离
- ✅ W2.5 dasclaw_pty (PR #2)
- ✅ W2.7 SandboxPolicy 4-tier enum (PR #3)
- ✅ W2.6 dasclaw_exec 接线 (PR #4)
- ✅ W2.3b ProxyRouted 真接入（本 PR）
- ⏳ W2.4 Windows backend（最后一块）
