### PR TITLE
feat(w3.2b-4): integrate dasclaw_net_proxy into desktop-client sandbox

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,6 +120,26 @@ cargo test -p ironclaw
 
 未装请：`cargo install cargo-nextest --locked`。CI 使用何种命令以仓库 workflow 为准（不强制改 CI）。
 
+### 构建缓存清理：默认使用 cargo sweep --time 3
+
+**磁盘满时优先用 `cargo sweep --time 3`，禁止用 `cargo clean` 或 `cargo sweep --time 0` 一次清干净**。一次性清掉全部产物会导致下次 build 需要从零重编全部依赖（10+ 分钟），sccache 也帮不上忙（增量缓存丢了）。
+
+```bash
+# 推荐：清掉 3 天没访问过的产物，保留近期增量缓存
+cargo sweep --time 3
+
+# 自动定时清理（cron）
+0 3 * * * cd ~/Documents/code/x-claw && cargo sweep --time 3
+
+# 禁止：一次清干净
+# cargo clean              ← 不要用
+# cargo sweep --time 0     ← 不要用
+```
+
+未装请：`cargo install cargo-sweep --locked`。
+
+详细工作流（含 sccache、`cargo build -p desktop-client --lib` 增量编译）见 [desktop-client/README.md](desktop-client/README.md)。
+
 ### 外部库使用
 
 - **先搜索项目中该库的现有用法**（`rg "libsql::" src/`），参考项目代码而非外部文档

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4627,6 +4627,7 @@ dependencies = [
  "cron",
  "crossterm",
  "dasclaw_exec",
+ "dasclaw_net_proxy",
  "dasclaw_sandbox",
  "deadpool-postgres",
  "dirs 6.0.0",

--- a/desktop-client/ironclaw/Cargo.toml
+++ b/desktop-client/ironclaw/Cargo.toml
@@ -92,6 +92,8 @@ x_claw_agent = { path = "../../crates/x_claw_agent", version = "0.1.0" }
 # W3.1a: OS-level sandbox executor (replaces Docker sandbox path)
 dasclaw_exec = { path = "../../crates/dasclaw_exec", version = "0.1.0" }
 dasclaw_sandbox = { path = "../../crates/dasclaw_sandbox", version = "0.0.0-w1" }
+# W3.2b: audited HTTP egress proxy (allowlist + credential injection)
+dasclaw_net_proxy = { path = "../../crates/dasclaw_net_proxy", version = "0.1.0" }
 ironclaw_workspace_cap = { path = "../../crates/ironclaw_workspace_cap", version = "0.1.0" }
 
 # Safety/sanitization

--- a/desktop-client/ironclaw/src/sandbox/mod.rs
+++ b/desktop-client/ironclaw/src/sandbox/mod.rs
@@ -30,6 +30,8 @@ pub mod config;
 pub mod detect;
 pub mod docker_conn;
 pub mod error;
+/// W3.2b-4: bridge to [`dasclaw_net_proxy`] for sandbox egress enforcement.
+pub mod net_proxy;
 /// W3.1a: codex-style OS-level executor (replaces Docker `SandboxManager` for
 /// tool execution). See [`os_executor::OsExecutor`].
 pub mod os_executor;

--- a/desktop-client/ironclaw/src/sandbox/net_proxy.rs
+++ b/desktop-client/ironclaw/src/sandbox/net_proxy.rs
@@ -1,0 +1,369 @@
+//! W3.2b-4: Desktop-client integration of [`dasclaw_net_proxy`].
+//!
+//! Bridges the OS-sandbox layer (`SandboxConfig` + `SecretsStore`) to the
+//! audited HTTP egress proxy. Spawned tool containers receive `HTTPS_PROXY` /
+//! `HTTP_PROXY` / `NO_PROXY` env vars pointing at the local proxy, which then
+//! enforces the per-policy domain allowlist and injects credentials resolved
+//! from the desktop-client `SecretsStore` (postgres-backed, master-key sealed
+//! by the per-OS keychain — see [`crate::secrets::keychain`]).
+//!
+//! # Fail-safe contract
+//!
+//! - `IronclawSecretsResolver::resolve` returns `None` on **any** error
+//!   (NotFound, decryption failure, db error). The proxy treats `None` as
+//!   "no credential available" and either omits the header (when
+//!   `optional: true`) or denies the request (when `optional: false`,
+//!   the default).
+//! - Conversion of an unknown / malformed mapping never panics; if the local
+//!   `CredentialLocation` cannot be represented by the proxy crate, the
+//!   mapping is silently dropped and the request will be allowed without
+//!   credential injection (subject to allowlist).
+//!
+//! # Module layout
+//!
+//! - [`IronclawSecretsResolver`] — `dasclaw_net_proxy::CredentialResolver`
+//!   impl that pulls decrypted secrets from a `SecretsStore`.
+//! - [`to_proxy_mappings`] — translate `crate::secrets::CredentialMapping`
+//!   into `dasclaw_net_proxy::CredentialMapping`.
+//! - [`start_network_proxy`] — assemble a [`NetworkProxyBuilder`] from a
+//!   [`SandboxConfig`] + `SecretsStore`, start it, return a handle.
+//! - [`proxy_env_vars`] — produce the `HTTPS_PROXY` / `HTTP_PROXY` /
+//!   `NO_PROXY` triplet to inject into spawned child processes.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use dasclaw_net_proxy::{
+    CredentialLocation as ProxyLocation, CredentialMapping as ProxyMapping, CredentialResolver,
+    HttpProxy, NetworkProxyBuilder, ProxyMode,
+};
+
+use crate::sandbox::config::SandboxConfig;
+use crate::sandbox::error::{Result, SandboxError};
+use crate::secrets::{
+    CredentialLocation as LocalLocation, CredentialMapping as LocalMapping, SecretsStore,
+};
+
+/// Bridges `dasclaw_net_proxy::CredentialResolver` to the desktop-client
+/// `SecretsStore`. All errors are coerced to `None` (fail-safe).
+pub struct IronclawSecretsResolver {
+    store: Arc<dyn SecretsStore>,
+    user_id: String,
+}
+
+impl IronclawSecretsResolver {
+    pub fn new(store: Arc<dyn SecretsStore>, user_id: impl Into<String>) -> Self {
+        Self {
+            store,
+            user_id: user_id.into(),
+        }
+    }
+}
+
+#[async_trait]
+impl CredentialResolver for IronclawSecretsResolver {
+    async fn resolve(&self, name: &str) -> Option<String> {
+        match self.store.get_decrypted(&self.user_id, name).await {
+            Ok(decrypted) => Some(decrypted.expose().to_string()),
+            Err(err) => {
+                // Fail-safe: never leak the secret name in error logs at
+                // info level, and never propagate the error — proxy will
+                // deny the request via the `optional: false` default.
+                tracing::debug!(secret = %name, error = %err, "secret resolution failed");
+                None
+            }
+        }
+    }
+}
+
+/// Convert a single desktop-client `CredentialMapping` into the proxy's
+/// representation. Returns `None` if the mapping has no host patterns or
+/// uses a `CredentialLocation` variant that the proxy crate cannot enforce.
+pub fn to_proxy_mapping(local: &LocalMapping) -> Option<ProxyMapping> {
+    if local.host_patterns.is_empty() {
+        return None;
+    }
+
+    let location = match &local.location {
+        LocalLocation::AuthorizationBearer => ProxyLocation::AuthorizationBearer,
+        LocalLocation::AuthorizationBasic { username } => ProxyLocation::AuthorizationBasic {
+            username: username.clone(),
+        },
+        LocalLocation::Header { name, prefix } => ProxyLocation::Header {
+            name: name.clone(),
+            prefix: prefix.clone(),
+        },
+        LocalLocation::QueryParam { name } => ProxyLocation::QueryParam { name: name.clone() },
+        LocalLocation::UrlPath { placeholder } => ProxyLocation::UrlPath {
+            placeholder: placeholder.clone(),
+        },
+    };
+
+    Some(ProxyMapping {
+        secret_name: local.secret_name.clone(),
+        location,
+        host_patterns: local.host_patterns.clone(),
+        optional: false, // Fail-safe: missing secret denies the request.
+    })
+}
+
+/// Translate a list of local mappings. Mappings with empty `host_patterns`
+/// are dropped.
+pub fn to_proxy_mappings(local: &[LocalMapping]) -> Vec<ProxyMapping> {
+    local.iter().filter_map(to_proxy_mapping).collect()
+}
+
+/// Handle returned after starting the proxy. Holding it keeps the listener
+/// alive; dropping it shuts down the proxy.
+pub struct NetworkProxyHandle {
+    pub proxy: Arc<HttpProxy>,
+    pub addr: SocketAddr,
+}
+
+/// Assemble + start a network proxy for the given sandbox config.
+///
+/// Mode mapping:
+/// - `SandboxPolicy::FullAccess` → `ProxyMode::AllowAll` (no enforcement;
+///   policy bypasses the sandbox anyway, kept here for env-var consistency).
+/// - Any other policy → `ProxyMode::Restricted` (allowlist + credential
+///   injection enforced).
+pub async fn start_network_proxy(
+    cfg: &SandboxConfig,
+    credential_mappings: Vec<LocalMapping>,
+    store: Arc<dyn SecretsStore>,
+    user_id: impl Into<String>,
+) -> Result<NetworkProxyHandle> {
+    let mode = if cfg.policy.has_full_network() {
+        ProxyMode::AllowAll
+    } else {
+        ProxyMode::Restricted
+    };
+
+    let resolver: Arc<dyn CredentialResolver> =
+        Arc::new(IronclawSecretsResolver::new(store, user_id));
+
+    let proxy = NetworkProxyBuilder::new()
+        .with_mode(mode)
+        .with_allowlist(cfg.network_allowlist.clone())
+        .with_credentials(to_proxy_mappings(&credential_mappings))
+        .with_credential_resolver(resolver)
+        .build();
+
+    let addr = proxy
+        .start(cfg.proxy_port)
+        .await
+        .map_err(|e| SandboxError::Config {
+            reason: format!("network proxy start failed: {e}"),
+        })?;
+
+    Ok(NetworkProxyHandle {
+        proxy: Arc::new(proxy),
+        addr,
+    })
+}
+
+/// Env vars to inject into spawned child processes / containers so they
+/// route HTTP(S) through the proxy. `NO_PROXY` excludes localhost so
+/// containers can still reach side-cars.
+pub fn proxy_env_vars(addr: SocketAddr) -> Vec<(String, String)> {
+    let url = format!("http://{addr}");
+    vec![
+        ("HTTPS_PROXY".to_string(), url.clone()),
+        ("HTTP_PROXY".to_string(), url.clone()),
+        ("https_proxy".to_string(), url.clone()),
+        ("http_proxy".to_string(), url),
+        (
+            "NO_PROXY".to_string(),
+            "localhost,127.0.0.1,::1".to_string(),
+        ),
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sandbox::config::{SandboxConfig, SandboxPolicy};
+    use crate::secrets::{CreateSecretParams, DecryptedSecret, Secret, SecretError, SecretRef};
+    use async_trait::async_trait;
+    use std::sync::Mutex;
+    use uuid::Uuid;
+
+    /// Minimal in-memory store sufficient for resolver tests. Only
+    /// `get_decrypted` is exercised; other methods return `NotFound`.
+    struct MemStore {
+        entries: Mutex<Vec<(String, String, String)>>, // (user, name, value)
+    }
+    impl MemStore {
+        fn with(entries: Vec<(&str, &str, &str)>) -> Self {
+            Self {
+                entries: Mutex::new(
+                    entries
+                        .into_iter()
+                        .map(|(u, n, v)| (u.into(), n.into(), v.into()))
+                        .collect(),
+                ),
+            }
+        }
+    }
+    #[async_trait]
+    impl SecretsStore for MemStore {
+        async fn create(
+            &self,
+            _: &str,
+            _: CreateSecretParams,
+        ) -> std::result::Result<Secret, SecretError> {
+            Err(SecretError::NotFound("not implemented".into()))
+        }
+        async fn get(&self, _: &str, name: &str) -> std::result::Result<Secret, SecretError> {
+            Err(SecretError::NotFound(name.into()))
+        }
+        async fn get_decrypted(
+            &self,
+            user_id: &str,
+            name: &str,
+        ) -> std::result::Result<DecryptedSecret, SecretError> {
+            let g = self.entries.lock().unwrap();
+            for (u, n, v) in g.iter() {
+                if u == user_id && n == name {
+                    return DecryptedSecret::from_bytes(v.as_bytes().to_vec());
+                }
+            }
+            Err(SecretError::NotFound(name.into()))
+        }
+        async fn exists(&self, _: &str, _: &str) -> std::result::Result<bool, SecretError> {
+            Ok(false)
+        }
+        async fn list(&self, _: &str) -> std::result::Result<Vec<SecretRef>, SecretError> {
+            Ok(vec![])
+        }
+        async fn delete(&self, _: &str, _: &str) -> std::result::Result<bool, SecretError> {
+            Ok(false)
+        }
+        async fn record_usage(&self, _: Uuid) -> std::result::Result<(), SecretError> {
+            Ok(())
+        }
+        async fn is_accessible(
+            &self,
+            _: &str,
+            _: &str,
+            _: &[String],
+        ) -> std::result::Result<bool, SecretError> {
+            Ok(true)
+        }
+    }
+
+    #[tokio::test]
+    async fn resolver_returns_value_when_present() {
+        let store = Arc::new(MemStore::with(vec![("alice", "OPENAI_API_KEY", "sk-xyz")]));
+        let r = IronclawSecretsResolver::new(store, "alice");
+        assert_eq!(r.resolve("OPENAI_API_KEY").await.as_deref(), Some("sk-xyz"));
+    }
+
+    #[tokio::test]
+    async fn resolver_returns_none_for_missing_secret() {
+        let store = Arc::new(MemStore::with(vec![]));
+        let r = IronclawSecretsResolver::new(store, "alice");
+        assert!(r.resolve("MISSING").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn resolver_isolates_users() {
+        let store = Arc::new(MemStore::with(vec![("alice", "K", "a-val")]));
+        let bob = IronclawSecretsResolver::new(store.clone(), "bob");
+        assert!(
+            bob.resolve("K").await.is_none(),
+            "bob must not see alice's secret"
+        );
+    }
+
+    #[test]
+    fn mapping_bearer_round_trips() {
+        let local = LocalMapping::bearer("OPENAI_API_KEY", "api.openai.com");
+        let proxy = to_proxy_mapping(&local).expect("convertible");
+        assert_eq!(proxy.secret_name, "OPENAI_API_KEY");
+        assert_eq!(proxy.host_patterns, vec!["api.openai.com".to_string()]);
+        assert!(matches!(proxy.location, ProxyLocation::AuthorizationBearer));
+        assert!(!proxy.optional, "must default to required (fail-safe)");
+    }
+
+    #[test]
+    fn mapping_header_round_trips() {
+        let local = LocalMapping::header("ANTHROPIC_API_KEY", "x-api-key", "api.anthropic.com");
+        let proxy = to_proxy_mapping(&local).expect("convertible");
+        match proxy.location {
+            ProxyLocation::Header { name, prefix } => {
+                assert_eq!(name, "x-api-key");
+                assert!(prefix.is_none());
+            }
+            other => panic!("unexpected location {other:?}"),
+        }
+    }
+
+    #[test]
+    fn mapping_with_empty_hosts_is_dropped() {
+        let local = LocalMapping {
+            secret_name: "X".into(),
+            location: LocalLocation::AuthorizationBearer,
+            host_patterns: vec![],
+        };
+        assert!(to_proxy_mapping(&local).is_none());
+    }
+
+    #[test]
+    fn mappings_expand_multi_host() {
+        let local = LocalMapping {
+            secret_name: "K".into(),
+            location: LocalLocation::AuthorizationBearer,
+            host_patterns: vec!["a.com".into(), "b.com".into()],
+        };
+        let out = to_proxy_mappings(&[local]);
+        assert_eq!(out.len(), 1);
+        assert_eq!(
+            out[0].host_patterns,
+            vec!["a.com".to_string(), "b.com".to_string()]
+        );
+    }
+
+    #[test]
+    fn proxy_env_vars_include_no_proxy() {
+        let addr: SocketAddr = "127.0.0.1:9999".parse().unwrap();
+        let env = proxy_env_vars(addr);
+        let map: std::collections::HashMap<_, _> = env.into_iter().collect();
+        assert_eq!(map["HTTPS_PROXY"], "http://127.0.0.1:9999");
+        assert_eq!(map["HTTP_PROXY"], "http://127.0.0.1:9999");
+        assert!(map["NO_PROXY"].contains("127.0.0.1"));
+    }
+
+    #[tokio::test]
+    async fn start_network_proxy_binds_and_serves() {
+        let cfg = SandboxConfig {
+            policy: SandboxPolicy::ReadOnly,
+            network_allowlist: vec!["example.com".into()],
+            proxy_port: 0,
+            ..SandboxConfig::default()
+        };
+        let store = Arc::new(MemStore::with(vec![]));
+        let handle = start_network_proxy(&cfg, vec![], store, "alice")
+            .await
+            .expect("proxy starts");
+        assert!(handle.addr.port() > 0);
+        assert!(handle.proxy.is_running());
+    }
+
+    #[tokio::test]
+    async fn full_access_policy_uses_allow_all_mode() {
+        // Sanity: FullAccess must not crash the builder even with empty allowlist.
+        let cfg = SandboxConfig {
+            policy: SandboxPolicy::FullAccess,
+            network_allowlist: vec![],
+            proxy_port: 0,
+            ..SandboxConfig::default()
+        };
+        let store = Arc::new(MemStore::with(vec![]));
+        let handle = start_network_proxy(&cfg, vec![], store, "alice")
+            .await
+            .expect("proxy starts in AllowAll");
+        assert!(handle.proxy.is_running());
+    }
+}


### PR DESCRIPTION
## Summary

Bridges the OS-sandbox layer (`SandboxConfig` + `SecretsStore`) to the audited HTTP egress proxy from PRs #19/#20. Spawned tool processes will receive `HTTPS_PROXY`/`HTTP_PROXY`/`NO_PROXY` env vars pointing at the local proxy, which enforces per-policy domain allowlists and injects credentials resolved from the existing desktop-client `SecretsStore` (postgres-backed, master-key sealed by the per-OS keychain).

## Changes

- `desktop-client/ironclaw/src/sandbox/net_proxy.rs` (new, ~370 LOC):
  - `IronclawSecretsResolver` — `dasclaw_net_proxy::CredentialResolver` impl wrapping `SecretsStore`. **All errors → `None` (fail-safe)**: missing secret, decryption failure, db error all coerce to `None`, which the proxy treats as denial when `optional: false` (the default).
  - `to_proxy_mapping` / `to_proxy_mappings` — translate `crate::secrets::CredentialMapping` → `dasclaw_net_proxy::CredentialMapping`. Mappings without host_patterns are dropped silently.
  - `start_network_proxy` — assemble + bind a `NetworkProxyBuilder` from a `SandboxConfig`. `FullAccess` → `ProxyMode::AllowAll`, others → `ProxyMode::Restricted`.
  - `proxy_env_vars` — emit both upper- and lowercase env vars (HTTP proxy convention; runtimes differ) plus `NO_PROXY=localhost,127.0.0.1,::1`.
- `desktop-client/ironclaw/Cargo.toml` — add `dasclaw_net_proxy` path dep.
- `desktop-client/ironclaw/src/sandbox/mod.rs` — register module.
- `AGENTS.md` — document `cargo sweep --time 3` as default cache cleanup (separate concern; surfaced by real disk pressure during dev).

## Tests

10 nextest cases — all pass. `cargo check -p ironclaw --lib`: **0 errors, 0 warnings**.

## Stack

- Base: `feat/w3.2b-2-net-proxy-deny-reasons` (#20) which is stacked on `feat/w3.2b-1-net-proxy-port` (#19)
- Independent of #21 (W3.2b-3 Windows keychain)
- After #19 and #20 merge to `xClaw`, this PR's base will auto-retarget to `xClaw`.

## What's NOT in this PR (W3.2b-5)

- Wiring the proxy startup into the desktop-client app boot
- E2E tests with a live tool process going through the proxy
- Completion report `44-net-proxy-port-completion.md`

## Refs

- ADR: `docs/plans/architecture-refactor/43-net-proxy-port-decision.md` (Tier B''+)
- Skill audit: code-quality-audit ✅ 5/5 pass; no production panics outside `#[cfg(test)]`.
