### PR TITLE
feat(w3.2b-5): plumb proxy env vars through ShellTool + completion report

### DIFF
--- a/desktop-client/ironclaw/src/tools/builtin/shell.rs
+++ b/desktop-client/ironclaw/src/tools/builtin/shell.rs
@@ -556,6 +556,11 @@ pub struct ShellTool {
     sandbox: Option<Arc<OsExecutor>>,
     /// Sandbox policy to use when sandbox is available.
     sandbox_policy: SandboxPolicy,
+    /// W3.2b-5: extra env vars merged into every spawned command (sandboxed
+    /// or direct). Typically populated with `HTTPS_PROXY`/`HTTP_PROXY`/
+    /// `NO_PROXY` from [`crate::sandbox::net_proxy::proxy_env_vars`] so tool
+    /// processes route HTTP traffic through the audited egress proxy.
+    extra_env: HashMap<String, String>,
 }
 
 impl std::fmt::Debug for ShellTool {
@@ -579,7 +584,18 @@ impl ShellTool {
             allow_dangerous: false,
             sandbox: None,
             sandbox_policy: SandboxPolicy::ReadOnly,
+            extra_env: HashMap::new(),
         }
+    }
+
+    /// W3.2b-5: set the extra env vars merged into every spawned command.
+    ///
+    /// Use [`crate::sandbox::net_proxy::proxy_env_vars`] to obtain the
+    /// `HTTPS_PROXY`/`HTTP_PROXY`/`NO_PROXY` triplet pointing at a running
+    /// [`crate::sandbox::net_proxy::NetworkProxyHandle`].
+    pub fn with_extra_env(mut self, env: HashMap<String, String>) -> Self {
+        self.extra_env = env;
+        self
     }
 
     /// Set the working directory.
@@ -637,14 +653,14 @@ impl ShellTool {
     ) -> Result<(String, i64), ToolError> {
         // Outer timeout still wraps the executor (defense in depth: OsExecutor
         // also enforces its own timeout, but the caller's value can be tighter).
+        // W3.2b-5: forward `extra_env` (typically proxy env vars) into the
+        // sandboxed child process so HTTP egress is routed through the audited
+        // proxy. The OS sandbox itself enforces filesystem/network policy; the
+        // proxy enforces domain allowlist + credential injection on top.
+        let env = self.extra_env.clone();
         let result = tokio::time::timeout(timeout, async {
             sandbox
-                .execute(
-                    cmd,
-                    workdir,
-                    self.sandbox_policy,
-                    std::collections::HashMap::new(),
-                )
+                .execute(cmd, workdir, self.sandbox_policy, env)
                 .await
         })
         .await;
@@ -818,9 +834,20 @@ impl ShellTool {
                 .await;
         }
 
+        // W3.2b-5: when running unsandboxed, merge configured proxy env vars
+        // (`self.extra_env`) under the caller-supplied `extra_env`. Caller
+        // wins on conflict so per-call overrides remain possible.
+        let merged_env = if self.extra_env.is_empty() {
+            extra_env.clone()
+        } else {
+            let mut merged = self.extra_env.clone();
+            merged.extend(extra_env.iter().map(|(k, v)| (k.clone(), v.clone())));
+            merged
+        };
+
         // Only execute directly when no sandbox was configured at all.
         let (output, code) = self
-            .execute_direct(cmd, &cwd, timeout_duration, extra_env)
+            .execute_direct(cmd, &cwd, timeout_duration, &merged_env)
             .await?;
         Ok((output, code as i64))
     }
@@ -1075,6 +1102,50 @@ mod tests {
 
         assert_eq!(tool.sandbox_policy, SandboxPolicy::WorkspaceWrite);
         assert_eq!(tool.timeout, Duration::from_secs(60));
+    }
+
+    /// W3.2b-5: `with_extra_env` populates the env map that gets forwarded
+    /// to both sandboxed and direct execution paths.
+    #[test]
+    fn test_with_extra_env_populates_field() {
+        let mut env = HashMap::new();
+        env.insert(
+            "HTTPS_PROXY".to_string(),
+            "http://127.0.0.1:9090".to_string(),
+        );
+        env.insert("NO_PROXY".to_string(), "localhost".to_string());
+        let tool = ShellTool::new().with_extra_env(env.clone());
+        assert_eq!(tool.extra_env, env);
+    }
+
+    /// W3.2b-5: when the unsandboxed path runs, `self.extra_env` is merged
+    /// into the spawned process environment. Caller-supplied env wins on
+    /// conflict so per-call overrides remain possible.
+    #[tokio::test]
+    async fn test_extra_env_injected_into_direct_execution() {
+        let mut configured = HashMap::new();
+        configured.insert("TEST_PROXY_VAR".to_string(), "from-config".to_string());
+        configured.insert("TEST_OVERRIDE_VAR".to_string(), "from-config".to_string());
+        let tool = ShellTool::new().with_extra_env(configured);
+
+        // Caller overrides one var; the other should come from configured.
+        let mut per_call = HashMap::new();
+        per_call.insert("TEST_OVERRIDE_VAR".to_string(), "from-call".to_string());
+
+        let (out, code) = tool
+            .execute_command(
+                "echo \"$TEST_PROXY_VAR|$TEST_OVERRIDE_VAR\"",
+                None,
+                Some(5),
+                &per_call,
+            )
+            .await
+            .expect("command runs");
+        assert_eq!(code, 0, "command exited non-zero: {out}");
+        assert!(
+            out.contains("from-config|from-call"),
+            "expected merged env, got: {out}"
+        );
     }
 
     // ── Command token matching ─────────────────────────────────────────

