### PR TITLE
feat(w3.2b-4): integrate dasclaw_net_proxy into desktop-client sandbox

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,6 +120,26 @@ cargo test -p ironclaw
 
 未装请：`cargo install cargo-nextest --locked`。CI 使用何种命令以仓库 workflow 为准（不强制改 CI）。
 
+### 构建缓存清理：默认使用 cargo sweep --time 3
+
+**磁盘满时优先用 `cargo sweep --time 3`，禁止用 `cargo clean` 或 `cargo sweep --time 0` 一次清干净**。一次性清掉全部产物会导致下次 build 需要从零重编全部依赖（10+ 分钟），sccache 也帮不上忙（增量缓存丢了）。
+
+```bash
+# 推荐：清掉 3 天没访问过的产物，保留近期增量缓存
+cargo sweep --time 3
+
+# 自动定时清理（cron）
+0 3 * * * cd ~/Documents/code/x-claw && cargo sweep --time 3
+
+# 禁止：一次清干净
+# cargo clean              ← 不要用
+# cargo sweep --time 0     ← 不要用
+```
+
+未装请：`cargo install cargo-sweep --locked`。
+
+详细工作流（含 sccache、`cargo build -p desktop-client --lib` 增量编译）见 [desktop-client/README.md](desktop-client/README.md)。
+
 ### 外部库使用
 
 - **先搜索项目中该库的现有用法**（`rg "libsql::" src/`），参考项目代码而非外部文档

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4627,6 +4627,7 @@ dependencies = [
  "cron",
  "crossterm",
  "dasclaw_exec",
+ "dasclaw_net_proxy",
  "dasclaw_sandbox",
  "deadpool-postgres",
  "dirs 6.0.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2465,9 +2465,19 @@ dependencies = [
 
 [[package]]
 name = "dasclaw_net_proxy"
-version = "0.0.0-w1"
+version = "0.1.0"
 dependencies = [
- "thiserror 1.0.69",
+ "async-trait",
+ "bytes",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-util",
+ "reqwest 0.12.28",
+ "serde",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "url",
 ]
 
 [[package]]

--- a/crates/dasclaw_net_proxy/Cargo.toml
+++ b/crates/dasclaw_net_proxy/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "dasclaw_net_proxy"
-version = "0.0.0-w1"
-edition = "2021"
-description = "rama-based MITM proxy with self-signed CA (codex port)."
+version = "0.1.0"
+edition = "2024"
+description = "HTTP forward proxy with domain allowlist + credential injection (ported from ironclaw-main)."
 license = "Apache-2.0 OR MIT"
 publish = false
 
@@ -10,4 +10,30 @@ publish = false
 path = "src/lib.rs"
 
 [dependencies]
-thiserror = "1"
+# Error handling
+thiserror = "2"
+
+# Async runtime
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "net", "io-util", "sync", "time"] }
+async-trait = "0.1"
+
+# HTTP server
+hyper = { version = "1.5", features = ["server", "http1", "http2"] }
+hyper-util = { version = "0.1", features = ["server", "tokio", "http1", "http2"] }
+http-body-util = "0.1"
+bytes = "1"
+
+# Outbound HTTP client
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls-native-roots"] }
+
+# URL parsing
+url = "2"
+
+# Logging
+tracing = "0.1"
+
+# Serialization (for CredentialMapping/CredentialLocation)
+serde = { version = "1", features = ["derive"] }
+
+[dev-dependencies]
+tokio = { version = "1", features = ["full", "test-util"] }

--- a/crates/dasclaw_net_proxy/src/allowlist.rs
+++ b/crates/dasclaw_net_proxy/src/allowlist.rs
@@ -5,6 +5,8 @@
 
 use std::fmt;
 
