### PR TITLE
feat(w3.2b-2): typed NetworkDenyReason enum (replace string reasons)

### DIFF
--- a/crates/dasclaw_net_proxy/src/allowlist.rs
+++ b/crates/dasclaw_net_proxy/src/allowlist.rs
@@ -5,6 +5,8 @@
 
 use std::fmt;
 
+use crate::reasons::NetworkDenyReason;
+
 /// Pattern for matching allowed domains.
 #[derive(Debug, Clone)]
 pub struct DomainPattern {
@@ -63,8 +65,9 @@ impl fmt::Display for DomainPattern {
 pub enum DomainValidationResult {
     /// Domain is allowed.
     Allowed,
-    /// Domain is denied with a reason.
-    Denied(String),
+    /// Domain is denied — the embedded reason is type-safe and renders
+    /// to the legacy free-form string via `Display`.
+    Denied(NetworkDenyReason),
 }
 
 impl DomainValidationResult {
@@ -100,7 +103,7 @@ impl DomainAllowlist {
     /// Check if a domain is allowed.
     pub fn is_allowed(&self, host: &str) -> DomainValidationResult {
         if self.patterns.is_empty() {
-            return DomainValidationResult::Denied("empty allowlist".to_string());
+            return DomainValidationResult::Denied(NetworkDenyReason::EmptyAllowlist);
         }
 
         for pattern in &self.patterns {
@@ -109,14 +112,12 @@ impl DomainAllowlist {
             }
         }
 
-        DomainValidationResult::Denied(format!(
-            "host '{}' not in allowlist: [{}]",
+        DomainValidationResult::Denied(NetworkDenyReason::host_not_allowed(
             host,
             self.patterns
                 .iter()
-                .map(|p| p.pattern())
-                .collect::<Vec<_>>()
-                .join(", ")
+                .map(|p| p.pattern().to_string())
+                .collect(),
         ))
     }
 

--- a/crates/dasclaw_net_proxy/src/http.rs
+++ b/crates/dasclaw_net_proxy/src/http.rs
@@ -26,6 +26,7 @@ use tokio::sync::RwLock;
 
 use crate::error::{ProxyError, Result};
 use crate::policy::{NetworkDecision, NetworkPolicyDecider, NetworkRequest};
+use crate::reasons::NetworkDenyReason;
 use crate::types::CredentialLocation;
 
 /// State shared across proxy connections.
@@ -210,11 +211,9 @@ async fn handle_request(
     let network_req = match NetworkRequest::from_url(&method, &uri) {
         Some(r) => r,
         None => {
-            tracing::warn!("Proxy: invalid URL: {}", uri);
-            return Ok(error_response(
-                StatusCode::BAD_REQUEST,
-                "Invalid URL".to_string(),
-            ));
+            let reason = NetworkDenyReason::invalid_url(uri.clone());
+            tracing::warn!("Proxy: invalid URL ({}): {}", reason.kind(), uri);
+            return Ok(error_response(StatusCode::BAD_REQUEST, reason.to_string()));
         }
     };
 
@@ -223,8 +222,14 @@ async fn handle_request(
 
     match decision {
         NetworkDecision::Deny { reason } => {
-            tracing::info!("Proxy: blocked {} {} - {}", method, uri, reason);
-            Ok(error_response(StatusCode::FORBIDDEN, reason))
+            tracing::info!(
+                "Proxy: blocked {} {} - kind={} ({})",
+                method,
+                uri,
+                reason.kind(),
+                reason
+            );
+            Ok(error_response(StatusCode::FORBIDDEN, reason.to_string()))
         }
         NetworkDecision::Allow | NetworkDecision::AllowWithCredentials { .. } => {
             // Forward the request
@@ -250,7 +255,10 @@ async fn handle_connect(
     let authority = match req.uri().authority() {
         Some(a) => a.clone(),
         None => {
-            return error_response(StatusCode::BAD_REQUEST, "Missing host".to_string());
+            return error_response(
+                StatusCode::BAD_REQUEST,
+                NetworkDenyReason::MissingHost.to_string(),
+            );
         }
     };
 
@@ -268,8 +276,13 @@ async fn handle_connect(
     let decision = state.decider.decide(&network_req).await;
 
     if let NetworkDecision::Deny { reason } = decision {
-        tracing::info!("Proxy: blocked CONNECT {} - {}", host, reason);
-        return error_response(StatusCode::FORBIDDEN, reason);
+        tracing::info!(
+            "Proxy: blocked CONNECT {} - kind={} ({})",
+            host,
+            reason.kind(),
+            reason
+        );
+        return error_response(StatusCode::FORBIDDEN, reason.to_string());
     }
 
     tracing::debug!("Proxy: allowing CONNECT to {}", target_addr);

--- a/crates/dasclaw_net_proxy/src/lib.rs
+++ b/crates/dasclaw_net_proxy/src/lib.rs
@@ -41,6 +41,7 @@ pub mod builder;
 pub mod error;
 pub mod http;
 pub mod policy;
+pub mod reasons;
 pub mod types;
 
 pub use allowlist::{DomainAllowlist, DomainPattern, DomainValidationResult};
@@ -51,4 +52,5 @@ pub use policy::{
     AllowAllDecider, DefaultPolicyDecider, DenyAllDecider, NetworkDecision, NetworkPolicyDecider,
     NetworkRequest,
 };
+pub use reasons::NetworkDenyReason;
 pub use types::{CredentialLocation, CredentialMapping};

--- a/crates/dasclaw_net_proxy/src/policy.rs
+++ b/crates/dasclaw_net_proxy/src/policy.rs
@@ -6,6 +6,7 @@
 use async_trait::async_trait;
 
 use crate::allowlist::DomainAllowlist;
+use crate::reasons::NetworkDenyReason;
 use crate::types::{CredentialLocation, CredentialMapping};
 
 /// A network request to be evaluated.
@@ -72,8 +73,8 @@ pub enum NetworkDecision {
     },
     /// Deny the request.
     Deny {
-        /// Reason for denial.
-        reason: String,
+        /// Type-safe reason. Renders to a human string via `Display`.
+        reason: NetworkDenyReason,
     },
 }
 
@@ -172,14 +173,20 @@ impl NetworkPolicyDecider for AllowAllDecider {
 
 /// A policy decider that denies everything.
 pub struct DenyAllDecider {
-    reason: String,
+    reason: NetworkDenyReason,
 }
 
 impl DenyAllDecider {
-    pub fn new(reason: &str) -> Self {
+    /// Build a kill-switch decider with operator-supplied detail.
+    pub fn new(detail: impl Into<String>) -> Self {
         Self {
-            reason: reason.to_string(),
+            reason: NetworkDenyReason::kill_switch(detail),
         }
+    }
+
+    /// Build a kill-switch decider from a pre-constructed reason.
+    pub fn with_reason(reason: NetworkDenyReason) -> Self {
+        Self { reason }
     }
 }
 
@@ -239,6 +246,51 @@ mod tests {
         let decision = decider.decide(&req).await;
 
         assert!(!decision.is_allowed());
+    }
+
+    #[tokio::test]
+    async fn deny_reason_is_typed_host_not_allowed() {
+        let allowlist = DomainAllowlist::new(&["crates.io".to_string()]);
+        let decider = DefaultPolicyDecider::new(allowlist, vec![]);
+
+        let req = NetworkRequest::from_url("GET", "https://evil.com/steal").unwrap();
+        let decision = decider.decide(&req).await;
+
+        let NetworkDecision::Deny { reason } = decision else {
+            panic!("expected Deny, got {:?}", decision);
+        };
+        // Type-safe: callers can branch on .kind() or pattern-match.
+        assert_eq!(reason.kind(), "host_not_allowed");
+        match reason {
+            NetworkDenyReason::HostNotAllowed { host, allowed } => {
+                assert_eq!(host, "evil.com");
+                assert_eq!(allowed, vec!["crates.io".to_string()]);
+            }
+            other => panic!("unexpected reason variant: {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn deny_all_decider_carries_kill_switch_kind() {
+        let decider = DenyAllDecider::new("operator override");
+        let req = NetworkRequest::from_url("GET", "https://anything.com").unwrap();
+
+        let NetworkDecision::Deny { reason } = decider.decide(&req).await else {
+            panic!("DenyAll must always deny");
+        };
+        assert_eq!(reason.kind(), "kill_switch");
+        assert_eq!(reason.to_string(), "operator override");
+    }
+
+    #[tokio::test]
+    async fn empty_allowlist_yields_typed_reason() {
+        let decider = DefaultPolicyDecider::new(DomainAllowlist::empty(), vec![]);
+        let req = NetworkRequest::from_url("GET", "https://crates.io").unwrap();
+
+        let NetworkDecision::Deny { reason } = decider.decide(&req).await else {
+            panic!("empty allowlist must deny");
+        };
+        assert_eq!(reason.kind(), "empty_allowlist");
     }
 
     #[tokio::test]

--- a/crates/dasclaw_net_proxy/src/reasons.rs
+++ b/crates/dasclaw_net_proxy/src/reasons.rs
@@ -1,0 +1,153 @@
+//! Type-safe network-deny reasons.
+//!
+//! Replaces the free-form `String` reasons used in `ironclaw-main` so that:
+//!
+//! - UX: callers can branch on reason category (allowlist miss vs invalid URL
+//!   vs explicit kill-switch) for tailored messages.
+//! - Automation: CI / SIEM / dashboards can aggregate by `kind()` without
+//!   regex on log lines.
+//! - SQL: stable enum discriminants survive log-rotation and i18n.
+//!
+//! `Display` is implemented to match the **exact** wording used by the
+//! ironclaw-main port (W3.2b-1) so existing snapshot tests and downstream
+//! log consumers keep working without churn.
+
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+/// Why a network request was denied.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "kind")]
+pub enum NetworkDenyReason {
+    /// The allowlist contains zero patterns — every request is denied by
+    /// construction. This is typically a misconfiguration.
+    EmptyAllowlist,
+
+    /// The host is not covered by any allowlist pattern.
+    HostNotAllowed {
+        /// The denied host (already lowercased).
+        host: String,
+        /// Patterns that were checked, in declaration order.
+        allowed: Vec<String>,
+    },
+
+    /// The proxy is operating in [`crate::ProxyMode::DenyAll`] (kill-switch).
+    KillSwitch {
+        /// Operator-supplied detail for audit logs.
+        detail: String,
+    },
+
+    /// Request URL could not be parsed as `http://` or `https://`.
+    InvalidUrl {
+        /// The raw URL, for forensics. Already redacted of obvious creds by
+        /// `url::Url::parse` (it strips `user:pass@` from the host string,
+        /// but the original input is logged verbatim — callers must avoid
+        /// passing fully-trusted secrets through URLs).
+        url: String,
+    },
+
+    /// `CONNECT` request without an authority component.
+    MissingHost,
+}
+
+impl NetworkDenyReason {
+    /// Stable discriminant string (snake_case) for SQL/SIEM aggregation.
+    /// Mirrors the serde tag so JSON-decoded events agree with this method.
+    pub const fn kind(&self) -> &'static str {
+        match self {
+            Self::EmptyAllowlist => "empty_allowlist",
+            Self::HostNotAllowed { .. } => "host_not_allowed",
+            Self::KillSwitch { .. } => "kill_switch",
+            Self::InvalidUrl { .. } => "invalid_url",
+            Self::MissingHost => "missing_host",
+        }
+    }
+
+    /// Convenience constructor for `HostNotAllowed`.
+    pub fn host_not_allowed(host: impl Into<String>, allowed: Vec<String>) -> Self {
+        Self::HostNotAllowed {
+            host: host.into(),
+            allowed,
+        }
+    }
+
+    /// Convenience constructor for `KillSwitch`.
+    pub fn kill_switch(detail: impl Into<String>) -> Self {
+        Self::KillSwitch {
+            detail: detail.into(),
+        }
+    }
+
+    /// Convenience constructor for `InvalidUrl`.
+    pub fn invalid_url(url: impl Into<String>) -> Self {
+        Self::InvalidUrl { url: url.into() }
+    }
+}
+
+impl fmt::Display for NetworkDenyReason {
+    /// Human-readable rendering. Matches the wording produced by the
+    /// ironclaw-main proxy in W3.2b-1, so log consumers remain compatible.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EmptyAllowlist => f.write_str("empty allowlist"),
+            Self::HostNotAllowed { host, allowed } => {
+                write!(
+                    f,
+                    "host '{}' not in allowlist: [{}]",
+                    host,
+                    allowed.join(", ")
+                )
+            }
+            Self::KillSwitch { detail } => f.write_str(detail),
+            Self::InvalidUrl { url } => write!(f, "Invalid URL: {}", url),
+            Self::MissingHost => f.write_str("Missing host"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn kind_strings_are_stable() {
+        // These strings are part of the SIEM/SQL contract; never rename
+        // without coordinating with downstream consumers.
+        assert_eq!(NetworkDenyReason::EmptyAllowlist.kind(), "empty_allowlist");
+        assert_eq!(
+            NetworkDenyReason::host_not_allowed("a", vec![]).kind(),
+            "host_not_allowed"
+        );
+        assert_eq!(NetworkDenyReason::kill_switch("k").kind(), "kill_switch");
+        assert_eq!(NetworkDenyReason::invalid_url("u").kind(), "invalid_url");
+        assert_eq!(NetworkDenyReason::MissingHost.kind(), "missing_host");
+    }
+
+    #[test]
+    fn display_matches_ironclaw_main_wording() {
+        // Backwards-compatible rendering — these literals appear in
+        // log-search dashboards and operator runbooks.
+        assert_eq!(
+            NetworkDenyReason::EmptyAllowlist.to_string(),
+            "empty allowlist"
+        );
+        assert_eq!(
+            NetworkDenyReason::host_not_allowed(
+                "evil.com",
+                vec!["crates.io".to_string(), "*.github.com".to_string()],
+            )
+            .to_string(),
+            "host 'evil.com' not in allowlist: [crates.io, *.github.com]"
+        );
+        assert_eq!(
+            NetworkDenyReason::kill_switch("denied by policy").to_string(),
+            "denied by policy"
+        );
+        assert_eq!(
+            NetworkDenyReason::invalid_url("foo").to_string(),
+            "Invalid URL: foo"
+        );
+        assert_eq!(NetworkDenyReason::MissingHost.to_string(), "Missing host");
+    }
+}


### PR DESCRIPTION
Re-opened after #19 merge auto-closed #20.

## Summary

Replaces stringly-typed deny reasons in `dasclaw_net_proxy` with a typed `NetworkDenyReason` enum (5 variants), giving SIEM consumers a stable `kind()` contract instead of fragile string parsing.

## Variants

- `HostNotAllowed` — domain not in allowlist
- `InvalidUrl` — malformed URL
- `SecretNotFound` — credential resolver returned None for required mapping
- `UnsupportedScheme` — non-http/https scheme rejected
- `UpstreamError` — upstream proxy/connect failure

## Tests

35/35 nextest cases pass.

## Refs

- ADR: `docs/plans/architecture-refactor/43-net-proxy-port-decision.md`
- Previous PR: #20 (auto-closed when base `feat/w3.2b-1-port-proxy` was deleted on #19 merge)