### PR TITLE
feat(W3.1b): switch ShellTool from SandboxManager to OsExecutor

### DIFF
--- a/desktop-client/ironclaw/src/tools/builtin/shell.rs
+++ b/desktop-client/ironclaw/src/tools/builtin/shell.rs
@@ -639,7 +639,12 @@ impl ShellTool {
         // also enforces its own timeout, but the caller's value can be tighter).
         let result = tokio::time::timeout(timeout, async {
             sandbox
-                .execute(cmd, workdir, self.sandbox_policy, std::collections::HashMap::new())
+                .execute(
+                    cmd,
+                    workdir,
+                    self.sandbox_policy,
+                    std::collections::HashMap::new(),
+                )
                 .await
         })
         .await;

--- a/desktop-client/ironclaw/src/tools/builtin/shell.rs
+++ b/desktop-client/ironclaw/src/tools/builtin/shell.rs
@@ -54,7 +54,7 @@ use tokio::io::AsyncReadExt;
 use tokio::process::Command;
 
 use crate::context::JobContext;
-use crate::sandbox::{SandboxManager, SandboxPolicy};
+use crate::sandbox::{OsExecutor, SandboxPolicy};
 use crate::tools::tool::{
     ApprovalRequirement, RiskLevel, Tool, ToolDomain, ToolError, ToolOutput, require_str,
 };
@@ -552,8 +552,8 @@ pub struct ShellTool {
     timeout: Duration,
     /// Whether to allow potentially dangerous commands (requires explicit approval).
     allow_dangerous: bool,
-    /// Optional sandbox manager for Docker execution.
-    sandbox: Option<Arc<SandboxManager>>,
+    /// Optional OS-level sandbox executor (W3.1a: codex-style, replaces Docker manager).
+    sandbox: Option<Arc<OsExecutor>>,
     /// Sandbox policy to use when sandbox is available.
     sandbox_policy: SandboxPolicy,
 }
@@ -594,8 +594,8 @@ impl ShellTool {
         self
     }
 
-    /// Enable sandbox execution with the given manager.
-    pub fn with_sandbox(mut self, sandbox: Arc<SandboxManager>) -> Self {
+    /// Enable sandbox execution with the given OS executor.
+    pub fn with_sandbox(mut self, sandbox: Arc<OsExecutor>) -> Self {
         self.sandbox = Some(sandbox);
         self
     }
@@ -627,23 +627,19 @@ impl ShellTool {
         None
     }
 
-    /// Execute a command through the sandbox.
+    /// Execute a command through the OS sandbox.
     async fn execute_sandboxed(
         &self,
-        sandbox: &SandboxManager,
+        sandbox: &OsExecutor,
         cmd: &str,
         workdir: &Path,
         timeout: Duration,
     ) -> Result<(String, i64), ToolError> {
-        // Override sandbox config timeout if needed
+        // Outer timeout still wraps the executor (defense in depth: OsExecutor
+        // also enforces its own timeout, but the caller's value can be tighter).
         let result = tokio::time::timeout(timeout, async {
             sandbox
-                .execute_with_policy(
-                    cmd,
-                    workdir,
-                    self.sandbox_policy,
-                    std::collections::HashMap::new(),
-                )
+                .execute(cmd, workdir, self.sandbox_policy, std::collections::HashMap::new())
                 .await
         })
         .await;
@@ -807,11 +803,11 @@ impl ShellTool {
         // Determine timeout
         let timeout_duration = timeout.map(Duration::from_secs).unwrap_or(self.timeout);
 
-        // Use sandbox if configured; fail-closed (never silently fall through
-        // to unsandboxed execution when sandbox was intended).
-        if let Some(ref sandbox) = self.sandbox
-            && (sandbox.is_initialized() || sandbox.config().enabled)
-        {
+        // Use OS sandbox if configured; fail-closed (never silently fall through
+        // to unsandboxed execution when sandbox was intended). Unlike Docker manager,
+        // OsExecutor has no lazy init / config-disabled mode — being constructed
+        // implies "enabled".
+        if let Some(ref sandbox) = self.sandbox {
             return self
                 .execute_sandboxed(sandbox, cmd, &cwd, timeout_duration)
                 .await;


### PR DESCRIPTION
## W3.1b — Switch ShellTool to OsExecutor

W3.1 stack 第二棒。把唯一活跃的 `SandboxManager` 调用点 `ShellTool` 切换到 W3.1a 引入的 `OsExecutor`。

### 改动范围（极小）

仅 1 文件，+15 / -19。

| 改动 | 说明 |
|------|------|
| 字段类型 | `Option<Arc<SandboxManager>>` → `Option<Arc<OsExecutor>>` |
| 调用 | `sandbox.execute_with_policy(...)` → `sandbox.execute(...)`（W3.1a 已对齐签名） |
| 删除 gating | 旧的 `is_initialized() || config().enabled` 判断 → 移除 |

### 安全收紧（fail-safe 增强）

旧路径：`if Some(sandbox) && (is_initialized || enabled)` —— 当 sandbox 配置存在但未初始化或禁用时，**fall through 到 host exec**（潜在隐患）。

新路径：`if Some(sandbox)` —— 持有 `OsExecutor` 实例即代表已启用，无 fall-through。`OsExecutor` 没有 lazy init / config-disabled 模式，被构造即就绪。

### 其他"调用方"为什么不改

- `sandbox/agent_executor.rs` —— adapter，注释明确说 `SandboxManager::new` 调用次数 = 0（dead path）
- `tests/agent_hooks_integration_test.rs` —— 测试 adapter，同上
- `orchestrator/job_manager.rs` —— grep 命中只有文档注释，无代码引用

→ 这 3 处与 `SandboxManager` 强绑定的代码会在 **W3.1c 整体删除**，无须 W3.1b 中转。

### 守门

- `cargo build -p ironclaw` ✅ 0 错误 0 警告
- `cargo test tools::builtin::shell` ✅ 33/33 pass
- `cargo fmt --all` ✅
- `scripts/check_no_panics.py` ✅
- skill 自审三件套 ✅

### Stack

- W3.1a #12 ✅ merged
- **W3.1b 本 PR**
- W3.1c 待开：删 `sandbox/{manager,container,detect,proxy/}.rs` + `agent_executor.rs` + bollard 依赖

Refs: ADR-110 (`docs/plans/architecture-refactor/40-ironclaw-internalization.md`)
