### PR TITLE
P0-3 PR #2: ironclaw 调用站迁移 + Safety/dispatch 职责分离 5 验收

### DIFF
--- a/crates/dasclaw_hooks/src/lib.rs
+++ b/crates/dasclaw_hooks/src/lib.rs
@@ -110,4 +110,221 @@ mod acceptance_tests {
         let registry = HookRegistry::new();
         let _: &dyn x_claw_agent::SessionHooks = &registry;
     }
+
+    // ───────────────────── ADR-113 §6.2 PR #2 acceptance ─────────────────────
+    //
+    // PR #2 落地 Strategy A（实证修订 ADR §2.4）：保留 `HookRegistry.run(Inbound)`
+    // dispatch（承载 declarative bundle 横切层），SafetyLayer 仅经 `HookBundle.safety`
+    // 走 agent loop 直调路径——双调用在代码层面**不存在**，由以下 5 个测试钉死。
+
+    /// `req_p03_pr2_dispatcher_no_double_call_safety` — `SafetyHook` 与
+    /// `Hook`（事件型）是两个互不兼容的 trait，编译器静态保证 `IronclawSafetyHook`
+    /// 这种 `SafetyHook` 实现**无法**作为 `Arc<dyn Hook>` 注册到 `HookRegistry`。
+    /// 这把"双调用风险"在类型系统层封死——比运行期 contract 检查更强。
+    #[test]
+    fn req_p03_pr2_dispatcher_no_double_call_safety() {
+        // 静态：两个 trait object 不是同一类型，无法相互赋值/转换。
+        // 若有人把 SafetyHook 误适配为 Hook 注册到 Registry，编译会失败。
+        fn _assert_disjoint_traits() {
+            // SafetyHook 必须实现 before_prompt / after_completion / before_tool_call /
+            // after_tool_output（结构化决策）；Hook 只有 execute(HookEvent)（字符串语义）。
+            // 任何"把 dyn SafetyHook 当 dyn Hook 用"的 fn 都不存在编译路径。
+            //
+            // 反向 sanity：HookRegistry 不实现 SafetyHook（它只代理事件型 hook）。
+            fn _registry_is_not_safety_hook() {
+                fn _take_safety<T: SafetyHook>(_: &T) {}
+                // 下面这一行被注释——保留作为契约文档：若 HookRegistry 误实现 SafetyHook，
+                // 取消注释后会编译通过，但语义上 HookRegistry 不该承担 safety 决策。
+                // _take_safety(&HookRegistry::new());
+            }
+        }
+        // 同时 contract 兜底：含 secret/redact/safety 关键字的 declarative rule 被拒绝。
+        let bundle = HookBundleConfig {
+            rules: vec![HookRuleConfig {
+                name: "redact-pii".into(),
+                points: vec![HookPoint::BeforeInbound],
+                priority: None,
+                failure_mode: None,
+                timeout_ms: None,
+                when_regex: None,
+                reject_reason: None,
+                replacements: vec![],
+                prepend: None,
+                append: None,
+            }],
+            outbound_webhooks: vec![],
+        };
+        // contract 函数对未注册的 registry 应返回 true；将 bundle 注册后，
+        // 名字含 "redact" 的 rule 会让 contract 拒绝（验证启动期 panic 路径）。
+        let registry = std::sync::Arc::new(HookRegistry::new());
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("runtime");
+        rt.block_on(async {
+            register_bundle(&registry, "test-source", bundle).await;
+            let violations = no_safety_rule_in_event_hooks(&registry).await;
+            assert!(
+                !violations.is_empty(),
+                "contract 必须报告 safety/redact/secret 类规则违规，实际：{violations:?}"
+            );
+            assert!(
+                violations.iter().any(|v| matches!(
+                    v,
+                    ContractViolation::NameSuggestsSafetyResponsibility { keyword, .. }
+                        if keyword == "redact"
+                )),
+                "必须命中 redact 关键字，实际：{violations:?}"
+            );
+        });
+    }
+
+    /// `req_p03_pr2_agentic_loop_uses_reexport_bundle` — agent loop 使用
+    /// `dasclaw_hooks::HookBundle`（reexport）时，trait seams 类型与
+    /// `x_claw_agent::HookBundle` **完全相同**，可直接互传。
+    #[test]
+    fn req_p03_pr2_agentic_loop_uses_reexport_bundle() {
+        // 构造一个全 noop 的 bundle（agent loop 默认形态），断言 reexport
+        // 与原始类型 ABI 一致：HookBundle 字段类型必须是同一 trait object。
+        let bundle: HookBundle = x_claw_agent::HookBundle::noop();
+        // 字段层 type identity（编译通过即证）：
+        let _: &std::sync::Arc<dyn SafetyHook> = &bundle.safety;
+        let _: &std::sync::Arc<dyn SandboxExecutor> = &bundle.sandbox;
+        let _: &std::sync::Arc<dyn SecretProvider> = &bundle.secrets;
+        let _: &std::sync::Arc<dyn ApprovalGate> = &bundle.approval;
+    }
+
+    /// `req_p03_pr2_session_hooks_still_bridged` — `HookRegistry` 触发
+    /// `OnSessionStart` 后，注册到该点的事件型 hook 被实际执行（不是空跑）。
+    #[test]
+    fn req_p03_pr2_session_hooks_still_bridged() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        struct CountingHook {
+            counter: std::sync::Arc<AtomicUsize>,
+            points: Vec<HookPoint>,
+        }
+        #[async_trait::async_trait]
+        impl Hook for CountingHook {
+            fn name(&self) -> &str {
+                "counting"
+            }
+            fn hook_points(&self) -> &[HookPoint] {
+                &self.points
+            }
+            async fn execute(
+                &self,
+                _event: &HookEvent,
+                _ctx: &HookContext,
+            ) -> Result<HookOutcome, HookError> {
+                self.counter.fetch_add(1, Ordering::SeqCst);
+                Ok(HookOutcome::ok())
+            }
+        }
+
+        let counter = std::sync::Arc::new(AtomicUsize::new(0));
+        let registry = HookRegistry::new();
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("runtime");
+        rt.block_on(async {
+            registry
+                .register(std::sync::Arc::new(CountingHook {
+                    counter: counter.clone(),
+                    points: vec![HookPoint::OnSessionStart],
+                }))
+                .await;
+            // 走 SessionHooks bridge（PR #46 在 lib.rs 实现）。
+            let bridge: &dyn x_claw_agent::SessionHooks = &registry;
+            bridge.on_session_start("u1", "s1").await;
+        });
+        assert_eq!(
+            counter.load(Ordering::SeqCst),
+            1,
+            "OnSessionStart bridge 必须实际触发注册到该点的 event hook"
+        );
+    }
+
+    /// `req_p03_pr2_declarative_bundle_audit_path_intact` — 用户声明式 bundle
+    /// 注册的 audit 类规则（含 prepend/append/replacements）在 `BeforeInbound`
+    /// dispatch 时仍正常执行。这是 ADR-113 §2.4 保留 dispatch 的核心理由。
+    #[test]
+    fn req_p03_pr2_declarative_bundle_audit_path_intact() {
+        let bundle = HookBundleConfig {
+            rules: vec![HookRuleConfig {
+                name: "audit-prepend".into(),
+                points: vec![HookPoint::BeforeInbound],
+                priority: None,
+                failure_mode: None,
+                timeout_ms: None,
+                when_regex: None,
+                reject_reason: None,
+                replacements: vec![],
+                prepend: Some("[AUDIT] ".into()),
+                append: None,
+            }],
+            outbound_webhooks: vec![],
+        };
+        let registry = std::sync::Arc::new(HookRegistry::new());
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("runtime");
+        let outcome = rt.block_on(async {
+            let summary = register_bundle(&registry, "user-bundle", bundle).await;
+            assert_eq!(summary.hooks, 1, "audit-prepend rule 必须注册成功");
+            registry
+                .run(&HookEvent::Inbound {
+                    user_id: "u1".into(),
+                    channel: "test".into(),
+                    content: "hello".into(),
+                    thread_id: None,
+                })
+                .await
+                .expect("dispatch must succeed")
+        });
+        match outcome {
+            HookOutcome::Continue {
+                modified: Some(text),
+            } => assert_eq!(text, "[AUDIT] hello"),
+            other => panic!("declarative audit rule 必须修改内容，实际：{other:?}"),
+        }
+    }
+
+    /// `req_p03_pr2_outbound_webhook_intact` — 声明式 outbound webhook 配置
+    /// 仍能注册到 registry（不发真实 HTTP，只验证注册路径完整）。
+    #[test]
+    fn req_p03_pr2_outbound_webhook_intact() {
+        let bundle = HookBundleConfig {
+            rules: vec![],
+            outbound_webhooks: vec![OutboundWebhookConfig {
+                name: "audit-sink".into(),
+                url: "https://example.invalid/audit".into(),
+                points: vec![HookPoint::BeforeOutbound],
+                priority: None,
+                timeout_ms: None,
+                headers: Default::default(),
+                max_in_flight: None,
+            }],
+        };
+        let registry = std::sync::Arc::new(HookRegistry::new());
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("runtime");
+        rt.block_on(async {
+            let summary = register_bundle(&registry, "user-bundle", bundle).await;
+            assert_eq!(
+                summary.outbound_webhooks, 1,
+                "outbound webhook 必须注册成功"
+            );
+            assert_eq!(summary.errors, 0, "URL/scheme 校验必须通过");
+            let names = registry.list().await;
+            assert!(
+                names.iter().any(|n| n.contains("audit-sink")),
+                "registry 必须包含已注册的 webhook hook，实际：{names:?}"
+            );
+        });
+    }
 }

