### PR TITLE
docs: AGENTS.md trigger table + Round 19 lessons (W3.2b retrospective)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,19 @@
 3. 最后才用 `rg` 定位确切位置
 4. 对于"X 没有 Y"这类否定性结论，**必须明确给出 Level 1 + Level 3 双证据**才能落笔
 
+**触发判断表**（什么场景必须做三层验证）：
+
+| 场景 | 是否必须做三层验证 |
+|------|---------------------|
+| 否定性结论："X 没有 Y" / "X 是独家的" / "缺失 Y" | ✅ 必须 |
+| 新增模块 / 新建 crate / 新建文件 | ✅ 必须（先 semantic_search 是否已有等价） |
+| 跨项目对账（codex / claw-code / ironclaw 能力对比） | ✅ 必须 |
+| 架构对账文档（如 14-md） | ✅ 必须（Round 17/18 实证错误率 4/19） |
+| 已知模块内 bug 修复 | ❌ 不需要 |
+| 仅文档 / 格式化 / lint 修改 | ❌ 不需要 |
+| 已确定模块内 feature 扩展（不涉及"是否复用"） | ⚠️ 可选 |
+| commit message 写"已检查 X 是否已有，结论：…" | ✅ 推荐（过程透明度） |
+
 **教训来源**：
 - Round 1-15 多次误判（"codex 没 forkSubagent"、"ironclaw Prompt Cache 独家"）的根因均为字面量搜索陷阱。
 - **Round 18 实证**：14 文档 Round 17 版本列出的 4 项 P0/P1 "缺口"（`<system-reminder>` 标签 / CYBER_RISK_INSTRUCTION 文本 / 多层 CLAUDE.md 加载 / 压缩阈值），经 `semantic_search` 验证全部是**伪缺口** —— claw-code `runtime/src/prompt.rs:480` 与 `prompt.rs:197`、codex `openai_models.rs:306` 早已实现。4/19 的文档错误率直接证明：**不做 semantic_search 就动笔写对账文档是不合格的**。

--- a/docs/plans/architecture-refactor/44-net-proxy-port-completion.md
+++ b/docs/plans/architecture-refactor/44-net-proxy-port-completion.md
@@ -98,3 +98,36 @@ The `proxy_handle` must be kept alive for the lifetime of the executor; dropping
 - Bridge: `desktop-client/ironclaw/src/sandbox/net_proxy.rs`
 - Caller: `desktop-client/ironclaw/src/tools/builtin/shell.rs` (`with_extra_env`)
 - Keychain: `desktop-client/ironclaw/src/secrets/keychain.rs`
