### PR TITLE
feat(apply-patch): port codex lark parser to dasclaw_apply_patch (Closes #52)

### DIFF
--- a/crates/dasclaw_apply_patch/src/lib.rs
+++ b/crates/dasclaw_apply_patch/src/lib.rs
@@ -1,24 +1,35 @@
-//! Lark-grammar apply_patch protocol (codex port).
+//! `dasclaw_apply_patch` — lark-grammar `apply_patch` parser ported from
+//! `codex-cli-main/codex-rs/apply-patch`.
 //!
-//! W1 skeleton — trait surface only, no impl.
-//! See `docs/plans/architecture-refactor/31-target-architecture.md` §4 for design.
+//! This crate exposes only the **parser** surface (W3 issue #52). Patch
+//! application (filesystem mutation, hunk seek/replace) is intentionally
+//! out of scope and lives in a follow-up issue.
+//!
+//! # Public API
+//!
+//! - [`parse_patch`] — parse a complete patch (lenient by default).
+//! - [`parse_patch_streaming`] — parse partial/streaming patch text for
+//!   progress reporting only.
+//! - [`ApplyPatchArgs`], [`Hunk`], [`UpdateFileChunk`], [`ParseError`].
+//!
+//! # Example
+//!
+//! ```
+//! use dasclaw_apply_patch::{parse_patch, Hunk};
+//!
+//! let patch = "*** Begin Patch\n\
+//!              *** Add File: hello.txt\n\
+//!              +world\n\
+//!              *** End Patch";
+//! let args = parse_patch(patch).unwrap();
+//! assert!(matches!(args.hunks[0], Hunk::AddFile { .. }));
+//! ```
 
-#![allow(dead_code)]
+mod parser;
 
-/// Placeholder error type. Replaced with module-specific errors in W2+.
-#[derive(Debug, thiserror::Error)]
-#[error("dasclaw_apply_patch skeleton error: {0}")]
-pub struct SkeletonError(pub String);
-
-/// Primary entry trait (placeholder). Replaced with full surface in W2+.
-pub trait ApplyPatch {
-    /// Lark-grammar apply_patch protocol (codex port).
-    fn apply(&self, patch: &str) -> Result<(), SkeletonError>;
-}
-
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn skeleton_compiles() { /* W1 placeholder */
-    }
-}
+pub use parser::parse_patch;
+pub use parser::parse_patch_streaming;
+pub use parser::ApplyPatchArgs;
+pub use parser::Hunk;
+pub use parser::ParseError;
+pub use parser::UpdateFileChunk;

