### PR TITLE
feat(sandbox/exec): W2.3b ProxyRouted 真接入

### DIFF
--- a/crates/dasclaw_exec/src/lib.rs
+++ b/crates/dasclaw_exec/src/lib.rs
@@ -39,9 +39,11 @@
 
 #![forbid(unsafe_code)]
 
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 
+use dasclaw_sandbox::proxy::detect_loopback_ports;
 use dasclaw_sandbox::{
     SandboxBackendConfig, SandboxError, SandboxExecRequest, SandboxablePreference, select_backend,
 };
@@ -157,6 +159,21 @@ impl ProcessExecutor for SandboxedExecutor {
 /// [`ironclaw_workspace_cap::policy::SandboxPolicy::is_path_writable`] 用户态决策
 /// 与 [`ironclaw_workspace_cap::WorkspaceCap`] 文件接口共同强制。
 pub fn policy_to_backend_config(policy: &SandboxPolicy, cwd: &Path) -> SandboxBackendConfig {
+    policy_to_backend_config_with_env(policy, cwd, &std::env::vars().collect())
+}
+
+/// 可注入 env 的测试友好版本。`env` 应为完整进程环境变量集（
+/// `std::env::vars().collect::<HashMap<_, _>>()`）；proxy 端口从这里提取。
+///
+/// 只在网络受限（`network_access=false` 或 `Restricted`）且检测到代理时才
+/// 填充 `proxy_loopback_ports`；网络全开时 hole punch 多余，不填。
+pub fn policy_to_backend_config_with_env(
+    policy: &SandboxPolicy,
+    cwd: &Path,
+    env: &HashMap<String, String>,
+) -> SandboxBackendConfig {
+    let proxy_ports_when_restricted = || detect_loopback_ports(env);
+
     match policy {
         SandboxPolicy::DangerFullAccess => SandboxBackendConfig {
             readable_roots: vec![PathBuf::from("/")],
@@ -170,16 +187,27 @@ pub fn policy_to_backend_config(policy: &SandboxPolicy, cwd: &Path) -> SandboxBa
             writable_roots: vec![],
             allow_network: *network_access,
             allow_spawn: true,
-            proxy_loopback_ports: vec![],
+            proxy_loopback_ports: if *network_access {
+                vec![]
+            } else {
+                proxy_ports_when_restricted()
+            },
         },
-        SandboxPolicy::ExternalSandbox { network_access } => SandboxBackendConfig {
-            // 进程内被外层容器隔离，本地视为只读。
-            readable_roots: vec![PathBuf::from("/")],
-            writable_roots: vec![],
-            allow_network: matches!(network_access, NetworkAccess::Enabled),
-            allow_spawn: true,
-            proxy_loopback_ports: vec![],
-        },
+        SandboxPolicy::ExternalSandbox { network_access } => {
+            let net_enabled = matches!(network_access, NetworkAccess::Enabled);
+            SandboxBackendConfig {
+                // 进程内被外层容器隔离，本地视为只读。
+                readable_roots: vec![PathBuf::from("/")],
+                writable_roots: vec![],
+                allow_network: net_enabled,
+                allow_spawn: true,
+                proxy_loopback_ports: if net_enabled {
+                    vec![]
+                } else {
+                    proxy_ports_when_restricted()
+                },
+            }
+        }
         SandboxPolicy::WorkspaceWrite { network_access, .. } => {
             let roots = policy.get_writable_roots_with_cwd(cwd);
             let writable_roots: Vec<PathBuf> = roots.iter().map(|r| r.root.clone()).collect();
@@ -188,7 +216,11 @@ pub fn policy_to_backend_config(policy: &SandboxPolicy, cwd: &Path) -> SandboxBa
                 writable_roots,
                 allow_network: *network_access,
                 allow_spawn: true,
-                proxy_loopback_ports: vec![],
+                proxy_loopback_ports: if *network_access {
+                    vec![]
+                } else {
+                    proxy_ports_when_restricted()
+                },
             }
         }
     }
@@ -268,6 +300,108 @@ mod tests {
                 "Unix 默认应包含 /tmp"
             );
         }