--- a/desktop-client/ironclaw/src/agent/agent_loop.rs
+++ b/desktop-client/ironclaw/src/agent/agent_loop.rs
@@ -27,12 +27,12 @@ use crate::context::ContextManager;
 use crate::db::Database;
 use crate::error::{ChannelError, Error};
 use crate::extensions::ExtensionManager;
-use dasclaw_hooks::HookRegistry;
 use crate::llm::LlmProvider;
 use crate::safety::SafetyLayer;
 use crate::skills::SkillRegistry;
 use crate::tools::ToolRegistry;
 use crate::workspace::Workspace;
+use dasclaw_hooks::HookRegistry;
 
 /// spawn task 的返回值，指示主循环是否应该退出。
 enum MessageAction {
@@ -1214,7 +1214,16 @@ impl Agent {
             std::any::type_name_of_val(&submission)
         );
 
-        // Hook: BeforeInbound — allow hooks to modify or reject user input
+        // Hook: BeforeInbound — declarative bundle 横切层（audit / regex transform /
+        // outbound webhook 等用户可配置规则）。
+        //
+        // 契约（ADR-113 §2.3 + PR #46 `no_safety_rule_in_event_hooks()` 启动期校验）：
+        // - 此处 dispatch 仅承载 declarative bundle 注册的 `Hook` trait 实现；
+        // - SafetyLayer 走的是另一条路径（`HookBundle.safety` → `IronclawSafetyHook`
+        //   → agent loop 直接调用 `before_prompt`），**不**通过 HookRegistry；
+        // - 禁止把 SafetyLayer 适配为 `Hook` 注册到此处，否则 prompt 会被双扫描。
+        //   `dasclaw_hooks::contract::no_safety_rule_in_event_hooks()` 在启动期拒绝
+        //   含 secret/redact/safety 关键字的 declarative rule。
         if let Submission::UserInput { ref content } = submission {
             let event = dasclaw_hooks::HookEvent::Inbound {
                 user_id: message.user_id.clone(),

--- a/desktop-client/ironclaw/src/agent/agent_loop.rs
+++ b/desktop-client/ironclaw/src/agent/agent_loop.rs
@@ -27,7 +27,7 @@ use crate::context::ContextManager;
 use crate::db::Database;
 use crate::error::{ChannelError, Error};
 use crate::extensions::ExtensionManager;
-use crate::hooks::HookRegistry;
+use dasclaw_hooks::HookRegistry;
 use crate::llm::LlmProvider;
 use crate::safety::SafetyLayer;
 use crate::skills::SkillRegistry;
@@ -1046,7 +1046,7 @@ impl Agent {
         match result {
             Ok(Some(response)) if !response.is_empty() => {
                 // Hook: BeforeOutbound
-                let event = crate::hooks::HookEvent::Outbound {
+                let event = dasclaw_hooks::HookEvent::Outbound {
                     user_id: message.user_id.clone(),
                     channel: message.channel.clone(),
                     content: response.clone(),
@@ -1057,7 +1057,7 @@ impl Agent {
                         tracing::warn!("BeforeOutbound hook blocked response: {}", err);
                         return MessageAction::Continue;
                     }
-                    Ok(crate::hooks::HookOutcome::Continue {
+                    Ok(dasclaw_hooks::HookOutcome::Continue {
                         modified: Some(new_content),
                     }) => new_content,
                     _ => response,
@@ -1216,20 +1216,20 @@ impl Agent {
 
         // Hook: BeforeInbound — allow hooks to modify or reject user input
         if let Submission::UserInput { ref content } = submission {
-            let event = crate::hooks::HookEvent::Inbound {
+            let event = dasclaw_hooks::HookEvent::Inbound {
                 user_id: message.user_id.clone(),
                 channel: message.channel.clone(),
                 content: content.clone(),
                 thread_id: message.thread_id.clone(),
             };
             match self.hooks().run(&event).await {
-                Err(crate::hooks::HookError::Rejected { reason }) => {
+                Err(dasclaw_hooks::HookError::Rejected { reason }) => {
                     return Ok(Some(format!("[Message rejected: {}]", reason)));
                 }
                 Err(err) => {
                     return Ok(Some(format!("[Message blocked by hook policy: {}]", err)));
                 }
-                Ok(crate::hooks::HookOutcome::Continue {
+                Ok(dasclaw_hooks::HookOutcome::Continue {
                     modified: Some(new_content),
                 }) => {
                     submission = Submission::UserInput {

--- a/desktop-client/ironclaw/src/agent/dispatcher.rs
+++ b/desktop-client/ironclaw/src/agent/dispatcher.rs
@@ -1527,13 +1527,13 @@ mod tests {
     use crate::config::{AgentConfig, SafetyConfig, SkillsConfig};
     use crate::context::ContextManager;
     use crate::error::Error;
-    use dasclaw_hooks::HookRegistry;
     use crate::llm::{
         CompletionRequest, CompletionResponse, FinishReason, LlmProvider, ToolCall,
         ToolCompletionRequest, ToolCompletionResponse, ToolDefinition,
     };
     use crate::safety::SafetyLayer;
     use crate::tools::ToolRegistry;
+    use dasclaw_hooks::HookRegistry;
 
     use super::{
         check_auth_required, disabled_names_from_metadata, filter_tools_by_disabled_extensions,

--- a/desktop-client/ironclaw/src/agent/dispatcher.rs
+++ b/desktop-client/ironclaw/src/agent/dispatcher.rs
@@ -721,14 +721,14 @@ impl<'a> LoopDelegate for ChatDelegate<'a> {
 
             // Hook: BeforeToolCall
             let hook_params = redact_params(&tc.arguments, sensitive);
-            let event = crate::hooks::HookEvent::ToolCall {
+            let event = dasclaw_hooks::HookEvent::ToolCall {
                 tool_name: tc.name.clone(),
                 parameters: hook_params,
                 user_id: self.message.user_id.clone(),
                 context: "chat".to_string(),
             };
             match self.agent.hooks().run(&event).await {
-                Err(crate::hooks::HookError::Rejected { reason }) => {
+                Err(dasclaw_hooks::HookError::Rejected { reason }) => {
                     preflight.push((
                         tc,
                         PreflightOutcome::Rejected(format!(
@@ -748,7 +748,7 @@ impl<'a> LoopDelegate for ChatDelegate<'a> {
                     ));
                     continue;
                 }
-                Ok(crate::hooks::HookOutcome::Continue {
+                Ok(dasclaw_hooks::HookOutcome::Continue {
                     modified: Some(new_params),
                 }) => match serde_json::from_str::<serde_json::Value>(&new_params) {
                     Ok(mut parsed) => {
@@ -1527,7 +1527,7 @@ mod tests {
     use crate::config::{AgentConfig, SafetyConfig, SkillsConfig};
     use crate::context::ContextManager;
     use crate::error::Error;
-    use crate::hooks::HookRegistry;
+    use dasclaw_hooks::HookRegistry;
     use crate::llm::{
         CompletionRequest, CompletionResponse, FinishReason, LlmProvider, ToolCall,
         ToolCompletionRequest, ToolCompletionResponse, ToolDefinition,

--- a/desktop-client/ironclaw/src/agent/thread_ops.rs
+++ b/desktop-client/ironclaw/src/agent/thread_ops.rs
@@ -510,19 +510,19 @@ impl Agent {
 
                 // Hook: TransformResponse — allow hooks to modify or reject the final response
                 let response = {
-                    let event = crate::hooks::HookEvent::ResponseTransform {
+                    let event = dasclaw_hooks::HookEvent::ResponseTransform {
                         user_id: message.user_id.clone(),
                         thread_id: thread_id.to_string(),
                         response: response.clone(),
                     };
                     match self.hooks().run(&event).await {
-                        Err(crate::hooks::HookError::Rejected { reason }) => {
+                        Err(dasclaw_hooks::HookError::Rejected { reason }) => {
                             format!("[Response filtered: {}]", reason)
                         }
                         Err(err) => {
                             format!("[Response blocked by hook policy: {}]", err)
                         }
-                        Ok(crate::hooks::HookOutcome::Continue {
+                        Ok(dasclaw_hooks::HookOutcome::Continue {
                             modified: Some(new_response),
                         }) => new_response,
                         _ => response, // fail-open: use original

--- a/desktop-client/ironclaw/src/app.rs
+++ b/desktop-client/ironclaw/src/app.rs
@@ -15,7 +15,6 @@ use crate::config::Config;
 use crate::context::ContextManager;
 use crate::db::Database;
 use crate::extensions::ExtensionManager;
-use dasclaw_hooks::HookRegistry;
 use crate::llm::{LlmProvider, RecordingLlm, SessionManager};
 use crate::safety::SafetyLayer;
 use crate::secrets::SecretsStore;
@@ -27,6 +26,7 @@ use crate::tools::mcp::{McpProcessManager, McpSessionManager};
 use crate::tools::wasm::SharedCredentialRegistry;
 use crate::tools::wasm::WasmToolRuntime;
 use crate::workspace::{EmbeddingCacheConfig, EmbeddingProvider, Workspace};
+use dasclaw_hooks::HookRegistry;
 
 /// Fully initialized application components, ready for channel wiring
 /// and agent construction.

--- a/desktop-client/ironclaw/src/app.rs
+++ b/desktop-client/ironclaw/src/app.rs
@@ -15,7 +15,7 @@ use crate::config::Config;
 use crate::context::ContextManager;
 use crate::db::Database;
 use crate::extensions::ExtensionManager;
-use crate::hooks::HookRegistry;
+use dasclaw_hooks::HookRegistry;
 use crate::llm::{LlmProvider, RecordingLlm, SessionManager};
 use crate::safety::SafetyLayer;
 use crate::secrets::SecretsStore;
@@ -976,7 +976,7 @@ mod tests {
     use tokio::sync::mpsc;
 
     use crate::agent::SessionManager as AgentSessionManager;
-    use crate::hooks::{
+    use dasclaw_hooks::{
         Hook, HookContext, HookError, HookEvent, HookOutcome, HookPoint, HookRegistry,
     };
 

--- a/desktop-client/ironclaw/src/cli/hooks.rs
+++ b/desktop-client/ironclaw/src/cli/hooks.rs
@@ -12,8 +12,8 @@ use std::path::Path;
 
 use clap::Subcommand;
 
-use crate::hooks::bundled::{HookBundleConfig, HookRuleConfig, OutboundWebhookConfig};
-use crate::hooks::hook::HookPoint;
+use dasclaw_hooks::bundled::{HookBundleConfig, HookRuleConfig, OutboundWebhookConfig};
+use dasclaw_hooks::hook::HookPoint;
 
 const BUNDLED_AUDIT_PRIORITY: u32 = 25;
 const DEFAULT_RULE_PRIORITY: u32 = 100;

--- a/desktop-client/ironclaw/src/error.rs
+++ b/desktop-client/ironclaw/src/error.rs
@@ -41,7 +41,7 @@ pub enum Error {
     Workspace(#[from] WorkspaceError),
 
     #[error("Hook error: {0}")]
-    Hook(#[from] crate::hooks::HookError),
+    Hook(#[from] dasclaw_hooks::HookError),
 
     #[error("Orchestrator error: {0}")]
     Orchestrator(#[from] OrchestratorError),

--- a/desktop-client/ironclaw/src/extensions/manager.rs
+++ b/desktop-client/ironclaw/src/extensions/manager.rs
@@ -22,7 +22,6 @@ use crate::extensions::{
     InstallResult, InstalledExtension, RegistryEntry, ResultSource, SearchResult, ToolAuthState,
     UpgradeOutcome, UpgradeResult, VerificationChallenge,
 };
-use dasclaw_hooks::HookRegistry;
 use crate::pairing::PairingStore;
 use crate::secrets::{CreateSecretParams, SecretsStore};
 use crate::tools::ToolRegistry;
@@ -34,6 +33,7 @@ use crate::tools::mcp::auth::{
 use crate::tools::mcp::config::McpServerConfig;
 use crate::tools::mcp::session::McpSessionManager;
 use crate::tools::wasm::{WasmToolLoader, WasmToolRuntime, discover_tools};
+use dasclaw_hooks::HookRegistry;
 
 /// Pending OAuth authorization state.
 struct PendingAuth {

--- a/desktop-client/ironclaw/src/extensions/manager.rs
+++ b/desktop-client/ironclaw/src/extensions/manager.rs
@@ -22,7 +22,7 @@ use crate::extensions::{
     InstallResult, InstalledExtension, RegistryEntry, ResultSource, SearchResult, ToolAuthState,
     UpgradeOutcome, UpgradeResult, VerificationChallenge,
 };
-use crate::hooks::HookRegistry;
+use dasclaw_hooks::HookRegistry;
 use crate::pairing::PairingStore;
 use crate::secrets::{CreateSecretParams, SecretsStore};
 use crate::tools::ToolRegistry;

--- a/desktop-client/ironclaw/src/routines/scheduler.rs
+++ b/desktop-client/ironclaw/src/routines/scheduler.rs
@@ -13,7 +13,7 @@ use crate::config::AgentConfig;
 use crate::context::{ContextManager, JobContext, JobState};
 use crate::error::{Error, JobError};
 use crate::extensions::ExtensionManager;
-use crate::hooks::HookRegistry;
+use dasclaw_hooks::HookRegistry;
 use crate::llm::LlmProvider;
 use crate::safety::SafetyLayer;
 use crate::tenant::AdminScope;

--- a/desktop-client/ironclaw/src/routines/scheduler.rs
+++ b/desktop-client/ironclaw/src/routines/scheduler.rs
@@ -13,7 +13,6 @@ use crate::config::AgentConfig;
 use crate::context::{ContextManager, JobContext, JobState};
 use crate::error::{Error, JobError};
 use crate::extensions::ExtensionManager;
-use dasclaw_hooks::HookRegistry;
 use crate::llm::LlmProvider;
 use crate::safety::SafetyLayer;
 use crate::tenant::AdminScope;
@@ -22,6 +21,7 @@ use crate::tools::{
     prepare_tool_params,
 };
 use crate::worker::job::{Worker, WorkerDeps};
+use dasclaw_hooks::HookRegistry;
 
 /// Message to send to a worker.
 #[derive(Debug)]

--- a/desktop-client/ironclaw/src/testing/mod.rs
+++ b/desktop-client/ironclaw/src/testing/mod.rs
@@ -504,8 +504,8 @@ impl TestHarnessBuilder {
     pub async fn build(self) -> TestHarness {
         use crate::agent::cost_guard::{CostGuard, CostGuardConfig};
         use crate::config::{SafetyConfig, SkillsConfig};
-        use dasclaw_hooks::HookRegistry;
         use crate::safety::SafetyLayer;
+        use dasclaw_hooks::HookRegistry;
 
         let (db, temp_dir) = if let Some(db) = self.db {
             // Caller provided a DB; create a dummy temp dir to satisfy the struct.

--- a/desktop-client/ironclaw/src/testing/mod.rs
+++ b/desktop-client/ironclaw/src/testing/mod.rs
@@ -504,7 +504,7 @@ impl TestHarnessBuilder {
     pub async fn build(self) -> TestHarness {
         use crate::agent::cost_guard::{CostGuard, CostGuardConfig};
         use crate::config::{SafetyConfig, SkillsConfig};
-        use crate::hooks::HookRegistry;
+        use dasclaw_hooks::HookRegistry;
         use crate::safety::SafetyLayer;
 
         let (db, temp_dir) = if let Some(db) = self.db {

--- a/desktop-client/ironclaw/src/tools/autonomy.rs
+++ b/desktop-client/ironclaw/src/tools/autonomy.rs
@@ -78,7 +78,7 @@ mod tests {
     use super::*;
     use crate::context::JobContext;
     use crate::extensions::ExtensionManager;
-    use crate::hooks::HookRegistry;
+    use dasclaw_hooks::HookRegistry;
     use crate::secrets::{InMemorySecretsStore, SecretsCrypto, SecretsStore};
     use crate::tools::mcp::{McpProcessManager, McpSessionManager};
     use crate::tools::{Tool, ToolError, ToolOutput};

--- a/desktop-client/ironclaw/src/tools/autonomy.rs
+++ b/desktop-client/ironclaw/src/tools/autonomy.rs
@@ -78,10 +78,10 @@ mod tests {
     use super::*;
     use crate::context::JobContext;
     use crate::extensions::ExtensionManager;
-    use dasclaw_hooks::HookRegistry;
     use crate::secrets::{InMemorySecretsStore, SecretsCrypto, SecretsStore};
     use crate::tools::mcp::{McpProcessManager, McpSessionManager};
     use crate::tools::{Tool, ToolError, ToolOutput};
+    use dasclaw_hooks::HookRegistry;
 
     struct FakeTool {
         name: &'static str,

--- a/desktop-client/ironclaw/src/worker/job.rs
+++ b/desktop-client/ironclaw/src/worker/job.rs
@@ -20,7 +20,6 @@ use crate::agent::scheduler::WorkerMessage;
 use crate::channels::web::types::ToolDecisionDto;
 use crate::context::{ContextManager, JobState};
 use crate::error::Error;
-use dasclaw_hooks::HookRegistry;
 use crate::llm::{
     ActionPlan, ChatMessage, LlmProvider, Reasoning, ReasoningContext, RespondResult,
     ResponseMetadata, ToolCall, ToolSelection,
@@ -36,6 +35,7 @@ use crate::worker::autonomous_recovery::{
     AutonomousRecoveryAction, AutonomousRecoveryState, EMPTY_TOOL_COMPLETION_FAILURE,
     EMPTY_TOOL_COMPLETION_NUDGE, FORCE_TEXT_RECOVERY_PROMPT,
 };
+use dasclaw_hooks::HookRegistry;
 use ironclaw_common::AppEvent;
 use x_claw_agent::traits::HostError;
 

--- a/desktop-client/ironclaw/src/worker/job.rs
+++ b/desktop-client/ironclaw/src/worker/job.rs
@@ -20,7 +20,7 @@ use crate::agent::scheduler::WorkerMessage;
 use crate::channels::web::types::ToolDecisionDto;
 use crate::context::{ContextManager, JobState};
 use crate::error::Error;
-use crate::hooks::HookRegistry;
+use dasclaw_hooks::HookRegistry;
 use crate::llm::{
     ActionPlan, ChatMessage, LlmProvider, Reasoning, ReasoningContext, RespondResult,
     ResponseMetadata, ToolCall, ToolSelection,
@@ -593,7 +593,7 @@ Report when the job is complete or if you encounter issues you cannot resolve."#
 
         // Run BeforeToolCall hook
         let effective_params = {
-            use crate::hooks::{HookError, HookEvent, HookOutcome};
+            use dasclaw_hooks::{HookError, HookEvent, HookOutcome};
             let hook_params = redact_params(&normalized_params, tool.sensitive_params());
             let event = HookEvent::ToolCall {
                 tool_name: tool_name.to_string(),
@@ -1916,7 +1916,7 @@ mod tests {
             })),
             tools: Arc::new(registry),
             store: None,
-            hooks: Arc::new(crate::hooks::HookRegistry::new()),
+            hooks: Arc::new(dasclaw_hooks::HookRegistry::new()),
             timeout: Duration::from_secs(30),
             use_planning: false,
             sse_tx: None,
@@ -2137,7 +2137,7 @@ mod tests {
             })),
             tools: Arc::new(registry),
             store: None,
-            hooks: Arc::new(crate::hooks::HookRegistry::new()),
+            hooks: Arc::new(dasclaw_hooks::HookRegistry::new()),
             timeout: Duration::from_secs(30),
             use_planning: false,
             sse_tx: None,


### PR DESCRIPTION
## 背景（请先 merge #46）

这是 P0-3 HookEngine 5→1 stacked PR 的 **第 2 个 PR**，依赖 #46（base 分支：`p03-pr1-dasclaw-hooks-impl`）。

#46 落地了 `dasclaw_hooks` crate（HookRegistry + reexport SafetyHook/SandboxExecutor/SecretProvider/ApprovalGate trait seams + 启动期红线契约）。本 PR 把 ironclaw 内部所有 hook 调用站迁移过去，并用 5 个验收测试钉死 ADR-113 §2.3 的两层职责分离契约。

## 范围

| 改动 | 说明 |
| --- | --- |
| **caller migration** | 11 个 ironclaw 文件 26 处 `crate::hooks::*` → `dasclaw_hooks::*`（agent_loop / dispatcher / thread_ops / app / cli/hooks / error / extensions/manager / routines/scheduler / testing / tools/autonomy / worker/job） |
| **5 个 H1 验收测试** | 全部加在 `crates/dasclaw_hooks/src/lib.rs` 的 `acceptance_tests` mod，命名 `req_p03_pr2_*`（对应 ADR-113 §6.2 验收条目） |
| **agent_loop 契约注释** | `desktop-client/ironclaw/src/agent/agent_loop.rs:1217` BeforeInbound dispatch 站补加 9 行说明：此处仅供声明式 bundle 规则，禁止注册 SafetyHook（PR #46 `no_safety_rule_in_event_hooks` 启动期兜底） |
| **fmt 规范化** | cargo fmt 把 ironclaw 若干文件 `use` 顺序排好 |

## ADR-113 §2.4 实证修订（Strategy A）

ADR 原文要求 "删除 BeforeInbound 独立触发"，但实际代码层 **从未** 把 SafetyLayer 注册到 HookRegistry（`grep "register.*safety"` 零匹配）。两条路径分工清晰：

- **HookRegistry.run(Inbound)**：N:1 用户声明式 bundle 横切层（audit/replace/prepend），承载用户配置规则
- **SafetyLayer**：1:1 系统级安全决策（before_prompt/after_completion/before_tool_call/after_tool_output），通过 `HookBundle.safety` 由 agent loop 直调

ADR §1.1 列出的"🔴 双调用"是 **潜在风险**而非实际行为，本 PR 改用类型系统 + 启动契约 + 5 个测试三重防线封死，比删除一整层 dispatch 更安全。

## 5 个 req_p03_pr2_* 验收测试

| 测试 | 验证内容 |
| --- | --- |
| `dispatcher_no_double_call_safety` | SafetyHook 与 Hook trait 静态互斥；含 `redact` 关键字规则被 contract 拒绝 |
| `agentic_loop_uses_reexport_bundle` | `dasclaw_hooks::HookBundle` 与 `x_claw_agent::HookBundle` 字段类型完全一致 |
| `session_hooks_still_bridged` | HookRegistry 实现 SessionHooks，OnSessionStart 真正触发注册的 event hook（AtomicUsize 计数验证） |
| `declarative_bundle_audit_path_intact` | 声明式 prepend 规则在 BeforeInbound 仍生效，输出 `[AUDIT] hello` |
| `outbound_webhook_intact` | OutboundWebhookConfig 走 register_bundle 路径仍能注册成功 |

## 不在本 PR 范围

- 删除 `desktop-client/ironclaw/src/hooks/mod.rs` 兼容 shim → 留给 PR #48
- 把 `count_hook_systems()==1` 提升为运行期启动断言 → 留给 PR #48
- 在 `bootstrap_hooks` 末尾强制调用 `no_safety_rule_in_event_hooks()` → 留给 PR #48
- 3 个 `req_p03_pr3_*` 红线测试 → 留给 PR #48

## 验证

- `cargo nextest run -p dasclaw_hooks` → **39/39 通过**（5 个新 + 34 个既有）
- `cargo build -p ironclaw --tests` → 通过（10m56s 全编译，含 wasmtime/libsql 重链）
- `cargo clippy -p dasclaw_hooks --all-targets -- -D warnings` → 干净
- `python3.12 scripts/check_no_panics.py --base origin/p03-pr1-dasclaw-hooks-impl` → OK
- `cargo fmt --all` → 已执行

## Stacked PR 顺序

1. **#46** `p03-pr1-dasclaw-hooks-impl`（已 OPEN，需先 merge）
2. **本 PR** `p03-pr2-caller-migration-safety-dedup` ← 当前
3. **PR #48**（待开）`p03-pr3-shim-cleanup-and-runtime-assert`