+
+## Round 19 lessons (W3.2b retrospective)
+
+Recorded after the 5-PR delivery to keep the analysis tooling discipline honest. Source: AGENTS.md §"分析工具使用规范" Round 17/18 lineage.
+
+### What went right
+
+1. **Avoided keyring-rs rewrite**: Before W3.2b-3 (Windows keychain), discovered `desktop-client/ironclaw/src/secrets/keychain.rs` already had **318 LOC** of mature macOS (`security-framework`) + Linux (`secret-service`) implementation. Decision: add Windows via `windows-rs` DPAPI as a third platform module rather than introducing keyring-rs and replacing all three. Saved ~200 LOC of churn and preserved the existing fail-safe contract.
+2. **Reused detect_loopback_ports**: Before designing how OS sandbox would let the local proxy through, ran `grep "PROXY_URL_ENV"` and found `crates/dasclaw_sandbox/src/proxy.rs::detect_loopback_ports` already ported from codex during W2.2b. `crates/dasclaw_exec/src/lib.rs:175` already calls it. Conclusion: the OS-sandbox-↔-proxy plumbing was solved 2 weeks ago; W3.2b only had to ship the proxy itself.
+3. **Reused secrets architecture**: `ironclaw-main` had 2961 LOC mature secrets KMS (master_key + HKDF + AES-GCM + per-secret salt + CAS + ACL). W3.2b-3 reused all of it instead of reinventing.
+
+### What was a near-miss (recorded for transparency)
+
+**`to_proxy_mapping` cross-crate type translation (W3.2b-4)**:
+- `crate::secrets::CredentialMapping` and `dasclaw_net_proxy::CredentialMapping` have nearly identical fields.
+- A naive reading flags this as duplication. The correct view is: they live in different crates (app vs. lib) with different ownership boundaries, and a `From` impl in either direction would create a circular dep (lib crate cannot depend on app crate; app's domain types should not be defined inside the lib crate either).
+- Hand-rolled `match` translation in `desktop-client/ironclaw/src/sandbox/net_proxy.rs::to_proxy_mapping` is correct.
+- **What was missed at the time**: the commit message did not state this trade-off. A reader could legitimately wonder "why not `From`?" and assume the author didn't think about it.
+- **Lesson for next time**: when hand-translating between two near-identical types, the commit message must include "why not `From` / `TryFrom`" reasoning, even when the answer is "circular dep".
+
+### What did NOT go wrong this round
+
+Cross-checked W3.2b-1 / 2 / 4 / 5 against existing implementations via `grep` over the full workspace + `codex-cli-main/`, `claw-code/`, `ironclaw-main/`. No "module already exists, rewrote it" findings. The only adjacent prior art (`crates/dasclaw_net_proxy/src/builder.rs` line 3 docstring explicitly cites it) is `ironclaw-main/src/sandbox/proxy/mod.rs::NetworkProxyBuilder`, which is the source we are porting *from* — by design.
+
+### Trigger for the analysis matrix in AGENTS.md
+
+The "触发判断表" (trigger table) in AGENTS.md §"分析工具使用规范" was added after Round 19 to make the rule actionable:
+
+- New crate / new module → must `semantic_search` first (this would have caught keyring-rs rewrite if it had been attempted).
+- Negative claim ("X has no Y") → must show Level 1 + Level 3 evidence before writing it down.
+- Hand-rolled type translation between two near-identical types → commit message must explain why no `From` impl.
+
+This closes the loop on Round 17's discovery that the previous version of doc 14 had a 4/19 false-negative rate when negative claims were made without `semantic_search` evidence.


### PR DESCRIPTION
## Summary

Two-file docs follow-up after the W3.2b net-proxy port (PRs #19, #21, #23, #24, #25 all merged).

## Changes

### `AGENTS.md`
- Add **trigger table** under §"分析工具使用规范" so the rule is actionable, not just stated.
- Lists which scenarios MUST do three-level analysis (semantic_search + vscode_listCodeUsages + rg) and which do not.

### `docs/plans/architecture-refactor/44-net-proxy-port-completion.md`
- Add **Round 19 lessons** section:
  - **What went right**: avoided keyring-rs rewrite (reused 318 LOC existing keychain.rs); reused `detect_loopback_ports` (W2.2b prior art); reused 2961 LOC ironclaw-main secrets KMS.
  - **Near-miss**: `to_proxy_mapping` cross-crate type translation. The commit message did not explain 'why not `From`' (answer: circular dep across app/lib boundary). Lesson: hand-rolled translations between near-identical types must include this reasoning in the commit message.
  - **What did NOT go wrong**: cross-checked all 5 sub-PRs against codex-cli, claw-code, ironclaw-main via grep — no "module already exists, rewrote it" findings.

## Why now

Closes the loop on user-raised questions during the W3.2b retrospective:
1. "3 个分析工具的标准有没有加到 AGENTS.md" — yes (Round 17/18), but no actionable trigger checklist until now.
2. "之前做的功能有没有模块已存在但没发现又写一遍" — answered with grep-validated audit in Round 19 section.

## Out of scope

- AGENTS.md line 84 references `docs/plans/architecture-refactor/14-claude-code-capability-parity.md` which does not exist in the workspace. This is a pre-existing dead link not introduced by this PR; will be fixed in a separate cleanup PR or by creating the missing doc when the next architecture-parity audit happens.