### PR TITLE
feat(w3.2b-1): port HTTP forward proxy from ironclaw-main to dasclaw_net_proxy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2465,9 +2465,19 @@ dependencies = [
 
 [[package]]
 name = "dasclaw_net_proxy"
-version = "0.0.0-w1"
+version = "0.1.0"
 dependencies = [
- "thiserror 1.0.69",
+ "async-trait",
+ "bytes",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-util",
+ "reqwest 0.12.28",
+ "serde",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "url",
 ]
 
 [[package]]

--- a/crates/dasclaw_net_proxy/Cargo.toml
+++ b/crates/dasclaw_net_proxy/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "dasclaw_net_proxy"
-version = "0.0.0-w1"
-edition = "2021"
-description = "rama-based MITM proxy with self-signed CA (codex port)."
+version = "0.1.0"
+edition = "2024"
+description = "HTTP forward proxy with domain allowlist + credential injection (ported from ironclaw-main)."
 license = "Apache-2.0 OR MIT"
 publish = false
 
@@ -10,4 +10,30 @@ publish = false
 path = "src/lib.rs"
 
 [dependencies]
-thiserror = "1"
+# Error handling
+thiserror = "2"
+
+# Async runtime
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "net", "io-util", "sync", "time"] }
+async-trait = "0.1"
+
+# HTTP server
+hyper = { version = "1.5", features = ["server", "http1", "http2"] }
+hyper-util = { version = "0.1", features = ["server", "tokio", "http1", "http2"] }
+http-body-util = "0.1"
+bytes = "1"
+
+# Outbound HTTP client
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls-native-roots"] }
+
+# URL parsing
+url = "2"
+
+# Logging
+tracing = "0.1"
+
+# Serialization (for CredentialMapping/CredentialLocation)
+serde = { version = "1", features = ["derive"] }
+
+[dev-dependencies]
+tokio = { version = "1", features = ["full", "test-util"] }