+use crate::reasons::NetworkDenyReason;
+
 /// Pattern for matching allowed domains.
 #[derive(Debug, Clone)]
 pub struct DomainPattern {
@@ -63,8 +65,9 @@ impl fmt::Display for DomainPattern {
 pub enum DomainValidationResult {
     /// Domain is allowed.
     Allowed,
-    /// Domain is denied with a reason.
-    Denied(String),
+    /// Domain is denied — the embedded reason is type-safe and renders
+    /// to the legacy free-form string via `Display`.
+    Denied(NetworkDenyReason),
 }
 
 impl DomainValidationResult {
@@ -100,7 +103,7 @@ impl DomainAllowlist {
     /// Check if a domain is allowed.
     pub fn is_allowed(&self, host: &str) -> DomainValidationResult {
         if self.patterns.is_empty() {
-            return DomainValidationResult::Denied("empty allowlist".to_string());
+            return DomainValidationResult::Denied(NetworkDenyReason::EmptyAllowlist);
         }
 
         for pattern in &self.patterns {
@@ -109,14 +112,12 @@ impl DomainAllowlist {
             }
         }
 
-        DomainValidationResult::Denied(format!(
-            "host '{}' not in allowlist: [{}]",
+        DomainValidationResult::Denied(NetworkDenyReason::host_not_allowed(
             host,
             self.patterns
                 .iter()
-                .map(|p| p.pattern())
-                .collect::<Vec<_>>()
-                .join(", ")
+                .map(|p| p.pattern().to_string())
+                .collect(),
         ))
     }
 

--- a/crates/dasclaw_net_proxy/src/allowlist.rs
+++ b/crates/dasclaw_net_proxy/src/allowlist.rs
@@ -1,0 +1,337 @@
+//! Domain allowlist for the network proxy.
+//!
+//! Validates that HTTP requests only go to allowed domains.
+//! Supports exact matches and wildcard patterns.
+
+use std::fmt;
+
+/// Pattern for matching allowed domains.
+#[derive(Debug, Clone)]
+pub struct DomainPattern {
+    /// The domain pattern (e.g., "api.example.com" or "*.example.com").
+    pattern: String,
+    /// Whether this is a wildcard pattern.
+    is_wildcard: bool,
+    /// The base domain for wildcard matching.
+    base_domain: String,
+}
+
+impl DomainPattern {
+    /// Create a new domain pattern.
+    pub fn new(pattern: &str) -> Self {
+        let is_wildcard = pattern.starts_with("*.");
+        let base_domain = if is_wildcard {
+            pattern[2..].to_lowercase()
+        } else {
+            pattern.to_lowercase()
+        };
+
+        Self {
+            pattern: pattern.to_string(),
+            is_wildcard,
+            base_domain,
+        }
+    }
+
+    /// Check if a host matches this pattern.
+    pub fn matches(&self, host: &str) -> bool {
+        let host_lower = host.to_lowercase();
+
+        if self.is_wildcard {
+            // *.example.com matches foo.example.com, bar.baz.example.com, example.com
+            host_lower == self.base_domain
+                || host_lower.ends_with(&format!(".{}", self.base_domain))
+        } else {
+            host_lower == self.base_domain
+        }
+    }
+
+    /// Get the pattern string.
+    pub fn pattern(&self) -> &str {
+        &self.pattern
+    }
+}
+
+impl fmt::Display for DomainPattern {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.pattern)
+    }
+}
+
+/// Result of domain validation.
+#[derive(Debug, Clone)]
+pub enum DomainValidationResult {
+    /// Domain is allowed.
+    Allowed,
+    /// Domain is denied with a reason.
+    Denied(String),
+}
+
+impl DomainValidationResult {
+    pub fn is_allowed(&self) -> bool {
+        matches!(self, DomainValidationResult::Allowed)
+    }
+}
+
+/// Validates domains against an allowlist.
+#[derive(Debug, Clone)]
+pub struct DomainAllowlist {
+    patterns: Vec<DomainPattern>,
+}
+
+impl DomainAllowlist {
+    /// Create a new allowlist from domain strings.
+    pub fn new(domains: &[String]) -> Self {
+        Self {
+            patterns: domains.iter().map(|d| DomainPattern::new(d)).collect(),
+        }
+    }
+
+    /// Create an empty allowlist (denies everything).
+    pub fn empty() -> Self {
+        Self { patterns: vec![] }
+    }
+
+    /// Add a domain pattern to the allowlist.
+    pub fn add(&mut self, pattern: &str) {
+        self.patterns.push(DomainPattern::new(pattern));
+    }
+
+    /// Check if a domain is allowed.
+    pub fn is_allowed(&self, host: &str) -> DomainValidationResult {
+        if self.patterns.is_empty() {
+            return DomainValidationResult::Denied("empty allowlist".to_string());
+        }
+
+        for pattern in &self.patterns {
+            if pattern.matches(host) {
+                return DomainValidationResult::Allowed;
+            }
+        }
+
+        DomainValidationResult::Denied(format!(
+            "host '{}' not in allowlist: [{}]",
+            host,
+            self.patterns
+                .iter()
+                .map(|p| p.pattern())
+                .collect::<Vec<_>>()
+                .join(", ")
+        ))
+    }
+
+    /// Get all patterns in the allowlist.
+    pub fn patterns(&self) -> &[DomainPattern] {
+        &self.patterns
+    }
+
+    /// Check if the allowlist is empty.
+    pub fn is_empty(&self) -> bool {
+        self.patterns.is_empty()
+    }
+
+    /// Get the number of patterns.
+    pub fn len(&self) -> usize {
+        self.patterns.len()
+    }
+}
+
+impl Default for DomainAllowlist {
+    /// Empty allowlist (denies everything). Callers should explicitly
+    /// supply a non-empty pattern list via [`DomainAllowlist::new`].
+    fn default() -> Self {
+        Self::empty()
+    }
+}
+
+/// Parse host from a URL string.
+pub fn extract_host(url: &str) -> Option<String> {
+    let parsed = url::Url::parse(url).ok()?;
+    if !matches!(parsed.scheme(), "http" | "https") {
+        return None;
+    }
+    parsed.host_str().map(|h| {
+        h.strip_prefix('[')
+            .and_then(|v| v.strip_suffix(']'))
+            .unwrap_or(h)
+            .to_lowercase()
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_exact_match() {
+        let pattern = DomainPattern::new("api.example.com");
+        assert!(pattern.matches("api.example.com"));
+        assert!(pattern.matches("API.EXAMPLE.COM"));
+        assert!(!pattern.matches("foo.api.example.com"));
+        assert!(!pattern.matches("example.com"));
+    }
+
+    #[test]
+    fn test_wildcard_match() {
+        let pattern = DomainPattern::new("*.example.com");
+        assert!(pattern.matches("api.example.com"));
+        assert!(pattern.matches("foo.bar.example.com"));
+        assert!(pattern.matches("example.com")); // Base domain also matches
+        assert!(!pattern.matches("exampleXcom"));
+        assert!(!pattern.matches("other.com"));
+    }
+
+    #[test]
+    fn test_allowlist_allows() {
+        let allowlist =
+            DomainAllowlist::new(&["crates.io".to_string(), "*.github.com".to_string()]);
+
+        assert!(allowlist.is_allowed("crates.io").is_allowed());
+        assert!(allowlist.is_allowed("api.github.com").is_allowed());
+        assert!(
+            !allowlist
+                .is_allowed("raw.githubusercontent.com")
+                .is_allowed()
+        );
+    }
+
+    #[test]
+    fn test_allowlist_denies() {
+        let allowlist = DomainAllowlist::new(&["crates.io".to_string()]);
+
+        let result = allowlist.is_allowed("evil.com");
+        assert!(!result.is_allowed());
+    }
+
+    #[test]
+    fn test_empty_allowlist() {
+        let allowlist = DomainAllowlist::empty();
+        assert!(!allowlist.is_allowed("anything.com").is_allowed());
+    }
+
+    #[test]
+    fn test_extract_host() {
+        assert_eq!(
+            extract_host("https://api.example.com/v1/endpoint"),
+            Some("api.example.com".to_string())
+        );
+        assert_eq!(
+            extract_host("http://localhost:8080/api"),
+            Some("localhost".to_string())
+        );
+        assert_eq!(
+            extract_host("https://EXAMPLE.COM"),
+            Some("example.com".to_string())
+        );
+        assert_eq!(
+            extract_host("https://user:pass@api.example.com:443/path"),
+            Some("api.example.com".to_string())
+        );
+        assert_eq!(
+            extract_host("http://[::1]:8080/path"),
+            Some("::1".to_string())
+        );
+        assert_eq!(extract_host("not-a-url"), None);
+        assert_eq!(extract_host("ftp://example.com/file"), None);
+    }
+
+    // === QA Plan P1 - 4.5: Adversarial allowlist tests ===
+
+    #[test]
+    fn test_subdomain_bypass_attempt() {
+        let allowlist = DomainAllowlist::new(&["api.example.com".to_string()]);
+
+        // Exact match should work
+        assert!(allowlist.is_allowed("api.example.com").is_allowed());
+
+        // Subdomain of exact match should NOT be allowed
+        assert!(!allowlist.is_allowed("evil.api.example.com").is_allowed());
+
+        // Similar-looking domains should NOT be allowed
+        assert!(
+            !allowlist
+                .is_allowed("api.example.com.evil.com")
+                .is_allowed()
+        );
+        assert!(!allowlist.is_allowed("api-example.com").is_allowed());
+        assert!(!allowlist.is_allowed("notapi.example.com").is_allowed());
+    }
+
+    #[test]
+    fn test_wildcard_depth() {
+        let allowlist = DomainAllowlist::new(&["*.github.com".to_string()]);
+
+        // Direct subdomain
+        assert!(allowlist.is_allowed("api.github.com").is_allowed());
+        // Multi-level subdomain
+        assert!(allowlist.is_allowed("a.b.c.github.com").is_allowed());
+        // Base domain itself
+        assert!(allowlist.is_allowed("github.com").is_allowed());
+
+        // But NOT a completely different domain
+        assert!(!allowlist.is_allowed("github.com.evil.com").is_allowed());
+        assert!(!allowlist.is_allowed("notgithub.com").is_allowed());
+    }
+
+    #[test]
+    fn test_case_insensitive_domains() {
+        let allowlist = DomainAllowlist::new(&["crates.io".to_string()]);
+
+        assert!(allowlist.is_allowed("CRATES.IO").is_allowed());
+        assert!(allowlist.is_allowed("Crates.Io").is_allowed());
+        assert!(allowlist.is_allowed("cRaTeS.iO").is_allowed());
+    }
+
+    #[test]
+    fn test_extract_host_with_credentials_in_url() {
+        // Credentials in URL should not affect host extraction
+        assert_eq!(
+            extract_host("https://secret_key:password@evil.com/exfil"),
+            Some("evil.com".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_host_port_ignored() {
+        // Port should not affect host extraction
+        assert_eq!(
+            extract_host("https://api.example.com:9999/path"),
+            Some("api.example.com".to_string())
+        );
+    }
+
+    #[test]
+    fn test_empty_and_single_pattern() {
+        // Empty allowlist denies everything
+        let empty = DomainAllowlist::empty();
+        assert!(!empty.is_allowed("localhost").is_allowed());
+        assert!(!empty.is_allowed("127.0.0.1").is_allowed());
+
+        // Single wildcard should allow subdomains but not unrelated domains
+        let single = DomainAllowlist::new(&["*.example.com".to_string()]);
+        assert!(single.is_allowed("any.example.com").is_allowed());
+        assert!(!single.is_allowed("other.org").is_allowed());
+    }
+
+    #[test]
+    fn test_ip_address_not_matched_by_domain() {
+        let allowlist = DomainAllowlist::new(&["example.com".to_string()]);
+
+        // IP addresses should NOT match domain names
+        assert!(!allowlist.is_allowed("93.184.216.34").is_allowed());
+        assert!(!allowlist.is_allowed("127.0.0.1").is_allowed());
+    }
+
+    #[test]
+    fn test_extract_host_ipv6() {
+        // IPv6 addresses with brackets stripped
+        assert_eq!(
+            extract_host("https://[::1]:8080/api"),
+            Some("::1".to_string())
+        );
+        assert_eq!(
+            extract_host("https://[2001:db8::1]/path"),
+            Some("2001:db8::1".to_string())
+        );
+    }
+}

--- a/crates/dasclaw_net_proxy/src/builder.rs
+++ b/crates/dasclaw_net_proxy/src/builder.rs
@@ -1,0 +1,150 @@
+//! Builder for assembling an [`HttpProxy`] from allowlist + credential mappings.
+//!
+//! Simplified port from `ironclaw-main/src/sandbox/proxy/mod.rs::NetworkProxyBuilder`.
+//! The `from_config` constructor is intentionally **not** ported — callers in
+//! W3.2b-4 wire the proxy from desktop-client `SandboxConfig` directly via
+//! `with_allowlist`/`with_credentials`/`with_credential_resolver`, keeping
+//! this crate decoupled from any specific config schema.
+
+use std::sync::Arc;
+
+use crate::allowlist::DomainAllowlist;
+use crate::error::Result;
+use crate::http::{CredentialResolver, EnvCredentialResolver, HttpProxy};
+use crate::policy::{AllowAllDecider, DefaultPolicyDecider, DenyAllDecider, NetworkPolicyDecider};
+use crate::types::CredentialMapping;
+
+/// What policy mode to apply when no custom decider is supplied.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ProxyMode {
+    /// Default: enforce allowlist + credential mappings.
+    #[default]
+    Restricted,
+    /// Allow everything (use only when caller has its own enforcement).
+    AllowAll,
+    /// Deny everything (kill-switch).
+    DenyAll,
+}
+
+/// Fluent builder for [`HttpProxy`].
+pub struct NetworkProxyBuilder {
+    allowlist: Vec<String>,
+    credential_mappings: Vec<CredentialMapping>,
+    credential_resolver: Arc<dyn CredentialResolver>,
+    mode: ProxyMode,
+    deny_reason: String,
+}
+
+impl NetworkProxyBuilder {
+    /// Create a new builder with safe defaults: empty allowlist, no
+    /// credentials, env-based resolver, [`ProxyMode::Restricted`].
+    ///
+    /// **Note**: an empty allowlist combined with `Restricted` mode denies
+    /// every request. Callers must add at least one allowed domain via
+    /// [`Self::with_allowlist`] or [`Self::allow_domain`].
+    pub fn new() -> Self {
+        Self {
+            allowlist: Vec::new(),
+            credential_mappings: Vec::new(),
+            credential_resolver: Arc::new(EnvCredentialResolver),
+            mode: ProxyMode::default(),
+            deny_reason: "denied by policy".to_string(),
+        }
+    }
+
+    pub fn with_allowlist(mut self, domains: Vec<String>) -> Self {
+        self.allowlist = domains;
+        self
+    }
+
+    pub fn allow_domain(mut self, domain: impl Into<String>) -> Self {
+        self.allowlist.push(domain.into());
+        self
+    }
+
+    pub fn with_credentials(mut self, mappings: Vec<CredentialMapping>) -> Self {
+        self.credential_mappings = mappings;
+        self
+    }
+
+    pub fn with_credential_resolver(mut self, resolver: Arc<dyn CredentialResolver>) -> Self {
+        self.credential_resolver = resolver;
+        self
+    }
+
+    pub fn with_mode(mut self, mode: ProxyMode) -> Self {
+        self.mode = mode;
+        self
+    }
+
+    pub fn with_deny_reason(mut self, reason: impl Into<String>) -> Self {
+        self.deny_reason = reason.into();
+        self
+    }
+
+    /// Assemble the proxy without starting it.
+    pub fn build(self) -> HttpProxy {
+        let decider: Arc<dyn NetworkPolicyDecider> = match self.mode {
+            ProxyMode::AllowAll => Arc::new(AllowAllDecider),
+            ProxyMode::DenyAll => Arc::new(DenyAllDecider::new(&self.deny_reason)),
+            ProxyMode::Restricted => Arc::new(DefaultPolicyDecider::new(
+                DomainAllowlist::new(&self.allowlist),
+                self.credential_mappings,
+            )),
+        };
+
+        HttpProxy::new(decider, self.credential_resolver)
+    }
+
+    /// Build the proxy and start listening on the given port (0 = auto).
+    pub async fn build_and_start(self, port: u16) -> Result<HttpProxy> {
+        let proxy = self.build();
+        proxy.start(port).await?;
+        Ok(proxy)
+    }
+}
+
+impl Default for NetworkProxyBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_is_restricted_with_empty_allowlist() {
+        let b = NetworkProxyBuilder::new();
+        assert_eq!(b.mode, ProxyMode::Restricted);
+        assert!(b.allowlist.is_empty());
+    }
+
+    #[test]
+    fn allow_domain_appends() {
+        let b = NetworkProxyBuilder::new()
+            .allow_domain("a.com")
+            .allow_domain("b.com");
+        assert_eq!(b.allowlist, vec!["a.com".to_string(), "b.com".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn builds_proxy_in_each_mode() {
+        for mode in [
+            ProxyMode::Restricted,
+            ProxyMode::AllowAll,
+            ProxyMode::DenyAll,
+        ] {
+            let proxy = NetworkProxyBuilder::new()
+                .with_mode(mode)
+                .allow_domain("example.com")
+                .build();
+            assert!(
+                !proxy.is_running(),
+                "mode {:?}: proxy must not auto-start",
+                mode
+            );
+        }
+    }
+}

--- a/crates/dasclaw_net_proxy/src/error.rs
+++ b/crates/dasclaw_net_proxy/src/error.rs
@@ -1,0 +1,36 @@
+//! Error types for the network proxy.
+
+use std::io;
+
+/// Result alias for proxy operations.
+pub type Result<T> = std::result::Result<T, ProxyError>;
+
+/// Errors emitted by the network-proxy crate.
+#[derive(Debug, thiserror::Error)]
+pub enum ProxyError {
+    /// Failed to bind the listener or get its local address.
+    #[error("proxy bind failure: {reason}")]
+    Bind { reason: String },
+
+    /// Lower-level I/O error.
+    #[error("proxy io error: {0}")]
+    Io(#[from] io::Error),
+
+    /// Generic proxy error (forwarding, decoding, ...).
+    #[error("proxy error: {reason}")]
+    Other { reason: String },
+}
+
+impl ProxyError {
+    pub fn bind(reason: impl Into<String>) -> Self {
+        Self::Bind {
+            reason: reason.into(),
+        }
+    }
+
+    pub fn other(reason: impl Into<String>) -> Self {
+        Self::Other {
+            reason: reason.into(),
+        }
+    }
+}

--- a/crates/dasclaw_net_proxy/src/http.rs
+++ b/crates/dasclaw_net_proxy/src/http.rs
@@ -1,0 +1,552 @@
+//! HTTP proxy server for sandboxed network access.
+//!
+//! This proxy runs on the host and handles all network requests from containers.
+//! It validates requests against the allowlist and injects credentials when needed.
+//!
+//! ```text
+//! Container ──► http_proxy=host.docker.internal:PORT ──► This Proxy ──► Internet
+//!                                                             │
+//!                                                             ├─► Validate domain
+//!                                                             ├─► Inject credentials
+//!                                                             └─► Log requests
+//! ```
+
+use std::convert::Infallible;
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use bytes::Bytes;
+use http_body_util::{BodyExt, Empty, Full, combinators::BoxBody};
+use hyper::server::conn::http1;
+use hyper::service::service_fn;
+use hyper::{Method, Request, Response, StatusCode};
+use hyper_util::rt::TokioIo;
+use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::RwLock;
+
+use crate::error::{ProxyError, Result};
+use crate::policy::{NetworkDecision, NetworkPolicyDecider, NetworkRequest};
+use crate::types::CredentialLocation;
+
+/// State shared across proxy connections.
+struct ProxyState {
+    /// Policy decider for network requests.
+    decider: Arc<dyn NetworkPolicyDecider>,
+    /// Credential resolver (maps secret names to values).
+    credential_resolver: Arc<dyn CredentialResolver>,
+    /// Shared HTTP client for forwarding requests.
+    http_client: reqwest::Client,
+    /// Request counter for logging.
+    request_count: std::sync::atomic::AtomicU64,
+    /// Whether the proxy is running.
+    running: std::sync::atomic::AtomicBool,
+}
+
+/// Resolves secret names to their values.
+#[async_trait::async_trait]
+pub trait CredentialResolver: Send + Sync {
+    /// Get the value of a secret by name.
+    async fn resolve(&self, name: &str) -> Option<String>;
+}
+
+/// A credential resolver that uses environment variables.
+pub struct EnvCredentialResolver;
+
+#[async_trait::async_trait]
+impl CredentialResolver for EnvCredentialResolver {
+    async fn resolve(&self, name: &str) -> Option<String> {
+        std::env::var(name).ok()
+    }
+}
+
+/// A credential resolver that returns nothing (for testing).
+pub struct NoCredentialResolver;
+
+#[async_trait::async_trait]
+impl CredentialResolver for NoCredentialResolver {
+    async fn resolve(&self, _name: &str) -> Option<String> {
+        None
+    }
+}
+
+/// HTTP proxy server.
+pub struct HttpProxy {
+    state: Arc<ProxyState>,
+    addr: RwLock<Option<SocketAddr>>,
+    shutdown_tx: RwLock<Option<tokio::sync::oneshot::Sender<()>>>,
+}
+
+impl HttpProxy {
+    /// Create a new HTTP proxy.
+    pub fn new(
+        decider: Arc<dyn NetworkPolicyDecider>,
+        credential_resolver: Arc<dyn CredentialResolver>,
+    ) -> Self {
+        Self {
+            state: Arc::new(ProxyState {
+                decider,
+                credential_resolver,
+                http_client: reqwest::Client::new(),
+                request_count: std::sync::atomic::AtomicU64::new(0),
+                running: std::sync::atomic::AtomicBool::new(false),
+            }),
+            addr: RwLock::new(None),
+            shutdown_tx: RwLock::new(None),
+        }
+    }
+
+    /// Start the proxy server on the given port (0 for auto-assign).
+    pub async fn start(&self, port: u16) -> Result<SocketAddr> {
+        let listener = TcpListener::bind(format!("127.0.0.1:{}", port))
+            .await
+            .map_err(|e| ProxyError::bind(format!("failed to bind: {}", e)))?;
+
+        let addr = listener
+            .local_addr()
+            .map_err(|e| ProxyError::bind(format!("failed to get local addr: {}", e)))?;
+
+        *self.addr.write().await = Some(addr);
+
+        let (shutdown_tx, mut shutdown_rx) = tokio::sync::oneshot::channel();
+        *self.shutdown_tx.write().await = Some(shutdown_tx);
+
+        self.state
+            .running
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+
+        let state = self.state.clone();
+
+        tokio::spawn(async move {
+            tracing::info!("Sandbox proxy started on {}", addr);
+
+            loop {
+                tokio::select! {
+                    accept_result = listener.accept() => {
+                        match accept_result {
+                            Ok((stream, _)) => {
+                                let io = TokioIo::new(stream);
+                                let state = state.clone();
+
+                                tokio::spawn(async move {
+                                    let service = service_fn(move |req| {
+                                        let state = state.clone();
+                                        async move { handle_request(req, state).await }
+                                    });
+
+                                    if let Err(e) = http1::Builder::new()
+                                        .preserve_header_case(true)
+                                        .title_case_headers(true)
+                                        .serve_connection(io, service)
+                                        .with_upgrades()
+                                        .await
+                                    {
+                                        tracing::debug!("Proxy connection error: {}", e);
+                                    }
+                                });
+                            }
+                            Err(e) => {
+                                tracing::error!("Proxy accept error: {}", e);
+                            }
+                        }
+                    }
+                    _ = &mut shutdown_rx => {
+                        tracing::debug!("Sandbox proxy shutting down");
+                        break;
+                    }
+                }
+            }
+
+            state
+                .running
+                .store(false, std::sync::atomic::Ordering::SeqCst);
+        });
+
+        Ok(addr)
+    }
+
+    /// Stop the proxy server.
+    pub async fn stop(&self) {
+        if let Some(tx) = self.shutdown_tx.write().await.take() {
+            let _ = tx.send(());
+        }
+    }
+
+    /// Get the address the proxy is listening on.
+    pub async fn addr(&self) -> Option<SocketAddr> {
+        *self.addr.read().await
+    }
+
+    /// Check if the proxy is running.
+    pub fn is_running(&self) -> bool {
+        self.state.running.load(std::sync::atomic::Ordering::SeqCst)
+    }
+
+    /// Get the number of requests handled.
+    pub fn request_count(&self) -> u64 {
+        self.state
+            .request_count
+            .load(std::sync::atomic::Ordering::SeqCst)
+    }
+}
+
+/// Handle an incoming proxy request.
+async fn handle_request(
+    req: Request<hyper::body::Incoming>,
+    state: Arc<ProxyState>,
+) -> std::result::Result<Response<BoxBody<Bytes, Infallible>>, Infallible> {
+    state
+        .request_count
+        .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+
+    // Handle CONNECT method for HTTPS tunneling
+    if req.method() == Method::CONNECT {
+        return Ok(handle_connect(req, state).await);
+    }
+
+    // For HTTP requests, validate and forward
+    let uri = req.uri().to_string();
+    let method = req.method().to_string();
+
+    let network_req = match NetworkRequest::from_url(&method, &uri) {
+        Some(r) => r,
+        None => {
+            tracing::warn!("Proxy: invalid URL: {}", uri);
+            return Ok(error_response(
+                StatusCode::BAD_REQUEST,
+                "Invalid URL".to_string(),
+            ));
+        }
+    };
+
+    // Make policy decision
+    let decision = state.decider.decide(&network_req).await;
+
+    match decision {
+        NetworkDecision::Deny { reason } => {
+            tracing::info!("Proxy: blocked {} {} - {}", method, uri, reason);
+            Ok(error_response(StatusCode::FORBIDDEN, reason))
+        }
+        NetworkDecision::Allow | NetworkDecision::AllowWithCredentials { .. } => {
+            // Forward the request
+            forward_request(req, decision, state).await
+        }
+    }
+}
+
+/// Handle CONNECT method for HTTPS tunneling.
+///
+/// Establishes a bidirectional TCP tunnel between the client and the target host.
+/// Returns 200 OK to signal the client to begin TLS over the upgraded connection.
+///
+/// NOTE: Credential injection is not possible through CONNECT tunnels since the proxy
+/// cannot inspect or modify TLS-encrypted traffic without MITM. Containers that need
+/// authenticated HTTPS should fetch credentials via the orchestrator's
+/// `GET /worker/{id}/credentials` endpoint and set them as environment variables.
+async fn handle_connect(
+    req: Request<hyper::body::Incoming>,
+    state: Arc<ProxyState>,
+) -> Response<BoxBody<Bytes, Infallible>> {
+    // Extract host:port from CONNECT target (e.g. "api.github.com:443")
+    let authority = match req.uri().authority() {
+        Some(a) => a.clone(),
+        None => {
+            return error_response(StatusCode::BAD_REQUEST, "Missing host".to_string());
+        }
+    };
+
+    let host = authority.host().to_string();
+    let target_addr = authority.as_str().to_string();
+
+    // Check if host is allowed
+    let network_req = NetworkRequest {
+        method: "CONNECT".to_string(),
+        url: format!("https://{}", host),
+        host: host.clone(),
+        path: "/".to_string(),
+    };
+
+    let decision = state.decider.decide(&network_req).await;
+
+    if let NetworkDecision::Deny { reason } = decision {
+        tracing::info!("Proxy: blocked CONNECT {} - {}", host, reason);
+        return error_response(StatusCode::FORBIDDEN, reason);
+    }
+
+    tracing::debug!("Proxy: allowing CONNECT to {}", target_addr);
+
+    // Spawn a fire-and-forget task to establish the tunnel after the upgrade
+    // completes.  The 30-minute timeout guarantees every tunnel task terminates
+    // even if the remote peer hangs, so no `JoinSet` tracking is needed.
+    // On process exit these tasks are dropped by the runtime.
+    let target = target_addr.clone();
+    tokio::spawn(async move {
+        match hyper::upgrade::on(req).await {
+            Ok(upgraded) => {
+                let mut client_stream = TokioIo::new(upgraded);
+                match TcpStream::connect(&target).await {
+                    Ok(mut server_stream) => {
+                        let tunnel_timeout = std::time::Duration::from_secs(30 * 60);
+                        match tokio::time::timeout(
+                            tunnel_timeout,
+                            tokio::io::copy_bidirectional(&mut client_stream, &mut server_stream),
+                        )
+                        .await
+                        {
+                            Ok(Ok(_)) => {}
+                            Ok(Err(e)) => {
+                                tracing::debug!("Proxy: tunnel to {} closed: {}", target, e);
+                            }
+                            Err(_) => {
+                                tracing::info!(
+                                    "Proxy: tunnel to {} timed out after 30m, closing",
+                                    target
+                                );
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        tracing::error!("Proxy: failed to connect to {}: {}", target, e);
+                    }
+                }
+            }
+            Err(e) => {
+                tracing::error!("Proxy: upgrade failed for {}: {}", target, e);
+            }
+        }
+    });
+
+    // Return 200 OK so the client begins the TLS handshake over the upgraded connection
+    make_response(StatusCode::OK, empty_body())
+}
+
+/// Forward a request to the target server.
+async fn forward_request(
+    req: Request<hyper::body::Incoming>,
+    decision: NetworkDecision,
+    state: Arc<ProxyState>,
+) -> std::result::Result<Response<BoxBody<Bytes, Infallible>>, Infallible> {
+    let method = req.method().clone();
+    let uri = req.uri().clone();
+
+    // Build the forwarded request
+    let mut builder = state.http_client.request(
+        reqwest::Method::from_bytes(method.as_str().as_bytes()).unwrap_or(reqwest::Method::GET),
+        uri.to_string(),
+    );
+
+    // Copy headers (except hop-by-hop headers)
+    for (name, value) in req.headers() {
+        if !is_hop_by_hop_header(name.as_str())
+            && let Ok(v) = value.to_str()
+        {
+            builder = builder.header(name.as_str(), v);
+        }
+    }
+
+    // Inject credentials if needed
+    if let NetworkDecision::AllowWithCredentials {
+        secret_name,
+        location,
+    } = decision
+    {
+        if let Some(credential) = state.credential_resolver.resolve(&secret_name).await {
+            builder = match location {
+                CredentialLocation::AuthorizationBearer => {
+                    builder.header("Authorization", format!("Bearer {}", credential))
+                }
+                CredentialLocation::Header { name, prefix } => {
+                    let value = match prefix {
+                        Some(p) => format!("{}{}", p, credential),
+                        None => credential.clone(),
+                    };
+                    builder.header(name, value)
+                }
+                CredentialLocation::QueryParam { name } => builder.query(&[(name, credential)]),
+                // Known limitation: AuthorizationBasic requires the proxy to
+                // construct a Base64 username:password pair from a single secret,
+                // and UrlPath requires rewriting the request URI. Neither is
+                // implemented yet. Containers needing these auth styles should
+                // fetch credentials via the orchestrator's GET /worker/{id}/credentials
+                // endpoint and set them directly.
+                CredentialLocation::AuthorizationBasic { .. }
+                | CredentialLocation::UrlPath { .. } => {
+                    tracing::warn!(
+                        "Proxy: credential location {:?} not supported for forward proxy, skipping",
+                        location
+                    );
+                    builder
+                }
+            };
+            tracing::debug!("Proxy: injected credential for {}", secret_name);
+        } else {
+            tracing::warn!("Proxy: credential {} not found", secret_name);
+        }
+    }
+
+    // Copy body
+    let body_bytes = match req.collect().await {
+        Ok(collected) => collected.to_bytes(),
+        Err(e) => {
+            tracing::error!("Proxy: failed to read request body: {}", e);
+            return Ok(error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Failed to read body".to_string(),
+            ));
+        }
+    };
+
+    if !body_bytes.is_empty() {
+        builder = builder.body(body_bytes.to_vec());
+    }
+
+    // Send the request
+    match builder.send().await {
+        Ok(response) => {
+            let status = response.status();
+            let headers = response.headers().clone();
+
+            match response.bytes().await {
+                Ok(body) => {
+                    let mut resp_builder = Response::builder().status(status.as_u16());
+
+                    for (name, value) in headers.iter() {
+                        if !is_hop_by_hop_header(name.as_str()) {
+                            resp_builder = resp_builder.header(name.as_str(), value.as_bytes());
+                        }
+                    }
+
+                    Ok(make_response_from_builder(resp_builder, full_body(body)))
+                }
+                Err(e) => {
+                    tracing::error!("Proxy: failed to read response body: {}", e);
+                    Ok(error_response(
+                        StatusCode::BAD_GATEWAY,
+                        "Failed to read response".to_string(),
+                    ))
+                }
+            }
+        }
+        Err(e) => {
+            tracing::error!("Proxy: request failed: {}", e);
+            Ok(error_response(
+                StatusCode::BAD_GATEWAY,
+                format!("Request failed: {}", e),
+            ))
+        }
+    }
+}
+
+/// Check if a header is hop-by-hop (should not be forwarded).
+fn is_hop_by_hop_header(name: &str) -> bool {
+    matches!(
+        name.to_lowercase().as_str(),
+        "connection"
+            | "keep-alive"
+            | "proxy-authenticate"
+            | "proxy-authorization"
+            | "te"
+            | "trailers"
+            | "transfer-encoding"
+            | "upgrade"
+    )
+}
+
+/// Build a response with guaranteed success (valid status + simple body cannot fail).
+fn make_response(
+    status: StatusCode,
+    body: BoxBody<Bytes, Infallible>,
+) -> Response<BoxBody<Bytes, Infallible>> {
+    Response::builder()
+        .status(status)
+        .body(body)
+        .unwrap_or_else(|_| {
+            let mut resp = Response::new(
+                Full::new(Bytes::from("Internal error"))
+                    .map_err(|_| unreachable!())
+                    .boxed(),
+            );
+            *resp.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;
+            resp
+        })
+}
+
+/// Finalize a partially-built response, falling back to 500 on builder error.
+fn make_response_from_builder(
+    builder: hyper::http::response::Builder,
+    body: BoxBody<Bytes, Infallible>,
+) -> Response<BoxBody<Bytes, Infallible>> {
+    builder.body(body).unwrap_or_else(|_| {
+        Response::builder()
+            .status(StatusCode::INTERNAL_SERVER_ERROR)
+            .body(full_body(Bytes::from("Response build error")))
+            .unwrap_or_else(|_| {
+                Response::new(
+                    Full::new(Bytes::from("Internal error"))
+                        .map_err(|_| unreachable!())
+                        .boxed(),
+                )
+            })
+    })
+}
+
+/// Create an error response.
+fn error_response(status: StatusCode, message: String) -> Response<BoxBody<Bytes, Infallible>> {
+    make_response_from_builder(
+        Response::builder()
+            .status(status)
+            .header("Content-Type", "text/plain"),
+        full_body(Bytes::from(message)),
+    )
+}
+
+/// Create an empty body.
+fn empty_body() -> BoxBody<Bytes, Infallible> {
+    Empty::<Bytes>::new().map_err(|_| unreachable!()).boxed()
+}
+
+/// Create a body from bytes.
+fn full_body(bytes: Bytes) -> BoxBody<Bytes, Infallible> {
+    Full::new(bytes).map_err(|_| unreachable!()).boxed()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::allowlist::DomainAllowlist;
+    use crate::policy::DefaultPolicyDecider;
+
+    #[tokio::test]
+    async fn test_proxy_starts_and_stops() {
+        let allowlist = DomainAllowlist::new(&["example.com".to_string()]);
+        let decider = Arc::new(DefaultPolicyDecider::new(allowlist, vec![]));
+        let resolver = Arc::new(NoCredentialResolver);
+
+        let proxy = HttpProxy::new(decider, resolver);
+
+        let addr = proxy.start(0).await.unwrap();
+        assert!(proxy.is_running());
+        assert!(addr.port() > 0);
+
+        proxy.stop().await;
+        // Give it a moment to shut down
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    }
+
+    #[test]
+    fn test_hop_by_hop_headers() {
+        assert!(is_hop_by_hop_header("connection"));
+        assert!(is_hop_by_hop_header("Connection"));
+        assert!(is_hop_by_hop_header("transfer-encoding"));
+        assert!(!is_hop_by_hop_header("content-type"));
+        assert!(!is_hop_by_hop_header("authorization"));
+    }
+
+    #[test]
+    fn test_make_response_does_not_panic() {
+        let resp = make_response(StatusCode::OK, empty_body());
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let resp = error_response(StatusCode::FORBIDDEN, "denied".to_string());
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    }
+}

--- a/crates/dasclaw_net_proxy/src/http.rs
+++ b/crates/dasclaw_net_proxy/src/http.rs
@@ -26,6 +26,7 @@ use tokio::sync::RwLock;
 
 use crate::error::{ProxyError, Result};
 use crate::policy::{NetworkDecision, NetworkPolicyDecider, NetworkRequest};
+use crate::reasons::NetworkDenyReason;
 use crate::types::CredentialLocation;
 
 /// State shared across proxy connections.
@@ -210,11 +211,9 @@ async fn handle_request(
     let network_req = match NetworkRequest::from_url(&method, &uri) {
         Some(r) => r,
         None => {
-            tracing::warn!("Proxy: invalid URL: {}", uri);
-            return Ok(error_response(
-                StatusCode::BAD_REQUEST,
-                "Invalid URL".to_string(),
-            ));
+            let reason = NetworkDenyReason::invalid_url(uri.clone());
+            tracing::warn!("Proxy: invalid URL ({}): {}", reason.kind(), uri);
+            return Ok(error_response(StatusCode::BAD_REQUEST, reason.to_string()));
         }
     };
 
@@ -223,8 +222,14 @@ async fn handle_request(
 
     match decision {
         NetworkDecision::Deny { reason } => {
-            tracing::info!("Proxy: blocked {} {} - {}", method, uri, reason);
-            Ok(error_response(StatusCode::FORBIDDEN, reason))
+            tracing::info!(
+                "Proxy: blocked {} {} - kind={} ({})",
+                method,
+                uri,
+                reason.kind(),
+                reason
+            );
+            Ok(error_response(StatusCode::FORBIDDEN, reason.to_string()))
         }
         NetworkDecision::Allow | NetworkDecision::AllowWithCredentials { .. } => {
             // Forward the request
@@ -250,7 +255,10 @@ async fn handle_connect(
     let authority = match req.uri().authority() {
         Some(a) => a.clone(),
         None => {
-            return error_response(StatusCode::BAD_REQUEST, "Missing host".to_string());
+            return error_response(
+                StatusCode::BAD_REQUEST,
+                NetworkDenyReason::MissingHost.to_string(),
+            );
         }
     };
 
@@ -268,8 +276,13 @@ async fn handle_connect(
     let decision = state.decider.decide(&network_req).await;
 
     if let NetworkDecision::Deny { reason } = decision {
-        tracing::info!("Proxy: blocked CONNECT {} - {}", host, reason);
-        return error_response(StatusCode::FORBIDDEN, reason);
+        tracing::info!(
+            "Proxy: blocked CONNECT {} - kind={} ({})",
+            host,
+            reason.kind(),
+            reason
+        );
+        return error_response(StatusCode::FORBIDDEN, reason.to_string());
     }
 
     tracing::debug!("Proxy: allowing CONNECT to {}", target_addr);

--- a/crates/dasclaw_net_proxy/src/lib.rs
+++ b/crates/dasclaw_net_proxy/src/lib.rs
@@ -1,24 +1,54 @@
-//! rama-based MITM proxy with self-signed CA (codex port).
+//! HTTP forward proxy with domain allowlist + credential injection.
 //!
-//! W1 skeleton — trait surface only, no impl.
-//! See `docs/plans/architecture-refactor/31-target-architecture.md` §4 for design.
+//! Ported from `ironclaw-main/src/sandbox/proxy/*` per ADR
+//! `docs/plans/architecture-refactor/43-net-proxy-port-adr.md` (W3.2b-1).
+//!
+//! # Architecture
+//!
+//! ```text
+//! ┌─────────────────────────────────────────────────────────────────┐
+//! │                      Network Proxy                               │
+//! │                                                                  │
+//! │  ┌─────────────┐    ┌─────────────┐    ┌─────────────────────┐  │
+//! │  │ HTTP Proxy  │───▶│   Policy    │───▶│ Credential Resolver │  │
+//! │  │   Server    │    │   Decider   │    │  (host-supplied)    │  │
+//! │  └─────────────┘    └─────────────┘    └─────────────────────┘  │
+//! │         │                  │                                     │
+//! │         │                  ▼                                     │
+//! │         │           ┌─────────────┐                             │
+//! │         │           │  Allowlist  │                             │
+//! │         │           │  Validator  │                             │
+//! │         │           └─────────────┘                             │
+//! │         ▼                                                        │
+//! │  ┌──────────────────────────────────────────────────────────┐   │
+//! │  │                    Internet                               │   │
+//! │  └──────────────────────────────────────────────────────────┘   │
+//! └─────────────────────────────────────────────────────────────────┘
+//! ```
+//!
+//! # Decoupling
+//!
+//! This crate is intentionally decoupled from any secrets-store backend:
+//! credential **resolution** is performed via the [`CredentialResolver`]
+//! trait, and credential **types** ([`CredentialMapping`], [`CredentialLocation`])
+//! are pure data structures. Wire a real backend (e.g. `secrets::SecretsStore`)
+//! by implementing [`CredentialResolver`] in the consuming crate.
+//!
+//! [`CredentialResolver`]: http::CredentialResolver
 
-#![allow(dead_code)]
+pub mod allowlist;
+pub mod builder;
+pub mod error;
+pub mod http;
+pub mod policy;
+pub mod types;
 
-/// Placeholder error type. Replaced with module-specific errors in W2+.
-#[derive(Debug, thiserror::Error)]
-#[error("dasclaw_net_proxy skeleton error: {0}")]
-pub struct SkeletonError(pub String);
-
-/// Primary entry trait (placeholder). Replaced with full surface in W2+.
-pub trait NetProxy {
-    /// rama-based MITM proxy with self-signed CA (codex port).
-    fn start(&self) -> Result<(), SkeletonError>;
-}
-
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn skeleton_compiles() { /* W1 placeholder */
-    }
-}
+pub use allowlist::{DomainAllowlist, DomainPattern, DomainValidationResult};
+pub use builder::{NetworkProxyBuilder, ProxyMode};
+pub use error::{ProxyError, Result};
+pub use http::{CredentialResolver, EnvCredentialResolver, HttpProxy, NoCredentialResolver};
+pub use policy::{
+    AllowAllDecider, DefaultPolicyDecider, DenyAllDecider, NetworkDecision, NetworkPolicyDecider,
+    NetworkRequest,
+};
+pub use types::{CredentialLocation, CredentialMapping};

--- a/crates/dasclaw_net_proxy/src/lib.rs
+++ b/crates/dasclaw_net_proxy/src/lib.rs
@@ -41,6 +41,7 @@ pub mod builder;
 pub mod error;
 pub mod http;
 pub mod policy;
+pub mod reasons;
 pub mod types;
 
 pub use allowlist::{DomainAllowlist, DomainPattern, DomainValidationResult};
@@ -51,4 +52,5 @@ pub use policy::{
     AllowAllDecider, DefaultPolicyDecider, DenyAllDecider, NetworkDecision, NetworkPolicyDecider,
     NetworkRequest,
 };
+pub use reasons::NetworkDenyReason;
 pub use types::{CredentialLocation, CredentialMapping};

--- a/crates/dasclaw_net_proxy/src/policy.rs
+++ b/crates/dasclaw_net_proxy/src/policy.rs
@@ -6,6 +6,7 @@
 use async_trait::async_trait;
 
 use crate::allowlist::DomainAllowlist;
+use crate::reasons::NetworkDenyReason;
 use crate::types::{CredentialLocation, CredentialMapping};
 
 /// A network request to be evaluated.
@@ -72,8 +73,8 @@ pub enum NetworkDecision {
     },
     /// Deny the request.
     Deny {
-        /// Reason for denial.
-        reason: String,
+        /// Type-safe reason. Renders to a human string via `Display`.
+        reason: NetworkDenyReason,
     },
 }
 
@@ -172,14 +173,20 @@ impl NetworkPolicyDecider for AllowAllDecider {
 
 /// A policy decider that denies everything.
 pub struct DenyAllDecider {
-    reason: String,
+    reason: NetworkDenyReason,
 }
 
 impl DenyAllDecider {
-    pub fn new(reason: &str) -> Self {
+    /// Build a kill-switch decider with operator-supplied detail.
+    pub fn new(detail: impl Into<String>) -> Self {
         Self {
-            reason: reason.to_string(),
+            reason: NetworkDenyReason::kill_switch(detail),
         }
+    }
+
+    /// Build a kill-switch decider from a pre-constructed reason.
+    pub fn with_reason(reason: NetworkDenyReason) -> Self {
+        Self { reason }
     }
 }
 
@@ -239,6 +246,51 @@ mod tests {
         let decision = decider.decide(&req).await;
 
         assert!(!decision.is_allowed());
+    }
+
+    #[tokio::test]
+    async fn deny_reason_is_typed_host_not_allowed() {
+        let allowlist = DomainAllowlist::new(&["crates.io".to_string()]);
+        let decider = DefaultPolicyDecider::new(allowlist, vec![]);
+
+        let req = NetworkRequest::from_url("GET", "https://evil.com/steal").unwrap();
+        let decision = decider.decide(&req).await;
+
+        let NetworkDecision::Deny { reason } = decision else {
+            panic!("expected Deny, got {:?}", decision);
+        };
+        // Type-safe: callers can branch on .kind() or pattern-match.
+        assert_eq!(reason.kind(), "host_not_allowed");
+        match reason {
+            NetworkDenyReason::HostNotAllowed { host, allowed } => {
+                assert_eq!(host, "evil.com");
+                assert_eq!(allowed, vec!["crates.io".to_string()]);
+            }
+            other => panic!("unexpected reason variant: {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn deny_all_decider_carries_kill_switch_kind() {
+        let decider = DenyAllDecider::new("operator override");
+        let req = NetworkRequest::from_url("GET", "https://anything.com").unwrap();
+
+        let NetworkDecision::Deny { reason } = decider.decide(&req).await else {
+            panic!("DenyAll must always deny");
+        };
+        assert_eq!(reason.kind(), "kill_switch");
+        assert_eq!(reason.to_string(), "operator override");
+    }
+
+    #[tokio::test]
+    async fn empty_allowlist_yields_typed_reason() {
+        let decider = DefaultPolicyDecider::new(DomainAllowlist::empty(), vec![]);
+        let req = NetworkRequest::from_url("GET", "https://crates.io").unwrap();
+
+        let NetworkDecision::Deny { reason } = decider.decide(&req).await else {
+            panic!("empty allowlist must deny");
+        };
+        assert_eq!(reason.kind(), "empty_allowlist");
     }
 
     #[tokio::test]

--- a/crates/dasclaw_net_proxy/src/policy.rs
+++ b/crates/dasclaw_net_proxy/src/policy.rs
@@ -1,0 +1,306 @@
+//! Network policy decision making.
+//!
+//! Determines whether network requests should be allowed, denied,
+//! or allowed with credential injection.
+
+use async_trait::async_trait;
+
+use crate::allowlist::DomainAllowlist;
+use crate::types::{CredentialLocation, CredentialMapping};
+
+/// A network request to be evaluated.
+#[derive(Debug, Clone)]
+pub struct NetworkRequest {
+    /// HTTP method (GET, POST, etc.).
+    pub method: String,
+    /// Full URL being requested.
+    pub url: String,
+    /// Host extracted from URL.
+    pub host: String,
+    /// Path portion of the URL.
+    pub path: String,
+}
+
+impl NetworkRequest {
+    /// Create from a URL string.
+    pub fn from_url(method: &str, url: &str) -> Option<Self> {
+        let parsed = url::Url::parse(url).ok()?;
+        if !matches!(parsed.scheme(), "http" | "https") {
+            return None;
+        }
+
+        let host = parsed.host_str()?;
+        let host = host
+            .strip_prefix('[')
+            .and_then(|v| v.strip_suffix(']'))
+            .unwrap_or(host)
+            .to_lowercase();
+        let path = parsed.path().to_string();
+
+        Some(Self {
+            method: method.to_uppercase(),
+            url: url.to_string(),
+            host,
+            path,
+        })
+    }
+}
+
+/// Extract path from a URL.
+#[cfg(test)]
+fn extract_path(url: &str) -> String {
+    let Ok(parsed) = url::Url::parse(url) else {
+        return "/".to_string();
+    };
+    if !matches!(parsed.scheme(), "http" | "https") {
+        return "/".to_string();
+    }
+    parsed.path().to_string()
+}
+
+/// Decision for a network request.
+#[derive(Debug, Clone)]
+pub enum NetworkDecision {
+    /// Allow the request as-is.
+    Allow,
+    /// Allow with credential injection.
+    AllowWithCredentials {
+        /// Name of the secret to look up.
+        secret_name: String,
+        /// Where to inject the credential.
+        location: CredentialLocation,
+    },
+    /// Deny the request.
+    Deny {
+        /// Reason for denial.
+        reason: String,
+    },
+}
+
+impl NetworkDecision {
+    pub fn is_allowed(&self) -> bool {
+        !matches!(self, NetworkDecision::Deny { .. })
+    }
+}
+
+/// Trait for making network policy decisions.
+#[async_trait]
+pub trait NetworkPolicyDecider: Send + Sync {
+    /// Decide whether a request should be allowed.
+    async fn decide(&self, request: &NetworkRequest) -> NetworkDecision;
+}
+
+/// Default policy decider that uses allowlist and credential mappings.
+pub struct DefaultPolicyDecider {
+    allowlist: DomainAllowlist,
+    credential_mappings: Vec<CredentialMapping>,
+}
+
+impl DefaultPolicyDecider {
+    /// Create a new policy decider.
+    pub fn new(allowlist: DomainAllowlist, credential_mappings: Vec<CredentialMapping>) -> Self {
+        Self {
+            allowlist,
+            credential_mappings,
+        }
+    }
+
+    /// Find credential mapping for a host (supports glob patterns like `*.example.com`).
+    fn find_credential(&self, host: &str) -> Option<&CredentialMapping> {
+        let host_lower = host.to_lowercase();
+        self.credential_mappings.iter().find(|m| {
+            m.host_patterns
+                .iter()
+                .any(|pattern| host_matches_pattern(&host_lower, pattern))
+        })
+    }
+}
+
+#[async_trait]
+impl NetworkPolicyDecider for DefaultPolicyDecider {
+    async fn decide(&self, request: &NetworkRequest) -> NetworkDecision {
+        // First check if the domain is allowed
+        let validation = self.allowlist.is_allowed(&request.host);
+        if !validation.is_allowed()
+            && let crate::allowlist::DomainValidationResult::Denied(reason) = validation
+        {
+            return NetworkDecision::Deny { reason };
+        }
+
+        // Check if we need to inject credentials
+        if let Some(mapping) = self.find_credential(&request.host) {
+            return NetworkDecision::AllowWithCredentials {
+                secret_name: mapping.secret_name.clone(),
+                location: mapping.location.clone(),
+            };
+        }
+
+        NetworkDecision::Allow
+    }
+}
+
+/// Check if a host matches a pattern (supports `*.example.com` wildcards).
+fn host_matches_pattern(host: &str, pattern: &str) -> bool {
+    let pattern_lower = pattern.to_lowercase();
+    if pattern_lower == host {
+        return true;
+    }
+
+    // Support wildcard: *.example.com matches sub.example.com
+    if let Some(suffix) = pattern_lower.strip_prefix("*.")
+        && host.ends_with(suffix)
+        && host.len() > suffix.len()
+    {
+        let prefix = &host[..host.len() - suffix.len()];
+        if prefix.ends_with('.') || prefix.is_empty() {
+            return true;
+        }
+    }
+
+    false
+}
+
+/// A policy decider that allows everything (use with FullAccess policy).
+pub struct AllowAllDecider;
+
+#[async_trait]
+impl NetworkPolicyDecider for AllowAllDecider {
+    async fn decide(&self, _request: &NetworkRequest) -> NetworkDecision {
+        NetworkDecision::Allow
+    }
+}
+
+/// A policy decider that denies everything.
+pub struct DenyAllDecider {
+    reason: String,
+}
+
+impl DenyAllDecider {
+    pub fn new(reason: &str) -> Self {
+        Self {
+            reason: reason.to_string(),
+        }
+    }
+}
+
+#[async_trait]
+impl NetworkPolicyDecider for DenyAllDecider {
+    async fn decide(&self, _request: &NetworkRequest) -> NetworkDecision {
+        NetworkDecision::Deny {
+            reason: self.reason.clone(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_network_request_from_url() {
+        let req = NetworkRequest::from_url("GET", "https://api.example.com/v1/data").unwrap();
+        assert_eq!(req.method, "GET");
+        assert_eq!(req.host, "api.example.com");
+        assert_eq!(req.path, "/v1/data");
+    }
+
+    #[test]
+    fn test_extract_path() {
+        assert_eq!(
+            extract_path("https://example.com/api/v1"),
+            "/api/v1".to_string()
+        );
+        assert_eq!(extract_path("https://example.com"), "/".to_string());
+        assert_eq!(extract_path("https://example.com/"), "/".to_string());
+        assert_eq!(
+            extract_path("https://example.com/path?q=1#frag"),
+            "/path".to_string()
+        );
+        assert_eq!(extract_path("ftp://example.com/path"), "/".to_string());
+    }
+
+    #[tokio::test]
+    async fn test_default_policy_allows_listed_domain() {
+        let allowlist = DomainAllowlist::new(&["crates.io".to_string()]);
+        let decider = DefaultPolicyDecider::new(allowlist, vec![]);
+
+        let req = NetworkRequest::from_url("GET", "https://crates.io/api/v1/crates").unwrap();
+        let decision = decider.decide(&req).await;
+
+        assert!(decision.is_allowed());
+    }
+
+    #[tokio::test]
+    async fn test_default_policy_denies_unlisted_domain() {
+        let allowlist = DomainAllowlist::new(&["crates.io".to_string()]);
+        let decider = DefaultPolicyDecider::new(allowlist, vec![]);
+
+        let req = NetworkRequest::from_url("GET", "https://evil.com/steal").unwrap();
+        let decision = decider.decide(&req).await;
+
+        assert!(!decision.is_allowed());
+    }
+
+    #[tokio::test]
+    async fn test_credential_injection() {
+        let allowlist = DomainAllowlist::new(&["api.openai.com".to_string()]);
+        let credentials = vec![CredentialMapping::bearer(
+            "OPENAI_API_KEY",
+            "api.openai.com",
+        )];
+        let decider = DefaultPolicyDecider::new(allowlist, credentials);
+
+        let req =
+            NetworkRequest::from_url("POST", "https://api.openai.com/v1/chat/completions").unwrap();
+        let decision = decider.decide(&req).await;
+
+        match decision {
+            NetworkDecision::AllowWithCredentials { secret_name, .. } => {
+                assert_eq!(secret_name, "OPENAI_API_KEY");
+            }
+            _ => panic!("Expected AllowWithCredentials"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_credential_injection_with_wildcard_host_pattern() {
+        let allowlist =
+            DomainAllowlist::new(&["api.example.com".to_string(), "sub.example.com".to_string()]);
+        let credentials = vec![CredentialMapping {
+            secret_name: "EXAMPLE_KEY".to_string(),
+            location: CredentialLocation::AuthorizationBearer,
+            host_patterns: vec!["*.example.com".to_string()],
+            optional: false,
+        }];
+        let decider = DefaultPolicyDecider::new(allowlist, credentials);
+
+        let req = NetworkRequest::from_url("GET", "https://api.example.com/data").unwrap();
+        let decision = decider.decide(&req).await;
+
+        match decision {
+            NetworkDecision::AllowWithCredentials { secret_name, .. } => {
+                assert_eq!(secret_name, "EXAMPLE_KEY");
+            }
+            _ => panic!("Expected AllowWithCredentials for wildcard match"),
+        }
+
+        let req2 = NetworkRequest::from_url("GET", "https://sub.example.com/data").unwrap();
+        let decision2 = decider.decide(&req2).await;
+        assert!(
+            matches!(decision2, NetworkDecision::AllowWithCredentials { .. }),
+            "Wildcard pattern should match sub.example.com too"
+        );
+    }
+
+    #[test]
+    fn test_host_matches_pattern_exact() {
+        assert!(host_matches_pattern("api.openai.com", "api.openai.com"));
+        assert!(!host_matches_pattern("api.openai.com", "evil.com"));
+    }
+
+    #[test]
+    fn test_host_matches_pattern_wildcard() {
+        assert!(host_matches_pattern("api.example.com", "*.example.com"));
+        assert!(!host_matches_pattern("example.com", "*.example.com"));
+    }
+}

--- a/crates/dasclaw_net_proxy/src/reasons.rs
+++ b/crates/dasclaw_net_proxy/src/reasons.rs
@@ -1,0 +1,153 @@
+//! Type-safe network-deny reasons.
+//!
+//! Replaces the free-form `String` reasons used in `ironclaw-main` so that:
+//!
+//! - UX: callers can branch on reason category (allowlist miss vs invalid URL
+//!   vs explicit kill-switch) for tailored messages.
+//! - Automation: CI / SIEM / dashboards can aggregate by `kind()` without
+//!   regex on log lines.
+//! - SQL: stable enum discriminants survive log-rotation and i18n.
+//!
+//! `Display` is implemented to match the **exact** wording used by the
+//! ironclaw-main port (W3.2b-1) so existing snapshot tests and downstream
+//! log consumers keep working without churn.
+
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+/// Why a network request was denied.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "kind")]
+pub enum NetworkDenyReason {
+    /// The allowlist contains zero patterns — every request is denied by
+    /// construction. This is typically a misconfiguration.
+    EmptyAllowlist,
+
+    /// The host is not covered by any allowlist pattern.
+    HostNotAllowed {
+        /// The denied host (already lowercased).
+        host: String,
+        /// Patterns that were checked, in declaration order.
+        allowed: Vec<String>,
+    },
+
+    /// The proxy is operating in [`crate::ProxyMode::DenyAll`] (kill-switch).
+    KillSwitch {
+        /// Operator-supplied detail for audit logs.
+        detail: String,
+    },
+
+    /// Request URL could not be parsed as `http://` or `https://`.
+    InvalidUrl {
+        /// The raw URL, for forensics. Already redacted of obvious creds by
+        /// `url::Url::parse` (it strips `user:pass@` from the host string,
+        /// but the original input is logged verbatim — callers must avoid
+        /// passing fully-trusted secrets through URLs).
+        url: String,
+    },
+
+    /// `CONNECT` request without an authority component.
+    MissingHost,
+}
+
+impl NetworkDenyReason {
+    /// Stable discriminant string (snake_case) for SQL/SIEM aggregation.
+    /// Mirrors the serde tag so JSON-decoded events agree with this method.
+    pub const fn kind(&self) -> &'static str {
+        match self {
+            Self::EmptyAllowlist => "empty_allowlist",
+            Self::HostNotAllowed { .. } => "host_not_allowed",
+            Self::KillSwitch { .. } => "kill_switch",
+            Self::InvalidUrl { .. } => "invalid_url",
+            Self::MissingHost => "missing_host",
+        }
+    }
+
+    /// Convenience constructor for `HostNotAllowed`.
+    pub fn host_not_allowed(host: impl Into<String>, allowed: Vec<String>) -> Self {
+        Self::HostNotAllowed {
+            host: host.into(),
+            allowed,
+        }
+    }
+
+    /// Convenience constructor for `KillSwitch`.
+    pub fn kill_switch(detail: impl Into<String>) -> Self {
+        Self::KillSwitch {
+            detail: detail.into(),
+        }
+    }
+
+    /// Convenience constructor for `InvalidUrl`.
+    pub fn invalid_url(url: impl Into<String>) -> Self {
+        Self::InvalidUrl { url: url.into() }
+    }
+}
+
+impl fmt::Display for NetworkDenyReason {
+    /// Human-readable rendering. Matches the wording produced by the
+    /// ironclaw-main proxy in W3.2b-1, so log consumers remain compatible.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EmptyAllowlist => f.write_str("empty allowlist"),
+            Self::HostNotAllowed { host, allowed } => {
+                write!(
+                    f,
+                    "host '{}' not in allowlist: [{}]",
+                    host,
+                    allowed.join(", ")
+                )
+            }
+            Self::KillSwitch { detail } => f.write_str(detail),
+            Self::InvalidUrl { url } => write!(f, "Invalid URL: {}", url),
+            Self::MissingHost => f.write_str("Missing host"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn kind_strings_are_stable() {
+        // These strings are part of the SIEM/SQL contract; never rename
+        // without coordinating with downstream consumers.
+        assert_eq!(NetworkDenyReason::EmptyAllowlist.kind(), "empty_allowlist");
+        assert_eq!(
+            NetworkDenyReason::host_not_allowed("a", vec![]).kind(),
+            "host_not_allowed"
+        );
+        assert_eq!(NetworkDenyReason::kill_switch("k").kind(), "kill_switch");
+        assert_eq!(NetworkDenyReason::invalid_url("u").kind(), "invalid_url");
+        assert_eq!(NetworkDenyReason::MissingHost.kind(), "missing_host");
+    }
+
+    #[test]
+    fn display_matches_ironclaw_main_wording() {
+        // Backwards-compatible rendering — these literals appear in
+        // log-search dashboards and operator runbooks.
+        assert_eq!(
+            NetworkDenyReason::EmptyAllowlist.to_string(),
+            "empty allowlist"
+        );
+        assert_eq!(
+            NetworkDenyReason::host_not_allowed(
+                "evil.com",
+                vec!["crates.io".to_string(), "*.github.com".to_string()],
+            )
+            .to_string(),
+            "host 'evil.com' not in allowlist: [crates.io, *.github.com]"
+        );
+        assert_eq!(
+            NetworkDenyReason::kill_switch("denied by policy").to_string(),
+            "denied by policy"
+        );
+        assert_eq!(
+            NetworkDenyReason::invalid_url("foo").to_string(),
+            "Invalid URL: foo"
+        );
+        assert_eq!(NetworkDenyReason::MissingHost.to_string(), "Missing host");
+    }
+}

--- a/crates/dasclaw_net_proxy/src/types.rs
+++ b/crates/dasclaw_net_proxy/src/types.rs
@@ -1,0 +1,110 @@
+//! Credential injection types (decoupled from secrets backend).
+//!
+//! These mirror `ironclaw-main/src/secrets/types.rs` but contain only the
+//! pure-data structures needed by the proxy's policy engine. The actual
+//! credential **resolution** (looking up secret values) is delegated to
+//! the `CredentialResolver` trait so this crate has no dependency on any
+//! secrets-store implementation.
+
+use serde::{Deserialize, Serialize};
+
+/// Where a credential should be injected into an HTTP request.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum CredentialLocation {
+    /// `Authorization: Bearer {secret}`.
+    #[default]
+    AuthorizationBearer,
+    /// `Authorization: Basic base64(username:secret)`.
+    ///
+    /// Note: forward proxy implementation currently logs and skips this
+    /// location (requires base64-encoding a username:secret pair); tools
+    /// needing Basic auth should fetch credentials out-of-band.
+    AuthorizationBasic { username: String },
+    /// Custom header injection.
+    Header {
+        name: String,
+        prefix: Option<String>,
+    },
+    /// Query parameter injection.
+    QueryParam { name: String },
+    /// URL placeholder substitution.
+    ///
+    /// Note: forward proxy implementation currently logs and skips this
+    /// location (requires rewriting the request URI).
+    UrlPath { placeholder: String },
+}
+
+/// Mapping from a secret name to where/when it should be injected.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CredentialMapping {
+    /// Name of the secret to resolve.
+    pub secret_name: String,
+    /// Where to inject the resolved value.
+    pub location: CredentialLocation,
+    /// Host glob patterns this credential applies to (e.g. `*.openai.com`).
+    pub host_patterns: Vec<String>,
+    /// When `true`, the request proceeds even if the secret cannot be resolved.
+    ///
+    /// **Defaults to `false` (required)** so a tool that simply declares a
+    /// credential without explicitly opting into "optional" cannot be
+    /// silently downgraded to an unauthenticated request.
+    #[serde(default)]
+    pub optional: bool,
+}
+
+impl CredentialMapping {
+    /// Convenience constructor for a Bearer-token mapping.
+    pub fn bearer(secret_name: impl Into<String>, host_pattern: impl Into<String>) -> Self {
+        Self {
+            secret_name: secret_name.into(),
+            location: CredentialLocation::AuthorizationBearer,
+            host_patterns: vec![host_pattern.into()],
+            optional: false,
+        }
+    }
+
+    /// Convenience constructor for a custom-header mapping.
+    pub fn header(
+        secret_name: impl Into<String>,
+        header_name: impl Into<String>,
+        host_pattern: impl Into<String>,
+    ) -> Self {
+        Self {
+            secret_name: secret_name.into(),
+            location: CredentialLocation::Header {
+                name: header_name.into(),
+                prefix: None,
+            },
+            host_patterns: vec![host_pattern.into()],
+            optional: false,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bearer_default_optional_false() {
+        let m = CredentialMapping::bearer("OPENAI_API_KEY", "api.openai.com");
+        assert!(!m.optional, "Fail-Safe default: required, not optional");
+        assert_eq!(m.secret_name, "OPENAI_API_KEY");
+        assert!(matches!(
+            m.location,
+            CredentialLocation::AuthorizationBearer
+        ));
+    }
+
+    #[test]
+    fn header_with_no_prefix() {
+        let m = CredentialMapping::header("X_KEY", "X-Api-Key", "api.example.com");
+        match &m.location {
+            CredentialLocation::Header { name, prefix } => {
+                assert_eq!(name, "X-Api-Key");
+                assert!(prefix.is_none());
+            }
+            _ => panic!("expected Header"),
+        }
+    }
+}

--- a/desktop-client/ironclaw/Cargo.toml
+++ b/desktop-client/ironclaw/Cargo.toml
@@ -92,6 +92,8 @@ x_claw_agent = { path = "../../crates/x_claw_agent", version = "0.1.0" }
 # W3.1a: OS-level sandbox executor (replaces Docker sandbox path)
 dasclaw_exec = { path = "../../crates/dasclaw_exec", version = "0.1.0" }
 dasclaw_sandbox = { path = "../../crates/dasclaw_sandbox", version = "0.0.0-w1" }
+# W3.2b: audited HTTP egress proxy (allowlist + credential injection)
+dasclaw_net_proxy = { path = "../../crates/dasclaw_net_proxy", version = "0.1.0" }
 ironclaw_workspace_cap = { path = "../../crates/ironclaw_workspace_cap", version = "0.1.0" }
 
 # Safety/sanitization

--- a/desktop-client/ironclaw/src/sandbox/mod.rs
+++ b/desktop-client/ironclaw/src/sandbox/mod.rs
@@ -30,6 +30,8 @@ pub mod config;
 pub mod detect;
 pub mod docker_conn;
 pub mod error;
+/// W3.2b-4: bridge to [`dasclaw_net_proxy`] for sandbox egress enforcement.
+pub mod net_proxy;
 /// W3.1a: codex-style OS-level executor (replaces Docker `SandboxManager` for
 /// tool execution). See [`os_executor::OsExecutor`].
 pub mod os_executor;

--- a/desktop-client/ironclaw/src/sandbox/net_proxy.rs
+++ b/desktop-client/ironclaw/src/sandbox/net_proxy.rs
@@ -1,0 +1,369 @@
+//! W3.2b-4: Desktop-client integration of [`dasclaw_net_proxy`].
+//!
+//! Bridges the OS-sandbox layer (`SandboxConfig` + `SecretsStore`) to the
+//! audited HTTP egress proxy. Spawned tool containers receive `HTTPS_PROXY` /
+//! `HTTP_PROXY` / `NO_PROXY` env vars pointing at the local proxy, which then
+//! enforces the per-policy domain allowlist and injects credentials resolved
+//! from the desktop-client `SecretsStore` (postgres-backed, master-key sealed
+//! by the per-OS keychain — see [`crate::secrets::keychain`]).
+//!
+//! # Fail-safe contract
+//!
+//! - `IronclawSecretsResolver::resolve` returns `None` on **any** error
+//!   (NotFound, decryption failure, db error). The proxy treats `None` as
+//!   "no credential available" and either omits the header (when
+//!   `optional: true`) or denies the request (when `optional: false`,
+//!   the default).
+//! - Conversion of an unknown / malformed mapping never panics; if the local
+//!   `CredentialLocation` cannot be represented by the proxy crate, the
+//!   mapping is silently dropped and the request will be allowed without
+//!   credential injection (subject to allowlist).
+//!
+//! # Module layout
+//!
+//! - [`IronclawSecretsResolver`] — `dasclaw_net_proxy::CredentialResolver`
+//!   impl that pulls decrypted secrets from a `SecretsStore`.
+//! - [`to_proxy_mappings`] — translate `crate::secrets::CredentialMapping`
+//!   into `dasclaw_net_proxy::CredentialMapping`.
+//! - [`start_network_proxy`] — assemble a [`NetworkProxyBuilder`] from a
+//!   [`SandboxConfig`] + `SecretsStore`, start it, return a handle.
+//! - [`proxy_env_vars`] — produce the `HTTPS_PROXY` / `HTTP_PROXY` /
+//!   `NO_PROXY` triplet to inject into spawned child processes.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use dasclaw_net_proxy::{
+    CredentialLocation as ProxyLocation, CredentialMapping as ProxyMapping, CredentialResolver,
+    HttpProxy, NetworkProxyBuilder, ProxyMode,
+};
+
+use crate::sandbox::config::SandboxConfig;
+use crate::sandbox::error::{Result, SandboxError};
+use crate::secrets::{
+    CredentialLocation as LocalLocation, CredentialMapping as LocalMapping, SecretsStore,
+};
+
+/// Bridges `dasclaw_net_proxy::CredentialResolver` to the desktop-client
+/// `SecretsStore`. All errors are coerced to `None` (fail-safe).
+pub struct IronclawSecretsResolver {
+    store: Arc<dyn SecretsStore>,
+    user_id: String,
+}
+
+impl IronclawSecretsResolver {
+    pub fn new(store: Arc<dyn SecretsStore>, user_id: impl Into<String>) -> Self {
+        Self {
+            store,
+            user_id: user_id.into(),
+        }
+    }
+}
+
+#[async_trait]
+impl CredentialResolver for IronclawSecretsResolver {
+    async fn resolve(&self, name: &str) -> Option<String> {
+        match self.store.get_decrypted(&self.user_id, name).await {
+            Ok(decrypted) => Some(decrypted.expose().to_string()),
+            Err(err) => {
+                // Fail-safe: never leak the secret name in error logs at
+                // info level, and never propagate the error — proxy will
+                // deny the request via the `optional: false` default.
+                tracing::debug!(secret = %name, error = %err, "secret resolution failed");
+                None
+            }
+        }
+    }
+}
+
+/// Convert a single desktop-client `CredentialMapping` into the proxy's
+/// representation. Returns `None` if the mapping has no host patterns or
+/// uses a `CredentialLocation` variant that the proxy crate cannot enforce.
+pub fn to_proxy_mapping(local: &LocalMapping) -> Option<ProxyMapping> {
+    if local.host_patterns.is_empty() {
+        return None;
+    }
+
+    let location = match &local.location {
+        LocalLocation::AuthorizationBearer => ProxyLocation::AuthorizationBearer,
+        LocalLocation::AuthorizationBasic { username } => ProxyLocation::AuthorizationBasic {
+            username: username.clone(),
+        },
+        LocalLocation::Header { name, prefix } => ProxyLocation::Header {
+            name: name.clone(),
+            prefix: prefix.clone(),
+        },
+        LocalLocation::QueryParam { name } => ProxyLocation::QueryParam { name: name.clone() },
+        LocalLocation::UrlPath { placeholder } => ProxyLocation::UrlPath {
+            placeholder: placeholder.clone(),
+        },
+    };
+
+    Some(ProxyMapping {
+        secret_name: local.secret_name.clone(),
+        location,
+        host_patterns: local.host_patterns.clone(),
+        optional: false, // Fail-safe: missing secret denies the request.
+    })
+}
+
+/// Translate a list of local mappings. Mappings with empty `host_patterns`
+/// are dropped.
+pub fn to_proxy_mappings(local: &[LocalMapping]) -> Vec<ProxyMapping> {
+    local.iter().filter_map(to_proxy_mapping).collect()
+}
+
+/// Handle returned after starting the proxy. Holding it keeps the listener
+/// alive; dropping it shuts down the proxy.
+pub struct NetworkProxyHandle {
+    pub proxy: Arc<HttpProxy>,
+    pub addr: SocketAddr,
+}
+
+/// Assemble + start a network proxy for the given sandbox config.
+///
+/// Mode mapping:
+/// - `SandboxPolicy::FullAccess` → `ProxyMode::AllowAll` (no enforcement;
+///   policy bypasses the sandbox anyway, kept here for env-var consistency).
+/// - Any other policy → `ProxyMode::Restricted` (allowlist + credential
+///   injection enforced).
+pub async fn start_network_proxy(
+    cfg: &SandboxConfig,
+    credential_mappings: Vec<LocalMapping>,
+    store: Arc<dyn SecretsStore>,
+    user_id: impl Into<String>,
+) -> Result<NetworkProxyHandle> {
+    let mode = if cfg.policy.has_full_network() {
+        ProxyMode::AllowAll
+    } else {
+        ProxyMode::Restricted
+    };
+
+    let resolver: Arc<dyn CredentialResolver> =
+        Arc::new(IronclawSecretsResolver::new(store, user_id));
+
+    let proxy = NetworkProxyBuilder::new()
+        .with_mode(mode)
+        .with_allowlist(cfg.network_allowlist.clone())
+        .with_credentials(to_proxy_mappings(&credential_mappings))
+        .with_credential_resolver(resolver)
+        .build();
+
+    let addr = proxy
+        .start(cfg.proxy_port)
+        .await
+        .map_err(|e| SandboxError::Config {
+            reason: format!("network proxy start failed: {e}"),
+        })?;
+
+    Ok(NetworkProxyHandle {
+        proxy: Arc::new(proxy),
+        addr,
+    })
+}
+
+/// Env vars to inject into spawned child processes / containers so they
+/// route HTTP(S) through the proxy. `NO_PROXY` excludes localhost so
+/// containers can still reach side-cars.
+pub fn proxy_env_vars(addr: SocketAddr) -> Vec<(String, String)> {
+    let url = format!("http://{addr}");
+    vec![
+        ("HTTPS_PROXY".to_string(), url.clone()),
+        ("HTTP_PROXY".to_string(), url.clone()),
+        ("https_proxy".to_string(), url.clone()),
+        ("http_proxy".to_string(), url),
+        (
+            "NO_PROXY".to_string(),
+            "localhost,127.0.0.1,::1".to_string(),
+        ),
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sandbox::config::{SandboxConfig, SandboxPolicy};
+    use crate::secrets::{CreateSecretParams, DecryptedSecret, Secret, SecretError, SecretRef};
+    use async_trait::async_trait;
+    use std::sync::Mutex;
+    use uuid::Uuid;
+
+    /// Minimal in-memory store sufficient for resolver tests. Only
+    /// `get_decrypted` is exercised; other methods return `NotFound`.
+    struct MemStore {
+        entries: Mutex<Vec<(String, String, String)>>, // (user, name, value)
+    }
+    impl MemStore {
+        fn with(entries: Vec<(&str, &str, &str)>) -> Self {
+            Self {
+                entries: Mutex::new(
+                    entries
+                        .into_iter()
+                        .map(|(u, n, v)| (u.into(), n.into(), v.into()))
+                        .collect(),
+                ),
+            }
+        }
+    }
+    #[async_trait]
+    impl SecretsStore for MemStore {
+        async fn create(
+            &self,
+            _: &str,
+            _: CreateSecretParams,
+        ) -> std::result::Result<Secret, SecretError> {
+            Err(SecretError::NotFound("not implemented".into()))
+        }
+        async fn get(&self, _: &str, name: &str) -> std::result::Result<Secret, SecretError> {
+            Err(SecretError::NotFound(name.into()))
+        }
+        async fn get_decrypted(
+            &self,
+            user_id: &str,
+            name: &str,
+        ) -> std::result::Result<DecryptedSecret, SecretError> {
+            let g = self.entries.lock().unwrap();
+            for (u, n, v) in g.iter() {
+                if u == user_id && n == name {
+                    return DecryptedSecret::from_bytes(v.as_bytes().to_vec());
+                }
+            }
+            Err(SecretError::NotFound(name.into()))
+        }
+        async fn exists(&self, _: &str, _: &str) -> std::result::Result<bool, SecretError> {
+            Ok(false)
+        }
+        async fn list(&self, _: &str) -> std::result::Result<Vec<SecretRef>, SecretError> {
+            Ok(vec![])
+        }
+        async fn delete(&self, _: &str, _: &str) -> std::result::Result<bool, SecretError> {
+            Ok(false)
+        }
+        async fn record_usage(&self, _: Uuid) -> std::result::Result<(), SecretError> {
+            Ok(())
+        }
+        async fn is_accessible(
+            &self,
+            _: &str,
+            _: &str,
+            _: &[String],
+        ) -> std::result::Result<bool, SecretError> {
+            Ok(true)
+        }
+    }
+
+    #[tokio::test]
+    async fn resolver_returns_value_when_present() {
+        let store = Arc::new(MemStore::with(vec![("alice", "OPENAI_API_KEY", "sk-xyz")]));
+        let r = IronclawSecretsResolver::new(store, "alice");
+        assert_eq!(r.resolve("OPENAI_API_KEY").await.as_deref(), Some("sk-xyz"));
+    }
+
+    #[tokio::test]
+    async fn resolver_returns_none_for_missing_secret() {
+        let store = Arc::new(MemStore::with(vec![]));
+        let r = IronclawSecretsResolver::new(store, "alice");
+        assert!(r.resolve("MISSING").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn resolver_isolates_users() {
+        let store = Arc::new(MemStore::with(vec![("alice", "K", "a-val")]));
+        let bob = IronclawSecretsResolver::new(store.clone(), "bob");
+        assert!(
+            bob.resolve("K").await.is_none(),
+            "bob must not see alice's secret"
+        );
+    }
+
+    #[test]
+    fn mapping_bearer_round_trips() {
+        let local = LocalMapping::bearer("OPENAI_API_KEY", "api.openai.com");
+        let proxy = to_proxy_mapping(&local).expect("convertible");
+        assert_eq!(proxy.secret_name, "OPENAI_API_KEY");
+        assert_eq!(proxy.host_patterns, vec!["api.openai.com".to_string()]);
+        assert!(matches!(proxy.location, ProxyLocation::AuthorizationBearer));
+        assert!(!proxy.optional, "must default to required (fail-safe)");
+    }
+
+    #[test]
+    fn mapping_header_round_trips() {
+        let local = LocalMapping::header("ANTHROPIC_API_KEY", "x-api-key", "api.anthropic.com");
+        let proxy = to_proxy_mapping(&local).expect("convertible");
+        match proxy.location {
+            ProxyLocation::Header { name, prefix } => {
+                assert_eq!(name, "x-api-key");
+                assert!(prefix.is_none());
+            }
+            other => panic!("unexpected location {other:?}"),
+        }
+    }
+
+    #[test]
+    fn mapping_with_empty_hosts_is_dropped() {
+        let local = LocalMapping {
+            secret_name: "X".into(),
+            location: LocalLocation::AuthorizationBearer,
+            host_patterns: vec![],
+        };
+        assert!(to_proxy_mapping(&local).is_none());
+    }
+
+    #[test]
+    fn mappings_expand_multi_host() {
+        let local = LocalMapping {
+            secret_name: "K".into(),
+            location: LocalLocation::AuthorizationBearer,
+            host_patterns: vec!["a.com".into(), "b.com".into()],
+        };
+        let out = to_proxy_mappings(&[local]);
+        assert_eq!(out.len(), 1);
+        assert_eq!(
+            out[0].host_patterns,
+            vec!["a.com".to_string(), "b.com".to_string()]
+        );
+    }
+
+    #[test]
+    fn proxy_env_vars_include_no_proxy() {
+        let addr: SocketAddr = "127.0.0.1:9999".parse().unwrap();
+        let env = proxy_env_vars(addr);
+        let map: std::collections::HashMap<_, _> = env.into_iter().collect();
+        assert_eq!(map["HTTPS_PROXY"], "http://127.0.0.1:9999");
+        assert_eq!(map["HTTP_PROXY"], "http://127.0.0.1:9999");
+        assert!(map["NO_PROXY"].contains("127.0.0.1"));
+    }
+
+    #[tokio::test]
+    async fn start_network_proxy_binds_and_serves() {
+        let cfg = SandboxConfig {
+            policy: SandboxPolicy::ReadOnly,
+            network_allowlist: vec!["example.com".into()],
+            proxy_port: 0,
+            ..SandboxConfig::default()
+        };
+        let store = Arc::new(MemStore::with(vec![]));
+        let handle = start_network_proxy(&cfg, vec![], store, "alice")
+            .await
+            .expect("proxy starts");
+        assert!(handle.addr.port() > 0);
+        assert!(handle.proxy.is_running());
+    }
+
+    #[tokio::test]
+    async fn full_access_policy_uses_allow_all_mode() {
+        // Sanity: FullAccess must not crash the builder even with empty allowlist.
+        let cfg = SandboxConfig {
+            policy: SandboxPolicy::FullAccess,
+            network_allowlist: vec![],
+            proxy_port: 0,
+            ..SandboxConfig::default()
+        };
+        let store = Arc::new(MemStore::with(vec![]));
+        let handle = start_network_proxy(&cfg, vec![], store, "alice")
+            .await
+            .expect("proxy starts in AllowAll");
+        assert!(handle.proxy.is_running());
+    }
+}


### PR DESCRIPTION
## Summary

Bridges the OS-sandbox layer (`SandboxConfig` + `SecretsStore`) to the audited HTTP egress proxy from PRs #19/#20. Spawned tool processes will receive `HTTPS_PROXY`/`HTTP_PROXY`/`NO_PROXY` env vars pointing at the local proxy, which enforces per-policy domain allowlists and injects credentials resolved from the existing desktop-client `SecretsStore` (postgres-backed, master-key sealed by the per-OS keychain).

## Changes

- `desktop-client/ironclaw/src/sandbox/net_proxy.rs` (new, ~370 LOC):
  - `IronclawSecretsResolver` — `dasclaw_net_proxy::CredentialResolver` impl wrapping `SecretsStore`. **All errors → `None` (fail-safe)**: missing secret, decryption failure, db error all coerce to `None`, which the proxy treats as denial when `optional: false` (the default).
  - `to_proxy_mapping` / `to_proxy_mappings` — translate `crate::secrets::CredentialMapping` → `dasclaw_net_proxy::CredentialMapping`. Mappings without host_patterns are dropped silently.
  - `start_network_proxy` — assemble + bind a `NetworkProxyBuilder` from a `SandboxConfig`. `FullAccess` → `ProxyMode::AllowAll`, others → `ProxyMode::Restricted`.
  - `proxy_env_vars` — emit both upper- and lowercase env vars (HTTP proxy convention; runtimes differ) plus `NO_PROXY=localhost,127.0.0.1,::1`.
- `desktop-client/ironclaw/Cargo.toml` — add `dasclaw_net_proxy` path dep.
- `desktop-client/ironclaw/src/sandbox/mod.rs` — register module.
- `AGENTS.md` — document `cargo sweep --time 3` as default cache cleanup (separate concern; surfaced by real disk pressure during dev).

## Tests

10 nextest cases — all pass. `cargo check -p ironclaw --lib`: **0 errors, 0 warnings**.

## Stack

- Base: `feat/w3.2b-2-net-proxy-deny-reasons` (#20) which is stacked on `feat/w3.2b-1-net-proxy-port` (#19)
- Independent of #21 (W3.2b-3 Windows keychain)
- After #19 and #20 merge to `xClaw`, this PR's base will auto-retarget to `xClaw`.

## What's NOT in this PR (W3.2b-5)

- Wiring the proxy startup into the desktop-client app boot
- E2E tests with a live tool process going through the proxy
- Completion report `44-net-proxy-port-completion.md`

## Refs

- ADR: `docs/plans/architecture-refactor/43-net-proxy-port-decision.md` (Tier B''+)
- Skill audit: code-quality-audit ✅ 5/5 pass; no production panics outside `#[cfg(test)]`.