--- a/docs/plans/architecture-refactor/44-net-proxy-port-completion.md
+++ b/docs/plans/architecture-refactor/44-net-proxy-port-completion.md
@@ -1,0 +1,100 @@
+# 44 — Net Proxy Port: Completion Report (W3.2b-1 → W3.2b-5)
+
+> **Status**: Implementation complete — all 5 sub-PRs merged into `xClaw`.
+>
+> **Predecessor**: [43-net-proxy-port-adr.md](./43-net-proxy-port-adr.md) (Tier B''+ decision)
+
+## Scope delivered
+
+Ported the audited HTTP forward proxy from `ironclaw-main` into the workspace and wired it into the desktop-client sandbox layer. The proxy now sits between sandboxed tool processes and the public internet, enforcing per-policy domain allowlists and injecting credentials resolved from the existing `SecretsStore` (postgres-backed, master-key sealed by the per-OS keychain).
+
+## Sub-PR breakdown
+
+| Sub-PR | Scope | LOC | Tests |
+|--------|-------|-----|-------|
+| #19 W3.2b-1 | Port `dasclaw_net_proxy` crate (HTTP CONNECT + forward, allowlist, credential resolver trait) | ~1495 | 30 |
+| #23 W3.2b-2 | Replace stringly-typed deny reasons with `NetworkDenyReason` enum (5 variants, `kind()` for SIEM) | +213 | 35 |
+| #21 W3.2b-3 | Windows keychain via `windows-rs` Credential Manager + DPAPI; preserves macOS Keychain (security-framework) and Linux Secret Service (secret-service) untouched | +209 | 4 |
+| #24 W3.2b-4 | desktop-client integration bridge `sandbox::net_proxy` (resolver + builder + env vars) | +374 | 10 |
+| (this PR) W3.2b-5 | `ShellTool::with_extra_env` plumbing + completion report | ~80 | 2 |
+
+**Cumulative**: ~2370 LOC, 81 nextest cases, 0 errors, 0 warnings on `cargo check -p ironclaw --lib`.
+
+## Architecture
+
+```
+   ┌───────────────────────────────────────────────────────────┐
+   │ desktop-client                                            │
+   │                                                           │
+   │  SecretsStore (pg + master-key + per-OS keychain)         │
+   │           │                                               │
+   │           ▼                                               │
+   │  IronclawSecretsResolver  ─────►  dasclaw_net_proxy       │
+   │           │                       (HttpProxy on 127.x:N)  │
+   │           │                                ▲              │
+   │           │                  HTTPS_PROXY=http://127.x:N   │
+   │           ▼                                │              │
+   │  ShellTool.extra_env  ────►  OsExecutor  ──┘              │
+   │  (proxy_env_vars)            (Seatbelt /                  │
+   │                               Landlock+seccomp /          │
+   │                               Restricted Token)           │
+   └───────────────────────────────────────────────────────────┘
+                                  │
+                                  ▼ (allowlisted hosts only,
+                                     credentials injected)
+                            public internet
+```
+
+## Fail-safe contract
+
+1. **Resolver errors → `None`**: missing secret, decryption failure, db error all coerce to `None`. The proxy's `optional: false` default then denies the request rather than silently sending it without credentials.
+2. **OS sandbox + proxy are independent layers**: even if the proxy misbehaves, the OS sandbox (Seatbelt / Landlock+seccomp / Windows Restricted Token) still blocks raw socket access for `ReadOnly` and `WorkspaceWrite` policies. `FullAccess` opt-in still requires `SANDBOX_ALLOW_FULL_ACCESS=true`.
+3. **Empty mappings dropped silently**: `to_proxy_mapping` returns `None` for mappings without `host_patterns`, so a misconfigured mapping cannot accidentally widen scope.
+4. **No raw secrets in logs**: resolver errors log `secret = %name, error = %err` at `debug` level only; the decrypted value never appears in tracing output.
+
+## Caller integration pattern
+
+Callers wire it together at app boot:
+
+```rust
+use std::sync::Arc;
+use desktop_client::ironclaw::sandbox::{
+    OsExecutor, SandboxConfig, SandboxPolicy,
+    net_proxy::{start_network_proxy, proxy_env_vars},
+};
+
+// 1. Start the proxy from the active sandbox config + secrets store.
+let cfg = SandboxConfig::default();
+let proxy_handle = start_network_proxy(&cfg, mappings, secrets_store, user_id).await?;
+
+// 2. Build the OS executor.
+let executor = Arc::new(OsExecutor::new(timeout, allow_full_access));
+
+// 3. Construct ShellTool with both the executor and the proxy env vars.
+let env = proxy_env_vars(proxy_handle.addr).into_iter().collect();
+let shell = ShellTool::new()
+    .with_sandbox(executor)
+    .with_sandbox_policy(SandboxPolicy::WorkspaceWrite)
+    .with_extra_env(env);
+
+registry.register_sync(Arc::new(shell));
+```
+
+The `proxy_handle` must be kept alive for the lifetime of the executor; dropping it shuts down the proxy.
+
+## Out of scope (deferred)
+
+| Item | Reason |
+|------|--------|
+| **App-boot wiring in desktop-client `main`/`lib`** | The current desktop-client tool registry (`register_dev_tools`) does not yet receive a sandbox/secrets handle. Integrating it requires touching the app initialization path, which is being refactored separately. The plumbing is in place; the wire-up is a one-screen change once the registry signature is finalized. |
+| **E2E test with live tool process** | Requires the app-boot wiring above. Until then, sandbox + proxy + ShellTool are validated independently (81 unit tests across the stack). |
+| **MITM TLS interception (Tier A)** | Explicitly rejected by the ADR — CA private-key blast radius outweighs DLP benefit. Server-side gateway DLP remains the long-term path for inspection of encrypted egress. |
+| **Per-mapping `optional: true` flag** | Currently hard-coded to `false` (fail-safe). Adding a builder option is trivial when a real use case appears. |
+
+## Refs
+
+- ADR: [43-net-proxy-port-adr.md](./43-net-proxy-port-adr.md)
+- Crate: `crates/dasclaw_net_proxy/`
+- Bridge: `desktop-client/ironclaw/src/sandbox/net_proxy.rs`
+- Caller: `desktop-client/ironclaw/src/tools/builtin/shell.rs` (`with_extra_env`)
+- Keychain: `desktop-client/ironclaw/src/secrets/keychain.rs`


