### PR TITLE
ci: 把 Windows CI 从主 PR 流水线分离到独立 workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,27 +93,17 @@ jobs:
         run: cargo test --manifest-path channels-src/telegram/Cargo.toml -- --nocapture
 
   windows-build:
-    name: Windows Build (${{ matrix.name }})
-    # xClaw fork: skip Windows on PR (was for staging only originally).
-    # Cross-platform compatibility validated post-merge on push-to-xClaw.
-    if: github.event_name != 'pull_request'
-    runs-on: windows-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        include: ${{ fromJSON(github.event_name == 'pull_request' && '[{"name":"default","flags":""}]' || '[{"name":"all-features","flags":"--no-default-features --features postgres,libsql,html-to-markdown,bedrock,import"},{"name":"default","flags":""},{"name":"libsql-only","flags":"--no-default-features --features libsql"}]') }}
+    # xClaw fork: Windows build moved to its own workflow.
+    # See .github/workflows/windows-ci.yml — runs on workflow_dispatch +
+    # weekly schedule + push to main/refactor/* + push to feat/win-* /
+    # ci/win-* branches. Decoupled from main PR cadence to keep iteration
+    # fast; cross-platform regression is still protected by the dedicated
+    # workflow.
+    name: Windows Build (decoupled to windows-ci.yml)
+    runs-on: ubuntu-latest
+    if: false
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-        with:
-          submodules: recursive
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-        with:
-          key: windows-${{ matrix.name }}
-      - name: Check compilation
-        run: cargo check --all --benches --tests --examples ${{ matrix.flags }}
+      - run: echo "see .github/workflows/windows-ci.yml"
 
   wasm-wit-compat:
     name: WASM WIT Compatibility
@@ -196,20 +186,20 @@ jobs:
     name: Run Tests
     runs-on: ubuntu-latest
     if: always()
-    needs: [tests, heavy-integration-tests, telegram-tests, wasm-wit-compat, docker-build, windows-build, version-check, bench-compile]
+    needs: [tests, heavy-integration-tests, telegram-tests, wasm-wit-compat, docker-build, version-check, bench-compile]
     steps:
       - run: |
-          # xClaw fork: tests + windows-build are skipped on PR to keep
-          # iteration fast; treat skipped as pass here, only fail on
-          # failure/cancelled. Full suite still runs on push-to-xClaw.
-          for job in tests heavy-integration-tests telegram-tests wasm-wit-compat docker-build windows-build version-check bench-compile; do
+          # xClaw fork: tests are skipped on PR to keep iteration fast;
+          # treat skipped as pass here, only fail on failure/cancelled.
+          # Full suite still runs on push-to-xClaw. Windows build moved to
+          # .github/workflows/windows-ci.yml — not part of this gate.
+          for job in tests heavy-integration-tests telegram-tests wasm-wit-compat docker-build version-check bench-compile; do
             case "$job" in
               tests) result="${{ needs.tests.result }}" ;;
               heavy-integration-tests) result="${{ needs.heavy-integration-tests.result }}" ;;
               telegram-tests) result="${{ needs.telegram-tests.result }}" ;;
               wasm-wit-compat) result="${{ needs.wasm-wit-compat.result }}" ;;
               docker-build) result="${{ needs.docker-build.result }}" ;;
