### PR TITLE
chore(github): bootstrap Project board automation + Copilot Coding Agent instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,64 @@
+# Copilot Coding Agent Instructions for x-claw
+
+> 本文件由 GitHub Copilot Coding Agent 在派单时自动注入。所有规约的**真理来源**是
+> [`AGENTS.md`](../AGENTS.md)（仓库根），本文件只是它的精简检查清单。
+
+## 1. 强制阅读顺序（开任何 PR 之前）
+
+1. [`AGENTS.md`](../AGENTS.md) — 中文规约总入口
+2. 本 issue body 顶部的 `**Source**:` 链接（指向 `docs/plans/architecture-refactor/...`）
+3. 涉及红线的 ADR：[`docs/plans/architecture-refactor/adr-112-compatibility-evaluation.md`](../docs/plans/architecture-refactor/adr-112-compatibility-evaluation.md)、
+   [`adr-113-hook-engine-unification.md`](../docs/plans/architecture-refactor/adr-113-hook-engine-unification.md)
+4. 触及 crate 的 `lib.rs` 模块文档
+
+## 2. 不要碰的红线
+
+- 标了 `adr-redline` label 的 issue **禁止 agent 自动操作** — 留给人类
+- 不要新增 `unwrap()` / `expect()` / `panic!()` 在生产代码（`scripts/check_no_panics.py` 会拦）
+- 不要写补丁式代码：不在已有函数尾部追加 `if` 分支，不复制粘贴逻辑，不靠 flag 切换大块代码
+- 不要绕过编译期红线（如 `dasclaw_hooks::count_hook_systems()` 的 `const _: () = assert!(...)`）
+- 不要改 `--no-verify` / 不要 `git push --force` 到共享分支
+
+## 3. 必跑的本地管线（按顺序）
+
+```bash
+# 1. 只 check 本轮改动的 crate（1–3 分钟）
+cargo check -p <touched-crate> --tests
+
+# 2. 跑改动范围内的 nextest（< 1 分钟）
+cargo nextest run -p <touched-crate>
+
+# 3. fmt + check_no_panics
+cargo fmt --all
+python3.12 scripts/check_no_panics.py --base origin/xClaw
+
+# 4. crate 级 clippy（不跑 workspace）
+cargo clippy --no-deps -p <touched-crate> --all-targets -- -D warnings
+```
+
+完整 `cargo build` / workspace clippy / heavy integration **由 CI 兜底**，本地不要跑（10+ 分钟）。
+
+## 4. PR 必填项
+
+- 标题前缀对应 issue 类别：`feat(<area>):` / `fix(...):` / `docs(...):` 等
+- Body 必须含 `Closes #<issue>`（缺它 board 状态机不会推进，会被 CI 拦下）
+- Body 必须含 4 块：**背景/目标**、**改动范围**、**非目标（What's NOT in this PR）**、**验证（命令 + 结果）**
+- stacked PR 必须额外注明：base 分支不是 `xClaw`、merge 顺序、"先看 #X 再看本 PR"
+
+## 5. 测试纪律
+
+- TDD：先红测，再实现，再重构
+- 失败路径与成功路径同等重要；安全功能要 **Fail-Safe**，不允许 Fail-Open
+- 测试命名：需求测试用 `req_<module>_<id>_<desc>`，安全用 `test_security_<attack>`
+- 用 `cargo nextest run` 不用 `cargo test`
+
+## 6. 复用优先于新建
+
+新增 crate / 模块前先 `semantic_search` 是否已有等价实现（codex / claw-code / ironclaw 三方）。
+**否定性结论**（"X 没有 Y"、"缺失 Y"）必须三层验证：semantic_search → vscode_listCodeUsages → rg。
+
+## 7. 完成后
+
+- 跑 skills 管线：`code-quality-audit` → `code-simplifier` → `code-review-expert`（详见 `AGENTS.md` Skills 强制使用规范）
+- 在 PR 描述贴上 skill 自查产出
+- 若已完成一个闭环 milestone，按 `AGENTS.md` 会话轮换原则写 handoff

