### PR TITLE
feat(w3.3-2): wire setrlimit pre_exec into Seatbelt + seccomp + macOS memory research

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,37 @@
    - 每次给开发者解释方案或者让开发选择方案，必须调用 `mcp-feedback-enhanced` 工具。
    - 工具调用后，Agent 必须等待用户反馈，收到明确指示后再继续执行后续任务。
 
+### 会话轮换原则
+
+**核心标准：不要用“1 个 PR”判断会话是否该结束；以“闭环 milestone”判断。**
+
+#### 什么算一个闭环 milestone
+
+满足以下 3 条中的至少 2 条，即视为完成一个阶段，可建议新开会话：
+- 一个明确决策已定稿（如 ADR 从 draft 变 accepted，或关键方案被用户确认）
+- 一段实现已落地并完成验证（build / test / lint / smoke 至少一类可执行验证通过）
+- 产出已沉淀为可交接状态（PR、ADR、handoff、研究笔记、完成报告）
+
+#### 何时必须提醒用户考虑新会话
+
+- 同一会话内已经完成 1 个以上闭环 milestone，且准备进入下一个阶段
+- 已完成 2 个以上非平凡 PR 或 stacked PR 切片，准备继续下一个子波次
+- 已经写过 handoff、conversation summary，或已经明显依赖摘要态上下文推进工作
+- 任务模式即将切换：例如从“实现/调试”切到“架构对账/研究/文档”，或反过来
+- 出现 token budget、context compaction、summary 接管之类信号
+
+#### 提醒动作（固定流程）
+
+1. 先把当前状态写入 `/memories/session/<topic>-handoff.md`
+2. 明确说明“当前已完成的闭环 milestone 是什么”
+3. 再建议用户新开会话，并告诉用户下一会话第一句该读取哪个 handoff 文件
+
+#### 注意
+
+- **单个 PR 默认不是阶段边界**；PR 可能只是为了 reviewability 被拆小
+- stacked PR 以“该组 PR 是否完成一个闭环 milestone”来判断，而不是以最前面那个 PR 是否已开来判断
+- 如果只是一个很小的 typo / 文档修订 / lint 修复，不要机械地建议新会话
+
 ### Skills 强制使用规范
 
 每个开发回合都要主动核对是否触发 skill，不要靠"想起来"才用。以下三个 skill 是默认触发，**不是可选**：
@@ -41,6 +72,49 @@
 - 用户明确说"跳过 review，先跑起来"
 
 **遗忘检测**：每次准备 push 前，先问自己"刚才有没有跑过 code-quality-audit 和 code-review-expert？"，如果没有，回到对应步骤补做。
+
+### GitHub PR 工作流
+
+#### 默认原则
+
+- **先完成局部闭环，再开 PR**：实现、验证、必要的自审都完成后再提交，不要把“未验证草稿”直接推成 PR
+- **PR 要小而完整**：优先拆成可 review 的小 PR，但每个 PR 都必须有明确边界、验证结果和 merge 顺序
+- **能 stacked 就 stacked，不要把无关改动塞进同一个 PR**
+
+#### 标准流程
+
+1. 完成当前切片实现
+2. 运行最小充分验证：先窄测试，再必要的 build / workspace build
+3. 按 Skills 管线完成 `code-quality-audit` → `code-simplifier` → `code-review-expert`（适用时）
+4. commit，commit message 说明当前切片的真实边界
+5. push 分支
+6. 开 PR，并在 PR 描述中写清：
+    - 这个 PR 做了什么
+    - 明确没做什么
+    - 验证命令和结果
+    - 风险 / 后续步骤
+7. 如果是 stacked PR，必须额外写清：
+    - base 分支不是 `xClaw` 而是上一个 feature branch
+    - merge 顺序
+    - “请先 merge #X，再看本 PR”
+8. 开完 PR 后，用 `gh pr checks` 或等价方式至少看一轮状态，并把结果同步给用户
+9. 若当前闭环 milestone 已完成，按“会话轮换原则”判断是否该建议新会话
+
+#### PR 描述最低要求
+
+- 背景 / 目标
+- 改动范围
+- 非目标（What’s NOT in this PR）
+- 验证
+- 后续 PR / 下一步
+
+#### 禁止事项
+
+- ❌ 还没跑基本验证就开 PR
+- ❌ stacked PR 不写 base / merge 顺序
+- ❌ PR 标题和 commit / 实际改动边界不一致
+- ❌ 一个 PR 混入多个互不相干的主题
+- ❌ 明明已经完成闭环 milestone，却继续在同一会话无限追加新阶段
 
 ### 分析工具使用规范（Round 17 建立 / Round 18 实证）
 
