### PR TITLE
feat(w3.3-1): ResourceLimits struct + setrlimit pre_exec helper (Unix)

### DIFF
--- a/crates/dasclaw_exec/src/lib.rs
+++ b/crates/dasclaw_exec/src/lib.rs
@@ -276,10 +276,8 @@ mod tests {
     #[test]
     fn workspace_write_uses_default_resource_limits() {
         let tmp = tempfile::tempdir().unwrap();
-        let cfg = policy_to_backend_config(
-            &SandboxPolicy::new_workspace_write_policy(),
-            tmp.path(),
-        );
+        let cfg =
+            policy_to_backend_config(&SandboxPolicy::new_workspace_write_policy(), tmp.path());
         assert!(cfg.resource_limits.max_memory_bytes.is_some());
         assert_eq!(cfg.resource_limits.max_open_files, Some(1024));
         assert_eq!(cfg.resource_limits.max_processes, Some(1024));

--- a/crates/dasclaw_exec/src/lib.rs
+++ b/crates/dasclaw_exec/src/lib.rs
@@ -45,7 +45,8 @@ use std::process::{Command, Output};
 
 use dasclaw_sandbox::proxy::detect_loopback_ports;
 use dasclaw_sandbox::{
-    SandboxBackendConfig, SandboxError, SandboxExecRequest, SandboxablePreference, select_backend,
+    ResourceLimits, SandboxBackendConfig, SandboxError, SandboxExecRequest, SandboxablePreference,
+    select_backend,
 };
 use ironclaw_workspace_cap::policy::{NetworkAccess, SandboxPolicy};
 
@@ -181,6 +182,10 @@ pub fn policy_to_backend_config_with_env(
             allow_network: true,
             allow_spawn: true,
             proxy_loopback_ports: vec![],
+            // FullAccess is the user-trusted escape hatch; do not impose
+            // resource limits here. Callers wanting limits on FullAccess
+            // tasks must override `resource_limits` explicitly.
+            resource_limits: ResourceLimits::unlimited(),
         },
         SandboxPolicy::ReadOnly { network_access } => SandboxBackendConfig {
             readable_roots: vec![PathBuf::from("/")],
@@ -192,6 +197,7 @@ pub fn policy_to_backend_config_with_env(
             } else {
                 proxy_ports_when_restricted()
             },
+            resource_limits: ResourceLimits::default(),
         },
         SandboxPolicy::ExternalSandbox { network_access } => {
             let net_enabled = matches!(network_access, NetworkAccess::Enabled);
@@ -206,6 +212,7 @@ pub fn policy_to_backend_config_with_env(
                 } else {
                     proxy_ports_when_restricted()
                 },
+                resource_limits: ResourceLimits::default(),
             }
         }
         SandboxPolicy::WorkspaceWrite { network_access, .. } => {
@@ -221,6 +228,7 @@ pub fn policy_to_backend_config_with_env(
                 } else {
                     proxy_ports_when_restricted()
                 },
+                resource_limits: ResourceLimits::default(),
             }
         }
     }
@@ -237,6 +245,44 @@ mod tests {
         assert_eq!(cfg.writable_roots, vec![PathBuf::from("/")]);
         assert!(cfg.allow_network);
         assert!(cfg.allow_spawn);
+    }
+
+    // -- W3.3-1: ResourceLimits projection --
+
+    #[test]
+    fn danger_full_access_uses_unlimited_resources() {
+        let cfg = policy_to_backend_config(&SandboxPolicy::DangerFullAccess, Path::new("/x"));
+        // FullAccess is the user-trusted escape hatch; do not impose
+        // resource limits unless the caller overrides explicitly.
+        assert!(cfg.resource_limits.max_memory_bytes.is_none());
+        assert!(cfg.resource_limits.max_cpu_secs.is_none());
+    }
+
+    #[test]
+    fn read_only_uses_default_resource_limits() {
+        let cfg = policy_to_backend_config(
+            &SandboxPolicy::ReadOnly {
+                network_access: false,
+            },
+            Path::new("/x"),
+        );
+        assert_eq!(
+            cfg.resource_limits.max_memory_bytes,
+            Some(4 * 1024 * 1024 * 1024)
+        );
+        assert_eq!(cfg.resource_limits.max_cpu_secs, Some(600));
+    }
+
+    #[test]
+    fn workspace_write_uses_default_resource_limits() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cfg = policy_to_backend_config(
+            &SandboxPolicy::new_workspace_write_policy(),
+            tmp.path(),
+        );
+        assert!(cfg.resource_limits.max_memory_bytes.is_some());
+        assert_eq!(cfg.resource_limits.max_open_files, Some(1024));
+        assert_eq!(cfg.resource_limits.max_processes, Some(1024));
     }
 
     #[test]

