### PR TITLE
P0-2 PR #4: migrate 14 caller sites to bootstrap_tools

### DIFF
--- a/desktop-client/ironclaw/src/agent/agent_loop.rs
+++ b/desktop-client/ironclaw/src/agent/agent_loop.rs
@@ -796,10 +796,28 @@ impl Agent {
                         self.deps.sandbox_readiness,
                     ));
 
-                    // Register routine tools
+                    // Register routine tools via the unified bootstrap API.
+                    // The orchestrator path already wired builtin / dev / etc.
+                    // earlier in startup; this stage-2 call is purely additive
+                    // — `register_sync` is `HashMap::insert`-style, so the
+                    // re-register of builtins is a no-op overwrite.
                     self.deps
                         .tools
-                        .register_routine_tools(Arc::clone(store), Arc::clone(&engine));
+                        .bootstrap_tools(&crate::tools::bootstrap::BootstrapContext {
+                            mode: crate::tools::bootstrap::BootstrapMode::Orchestrator {
+                                allow_local_tools: false,
+                            },
+                            routine_store: Some(Arc::clone(store)),
+                            routine_engine: Some(Arc::clone(&engine)),
+                            ..Default::default()
+                        })
+                        .await
+                        .map_err(|e| {
+                            crate::error::Error::Tool(crate::error::ToolError::ExecutionFailed {
+                                name: "bootstrap_tools".to_string(),
+                                reason: e.to_string(),
+                            })
+                        })?;
 
                     // Load initial event cache
                     engine.refresh_event_cache().await;

--- a/desktop-client/ironclaw/src/app.rs
+++ b/desktop-client/ironclaw/src/app.rs
@@ -22,6 +22,7 @@ use crate::secrets::SecretsStore;
 use crate::skills::SkillRegistry;
 use crate::skills::catalog::SkillCatalog;
 use crate::tools::ToolRegistry;
+use crate::tools::bootstrap::{BootstrapContext, BootstrapMode, ImageApiConfig, VisionApiConfig};
 use crate::tools::mcp::{McpProcessManager, McpSessionManager};
 use crate::tools::wasm::SharedCredentialRegistry;
 use crate::tools::wasm::WasmToolRuntime;
@@ -315,12 +316,17 @@ impl AppBuilder {
         } else {
             Arc::new(ToolRegistry::new())
         };
-        tools.register_builtin_tools();
-        tools.register_tool_info();
-
-        if let Some(ref ss) = self.secrets_store {
-            tools.register_secrets_tools(Arc::clone(ss));
-        }
+        // Build a single bootstrap context that aggregates every tool group
+        // available at this init phase, then dispatch via `bootstrap_tools`.
+        // Multi-stage init: subsequent phases (`init_extensions`, `build_all`)
+        // call `bootstrap_tools` again with extra fields populated.
+        let mut ctx = BootstrapContext {
+            mode: BootstrapMode::Orchestrator {
+                allow_local_tools: self.config.agent.allow_local_tools,
+            },
+            secrets_store: self.secrets_store.clone(),
+            ..Default::default()
+        };
 
         // Create embeddings provider using the unified method
         let embeddings = self
