### PR TITLE
feat(project-docs): land ProjectDocLoader trait + DocLayer/ProjectDoc surface (Closes #54)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2500,9 +2500,6 @@ dependencies = [
 [[package]]
 name = "dasclaw_project_docs"
 version = "0.0.0-w1"
-dependencies = [
- "thiserror 1.0.69",
-]
 
 [[package]]
 name = "dasclaw_pty"

--- a/crates/dasclaw_project_docs/Cargo.toml
+++ b/crates/dasclaw_project_docs/Cargo.toml
@@ -10,4 +10,3 @@ publish = false
 path = "src/lib.rs"
 
 [dependencies]
-thiserror = "1"

--- a/crates/dasclaw_project_docs/src/lib.rs
+++ b/crates/dasclaw_project_docs/src/lib.rs
@@ -1,24 +1,85 @@
 //! AGENTS.md / CLAUDE.md multi-layer project doc loader.
 //!
-//! W1 skeleton — trait surface only, no impl.
-//! See `docs/plans/architecture-refactor/31-target-architecture.md` §4 for design.
+//! W3 issue #54 — public surface only. Downstream issues fill the impl:
+//! - #55: priority `AGENTS.md > CLAUDE.md > .codex/agents.md`
+//! - #56: 3-layer merge (user / project / cwd)
+//! - #57: recursive upward search to repo root / `$HOME`
+//! - #58: `max_bytes` truncation
+//! - #59: `OnSessionStart` hook injection
+//!
+//! See `docs/plans/architecture-refactor/31-target-architecture.md` §4 and
+//! `32-execution-plan.md` W3 task 3 for the full design.
 
-#![allow(dead_code)]
+use std::path::{Path, PathBuf};
 
-/// Placeholder error type. Replaced with module-specific errors in W2+.
-#[derive(Debug, thiserror::Error)]
-#[error("dasclaw_project_docs skeleton error: {0}")]
-pub struct SkeletonError(pub String);
+/// Origin tier of a [`ProjectDoc`].
+///
+/// The 3-layer model mirrors codex `agents_md.rs`: globally-applied user
+/// instructions, repo-scoped project instructions, and request-scoped
+/// `cwd` instructions. Order in this enum matches load priority — last
+/// layer wins on conflict in the merge step (#56).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum DocLayer {
+    /// Per-user global doc (e.g. `$HOME/.codex/AGENTS.md`).
+    UserGlobal,
+    /// Repo-scoped doc found by walking up to repo root (e.g. `<repo>/AGENTS.md`).
+    Project,
+    /// Doc adjacent to the request `cwd` (e.g. `<cwd>/AGENTS.md`).
+    Cwd,
+}
 
-/// Primary entry trait (placeholder). Replaced with full surface in W2+.
+/// A single project-doc fragment loaded from disk.
+///
+/// `bytes` is the size of `content` *after* truncation (#58); the raw on-disk
+/// size is intentionally not exposed — downstream consumers must not assume
+/// `content.len() == file_size`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProjectDoc {
+    /// Doc body, possibly truncated by `max_bytes` (#58).
+    pub content: String,
+    /// Absolute path the doc was read from.
+    pub source_path: PathBuf,
+    /// Which layer this doc was discovered in.
+    pub layer: DocLayer,
+    /// Length of `content` in bytes after truncation.
+    pub bytes: usize,
+}
+
+/// Loader contract for project-scoped instruction docs.
+///
+/// W3 placeholder: the default implementation returns an empty `Vec`.
+/// Downstream issues (#55-#59) plug in real loaders without changing this
+/// surface.
 pub trait ProjectDocLoader {
-    /// AGENTS.md / CLAUDE.md multi-layer project doc loader.
-    fn load(&self, cwd: &std::path::Path) -> Result<String, SkeletonError>;
+    /// Load all docs visible from `cwd`, in load-priority order.
+    ///
+    /// Implementations must not panic on missing files or permission errors:
+    /// project-doc loading is a best-effort enrichment path, not a hard
+    /// dependency.
+    fn load(&self, cwd: &Path) -> Vec<ProjectDoc>;
+}
+
+/// W3 placeholder loader — returns an empty `Vec`.
+///
+/// Used as the default wiring point until #55 lands the real layered loader.
+/// Kept in the public API so downstream crates can compose against the trait
+/// without depending on a private struct.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct EmptyProjectDocLoader;
+
+impl ProjectDocLoader for EmptyProjectDocLoader {
+    fn load(&self, _cwd: &Path) -> Vec<ProjectDoc> {
+        Vec::new()
+    }
 }
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+
     #[test]
-    fn skeleton_compiles() { /* W1 placeholder */
+    fn empty_loader_returns_no_docs() {
+        let loader = EmptyProjectDocLoader;
+        assert!(loader.load(Path::new("/tmp")).is_empty());
     }
 }