+    }
+
+    // -- W2.3b proxy 集成 --
+
+    fn proxy_env(url: &str) -> HashMap<String, String> {
+        let mut e = HashMap::new();
+        e.insert("HTTPS_PROXY".to_string(), url.to_string());
+        e
+    }
+
+    #[test]
+    fn workspace_write_with_proxy_env_populates_proxy_ports() {
+        let tmp = tempfile::tempdir().unwrap();
+        let env = proxy_env("http://127.0.0.1:8080");
+        let cfg = policy_to_backend_config_with_env(
+            &SandboxPolicy::new_workspace_write_policy(),
+            tmp.path(),
+            &env,
+        );
+        assert_eq!(
+            cfg.proxy_loopback_ports,
+            vec![8080],
+            "网络受限 + 检测到 loopback proxy 应填 hole-punch 端口"
+        );
+        assert!(!cfg.allow_network, "WorkspaceWrite 默认 network=false");
+    }
+
+    #[test]
+    fn workspace_write_with_network_enabled_skips_proxy_ports() {
+        let tmp = tempfile::tempdir().unwrap();
+        let env = proxy_env("http://127.0.0.1:8080");
+        let cfg = policy_to_backend_config_with_env(
+            &SandboxPolicy::WorkspaceWrite {
+                writable_roots: vec![],
+                network_access: true,
+                exclude_tmpdir_env_var: true,
+                exclude_slash_tmp: true,
+            },
+            tmp.path(),
+            &env,
+        );
+        assert!(
+            cfg.proxy_loopback_ports.is_empty(),
+            "网络全开时 hole-punch 多余，不应填 proxy 端口"
+        );
+        assert!(cfg.allow_network);
+    }
+
+    #[test]
+    fn read_only_with_proxy_env_populates_proxy_ports_when_network_denied() {
+        let env = proxy_env("socks5://localhost:1080");
+        let cfg = policy_to_backend_config_with_env(
+            &SandboxPolicy::ReadOnly {
+                network_access: false,
+            },
+            Path::new("/x"),
+            &env,
+        );
+        assert_eq!(cfg.proxy_loopback_ports, vec![1080]);
+    }
+
+    #[test]
+    fn external_sandbox_restricted_with_proxy_env_picks_up_ports() {
+        let env = proxy_env("http://127.0.0.1:9999");
+        let cfg = policy_to_backend_config_with_env(
+            &SandboxPolicy::ExternalSandbox {
+                network_access: NetworkAccess::Restricted,
+            },
+            Path::new("/x"),
+            &env,
+        );
+        assert_eq!(cfg.proxy_loopback_ports, vec![9999]);
+        assert!(!cfg.allow_network);
+    }
+
+    #[test]
+    fn external_sandbox_enabled_skips_proxy_ports() {
+        let env = proxy_env("http://127.0.0.1:9999");
+        let cfg = policy_to_backend_config_with_env(
+            &SandboxPolicy::ExternalSandbox {
+                network_access: NetworkAccess::Enabled,
+            },
+            Path::new("/x"),
+            &env,
+        );
+        assert!(cfg.proxy_loopback_ports.is_empty());
+        assert!(cfg.allow_network);
+    }
+
+    #[test]
+    fn non_loopback_proxy_does_not_populate_ports() {
+        // 真实远程 proxy（不是 loopback）→ sandbox 不该 hole-punch loopback
+        let env = proxy_env("http://corp-proxy.internal:3128");
+        let cfg = policy_to_backend_config_with_env(
+            &SandboxPolicy::new_workspace_write_policy(),
+            Path::new("/x"),
+            &env,
+        );
+        assert!(
+            cfg.proxy_loopback_ports.is_empty(),
+            "非 loopback proxy 不应触发 hole-punch"
+        );
     }
 
     // -- ProcessExecutor 接口契约 --