--- a/.github/workflows/pr-closes-issue-check.yml
+++ b/.github/workflows/pr-closes-issue-check.yml
@@ -1,0 +1,31 @@
+name: PR — Closes #issue check
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened, ready_for_review]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  closes-link:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
+    steps:
+      - name: Require Closes/Fixes/Resolves #N in PR body
+        env:
+          BODY: ${{ github.event.pull_request.body }}
+        run: |
+          set -euo pipefail
+          if [ -z "${BODY:-}" ]; then
+            echo "::error::PR body is empty. Add 'Closes #<issue>' to link this PR to an issue."
+            exit 1
+          fi
+          # Match GitHub's own closing keyword set (case-insensitive)
+          # See: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
+          if printf '%s' "$BODY" | grep -iEq '(close[sd]?|fix(e[sd])?|resolve[sd]?)[[:space:]]+#[0-9]+'; then
+            echo "OK: PR body contains a closing keyword + #issue."
+          else
+            echo "::error::PR body must contain 'Closes #<issue>' (or Fixes/Resolves) so the project board state machine advances on merge. See .github/copilot-instructions.md §4."
+            exit 1
+          fi

--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -1,0 +1,114 @@
+name: Project board automation
+
+# Syncs issues + PRs into the architecture-refactor Project (v2) and
+# transitions their Status field on lifecycle events.
+#
+# Activation:
+#   Set repository variable PROJECT_URL to the Project v2 URL (e.g.
+#   https://github.com/users/Linnanli/projects/N) and create a Personal
+#   Access Token (classic, scopes: project, repo) stored as repository
+#   secret PROJECT_TOKEN. Without these vars/secrets every step is a no-op.
+#
+# Status field values used (must match Project's Status options):
+#   - Backlog
+#   - Ready
+#   - In-Progress
+#   - In-Review
+#   - Done
+#   - Blocked
+
+on:
+  issues:
+    types: [opened, reopened, labeled, closed]
+  pull_request:
+    types: [opened, ready_for_review, review_requested, closed, reopened]
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+
+jobs:
+  add-and-transition:
+    runs-on: ubuntu-latest
+    if: ${{ vars.PROJECT_URL != '' }}
+    steps:
+      - name: Add item to Project
+        uses: actions/add-to-project@v1.0.2
+        with:
+          project-url: ${{ vars.PROJECT_URL }}
+          github-token: ${{ secrets.PROJECT_TOKEN }}
+
+      - name: Compute target Status
+        id: status
+        env:
+          EVENT: ${{ github.event_name }}
+          ACTION: ${{ github.event.action }}
+          MERGED: ${{ github.event.pull_request.merged }}
+          DRAFT: ${{ github.event.pull_request.draft }}
+          LABELS: ${{ toJSON(github.event.issue.labels) }}
+        run: |
+          set -euo pipefail
+          target=""
+          if [ "$EVENT" = "issues" ]; then
+            case "$ACTION" in
+              opened|reopened) target="Backlog" ;;
+              labeled)
+                if printf '%s' "$LABELS" | grep -q '"ready-for-dev"'; then target="Ready"; fi
+                if printf '%s' "$LABELS" | grep -q '"blocked"'; then target="Blocked"; fi
+                ;;
+              closed) target="Done" ;;
+            esac
+          elif [ "$EVENT" = "pull_request" ]; then
+            case "$ACTION" in
+              opened|reopened)
+                if [ "$DRAFT" = "true" ]; then target="In-Progress"; else target="In-Review"; fi
+                ;;
+              ready_for_review|review_requested) target="In-Review" ;;
+              closed)
+                if [ "$MERGED" = "true" ]; then target="Done"; fi
+                ;;
+            esac
+          fi
+          echo "target=$target" >> "$GITHUB_OUTPUT"
+          echo "Computed target Status: '$target'"
+
+      - name: Set Status field on Project item
+        if: steps.status.outputs.target != ''
+        env:
+          GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+          PROJECT_URL: ${{ vars.PROJECT_URL }}
+          TARGET: ${{ steps.status.outputs.target }}
+          ITEM_NODE_ID: ${{ github.event.issue.node_id || github.event.pull_request.node_id }}
+        run: |
+          set -euo pipefail
+          owner=$(echo "$PROJECT_URL" | awk -F/ '{print $5}')
+          number=$(echo "$PROJECT_URL" | awk -F/ '{print $7}')
+          kind=$(echo "$PROJECT_URL" | awk -F/ '{print $4}')   # users | orgs
+
+          # 1. Resolve project node id + Status field id + target option id
+          if [ "$kind" = "users" ]; then
+            project_id=$(gh api graphql -f query='query($l:String!,$n:Int!){user(login:$l){projectV2(number:$n){id}}}' -f l="$owner" -F n="$number" --jq .data.user.projectV2.id)
+            field_json=$(gh api graphql -f query='query($l:String!,$n:Int!){user(login:$l){projectV2(number:$n){field(name:"Status"){... on ProjectV2SingleSelectField{id options{id name}}}}}}' -f l="$owner" -F n="$number")
+          else
+            project_id=$(gh api graphql -f query='query($l:String!,$n:Int!){organization(login:$l){projectV2(number:$n){id}}}' -f l="$owner" -F n="$number" --jq .data.organization.projectV2.id)
+            field_json=$(gh api graphql -f query='query($l:String!,$n:Int!){organization(login:$l){projectV2(number:$n){field(name:"Status"){... on ProjectV2SingleSelectField{id options{id name}}}}}}' -f l="$owner" -F n="$number")
+          fi
+          field_id=$(echo "$field_json" | jq -r '.. | .field? // empty | .id' | head -1)
+          option_id=$(echo "$field_json" | jq -r --arg t "$TARGET" '.. | .options? // empty | .[] | select(.name==$t) | .id' | head -1)
+          if [ -z "$field_id" ] || [ -z "$option_id" ]; then
+            echo "::warning::Status field or option '$TARGET' not found in Project. Skipping."
+            exit 0
+          fi
+
+          # 2. Resolve project item id for this issue/PR
+          item_id=$(gh api graphql -f query='query($p:ID!,$c:String){node(id:$p){... on ProjectV2{items(first:100,after:$c){nodes{id content{... on Issue{id} ... on PullRequest{id}}} pageInfo{hasNextPage endCursor}}}}}' -f p="$project_id" --jq ".data.node.items.nodes[] | select(.content.id==\"$ITEM_NODE_ID\") | .id" | head -1)
+          if [ -z "$item_id" ]; then
+            echo "::warning::Project item for $ITEM_NODE_ID not found (add-to-project may need a moment). Skipping."
+            exit 0
+          fi
+
+          # 3. Update Status
+          gh api graphql -f query='mutation($p:ID!,$i:ID!,$f:ID!,$o:String!){updateProjectV2ItemFieldValue(input:{projectId:$p,itemId:$i,fieldId:$f,value:{singleSelectOptionId:$o}}){projectV2Item{id}}}' \
+            -f p="$project_id" -f i="$item_id" -f f="$field_id" -f o="$option_id"
+          echo "Set Status='$TARGET' on item $item_id"