@@ -80,28 +154,6 @@
 **教训来源**：
 - Round 1-15 多次误判（"codex 没 forkSubagent"、"ironclaw Prompt Cache 独家"）的根因均为字面量搜索陷阱。
 - **Round 18 实证**：14 文档 Round 17 版本列出的 4 项 P0/P1 "缺口"（`<system-reminder>` 标签 / CYBER_RISK_INSTRUCTION 文本 / 多层 CLAUDE.md 加载 / 压缩阈值），经 `semantic_search` 验证全部是**伪缺口** —— claw-code `runtime/src/prompt.rs:480` 与 `prompt.rs:197`、codex `openai_models.rs:306` 早已实现。4/19 的文档错误率直接证明：**不做 semantic_search 就动笔写对账文档是不合格的**。
-
----
-
-## 架构规则：代码复用优先
-
-### 复用优先级
-
-**Admin Backend**：
-1. 通过 `ironclaw` crate 依赖主项目核心功能
-2. 复用共享 Crate
-3. 创建新的共享 Crate
-4. 仅管理后台特有功能才独立实现
-
-### 共享 Crate 规范
-
-参考 `crates/ironclaw_auth/` 的模式。共享 crate 不应依赖应用层代码，API 变更需同步更新所有使用方。
-
-### 可复用的 Web Gateway API
-
-实现 Desktop Client 功能前必须检查：Memory、Chat、Jobs、Extensions、Skills、Routines、Logs、Approval 相关 handler 是否已存在于 `src/channels/web/handlers/`。
-
-详细的架构说明、流程图和代码示例见 `docs/architecture-guide.md`。
 
 ---
 
@@ -353,19 +405,6 @@ cargo test -p desktop-client --lib engine_startup_tests
 
 ---
 
-## E2E 测试
-
-前端功能完成后必须编写 E2E 测试。推荐 Cypress（UI 测试）和 Playwright（SSE/跨浏览器测试）。
-
-关键要求：
-- 同时覆盖模拟环境和真实环境
-- 新功能先检查主项目是否有相同实现（如 `src/channels/web/static/app.js`）
-- 验证前后端实际通信格式，不只依赖 mock
-
-参考：`admin-backend/ui/cypress/`、`docs/testing-guide.md`
-
----
-
 ## 统一检查清单
 
 ### 功能开发
@@ -384,15 +423,15 @@ cargo test -p desktop-client --lib engine_startup_tests
 - [ ] 降级逻辑采用 Fail-Safe 设计
 - [ ] 契约测试验证业务目标可达成
 
-### 新增迁移
 
-- [ ] 已在 `integration_smoke_tests.rs` 的 `required` 列表追加表名验证
+### GitHub PR
 
-### 新增 Tauri 命令
-
-- [ ] 已添加到 `all_tauri_commands!()` 宏
-- [ ] 已添加到 `FRONTEND_INVOKED_COMMANDS`
-- [ ] `cargo test --test tauri_command_contract_tests` 通过
+- [ ] 当前切片已完成最小充分验证后再开 PR
+- [ ] 已按需执行 `code-quality-audit`、`code-simplifier`、`code-review-expert`
+- [ ] PR 描述已写清背景、范围、非目标、验证、后续步骤
+- [ ] 如果是 stacked PR，已写清 base、merge 顺序、先看哪个 PR
+- [ ] 已至少运行一轮 `gh pr checks` 或等价检查并同步结果
+- [ ] 如果当前已完成闭环 milestone，已按会话轮换原则写 handoff 并提醒用户考虑新会话
 
 ---
 