@@ -328,7 +334,7 @@ impl AppBuilder {
             .embeddings
             .create_provider(&self.config.llm.nearai.base_url, self.session.clone());
 
-        // Register memory tools if database is available
+        // Build workspace (memory tools backing) if a database is available.
         let workspace_user_id = self.config.owner_id.as_str();
         let workspace = if let Some(ref db) = self.db {
             let emb_cache_config = EmbeddingCacheConfig {
@@ -368,12 +374,12 @@ impl AppBuilder {
                     self.config.search.clone(),
                     self.config.workspace.clone(),
                 ));
-                tools.register_memory_tools_with_resolver(pool);
+                ctx.db_pool = Some(pool);
                 tracing::info!(
                     "Memory tools configured with per-user workspace resolver (multi-tenant mode)"
                 );
             } else {
-                tools.register_memory_tools(Arc::clone(&ws));
+                ctx.workspace = Some(Arc::clone(&ws));
             }
 
             Some(ws)
@@ -381,7 +387,7 @@ impl AppBuilder {
             None
         };
 
-        // Register image/vision tools if we have a workspace and LLM API credentials
+        // Image / vision tools require a workspace and LLM API credentials.
         if workspace.is_some() {
             let (api_base, api_key_opt) = if let Some(ref provider) = self.config.llm.provider {
                 (
@@ -402,7 +408,6 @@ impl AppBuilder {
             };
 
             if let Some(api_key) = api_key_opt {
-                // Check for image generation models
                 let model_name = self
                     .config
                     .llm
@@ -414,15 +419,25 @@ impl AppBuilder {
                 let gen_model = crate::llm::image_models::suggest_image_model(&models)
                     .unwrap_or("flux-1.1-pro")
                     .to_string();
-                tools.register_image_tools(api_base.clone(), api_key.clone(), gen_model, None);
+                ctx.image_api = Some(ImageApiConfig {
+                    api_base: api_base.clone(),
+                    api_key: api_key.clone(),
+                    gen_model,
+                });
 
-                // Check for vision models
                 let vision_model = crate::llm::vision_models::suggest_vision_model(&models)
                     .unwrap_or(&model_name)
                     .to_string();
-                tools.register_vision_tools(api_base, api_key, vision_model, None);
+                ctx.vision_api = Some(VisionApiConfig {
+                    api_base,
+                    api_key,
+                    vision_model,
+                });
             }
         }
+
+        tools.bootstrap_tools(&ctx).await?;
+        tools.register_tool_info();
 
         // Register builder tool if enabled
         let builder = if self.config.builder.enabled
@@ -735,7 +750,18 @@ impl AppBuilder {
                 self.db.clone(),
                 catalog_entries.clone(),
             ));
-            tools.register_extension_tools(Arc::clone(&manager));
+            // Register the extension-management tool group via bootstrap_tools.
+            // Other groups already registered in init_tools are reapplied
+            // (idempotent — `register_sync` uses `HashMap::insert`).
+            tools
+                .bootstrap_tools(&BootstrapContext {
+                    mode: BootstrapMode::Orchestrator {
+                        allow_local_tools: self.config.agent.allow_local_tools,
+                    },
+                    extension_manager: Some(Arc::clone(&manager)),
+                    ..Default::default()
+                })
+                .await?;
             tracing::debug!("Extension manager initialized with in-chat discovery tools");
 
             if !startup_mcp_clients.is_empty() {
@@ -751,13 +777,10 @@ impl AppBuilder {
             Some(manager)
         };
 
-        // register_builder_tool() already calls register_dev_tools() internally,
-        // so only register them here when the builder didn't already do it.
-        let builder_registered_dev_tools = self.config.builder.enabled
-            && (self.config.agent.allow_local_tools || !self.config.sandbox.enabled);
-        if self.config.agent.allow_local_tools && !builder_registered_dev_tools {
-            tools.register_dev_tools();
-        }
+        // Dev tools are dispatched via `mode = Orchestrator { allow_local_tools }`
+        // inside `init_tools`. The legacy late-bound `register_dev_tools` call
+        // here is no longer needed — `register_sync` is idempotent regardless
+        // of whether `register_builder_tool` already ran.
 
         Ok((
             mcp_session_manager,
@@ -886,7 +909,16 @@ impl AppBuilder {
             }
             let registry = Arc::new(std::sync::RwLock::new(registry));
             let catalog = crate::skills::catalog::shared_catalog();
-            tools.register_skill_tools(Arc::clone(&registry), Arc::clone(&catalog));
+            tools
+                .bootstrap_tools(&BootstrapContext {
+                    mode: BootstrapMode::Orchestrator {
+                        allow_local_tools: self.config.agent.allow_local_tools,
+                    },
+                    skill_registry: Some(Arc::clone(&registry)),
+                    skill_catalog: Some(Arc::clone(&catalog)),
+                    ..Default::default()
+                })
+                .await?;
             (Some(registry), Some(catalog))
         } else {
             (None, None)

--- a/desktop-client/ironclaw/src/main.rs
+++ b/desktop-client/ironclaw/src/main.rs
@@ -23,6 +23,7 @@ use ironclaw::{
     llm::create_session_manager,
     orchestrator::{ReaperConfig, SandboxReaper},
     pairing::PairingStore,
+    tools::bootstrap::{BootstrapContext, BootstrapMode, JobToolsConfig},
     tracing_fmt::{init_cli_tracing, init_worker_tracing},
     webhooks::{self, ToolWebhookState},
 };
@@ -571,20 +572,29 @@ async fn async_main() -> anyhow::Result<()> {
         Arc::new(tokio::sync::RwLock::new(None));
 
     // Register job tools (sandbox deps auto-injected when container_job_manager is available)
-    components.tools.register_job_tools(
-        Arc::clone(&components.context_manager),
-        Some(scheduler_slot.clone()),
-        container_job_manager.clone(),
-        components.db.clone(),
-        job_event_tx.clone(),
-        Some(channels.inject_sender()),
-        if config.sandbox.enabled {
-            Some(Arc::clone(&prompt_queue))
-        } else {
-            None
-        },
-        components.secrets_store.clone(),
-    );
+    components
+        .tools
+        .bootstrap_tools(&BootstrapContext {
+            mode: BootstrapMode::Orchestrator {
+                allow_local_tools: config.agent.allow_local_tools,
+            },
+            job_config: Some(JobToolsConfig {
+                context_manager: Arc::clone(&components.context_manager),
+                scheduler_slot: Some(scheduler_slot.clone()),
+                job_manager: container_job_manager.clone(),
+                store: components.db.clone(),
+                job_event_tx: job_event_tx.clone(),
+                inject_tx: Some(channels.inject_sender()),
+                prompt_queue: if config.sandbox.enabled {
+                    Some(Arc::clone(&prompt_queue))
+                } else {
+                    None
+                },
+                secrets_store: components.secrets_store.clone(),
+            }),
+            ..Default::default()
+        })
+        .await?;
 
     // ── Gateway channel ────────────────────────────────────────────────
 
@@ -818,8 +828,15 @@ async fn async_main() -> anyhow::Result<()> {
     // Register message tool for sending messages to connected channels
     components
         .tools
-        .register_message_tools(Arc::clone(&channels), components.extension_manager.clone())
-        .await;
+        .bootstrap_tools(&BootstrapContext {
+            mode: BootstrapMode::Orchestrator {
+                allow_local_tools: config.agent.allow_local_tools,
+            },
+            channels: Some(Arc::clone(&channels)),
+            extension_manager: components.extension_manager.clone(),
+            ..Default::default()
+        })
+        .await?;
 
     // Default user ID for extension operations (single-user mode).
     let ext_user_id = config.owner_id.clone();

--- a/desktop-client/ironclaw/src/testing/mod.rs
+++ b/desktop-client/ironclaw/src/testing/mod.rs
@@ -517,11 +517,16 @@ impl TestHarnessBuilder {
 
         let llm: Arc<dyn LlmProvider> = self.llm.unwrap_or_else(|| Arc::new(StubLlm::default()));
 
-        let tools = self.tools.unwrap_or_else(|| {
-            let t = Arc::new(ToolRegistry::new());
-            t.register_builtin_tools();
-            t
-        });
+        let tools = match self.tools {
+            Some(t) => t,
+            None => {
+                let t = Arc::new(ToolRegistry::new());
+                t.bootstrap_tools(&crate::tools::bootstrap::BootstrapContext::for_test())
+                    .await
+                    .expect("for_test() bootstrap is infallible");
+                t
+            }
+        };
 
         let safety = Arc::new(SafetyLayer::new(&SafetyConfig {
             max_output_length: 100_000,

--- a/desktop-client/ironclaw/src/tools/bootstrap.rs
+++ b/desktop-client/ironclaw/src/tools/bootstrap.rs
@@ -36,21 +36,24 @@
 //!
 //! # Rollout note
 //!
-//! This struct landed in PR #2 of the P0-2 stacked series. PR #3 (this PR)
-//! adds the `bootstrap_tools()` method and replaces the 9 forward-compat
-//! marker traits with concrete types. PR #4 migrates the 12 legacy
-//! `register_*_tools` call sites and deletes the public compat wrappers.
+//! This struct landed in PR #2 of the P0-2 stacked series. PR #3 added the
+//! `bootstrap_tools()` method and replaced the 9 forward-compat marker traits
+//! with concrete types. PR #4 (this PR) extended `JobToolsConfig` to carry the
+//! full job-tool dependency set, migrated all 14 legacy `register_*_tools`
+//! call sites to `bootstrap_tools()`, and removed the public compat wrappers.
 
 use std::sync::Arc;
 
 use crate::agent::routine_engine::RoutineEngine;
-use crate::channels::ChannelManager;
+use crate::channels::{ChannelManager, IncomingMessage};
+use crate::context::ContextManager;
 use crate::db::Database;
 use crate::extensions::ExtensionManager;
+use crate::orchestrator::job_manager::ContainerJobManager;
 use crate::secrets::SecretsStore;
 use crate::skills::catalog::SkillCatalog;
 use crate::skills::registry::SkillRegistry;
-use crate::tools::builtin::memory::WorkspaceResolver;
+use crate::tools::builtin::{PromptQueue, SchedulerSlot, memory::WorkspaceResolver};
 use crate::workspace::Workspace;
 
 /// Deployment mode that selects which tool groups are registered by default.
@@ -101,11 +104,41 @@ pub enum BootstrapError {
 // would create cycles during incremental compilation, so callers fill the
 // fields with their own `Arc<...>` values at the call site.
 
-/// Configuration bundle for `register_job_tools`.
-#[derive(Debug, Clone, Default)]
+/// Configuration bundle for the job-tool group (`create_job`, `list_jobs`,
+/// `job_status`, `cancel_job`, optional `job_events` / `job_prompt`).
+///
+/// `context_manager` is required (every job tool keys on it). All other
+/// fields are optional: each missing dependency simply skips the matching
+/// capability (e.g. without a `prompt_queue` the `job_prompt` tool is not
+/// registered).
+#[derive(Clone)]
 pub struct JobToolsConfig {
-    pub admin_base_url: Option<String>,
-    pub agent_id: Option<String>,
+    pub context_manager: Arc<ContextManager>,
+    pub scheduler_slot: Option<SchedulerSlot>,
+    pub job_manager: Option<Arc<ContainerJobManager>>,
+    pub store: Option<Arc<dyn Database>>,
+    pub job_event_tx:
+        Option<tokio::sync::broadcast::Sender<(uuid::Uuid, String, ironclaw_common::AppEvent)>>,
+    pub inject_tx: Option<tokio::sync::mpsc::Sender<IncomingMessage>>,
+    pub prompt_queue: Option<PromptQueue>,
+    pub secrets_store: Option<Arc<dyn SecretsStore + Send + Sync>>,
+}
+
+impl JobToolsConfig {
+    /// Construct a minimal config with only the required `ContextManager`.
+    /// Optional dependencies can be filled in via direct field assignment.
+    pub fn new(context_manager: Arc<ContextManager>) -> Self {
+        Self {
+            context_manager,
+            scheduler_slot: None,
+            job_manager: None,
+            store: None,
+            job_event_tx: None,
+            inject_tx: None,
+            prompt_queue: None,
+            secrets_store: None,
+        }
+    }
 }
 
 /// Configuration bundle for `register_image_tools`.
@@ -144,8 +177,12 @@ pub struct VisionApiConfig {
 /// | `image_api`                                     | image                           |
 /// | `vision_api`                                    | vision                          |
 /// | `channels` + `extension_manager`                | message (async)                 |
+///
+/// Note: This struct is intentionally **not** `#[non_exhaustive]` — callers
+/// build it via `..Default::default()` spread expressions across the workspace
+/// (`main.rs`, `app.rs`, integration tests). Adding a field is therefore a
+/// non-breaking change as long as the new field carries a `Default` impl.
 #[derive(Default)]
-#[non_exhaustive]
 pub struct BootstrapContext {
     /// Deployment mode. Required.
     pub mode: BootstrapMode,

--- a/desktop-client/ironclaw/src/tools/registry.rs
+++ b/desktop-client/ironclaw/src/tools/registry.rs
@@ -279,22 +279,9 @@ impl ToolRegistry {
     /// Register all built-in tools.
     /// Register the standard built-in tools (echo, time, json, http).
     ///
-    /// Call this once during startup to register the orchestrator-domain tools.
-    /// Container-domain tools (file ops, shell) must be registered separately
-    /// inside the sandboxed worker.
-    ///
-    /// # Deprecated public surface (PR #3)
-    ///
-    /// Slated for privatization in PR #4 once the 12 legacy call sites move to
-    /// [`Self::bootstrap_tools`]. The implementation lives in
-    /// [`Self::register_builtin_tools_internal`]; this is a thin wrapper kept
-    /// for source compatibility during the migration.
-    #[doc(hidden)]
-    pub fn register_builtin_tools(&self) {
-        self.register_builtin_tools_internal();
-    }
-
-    fn register_builtin_tools_internal(&self) {
+    /// Private helper invoked by [`Self::bootstrap_tools`]. External callers
+    /// migrated to `bootstrap_tools` in PR #4.
+    fn register_builtin_tools(&self) {
         self.register_sync(Arc::new(EchoTool));
         self.register_sync(Arc::new(TimeTool));
         self.register_sync(Arc::new(JsonTool));
@@ -311,38 +298,12 @@ impl ToolRegistry {
     /// Register the `tool_info` discovery tool.
     ///
     /// Requires `Arc<Self>` so the tool can query the registry for other tools'
-    /// schemas at runtime. Call after `register_builtin_tools()`.
+    /// schemas at runtime. Call after `bootstrap_tools()`.
     pub fn register_tool_info(self: &Arc<Self>) {
         use crate::tools::builtin::ToolInfoTool;
         let tool = ToolInfoTool::new(Arc::downgrade(self));
         self.register_sync(Arc::new(tool));
         tracing::debug!("Registered tool_info discovery tool");
-    }
-
-    /// Register only orchestrator-domain tools (safe for the main process).
-    ///
-    /// This registers tools that don't touch the filesystem or run shell commands:
-    /// echo, time, json, http. Use this when `allow_local_tools = false` and
-    /// container-domain tools should only be available inside sandboxed containers.
-    /// PR #3 compat wrapper. Will be privatized in PR #4.
-    #[doc(hidden)]
-    pub fn register_orchestrator_tools(&self) {
-        self.register_orchestrator_tools_internal();
-    }
-
-    fn register_orchestrator_tools_internal(&self) {
-        self.register_builtin_tools_internal();
-        // register_builtin_tools_internal already only registers orchestrator-domain tools
-    }
-
-    /// PR #3 compat wrapper. Will be privatized in PR #4.
-    #[doc(hidden)]
-    pub fn register_container_tools(&self) {
-        self.register_container_tools_internal();
-    }
-
-    fn register_container_tools_internal(&self) {
-        self.register_dev_tools_internal();
     }
 
     /// Single-API tool bootstrap — applies a [`BootstrapContext`] to the
@@ -376,47 +337,47 @@ impl ToolRegistry {
         // Mode-driven base set: builtin always, dev/container conditional.
         match ctx.mode {
             BootstrapMode::Test => {
-                self.register_builtin_tools_internal();
+                self.register_builtin_tools();
                 // Test mode is intentionally minimal — no further dispatch.
                 return Ok(());
             }
             BootstrapMode::Orchestrator {
                 allow_local_tools: false,
             } => {
-                self.register_builtin_tools_internal();
+                self.register_builtin_tools();
             }
             BootstrapMode::Orchestrator {
                 allow_local_tools: true,
             }
             | BootstrapMode::Container => {
-                self.register_builtin_tools_internal();
-                self.register_dev_tools_internal();
+                self.register_builtin_tools();
+                self.register_dev_tools();
             }
         }
 
         // Field-gated tool groups (sync first, async last).
         if let Some(store) = &ctx.secrets_store {
-            self.register_secrets_tools_internal(Arc::clone(store));
+            self.register_secrets_tools(Arc::clone(store));
         }
         // Memory: prefer the resolver path when both are present, fall back to workspace.
         match (&ctx.db_pool, &ctx.workspace) {
             (Some(resolver), _) => {
-                self.register_memory_tools_with_resolver_internal(Arc::clone(resolver));
+                self.register_memory_tools_with_resolver(Arc::clone(resolver));
             }
-            (None, Some(ws)) => self.register_memory_tools_internal(Arc::clone(ws)),
+            (None, Some(ws)) => self.register_memory_tools(Arc::clone(ws)),
             (None, None) => {}
         }
         if let Some(em) = &ctx.extension_manager {
-            self.register_extension_tools_internal(Arc::clone(em));
+            self.register_extension_tools(Arc::clone(em));
         }
         if let (Some(reg), Some(cat)) = (&ctx.skill_registry, &ctx.skill_catalog) {
-            self.register_skill_tools_internal(Arc::clone(reg), Arc::clone(cat));
+            self.register_skill_tools(Arc::clone(reg), Arc::clone(cat));
         }
         if let (Some(store), Some(eng)) = (&ctx.routine_store, &ctx.routine_engine) {
-            self.register_routine_tools_internal(Arc::clone(store), Arc::clone(eng));
+            self.register_routine_tools(Arc::clone(store), Arc::clone(eng));
         }
         if let Some(api) = &ctx.image_api {
-            self.register_image_tools_internal(
+            self.register_image_tools(
                 api.api_base.clone(),
                 api.api_key.clone(),
                 api.gen_model.clone(),
@@ -424,7 +385,7 @@ impl ToolRegistry {
             );
         }
         if let Some(api) = &ctx.vision_api {
-            self.register_vision_tools_internal(
+            self.register_vision_tools(
                 api.api_base.clone(),
                 api.api_key.clone(),
                 api.vision_model.clone(),
@@ -432,21 +393,26 @@ impl ToolRegistry {
             );
         }
 
-        // Job tools: require a ContextManager. The PR #2 `JobToolsConfig`
-        // bundle only carries `admin_base_url` / `agent_id`, which is not
-        // enough to drive `register_job_tools_internal` (it needs
-        // `Arc<ContextManager>` plus six optional dependencies). PR #4 extends
-        // `JobToolsConfig` and wires the call site; for PR #3 the field is
-        // reserved.
-        let _ = &ctx.job_config;
+        // Job tools: require a `ContextManager`. PR #4 wires the full
+        // dependency set (scheduler slot, container job manager, event/
+        // inject channels, prompt queue, secrets store).
+        if let Some(jc) = &ctx.job_config {
+            self.register_job_tools(
+                Arc::clone(&jc.context_manager),
+                jc.scheduler_slot.clone(),
+                jc.job_manager.clone(),
+                jc.store.clone(),
+                jc.job_event_tx.clone(),
+                jc.inject_tx.clone(),
+                jc.prompt_queue.clone(),
+                jc.secrets_store.clone(),
+            );
+        }
 
         // Async last so its single .await does not block earlier sync paths.
         if let Some(channels) = &ctx.channels {
-            self.register_message_tools_internal(
-                Arc::clone(channels),
-                ctx.extension_manager.clone(),
-            )
-            .await;
+            self.register_message_tools(Arc::clone(channels), ctx.extension_manager.clone())
+                .await;
         }
 
         Ok(())
@@ -508,16 +474,9 @@ impl ToolRegistry {
 
     /// Register development tools for building software.
     ///
-    /// These tools provide shell access, file operations, and code editing
-    /// capabilities needed for the software builder. Call this after
-    /// `register_builtin_tools()` to enable code generation features.
-    /// PR #3 compat wrapper. Will be privatized in PR #4.
-    #[doc(hidden)]
-    pub fn register_dev_tools(&self) {
-        self.register_dev_tools_internal();
-    }
-
-    fn register_dev_tools_internal(&self) {
+    /// Private helper invoked by [`Self::bootstrap_tools`] when `mode` is
+    /// `Container` or `Orchestrator { allow_local_tools: true }`.
+    fn register_dev_tools(&self) {
         self.register_sync(Arc::new(ShellTool::new()));
         self.register_sync(Arc::new(ReadFileTool::new()));
         self.register_sync(Arc::new(WriteFileTool::new()));
@@ -552,18 +511,8 @@ impl ToolRegistry {
 
     /// Register memory tools with a workspace resolver.
     ///
-    /// Memory tools require a workspace resolver for persistence. Call this after
-    /// `register_builtin_tools()` if you have a workspace available.
-    /// PR #3 compat wrapper. Will be privatized in PR #4.
-    #[doc(hidden)]
-    pub fn register_memory_tools_with_resolver(
-        &self,
-        resolver: Arc<dyn crate::tools::builtin::memory::WorkspaceResolver>,
-    ) {
-        self.register_memory_tools_with_resolver_internal(resolver);
-    }
-
-    fn register_memory_tools_with_resolver_internal(
+    /// Private helper invoked by [`Self::bootstrap_tools`] when `db_pool` is set.
+    fn register_memory_tools_with_resolver(
         &self,
         resolver: Arc<dyn crate::tools::builtin::memory::WorkspaceResolver>,
     ) {
@@ -575,17 +524,11 @@ impl ToolRegistry {
         tracing::debug!("Registered 4 memory tools");
     }
 
-    /// Register memory tools with a fixed workspace (backward compatibility).
+    /// Register memory tools with a fixed workspace.
     ///
-    /// Memory tools require a workspace for persistence. Call this after
-    /// `register_builtin_tools()` if you have a workspace available.
-    /// PR #3 compat wrapper. Will be privatized in PR #4.
-    #[doc(hidden)]
-    pub fn register_memory_tools(&self, workspace: Arc<Workspace>) {
-        self.register_memory_tools_internal(workspace);
-    }
-
-    fn register_memory_tools_internal(&self, workspace: Arc<Workspace>) {
+    /// Private helper invoked by [`Self::bootstrap_tools`] when `workspace`
+    /// is set without a `db_pool` resolver.
+    fn register_memory_tools(&self, workspace: Arc<Workspace>) {
         self.register_sync(Arc::new(MemorySearchTool::from_workspace(Arc::clone(
             &workspace,
         ))));
@@ -602,40 +545,12 @@ impl ToolRegistry {
 
     /// Register job management tools.
     ///
-    /// Job tools allow the LLM to create, list, check status, and cancel jobs.
-    /// When sandbox deps are provided, `create_job` automatically delegates to
-    /// Docker containers. Otherwise it dispatches via the Scheduler (which
-    /// persists to DB and spawns a worker).
-    /// PR #3 compat wrapper. Will be privatized in PR #4.
-    #[doc(hidden)]
+    /// Private helper invoked by [`Self::bootstrap_tools`] when `job_config`
+    /// is provided. When sandbox deps are present, `create_job` automatically
+    /// delegates to Docker containers; otherwise it dispatches via the
+    /// Scheduler (which persists to DB and spawns a worker).
     #[allow(clippy::too_many_arguments)]
-    pub fn register_job_tools(
-        &self,
-        context_manager: Arc<ContextManager>,
-        scheduler_slot: Option<crate::tools::builtin::SchedulerSlot>,
-        job_manager: Option<Arc<ContainerJobManager>>,
-        store: Option<Arc<dyn Database>>,
-        job_event_tx: Option<
-            tokio::sync::broadcast::Sender<(uuid::Uuid, String, ironclaw_common::AppEvent)>,
-        >,
-        inject_tx: Option<tokio::sync::mpsc::Sender<crate::channels::IncomingMessage>>,
-        prompt_queue: Option<PromptQueue>,
-        secrets_store: Option<Arc<dyn SecretsStore + Send + Sync>>,
-    ) {
-        self.register_job_tools_internal(
-            context_manager,
-            scheduler_slot,
-            job_manager,
-            store,
-            job_event_tx,
-            inject_tx,
-            prompt_queue,
-            secrets_store,
-        );
-    }
-
-    #[allow(clippy::too_many_arguments)]
-    fn register_job_tools_internal(
+    fn register_job_tools(
         &self,
         context_manager: Arc<ContextManager>,
         scheduler_slot: Option<crate::tools::builtin::SchedulerSlot>,
@@ -699,21 +614,10 @@ impl ToolRegistry {
 
     /// Register secret management tools (list, delete).
     ///
-    /// These allow the LLM to persist API keys and tokens encrypted in the database.
-    /// Values are never returned to the LLM; only names and metadata are exposed.
-    /// PR #3 compat wrapper. Will be privatized in PR #4.
-    #[doc(hidden)]
-    pub fn register_secrets_tools(
-        &self,
-        store: Arc<dyn crate::secrets::SecretsStore + Send + Sync>,
-    ) {
-        self.register_secrets_tools_internal(store);
-    }
-
-    fn register_secrets_tools_internal(
-        &self,
-        store: Arc<dyn crate::secrets::SecretsStore + Send + Sync>,
-    ) {
+    /// Private helper invoked by [`Self::bootstrap_tools`] when `secrets_store`
+    /// is set. Values are never returned to the LLM; only names and metadata
+    /// are exposed.
+    fn register_secrets_tools(&self, store: Arc<dyn crate::secrets::SecretsStore + Send + Sync>) {
         use crate::tools::builtin::{SecretDeleteTool, SecretListTool};
         self.register_sync(Arc::new(SecretListTool::new(Arc::clone(&store))));
         self.register_sync(Arc::new(SecretDeleteTool::new(store)));
@@ -722,14 +626,9 @@ impl ToolRegistry {
 
     /// Register extension management tools (search, install, auth, activate, list, remove).
     ///
-    /// These allow the LLM to manage MCP servers and WASM tools through conversation.
-    /// PR #3 compat wrapper. Will be privatized in PR #4.
-    #[doc(hidden)]
-    pub fn register_extension_tools(&self, manager: Arc<ExtensionManager>) {
-        self.register_extension_tools_internal(manager);
-    }
-
-    fn register_extension_tools_internal(&self, manager: Arc<ExtensionManager>) {
+    /// Private helper invoked by [`Self::bootstrap_tools`] when
+    /// `extension_manager` is set.
+    fn register_extension_tools(&self, manager: Arc<ExtensionManager>) {
         self.register_sync(Arc::new(ToolSearchTool::new(Arc::clone(&manager))));
         self.register_sync(Arc::new(ToolInstallTool::new(Arc::clone(&manager))));
         self.register_sync(Arc::new(ToolAuthTool::new(Arc::clone(&manager))));
@@ -743,18 +642,9 @@ impl ToolRegistry {
 
     /// Register skill management tools (list, search, install, remove).
     ///
-    /// These allow the LLM to manage prompt-level skills through conversation.
-    /// PR #3 compat wrapper. Will be privatized in PR #4.
-    #[doc(hidden)]
-    pub fn register_skill_tools(
-        &self,
-        registry: Arc<std::sync::RwLock<SkillRegistry>>,
-        catalog: Arc<SkillCatalog>,
-    ) {
-        self.register_skill_tools_internal(registry, catalog);
-    }
-
-    fn register_skill_tools_internal(
+    /// Private helper invoked by [`Self::bootstrap_tools`] when
+    /// `skill_registry` and `skill_catalog` are both set.
+    fn register_skill_tools(
         &self,
         registry: Arc<std::sync::RwLock<SkillRegistry>>,
         catalog: Arc<SkillCatalog>,
@@ -774,19 +664,9 @@ impl ToolRegistry {
 
     /// Register routine management tools.
     ///
-    /// These allow the LLM to create, list, update, delete, and view history
-    /// of routines (scheduled and event-driven tasks).
-    /// PR #3 compat wrapper. Will be privatized in PR #4.
-    #[doc(hidden)]
-    pub fn register_routine_tools(
-        &self,
-        store: Arc<dyn Database>,
-        engine: Arc<crate::agent::routine_engine::RoutineEngine>,
-    ) {
-        self.register_routine_tools_internal(store, engine);
-    }
-
-    fn register_routine_tools_internal(
+    /// Private helper invoked by [`Self::bootstrap_tools`] when both
+    /// `routine_store` and `routine_engine` are set.
+    fn register_routine_tools(
         &self,
         store: Arc<dyn Database>,
         engine: Arc<crate::agent::routine_engine::RoutineEngine>,
@@ -818,18 +698,11 @@ impl ToolRegistry {
     }
 
     /// Register message tool for sending messages to channels.
-    /// PR #3 compat wrapper. Will be privatized in PR #4.
-    #[doc(hidden)]
-    pub async fn register_message_tools(
-        &self,
-        channel_manager: Arc<crate::channels::ChannelManager>,
-        extension_manager: Option<Arc<crate::extensions::ExtensionManager>>,
-    ) {
-        self.register_message_tools_internal(channel_manager, extension_manager)
-            .await;
-    }
-
-    async fn register_message_tools_internal(
+    ///
+    /// Private helper invoked by [`Self::bootstrap_tools`] when `channels`
+    /// is set. The async path runs last so it does not block earlier sync
+    /// dispatches.
+    async fn register_message_tools(
         &self,
         channel_manager: Arc<crate::channels::ChannelManager>,
         extension_manager: Option<Arc<crate::extensions::ExtensionManager>>,
@@ -862,21 +735,9 @@ impl ToolRegistry {
 
     /// Register image generation and editing tools.
     ///
-    /// These tools allow the LLM to generate and edit images using cloud APIs.
-    /// Requires an API base URL, API key, and model name for the image generation backend.
-    /// PR #3 compat wrapper. Will be privatized in PR #4.
-    #[doc(hidden)]
-    pub fn register_image_tools(
-        &self,
-        api_base_url: String,
-        api_key: String,
-        gen_model: String,
-        base_dir: Option<std::path::PathBuf>,
-    ) {
-        self.register_image_tools_internal(api_base_url, api_key, gen_model, base_dir);
-    }
-
-    fn register_image_tools_internal(
+    /// Private helper invoked by [`Self::bootstrap_tools`] when `image_api`
+    /// is set.
+    fn register_image_tools(
         &self,
         api_base_url: String,
         api_key: String,
@@ -900,20 +761,9 @@ impl ToolRegistry {
 
     /// Register vision/image analysis tools.
     ///
-    /// These tools allow the LLM to analyze images using a vision-capable model.
-    /// PR #3 compat wrapper. Will be privatized in PR #4.
-    #[doc(hidden)]
-    pub fn register_vision_tools(
-        &self,
-        api_base_url: String,
-        api_key: String,
-        vision_model: String,
-        base_dir: Option<std::path::PathBuf>,
-    ) {
-        self.register_vision_tools_internal(api_base_url, api_key, vision_model, base_dir);
-    }
-
-    fn register_vision_tools_internal(
+    /// Private helper invoked by [`Self::bootstrap_tools`] when `vision_api`
+    /// is set.
+    fn register_vision_tools(
         &self,
         api_base_url: String,
         api_key: String,
@@ -942,7 +792,7 @@ impl ToolRegistry {
         config: Option<BuilderConfig>,
     ) -> Arc<dyn SoftwareBuilder> {
         // First register dev tools needed by the builder
-        self.register_dev_tools_internal();
+        self.register_dev_tools();
 
         // Create the builder (arg order: config, llm, tools)
         let builder: Arc<dyn SoftwareBuilder> = Arc::new(LlmSoftwareBuilder::new(
@@ -1594,5 +1444,165 @@ mod tests {
                 "Test mode must NOT register '{excluded}'"
             );
         }
+    }
+
+    // ─── PR #4: caller migration / JobToolsConfig dispatch ────────────────
+    //
+    // PR #4 deletes the public `register_*_tools` wrappers and routes every
+    // call site through `bootstrap_tools(&BootstrapContext{..})`. These tests
+    // pin the *new* invariants introduced by PR #4 — primarily the
+    // `JobToolsConfig` field-gate dispatch — so future regressions surface as
+    // a focused test failure rather than a generic build break.
+
+    use crate::context::ContextManager;
+    use crate::tools::bootstrap::JobToolsConfig;
+
+    #[tokio::test]
+    async fn req_p02_pr4_a_job_config_minimum_registers_core_job_tools() {
+        // With only the required `context_manager`, the four core job
+        // management tools (create_job / list_jobs / job_status / cancel_job)
+        // must register. Optional dependencies (sandbox, secrets, prompt
+        // queue) are absent → optional tools (job_events / job_prompt) stay
+        // unregistered.
+        let registry = Arc::new(ToolRegistry::new());
+        let ctx_mgr = Arc::new(ContextManager::new(8));
+        let ctx = BootstrapContext {
+            mode: BootstrapMode::Orchestrator {
+                allow_local_tools: false,
+            },
+            job_config: Some(JobToolsConfig::new(Arc::clone(&ctx_mgr))),
+            ..Default::default()
+        };
+        registry.bootstrap_tools(&ctx).await.unwrap();
+
+        for core in ["create_job", "list_jobs", "job_status", "cancel_job"] {
+            assert!(
+                registry.has(core).await,
+                "core job tool '{core}' must register when JobToolsConfig present"
+            );
+        }
+        // job_events requires `store`; job_prompt requires `prompt_queue`.
+        assert!(
+            !registry.has("job_events").await,
+            "job_events must not register without `store`"
+        );
+        assert!(
+            !registry.has("job_prompt").await,
+            "job_prompt must not register without `prompt_queue`"
+        );
+    }
+
+    #[tokio::test]
+    async fn req_p02_pr4_b_job_config_absent_skips_job_tools() {
+        // Field-gate parity: `job_config = None` must skip the entire job
+        // group, even when other production-shaped fields are filled in.
+        let registry = Arc::new(ToolRegistry::new());
+        let ctx = BootstrapContext {
+            mode: BootstrapMode::Orchestrator {
+                allow_local_tools: false,
+            },
+            job_config: None,
+            ..Default::default()
+        };
+        registry.bootstrap_tools(&ctx).await.unwrap();
+
+        for absent in ["create_job", "list_jobs", "job_status", "cancel_job"] {
+            assert!(
+                !registry.has(absent).await,
+                "'{absent}' must NOT register without JobToolsConfig"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn req_p02_pr4_c_test_mode_short_circuits_before_job_dispatch() {
+        // Regression guard: `BootstrapMode::Test` must short-circuit *before*
+        // any field-gated dispatch — even if a fully-formed JobToolsConfig is
+        // attached, no job tools may register. This pins the invariant that
+        // `req_p02_pr3_e` already guarantees, but specifically against the
+        // PR #4 job-dispatch path that did not exist when `_e` was authored.
+        let registry = Arc::new(ToolRegistry::new());
+        let ctx_mgr = Arc::new(ContextManager::new(8));
+        let ctx = BootstrapContext {
+            mode: BootstrapMode::Test,
+            job_config: Some(JobToolsConfig::new(ctx_mgr)),
+            ..Default::default()
+        };
+        registry.bootstrap_tools(&ctx).await.unwrap();
+
+        assert!(registry.has("echo").await, "Test mode keeps builtins");
+        assert!(
+            !registry.has("create_job").await,
+            "Test mode must skip job dispatch even with a populated JobToolsConfig"
+        );
+    }
+
+    #[tokio::test]
+    async fn req_p02_pr4_d_multi_stage_accumulates_job_then_secrets() {
+        // Production multi-stage init pattern (mirrors `app.rs` reaching
+        // `bootstrap_tools` twice — once after `init_tools`, once after a
+        // later phase wires more deps). Stage-1 wires the job group;
+        // stage-2 attaches a secrets store on top. Both groups must coexist
+        // after the second call without re-running the legacy register paths.
+        use crate::secrets::SecretsStore;
+        use crate::testing::credentials::test_secrets_store;
+
+        let registry = Arc::new(ToolRegistry::new());
+        let ctx_mgr = Arc::new(ContextManager::new(8));
+
+        // Stage 1: job tools only.
+        registry
+            .bootstrap_tools(&BootstrapContext {
+                mode: BootstrapMode::Orchestrator {
+                    allow_local_tools: false,
+                },
+                job_config: Some(JobToolsConfig::new(Arc::clone(&ctx_mgr))),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        assert!(registry.has("create_job").await);
+        assert!(!registry.has("secret_list").await);
+
+        // Stage 2: secrets store materializes; job group must survive.
+        let store: Arc<dyn SecretsStore + Send + Sync> = Arc::new(test_secrets_store());
+        registry
+            .bootstrap_tools(&BootstrapContext {
+                mode: BootstrapMode::Orchestrator {
+                    allow_local_tools: false,
+                },
+                secrets_store: Some(store),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        assert!(
+            registry.has("create_job").await,
+            "stage-1 job tools must survive stage-2 application"
+        );
+        assert!(
+            registry.has("secret_list").await,
+            "stage-2 secrets tools must register"
+        );
+    }
+
+    #[tokio::test]
+    async fn req_p02_pr4_e_job_config_new_carries_only_required_field() {
+        // Constructor contract: `JobToolsConfig::new(ctx)` produces a config
+        // whose required field is set and every optional field defaults to
+        // `None`. Asserts the invariant separately from the bootstrap path
+        // so a future field addition that breaks the default cannot pass
+        // unnoticed.
+        let ctx_mgr = Arc::new(ContextManager::new(8));
+        let cfg = JobToolsConfig::new(Arc::clone(&ctx_mgr));
+
+        assert!(Arc::ptr_eq(&cfg.context_manager, &ctx_mgr));
+        assert!(cfg.scheduler_slot.is_none());
+        assert!(cfg.job_manager.is_none());
+        assert!(cfg.store.is_none());
+        assert!(cfg.job_event_tx.is_none());
+        assert!(cfg.inject_tx.is_none());
+        assert!(cfg.prompt_queue.is_none());
+        assert!(cfg.secrets_store.is_none());
     }
 }

--- a/desktop-client/ironclaw/src/worker/container.rs
+++ b/desktop-client/ironclaw/src/worker/container.rs
@@ -74,7 +74,7 @@ impl WorkerRuntime {
     /// Create a new worker runtime.
     ///
     /// Reads `IRONCLAW_WORKER_TOKEN` from the environment for auth.
-    pub fn new(config: WorkerConfig) -> Result<Self, WorkerError> {
+    pub async fn new(config: WorkerConfig) -> Result<Self, WorkerError> {
         let client = Arc::new(WorkerHttpClient::from_env(
             config.orchestrator_url.clone(),
             config.job_id,
@@ -91,8 +91,17 @@ impl WorkerRuntime {
         }));
 
         let tools = Arc::new(ToolRegistry::new());
-        // Register only container-safe tools
-        tools.register_container_tools();
+        // Sandboxed worker: register the full container-domain tool set
+        // (filesystem, shell, dev tools) via the unified bootstrap API.
+        tools
+            .bootstrap_tools(&crate::tools::bootstrap::BootstrapContext {
+                mode: crate::tools::bootstrap::BootstrapMode::Container,
+                ..Default::default()
+            })
+            .await
+            .map_err(|e| WorkerError::ExecutionFailed {
+                reason: format!("bootstrap_tools failed: {e}"),
+            })?;
 
         Ok(Self {
             config,

--- a/desktop-client/ironclaw/src/worker/mod.rs
+++ b/desktop-client/ironclaw/src/worker/mod.rs
@@ -68,8 +68,9 @@ pub async fn run_worker(
         timeout: std::time::Duration::from_secs(600),
     };
 
-    let rt =
-        WorkerRuntime::new(config).map_err(|e| anyhow::anyhow!("Worker init failed: {}", e))?;
+    let rt = WorkerRuntime::new(config)
+        .await
+        .map_err(|e| anyhow::anyhow!("Worker init failed: {}", e))?;
 
     rt.run()
         .await

--- a/desktop-client/ironclaw/tests/e2e_telegram_message_routing.rs
+++ b/desktop-client/ironclaw/tests/e2e_telegram_message_routing.rs
@@ -217,8 +217,16 @@ mod tests {
         let channels = Arc::new(channel_manager);
 
         deps.tools
-            .register_message_tools(Arc::clone(&channels), deps.extension_manager.clone())
-            .await;
+            .bootstrap_tools(&ironclaw::tools::bootstrap::BootstrapContext {
+                mode: ironclaw::tools::bootstrap::BootstrapMode::Orchestrator {
+                    allow_local_tools: false,
+                },
+                channels: Some(Arc::clone(&channels)),
+                extension_manager: deps.extension_manager.clone(),
+                ..Default::default()
+            })
+            .await
+            .expect("e2e telegram: bootstrap_tools");
 
         let agent = Agent::new(
             components.config.agent.clone(),

--- a/desktop-client/ironclaw/tests/parity_harness.rs
+++ b/desktop-client/ironclaw/tests/parity_harness.rs
@@ -175,8 +175,15 @@ async fn run_scenario(
 ) -> ScenarioResult {
     let llm = Arc::new(ScriptedLlm::new(steps));
     let tools = Arc::new(ToolRegistry::new());
-    tools.register_builtin_tools();
-    tools.register_dev_tools();
+    tools
+        .bootstrap_tools(&ironclaw::tools::bootstrap::BootstrapContext {
+            mode: ironclaw::tools::bootstrap::BootstrapMode::Orchestrator {
+                allow_local_tools: true,
+            },
+            ..Default::default()
+        })
+        .await
+        .expect("bootstrap_tools is infallible for this context");
 
     let reasoning = Arc::new(Reasoning::new(
         Arc::clone(&llm) as Arc<dyn ironclaw::llm::LlmProvider>
@@ -222,8 +229,15 @@ async fn run_scenario_with_job_ctx(
 ) -> ScenarioResult {
     let llm = Arc::new(ScriptedLlm::new(steps));
     let tools = Arc::new(ToolRegistry::new());
-    tools.register_builtin_tools();
-    tools.register_dev_tools();
+    tools
+        .bootstrap_tools(&ironclaw::tools::bootstrap::BootstrapContext {
+            mode: ironclaw::tools::bootstrap::BootstrapMode::Orchestrator {
+                allow_local_tools: true,
+            },
+            ..Default::default()
+        })
+        .await
+        .expect("bootstrap_tools is infallible for this context");
 
     let reasoning = Arc::new(Reasoning::new(
         Arc::clone(&llm) as Arc<dyn ironclaw::llm::LlmProvider>
@@ -1380,8 +1394,15 @@ async fn ps_029_max_iterations_reached() {
 
     let llm = Arc::new(ScriptedLlm::new(steps));
     let tools = Arc::new(ToolRegistry::new());
-    tools.register_builtin_tools();
-    tools.register_dev_tools();
+    tools
+        .bootstrap_tools(&ironclaw::tools::bootstrap::BootstrapContext {
+            mode: ironclaw::tools::bootstrap::BootstrapMode::Orchestrator {
+                allow_local_tools: true,
+            },
+            ..Default::default()
+        })
+        .await
+        .expect("bootstrap_tools is infallible for this context");
 
     let reasoning = Arc::new(Reasoning::new(
         Arc::clone(&llm) as Arc<dyn ironclaw::llm::LlmProvider>
@@ -1434,7 +1455,10 @@ async fn ps_030_token_usage_tracked() {
         "Response for token test.",
     )]));
     let tools = Arc::new(ToolRegistry::new());
-    tools.register_builtin_tools();
+    tools
+        .bootstrap_tools(&ironclaw::tools::bootstrap::BootstrapContext::for_test())
+        .await
+        .expect("bootstrap_tools is infallible for this context");
 
     let reasoning = Arc::new(Reasoning::new(
         Arc::clone(&llm) as Arc<dyn ironclaw::llm::LlmProvider>

--- a/desktop-client/ironclaw/tests/shell_risk_regression.rs
+++ b/desktop-client/ironclaw/tests/shell_risk_regression.rs
@@ -22,6 +22,7 @@
 //!    variants remain `High`.
 //! 6. **`risk_level_for` trait method** — delegates to classify_command_risk.
 
+use ironclaw::tools::bootstrap::{BootstrapContext, BootstrapMode};
 use ironclaw::tools::{ApprovalRequirement, RiskLevel, Tool, ToolRegistry};
 use std::sync::Arc;
 
@@ -30,9 +31,16 @@ use std::sync::Arc;
 // ---------------------------------------------------------------------------
 
 async fn shell_tool() -> Arc<dyn Tool> {
-    let registry = ToolRegistry::new();
-    registry.register_builtin_tools();
-    registry.register_dev_tools();
+    let registry = Arc::new(ToolRegistry::new());
+    registry
+        .bootstrap_tools(&BootstrapContext {
+            mode: BootstrapMode::Orchestrator {
+                allow_local_tools: true,
+            },
+            ..Default::default()
+        })
+        .await
+        .expect("bootstrap_tools is infallible for this context");
     registry
         .all()
         .await

--- a/desktop-client/ironclaw/tests/support/gateway_workflow_harness.rs
+++ b/desktop-client/ironclaw/tests/support/gateway_workflow_harness.rs
@@ -179,16 +179,21 @@ impl GatewayWorkflowHarness {
             .register(Arc::new(MockGithubWebhookTool))
             .await;
 
-        components.tools.register_job_tools(
-            Arc::clone(&components.context_manager),
-            None,
-            None,
-            components.db.clone(),
-            None,
-            None,
-            None,
-            None,
-        );
+        let mut job_cfg = ironclaw::tools::bootstrap::JobToolsConfig::new(Arc::clone(
+            &components.context_manager,
+        ));
+        job_cfg.store = components.db.clone();
+        components
+            .tools
+            .bootstrap_tools(&ironclaw::tools::bootstrap::BootstrapContext {
+                mode: ironclaw::tools::bootstrap::BootstrapMode::Orchestrator {
+                    allow_local_tools: false,
+                },
+                job_config: Some(job_cfg),
+                ..Default::default()
+            })
+            .await
+            .expect("gateway harness: bootstrap_tools");
 
         // Agent::run() creates its own RoutineEngine and populates this slot.
         let routine_slot: Arc<tokio::sync::RwLock<Option<Arc<RoutineEngine>>>> =

--- a/desktop-client/ironclaw/tests/support/test_rig.rs
+++ b/desktop-client/ironclaw/tests/support/test_rig.rs
@@ -671,25 +671,18 @@ impl TestRigBuilder {
             }
         };
 
-        // 6. Register job tools, routine tools, and extra tools.
+        // 6. Bootstrap tool groups via the unified `bootstrap_tools()` entry
+        //    point (P0-2 PR #4). Build optional dependencies inline first, then
+        //    a single `BootstrapContext` carries every group at once. The test
+        //    rig forces `allow_local_tools = true` so filesystem/shell dev
+        //    tools are always present, regardless of upstream builder flags.
         {
-            // Ensure filesystem/shell dev tools are always available in the
-            // test rig, even if upstream builder flags/config disable local tools.
-            components.tools.register_dev_tools();
-
-            components.tools.register_job_tools(
-                Arc::clone(&components.context_manager),
-                Some(scheduler_slot.clone()),
-                None,
-                components.db.clone(),
-                None,
-                None,
-                None,
-                None,
-            );
-
-            // Routine tools: create a RoutineEngine with the LLM and workspace.
-            if let (Some(db_arc), Some(ws)) = (&components.db, &components.workspace) {
+            // Build the optional RoutineEngine once when both DB and workspace
+            // are present — needed by the routine tool group.
+            let routine_pair: Option<(
+                Arc<dyn ironclaw::db::Database>,
+                Arc<ironclaw::agent::routine_engine::RoutineEngine>,
+            )> = if let (Some(db_arc), Some(ws)) = (&components.db, &components.workspace) {
                 use ironclaw::agent::routine_engine::RoutineEngine;
                 use ironclaw::config::RoutineConfig;
 
@@ -707,22 +700,52 @@ impl TestRigBuilder {
                     components.safety.clone(),
                     ironclaw::agent::routine_engine::SandboxReadiness::DisabledByConfig,
                 ));
-                components
-                    .tools
-                    .register_routine_tools(Arc::clone(db_arc), engine);
-            }
+                Some((Arc::clone(db_arc), engine))
+            } else {
+                None
+            };
 
-            // Skills tools: ensure tests use temp skill dirs (sandbox-safe) even if
-            // AppBuilder did not wire them for this environment.
-            if enable_skills {
+            // Build the optional skill registry/catalog inline so tests use
+            // sandbox-safe temp dirs even when AppBuilder skipped wiring.
+            let skill_pair: Option<(
+                Arc<std::sync::RwLock<ironclaw::skills::SkillRegistry>>,
+                Arc<ironclaw::skills::catalog::SkillCatalog>,
+            )> = if enable_skills {
                 let registry = Arc::new(std::sync::RwLock::new(
                     ironclaw::skills::SkillRegistry::new(temp_dir.path().join("skills"))
                         .with_installed_dir(temp_dir.path().join("installed_skills")),
                 ));
                 let catalog = ironclaw::skills::catalog::shared_catalog();
-                components
-                    .tools
-                    .register_skill_tools(Arc::clone(&registry), Arc::clone(&catalog));
+                Some((registry, catalog))
+            } else {
+                None
+            };
+
+            let mut job_cfg = ironclaw::tools::bootstrap::JobToolsConfig::new(Arc::clone(
+                &components.context_manager,
+            ));
+            job_cfg.scheduler_slot = Some(scheduler_slot.clone());
+            job_cfg.store = components.db.clone();
+
+            let ctx = ironclaw::tools::bootstrap::BootstrapContext {
+                mode: ironclaw::tools::bootstrap::BootstrapMode::Orchestrator {
+                    allow_local_tools: true,
+                },
+                job_config: Some(job_cfg),
+                routine_store: routine_pair.as_ref().map(|(d, _)| Arc::clone(d)),
+                routine_engine: routine_pair.as_ref().map(|(_, e)| Arc::clone(e)),
+                skill_registry: skill_pair.as_ref().map(|(r, _)| Arc::clone(r)),
+                skill_catalog: skill_pair.as_ref().map(|(_, c)| Arc::clone(c)),
+                ..Default::default()
+            };
+            components
+                .tools
+                .bootstrap_tools(&ctx)
+                .await
+                .expect("test rig: bootstrap_tools (init phase)");
+
+            // Stash the skill pair on components for accessor parity.
+            if let Some((registry, catalog)) = skill_pair {
                 components.skill_registry = Some(registry);
                 components.skill_catalog = Some(catalog);
             }
@@ -837,9 +860,20 @@ impl TestRigBuilder {
         let channels = Arc::new(channel_manager);
 
         // 7b. Register message tool so routines can send messages to channels.
+        //     Re-bootstrap with `mode = Orchestrator { allow_local_tools: false }`:
+        //     base-set re-registration is idempotent (HashMap::insert), and
+        //     `channels` + `extension_manager` gate the message tool group.
         deps.tools
-            .register_message_tools(Arc::clone(&channels), deps.extension_manager.clone())
-            .await;
+            .bootstrap_tools(&ironclaw::tools::bootstrap::BootstrapContext {
+                mode: ironclaw::tools::bootstrap::BootstrapMode::Orchestrator {
+                    allow_local_tools: false,
+                },
+                channels: Some(Arc::clone(&channels)),
+                extension_manager: deps.extension_manager.clone(),
+                ..Default::default()
+            })
+            .await
+            .expect("test rig: bootstrap_tools (message phase)");
 
         // 8. Create Agent.
         let routine_config = if enable_routines {

--- a/desktop-client/ironclaw/tests/tool_reachability.rs
+++ b/desktop-client/ironclaw/tests/tool_reachability.rs
@@ -46,17 +46,24 @@ const DEV_TOOLS: &[&str] = &[
     "web_fetch",
 ];
 
-fn create_full_registry() -> Arc<ToolRegistry> {
+async fn create_full_registry() -> Arc<ToolRegistry> {
     let registry = Arc::new(ToolRegistry::new());
-    registry.register_builtin_tools();
-    registry.register_dev_tools();
+    registry
+        .bootstrap_tools(&ironclaw::tools::bootstrap::BootstrapContext {
+            mode: ironclaw::tools::bootstrap::BootstrapMode::Orchestrator {
+                allow_local_tools: true,
+            },
+            ..Default::default()
+        })
+        .await
+        .expect("bootstrap_tools is infallible for this context");
     registry
 }
 
 /// Every tool registered at startup must be retrievable by name.
 #[tokio::test]
 async fn test_all_registered_tools_reachable_by_name() {
-    let registry = create_full_registry();
+    let registry = create_full_registry().await;
     let all_names = registry.list().await;
     let all_set: BTreeSet<String> = all_names.into_iter().collect();
 
@@ -76,7 +83,7 @@ async fn test_all_registered_tools_reachable_by_name() {
 /// Every tool in the registry must appear in `tool_definitions()`.
 #[tokio::test]
 async fn test_all_tools_in_definitions() {
-    let registry = create_full_registry();
+    let registry = create_full_registry().await;
     let defs = registry.tool_definitions().await;
     let def_names: BTreeSet<String> = defs.iter().map(|d| d.name.clone()).collect();
 
@@ -97,7 +104,7 @@ async fn test_all_tools_in_definitions() {
 /// `get()` for every advertised tool name must return Some.
 #[tokio::test]
 async fn test_get_matches_list() {
-    let registry = create_full_registry();
+    let registry = create_full_registry().await;
     let all_names = registry.list().await;
 
     let mut unreachable = Vec::new();
@@ -116,7 +123,7 @@ async fn test_get_matches_list() {
 /// `parameters_schema()` for every tool must return valid JSON with a "type" field.
 #[tokio::test]
 async fn test_all_tools_have_valid_schema() {
-    let registry = create_full_registry();
+    let registry = create_full_registry().await;
     let all_names = registry.list().await;
 
     let mut bad_schemas = Vec::new();
@@ -137,7 +144,7 @@ async fn test_all_tools_have_valid_schema() {
 /// `name()` for every tool must match its registry key.
 #[tokio::test]
 async fn test_tool_name_matches_registry_key() {
-    let registry = create_full_registry();
+    let registry = create_full_registry().await;
     let all_names = registry.list().await;
 
     let mut mismatched = Vec::new();
@@ -157,7 +164,7 @@ async fn test_tool_name_matches_registry_key() {
 /// web_search and web_fetch specifically exist and have correct schemas.
 #[tokio::test]
 async fn test_web_tools_registered() {
-    let registry = create_full_registry();
+    let registry = create_full_registry().await;
 
     // web_search
     let ws = registry
@@ -186,7 +193,7 @@ async fn test_web_tools_registered() {
 /// No two tools share the same name.
 #[tokio::test]
 async fn test_no_duplicate_tool_names() {
-    let registry = create_full_registry();
+    let registry = create_full_registry().await;
     let defs = registry.tool_definitions().await;
     let mut seen = BTreeSet::new();
     let mut dupes = Vec::new();

--- a/desktop-client/ironclaw/tests/tool_schema_validation.rs
+++ b/desktop-client/ironclaw/tests/tool_schema_validation.rs
@@ -18,9 +18,16 @@ use ironclaw::tools::{Tool, ToolRegistry};
 /// construction helpers exist.
 #[tokio::test]
 async fn all_core_builtin_tool_schemas_are_valid() {
-    let registry = ToolRegistry::new();
-    registry.register_builtin_tools();
-    registry.register_dev_tools();
+    let registry = std::sync::Arc::new(ToolRegistry::new());
+    registry
+        .bootstrap_tools(&ironclaw::tools::bootstrap::BootstrapContext {
+            mode: ironclaw::tools::bootstrap::BootstrapMode::Orchestrator {
+                allow_local_tools: true,
+            },
+            ..Default::default()
+        })
+        .await
+        .expect("bootstrap_tools is infallible for this context");
 
     let tools = registry.all().await;
     assert!(
@@ -52,9 +59,16 @@ async fn all_core_builtin_tool_schemas_are_valid() {
 /// This guards against a new tool being added without schema validation coverage.
 #[tokio::test]
 async fn core_registration_covers_expected_tools() {
-    let registry = ToolRegistry::new();
-    registry.register_builtin_tools();
-    registry.register_dev_tools();
+    let registry = std::sync::Arc::new(ToolRegistry::new());
+    registry
+        .bootstrap_tools(&ironclaw::tools::bootstrap::BootstrapContext {
+            mode: ironclaw::tools::bootstrap::BootstrapMode::Orchestrator {
+                allow_local_tools: true,
+            },
+            ..Default::default()
+        })
+        .await
+        .expect("bootstrap_tools is infallible for this context");
 
     let mut names = registry.list().await;
     names.sort();
@@ -144,9 +158,16 @@ fn shell_tool_schema_is_valid() {
 /// panicking when called from within a multi-threaded runtime context.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn all_core_tools_work_in_multi_thread_runtime() {
-    let registry = ToolRegistry::new();
-    registry.register_builtin_tools();
-    registry.register_dev_tools();
+    let registry = std::sync::Arc::new(ToolRegistry::new());
+    registry
+        .bootstrap_tools(&ironclaw::tools::bootstrap::BootstrapContext {
+            mode: ironclaw::tools::bootstrap::BootstrapMode::Orchestrator {
+                allow_local_tools: true,
+            },
+            ..Default::default()
+        })
+        .await
+        .expect("bootstrap_tools is infallible for this context");
 
     let tools = registry.all().await;
     assert!(


### PR DESCRIPTION
**Stacked on #43** (`p02-pr3-bootstrap-tools-impl`). Merge after #43.

## Background

P0-2 of ADR-112 §5 collapses the legacy 12-method `register_*_tools` surface into a single `ToolRegistry::bootstrap_tools(&BootstrapContext)` entry point. PR #2 introduced `BootstrapContext`; PR #3 added `bootstrap_tools` and replaced 9 marker traits with concrete types; **this PR (#4)** migrates every caller and removes the public compat wrappers.

## What this PR does

### Source migrations (7 files, 14 call sites)

| File | Call sites | Notes |
|---|---|---|
| `src/app.rs` | 3 | `init_tools` end, `init_extensions` ext-mgr block, `build_all` skill phase. Removed the `builder_registered_dev_tools` late-bound flag (multi-stage `bootstrap_tools` subsumes it). |
| `src/main.rs` | 2 | Post-init job tools, post-channels message tools. |
| `src/agent/agent_loop.rs` | 1 | Routine tools wired with `Orchestrator { allow_local_tools: false }` as additive stage-2. Errors map to `Error::Tool(ToolError::ExecutionFailed)`. |
| `src/worker/container.rs` | 1 | `WorkerRuntime::new` is now `async`; uses `BootstrapMode::Container`. |
| `src/worker/mod.rs` | 1 | Caller awaits the new async `WorkerRuntime::new`. |
| `src/testing/mod.rs` | 1 | `BootstrapContext::for_test()` in lazy registry init. |

### `JobToolsConfig` extension (`bootstrap.rs`)

Extended from a marker shell to the full job-dispatch dependency set:

```rust
pub struct JobToolsConfig {
    pub context_manager: Arc<ContextManager>,            // required
    pub scheduler_slot: Option<SchedulerSlot>,
    pub job_manager: Option<Arc<ContainerJobManager>>,
    pub store: Option<Arc<dyn Database>>,
    pub job_event_tx: Option<broadcast::Sender<...>>,
    pub inject_tx: Option<mpsc::Sender<IncomingMessage>>,
    pub prompt_queue: Option<PromptQueue>,
    pub secrets_store: Option<Arc<dyn SecretsStore>>,
}

impl JobToolsConfig {
    pub fn new(context_manager: Arc<ContextManager>) -> Self { ... }
}
```

Removed `#[non_exhaustive]` on `BootstrapContext` because callers build it via `..Default::default()` spread expressions across crate boundaries (`main.rs` binary, integration tests). Documented in code that adding a field stays backward-compatible as long as it has a `Default` impl.

### Test rig migrations (5 files)

- `tests/support/test_rig.rs` — 5 sites collapsed to 2 `bootstrap_tools` calls. Builds optional `RoutineEngine` and skill registry/catalog inline so a single context wires builtin+dev+job+routine+skill at once.
- `tests/support/gateway_workflow_harness.rs` — 1 site (job tools).
- `tests/e2e_telegram_message_routing.rs` — 1 site (message tools).
- `tests/parity_harness.rs` — 4 sites (mixed builtin-only and builtin+dev).
- `tests/shell_risk_regression.rs`, `tests/tool_reachability.rs`, `tests/tool_schema_validation.rs` — helper migrations.

### Registry cleanup (`tools/registry.rs`)

- All 14 `#[doc(hidden)] pub fn register_*_tools` compat wrappers **deleted**.
- All `register_*_tools_internal` renamed back to plain private `register_*_tools` (mass `sed`).
- `register_orchestrator_tools` and `register_container_tools` fully removed — `BootstrapMode` dispatch in `bootstrap_tools` subsumes them.
- `bootstrap_tools` extended to dispatch `job_config` fields to the underlying private `register_job_tools` helper.

## Tests added (5 new)

`tools::registry::tests::req_p02_pr4_*`:

| Test | Invariant |
|---|---|
| **a** `job_config_minimum_registers_core_job_tools` | With only `context_manager`, the 4 core job tools register; optional `job_events`/`job_prompt` stay absent. |
| **b** `job_config_absent_skips_job_tools` | `job_config = None` skips the entire job group. |
| **c** `test_mode_short_circuits_before_job_dispatch` | Test mode short-circuits even with populated `JobToolsConfig` — regression guard for PR #3's `req_p02_pr3_e` contract. |
| **d** `multi_stage_accumulates_job_then_secrets` | Stage-1 job + stage-2 secrets coexist after two `bootstrap_tools` calls. |
| **e** `job_config_new_carries_only_required_field` | Constructor contract: required field set, every optional field defaults to `None`. |

## Validation

```
cargo build -p ironclaw --bins --tests             pass
cargo nextest run --lib 'tools::registry::tests::' \
                       'tools::bootstrap::tests::' 27/27 pass (22 existing + 5 new)
cargo fmt -p ironclaw                              clean
python3.12 scripts/check_no_panics.py              pass
  --base p02-pr3-bootstrap-tools-impl --head HEAD
```

## What's NOT in this PR

- ADR-112 §5 P0-3..P0-10 work
- Any new public surface for `register_*` helpers — deleted; the only entry point is `bootstrap_tools`
- Dropping any field from `BootstrapContext` (still additive)

## Risk

- **`#[non_exhaustive]` removal** is deliberate: gains struct-literal flexibility across crate boundaries at the cost of API-evolution rigor. Mitigated by the Default-impl contract documented in the struct's rustdoc.
- **`WorkerRuntime::new` became async** — single internal caller (`worker/mod.rs`) updated; no public API change.

## Stacked PR meta

- **Base branch**: `p02-pr3-bootstrap-tools-impl` (PR #43)
- **Please merge #43 first.** This PR's diff is computed against PR #43's tip, not `xClaw`.