### PR DESCRIPTION
## 背景与目标

把 [docs/plans/architecture-refactor/](docs/plans/architecture-refactor/) 多 Wave 计划接入 GitHub Project + Issues + Milestone 三层结构，开发过程中状态自动流转，开发人员能看进度、agent 能按 board 派单。

本 PR 是「计划落地」的**机制层**——只引入规约文件 + workflow，不改任何 Rust 代码。

Closes #77

Refs #76（shell_risk_regression 既有回归，独立 PR 修复，不在本 PR 范围）

## 改动范围

1. **`.github/copilot-instructions.md`** — Copilot Coding Agent 派单时自动注入，是 [`AGENTS.md`](AGENTS.md) 的精简检查清单（红线 / 本地管线 / PR 必填项 / 测试纪律 / Skills 管线）
2. **`.github/workflows/pr-closes-issue-check.yml`** — 强制每个非 draft PR body 含 `Closes/Fixes/Resolves #<issue>`，缺它 board 状态机推不动 → CI 红
3. **`.github/workflows/project-automation.yml`** — Project v2 状态机自动化，靠 repo variable `PROJECT_URL` + secret `PROJECT_TOKEN` 激活；未配置时整个 job 跳过（no-op）

### Project board 状态机（实现在 `project-automation.yml`）