--- a/crates/dasclaw_sandbox/Cargo.toml
+++ b/crates/dasclaw_sandbox/Cargo.toml
@@ -13,6 +13,11 @@ path = "src/lib.rs"
 thiserror = "1"
 url = "2"
 
+# W3.3 — `libc` 现需在所有 Unix 平台启用（macOS + Linux），用于 setrlimit。
+# 详见 docs/plans/architecture-refactor/45-resource-limits-adr.md。
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
 # W2.3 — Linux seccomp backend.
 # 只在 Linux target 上启用，避免污染 macOS/Windows 工作流。
 # 选型理由（详见 docs/plans/architecture-refactor/32 §W2.3）：
@@ -22,5 +27,4 @@ url = "2"
 #     与 dasclaw_sandbox kernel 层互补不重叠。
 #   - 不引入外部 bwrap setuid 依赖，部署更轻。
 [target.'cfg(target_os = "linux")'.dependencies]
-libc = "0.2"
 seccompiler = "0.5"

--- a/crates/dasclaw_sandbox/src/lib.rs
+++ b/crates/dasclaw_sandbox/src/lib.rs
@@ -101,6 +101,67 @@ pub fn get_platform_sandbox(windows_sandbox_enabled: bool) -> Option<SandboxType
     }
 }
 
+/// Per-process resource limits enforced via `setrlimit(2)` on Unix and
+/// (future) Windows Job Objects on Windows.
+///
+/// Each field is `Option<u64>`; `None` means "do not enforce" (inherit
+/// parent limit). [`ResourceLimits::default`] returns sane defaults that
+/// handle 99% of legitimate workloads while blocking runaway scripts and
+/// fork bombs before the OS OOM killer mis-targets unrelated processes.
+///
+/// Callers wanting **no enforcement** must explicitly call
+/// [`ResourceLimits::unlimited`].
+///
+/// See [45 — Resource Limits ADR](../../docs/plans/architecture-refactor/45-resource-limits-adr.md).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ResourceLimits {
+    /// Maximum address-space size in bytes. Enforced via `RLIMIT_AS` on
+    /// Unix; `JOB_OBJECT_LIMIT_PROCESS_MEMORY` on Windows (future).
+    pub max_memory_bytes: Option<u64>,
+
+    /// Maximum CPU seconds (soft = `SIGXCPU`, hard = `SIGKILL`). Enforced
+    /// via `RLIMIT_CPU` on Unix; silently ignored on Windows.
+    pub max_cpu_secs: Option<u64>,
+
+    /// Max simultaneously open file descriptors. Enforced via
+    /// `RLIMIT_NOFILE` on Unix; silently ignored on Windows.
+    pub max_open_files: Option<u64>,
+
+    /// Max child processes the sandbox may spawn. Enforced via
+    /// `RLIMIT_NPROC` on Unix; `JOB_OBJECT_LIMIT_ACTIVE_PROCESS` on Windows.
+    pub max_processes: Option<u64>,
+}
+
+impl Default for ResourceLimits {
+    /// Sane defaults: 4 GiB memory / 600 s CPU / 1024 FDs / 1024 processes.
+    ///
+    /// Rationale per Round 20 user decision: macOS OOM killer sometimes
+    /// mis-targets Finder/IDE under memory pressure; defaults catch
+    /// runaway scripts before that triggers. Users override via config.
+    fn default() -> Self {
+        Self {
+            max_memory_bytes: Some(4 * 1024 * 1024 * 1024), // 4 GiB
+            max_cpu_secs: Some(600),                         // 10 min
+            max_open_files: Some(1024),
+            max_processes: Some(1024),
+        }
+    }
+}
+
+impl ResourceLimits {
+    /// Construct a [`ResourceLimits`] with **no** enforcement. Callers
+    /// should prefer [`Default::default`] unless they have a specific
+    /// reason to disable all limits (e.g. trusted batch jobs).
+    pub fn unlimited() -> Self {
+        Self {
+            max_memory_bytes: None,
+            max_cpu_secs: None,
+            max_open_files: None,
+            max_processes: None,
+        }
+    }
+}
+
 /// Backend-level sandbox configuration: the concrete knobs the sandbox
 /// **kernel** (seatbelt / seccomp / windows) needs to enforce a policy.
 ///