--- a/crates/dasclaw_net_proxy/src/allowlist.rs
+++ b/crates/dasclaw_net_proxy/src/allowlist.rs
@@ -1,0 +1,337 @@
+//! Domain allowlist for the network proxy.
+//!
+//! Validates that HTTP requests only go to allowed domains.
+//! Supports exact matches and wildcard patterns.
+
+use std::fmt;
+
+/// Pattern for matching allowed domains.
+#[derive(Debug, Clone)]
+pub struct DomainPattern {
+    /// The domain pattern (e.g., "api.example.com" or "*.example.com").
+    pattern: String,
+    /// Whether this is a wildcard pattern.
+    is_wildcard: bool,
+    /// The base domain for wildcard matching.
+    base_domain: String,
+}
+
+impl DomainPattern {
+    /// Create a new domain pattern.
+    pub fn new(pattern: &str) -> Self {
+        let is_wildcard = pattern.starts_with("*.");
+        let base_domain = if is_wildcard {
+            pattern[2..].to_lowercase()
+        } else {
+            pattern.to_lowercase()
+        };
+
+        Self {
+            pattern: pattern.to_string(),
+            is_wildcard,
+            base_domain,
+        }
+    }
+
+    /// Check if a host matches this pattern.
+    pub fn matches(&self, host: &str) -> bool {
+        let host_lower = host.to_lowercase();
+
+        if self.is_wildcard {
+            // *.example.com matches foo.example.com, bar.baz.example.com, example.com
+            host_lower == self.base_domain
+                || host_lower.ends_with(&format!(".{}", self.base_domain))
+        } else {
+            host_lower == self.base_domain
+        }
+    }
+
+    /// Get the pattern string.
+    pub fn pattern(&self) -> &str {
+        &self.pattern
+    }
+}
+
+impl fmt::Display for DomainPattern {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.pattern)
+    }
+}
+
+/// Result of domain validation.
+#[derive(Debug, Clone)]
+pub enum DomainValidationResult {
+    /// Domain is allowed.
+    Allowed,
+    /// Domain is denied with a reason.
+    Denied(String),
+}
+
+impl DomainValidationResult {
+    pub fn is_allowed(&self) -> bool {
+        matches!(self, DomainValidationResult::Allowed)
+    }
+}
+
+/// Validates domains against an allowlist.
+#[derive(Debug, Clone)]
+pub struct DomainAllowlist {
+    patterns: Vec<DomainPattern>,
+}
+
+impl DomainAllowlist {
+    /// Create a new allowlist from domain strings.
+    pub fn new(domains: &[String]) -> Self {
+        Self {
+            patterns: domains.iter().map(|d| DomainPattern::new(d)).collect(),
+        }
+    }
+
+    /// Create an empty allowlist (denies everything).
+    pub fn empty() -> Self {
+        Self { patterns: vec![] }
+    }
+
+    /// Add a domain pattern to the allowlist.
+    pub fn add(&mut self, pattern: &str) {
+        self.patterns.push(DomainPattern::new(pattern));
+    }
+
+    /// Check if a domain is allowed.
+    pub fn is_allowed(&self, host: &str) -> DomainValidationResult {
+        if self.patterns.is_empty() {
+            return DomainValidationResult::Denied("empty allowlist".to_string());
+        }
+
+        for pattern in &self.patterns {
+            if pattern.matches(host) {
+                return DomainValidationResult::Allowed;
+            }
+        }
+
+        DomainValidationResult::Denied(format!(
+            "host '{}' not in allowlist: [{}]",
+            host,
+            self.patterns
+                .iter()
+                .map(|p| p.pattern())
+                .collect::<Vec<_>>()
+                .join(", ")
+        ))
+    }
+
+    /// Get all patterns in the allowlist.
+    pub fn patterns(&self) -> &[DomainPattern] {
+        &self.patterns
+    }
+
+    /// Check if the allowlist is empty.
+    pub fn is_empty(&self) -> bool {
+        self.patterns.is_empty()
+    }
+
+    /// Get the number of patterns.
+    pub fn len(&self) -> usize {
+        self.patterns.len()
+    }
+}
+
+impl Default for DomainAllowlist {
+    /// Empty allowlist (denies everything). Callers should explicitly
+    /// supply a non-empty pattern list via [`DomainAllowlist::new`].
+    fn default() -> Self {
+        Self::empty()
+    }
+}
+
+/// Parse host from a URL string.
+pub fn extract_host(url: &str) -> Option<String> {
+    let parsed = url::Url::parse(url).ok()?;
+    if !matches!(parsed.scheme(), "http" | "https") {
+        return None;
+    }
+    parsed.host_str().map(|h| {
+        h.strip_prefix('[')
+            .and_then(|v| v.strip_suffix(']'))
+            .unwrap_or(h)
+            .to_lowercase()
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_exact_match() {
+        let pattern = DomainPattern::new("api.example.com");
+        assert!(pattern.matches("api.example.com"));
+        assert!(pattern.matches("API.EXAMPLE.COM"));
+        assert!(!pattern.matches("foo.api.example.com"));
+        assert!(!pattern.matches("example.com"));
+    }
+
+    #[test]
+    fn test_wildcard_match() {
+        let pattern = DomainPattern::new("*.example.com");
+        assert!(pattern.matches("api.example.com"));
+        assert!(pattern.matches("foo.bar.example.com"));
+        assert!(pattern.matches("example.com")); // Base domain also matches
+        assert!(!pattern.matches("exampleXcom"));
+        assert!(!pattern.matches("other.com"));
+    }
+
+    #[test]
+    fn test_allowlist_allows() {
+        let allowlist =
+            DomainAllowlist::new(&["crates.io".to_string(), "*.github.com".to_string()]);
+
+        assert!(allowlist.is_allowed("crates.io").is_allowed());
+        assert!(allowlist.is_allowed("api.github.com").is_allowed());
+        assert!(
+            !allowlist
+                .is_allowed("raw.githubusercontent.com")
+                .is_allowed()
+        );
+    }
+
+    #[test]
+    fn test_allowlist_denies() {
+        let allowlist = DomainAllowlist::new(&["crates.io".to_string()]);
+
+        let result = allowlist.is_allowed("evil.com");
+        assert!(!result.is_allowed());
+    }
+
+    #[test]
+    fn test_empty_allowlist() {
+        let allowlist = DomainAllowlist::empty();
+        assert!(!allowlist.is_allowed("anything.com").is_allowed());
+    }
+
+    #[test]
+    fn test_extract_host() {
+        assert_eq!(
+            extract_host("https://api.example.com/v1/endpoint"),
+            Some("api.example.com".to_string())
+        );
+        assert_eq!(
+            extract_host("http://localhost:8080/api"),
+            Some("localhost".to_string())
+        );
+        assert_eq!(
+            extract_host("https://EXAMPLE.COM"),
+            Some("example.com".to_string())
+        );
+        assert_eq!(
+            extract_host("https://user:pass@api.example.com:443/path"),
+            Some("api.example.com".to_string())
+        );
+        assert_eq!(
+            extract_host("http://[::1]:8080/path"),
+            Some("::1".to_string())
+        );
+        assert_eq!(extract_host("not-a-url"), None);
+        assert_eq!(extract_host("ftp://example.com/file"), None);
+    }
+
+    // === QA Plan P1 - 4.5: Adversarial allowlist tests ===
+
+    #[test]
+    fn test_subdomain_bypass_attempt() {
+        let allowlist = DomainAllowlist::new(&["api.example.com".to_string()]);
+
+        // Exact match should work
+        assert!(allowlist.is_allowed("api.example.com").is_allowed());
+
+        // Subdomain of exact match should NOT be allowed
+        assert!(!allowlist.is_allowed("evil.api.example.com").is_allowed());
+
+        // Similar-looking domains should NOT be allowed
+        assert!(
+            !allowlist
+                .is_allowed("api.example.com.evil.com")
+                .is_allowed()
+        );
+        assert!(!allowlist.is_allowed("api-example.com").is_allowed());
+        assert!(!allowlist.is_allowed("notapi.example.com").is_allowed());
+    }
+
+    #[test]
+    fn test_wildcard_depth() {
+        let allowlist = DomainAllowlist::new(&["*.github.com".to_string()]);
+
+        // Direct subdomain
+        assert!(allowlist.is_allowed("api.github.com").is_allowed());
+        // Multi-level subdomain
+        assert!(allowlist.is_allowed("a.b.c.github.com").is_allowed());
+        // Base domain itself
+        assert!(allowlist.is_allowed("github.com").is_allowed());
+
+        // But NOT a completely different domain
+        assert!(!allowlist.is_allowed("github.com.evil.com").is_allowed());
+        assert!(!allowlist.is_allowed("notgithub.com").is_allowed());
+    }
+
+    #[test]
+    fn test_case_insensitive_domains() {
+        let allowlist = DomainAllowlist::new(&["crates.io".to_string()]);
+
+        assert!(allowlist.is_allowed("CRATES.IO").is_allowed());
+        assert!(allowlist.is_allowed("Crates.Io").is_allowed());
+        assert!(allowlist.is_allowed("cRaTeS.iO").is_allowed());
+    }
+
+    #[test]
+    fn test_extract_host_with_credentials_in_url() {
+        // Credentials in URL should not affect host extraction
+        assert_eq!(
+            extract_host("https://secret_key:password@evil.com/exfil"),
+            Some("evil.com".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_host_port_ignored() {
+        // Port should not affect host extraction
+        assert_eq!(
+            extract_host("https://api.example.com:9999/path"),
+            Some("api.example.com".to_string())
+        );
+    }
+
+    #[test]
+    fn test_empty_and_single_pattern() {
+        // Empty allowlist denies everything
+        let empty = DomainAllowlist::empty();
+        assert!(!empty.is_allowed("localhost").is_allowed());
+        assert!(!empty.is_allowed("127.0.0.1").is_allowed());
+
+        // Single wildcard should allow subdomains but not unrelated domains
+        let single = DomainAllowlist::new(&["*.example.com".to_string()]);
+        assert!(single.is_allowed("any.example.com").is_allowed());
+        assert!(!single.is_allowed("other.org").is_allowed());
+    }
+
+    #[test]
+    fn test_ip_address_not_matched_by_domain() {
+        let allowlist = DomainAllowlist::new(&["example.com".to_string()]);
+
+        // IP addresses should NOT match domain names
+        assert!(!allowlist.is_allowed("93.184.216.34").is_allowed());
+        assert!(!allowlist.is_allowed("127.0.0.1").is_allowed());
+    }
+
+    #[test]
+    fn test_extract_host_ipv6() {
+        // IPv6 addresses with brackets stripped
+        assert_eq!(
+            extract_host("https://[::1]:8080/api"),
+            Some("::1".to_string())
+        );
+        assert_eq!(
+            extract_host("https://[2001:db8::1]/path"),
+            Some("2001:db8::1".to_string())
+        );
+    }
+}

--- a/crates/dasclaw_net_proxy/src/builder.rs
+++ b/crates/dasclaw_net_proxy/src/builder.rs
@@ -1,0 +1,150 @@
+//! Builder for assembling an [`HttpProxy`] from allowlist + credential mappings.
+//!
+//! Simplified port from `ironclaw-main/src/sandbox/proxy/mod.rs::NetworkProxyBuilder`.
+//! The `from_config` constructor is intentionally **not** ported — callers in
+//! W3.2b-4 wire the proxy from desktop-client `SandboxConfig` directly via
+//! `with_allowlist`/`with_credentials`/`with_credential_resolver`, keeping
+//! this crate decoupled from any specific config schema.
+
+use std::sync::Arc;
+
+use crate::allowlist::DomainAllowlist;
+use crate::error::Result;
+use crate::http::{CredentialResolver, EnvCredentialResolver, HttpProxy};
+use crate::policy::{AllowAllDecider, DefaultPolicyDecider, DenyAllDecider, NetworkPolicyDecider};
+use crate::types::CredentialMapping;
+
+/// What policy mode to apply when no custom decider is supplied.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ProxyMode {
+    /// Default: enforce allowlist + credential mappings.
+    #[default]
+    Restricted,
+    /// Allow everything (use only when caller has its own enforcement).
+    AllowAll,
+    /// Deny everything (kill-switch).
+    DenyAll,
+}
+
+/// Fluent builder for [`HttpProxy`].
+pub struct NetworkProxyBuilder {
+    allowlist: Vec<String>,
+    credential_mappings: Vec<CredentialMapping>,
+    credential_resolver: Arc<dyn CredentialResolver>,
+    mode: ProxyMode,
+    deny_reason: String,
+}
+
+impl NetworkProxyBuilder {
+    /// Create a new builder with safe defaults: empty allowlist, no
+    /// credentials, env-based resolver, [`ProxyMode::Restricted`].
+    ///
+    /// **Note**: an empty allowlist combined with `Restricted` mode denies
+    /// every request. Callers must add at least one allowed domain via
+    /// [`Self::with_allowlist`] or [`Self::allow_domain`].
+    pub fn new() -> Self {
+        Self {
+            allowlist: Vec::new(),
+            credential_mappings: Vec::new(),
+            credential_resolver: Arc::new(EnvCredentialResolver),
+            mode: ProxyMode::default(),
+            deny_reason: "denied by policy".to_string(),
+        }
+    }
+
+    pub fn with_allowlist(mut self, domains: Vec<String>) -> Self {
+        self.allowlist = domains;
+        self
+    }
+
+    pub fn allow_domain(mut self, domain: impl Into<String>) -> Self {
+        self.allowlist.push(domain.into());
+        self
+    }
+
+    pub fn with_credentials(mut self, mappings: Vec<CredentialMapping>) -> Self {
+        self.credential_mappings = mappings;
+        self
+    }
+
+    pub fn with_credential_resolver(mut self, resolver: Arc<dyn CredentialResolver>) -> Self {
+        self.credential_resolver = resolver;
+        self
+    }
+
+    pub fn with_mode(mut self, mode: ProxyMode) -> Self {
+        self.mode = mode;
+        self
+    }
+
+    pub fn with_deny_reason(mut self, reason: impl Into<String>) -> Self {
+        self.deny_reason = reason.into();
+        self
+    }
+
+    /// Assemble the proxy without starting it.
+    pub fn build(self) -> HttpProxy {
+        let decider: Arc<dyn NetworkPolicyDecider> = match self.mode {
+            ProxyMode::AllowAll => Arc::new(AllowAllDecider),
+            ProxyMode::DenyAll => Arc::new(DenyAllDecider::new(&self.deny_reason)),
+            ProxyMode::Restricted => Arc::new(DefaultPolicyDecider::new(
+                DomainAllowlist::new(&self.allowlist),
+                self.credential_mappings,
+            )),
+        };
+
+        HttpProxy::new(decider, self.credential_resolver)
+    }
+
+    /// Build the proxy and start listening on the given port (0 = auto).
+    pub async fn build_and_start(self, port: u16) -> Result<HttpProxy> {
+        let proxy = self.build();
+        proxy.start(port).await?;
+        Ok(proxy)
+    }
+}
+
+impl Default for NetworkProxyBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_is_restricted_with_empty_allowlist() {
+        let b = NetworkProxyBuilder::new();
+        assert_eq!(b.mode, ProxyMode::Restricted);
+        assert!(b.allowlist.is_empty());
+    }
+
+    #[test]
+    fn allow_domain_appends() {
+        let b = NetworkProxyBuilder::new()
+            .allow_domain("a.com")
+            .allow_domain("b.com");
+        assert_eq!(b.allowlist, vec!["a.com".to_string(), "b.com".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn builds_proxy_in_each_mode() {
+        for mode in [
+            ProxyMode::Restricted,
+            ProxyMode::AllowAll,
+            ProxyMode::DenyAll,
+        ] {
+            let proxy = NetworkProxyBuilder::new()
+                .with_mode(mode)
+                .allow_domain("example.com")
+                .build();
+            assert!(
+                !proxy.is_running(),
+                "mode {:?}: proxy must not auto-start",
+                mode
+            );
+        }
+    }
+}

--- a/crates/dasclaw_net_proxy/src/error.rs
+++ b/crates/dasclaw_net_proxy/src/error.rs
@@ -1,0 +1,36 @@
+//! Error types for the network proxy.
+
+use std::io;
+
+/// Result alias for proxy operations.
+pub type Result<T> = std::result::Result<T, ProxyError>;
+
+/// Errors emitted by the network-proxy crate.
+#[derive(Debug, thiserror::Error)]
+pub enum ProxyError {
+    /// Failed to bind the listener or get its local address.
+    #[error("proxy bind failure: {reason}")]
+    Bind { reason: String },
+
+    /// Lower-level I/O error.
+    #[error("proxy io error: {0}")]
+    Io(#[from] io::Error),
+
+    /// Generic proxy error (forwarding, decoding, ...).
+    #[error("proxy error: {reason}")]
+    Other { reason: String },
+}
+
+impl ProxyError {
+    pub fn bind(reason: impl Into<String>) -> Self {
+        Self::Bind {
+            reason: reason.into(),
+        }
+    }
+
+    pub fn other(reason: impl Into<String>) -> Self {
+        Self::Other {
+            reason: reason.into(),
+        }
+    }
+}

--- a/crates/dasclaw_net_proxy/src/http.rs
+++ b/crates/dasclaw_net_proxy/src/http.rs
@@ -1,0 +1,552 @@
+//! HTTP proxy server for sandboxed network access.
+//!
+//! This proxy runs on the host and handles all network requests from containers.
+//! It validates requests against the allowlist and injects credentials when needed.
+//!
+//! ```text
+//! Container ──► http_proxy=host.docker.internal:PORT ──► This Proxy ──► Internet
+//!                                                             │
+//!                                                             ├─► Validate domain
+//!                                                             ├─► Inject credentials
+//!                                                             └─► Log requests
+//! ```
+
+use std::convert::Infallible;
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use bytes::Bytes;
+use http_body_util::{BodyExt, Empty, Full, combinators::BoxBody};
+use hyper::server::conn::http1;
+use hyper::service::service_fn;
+use hyper::{Method, Request, Response, StatusCode};
+use hyper_util::rt::TokioIo;
+use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::RwLock;
+
+use crate::error::{ProxyError, Result};
+use crate::policy::{NetworkDecision, NetworkPolicyDecider, NetworkRequest};
+use crate::types::CredentialLocation;
+
+/// State shared across proxy connections.
+struct ProxyState {
+    /// Policy decider for network requests.
+    decider: Arc<dyn NetworkPolicyDecider>,
+    /// Credential resolver (maps secret names to values).
+    credential_resolver: Arc<dyn CredentialResolver>,
+    /// Shared HTTP client for forwarding requests.
+    http_client: reqwest::Client,
+    /// Request counter for logging.
+    request_count: std::sync::atomic::AtomicU64,
+    /// Whether the proxy is running.
+    running: std::sync::atomic::AtomicBool,
+}
+
+/// Resolves secret names to their values.
+#[async_trait::async_trait]
+pub trait CredentialResolver: Send + Sync {
+    /// Get the value of a secret by name.
+    async fn resolve(&self, name: &str) -> Option<String>;
+}
+
+/// A credential resolver that uses environment variables.
+pub struct EnvCredentialResolver;
+
+#[async_trait::async_trait]
+impl CredentialResolver for EnvCredentialResolver {
+    async fn resolve(&self, name: &str) -> Option<String> {
+        std::env::var(name).ok()
+    }
+}
+
+/// A credential resolver that returns nothing (for testing).
+pub struct NoCredentialResolver;
+
+#[async_trait::async_trait]
+impl CredentialResolver for NoCredentialResolver {
+    async fn resolve(&self, _name: &str) -> Option<String> {
+        None
+    }
+}
+
+/// HTTP proxy server.
+pub struct HttpProxy {
+    state: Arc<ProxyState>,
+    addr: RwLock<Option<SocketAddr>>,
+    shutdown_tx: RwLock<Option<tokio::sync::oneshot::Sender<()>>>,
+}
+
+impl HttpProxy {
+    /// Create a new HTTP proxy.
+    pub fn new(
+        decider: Arc<dyn NetworkPolicyDecider>,
+        credential_resolver: Arc<dyn CredentialResolver>,
+    ) -> Self {
+        Self {
+            state: Arc::new(ProxyState {
+                decider,
+                credential_resolver,
+                http_client: reqwest::Client::new(),
+                request_count: std::sync::atomic::AtomicU64::new(0),
+                running: std::sync::atomic::AtomicBool::new(false),
+            }),
+            addr: RwLock::new(None),
+            shutdown_tx: RwLock::new(None),
+        }
+    }
+
+    /// Start the proxy server on the given port (0 for auto-assign).
+    pub async fn start(&self, port: u16) -> Result<SocketAddr> {
+        let listener = TcpListener::bind(format!("127.0.0.1:{}", port))
+            .await
+            .map_err(|e| ProxyError::bind(format!("failed to bind: {}", e)))?;
+
+        let addr = listener
+            .local_addr()
+            .map_err(|e| ProxyError::bind(format!("failed to get local addr: {}", e)))?;
+
+        *self.addr.write().await = Some(addr);
+
+        let (shutdown_tx, mut shutdown_rx) = tokio::sync::oneshot::channel();
+        *self.shutdown_tx.write().await = Some(shutdown_tx);
+
+        self.state
+            .running
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+
+        let state = self.state.clone();
+
+        tokio::spawn(async move {
+            tracing::info!("Sandbox proxy started on {}", addr);
+
+            loop {
+                tokio::select! {
+                    accept_result = listener.accept() => {
+                        match accept_result {
+                            Ok((stream, _)) => {
+                                let io = TokioIo::new(stream);
+                                let state = state.clone();
+
+                                tokio::spawn(async move {
+                                    let service = service_fn(move |req| {
+                                        let state = state.clone();
+                                        async move { handle_request(req, state).await }
+                                    });
+
+                                    if let Err(e) = http1::Builder::new()
+                                        .preserve_header_case(true)
+                                        .title_case_headers(true)
+                                        .serve_connection(io, service)
+                                        .with_upgrades()
+                                        .await
+                                    {
+                                        tracing::debug!("Proxy connection error: {}", e);
+                                    }
+                                });
+                            }
+                            Err(e) => {
+                                tracing::error!("Proxy accept error: {}", e);
+                            }
+                        }
+                    }
+                    _ = &mut shutdown_rx => {
+                        tracing::debug!("Sandbox proxy shutting down");
+                        break;
+                    }
+                }
+            }
+
+            state
+                .running
+                .store(false, std::sync::atomic::Ordering::SeqCst);
+        });
+
+        Ok(addr)
+    }
+
+    /// Stop the proxy server.
+    pub async fn stop(&self) {
+        if let Some(tx) = self.shutdown_tx.write().await.take() {
+            let _ = tx.send(());
+        }
+    }
+
+    /// Get the address the proxy is listening on.
+    pub async fn addr(&self) -> Option<SocketAddr> {
+        *self.addr.read().await
+    }
+
+    /// Check if the proxy is running.
+    pub fn is_running(&self) -> bool {
+        self.state.running.load(std::sync::atomic::Ordering::SeqCst)
+    }
+
+    /// Get the number of requests handled.
+    pub fn request_count(&self) -> u64 {
+        self.state
+            .request_count
+            .load(std::sync::atomic::Ordering::SeqCst)
+    }
+}
+
+/// Handle an incoming proxy request.
+async fn handle_request(
+    req: Request<hyper::body::Incoming>,
+    state: Arc<ProxyState>,
+) -> std::result::Result<Response<BoxBody<Bytes, Infallible>>, Infallible> {
+    state
+        .request_count
+        .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+
+    // Handle CONNECT method for HTTPS tunneling
+    if req.method() == Method::CONNECT {
+        return Ok(handle_connect(req, state).await);
+    }
+
+    // For HTTP requests, validate and forward
+    let uri = req.uri().to_string();
+    let method = req.method().to_string();
+
+    let network_req = match NetworkRequest::from_url(&method, &uri) {
+        Some(r) => r,
+        None => {
+            tracing::warn!("Proxy: invalid URL: {}", uri);
+            return Ok(error_response(
+                StatusCode::BAD_REQUEST,
+                "Invalid URL".to_string(),
+            ));
+        }
+    };
+
+    // Make policy decision
+    let decision = state.decider.decide(&network_req).await;
+
+    match decision {
+        NetworkDecision::Deny { reason } => {
+            tracing::info!("Proxy: blocked {} {} - {}", method, uri, reason);
+            Ok(error_response(StatusCode::FORBIDDEN, reason))
+        }
+        NetworkDecision::Allow | NetworkDecision::AllowWithCredentials { .. } => {
+            // Forward the request
+            forward_request(req, decision, state).await
+        }
+    }
+}
+
+/// Handle CONNECT method for HTTPS tunneling.
+///
+/// Establishes a bidirectional TCP tunnel between the client and the target host.
+/// Returns 200 OK to signal the client to begin TLS over the upgraded connection.
+///
+/// NOTE: Credential injection is not possible through CONNECT tunnels since the proxy
+/// cannot inspect or modify TLS-encrypted traffic without MITM. Containers that need
+/// authenticated HTTPS should fetch credentials via the orchestrator's
+/// `GET /worker/{id}/credentials` endpoint and set them as environment variables.
+async fn handle_connect(
+    req: Request<hyper::body::Incoming>,
+    state: Arc<ProxyState>,
+) -> Response<BoxBody<Bytes, Infallible>> {
+    // Extract host:port from CONNECT target (e.g. "api.github.com:443")
+    let authority = match req.uri().authority() {
+        Some(a) => a.clone(),
+        None => {
+            return error_response(StatusCode::BAD_REQUEST, "Missing host".to_string());
+        }
+    };
+
+    let host = authority.host().to_string();
+    let target_addr = authority.as_str().to_string();
+
+    // Check if host is allowed
+    let network_req = NetworkRequest {
+        method: "CONNECT".to_string(),
+        url: format!("https://{}", host),
+        host: host.clone(),
+        path: "/".to_string(),
+    };
+
+    let decision = state.decider.decide(&network_req).await;
+
+    if let NetworkDecision::Deny { reason } = decision {
+        tracing::info!("Proxy: blocked CONNECT {} - {}", host, reason);
+        return error_response(StatusCode::FORBIDDEN, reason);
+    }
+
+    tracing::debug!("Proxy: allowing CONNECT to {}", target_addr);
+
+    // Spawn a fire-and-forget task to establish the tunnel after the upgrade
+    // completes.  The 30-minute timeout guarantees every tunnel task terminates
+    // even if the remote peer hangs, so no `JoinSet` tracking is needed.
+    // On process exit these tasks are dropped by the runtime.
+    let target = target_addr.clone();
+    tokio::spawn(async move {
+        match hyper::upgrade::on(req).await {
+            Ok(upgraded) => {
+                let mut client_stream = TokioIo::new(upgraded);
+                match TcpStream::connect(&target).await {
+                    Ok(mut server_stream) => {
+                        let tunnel_timeout = std::time::Duration::from_secs(30 * 60);
+                        match tokio::time::timeout(
+                            tunnel_timeout,
+                            tokio::io::copy_bidirectional(&mut client_stream, &mut server_stream),
+                        )
+                        .await
+                        {
+                            Ok(Ok(_)) => {}
+                            Ok(Err(e)) => {
+                                tracing::debug!("Proxy: tunnel to {} closed: {}", target, e);
+                            }
+                            Err(_) => {
+                                tracing::info!(
+                                    "Proxy: tunnel to {} timed out after 30m, closing",
+                                    target
+                                );
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        tracing::error!("Proxy: failed to connect to {}: {}", target, e);
+                    }
+                }
+            }
+            Err(e) => {
+                tracing::error!("Proxy: upgrade failed for {}: {}", target, e);
+            }
+        }
+    });
+
+    // Return 200 OK so the client begins the TLS handshake over the upgraded connection
+    make_response(StatusCode::OK, empty_body())
+}
+
+/// Forward a request to the target server.
+async fn forward_request(
+    req: Request<hyper::body::Incoming>,
+    decision: NetworkDecision,
+    state: Arc<ProxyState>,
+) -> std::result::Result<Response<BoxBody<Bytes, Infallible>>, Infallible> {
+    let method = req.method().clone();
+    let uri = req.uri().clone();
+
+    // Build the forwarded request
+    let mut builder = state.http_client.request(
+        reqwest::Method::from_bytes(method.as_str().as_bytes()).unwrap_or(reqwest::Method::GET),
+        uri.to_string(),
+    );
+
+    // Copy headers (except hop-by-hop headers)
+    for (name, value) in req.headers() {
+        if !is_hop_by_hop_header(name.as_str())
+            && let Ok(v) = value.to_str()
+        {
+            builder = builder.header(name.as_str(), v);
+        }
+    }
+
+    // Inject credentials if needed
+    if let NetworkDecision::AllowWithCredentials {
+        secret_name,
+        location,
+    } = decision
+    {
+        if let Some(credential) = state.credential_resolver.resolve(&secret_name).await {
+            builder = match location {
+                CredentialLocation::AuthorizationBearer => {
+                    builder.header("Authorization", format!("Bearer {}", credential))
+                }
+                CredentialLocation::Header { name, prefix } => {
+                    let value = match prefix {
+                        Some(p) => format!("{}{}", p, credential),
+                        None => credential.clone(),
+                    };
+                    builder.header(name, value)
+                }
+                CredentialLocation::QueryParam { name } => builder.query(&[(name, credential)]),
+                // Known limitation: AuthorizationBasic requires the proxy to
+                // construct a Base64 username:password pair from a single secret,
+                // and UrlPath requires rewriting the request URI. Neither is
+                // implemented yet. Containers needing these auth styles should
+                // fetch credentials via the orchestrator's GET /worker/{id}/credentials
+                // endpoint and set them directly.
+                CredentialLocation::AuthorizationBasic { .. }
+                | CredentialLocation::UrlPath { .. } => {
+                    tracing::warn!(
+                        "Proxy: credential location {:?} not supported for forward proxy, skipping",
+                        location
+                    );
+                    builder
+                }
+            };
+            tracing::debug!("Proxy: injected credential for {}", secret_name);
+        } else {
+            tracing::warn!("Proxy: credential {} not found", secret_name);
+        }
+    }
+
+    // Copy body
+    let body_bytes = match req.collect().await {
+        Ok(collected) => collected.to_bytes(),
+        Err(e) => {
+            tracing::error!("Proxy: failed to read request body: {}", e);
+            return Ok(error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Failed to read body".to_string(),
+            ));
+        }
+    };
+
+    if !body_bytes.is_empty() {
+        builder = builder.body(body_bytes.to_vec());
+    }
+
+    // Send the request
+    match builder.send().await {
+        Ok(response) => {
+            let status = response.status();
+            let headers = response.headers().clone();
+
+            match response.bytes().await {
+                Ok(body) => {
+                    let mut resp_builder = Response::builder().status(status.as_u16());
+
+                    for (name, value) in headers.iter() {
+                        if !is_hop_by_hop_header(name.as_str()) {
+                            resp_builder = resp_builder.header(name.as_str(), value.as_bytes());
+                        }
+                    }
+
+                    Ok(make_response_from_builder(resp_builder, full_body(body)))
+                }
+                Err(e) => {
+                    tracing::error!("Proxy: failed to read response body: {}", e);
+                    Ok(error_response(
+                        StatusCode::BAD_GATEWAY,
+                        "Failed to read response".to_string(),
+                    ))
+                }
+            }
+        }
+        Err(e) => {
+            tracing::error!("Proxy: request failed: {}", e);
+            Ok(error_response(
+                StatusCode::BAD_GATEWAY,
+                format!("Request failed: {}", e),
+            ))
+        }
+    }
+}
+
+/// Check if a header is hop-by-hop (should not be forwarded).
+fn is_hop_by_hop_header(name: &str) -> bool {
+    matches!(
+        name.to_lowercase().as_str(),
+        "connection"
+            | "keep-alive"
+            | "proxy-authenticate"
+            | "proxy-authorization"
+            | "te"
+            | "trailers"
+            | "transfer-encoding"
+            | "upgrade"
+    )
+}
+
+/// Build a response with guaranteed success (valid status + simple body cannot fail).
+fn make_response(
+    status: StatusCode,
+    body: BoxBody<Bytes, Infallible>,
+) -> Response<BoxBody<Bytes, Infallible>> {
+    Response::builder()
+        .status(status)
+        .body(body)
+        .unwrap_or_else(|_| {
+            let mut resp = Response::new(
+                Full::new(Bytes::from("Internal error"))
+                    .map_err(|_| unreachable!())
+                    .boxed(),
+            );
+            *resp.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
+            resp
+        })
+}
+
+/// Finalize a partially-built response, falling back to 500 on builder error.
+fn make_response_from_builder(
+    builder: hyper::http::response::Builder,
+    body: BoxBody<Bytes, Infallible>,
+) -> Response<BoxBody<Bytes, Infallible>> {
+    builder.body(body).unwrap_or_else(|_| {
+        Response::builder()
+            .status(StatusCode::INTERNAL_SERVER_ERROR)
+            .body(full_body(Bytes::from("Response build error")))
+            .unwrap_or_else(|_| {
+                Response::new(
+                    Full::new(Bytes::from("Internal error"))
+                        .map_err(|_| unreachable!())
+                        .boxed(),
+                )
+            })
+    })
+}
+
+/// Create an error response.
+fn error_response(status: StatusCode, message: String) -> Response<BoxBody<Bytes, Infallible>> {
+    make_response_from_builder(
+        Response::builder()
+            .status(status)
+            .header("Content-Type", "text/plain"),
+        full_body(Bytes::from(message)),
+    )
+}
+
+/// Create an empty body.
+fn empty_body() -> BoxBody<Bytes, Infallible> {
+    Empty::<Bytes>::new().map_err(|_| unreachable!()).boxed()
+}
+
+/// Create a body from bytes.
+fn full_body(bytes: Bytes) -> BoxBody<Bytes, Infallible> {
+    Full::new(bytes).map_err(|_| unreachable!()).boxed()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::allowlist::DomainAllowlist;
+    use crate::policy::DefaultPolicyDecider;
+
+    #[tokio::test]
+    async fn test_proxy_starts_and_stops() {
+        let allowlist = DomainAllowlist::new(&["example.com".to_string()]);
+        let decider = Arc::new(DefaultPolicyDecider::new(allowlist, vec![]));
+        let resolver = Arc::new(NoCredentialResolver);
+
+        let proxy = HttpProxy::new(decider, resolver);
+
+        let addr = proxy.start(0).await.unwrap();
+        assert!(proxy.is_running());
+        assert!(addr.port() > 0);
+
+        proxy.stop().await;
+        // Give it a moment to shut down
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    }
+
+    #[test]
+    fn test_hop_by_hop_headers() {
+        assert!(is_hop_by_hop_header("connection"));
+        assert!(is_hop_by_hop_header("Connection"));
+        assert!(is_hop_by_hop_header("transfer-encoding"));
+        assert!(!is_hop_by_hop_header("content-type"));
+        assert!(!is_hop_by_hop_header("authorization"));
+    }
+
+    #[test]
+    fn test_make_response_does_not_panic() {
+        let resp = make_response(StatusCode::OK, empty_body());
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let resp = error_response(StatusCode::FORBIDDEN, "denied".to_string());
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    }
+}

--- a/crates/dasclaw_net_proxy/src/lib.rs
+++ b/crates/dasclaw_net_proxy/src/lib.rs
@@ -1,24 +1,54 @@
-//! rama-based MITM proxy with self-signed CA (codex port).
+//! HTTP forward proxy with domain allowlist + credential injection.
 //!
-//! W1 skeleton — trait surface only, no impl.
-//! See `docs/plans/architecture-refactor/31-target-architecture.md` §4 for design.
+//! Ported from `ironclaw-main/src/sandbox/proxy/*` per ADR
+//! `docs/plans/architecture-refactor/43-net-proxy-port-adr.md` (W3.2b-1).
+//!
+//! # Architecture
+//!
+//! ```text
+//! ┌─────────────────────────────────────────────────────────────────┐
+//! │                      Network Proxy                               │
+//! │                                                                  │
+//! │  ┌─────────────┐    ┌─────────────┐    ┌─────────────────────┐  │
+//! │  │ HTTP Proxy  │───▶│   Policy    │───▶│ Credential Resolver │  │
+//! │  │   Server    │    │   Decider   │    │  (host-supplied)    │  │
+//! │  └─────────────┘    └─────────────┘    └─────────────────────┘  │
+//! │         │                  │                                     │
+//! │         │                  ▼                                     │
+//! │         │           ┌─────────────┐                             │
+//! │         │           │  Allowlist  │                             │
+//! │         │           │  Validator  │                             │
+//! │         │           └─────────────┘                             │
+//! │         ▼                                                        │
+//! │  ┌──────────────────────────────────────────────────────────┐   │
+//! │  │                    Internet                               │   │
+//! │  └──────────────────────────────────────────────────────────┘   │
+//! └─────────────────────────────────────────────────────────────────┘
+//! ```
+//!
+//! # Decoupling
+//!
+//! This crate is intentionally decoupled from any secrets-store backend:
+//! credential **resolution** is performed via the [`CredentialResolver`]
+//! trait, and credential **types** ([`CredentialMapping`], [`CredentialLocation`])
+//! are pure data structures. Wire a real backend (e.g. `secrets::SecretsStore`)
+//! by implementing [`CredentialResolver`] in the consuming crate.
+//!
+//! [`CredentialResolver`]: http::CredentialResolver
 
-#![allow(dead_code)]
+pub mod allowlist;
+pub mod builder;
+pub mod error;
+pub mod http;
+pub mod policy;
+pub mod types;
 
-/// Placeholder error type. Replaced with module-specific errors in W2+.
-#[derive(Debug, thiserror::Error)]
-#[error("dasclaw_net_proxy skeleton error: {0}")]
-pub struct SkeletonError(pub String);
-
-/// Primary entry trait (placeholder). Replaced with full surface in W2+.
-pub trait NetProxy {
-    /// rama-based MITM proxy with self-signed CA (codex port).
-    fn start(&self) -> Result<(), SkeletonError>;
-}
-
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn skeleton_compiles() { /* W1 placeholder */
-    }
-}
+pub use allowlist::{DomainAllowlist, DomainPattern, DomainValidationResult};
+pub use builder::{NetworkProxyBuilder, ProxyMode};
+pub use error::{ProxyError, Result};
+pub use http::{CredentialResolver, EnvCredentialResolver, HttpProxy, NoCredentialResolver};
+pub use policy::{
+    AllowAllDecider, DefaultPolicyDecider, DenyAllDecider, NetworkDecision, NetworkPolicyDecider,
+    NetworkRequest,
+};
+pub use types::{CredentialLocation, CredentialMapping};

--- a/crates/dasclaw_net_proxy/src/policy.rs
+++ b/crates/dasclaw_net_proxy/src/policy.rs
@@ -1,0 +1,306 @@
+//! Network policy decision making.
+//!
+//! Determines whether network requests should be allowed, denied,
+//! or allowed with credential injection.
+
+use async_trait::async_trait;
+
+use crate::allowlist::DomainAllowlist;
+use crate::types::{CredentialLocation, CredentialMapping};
+
+/// A network request to be evaluated.
+#[derive(Debug, Clone)]
+pub struct NetworkRequest {
+    /// HTTP method (GET, POST, etc.).
+    pub method: String,
+    /// Full URL being requested.
+    pub url: String,
+    /// Host extracted from URL.
+    pub host: String,
+    /// Path portion of the URL.
+    pub path: String,
+}
+
+impl NetworkRequest {
+    /// Create from a URL string.
+    pub fn from_url(method: &str, url: &str) -> Option<Self> {
+        let parsed = url::Url::parse(url).ok()?;
+        if !matches!(parsed.scheme(), "http" | "https") {
+            return None;
+        }
+
+        let host = parsed.host_str()?;
+        let host = host
+            .strip_prefix('[')
+            .and_then(|v| v.strip_suffix(']'))
+            .unwrap_or(host)
+            .to_lowercase();
+        let path = parsed.path().to_string();
+
+        Some(Self {
+            method: method.to_uppercase(),
+            url: url.to_string(),
+            host,
+            path,
+        })
+    }
+}
+
+/// Extract path from a URL.
+#[cfg(test)]
+fn extract_path(url: &str) -> String {
+    let Ok(parsed) = url::Url::parse(url) else {
+        return "/".to_string();
+    };
+    if !matches!(parsed.scheme(), "http" | "https") {
+        return "/".to_string();
+    }
+    parsed.path().to_string()
+}
+
+/// Decision for a network request.
+#[derive(Debug, Clone)]
+pub enum NetworkDecision {
+    /// Allow the request as-is.
+    Allow,
+    /// Allow with credential injection.
+    AllowWithCredentials {
+        /// Name of the secret to look up.
+        secret_name: String,
+        /// Where to inject the credential.
+        location: CredentialLocation,
+    },
+    /// Deny the request.
+    Deny {
+        /// Reason for denial.
+        reason: String,
+    },
+}
+
+impl NetworkDecision {
+    pub fn is_allowed(&self) -> bool {
+        !matches!(self, NetworkDecision::Deny { .. })
+    }
+}
+
+/// Trait for making network policy decisions.
+#[async_trait]
+pub trait NetworkPolicyDecider: Send + Sync {
+    /// Decide whether a request should be allowed.
+    async fn decide(&self, request: &NetworkRequest) -> NetworkDecision;
+}
+
+/// Default policy decider that uses allowlist and credential mappings.
+pub struct DefaultPolicyDecider {
+    allowlist: DomainAllowlist,
+    credential_mappings: Vec<CredentialMapping>,
+}
+
+impl DefaultPolicyDecider {
+    /// Create a new policy decider.
+    pub fn new(allowlist: DomainAllowlist, credential_mappings: Vec<CredentialMapping>) -> Self {
+        Self {
+            allowlist,
+            credential_mappings,
+        }
+    }
+
+    /// Find credential mapping for a host (supports glob patterns like `*.example.com`).
+    fn find_credential(&self, host: &str) -> Option<&CredentialMapping> {
+        let host_lower = host.to_lowercase();
+        self.credential_mappings.iter().find(|m| {
+            m.host_patterns
+                .iter()
+                .any(|pattern| host_matches_pattern(&host_lower, pattern))
+        })
+    }
+}
+
+#[async_trait]
+impl NetworkPolicyDecider for DefaultPolicyDecider {
+    async fn decide(&self, request: &NetworkRequest) -> NetworkDecision {
+        // First check if the domain is allowed
+        let validation = self.allowlist.is_allowed(&request.host);
+        if !validation.is_allowed()
+            && let crate::allowlist::DomainValidationResult::Denied(reason) = validation
+        {
+            return NetworkDecision::Deny { reason };
+        }
+
+        // Check if we need to inject credentials
+        if let Some(mapping) = self.find_credential(&request.host) {
+            return NetworkDecision::AllowWithCredentials {
+                secret_name: mapping.secret_name.clone(),
+                location: mapping.location.clone(),
+            };
+        }
+
+        NetworkDecision::Allow
+    }
+}
+
+/// Check if a host matches a pattern (supports `*.example.com` wildcards).
+fn host_matches_pattern(host: &str, pattern: &str) -> bool {
+    let pattern_lower = pattern.to_lowercase();
+    if pattern_lower == host {
+        return true;
+    }
+
+    // Support wildcard: *.example.com matches sub.example.com
+    if let Some(suffix) = pattern_lower.strip_prefix("*.")
+        && host.ends_with(suffix)
+        && host.len() > suffix.len()
+    {
+        let prefix = &host[..host.len() - suffix.len()];
+        if prefix.ends_with('.') || prefix.is_empty() {
+            return true;
+        }
+    }
+
+    false
+}
+
+/// A policy decider that allows everything (use with FullAccess policy).
+pub struct AllowAllDecider;
+
+#[async_trait]
+impl NetworkPolicyDecider for AllowAllDecider {
+    async fn decide(&self, _request: &NetworkRequest) -> NetworkDecision {
+        NetworkDecision::Allow
+    }
+}
+
+/// A policy decider that denies everything.
+pub struct DenyAllDecider {
+    reason: String,
+}
+
+impl DenyAllDecider {
+    pub fn new(reason: &str) -> Self {
+        Self {
+            reason: reason.to_string(),
+        }
+    }
+}
+
+#[async_trait]
+impl NetworkPolicyDecider for DenyAllDecider {
+    async fn decide(&self, _request: &NetworkRequest) -> NetworkDecision {
+        NetworkDecision::Deny {
+            reason: self.reason.clone(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_network_request_from_url() {
+        let req = NetworkRequest::from_url("GET", "https://api.example.com/v1/data").unwrap();
+        assert_eq!(req.method, "GET");
+        assert_eq!(req.host, "api.example.com");
+        assert_eq!(req.path, "/v1/data");
+    }
+
+    #[test]
+    fn test_extract_path() {
+        assert_eq!(
+            extract_path("https://example.com/api/v1"),
+            "/api/v1".to_string()
+        );
+        assert_eq!(extract_path("https://example.com"), "/".to_string());
+        assert_eq!(extract_path("https://example.com/"), "/".to_string());
+        assert_eq!(
+            extract_path("https://example.com/path?q=1#frag"),
+            "/path".to_string()
+        );
+        assert_eq!(extract_path("ftp://example.com/path"), "/".to_string());
+    }
+
+    #[tokio::test]
+    async fn test_default_policy_allows_listed_domain() {
+        let allowlist = DomainAllowlist::new(&["crates.io".to_string()]);
+        let decider = DefaultPolicyDecider::new(allowlist, vec![]);
+
+        let req = NetworkRequest::from_url("GET", "https://crates.io/api/v1/crates").unwrap();
+        let decision = decider.decide(&req).await;
+
+        assert!(decision.is_allowed());
+    }
+
+    #[tokio::test]
+    async fn test_default_policy_denies_unlisted_domain() {
+        let allowlist = DomainAllowlist::new(&["crates.io".to_string()]);
+        let decider = DefaultPolicyDecider::new(allowlist, vec![]);
+
+        let req = NetworkRequest::from_url("GET", "https://evil.com/steal").unwrap();
+        let decision = decider.decide(&req).await;
+
+        assert!(!decision.is_allowed());
+    }
+
+    #[tokio::test]
+    async fn test_credential_injection() {
+        let allowlist = DomainAllowlist::new(&["api.openai.com".to_string()]);
+        let credentials = vec![CredentialMapping::bearer(
+            "OPENAI_API_KEY",
+            "api.openai.com",
+        )];
+        let decider = DefaultPolicyDecider::new(allowlist, credentials);
+
+        let req =
+            NetworkRequest::from_url("POST", "https://api.openai.com/v1/chat/completions").unwrap();
+        let decision = decider.decide(&req).await;
+
+        match decision {
+            NetworkDecision::AllowWithCredentials { secret_name, .. } => {
+                assert_eq!(secret_name, "OPENAI_API_KEY");
+            }
+            _ => panic!("Expected AllowWithCredentials"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_credential_injection_with_wildcard_host_pattern() {
+        let allowlist =
+            DomainAllowlist::new(&["api.example.com".to_string(), "sub.example.com".to_string()]);
+        let credentials = vec![CredentialMapping {
+            secret_name: "EXAMPLE_KEY".to_string(),
+            location: CredentialLocation::AuthorizationBearer,
+            host_patterns: vec!["*.example.com".to_string()],
+            optional: false,
+        }];
+        let decider = DefaultPolicyDecider::new(allowlist, credentials);
+
+        let req = NetworkRequest::from_url("GET", "https://api.example.com/data").unwrap();
+        let decision = decider.decide(&req).await;
+
+        match decision {
+            NetworkDecision::AllowWithCredentials { secret_name, .. } => {
+                assert_eq!(secret_name, "EXAMPLE_KEY");
+            }
+            _ => panic!("Expected AllowWithCredentials for wildcard match"),
+        }
+
+        let req2 = NetworkRequest::from_url("GET", "https://sub.example.com/data").unwrap();
+        let decision2 = decider.decide(&req2).await;
+        assert!(
+            matches!(decision2, NetworkDecision::AllowWithCredentials { .. }),
+            "Wildcard pattern should match sub.example.com too"
+        );
+    }
+
+    #[test]
+    fn test_host_matches_pattern_exact() {
+        assert!(host_matches_pattern("api.openai.com", "api.openai.com"));
+        assert!(!host_matches_pattern("api.openai.com", "evil.com"));
+    }
+
+    #[test]
+    fn test_host_matches_pattern_wildcard() {
+        assert!(host_matches_pattern("api.example.com", "*.example.com"));
+        assert!(!host_matches_pattern("example.com", "*.example.com"));
+    }
+}

--- a/crates/dasclaw_net_proxy/src/types.rs
+++ b/crates/dasclaw_net_proxy/src/types.rs
@@ -1,0 +1,110 @@
+//! Credential injection types (decoupled from secrets backend).
+//!
+//! These mirror `ironclaw-main/src/secrets/types.rs` but contain only the
+//! pure-data structures needed by the proxy's policy engine. The actual
+//! credential **resolution** (looking up secret values) is delegated to
+//! the `CredentialResolver` trait so this crate has no dependency on any
+//! secrets-store implementation.
+
+use serde::{Deserialize, Serialize};
+
+/// Where a credential should be injected into an HTTP request.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum CredentialLocation {
+    /// `Authorization: Bearer {secret}`.
+    #[default]
+    AuthorizationBearer,
+    /// `Authorization: Basic base64(username:secret)`.
+    ///
+    /// Note: forward proxy implementation currently logs and skips this
+    /// location (requires base64-encoding a username:secret pair); tools
+    /// needing Basic auth should fetch credentials out-of-band.
+    AuthorizationBasic { username: String },
+    /// Custom header injection.
+    Header {
+        name: String,
+        prefix: Option<String>,
+    },
+    /// Query parameter injection.
+    QueryParam { name: String },
+    /// URL placeholder substitution.
+    ///
+    /// Note: forward proxy implementation currently logs and skips this
+    /// location (requires rewriting the request URI).
+    UrlPath { placeholder: String },
+}
+
+/// Mapping from a secret name to where/when it should be injected.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CredentialMapping {
+    /// Name of the secret to resolve.
+    pub secret_name: String,
+    /// Where to inject the resolved value.
+    pub location: CredentialLocation,
+    /// Host glob patterns this credential applies to (e.g. `*.openai.com`).
+    pub host_patterns: Vec<String>,
+    /// When `true`, the request proceeds even if the secret cannot be resolved.
+    ///
+    /// **Defaults to `false` (required)** so a tool that simply declares a
+    /// credential without explicitly opting into "optional" cannot be
+    /// silently downgraded to an unauthenticated request.
+    #[serde(default)]
+    pub optional: bool,
+}
+
+impl CredentialMapping {
+    /// Convenience constructor for a Bearer-token mapping.
+    pub fn bearer(secret_name: impl Into<String>, host_pattern: impl Into<String>) -> Self {
+        Self {
+            secret_name: secret_name.into(),
+            location: CredentialLocation::AuthorizationBearer,
+            host_patterns: vec![host_pattern.into()],
+            optional: false,
+        }
+    }
+
+    /// Convenience constructor for a custom-header mapping.
+    pub fn header(
+        secret_name: impl Into<String>,
+        header_name: impl Into<String>,
+        host_pattern: impl Into<String>,
+    ) -> Self {
+        Self {
+            secret_name: secret_name.into(),
+            location: CredentialLocation::Header {
+                name: header_name.into(),
+                prefix: None,
+            },
+            host_patterns: vec![host_pattern.into()],
+            optional: false,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bearer_default_optional_false() {
+        let m = CredentialMapping::bearer("OPENAI_API_KEY", "api.openai.com");
+        assert!(!m.optional, "Fail-Safe default: required, not optional");
+        assert_eq!(m.secret_name, "OPENAI_API_KEY");
+        assert!(matches!(
+            m.location,
+            CredentialLocation::AuthorizationBearer
+        ));
+    }
+
+    #[test]
+    fn header_with_no_prefix() {
+        let m = CredentialMapping::header("X_KEY", "X-Api-Key", "api.example.com");
+        match &m.location {
+            CredentialLocation::Header { name, prefix } => {
+                assert_eq!(name, "X-Api-Key");
+                assert!(prefix.is_none());
+            }
+            _ => panic!("expected Header"),
+        }
+    }
+}


### PR DESCRIPTION
## 概述

按 ADR [`43-net-proxy-port-adr.md`](docs/plans/architecture-refactor/43-net-proxy-port-adr.md) Tier B''+ 决议执行 W3.2b-1：把 ironclaw-main 已稳定的 HTTP forward proxy 移植到 `crates/dasclaw_net_proxy`，**复用 1199 LOC + 新增 296 LOC = 1495 LOC**。

## 范围

| 文件 | LOC | 来源 |
|---|---|---|
| `src/allowlist.rs` | 337 | 复用 ironclaw-main + 1 处解耦 (`Default` 不再读 sandbox::config) |
| `src/policy.rs` | 306 | 复用 ironclaw-main + imports rewire (`crate::secrets` -> `crate::types`) |
| `src/http.rs` | 552 | 复用 ironclaw-main + imports rewire (`SandboxError` -> `ProxyError`) |
| `src/types.rs` | 110 | **新建** `CredentialMapping` / `CredentialLocation`（与 secrets 后端解耦）|
| `src/error.rs` | 36 | **新建** `ProxyError` thiserror 枚举 |
| `src/builder.rs` | 150 | **新建** 简化的 `NetworkProxyBuilder` + `ProxyMode` 枚举（不依赖 SandboxConfig）|

## 解耦设计

W1 骨架原计划 "rama-based MITM proxy"，ADR Tier B''+ 改为复用 ironclaw-main forward proxy。本次实现关键解耦：

1. **secrets 后端解耦**：`CredentialResolver` trait 由消费方实现，本 crate 不依赖任何 secrets-store
2. **config 后端解耦**：`NetworkProxyBuilder` 移除 `from_config`，调用方通过 `with_*` 链式 API 注入
3. **error 类型独立**：`ProxyError` 替代 `SandboxError::ProxyError`，避免循环依赖

## 质量门禁

- `cargo build -p dasclaw_net_proxy`：0 errors / 0 warnings ✅
- `cargo nextest run -p dasclaw_net_proxy`：30/30 PASS ✅
- `cargo clippy --all-targets -- -D warnings`：clean ✅
- `cargo build --workspace`：clean ✅
- `scripts/check_no_panics.py`：OK ✅

## 后续 W3.2b 规划

- W3.2b-2 (~60 LOC)：`NetworkDenyReason` 枚举替代字符串 reason
- W3.2b-3 (~150 LOC)：Windows keychain (windows-rs CredWriteW/CredReadW)
- W3.2b-4 (~150 LOC)：desktop-client 集成 + `IronclawSecretsResolver` 桥接
- W3.2b-5 (~100 LOC)：e2e 测试 + 完成报告 `44-md`

## 注意

- Edition 升级 2021 → 2024（对齐 ironclaw-main，let-chains 需要）
- `AuthorizationBasic` / `UrlPath` 在 forward proxy 模式下记日志后跳过（非新引入限制，沿袭 ironclaw-main 设计）
- HTTPS CONNECT 隧道为 TCP-bidir 透传，不做 TLS MITM（不修改 TLS payload，因此凭据注入仅对 HTTP 直连请求生效）