```
Backlog ──► Ready ──► In-Progress ──► In-Review ──► Done
              ▲                              │
              └──────── Blocked ◄────────────┘
```

| 触发 | 动作 |
|---|---|
| Issue 创建 / reopen | → Backlog |
| Issue 加 `ready-for-dev` 标签 | → Ready |
| Issue 加 `blocked` 标签 | → Blocked |
| PR draft 打开 | → In-Progress |
| PR ready_for_review / review_requested | → In-Review |
| PR merge | → Done |

### 已配套的"内容层"（不在本 PR，已通过 API 创建）

- 9 个 Milestone（W1–W9）已建（issue tracker）
- 19 个 label 已建（`wave:W*` / `area:*` / `effort:*` / `risk:*` / `agent-friendly` / `adr-redline` / `ready-for-dev` / `blocked` / `phase:P0`）
- 24 个 W3 + W4 issue 已建（#52–#75）
- 1 个 tracking issue #76（shell_risk_regression 回归）

## 非目标

- 不改 Rust / 不改测试
- 不创建 Project v2 本身（gh token 缺 `project` scope，需用户本地补一条 `gh auth refresh -s project` 然后跑 `gh project create`，详见下方"用户操作清单"）
- 不修复 #76 shell_risk_regression（独立 PR）

## 验证

- `cat .github/workflows/pr-closes-issue-check.yml | yamllint`：无配置即在 GitHub 端解析（无本地工具）
- `cat .github/workflows/project-automation.yml`：`if: vars.PROJECT_URL != ''` 守卫，未配置时整个 job 不会运行 → 安全可合
- 本 PR body 自身就符合 `pr-closes-issue-check.yml` 的要求（含 `Closes #77`），可作为 self-check

## 用户操作清单（merge 后做）

1. **补 gh scope**：`gh auth refresh -s project`
2. **创建 Project**：`gh project create --owner Linnanli --title "Architecture Refactor (W1-W9)"`
3. **加 Status 字段**：在 web UI 把 Status 字段的选项改成：`Backlog` / `Ready` / `In-Progress` / `In-Review` / `Done` / `Blocked`（与 yaml 中字符串对齐）
4. **加自定义字段**（可选）：`Wave`（W1-W9 single-select）、`Effort`（XS/S/M/L/XL）、`Risk`（low/med/high）
5. **绑 repo**：`gh project link <PROJECT_NUMBER> --owner Linnanli --repo xClaw`
6. **激活自动化**：
   - `gh variable set PROJECT_URL --body 'https://github.com/users/Linnanli/projects/<N>' --repo Linnanli/xClaw`
   - 创建 PAT（classic，scopes: `project,repo`）→ `gh secret set PROJECT_TOKEN --body '<pat>' --repo Linnanli/xClaw`
7. **批量加 24 个 issue 进 board**：`for n in $(seq 52 75); do gh project item-add <PROJECT_NUMBER> --owner Linnanli --url https://github.com/Linnanli/xClaw/issues/$n; done`

## 后续

- 把 W1/W2 已完成的 Wave 事后追加为 Done 状态的 issue（用于 plan 完整性）
- W5–W9 接近时再细拆（避免 issue 库膨胀）
- 本 PR merge 后下一个会话可专注 W3 issue 的 TDD 推进