### PR DESCRIPTION
## Summary

Closes the W3.2b net-proxy port: wires `proxy_env_vars()` from `sandbox::net_proxy` (PR #24) into `ShellTool` so OS-sandboxed tool processes route HTTP traffic through the audited egress proxy.

Also adds the W3.2b completion report rolling up the 5-PR delivery (#19, #21, #23, #24, this PR).

## Changes

### `desktop-client/ironclaw/src/tools/builtin/shell.rs`

- Add `extra_env: HashMap<String, String>` field to `ShellTool`.
- Add `with_extra_env(env)` builder.
- `execute_sandboxed` now forwards `self.extra_env.clone()` into `OsExecutor::execute` (was hard-coded `HashMap::new()`).
- `execute_command` merges `self.extra_env` under caller-supplied `extra_env` for the unsandboxed direct path. **Caller wins on conflict** so per-call overrides remain possible.

### `docs/plans/architecture-refactor/44-net-proxy-port-completion.md`

- Document the 5-PR rollup: scope, LOC/test counts, architecture diagram, fail-safe contract, integration pattern, and deferred items.

## Tests

- `test_with_extra_env_populates_field` — builder populates the field.
- `test_extra_env_injected_into_direct_execution` — verifies merge semantics (config + per-call, caller wins on conflict).

Full ironclaw shell + net_proxy nextest suite: **45/45 PASS**. `cargo check -p ironclaw --lib`: **0 errors, 0 warnings**.

## Caller integration pattern

```rust
let proxy = start_network_proxy(&cfg, mappings, secrets, user_id).await?;
let env = proxy_env_vars(proxy.addr).into_iter().collect();
let shell = ShellTool::new()
    .with_sandbox(executor)
    .with_sandbox_policy(SandboxPolicy::WorkspaceWrite)
    .with_extra_env(env);
```

## Deferred (out of scope)

- **App-boot wiring in desktop-client `main`/`lib`** — the current tool registry doesn't yet receive a sandbox/secrets handle. The plumbing is in place; the wire-up is a one-screen change once the registry signature is finalized. Tracked in completion report §"Out of scope".
- **E2E with live tool process** — depends on the boot wiring above.

## Refs

- ADR: `docs/plans/architecture-refactor/43-net-proxy-port-adr.md` (Tier B''+)
- Completion: `docs/plans/architecture-refactor/44-net-proxy-port-completion.md`
- Stack: #19 → #23 → #21 → #24 → this PR (all merged base commits in `xClaw`)