--- a/crates/dasclaw_project_docs/tests/loader_trait_contract.rs
+++ b/crates/dasclaw_project_docs/tests/loader_trait_contract.rs
@@ -1,0 +1,61 @@
+//! W3 issue #54 — public surface contract for `ProjectDocLoader`.
+//!
+//! Locks the trait + struct + enum shape required by 32-execution-plan.md
+//! W3 task 3 (E 类显式扩展). Downstream issues #55-#59 fill the impl; this
+//! contract guards the API so they don't have to redesign it.
+
+use std::path::{Path, PathBuf};
+
+use dasclaw_project_docs::{DocLayer, ProjectDoc, ProjectDocLoader};
+
+/// Placeholder loader (W1 skeleton-style) used to prove the trait is
+/// object-safe and that the default behaviour is "return nothing".
+struct EmptyLoader;
+
+impl ProjectDocLoader for EmptyLoader {
+    fn load(&self, _cwd: &Path) -> Vec<ProjectDoc> {
+        Vec::new()
+    }
+}
+
+#[test]
+fn req_w3_54_loader_trait_is_object_safe() {
+    // If the trait stops being object-safe (e.g. someone adds `Self: Sized`-incompatible
+    // generics) downstream owners (#55-#59) cannot compose loaders behind a trait object.
+    let loader: Box<dyn ProjectDocLoader> = Box::new(EmptyLoader);
+    assert!(loader.load(Path::new("/tmp")).is_empty());
+}
+
+#[test]
+fn req_w3_54_placeholder_load_returns_empty() {
+    // The W3 acceptance criteria require a placeholder impl that returns
+    // `Vec::new()` so downstream consumers can wire the trait without first
+    // shipping a full multi-layer loader.
+    let docs = EmptyLoader.load(Path::new("."));
+    assert!(docs.is_empty(), "placeholder loader must return empty vec");
+}
+
+#[test]
+fn req_w3_54_project_doc_struct_shape() {
+    // Lock the struct shape; downstream issues will populate `content` /
+    // `bytes` / `source_path` / `layer` from disk.
+    let doc = ProjectDoc {
+        content: "hello".to_string(),
+        source_path: PathBuf::from("/tmp/AGENTS.md"),
+        layer: DocLayer::Project,
+        bytes: 5,
+    };
+    assert_eq!(doc.content, "hello");
+    assert_eq!(doc.source_path, PathBuf::from("/tmp/AGENTS.md"));
+    assert_eq!(doc.bytes, 5);
+    assert!(matches!(doc.layer, DocLayer::Project));
+}
+
+#[test]
+fn req_w3_54_doc_layer_three_variants() {
+    // The 3-layer model (UserGlobal / Project / Cwd) is part of the issue's
+    // contract — it appears in 31-target-architecture.md §4 and in #56's
+    // 3-layer merge issue. Lock all three are constructible.
+    let layers = [DocLayer::UserGlobal, DocLayer::Project, DocLayer::Cwd];
+    assert_eq!(layers.len(), 3);
+}


### PR DESCRIPTION
## 背景 / 目标

W3 任务 3（v2.1 E 类显式扩展）要求在 `crates/dasclaw_project_docs/` 立公共 surface — 把 W1 占位骨架（`Result<String>` 形态）换成 issue #54 指定的契约：

```rust
pub trait ProjectDocLoader {
    fn load(&self, cwd: &Path) -> Vec<ProjectDoc>;
}
pub struct ProjectDoc { content, source_path, layer, bytes }
pub enum DocLayer { UserGlobal, Project, Cwd }
```

这是后续 #55 / #56 / #57 / #58 / #59 的前置 — 只有 surface 锁定后，下游 issue 才能并行落实加载、合并、向上递归、截断、hook 注入。

`Closes #54`

## 改动范围

- `crates/dasclaw_project_docs/src/lib.rs`：trait + 三类型重写；增 `EmptyProjectDocLoader` 占位实现（满足 #54 验收第 3 条 "placeholder 返回空 Vec"）
- `crates/dasclaw_project_docs/Cargo.toml`：去掉 `thiserror`（不再有 error type — 加载器按契约不能 panic，缺文件返回空 Vec）
- `crates/dasclaw_project_docs/tests/loader_trait_contract.rs`：4 个 `req_w3_54_*` 契约测试锁住公共 API
- `Cargo.lock`：跟随依赖移除自动更新

## 非目标（What's NOT in this PR）

- ❌ AGENTS.md / CLAUDE.md / `.codex/agents.md` 的文件名优先级（→ #55）
- ❌ 3 层合并（user / project / cwd）（→ #56）
- ❌ 向上递归到 repo root / `$HOME`（→ #57）
- ❌ `max_bytes` 截断（→ #58）
- ❌ `OnSessionStart` hook 注入到 system prompt（→ #59）
- ❌ 任何调用方接线（desktop-client / ironclaw 都还没消费这个 crate）

## 验证

```bash
$ cargo nextest run -p dasclaw_project_docs
Starting 5 tests across 2 binaries
PASS req_w3_54_doc_layer_three_variants
PASS req_w3_54_placeholder_load_returns_empty
PASS req_w3_54_project_doc_struct_shape
PASS req_w3_54_loader_trait_is_object_safe
PASS empty_loader_returns_no_docs
Summary 5 tests run: 5 passed, 0 skipped

$ cargo fmt --all                                                  # OK
$ python3.12 scripts/check_no_panics.py --base origin/xClaw       # OK
$ cargo clippy --no-deps -p dasclaw_project_docs --all-targets -- -D warnings  # clean
```

完整 workspace build / clippy 由 CI 兑现（按 AGENTS.md "本地分层验证" 节奏）。

## 验收（issue #54 复核）

- ✅ crate 编译通过（`cargo nextest run -p dasclaw_project_docs` 全绿）
- ✅ trait 与 struct 公开导出（`ProjectDocLoader` / `ProjectDoc` / `DocLayer` 都是 `pub`，契约测试通过 `Box<dyn ProjectDocLoader>` 验证 object-safe）
- ✅ 占位实现返回空 `Vec`（`EmptyProjectDocLoader` + 单测 `empty_loader_returns_no_docs`）

## 后续

`#55 → #56 → #57 → #58 → #59` 顺序落实真实加载器；本 PR 合并后这些可并行起跑。