--- a/crates/dasclaw_apply_patch/src/parser.rs
+++ b/crates/dasclaw_apply_patch/src/parser.rs
@@ -1,0 +1,948 @@
+//! Apply-patch parser ported from codex-cli-main/codex-rs/apply-patch.
+//!
+//! Implements the lark grammar:
+//!
+//! ```text
+//! start: begin_patch hunk+ end_patch
+//! begin_patch: "*** Begin Patch" LF
+//! end_patch: "*** End Patch" LF?
+//!
+//! hunk: add_hunk | delete_hunk | update_hunk
+//! add_hunk: "*** Add File: " filename LF add_line+
+//! delete_hunk: "*** Delete File: " filename LF
+//! update_hunk: "*** Update File: " filename LF change_move? change?
+//! filename: /(.+)/
+//! add_line: "+" /(.+)/ LF -> line
+//!
+//! change_move: "*** Move to: " filename LF
+//! change: (change_context | change_line)+ eof_line?
+//! change_context: ("@@" | "@@ " /(.+)/) LF
+//! change_line: ("+" | "-" | " ") /(.+)/ LF
+//! eof_line: "*** End of File" LF
+//! ```
+//!
+//! The parser is intentionally lenient around whitespace and supports stripping
+//! heredoc wrappers (`<<EOF .. EOF`) emitted by some models.
+
+use std::path::PathBuf;
+
+use thiserror::Error;
+
+const BEGIN_PATCH_MARKER: &str = "*** Begin Patch";
+const END_PATCH_MARKER: &str = "*** End Patch";
+const ADD_FILE_MARKER: &str = "*** Add File: ";
+const DELETE_FILE_MARKER: &str = "*** Delete File: ";
+const UPDATE_FILE_MARKER: &str = "*** Update File: ";
+const MOVE_TO_MARKER: &str = "*** Move to: ";
+const EOF_MARKER: &str = "*** End of File";
+const CHANGE_CONTEXT_MARKER: &str = "@@ ";
+const EMPTY_CHANGE_CONTEXT_MARKER: &str = "@@";
+
+/// Some OpenAI models (notably gpt-4.1) wrap the patch in heredoc syntax.
+/// Setting this to `false` enables lenient parsing for all callers; flip to
+/// `true` only if a strict-by-default parser is desired.
+const PARSE_IN_STRICT_MODE: bool = false;
+
+/// Parsed result of an `apply_patch` invocation.
+///
+/// `workdir` is reserved for callers that resolve hunks against a working
+/// directory; the parser itself always emits `None` here.
+#[derive(Debug, PartialEq, Clone)]
+pub struct ApplyPatchArgs {
+    pub patch: String,
+    pub hunks: Vec<Hunk>,
+    pub workdir: Option<String>,
+}
+
+#[derive(Debug, PartialEq, Error, Clone)]
+pub enum ParseError {
+    #[error("invalid patch: {0}")]
+    InvalidPatchError(String),
+    #[error("invalid hunk at line {line_number}, {message}")]
+    InvalidHunkError { message: String, line_number: usize },
+}
+use ParseError::*;
+
+#[derive(Debug, PartialEq, Clone)]
+#[allow(clippy::enum_variant_names)]
+pub enum Hunk {
+    AddFile {
+        path: PathBuf,
+        contents: String,
+    },
+    DeleteFile {
+        path: PathBuf,
+    },
+    UpdateFile {
+        path: PathBuf,
+        move_path: Option<PathBuf>,
+        /// Chunks should be in order, i.e. the `change_context` of one chunk
+        /// should occur later in the file than the previous chunk.
+        chunks: Vec<UpdateFileChunk>,
+    },
+}
+
+impl Hunk {
+    /// Returns the path affected by this hunk, using the move destination for
+    /// rename hunks.
+    pub fn path(&self) -> &std::path::Path {
+        match self {
+            Hunk::AddFile { path, .. } => path,
+            Hunk::DeleteFile { path } => path,
+            Hunk::UpdateFile {
+                move_path: Some(path),
+                ..
+            } => path,
+            Hunk::UpdateFile {
+                path,
+                move_path: None,
+                ..
+            } => path,
+        }
+    }
+}
+
+use Hunk::*;
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct UpdateFileChunk {
+    /// A single line of context used to narrow down the position of the chunk
+    /// (this is usually a class, method, or function definition.)
+    pub change_context: Option<String>,
+
+    /// A contiguous block of lines that should be replaced with `new_lines`.
+    /// `old_lines` must occur strictly after `change_context`.
+    pub old_lines: Vec<String>,
+    pub new_lines: Vec<String>,
+
+    /// If set to true, `old_lines` must occur at the end of the source file.
+    /// (Tolerance around trailing newlines should be encouraged.)
+    pub is_end_of_file: bool,
+}
+
+/// Parse a complete patch text. Lenient by default — accepts heredoc wrappers.
+pub fn parse_patch(patch: &str) -> Result<ApplyPatchArgs, ParseError> {
+    let mode = if PARSE_IN_STRICT_MODE {
+        ParseMode::Strict
+    } else {
+        ParseMode::Lenient
+    };
+    parse_patch_text(patch, mode)
+}
+
+/// Parse streamed patch text that may not have reached `*** End Patch` yet.
+///
+/// This entry point is for progress reporting only; callers must not use its
+/// output to apply a patch.
+pub fn parse_patch_streaming(patch: &str) -> Result<ApplyPatchArgs, ParseError> {
+    parse_patch_text(patch, ParseMode::Streaming)
+}
+
+enum ParseMode {
+    /// Parse the patch text argument as is.
+    Strict,
+    /// Tolerate `<<EOF .. EOF` heredoc wrappers around the patch body.
+    Lenient,
+    /// Parse partial patch text for progress reporting while the model is
+    /// still streaming. Requires a begin marker but not an end marker.
+    Streaming,
+}
+
+fn parse_patch_text(patch: &str, mode: ParseMode) -> Result<ApplyPatchArgs, ParseError> {
+    let lines: Vec<&str> = patch.trim().lines().collect();
+    let (patch_lines, hunk_lines) = match mode {
+        ParseMode::Strict => check_patch_boundaries_strict(&lines)?,
+        ParseMode::Lenient => check_patch_boundaries_lenient(&lines)?,
+        ParseMode::Streaming => check_patch_boundaries_streaming(&lines)?,
+    };
+
+    let mut hunks: Vec<Hunk> = Vec::new();
+    let mut remaining_lines = hunk_lines;
+    let mut line_number = 2;
+    let allow_incomplete = matches!(mode, ParseMode::Streaming);
+    while !remaining_lines.is_empty() {
+        let (hunk, hunk_lines) = parse_one_hunk(remaining_lines, line_number, allow_incomplete)?;
+        hunks.push(hunk);
+        line_number += hunk_lines;
+        remaining_lines = &remaining_lines[hunk_lines..]
+    }
+    let patch = patch_lines.join("\n");
+    Ok(ApplyPatchArgs {
+        hunks,
+        patch,
+        workdir: None,
+    })
+}
+
+fn check_patch_boundaries_streaming<'a>(
+    original_lines: &'a [&'a str],
+) -> Result<(&'a [&'a str], &'a [&'a str]), ParseError> {
+    match original_lines {
+        [first, ..] if first.trim() == BEGIN_PATCH_MARKER => {
+            let body_lines = if original_lines
+                .last()
+                .is_some_and(|line| line.trim() == END_PATCH_MARKER)
+            {
+                &original_lines[1..original_lines.len() - 1]
+            } else {
+                &original_lines[1..]
+            };
+            Ok((original_lines, body_lines))
+        }
+        _ => check_patch_boundaries_strict(original_lines),
+    }
+}
+
+fn check_patch_boundaries_strict<'a>(
+    lines: &'a [&'a str],
+) -> Result<(&'a [&'a str], &'a [&'a str]), ParseError> {
+    let (first_line, last_line) = match lines {
+        [] => (None, None),
+        [first] => (Some(first), Some(first)),
+        [first, .., last] => (Some(first), Some(last)),
+    };
+    check_start_and_end_lines_strict(first_line, last_line)?;
+    Ok((lines, &lines[1..lines.len() - 1]))
+}
+
+fn check_patch_boundaries_lenient<'a>(
+    original_lines: &'a [&'a str],
+) -> Result<(&'a [&'a str], &'a [&'a str]), ParseError> {
+    let original_parse_error = match check_patch_boundaries_strict(original_lines) {
+        Ok(lines) => return Ok(lines),
+        Err(e) => e,
+    };
+
+    match original_lines {
+        [first, .., last] => {
+            if (first == &"<<EOF" || first == &"<<'EOF'" || first == &"<<\"EOF\"")
+                && last.ends_with("EOF")
+                && original_lines.len() >= 4
+            {
+                let inner_lines = &original_lines[1..original_lines.len() - 1];
+                check_patch_boundaries_strict(inner_lines)
+            } else {
+                Err(original_parse_error)
+            }
+        }
+        _ => Err(original_parse_error),
+    }
+}
+
+fn check_start_and_end_lines_strict(
+    first_line: Option<&&str>,
+    last_line: Option<&&str>,
+) -> Result<(), ParseError> {
+    let first_line = first_line.map(|line| line.trim());
+    let last_line = last_line.map(|line| line.trim());
+
+    match (first_line, last_line) {
+        (Some(first), Some(last)) if first == BEGIN_PATCH_MARKER && last == END_PATCH_MARKER => {
+            Ok(())
+        }
+        (Some(first), _) if first != BEGIN_PATCH_MARKER => Err(InvalidPatchError(String::from(
+            "The first line of the patch must be '*** Begin Patch'",
+        ))),
+        _ => Err(InvalidPatchError(String::from(
+            "The last line of the patch must be '*** End Patch'",
+        ))),
+    }
+}
+
+fn parse_one_hunk(
+    lines: &[&str],
+    line_number: usize,
+    allow_incomplete: bool,
+) -> Result<(Hunk, usize), ParseError> {
+    let first_line = lines[0].trim();
+    if let Some(path) = first_line.strip_prefix(ADD_FILE_MARKER) {
+        let mut contents = String::new();
+        let mut parsed_lines = 1;
+        for add_line in &lines[1..] {
+            if let Some(line_to_add) = add_line.strip_prefix('+') {
+                contents.push_str(line_to_add);
+                contents.push('\n');
+                parsed_lines += 1;
+            } else {
+                break;
+            }
+        }
+        return Ok((
+            AddFile {
+                path: PathBuf::from(path),
+                contents,
+            },
+            parsed_lines,
+        ));
+    } else if let Some(path) = first_line.strip_prefix(DELETE_FILE_MARKER) {
+        return Ok((
+            DeleteFile {
+                path: PathBuf::from(path),
+            },
+            1,
+        ));
+    } else if let Some(path) = first_line.strip_prefix(UPDATE_FILE_MARKER) {
+        let mut remaining_lines = &lines[1..];
+        let mut parsed_lines = 1;
+
+        let move_path = remaining_lines
+            .first()
+            .and_then(|x| x.strip_prefix(MOVE_TO_MARKER));
+
+        if move_path.is_some() {
+            remaining_lines = &remaining_lines[1..];
+            parsed_lines += 1;
+        }
+
+        let mut chunks = Vec::new();
+        while !remaining_lines.is_empty() {
+            if remaining_lines[0].trim().is_empty() {
+                parsed_lines += 1;
+                remaining_lines = &remaining_lines[1..];
+                continue;
+            }
+
+            if remaining_lines[0].starts_with('*') {
+                break;
+            }
+
+            if allow_incomplete && remaining_lines[0] == "@" {
+                break;
+            }
+
+            let parsed_chunk = parse_update_file_chunk(
+                remaining_lines,
+                line_number + parsed_lines,
+                chunks.is_empty(),
+            );
+            let (chunk, chunk_lines) = match parsed_chunk {
+                Ok(parsed) => parsed,
+                Err(InvalidHunkError { .. }) if allow_incomplete && !chunks.is_empty() => {
+                    break;
+                }
+                Err(err) => return Err(err),
+            };
+            chunks.push(chunk);
+            parsed_lines += chunk_lines;
+            remaining_lines = &remaining_lines[chunk_lines..]
+        }
+
+        if chunks.is_empty() {
+            return Err(InvalidHunkError {
+                message: format!("Update file hunk for path '{path}' is empty"),
+                line_number,
+            });
+        }
+
+        return Ok((
+            UpdateFile {
+                path: PathBuf::from(path),
+                move_path: move_path.map(PathBuf::from),
+                chunks,
+            },
+            parsed_lines,
+        ));
+    }
+
+    Err(InvalidHunkError {
+        message: format!(
+            "'{first_line}' is not a valid hunk header. Valid hunk headers: '*** Add File: {{path}}', '*** Delete File: {{path}}', '*** Update File: {{path}}'"
+        ),
+        line_number,
+    })
+}
+
+fn parse_update_file_chunk(
+    lines: &[&str],
+    line_number: usize,
+    allow_missing_context: bool,
+) -> Result<(UpdateFileChunk, usize), ParseError> {
+    if lines.is_empty() {
+        return Err(InvalidHunkError {
+            message: "Update hunk does not contain any lines".to_string(),
+            line_number,
+        });
+    }
+    let (change_context, start_index) = if lines[0] == EMPTY_CHANGE_CONTEXT_MARKER {
+        (None, 1)
+    } else if let Some(context) = lines[0].strip_prefix(CHANGE_CONTEXT_MARKER) {
+        (Some(context.to_string()), 1)
+    } else {
+        if !allow_missing_context {
+            return Err(InvalidHunkError {
+                message: format!(
+                    "Expected update hunk to start with a @@ context marker, got: '{}'",
+                    lines[0]
+                ),
+                line_number,
+            });
+        }
+        (None, 0)
+    };
+    if start_index >= lines.len() {
+        return Err(InvalidHunkError {
+            message: "Update hunk does not contain any lines".to_string(),
+            line_number: line_number + 1,
+        });
+    }
+    let mut chunk = UpdateFileChunk {
+        change_context,
+        old_lines: Vec::new(),
+        new_lines: Vec::new(),
+        is_end_of_file: false,
+    };
+    let mut parsed_lines = 0;
+    for line in &lines[start_index..] {
+        match *line {
+            EOF_MARKER => {
+                if parsed_lines == 0 {
+                    return Err(InvalidHunkError {
+                        message: "Update hunk does not contain any lines".to_string(),
+                        line_number: line_number + 1,
+                    });
+                }
+                chunk.is_end_of_file = true;
+                parsed_lines += 1;
+                break;
+            }
+            line_contents => match line_contents.chars().next() {
+                None => {
+                    chunk.old_lines.push(String::new());
+                    chunk.new_lines.push(String::new());
+                    parsed_lines += 1;
+                }
+                Some(' ') => {
+                    chunk.old_lines.push(line_contents[1..].to_string());
+                    chunk.new_lines.push(line_contents[1..].to_string());
+                    parsed_lines += 1;
+                }
+                Some('+') => {
+                    chunk.new_lines.push(line_contents[1..].to_string());
+                    parsed_lines += 1;
+                }
+                Some('-') => {
+                    chunk.old_lines.push(line_contents[1..].to_string());
+                    parsed_lines += 1;
+                }
+                _ => {
+                    if parsed_lines == 0 {
+                        return Err(InvalidHunkError {
+                            message: format!(
+                                "Unexpected line found in update hunk: '{line_contents}'. Every line should start with ' ' (context line), '+' (added line), or '-' (removed line)"
+                            ),
+                            line_number: line_number + 1,
+                        });
+                    }
+                    // Assume this is the start of the next hunk.
+                    break;
+                }
+            },
+        }
+    }
+
+    Ok((chunk, parsed_lines + start_index))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_patch_streaming() {
+        assert_eq!(
+            parse_patch_streaming("*** Begin Patch\n*** Add File: src/hello.txt\n+hello\n+wor"),
+            Ok(ApplyPatchArgs {
+                hunks: vec![AddFile {
+                    path: PathBuf::from("src/hello.txt"),
+                    contents: "hello\nwor\n".to_string(),
+                }],
+                patch: "*** Begin Patch\n*** Add File: src/hello.txt\n+hello\n+wor".to_string(),
+                workdir: None,
+            })
+        );
+
+        assert_eq!(
+            parse_patch_streaming(
+                "*** Begin Patch\n*** Update File: src/old.rs\n*** Move to: src/new.rs\n@@\n-old\n+new",
+            ),
+            Ok(ApplyPatchArgs {
+                hunks: vec![UpdateFile {
+                    path: PathBuf::from("src/old.rs"),
+                    move_path: Some(PathBuf::from("src/new.rs")),
+                    chunks: vec![UpdateFileChunk {
+                        change_context: None,
+                        old_lines: vec!["old".to_string()],
+                        new_lines: vec!["new".to_string()],
+                        is_end_of_file: false,
+                    }],
+                }],
+                patch: "*** Begin Patch\n*** Update File: src/old.rs\n*** Move to: src/new.rs\n@@\n-old\n+new".to_string(),
+                workdir: None,
+            })
+        );
+
+        assert!(parse_patch_text(
+            "*** Begin Patch\n*** Delete File: gone.txt",
+            ParseMode::Streaming,
+        )
+        .is_ok());
+        assert!(parse_patch_text(
+            "*** Begin Patch\n*** Delete File: gone.txt",
+            ParseMode::Strict,
+        )
+        .is_err());
+
+        assert_eq!(
+            parse_patch_streaming(
+                "*** Begin Patch\n*** Add File: src/one.txt\n+one\n*** Delete File: src/two.txt\n",
+            ),
+            Ok(ApplyPatchArgs {
+                hunks: vec![
+                    AddFile {
+                        path: PathBuf::from("src/one.txt"),
+                        contents: "one\n".to_string(),
+                    },
+                    DeleteFile {
+                        path: PathBuf::from("src/two.txt"),
+                    },
+                ],
+                patch:
+                    "*** Begin Patch\n*** Add File: src/one.txt\n+one\n*** Delete File: src/two.txt"
+                        .to_string(),
+                workdir: None,
+            })
+        );
+    }
+
+    #[test]
+    fn test_parse_patch_streaming_hunk_count_monotonic() {
+        let patch = "\
+*** Begin Patch
+*** Add File: docs/release-notes.md
++# Release notes
++
++## CLI
++- Surface apply_patch progress while arguments stream.
++- Keep final patch application gated on the completed tool call.
++- Include file summaries in the progress event payload.
+*** Update File: src/config.rs
+@@ impl Config
+-    pub apply_patch_progress: bool,
++    pub stream_apply_patch_progress: bool,
+     pub include_diagnostics: bool,
+@@ fn default_progress_interval()
+-    Duration::from_millis(500)
++    Duration::from_millis(250)
+*** Delete File: src/legacy_patch_progress.rs
+*** Update File: crates/cli/src/main.rs
+*** Move to: crates/cli/src/bin/codex.rs
+@@ fn run()
+-    let args = Args::parse();
+-    dispatch(args)
++    let cli = Cli::parse();
++    dispatch(cli)
+*** Add File: tests/fixtures/apply_patch_progress.json
++{
++  \"type\": \"apply_patch_progress\",
++  \"hunks\": [
++    { \"operation\": \"add\", \"path\": \"docs/release-notes.md\" },
++    { \"operation\": \"update\", \"path\": \"src/config.rs\" }
++  ]
++}
+*** Update File: README.md
+@@ Development workflow
+ Build the Rust workspace before opening a pull request.
++When touching streamed tool calls, include parser coverage for partial input.
++Prefer tests that exercise the exact event payload shape.
+*** Delete File: docs/old-apply-patch-progress.md
+*** End Patch";
+
+        let mut max_hunk_count = 0;
+        let mut saw_hunk_counts = Vec::new();
+        for i in 1..=patch.len() {
+            let partial = &patch[..i];
+            if let Ok(parsed) = parse_patch_streaming(partial) {
+                let hunk_count = parsed.hunks.len();
+                assert!(
+                    hunk_count >= max_hunk_count,
+                    "hunk count should never decrease while streaming: {hunk_count} < {max_hunk_count} for {partial:?}",
+                );
+                if hunk_count > max_hunk_count {
+                    saw_hunk_counts.push(hunk_count);
+                    max_hunk_count = hunk_count;
+                }
+            }
+        }
+
+        assert_eq!(saw_hunk_counts, vec![1, 2, 3, 4, 5, 6, 7]);
+        let parsed = parse_patch_streaming(patch).unwrap();
+        assert_eq!(parsed.hunks.len(), 7);
+        assert_eq!(
+            parsed
+                .hunks
+                .iter()
+                .map(|hunk| match hunk {
+                    AddFile { .. } => "add",
+                    DeleteFile { .. } => "delete",
+                    UpdateFile {
+                        move_path: Some(_), ..
+                    } => "move-update",
+                    UpdateFile {
+                        move_path: None, ..
+                    } => "update",
+                })
+                .collect::<Vec<_>>(),
+            vec![
+                "add",
+                "update",
+                "delete",
+                "move-update",
+                "add",
+                "update",
+                "delete"
+            ]
+        );
+    }
+
+    #[test]
+    fn test_parse_patch_strict() {
+        assert_eq!(
+            parse_patch_text("bad", ParseMode::Strict),
+            Err(InvalidPatchError(
+                "The first line of the patch must be '*** Begin Patch'".to_string()
+            ))
+        );
+        assert_eq!(
+            parse_patch_text("*** Begin Patch\nbad", ParseMode::Strict),
+            Err(InvalidPatchError(
+                "The last line of the patch must be '*** End Patch'".to_string()
+            ))
+        );
+
+        assert_eq!(
+            parse_patch_text(
+                concat!(
+                    "*** Begin Patch",
+                    " ",
+                    "\n*** Add File: foo\n+hi\n",
+                    " ",
+                    "*** End Patch"
+                ),
+                ParseMode::Strict,
+            )
+            .unwrap()
+            .hunks,
+            vec![AddFile {
+                path: PathBuf::from("foo"),
+                contents: "hi\n".to_string(),
+            }]
+        );
+        assert_eq!(
+            parse_patch_text(
+                "*** Begin Patch\n*** Update File: test.py\n*** End Patch",
+                ParseMode::Strict,
+            ),
+            Err(InvalidHunkError {
+                message: "Update file hunk for path 'test.py' is empty".to_string(),
+                line_number: 2,
+            })
+        );
+        assert_eq!(
+            parse_patch_text("*** Begin Patch\n*** End Patch", ParseMode::Strict)
+                .unwrap()
+                .hunks,
+            Vec::new()
+        );
+        assert_eq!(
+            parse_patch_text(
+                "*** Begin Patch\n\
+                 *** Add File: path/add.py\n\
+                 +abc\n\
+                 +def\n\
+                 *** Delete File: path/delete.py\n\
+                 *** Update File: path/update.py\n\
+                 *** Move to: path/update2.py\n\
+                 @@ def f():\n\
+                 -    pass\n\
+                 +    return 123\n\
+                 *** End Patch",
+                ParseMode::Strict,
+            )
+            .unwrap()
+            .hunks,
+            vec![
+                AddFile {
+                    path: PathBuf::from("path/add.py"),
+                    contents: "abc\ndef\n".to_string(),
+                },
+                DeleteFile {
+                    path: PathBuf::from("path/delete.py"),
+                },
+                UpdateFile {
+                    path: PathBuf::from("path/update.py"),
+                    move_path: Some(PathBuf::from("path/update2.py")),
+                    chunks: vec![UpdateFileChunk {
+                        change_context: Some("def f():".to_string()),
+                        old_lines: vec!["    pass".to_string()],
+                        new_lines: vec!["    return 123".to_string()],
+                        is_end_of_file: false,
+                    }],
+                },
+            ]
+        );
+        assert_eq!(
+            parse_patch_text(
+                "*** Begin Patch\n\
+                 *** Update File: file.py\n\
+                 @@\n\
+                 +line\n\
+                 *** Add File: other.py\n\
+                 +content\n\
+                 *** End Patch",
+                ParseMode::Strict,
+            )
+            .unwrap()
+            .hunks,
+            vec![
+                UpdateFile {
+                    path: PathBuf::from("file.py"),
+                    move_path: None,
+                    chunks: vec![UpdateFileChunk {
+                        change_context: None,
+                        old_lines: vec![],
+                        new_lines: vec!["line".to_string()],
+                        is_end_of_file: false,
+                    }],
+                },
+                AddFile {
+                    path: PathBuf::from("other.py"),
+                    contents: "content\n".to_string(),
+                },
+            ]
+        );
+
+        assert_eq!(
+            parse_patch_text(
+                r#"*** Begin Patch
+*** Update File: file2.py
+ import foo
++bar
+*** End Patch"#,
+                ParseMode::Strict,
+            )
+            .unwrap()
+            .hunks,
+            vec![UpdateFile {
+                path: PathBuf::from("file2.py"),
+                move_path: None,
+                chunks: vec![UpdateFileChunk {
+                    change_context: None,
+                    old_lines: vec!["import foo".to_string()],
+                    new_lines: vec!["import foo".to_string(), "bar".to_string()],
+                    is_end_of_file: false,
+                }],
+            }]
+        );
+    }
+
+    #[test]
+    fn test_parse_patch_lenient() {
+        let patch_text = r#"*** Begin Patch
+*** Update File: file2.py
+ import foo
++bar
+*** End Patch"#;
+        let expected_patch = vec![UpdateFile {
+            path: PathBuf::from("file2.py"),
+            move_path: None,
+            chunks: vec![UpdateFileChunk {
+                change_context: None,
+                old_lines: vec!["import foo".to_string()],
+                new_lines: vec!["import foo".to_string(), "bar".to_string()],
+                is_end_of_file: false,
+            }],
+        }];
+        let expected_error =
+            InvalidPatchError("The first line of the patch must be '*** Begin Patch'".to_string());
+
+        let patch_text_in_heredoc = format!("<<EOF\n{patch_text}\nEOF\n");
+        assert_eq!(
+            parse_patch_text(&patch_text_in_heredoc, ParseMode::Strict),
+            Err(expected_error.clone())
+        );
+        assert_eq!(
+            parse_patch_text(&patch_text_in_heredoc, ParseMode::Lenient),
+            Ok(ApplyPatchArgs {
+                hunks: expected_patch.clone(),
+                patch: patch_text.to_string(),
+                workdir: None,
+            })
+        );
+
+        let patch_text_in_single_quoted = format!("<<'EOF'\n{patch_text}\nEOF\n");
+        assert_eq!(
+            parse_patch_text(&patch_text_in_single_quoted, ParseMode::Lenient),
+            Ok(ApplyPatchArgs {
+                hunks: expected_patch.clone(),
+                patch: patch_text.to_string(),
+                workdir: None,
+            })
+        );
+
+        let patch_text_in_double_quoted = format!("<<\"EOF\"\n{patch_text}\nEOF\n");
+        assert_eq!(
+            parse_patch_text(&patch_text_in_double_quoted, ParseMode::Lenient),
+            Ok(ApplyPatchArgs {
+                hunks: expected_patch,
+                patch: patch_text.to_string(),
+                workdir: None,
+            })
+        );
+
+        let patch_text_with_mismatched_quotes = format!("<<\"EOF'\n{patch_text}\nEOF\n");
+        assert_eq!(
+            parse_patch_text(&patch_text_with_mismatched_quotes, ParseMode::Lenient),
+            Err(expected_error.clone())
+        );
+
+        let patch_text_with_missing_closing_heredoc =
+            "<<EOF\n*** Begin Patch\n*** Update File: file2.py\nEOF\n".to_string();
+        assert_eq!(
+            parse_patch_text(&patch_text_with_missing_closing_heredoc, ParseMode::Lenient),
+            Err(InvalidPatchError(
+                "The last line of the patch must be '*** End Patch'".to_string()
+            ))
+        );
+    }
+
+    #[test]
+    fn test_parse_patch_accepts_absolute_path_strings() {
+        let patch_text = "*** Begin Patch\n\
+                          *** Add File: relative-add.py\n\
+                          +content\n\
+                          *** Delete File: /tmp/dasclaw_apply_patch_abs_delete.py\n\
+                          *** Update File: /tmp/dasclaw_apply_patch_abs_update.py\n\
+                          @@\n\
+                          -old\n\
+                          +new\n\
+                          *** End Patch";
+        let hunks = parse_patch_text(patch_text, ParseMode::Strict)
+            .unwrap()
+            .hunks;
+        assert_eq!(
+            hunks,
+            vec![
+                AddFile {
+                    path: PathBuf::from("relative-add.py"),
+                    contents: "content\n".to_string(),
+                },
+                DeleteFile {
+                    path: PathBuf::from("/tmp/dasclaw_apply_patch_abs_delete.py"),
+                },
+                UpdateFile {
+                    path: PathBuf::from("/tmp/dasclaw_apply_patch_abs_update.py"),
+                    move_path: None,
+                    chunks: vec![UpdateFileChunk {
+                        change_context: None,
+                        old_lines: vec!["old".to_string()],
+                        new_lines: vec!["new".to_string()],
+                        is_end_of_file: false,
+                    }],
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn test_parse_one_hunk_invalid_header() {
+        assert_eq!(
+            parse_one_hunk(&["bad"], 234, false),
+            Err(InvalidHunkError {
+                message: "'bad' is not a valid hunk header. \
+                Valid hunk headers: '*** Add File: {path}', '*** Delete File: {path}', '*** Update File: {path}'".to_string(),
+                line_number: 234,
+            })
+        );
+    }
+
+    #[test]
+    fn test_update_file_chunk_edge_cases() {
+        assert_eq!(
+            parse_update_file_chunk(&["bad"], 123, false),
+            Err(InvalidHunkError {
+                message: "Expected update hunk to start with a @@ context marker, got: 'bad'"
+                    .to_string(),
+                line_number: 123,
+            })
+        );
+        assert_eq!(
+            parse_update_file_chunk(&["@@"], 123, false),
+            Err(InvalidHunkError {
+                message: "Update hunk does not contain any lines".to_string(),
+                line_number: 124,
+            })
+        );
+        assert_eq!(
+            parse_update_file_chunk(&["@@", "bad"], 123, false),
+            Err(InvalidHunkError {
+                message: "Unexpected line found in update hunk: 'bad'. \
+                          Every line should start with ' ' (context line), '+' (added line), or '-' (removed line)"
+                    .to_string(),
+                line_number: 124,
+            })
+        );
+        assert_eq!(
+            parse_update_file_chunk(&["@@", "*** End of File"], 123, false),
+            Err(InvalidHunkError {
+                message: "Update hunk does not contain any lines".to_string(),
+                line_number: 124,
+            })
+        );
+        assert_eq!(
+            parse_update_file_chunk(
+                &[
+                    "@@ change_context",
+                    "",
+                    " context",
+                    "-remove",
+                    "+add",
+                    " context2",
+                    "*** End Patch",
+                ],
+                123,
+                false,
+            ),
+            Ok((
+                UpdateFileChunk {
+                    change_context: Some("change_context".to_string()),
+                    old_lines: vec![
+                        String::new(),
+                        "context".to_string(),
+                        "remove".to_string(),
+                        "context2".to_string(),
+                    ],
+                    new_lines: vec![
+                        String::new(),
+                        "context".to_string(),
+                        "add".to_string(),
+                        "context2".to_string(),
+                    ],
+                    is_end_of_file: false,
+                },
+                6,
+            ))
+        );
+        assert_eq!(
+            parse_update_file_chunk(&["@@", "+line", "*** End of File"], 123, false),
+            Ok((
+                UpdateFileChunk {
+                    change_context: None,
+                    old_lines: vec![],
+                    new_lines: vec!["line".to_string()],
+                    is_end_of_file: true,
+                },
+                3,
+            ))
+        );
+    }
+}

--- a/crates/dasclaw_apply_patch/tests/codex_fixtures_tests.rs
+++ b/crates/dasclaw_apply_patch/tests/codex_fixtures_tests.rs
@@ -1,0 +1,87 @@
+//! 集成测试：消费 codex apply-patch fixtures，验证 parser 与上游同源。
+//!
+//! 仅覆盖 parser 层职责：
+//! - 008_rejects_empty_update_hunk / 013_rejects_invalid_hunk_header 必须在 parse 层报错
+//! - 其余可解析的 patch.txt（不管 apply 是否成功）必须 parse 通过
+//!
+//! 005 与 006 的 reject 发生在 apply 层（patch 自身语法合法），由后续 apply crate 覆盖。
+
+use std::fs;
+use std::path::PathBuf;
+
+use dasclaw_apply_patch::{parse_patch, ParseError};
+
+fn fixtures_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../codex-cli-main/codex-rs/apply-patch/tests/fixtures/scenarios")
+}
+
+fn read_patch(scenario: &str) -> String {
+    let path = fixtures_root().join(scenario).join("patch.txt");
+    fs::read_to_string(&path).unwrap_or_else(|err| panic!("read fixture {}: {err}", path.display()))
+}
+
+#[test]
+fn req_w3_52_codex_fixture_002_multiple_operations_parses() {
+    parse_patch(&read_patch("002_multiple_operations")).expect("multi-op fixture parses");
+}
+
+#[test]
+fn req_w3_52_codex_fixture_003_multiple_chunks_parses() {
+    parse_patch(&read_patch("003_multiple_chunks")).expect("multi-chunk fixture parses");
+}
+
+#[test]
+fn req_w3_52_codex_fixture_004_move_to_new_directory_parses() {
+    parse_patch(&read_patch("004_move_to_new_directory")).expect("move fixture parses");
+}
+
+#[test]
+fn req_w3_52_codex_fixture_008_rejects_empty_update_hunk() {
+    let err = parse_patch(&read_patch("008_rejects_empty_update_hunk"))
+        .expect_err("empty update hunk must be rejected at parse layer");
+    assert!(
+        matches!(err, ParseError::InvalidHunkError { .. }),
+        "expected InvalidHunkError, got {err:?}",
+    );
+}
+
+#[test]
+fn req_w3_52_codex_fixture_013_rejects_invalid_hunk_header() {
+    let err = parse_patch(&read_patch("013_rejects_invalid_hunk_header"))
+        .expect_err("invalid hunk header must be rejected at parse layer");
+    assert!(
+        matches!(err, ParseError::InvalidHunkError { .. }),
+        "expected InvalidHunkError, got {err:?}",
+    );
+}
+
+#[test]
+fn req_w3_52_codex_fixture_014_update_file_appends_trailing_newline_parses() {
+    parse_patch(&read_patch("014_update_file_appends_trailing_newline"))
+        .expect("trailing newline fixture parses");
+}
+
+#[test]
+fn req_w3_52_codex_fixture_017_whitespace_padded_hunk_header_parses() {
+    parse_patch(&read_patch("017_whitespace_padded_hunk_header"))
+        .expect("whitespace-padded hunk header parses");
+}
+
+#[test]
+fn req_w3_52_codex_fixture_018_whitespace_padded_patch_markers_parses() {
+    parse_patch(&read_patch("018_whitespace_padded_patch_markers"))
+        .expect("whitespace-padded patch markers parse");
+}
+
+#[test]
+fn req_w3_52_codex_fixture_019_unicode_simple_parses() {
+    parse_patch(&read_patch("019_unicode_simple")).expect("unicode fixture parses");
+}
+
+#[test]
+fn req_w3_52_codex_fixture_022_update_file_end_of_file_marker_parses() {
+    let parsed = parse_patch(&read_patch("022_update_file_end_of_file_marker"))
+        .expect("eof marker fixture parses");
+    assert!(!parsed.hunks.is_empty(), "expected at least one hunk");
+}

--- a/crates/dasclaw_apply_patch/tests/parser_contract_tests.rs
+++ b/crates/dasclaw_apply_patch/tests/parser_contract_tests.rs
@@ -1,0 +1,152 @@
+//! Contract tests for `parse_patch` API.
+//!
+//! These tests pin the public surface required by W3 Issue #52:
+//! - `parse_patch(&str) -> Result<ApplyPatchArgs, ParseError>`
+//! - `Hunk::{AddFile, DeleteFile, UpdateFile}`
+//! - `UpdateFileChunk` with `change_context`, `old_lines`, `new_lines`, `is_end_of_file`
+//! - `ParseError::{InvalidPatchError, InvalidHunkError}`
+//!
+//! Source spec: codex-cli-main/codex-rs/apply-patch/src/parser.rs (lark grammar).
+
+use std::path::PathBuf;
+
+use dasclaw_apply_patch::parse_patch;
+use dasclaw_apply_patch::Hunk;
+use dasclaw_apply_patch::ParseError;
+use dasclaw_apply_patch::UpdateFileChunk;
+
+#[test]
+fn req_w3_52_add_file_hunk_parses() {
+    let patch = "*** Begin Patch\n\
+                 *** Add File: src/hello.txt\n\
+                 +hello\n\
+                 +world\n\
+                 *** End Patch";
+    let args = parse_patch(patch).expect("strict add-file should parse");
+    assert_eq!(args.hunks.len(), 1);
+    let Hunk::AddFile { path, contents } = &args.hunks[0] else {
+        panic!("expected AddFile, got {:?}", args.hunks[0]);
+    };
+    assert_eq!(path, &PathBuf::from("src/hello.txt"));
+    assert_eq!(contents, "hello\nworld\n");
+}
+
+#[test]
+fn req_w3_52_delete_file_hunk_parses() {
+    let patch = "*** Begin Patch\n\
+                 *** Delete File: gone.txt\n\
+                 *** End Patch";
+    let args = parse_patch(patch).expect("strict delete-file should parse");
+    assert_eq!(args.hunks.len(), 1);
+    let Hunk::DeleteFile { path } = &args.hunks[0] else {
+        panic!("expected DeleteFile, got {:?}", args.hunks[0]);
+    };
+    assert_eq!(path, &PathBuf::from("gone.txt"));
+}
+
+#[test]
+fn req_w3_52_update_file_with_context_marker_parses() {
+    let patch = "*** Begin Patch\n\
+                 *** Update File: file.py\n\
+                 @@ def f():\n\
+                 -    pass\n\
+                 +    return 123\n\
+                 *** End Patch";
+    let args = parse_patch(patch).expect("update with @@ context should parse");
+    let Hunk::UpdateFile {
+        path,
+        move_path,
+        chunks,
+    } = &args.hunks[0]
+    else {
+        panic!("expected UpdateFile, got {:?}", args.hunks[0]);
+    };
+    assert_eq!(path, &PathBuf::from("file.py"));
+    assert!(move_path.is_none());
+    assert_eq!(chunks.len(), 1);
+    assert_eq!(
+        chunks[0],
+        UpdateFileChunk {
+            change_context: Some("def f():".to_string()),
+            old_lines: vec!["    pass".to_string()],
+            new_lines: vec!["    return 123".to_string()],
+            is_end_of_file: false,
+        }
+    );
+}
+
+#[test]
+fn req_w3_52_update_with_move_and_eof_marker_parses() {
+    let patch = "*** Begin Patch\n\
+                 *** Update File: src/old.rs\n\
+                 *** Move to: src/new.rs\n\
+                 @@\n\
+                 -old\n\
+                 +new\n\
+                 *** End of File\n\
+                 *** End Patch";
+    let args = parse_patch(patch).expect("update with move + EOF should parse");
+    let Hunk::UpdateFile {
+        path,
+        move_path,
+        chunks,
+    } = &args.hunks[0]
+    else {
+        panic!("expected UpdateFile, got {:?}", args.hunks[0]);
+    };
+    assert_eq!(path, &PathBuf::from("src/old.rs"));
+    assert_eq!(
+        move_path.as_deref(),
+        Some(std::path::Path::new("src/new.rs"))
+    );
+    assert_eq!(chunks.len(), 1);
+    assert!(chunks[0].is_end_of_file);
+}
+
+#[test]
+fn req_w3_52_missing_begin_marker_returns_invalid_patch_error() {
+    let err = parse_patch("not a patch").expect_err("missing begin marker should fail");
+    match err {
+        ParseError::InvalidPatchError(msg) => {
+            assert!(msg.contains("Begin Patch"), "msg={msg}");
+        }
+        other => panic!("expected InvalidPatchError, got {other:?}"),
+    }
+}
+
+#[test]
+fn req_w3_52_invalid_hunk_header_returns_invalid_hunk_error() {
+    let patch = "*** Begin Patch\n\
+                 *** Bogus Hunk: foo\n\
+                 *** End Patch";
+    let err = parse_patch(patch).expect_err("bogus hunk header should fail");
+    match err {
+        ParseError::InvalidHunkError {
+            message,
+            line_number,
+        } => {
+            assert!(message.contains("not a valid hunk header"), "msg={message}");
+            assert_eq!(line_number, 2);
+        }
+        other => panic!("expected InvalidHunkError, got {other:?}"),
+    }
+}
+
+#[test]
+fn req_w3_52_lenient_mode_strips_heredoc_wrapper() {
+    let inner = "*** Begin Patch\n\
+                 *** Add File: foo.txt\n\
+                 +data\n\
+                 *** End Patch";
+    let patch = format!("<<'EOF'\n{inner}\nEOF\n");
+    let args = parse_patch(&patch).expect("lenient mode should strip heredoc");
+    assert_eq!(args.hunks.len(), 1);
+}
+
+#[test]
+fn req_w3_52_empty_patch_body_yields_no_hunks() {
+    let patch = "*** Begin Patch\n*** End Patch";
+    let args = parse_patch(patch).expect("empty patch should parse");
+    assert!(args.hunks.is_empty());
+    assert_eq!(args.workdir, None);
+}


### PR DESCRIPTION
## 背景

W3 wave 起步：把 codex apply-patch 的 lark grammar parser 直接 port 到 `crates/dasclaw_apply_patch`，作为后续 ApplyPatchTool 注册（#53）和 sandbox 集成的基础。

源：`codex-cli-main/codex-rs/apply-patch/src/parser.rs`（1108 LOC）。
目标：纯解析层，零 IO，零依赖（仅 `thiserror`）。

## 改动范围

- `crates/dasclaw_apply_patch/src/parser.rs`（新增）— 上游 parser 近乎逐字 port
- `crates/dasclaw_apply_patch/src/lib.rs`（重写）— 移除 W1 skeleton，改为 `mod parser;` + `pub use`
- `crates/dasclaw_apply_patch/tests/parser_contract_tests.rs`（新增，8 测试）— 公共 API 契约钉死
- `crates/dasclaw_apply_patch/tests/codex_fixtures_tests.rs`（新增，10 测试）— 消费 codex `tests/fixtures/scenarios/*/patch.txt`

公共 API：
- `parse_patch(&str) -> Result<ApplyPatchArgs, ParseError>`（lenient，剥离 heredoc 包装）
- `parse_patch_streaming(&str) -> Result<ApplyPatchArgs, ParseError>`（流式增量）
- `Hunk` / `UpdateFileChunk` / `ApplyPatchArgs` / `ParseError`

## 与上游唯一偏差

- 移除 `Hunk::resolve_path`（依赖 codex 内部 `AbsolutePathBuf`，属于 apply 层职责，不在 parser 范围）
- 其余字段、错误形态、解析行为与上游完全一致

## 非目标（What's NOT in this PR）

- ❌ 不做 ironclaw tools 注册 — 见 #53 [W3] ApplyPatchTool 注册
- ❌ 不做 patch apply / 文件 IO — 后续 PR
- ❌ 不做 sandbox / 审批联动 — 后续 PR
- ❌ 不引入 `AbsolutePathBuf`、`tempfile` 等运行时依赖

## 验证

```bash
cargo check -p dasclaw_apply_patch --tests          # 0 警 0 错
cargo nextest run -p dasclaw_apply_patch            # 25/25 PASS
cargo clippy --no-deps -p dasclaw_apply_patch \
  --all-targets -- -D warnings                       # 干净
cargo fmt --all -- --check                          # 干净
python3.12 scripts/check_no_panics.py \
  --base origin/xClaw                                # OK
```

测试分布：
- 7 inner unit tests（lib，从 codex 逐字 port，覆盖 strict/lenient/streaming/边界）
- 8 contract tests（`req_w3_52_*`，公共 API 钉契约）
- 10 fixture integration tests（`req_w3_52_codex_fixture_*`，消费上游 patch.txt 包括 008/013 reject 场景）

## 后续步骤

- #53 [W3] ApplyPatchTool 注册（消费本 PR 的 `parse_patch`）
- #62 [W3] apply 层（路径解析 + 文件 IO + 沙箱审批）

## 风险

- 低。纯解析层，无 IO 副作用，无 unsafe，无 panic 路径（全部 `Result` 传播）。
- 上游 codex parser 已在生产中验证，本 PR 仅做无副作用 port + 受控偏差。