--- a/crates/dasclaw_sandbox/src/linux/mod.rs
+++ b/crates/dasclaw_sandbox/src/linux/mod.rs
@@ -29,9 +29,10 @@
 //!
 //! - 不限制文件系统访问（依赖应用层 cap-std）
 //! - `allow_network=true` 时 seccomp 完全 bypass（无 syscall filter 安装）
-//! - `proxy_loopback_ports` 字段当前在 Linux 上只用于将来的 proxy-routed
-//!   模式，W2.3a 阶段未启用 — 调用方设了也会被忽略并发 debug 日志
-//!   （TODO W2.3b：实装 ProxyRouted 模式）
+//! - `proxy_loopback_ports` **非空** 且 `allow_network=false` 时切到
+//!   ProxyRouted 模式：允许 AF_INET/AF_INET6 socket 连本地代理桥，
+//!   拒 AF_UNIX 防旁路。env 透传由调用方在 [`crate::SandboxExecRequest`]
+//!   显式注入；`dasclaw_exec` 已经默认从宿主 env 检测 proxy 端口。
 
 #![cfg(target_os = "linux")]
 
@@ -121,10 +122,9 @@ impl Sandbox for LinuxSeccompSandbox {
 /// - `Restricted`：拒绝所有非 AF_UNIX socket 创建 + connect/accept/bind 等
 ///   网络 syscall。`cargo` / `npm` 等工具仍可工作（它们用 AF_UNIX
 ///   socketpair 与子进程通信）。
-/// - `ProxyRouted`：在 ProxyRouted 模式下允许 AF_INET/AF_INET6 socket（用于
-///   连接到本地代理桥），但拒绝 AF_UNIX socket 阻止旁路。**W2.3a 阶段
-///   声明此模式但 Sandbox::execute 暂未根据 proxy_loopback_ports 实际
-///   启用**（TODO W2.3b）。
+/// - `ProxyRouted`：允许 AF_INET/AF_INET6 socket（用于连接到本地代理桥），
+///   但拒绝 AF_UNIX socket 阻止旁路。`Sandbox::execute` 在
+///   `proxy_loopback_ports` 非空且 `allow_network=false` 时自动切此模式。
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum NetworkSeccompMode {
     Restricted,
@@ -270,5 +270,31 @@ mod tests {
         // 创建 socket。所以仅用单元测试保证 enum + arch 检测逻辑。
         let arch_ok = cfg!(any(target_arch = "x86_64", target_arch = "aarch64"));
         assert!(arch_ok, "Linux Tier-1 arch precondition");
+    }
+
+    /// W2.3b 路径覆盖测试：模拟 `Sandbox::execute` 内部如何根据
+    /// `proxy_loopback_ports.is_empty()` 选择 mode。本测试只覆盖映射
+    /// 决策，不实际安装 filter（apply 会污染线程）。
+    #[test]
+    fn empty_proxy_ports_picks_restricted_mode() {
+        let proxy_routed = !Vec::<u16>::new().is_empty();
+        let mode = if proxy_routed {
+            NetworkSeccompMode::ProxyRouted
+        } else {
+            NetworkSeccompMode::Restricted
+        };
+        assert_eq!(mode, NetworkSeccompMode::Restricted);
+    }
+
+    #[test]
+    fn nonempty_proxy_ports_picks_proxy_routed_mode() {
+        let ports: Vec<u16> = vec![8888];
+        let proxy_routed = !ports.is_empty();
+        let mode = if proxy_routed {
+            NetworkSeccompMode::ProxyRouted
+        } else {
+            NetworkSeccompMode::Restricted
+        };
+        assert_eq!(mode, NetworkSeccompMode::ProxyRouted);
     }
 }


### PR DESCRIPTION
Replaces auto-closed PR #5 after W2.6 merge.

W2.3b: Linux ProxyRouted 模式真接入，dasclaw_exec 通过 detect_loopback_ports 注入。

详见原 PR #5。