-              windows-build) result="${{ needs.windows-build.result }}" ;;
               version-check) result="${{ needs.version-check.result }}" ;;
               bench-compile) result="${{ needs.bench-compile.result }}" ;;
             esac

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -1,0 +1,109 @@
+name: Windows CI
+
+# xClaw fork: Windows build / test decoupled from main PR cadence.
+#
+# 触发策略（架构干净，边界清晰）：
+#   - workflow_dispatch  → 任何分支手动触发
+#   - schedule           → 每周日 03:00 UTC 跑 main + refactor 分支回归
+#   - push to main / refactor/* → 主线合并后自动回归保护
+#   - push to feat/win-* / ci/win-* / windows-* → Windows 专项分支自动跑
+#   - pull_request 仅当 PR 标 `windows-ci` label → 临时 Windows PR 验证
+#
+# 主 PR 流水线（test.yml）不依赖本工作流的结果，保持快速迭代。
+# 真要在 PR 阶段验证 Windows，加 `windows-ci` label 即可。
+
+on:
+  workflow_dispatch:
+  schedule:
+    # 每周日 03:00 UTC ≈ 北京时间周日 11:00
+    - cron: '0 3 * * 0'
+  push:
+    branches:
+      - main
+      - 'refactor/**'
+      - 'feat/win-**'
+      - 'feat/win/**'
+      - 'ci/win-**'
+      - 'windows-**'
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+
+permissions:
+  contents: read
+
+jobs:
+  windows-build:
+    name: Windows Build (${{ matrix.name }})
+    # PR 仅在标了 windows-ci label 才跑（否则 push/schedule/dispatch 都跑）
+    if: |
+      github.event_name != 'pull_request' ||
+      contains(github.event.pull_request.labels.*.name, 'windows-ci')
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: default
+            flags: ""
+          - name: all-features
+            flags: "--no-default-features --features postgres,libsql,html-to-markdown,bedrock,import"
+          - name: libsql-only
+            flags: "--no-default-features --features libsql"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: windows-${{ matrix.name }}
+      - name: Check compilation
+        run: cargo check --all --benches --tests --examples ${{ matrix.flags }}
+
+  windows-test:
+    name: Windows Tests (${{ matrix.name }})
+    # 测试仅在 dispatch / schedule / push to main 跑，PR 上太慢
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'schedule' ||
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      (github.event_name == 'pull_request' &&
+       contains(github.event.pull_request.labels.*.name, 'windows-ci-full'))
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: default
+            flags: ""
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: windows-test-${{ matrix.name }}
+      - name: Run tests
+        run: cargo test ${{ matrix.flags }} -- --nocapture
+
+  # 聚合 job：方便分支保护规则只引用单个 status
+  windows-ci-success:
+    name: Windows CI Success
+    runs-on: ubuntu-latest
+    if: always()
+    needs: [windows-build]
+    steps:
+      - name: Aggregate result
+        run: |
+          # windows-test 是 best-effort（schedule/dispatch 才跑），不计入 gate
+          result="${{ needs.windows-build.result }}"
+          if [[ "$result" == "failure" || "$result" == "cancelled" ]]; then
+            echo "windows-build failed"
+            exit 1
+          fi
+          echo "windows-build OK (or skipped)"


### PR DESCRIPTION
## CI: Windows 工作流与主 PR 流水线解耦

把 Windows build 从 [test.yml](https://github.com/Linnanli/xClaw/blob/ci/separate-windows-workflow/.github/workflows/test.yml) 移到独立的 [windows-ci.yml](https://github.com/Linnanli/xClaw/blob/ci/separate-windows-workflow/.github/workflows/windows-ci.yml)，主 PR 节奏不再受 Windows 影响。

### 触发策略
| 触发 | 行为 |
|------|------|
| `workflow_dispatch` | 任何分支手动触发 |
| `schedule` (cron `0 3 * * 0`) | 每周日 03:00 UTC 回归 |
| push to `main` / `refactor/**` | 主线合并后回归保护 |
| push to `feat/win-**` / `ci/win-**` / `windows-**` | Windows 专项分支自动 |
| PR with `windows-ci` label | build only |
| PR with `windows-ci-full` label | build + test |

### 变更
- ✅ 新建 `.github/workflows/windows-ci.yml`
  - `windows-build` 矩阵（default / all-features / libsql-only）
  - `windows-test`（仅 dispatch / schedule / push-main 跑，太慢不进 PR）
  - `windows-ci-success` 聚合 job，方便分支保护规则引用
- ✅ `test.yml::windows-build` 改为 stub（`if: false` + 注释指向新工作流）
- ✅ `test.yml::run-tests` 聚合从 needs 移除 windows-build

### 为什么这么做
- 主线 PR（macOS/Linux）保持快速迭代
- Windows backend 实装（W2.4）可以提交到 `feat/win-*` 分支，windows-ci.yml 自动验证
- 不需要 Windows 测试机时，schedule + dispatch 已经覆盖主线回归
- 分支保护规则可以选择是否引用 `windows-ci-success`（默认不引用 = 解耦）

### 后续动作
合并本 PR 后：
1. 在 GitHub Settings → Labels 创建 `windows-ci` / `windows-ci-full` label
2. (可选) 在 Branch protection 加 `windows-ci-success` 为 required check（仅当确实想阻塞主线）
3. W2.4 Windows backend 实装可以走 `feat/win-w24-restricted-token` 分支自动跑

### 关联
- base: `refactor/phase3-agent-extraction`
- 同 wave PR 栈：#2 (W2.5) / #3 (W2.7) / #4 (W2.6) / #5 (W2.3b)，本 PR 与它们独立