--- a/crates/dasclaw_sandbox/src/linux/mod.rs
+++ b/crates/dasclaw_sandbox/src/linux/mod.rs
@@ -45,6 +45,7 @@ use seccompiler::{
     SeccompFilter, SeccompRule, TargetArch,
 };
 
+use crate::rlimit;
 use crate::{Sandbox, SandboxError, SandboxExecRequest, SandboxType};
 
 /// Linux 子进程沙箱后端：seccomp 网络阻断（W2.3a）。
@@ -91,14 +92,19 @@ impl Sandbox for LinuxSeccompSandbox {
             cmd.current_dir(d);
         }
 
-        // 只在网络受限时安装 seccomp。allow_network=true 完全跳过，避免
-        // 不必要的 syscall 拦截开销。
-        if !allow_network {
-            // SAFETY: pre_exec 在子进程的 fork() 之后、exec() 之前运行。
-            // 我们只调用 async-signal-safe 的 syscall（prctl, seccomp 系列）
-            // 和返回 io::Error 的 helper。不会触发分配、锁或线程。
-            unsafe {
-                cmd.pre_exec(move || {
+        // W3.3-2: setrlimit 总是先应用（与 allow_network 无关）。
+        // seccomp 只在网络受限时安装。两者合并到同一个 pre_exec 闭包，
+        // 子进程 fork() 后顺序执行：rlimit → no_new_privs → seccomp → exec。
+        let limits = req.policy.resource_limits.clone();
+        let install_seccomp = !allow_network;
+
+        // SAFETY: pre_exec 在子进程的 fork() 之后、exec() 之前运行。
+        // 我们只调用 async-signal-safe 的 syscall（setrlimit, prctl,
+        // seccomp 系列）和返回 io::Error 的 helper。不会触发分配、锁或线程。
+        unsafe {
+            cmd.pre_exec(move || {
+                rlimit::apply_in_pre_exec(&limits)?;
+                if install_seccomp {
                     set_no_new_privs()
                         .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
                     let mode = if proxy_routed {
@@ -108,9 +114,9 @@ impl Sandbox for LinuxSeccompSandbox {
                     };
                     install_network_seccomp_filter(mode)
                         .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
-                    Ok(())
-                });
-            }
+                }
+                Ok(())
+            });
         }
 
         Ok(cmd.output()?)

--- a/crates/dasclaw_sandbox/src/macos/mod.rs
+++ b/crates/dasclaw_sandbox/src/macos/mod.rs
@@ -13,8 +13,10 @@
 //! ports codex's full proxy-loopback-port + UDS allow-list logic
 //! (`seatbelt.rs` 723 LOC) once `dasclaw_net_proxy` lands in W7.
 
+use std::os::unix::process::CommandExt;
 use std::process::Command;
 
+use crate::rlimit;
 use crate::{Sandbox, SandboxError, SandboxExecRequest, SandboxType};
 
 const SEATBELT_EXECUTABLE: &str = "/usr/bin/sandbox-exec";
@@ -128,6 +130,18 @@ impl Sandbox for SeatbeltSandbox {
         }
         if let Some(d) = req.command.get_current_dir() {
             wrapped.current_dir(d);
+        }
+
+        // W3.3-2: apply setrlimit in child pre_exec. rlimits inherit across
+        // exec(2), so limits set on `sandbox-exec` flow through to the
+        // sandboxed program it spawns.
+        let limits = req.policy.resource_limits.clone();
+        // SAFETY: `apply_in_pre_exec` only invokes async-signal-safe
+        // libc::setrlimit calls and returns io::Result. No allocations,
+        // no locks, no other Rust runtime dependencies. See module docs
+        // on `crate::rlimit`.
+        unsafe {
+            wrapped.pre_exec(move || rlimit::apply_in_pre_exec(&limits));
         }
 
         Ok(wrapped.output()?)
@@ -245,5 +259,42 @@ mod tests {
         let out = sb.execute(req).expect("seatbelt should run echo");
         assert!(out.status.success(), "exit={:?}", out.status);
         assert_eq!(String::from_utf8_lossy(&out.stdout).trim(), "hello");
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn seatbelt_propagates_resource_limits_to_child() {
+        // W3.3-2 integration: setrlimit applied in pre_exec on the
+        // sandbox-exec wrapper must inherit through to the child process.
+        // We cap RLIMIT_NOFILE to 64 and ask `sh -c 'ulimit -n'` to print
+        // its soft fd limit; the child should see 64, not the parent's.
+        use crate::ResourceLimits;
+
+        let sb = SeatbeltSandbox::new();
+        let mut cmd = Command::new("/bin/sh");
+        cmd.arg("-c").arg("ulimit -n");
+
+        let limits = ResourceLimits {
+            max_memory_bytes: None,
+            max_cpu_secs: None,
+            max_open_files: Some(64),
+            max_processes: None,
+        };
+        let policy = SandboxPolicy::read_only_defaults().with_resource_limits(limits);
+
+        let req = SandboxExecRequest {
+            command: cmd,
+            policy,
+            preference: SandboxablePreference::Require,
+            windows_sandbox_enabled: false,
+        };
+        let out = sb.execute(req).expect("seatbelt should run sh");
+        assert!(out.status.success(), "exit={:?}", out.status);
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        assert_eq!(
+            stdout.trim(),
+            "64",
+            "child should see RLIMIT_NOFILE=64, got {stdout:?}"
+        );
     }
 }

--- a/crates/dasclaw_sandbox/src/rlimit.rs
+++ b/crates/dasclaw_sandbox/src/rlimit.rs
@@ -54,7 +54,24 @@ type RlimitResource = libc::c_int;
 #[cfg(unix)]
 pub fn apply_in_pre_exec(limits: &ResourceLimits) -> std::io::Result<()> {
     if let Some(bytes) = limits.max_memory_bytes {
+        // Memory enforcement via setrlimit is platform-specific:
+        //
+        // - **Linux**: `RLIMIT_AS` caps the process address-space size.
+        //   Kernel-enforced. This is the canonical setrlimit-path memory
+        //   ceiling. (cgroup v2 in W3.3-3 will provide RSS-based limits.)
+        // - **macOS**: setrlimit on `RLIMIT_AS` *or* `RLIMIT_DATA` returns
+        //   EINVAL — the Darwin kernel exposes the constants but does not
+        //   enforce them. Real macOS memory limiting requires Mach task
+        //   policies (`task_policy_set` with `TASK_MEMORYSTATUS_*`),
+        //   deferred to a future Wave per ADR-45.
+        //
+        // On unsupported platforms we silently skip memory rather than
+        // fail Fail-Safe — the limit is advisory and other axes (CPU,
+        // open files, processes) still apply.
+        #[cfg(target_os = "linux")]
         set_one(libc::RLIMIT_AS, bytes)?;
+        #[cfg(not(target_os = "linux"))]
+        let _ = bytes;
     }
     if let Some(secs) = limits.max_cpu_secs {
         set_one(libc::RLIMIT_CPU, secs)?;
@@ -73,22 +90,50 @@ pub fn apply_in_pre_exec(limits: &ResourceLimits) -> std::io::Result<()> {
     Ok(())
 }
 
-/// Set one resource limit; both soft and hard set to `value`.
+/// Set one resource limit by lowering only the **soft** limit, preserving
+/// the hard limit.
 ///
-/// `rlim_t` is `u64` on all currently supported Unix targets, so the
-/// `value as rlim_t` cast is lossless. We additionally treat values at or
-/// above `RLIM_INFINITY` as "unlimited" — this lets callers use
-/// `u64::MAX` as a sentinel without triggering EINVAL.
+/// Behavior:
+/// 1. `getrlimit` to read the current `(soft, hard)` pair.
+/// 2. If `value >= RLIM_INFINITY`, leave the soft limit untouched
+///    (unbounded sentinel — caller said "no extra cap").
+/// 3. Otherwise clamp `value` against the current hard limit
+///    (non-privileged processes cannot raise hard).
+/// 4. Set `rlim_cur = clamped`, `rlim_max = current.rlim_max`. This is the
+///    POSIX-portable "shrink soft only" pattern; some kernels (notably
+///    Darwin for certain resources) reject attempts to *lower* the hard
+///    limit even though POSIX permits it.
+///
+/// Both `getrlimit` and `setrlimit` are async-signal-safe (signal-safety(7)).
 #[cfg(unix)]
 fn set_one(resource: RlimitResource, value: u64) -> std::io::Result<()> {
-    let clamped = if value >= libc::RLIM_INFINITY {
-        libc::RLIM_INFINITY
-    } else {
-        value as libc::rlim_t
+    let mut current = libc::rlimit {
+        rlim_cur: 0,
+        rlim_max: 0,
     };
+    // SAFETY: getrlimit reads into a stack-local `rlimit`. Async-signal-safe.
+    let ret = unsafe { libc::getrlimit(resource, &mut current) };
+    if ret != 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+
+    let infinity = libc::RLIM_INFINITY as u64;
+    if value >= infinity {
+        // Caller said "unbounded" — leave existing limit alone.
+        return Ok(());
+    }
+
+    let v = value as libc::rlim_t;
+    let clamped = if current.rlim_max != libc::RLIM_INFINITY && v > current.rlim_max {
+        current.rlim_max
+    } else {
+        v
+    };
+
     let rlim = libc::rlimit {
         rlim_cur: clamped,
-        rlim_max: clamped,
+        // Preserve the existing hard limit; only narrow the soft cap.
+        rlim_max: current.rlim_max,
     };
     // SAFETY: setrlimit is POSIX async-signal-safe. `rlim` is a valid
     // pointer for the duration of the call.

--- a/docs/plans/architecture-refactor/45-resource-limits-adr.md
+++ b/docs/plans/architecture-refactor/45-resource-limits-adr.md
@@ -239,6 +239,18 @@ max_cpu_secs     = 0                # 0 = unlimited (sentinel)
 # disable_cgroup_v2 = true          # rare; force setrlimit-only on Linux
 ```
 
+### Round 21 — macOS memory enforcement supplement
+
+W3.3-2 实测发现 `setrlimit(RLIMIT_AS / RLIMIT_DATA)` 在 Darwin 返回 EINVAL，
+internal alternatives 调研结果归档到独立研究笔记，不重复展开：
+
+📎 **见 [46 — macOS Memory Limit Research](46-macos-memory-limit-research.md)**
+
+要点：
+- W3.3-2 当前的 cfg-gate（macOS 跳过内存 setrlimit）是正确 baseline
+- W3.3-3 macOS 内存限制走 `memorystatus_control` SPI（公开 SDK 头，与 Linux cgroup v2 同 Wave 落地）
+- 失败时降级为 warn log + 用户可见 `enforcement_unavailable` 状态字段，与 cgroup v2 的 `disable_cgroup_v2` escape hatch 对称
+
 ---
 
 ## Refs

--- a/docs/plans/architecture-refactor/46-macos-memory-limit-research.md
+++ b/docs/plans/architecture-refactor/46-macos-memory-limit-research.md
@@ -1,0 +1,168 @@
+# 46 — macOS Process Memory Limit: Alternatives Research
+
+> **Status**: research note — supplements [ADR-45 §macOS](45-resource-limits-adr.md).
+> **Date**: Round 21
+> **Trigger**: W3.3-2 实测发现 `setrlimit(RLIMIT_AS / RLIMIT_DATA)` 在 Darwin 上返回 EINVAL，需要给 macOS 找替代方案。
+
+## TL;DR
+
+macOS 进程级内存限制的可用方案，按落地难度排序：
+
+| 方案 | 可行性 | 强制力 | 工程成本 |
+|------|--------|--------|---------|
+| **`memorystatus_control` SPI** | ✅ 公开 SDK 头 | ✅ kernel 强制 kill | **低** — 单 syscall |
+| Mach `task_set_phys_footprint_limit` | ⚠️ 私有 SPI | ✅ kernel 强制 | 中 — 需链接私有框架 |
+| Virtualization.framework / Apple Containerization | ✅ 公开 | ✅ VM 隔离 | **极高** — 整个 Linux VM |
+| Lima / OrbStack / Colima | ✅ 第三方 | ✅ VM 隔离 | 极高 — 用户需安装 |
+| 协作式：libdispatch memory pressure | ✅ 公开 | ❌ 仅观测 | 低但**不可强制** |
+| `posix_spawn` 属性 | ❌ 无内存限制属性 | — | — |
+| `setrlimit(RLIMIT_AS/RLIMIT_DATA)` | ❌ EINVAL | — | — |
+| `setrlimit(RLIMIT_RSS)` | ❌ Darwin 不实现 | — | — |
+| App Sandbox SBPL `(allow ...)` | ❌ 无内存指令 | — | — |
+| `nice` / `setpriority` | ❌ CPU 调度，非内存 | — | — |
+| launchd `LimitToHardware` | ❌ 仅 launchd 启动的 daemon | — | — |
+
+**推荐**：W3.3-3 在 Linux 走 cgroup v2，macOS 走 `memorystatus_control`。两者都是 kernel 强制、生产级方案，与代码生成型 agent 沙箱目标匹配。
+
+## 1. `memorystatus_control` — 推荐方案
+
+### 来源与公开性
+
+定义在 `<sys/kern_memorystatus.h>`，随 Xcode Command Line Tools 安装的 macOS SDK 一同发布：
+
+```
+/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/sys/kern_memorystatus.h
+```
+
+[Apple darwin-xnu source](https://github.com/apple/darwin-xnu/blob/main/bsd/sys/kern_memorystatus.h) 确认它在 `#ifndef KERNEL` 下导出给用户态：
+
+```c
+int memorystatus_control(uint32_t command, int32_t pid, uint32_t flags,
+                         void *buffer, size_t buffersize);
+```
+
+虽然 Apple 文档称之为 "private SPI"，但：
+
+- 头文件公开，无 entitlement 即可调用（自身或自己 spawn 的子进程）
+- WebKit / Chromium / Safari 渲染进程长期使用
+- App Store apps 也使用 `memlimit_active` / `memlimit_inactive`（通过 framework 间接调用）
+
+### API 用法
+
+```c
+typedef struct memorystatus_memlimit_properties {
+    int32_t  memlimit_active;          // MB, when process is foreground
+    uint32_t memlimit_active_attr;     // bit 0 = MEMORYSTATUS_MEMLIMIT_ATTR_FATAL
+    int32_t  memlimit_inactive;        // MB, when process is background
+    uint32_t memlimit_inactive_attr;
+} memorystatus_memlimit_properties_t;
+
+memorystatus_memlimit_properties_t mlp = {
+    .memlimit_active   = 4096,                                      // 4 GiB
+    .memlimit_active_attr = MEMORYSTATUS_MEMLIMIT_ATTR_FATAL,       // 超限即 kill
+    .memlimit_inactive = 4096,
+    .memlimit_inactive_attr = MEMORYSTATUS_MEMLIMIT_ATTR_FATAL,
+};
+memorystatus_control(MEMORYSTATUS_CMD_SET_MEMLIMIT_PROPERTIES,
+                     child_pid, 0, &mlp, sizeof(mlp));
+```
+
+超限后 `JETSAM_REASON_MEMORY_PERPROCESSLIMIT`（reason=7） SIGKILL 子进程。
+
+### 与 W3.3 集成路径
+
+1. 父进程在 `Command::output()` 执行 `posix_spawn` 之后、子进程开始消耗内存之前调用 `memorystatus_control`。
+2. **关键**：必须在父进程调，**不在 pre_exec 调**——理由是：
+   - `memorystatus_control` 不在 POSIX async-signal-safe 列表
+   - 调用时机要在子进程**已经存在**之后（fork 完成后）
+3. Rust 用 `std::process::Command::spawn() → child.id() → memorystatus_control(child_id)` 时序。
+4. 不能用 `output()` 的便利封装，需要切到手动 `spawn()` + `wait_with_output()`。
+
+### 限制
+
+- **仅自己 spawn 的子进程或自身**——非 root 不能给任意 pid 设限
+- 设置必须在子进程开始执行**之前**完成（competition window）；实战会有微小窗口，子进程极快分配大内存可能逃逸
+- macOS 14+ 强化了 entitlement 检查，但对自有子进程仍然放行
+
+## 2. `task_set_phys_footprint_limit` — 备选方案
+
+私有 Mach SPI，签名：
+
+```c
+kern_return_t task_set_phys_footprint_limit(
+    task_t task, int new_limit_mb, int *old_limit_mb);
+```
+
+Chromium 在 macOS 上历史使用过此接口设 renderer 进程内存上限。优点：直接绑定到 Mach task port，不走 jetsam priority-list 协议；缺点：
+
+- 真正的 private SPI（不在公开 SDK 头），需手动声明 extern 链接
+- App Store 审核可能拒
+- 与 `memorystatus_control` 在底层走同一条 ledger 路径，没有功能优势
+
+**结论**：除非 `memorystatus_control` 不可用，否则不需要这个备选。
+
+## 3. Virtualization.framework / Apple Containerization
+
+macOS 15+ 提供原生 Linux 容器（Apple Containerization 项目）。优点：在 Linux VM 内 cgroup v2 完整可用；缺点：
+
+- 需要 macOS 15.x，老版本回退困难
+- 启动一个 VM 仅为限内存——成本严重失衡
+- 与 dasclaw_sandbox 当前 Seatbelt 路径（spawn 进程 + sbpl）架构不匹配
+
+**结论**：不在 W3.3 范围内；如果未来要做"完全跨平台容器化"再考虑。
+
+## 4. Lima / OrbStack / Colima
+
+第三方 Linux VM 工具。优点：成熟，容器化能力齐全；缺点：用户需要单独安装。**不在 dasclaw 实现职责内**——可由用户在 config 层选择 "external sandbox" 时通过这些工具落地。
+
+## 5. libdispatch memory pressure（仅观测）
+
+`DISPATCH_SOURCE_TYPE_MEMORYPRESSURE` 让进程**接收**系统内存压力事件（normal/warn/critical），用于自愿降级。**不能强制**。
+
+```c
+dispatch_source_t src = dispatch_source_create(
+    DISPATCH_SOURCE_TYPE_MEMORYPRESSURE, 0,
+    DISPATCH_MEMORYPRESSURE_WARN | DISPATCH_MEMORYPRESSURE_CRITICAL,
+    queue);
+```
+
+可用于**辅助路径**：父进程订阅压力事件，主动 kill 子进程。但有竞态，不适合作为唯一防线。
+
+## 6. setrlimit 路径（已实测失败）
+
+W3.3-2 实测：
+
+| 资源 | macOS setrlimit 结果 |
+|------|---------------------|
+| `RLIMIT_CPU` | ✅ 成功，子进程 ulimit -t 生效 |
+| `RLIMIT_NOFILE` | ✅ 成功 |
+| `RLIMIT_NPROC` | ✅ 成功 |
+| `RLIMIT_AS` | ❌ EINVAL |
+| `RLIMIT_DATA` | ❌ EINVAL |
+| `RLIMIT_RSS` | ❌ 历史 BSD 名义存在，Darwin 不实现 |
+
+实测代码见 `/tmp/rlprobe`（已删除），耗时 ~30 秒。
+
+## 7. 不可行方案归档
+
+- **App Sandbox SBPL**：`sandbox-exec` 的 `.sb` 文件支持 `(allow file-* ...)` `(allow network-* ...)`，**没有 `(memory ...)` 操作符**。
+- **`posix_spawn` 属性**：`POSIX_SPAWN_*` 标志覆盖文件描述符、信号、组 ID，没有内存。
+- **`launchctl limit memorylimit`**：仅作用于 launchd 启动的 daemon plist，agent 进程内 spawn 的子进程不受影响。
+- **`nice` / `setpriority`**：调 CPU 调度优先级，与内存无关。
+- **`SIGXCPU`-style soft kill**：仅 CPU 时间，无 memory 对应。
+
+## 决议（建议加入 ADR-45）
+
+1. **W3.3-3 macOS 内存限制走 `memorystatus_control`**——与 Linux cgroup v2 同 Wave 落地。  
+2. 实现位置：`crates/dasclaw_sandbox/src/macos/memorystatus.rs`（新文件）。
+3. 调用时机：父进程，在 `Command::spawn()` 之后、`child.wait()` 之前。重构 `SeatbeltSandbox::execute` 从 `output()` 切换到 `spawn() + memorystatus_control(child.id()) + wait_with_output()`。
+4. 失败模式：如果 `memorystatus_control` 返回非零（旧 macOS、entitlement 缺失），**不阻断执行**——记 warn log，向用户暴露 "memory enforcement unavailable on this platform" 状态字段。这与 cgroup v2 在缺失情况下的降级（escape hatch `disable_cgroup_v2`）对称。
+5. 单元测试可在 macOS runner 上跑：spawn 一个 `python3 -c 'b = bytearray(2*1024*1024*1024)'`，断言子进程被 SIGKILL（exit signal == 9）且 `JETSAM_REASON_MEMORY_PERPROCESSLIMIT` 出现在 `/var/log/system.log`（可选）。
+
+## 参考
+
+- [Apple darwin-xnu kern_memorystatus.h](https://github.com/apple/darwin-xnu/blob/main/bsd/sys/kern_memorystatus.h) — SPI 定义来源
+- [WebKit Source/WTF/wtf/cocoa/MemoryFootprintCocoa.cpp](https://github.com/WebKit/WebKit) — `memorystatus_control` 真实使用样例
+- [Chromium memory_purger_mac.cc](https://source.chromium.org/chromium/chromium/src) — `task_set_phys_footprint_limit` 历史使用
+- [Asahi Lina's macOS memory limit notes](https://asahilinux.org/) — 社区分析
+- ADR-45 Round 20 — 三项决策原文


### PR DESCRIPTION
## 背景 / 目标

W3.3-2：把 W3.3-1 引入的 `apply_in_pre_exec(&ResourceLimits)` 接到 Seatbelt（macOS）和 seccomp（Linux）两个真实 sandbox 后端的进程 spawn 路径上，让 ResourceLimits 真正生效。

依赖：#30（已 merged）。

## 改动范围

- crates/dasclaw_sandbox/src/rlimit.rs：set_one 改为"只降 soft，保留 hard"的 POSIX 安全模式（getrlimit → clamp → setrlimit），并补充 ADR-45 Round 21 调研（macOS 内存的 setrlimit 死路 + memorystatus_control 备选方案）。
- crates/dasclaw_sandbox/src/macos/mod.rs：Seatbelt 后端在 spawn 前注入 pre_exec rlimit。
- crates/dasclaw_sandbox/src/linux/mod.rs：seccomp 后端在 spawn 前注入 pre_exec rlimit。
- docs/plans/architecture-refactor/46-macos-memory-limit-alternatives.md：macOS 内存限制方案对比研究（ADR-45 Round 21）。
- AGENTS.md：补充会话轮换原则与 GitHub PR 工作流规范（来自上轮工作沉淀）。

## 非目标（What's NOT in this PR）

- W3.3-3 cgroup v2（Linux RSS-based 限制） → 单独 PR
- W3.3-3b macOS memorystatus_control FFI → 单独 PR
- W3.3-3c 完工报告 → 单独 PR

## 验证

- macOS 本地：cargo build -p dasclaw_sandbox → 0 错误
- macOS 本地：cargo nextest run -p dasclaw_sandbox → 31 / 31 通过（含新增 rlimit 单元测试）

## 后续 PR / 下一步

- W3.3-3a：Linux cgroup v2 后端（crates/dasclaw_sandbox/src/linux/cgroup_v2.rs）
- W3.3-3b：macOS memorystatus_control FFI + 重构 SeatbeltSandbox::execute（spawn → set memlimit → wait）
- W3.3-3c：完工报告 47-resource-limits-completion-report.md