### PR TITLE
fix(ci): gate telegram_auth_integration panic on REQUIRE_TELEGRAM_WASM (#80)

### DIFF
--- a/desktop-client/ironclaw/tests/telegram_auth_integration.rs
+++ b/desktop-client/ironclaw/tests/telegram_auth_integration.rs
@@ -26,8 +26,15 @@ use ironclaw::pairing::PairingStore;
 use tokio::time::{Duration, timeout};
 
 /// Skip the test if the Telegram WASM module hasn't been built.
-/// In CI (detected via the `CI` env var), panic instead of skipping so a
-/// broken WASM build step doesn't silently produce green tests.
+///
+/// xClaw fork: `channels-src/telegram/` is not built by the default Tests
+/// workflow (see `.github/workflows/test.yml` — the WASM build step is
+/// intentionally removed because the Telegram channel is not active here).
+/// Therefore these tests must be opt-in: only panic when the operator
+/// explicitly opts into requiring the WASM artifact via
+/// `REQUIRE_TELEGRAM_WASM=1` (e.g. when re-enabling the channel for
+/// regression validation). Otherwise skip silently so a fork that doesn't
+/// ship the channel doesn't fail CI on every PR.
 macro_rules! require_telegram_wasm {
     () => {
         if !telegram_wasm_path().exists() {
@@ -36,7 +43,7 @@ macro_rules! require_telegram_wasm {
                  Build with: cd channels-src/telegram && cargo build --target wasm32-wasip2 --release",
                 telegram_wasm_path()
             );
-            if std::env::var("CI").is_ok() {
+            if std::env::var("REQUIRE_TELEGRAM_WASM").is_ok() {
                 panic!("{}", msg);
             }
             eprintln!("Skipping test: {}", msg);


### PR DESCRIPTION
## 背景

`Closes #80`

xClaw fork 的 `.github/workflows/test.yml` 注释里明确说 `channels-src/ is not active in xClaw`，对应 build WASM 步骤已被移除（line 50–53）。但 `tests/telegram_auth_integration.rs` 的 `require_telegram_wasm!` 宏判断 `std::env::var("CI").is_ok()` 强制 panic——这是为**主 ironclaw** 仓写的策略（CI 一定 build 了 WASM，缺产物视为 build broken），照搬到 xClaw 后变成"PR 必败"。

## 根因

```
xClaw 注释: channels-src/ is not active in xClaw
            ⇩ 移除 build WASM step
缺 WASM 产物 + CI=true（所有 GH Actions 默认设）
            ⇩ require_telegram_wasm! 命中 panic 分支
6 个测试 panic → Tests (default) 永远红
```

## 修

把 `require_telegram_wasm!` 的 panic 闸门从 `CI` 改成专用 `REQUIRE_TELEGRAM_WASM`：

```diff
-            if std::env::var("CI").is_ok() {
+            if std::env::var("REQUIRE_TELEGRAM_WASM").is_ok() {
                 panic!("{}", msg);
             }
```

语义：
- xClaw 默认 CI（无 `REQUIRE_TELEGRAM_WASM`）→ skip（与 fork 实际策略一致）
- 想验证 telegram 回归时 → `REQUIRE_TELEGRAM_WASM=1 + cargo build --target wasm32-wasip2`，缺产物则 panic
- 主 ironclaw 仓如果合并这个改动可在 workflow 显式 `env: REQUIRE_TELEGRAM_WASM: "1"` 维持 strict 行为

注释也同步更新解释 fork 语义。

## 测试

- `cargo nextest run -p ironclaw --test telegram_auth_integration` → 6/6 passed（本地无产物时走 skip 路径，nextest 显示 passed = early return）
- `cargo fmt` 通过
- `python3.12 scripts/check_no_panics.py` → OK

## 风险

- ⚠️ 不影响主 ironclaw 仓的严格语义——它可在 workflow 显式注入 `REQUIRE_TELEGRAM_WASM=1` 即恢复
- ⚠️ 不放行任何代码缺陷——产物存在时仍跑全测
- 范围最小：仅改一行环境变量名 + 注释

## 验证 #51 / #78 / #79 解锁

预期合入后：
- PR #79 `Tests (default)` → 绿（shell_risk_regression 12/12 已修，telegram 6 个会 skip）
- PR #51 `Tests (default)` → 绿（其代码与 telegram/shell_risk 均无关）
- PR #78 `Tests (default)` → 绿（纯 .github/* 改动）

## Merge 顺序建议

1. 本 PR（解锁 CI）
2. PR #79（修 #76 shell_risk）
3. PR #51（P0-3 hook unification）
4. PR #78（GitHub board 自动化）

也可任意顺序——彼此正交。