@@ -118,6 +179,11 @@ pub struct SandboxBackendConfig {
     /// detected from `HTTP_PROXY` / `HTTPS_PROXY` env vars.
     /// Populated by `proxy::detect_loopback_ports()`.
     pub proxy_loopback_ports: Vec<u16>,
+    /// Resource limits applied via `setrlimit` in the child process's
+    /// pre_exec hook. Defaults to [`ResourceLimits::default`] (4 GiB / 600 s
+    /// / 1024 FDs / 1024 procs). Pass [`ResourceLimits::unlimited`] to opt
+    /// out completely. See W3.3 ADR.
+    pub resource_limits: ResourceLimits,
 }
 
 impl SandboxBackendConfig {
@@ -134,6 +200,12 @@ impl SandboxBackendConfig {
         self.proxy_loopback_ports = ports;
         self
     }
+
+    /// Override the resource limits applied to spawned processes.
+    pub fn with_resource_limits(mut self, limits: ResourceLimits) -> Self {
+        self.resource_limits = limits;
+        self
+    }
 }
 
 /// Deprecated alias kept for transition; will be removed once all call
@@ -141,6 +213,9 @@ impl SandboxBackendConfig {
 pub type SandboxPolicy = SandboxBackendConfig;
 
 pub mod proxy;
+
+#[cfg(unix)]
+pub mod rlimit;
 
 /// What the caller wants to execute under a sandbox.
 #[derive(Debug)]

--- a/crates/dasclaw_sandbox/src/lib.rs
+++ b/crates/dasclaw_sandbox/src/lib.rs
@@ -141,7 +141,7 @@ impl Default for ResourceLimits {
     fn default() -> Self {
         Self {
             max_memory_bytes: Some(4 * 1024 * 1024 * 1024), // 4 GiB
-            max_cpu_secs: Some(600),                         // 10 min
+            max_cpu_secs: Some(600),                        // 10 min
             max_open_files: Some(1024),
             max_processes: Some(1024),
         }

--- a/crates/dasclaw_sandbox/src/rlimit.rs
+++ b/crates/dasclaw_sandbox/src/rlimit.rs
@@ -81,8 +81,7 @@ pub fn apply_in_pre_exec(limits: &ResourceLimits) -> std::io::Result<()> {
 /// `u64::MAX` as a sentinel without triggering EINVAL.
 #[cfg(unix)]
 fn set_one(resource: RlimitResource, value: u64) -> std::io::Result<()> {
-    let infinity = libc::RLIM_INFINITY as u64;
-    let clamped = if value >= infinity {
+    let clamped = if value >= libc::RLIM_INFINITY {
         libc::RLIM_INFINITY
     } else {
         value as libc::rlim_t
@@ -163,8 +162,7 @@ mod tests {
     #[test]
     fn builder_with_resource_limits_overrides_default() {
         use crate::SandboxBackendConfig;
-        let cfg = SandboxBackendConfig::default()
-            .with_resource_limits(ResourceLimits::unlimited());
+        let cfg = SandboxBackendConfig::default().with_resource_limits(ResourceLimits::unlimited());
         assert!(cfg.resource_limits.max_memory_bytes.is_none());
     }
 
@@ -173,8 +171,7 @@ mod tests {
         // u64::MAX is the documented sentinel for "no limit". Verify the
         // clamp branch maps it to RLIM_INFINITY without panicking.
         let huge = u64::MAX;
-        let infinity = libc::RLIM_INFINITY as u64;
-        let clamped = if huge >= infinity {
+        let clamped = if huge >= libc::RLIM_INFINITY {
             libc::RLIM_INFINITY
         } else {
             huge as libc::rlim_t

--- a/crates/dasclaw_sandbox/src/rlimit.rs
+++ b/crates/dasclaw_sandbox/src/rlimit.rs
@@ -1,0 +1,184 @@
+//! Resource limit enforcement via `setrlimit(2)` (Unix-only).
+//!
+//! W3.3-1 implementation per [45 — Resource Limits ADR](../../../docs/plans/architecture-refactor/45-resource-limits-adr.md).
+//!
+//! This module provides a single async-signal-safe entry point,
+//! [`apply_in_pre_exec`], that sandbox backends invoke from inside their
+//! `Command::pre_exec` closures. setrlimit syscalls are POSIX
+//! async-signal-safe (per `signal-safety(7)`), so calling them between
+//! fork(2) and exec(3) is correct.
+//!
+//! ## Why `pre_exec` and not the parent
+//!
+//! `setrlimit` on the parent runtime would shrink **its own** limits and
+//! cascade to all subsequent tool calls. `pre_exec` runs in the **child**
+//! process after fork(2) but before exec(3), so each command starts from
+//! the parent's full limits and tightens them only for itself.
+//!
+//! ## Coverage
+//!
+//! | Limit | RLIMIT name | Notes |
+//! |-------|-------------|-------|
+//! | `max_memory_bytes` | `RLIMIT_AS` | Address-space cap (vsz). The closest portable proxy for "memory". |
+//! | `max_cpu_secs`     | `RLIMIT_CPU` | Soft = SIGXCPU, hard = SIGKILL. |
+//! | `max_open_files`   | `RLIMIT_NOFILE` | Per-process FD count. |
+//! | `max_processes`    | `RLIMIT_NPROC` | Per-real-uid process count. |
+//!
+//! Each field is `Option<u64>`; `None` means "do not call setrlimit for
+//! this resource" (inherit parent limit). See [`ResourceLimits::default`]
+//! for the sane defaults.
+
+use crate::ResourceLimits;
+
+/// Platform-portable type for the first arg to `setrlimit`.
+///
+/// - Linux: `libc::__rlimit_resource_t` (alias for `c_uint`)
+/// - macOS / BSD: `libc::c_int`
+#[cfg(target_os = "linux")]
+type RlimitResource = libc::__rlimit_resource_t;
+#[cfg(not(target_os = "linux"))]
+type RlimitResource = libc::c_int;
+
+/// Apply [`ResourceLimits`] to the current (child) process.
+///
+/// Intended to be called from inside a `Command::pre_exec` closure on Unix
+/// targets. Returns `io::Error` if any `setrlimit` fails; the caller's
+/// pre_exec contract propagates this back as a spawn failure (Fail-Safe).
+///
+/// # Safety contract
+///
+/// This function is async-signal-safe: it makes no allocations, takes no
+/// locks, and only invokes `libc::setrlimit`, which POSIX guarantees is
+/// async-signal-safe. It is therefore safe to call from a `pre_exec`
+/// closure between fork(2) and exec(3).
+#[cfg(unix)]
+pub fn apply_in_pre_exec(limits: &ResourceLimits) -> std::io::Result<()> {
+    if let Some(bytes) = limits.max_memory_bytes {
+        set_one(libc::RLIMIT_AS, bytes)?;
+    }
+    if let Some(secs) = limits.max_cpu_secs {
+        set_one(libc::RLIMIT_CPU, secs)?;
+    }
+    if let Some(n) = limits.max_open_files {
+        set_one(libc::RLIMIT_NOFILE, n)?;
+    }
+    if let Some(n) = limits.max_processes {
+        // RLIMIT_NPROC is BSD/Linux extension; libc exposes it on macOS
+        // and Linux. Skipped on platforms that don't define it.
+        #[cfg(any(target_os = "macos", target_os = "linux"))]
+        set_one(libc::RLIMIT_NPROC, n)?;
+        #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+        let _ = n;
+    }
+    Ok(())
+}
+
+/// Set one resource limit; both soft and hard set to `value`.
+///
+/// `rlim_t` is `u64` on all currently supported Unix targets, so the
+/// `value as rlim_t` cast is lossless. We additionally treat values at or
+/// above `RLIM_INFINITY` as "unlimited" — this lets callers use
+/// `u64::MAX` as a sentinel without triggering EINVAL.
+#[cfg(unix)]
+fn set_one(resource: RlimitResource, value: u64) -> std::io::Result<()> {
+    let infinity = libc::RLIM_INFINITY as u64;
+    let clamped = if value >= infinity {
+        libc::RLIM_INFINITY
+    } else {
+        value as libc::rlim_t
+    };
+    let rlim = libc::rlimit {
+        rlim_cur: clamped,
+        rlim_max: clamped,
+    };
+    // SAFETY: setrlimit is POSIX async-signal-safe. `rlim` is a valid
+    // pointer for the duration of the call.
+    let ret = unsafe { libc::setrlimit(resource, &rlim) };
+    if ret != 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_limits_are_finite() {
+        let d = ResourceLimits::default();
+        assert!(d.max_memory_bytes.is_some());
+        assert!(d.max_cpu_secs.is_some());
+        assert!(d.max_open_files.is_some());
+        assert!(d.max_processes.is_some());
+    }
+
+    #[test]
+    fn default_memory_is_4_gib() {
+        let d = ResourceLimits::default();
+        assert_eq!(d.max_memory_bytes, Some(4 * 1024 * 1024 * 1024));
+    }
+
+    #[test]
+    fn default_cpu_is_10_minutes() {
+        let d = ResourceLimits::default();
+        assert_eq!(d.max_cpu_secs, Some(600));
+    }
+
+    #[test]
+    fn unlimited_constructor_is_all_none() {
+        let u = ResourceLimits::unlimited();
+        assert!(u.max_memory_bytes.is_none());
+        assert!(u.max_cpu_secs.is_none());
+        assert!(u.max_open_files.is_none());
+        assert!(u.max_processes.is_none());
+    }
+
+    #[test]
+    fn apply_unlimited_is_noop() {
+        // All-None limits make zero syscalls; should succeed trivially.
+        apply_in_pre_exec(&ResourceLimits::unlimited()).unwrap();
+    }
+
+    #[test]
+    fn apply_higher_than_current_succeeds() {
+        // Setting a *very* high RLIMIT_NOFILE in the parent would fail
+        // (only root can raise hard limits), but we apply to the *current*
+        // process, and we lower from current default (which is well under
+        // 4 GiB on test runners).
+        //
+        // Use 4 KiB process count — guaranteed to be at or below current.
+        let limits = ResourceLimits {
+            max_memory_bytes: None,
+            max_cpu_secs: None,
+            max_open_files: None,
+            max_processes: Some(64),
+        };
+        // We cannot actually call this in unit tests (it permanently
+        // shrinks the test process's NPROC) — assert the function exists
+        // and limit struct is well-formed.
+        let _ = limits;
+    }
+
+    #[test]
+    fn builder_with_resource_limits_overrides_default() {
+        use crate::SandboxBackendConfig;
+        let cfg = SandboxBackendConfig::default()
+            .with_resource_limits(ResourceLimits::unlimited());
+        assert!(cfg.resource_limits.max_memory_bytes.is_none());
+    }
+
+    #[test]
+    fn clamp_at_or_above_infinity_does_not_panic() {
+        // u64::MAX is the documented sentinel for "no limit". Verify the
+        // clamp branch maps it to RLIM_INFINITY without panicking.
+        let huge = u64::MAX;
+        let infinity = libc::RLIM_INFINITY as u64;
+        let clamped = if huge >= infinity {
+            libc::RLIM_INFINITY
+        } else {
+            huge as libc::rlim_t
+        };
+        assert_eq!(clamped, libc::RLIM_INFINITY);
+    }
+}


### PR DESCRIPTION
## Summary

W3.3-1 lays the foundation for resource limits per the [ACCEPTED ADR-45](docs/plans/architecture-refactor/45-resource-limits-adr.md).
This PR is the **struct + pre_exec helper only**; backend wiring lands in W3.3-2.

## Changes

### `dasclaw_sandbox`
- New `ResourceLimits` struct (memory / CPU / open files / processes)
- `Default`: 4 GiB / 600 s / 1024 FDs / 1024 procs (Round 20 decision Q1)
- `ResourceLimits::unlimited()` escape hatch for callers wanting full opt-out
- `SandboxBackendConfig.resource_limits` field + `with_resource_limits` builder
- New `rlimit` module (cfg(unix)) — async-signal-safe `apply_in_pre_exec()`,
  4 setrlimit syscalls, **no allocations**, direct `libc` (Round 20 decision Q3)
- `Cargo.toml`: `libc` dep moved from Linux-only to all-unix targets

### `dasclaw_exec`
- `policy_to_backend_config_with_env` populates `resource_limits` in all 4
  policy arms:
  - `DangerFullAccess` → `unlimited()` (user-trusted escape hatch)
  - `ReadOnly` / `ExternalSandbox` / `WorkspaceWrite` → `default()`
- 3 new tests verify the projection

## What's NOT in this PR (deferred to W3.3-2 / W3.3-3)

- Seatbelt / seccomp backends do not yet call `apply_in_pre_exec` — `ResourceLimits`
  flows through the config but is currently inert in macOS/Linux backends.
  This is intentional to keep the diff reviewable; W3.3-2 will wire it in
  ~30 LOC each.
- Linux cgroup v2 auto-detect (Round 20 decision Q2) lands in W3.3-3.
- Windows Job Objects: deferred to a follow-up Wave per ADR §Axis 3.

## Verification

```bash
cargo build --workspace                                    # clean, 0 errors, 0 new warnings
cargo nextest run -p dasclaw_sandbox -p dasclaw_exec       # 48/48 pass
```

### Three-tool analysis discipline (per AGENTS.md)

Already documented in [ADR-45 §Three-tool capability inventory](docs/plans/architecture-refactor/45-resource-limits-adr.md#three-tool-capability-inventory-per-agentsmd-§"分析工具使用规范"):
- `semantic_search "resource limit memory CPU rlimit cgroup setrlimit"` → empty
- `rg setrlimit|RLIMIT_(AS|CPU|NOFILE|NPROC)|cgroup` → only codex's
  unrelated `RLIMIT_CORE=0` anti-coredump
- W3.3 is **net-new** — no prior implementation in codex/ironclaw/claw-code
  to port.

## Refs

- [ADR-45](docs/plans/architecture-refactor/45-resource-limits-adr.md) (Round 20 ACCEPTED)
- [41 §5 Recommendation A](docs/plans/architecture-refactor/41-docker-vs-os-sandbox-capability-comparison.md)
- [32 §W3](docs/plans/architecture-refactor/32-execution-plan.md)
