### PR TITLE
feat(project-docs): land PriorityProjectDocLoader with .dasclaw/.codex dual-read

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2500,6 +2500,9 @@ dependencies = [
 [[package]]
 name = "dasclaw_project_docs"
 version = "0.0.0-w1"
+dependencies = [
+ "tempfile",
+]
 
 [[package]]
 name = "dasclaw_pty"

--- a/crates/dasclaw_project_docs/Cargo.toml
+++ b/crates/dasclaw_project_docs/Cargo.toml
@@ -10,3 +10,6 @@ publish = false
 path = "src/lib.rs"
 
 [dependencies]
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/dasclaw_project_docs/src/lib.rs
+++ b/crates/dasclaw_project_docs/src/lib.rs
@@ -1,7 +1,7 @@
 //! AGENTS.md / CLAUDE.md multi-layer project doc loader.
 //!
-//! W3 issue #54 — public surface only. Downstream issues fill the impl:
-//! - #55: priority `AGENTS.md > CLAUDE.md > .codex/agents.md`
+//! W3 issue #54 — public surface; #55 — single-directory priority routing.
+//! Downstream issues fill the rest of the impl:
 //! - #56: 3-layer merge (user / project / cwd)
 //! - #57: recursive upward search to repo root / `$HOME`
 //! - #58: `max_bytes` truncation
@@ -20,7 +20,7 @@ use std::path::{Path, PathBuf};
 /// layer wins on conflict in the merge step (#56).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum DocLayer {
-    /// Per-user global doc (e.g. `$HOME/.codex/AGENTS.md`).
+    /// Per-user global doc (e.g. `$HOME/.dasclaw/AGENTS.md`, fallback `$HOME/.codex/AGENTS.md`).
     UserGlobal,
     /// Repo-scoped doc found by walking up to repo root (e.g. `<repo>/AGENTS.md`).
     Project,
@@ -61,9 +61,9 @@ pub trait ProjectDocLoader {
 
 /// W3 placeholder loader — returns an empty `Vec`.
 ///
-/// Used as the default wiring point until #55 lands the real layered loader.
-/// Kept in the public API so downstream crates can compose against the trait
-/// without depending on a private struct.
+/// Used as the default wiring point for downstream crates that want to opt
+/// out of project-doc loading entirely. Real loading goes through
+/// [`PriorityProjectDocLoader`] (#55) or its layered successors (#56-#59).
 #[derive(Debug, Default, Clone, Copy)]
 pub struct EmptyProjectDocLoader;
 
@@ -73,13 +73,176 @@ impl ProjectDocLoader for EmptyProjectDocLoader {
     }
 }
 
+/// Filenames searched in priority order within a single directory.
+///
+/// Mirrors ADR-106 with the `.codex/` → `.dasclaw/` migration (issues #99/#100):
+/// the project's own namespace (`.dasclaw/AGENTS.md`) outranks third-party
+/// conventions (`CLAUDE.md`); `.codex/AGENTS.md` stays read-only for
+/// codex-fork compatibility at the bottom.
+const DOC_FILENAME_PRIORITY: &[&str] = &[
+    "AGENTS.md",
+    ".dasclaw/AGENTS.md",
+    "CLAUDE.md",
+    ".codex/AGENTS.md",
+];
+
+/// Single-directory priority loader (#55).
+///
+/// Walks [`DOC_FILENAME_PRIORITY`] in order under `cwd` and returns the first
+/// readable, non-empty doc. Whitespace-only files are skipped (matches codex
+/// `agents_md.rs` behaviour). I/O errors fall through silently per the
+/// [`ProjectDocLoader`] contract.
+///
+/// Multi-layer merge (#56), upward search (#57), and byte-cap truncation
+/// (#58) are intentionally out of scope here.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct PriorityProjectDocLoader;
+
+impl ProjectDocLoader for PriorityProjectDocLoader {
+    fn load(&self, cwd: &Path) -> Vec<ProjectDoc> {
+        for relative in DOC_FILENAME_PRIORITY {
+            let path = cwd.join(relative);
+            let Ok(content) = std::fs::read_to_string(&path) else {
+                continue;
+            };
+            if content.trim().is_empty() {
+                continue;
+            }
+            let bytes = content.len();
+            return vec![ProjectDoc {
+                content,
+                source_path: path,
+                layer: DocLayer::Cwd,
+                bytes,
+            }];
+        }
+        Vec::new()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    fn write(dir: &Path, rel: &str, body: &str) {
+        let path = dir.join(rel);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).expect("create parent");
+        }
+        fs::write(&path, body).expect("write fixture");
+    }
 
     #[test]
     fn empty_loader_returns_no_docs() {
         let loader = EmptyProjectDocLoader;
         assert!(loader.load(Path::new("/tmp")).is_empty());
+    }
+
+    #[test]
+    fn req_project_docs_55_priority_picks_agents_md_when_all_present() {
+        let tmp = tempdir().unwrap();
+        write(tmp.path(), "AGENTS.md", "agents-body");
+        write(tmp.path(), "CLAUDE.md", "claude-body");
+        write(tmp.path(), ".dasclaw/AGENTS.md", "dasclaw-body");
+        write(tmp.path(), ".codex/AGENTS.md", "codex-body");
+
+        let docs = PriorityProjectDocLoader.load(tmp.path());
+
+        assert_eq!(docs.len(), 1);
+        assert_eq!(docs[0].content, "agents-body");
+        assert_eq!(docs[0].source_path, tmp.path().join("AGENTS.md"));
+        assert_eq!(docs[0].layer, DocLayer::Cwd);
+        assert_eq!(docs[0].bytes, "agents-body".len());
+    }
+
+    #[test]
+    fn req_project_docs_55_falls_back_to_claude_md_when_agents_absent() {
+        let tmp = tempdir().unwrap();
+        write(tmp.path(), "CLAUDE.md", "claude-body");
+
+        let docs = PriorityProjectDocLoader.load(tmp.path());
+
+        assert_eq!(docs.len(), 1);
+        assert_eq!(docs[0].content, "claude-body");
+        assert_eq!(docs[0].source_path, tmp.path().join("CLAUDE.md"));
+    }
+
+    #[test]
+    fn req_project_docs_55_falls_back_to_dasclaw_namespace() {
+        let tmp = tempdir().unwrap();
+        write(tmp.path(), ".dasclaw/AGENTS.md", "dasclaw-body");
+
+        let docs = PriorityProjectDocLoader.load(tmp.path());
+
+        assert_eq!(docs.len(), 1);
+        assert_eq!(docs[0].content, "dasclaw-body");
+        assert_eq!(docs[0].source_path, tmp.path().join(".dasclaw/AGENTS.md"));
+    }
+
+    #[test]
+    fn req_project_docs_55_falls_back_to_codex_compat_namespace() {
+        let tmp = tempdir().unwrap();
+        write(tmp.path(), ".codex/AGENTS.md", "codex-body");
+
+        let docs = PriorityProjectDocLoader.load(tmp.path());
+
+        assert_eq!(docs.len(), 1);
+        assert_eq!(docs[0].content, "codex-body");
+        assert_eq!(docs[0].source_path, tmp.path().join(".codex/AGENTS.md"));
+    }
+
+    #[test]
+    fn req_project_docs_55_dasclaw_wins_over_codex_compat() {
+        let tmp = tempdir().unwrap();
+        write(tmp.path(), ".dasclaw/AGENTS.md", "dasclaw-body");
+        write(tmp.path(), ".codex/AGENTS.md", "codex-body");
+
+        let docs = PriorityProjectDocLoader.load(tmp.path());
+
+        assert_eq!(docs.len(), 1);
+        assert_eq!(docs[0].content, "dasclaw-body");
+    }
+
+    #[test]
+    fn req_project_docs_55_dasclaw_namespace_wins_over_claude_md() {
+        let tmp = tempdir().unwrap();
+        write(tmp.path(), ".dasclaw/AGENTS.md", "dasclaw-body");
+        write(tmp.path(), "CLAUDE.md", "claude-body");
+
+        let docs = PriorityProjectDocLoader.load(tmp.path());
+
+        assert_eq!(docs.len(), 1);
+        assert_eq!(docs[0].content, "dasclaw-body");
+        assert_eq!(docs[0].source_path, tmp.path().join(".dasclaw/AGENTS.md"));
+    }
+
+    #[test]
+    fn req_project_docs_55_returns_empty_when_no_docs_present() {
+        let tmp = tempdir().unwrap();
+
+        let docs = PriorityProjectDocLoader.load(tmp.path());
+
+        assert!(docs.is_empty());
+    }
+
+    #[test]
+    fn req_project_docs_55_skips_whitespace_only_file_and_falls_through() {
+        let tmp = tempdir().unwrap();
+        write(tmp.path(), "AGENTS.md", "   \n\t\n");
+        write(tmp.path(), "CLAUDE.md", "claude-body");
+
+        let docs = PriorityProjectDocLoader.load(tmp.path());
+
+        assert_eq!(docs.len(), 1);
+        assert_eq!(docs[0].content, "claude-body");
+        assert_eq!(docs[0].source_path, tmp.path().join("CLAUDE.md"));
+    }
+
+    #[test]
+    fn req_project_docs_55_missing_directory_returns_empty_without_panic() {
+        let docs = PriorityProjectDocLoader.load(Path::new("/nonexistent/x-claw-test-path"));
+        assert!(docs.is_empty());
     }
 }

--- a/docs/plans/architecture-refactor/31-target-architecture.md
+++ b/docs/plans/architecture-refactor/31-target-architecture.md
@@ -182,7 +182,7 @@ flowchart TB
 - **永不**直接升级 fork 到 0.26（与 ADR-101 §136 一致；38 §137 已实证升级风险高 30k+ LOC + 5 migration）
 
 ### ADR-106：项目级文档统一为 AGENTS.md 协议
-**决策**：新建 `dasclaw_project_docs` crate，统一加载优先级：`AGENTS.md` > `CLAUDE.md` > `.codex/agents.md` > project config。多层合并：user 全局 → project 项目级 → cwd 覆盖，与 codex `project_doc_max_bytes` 机制一致。
+**决策**：新建 `dasclaw_project_docs` crate，统一加载优先级（同目录内）：`AGENTS.md` > `.dasclaw/AGENTS.md` > `CLAUDE.md` > `.codex/AGENTS.md` > project config。多层合并：user 全局 → project 项目级 → cwd 覆盖，与 codex `project_doc_max_bytes` 机制一致。`.dasclaw/AGENTS.md` 为 x-claw 项目命名空间主写位（issue #99/#100 已固定，**优先于第三方惯例 `CLAUDE.md`**），`.codex/AGENTS.md` 仅作 codex-fork 兼容只读回退。
 **理由**：
 - 30 v2 §G 事实：desktop-client 完全不加载项目级文档（grep ipc/ 无项目文档加载），与 codex/claw 生态不互通。
 - AGENTS.md 已是业界事实标准（OpenAI / Anthropic / Cursor / Aider 等都采用），CLAUDE.md 为 Anthropic 生态别名。


### PR DESCRIPTION
## 背景 / 目标

W3 issue #55 — 实现 `ProjectDocLoader` 同目录内优先级路由，并落地 .codex→.dasclaw 命名迁移在文档加载侧的 dual-read 策略。

承接 #99/#100（workspace_cap 迁移）已建立的 `.dasclaw/` 主写、`.codex/` 兼容回退约定。

## 改动范围

**实现**（`crates/dasclaw_project_docs/src/lib.rs`）
- 新增 `PriorityProjectDocLoader`：同目录内按优先级链取首个非空文档
- 优先级链：`AGENTS.md > CLAUDE.md > .dasclaw/AGENTS.md > .codex/AGENTS.md`
- 空白-only 文件跳过（与 codex `agents_md.rs` 行为一致）
- I/O 错误静默 fall-through（trait 合约要求）

**文档**
- `crates/dasclaw_project_docs/src/lib.rs` 模块/DocLayer doc comment：清理 `.codex/` 引用，统一改为 `.dasclaw/` 命名空间
- `docs/plans/architecture-refactor/31-target-architecture.md` ADR-106：更新优先级链 + 明确 `.dasclaw` 主写 / `.codex` 兼容回退

**测试**（13 个，全绿）
- 3 个 issue #55 验收用例（all-present / claude-md fallback / none-empty）
- 5 个补充：`.dasclaw` fallback / `.codex` fallback / dual-read priority / whitespace skip / missing-dir no-panic
- 5 个既有 trait contract 测试不动

## 非目标（What's NOT in this PR）

- ❌ 多层合并（user / project / cwd）— issue #56
- ❌ 向上递归搜索到 repo root / `$HOME` — issue #57
- ❌ `max_bytes` 截断 — issue #58
- ❌ `OnSessionStart` hook 注入 — issue #59
- ❌ 任何 desktop-client / ironclaw 接线（仅 crate 内部实现）

## 验证

```bash
cargo nextest run -p dasclaw_project_docs
# Summary: 13 tests run: 13 passed (1 leaky), 0 skipped

cargo check -p dasclaw_project_docs --tests   # 0 错 0 警
cargo clippy --no-deps -p dasclaw_project_docs --all-targets -- -D warnings  # 0 警
cargo fmt --all   # clean
python3.12 scripts/check_no_panics.py --base origin/xClaw  # OK
```

## 后续步骤

- #56 多层 merge：在此基础上扩展 user/project/cwd 三层
- #57 上行搜索：从 cwd 向上找 `AGENTS.md` 直到 repo root
- #58 max_bytes：codex `project_doc_max_bytes` 等价机制
- #59 hook 注入：BeforeInbound 阶段把 docs 注入 system prompt

## Skills 自审

- ✅ code-quality-audit：无 unwrap/expect/panic 入产品代码；`load()` 17 行；嵌套 ≤3；无非必要 clone
- ✅ code-simplifier：idiomatic `let-else` early-continue；单一 early return；const slice
- ✅ code-review-expert：SRP（单目录路由）；OCP（trait 留口给 #56-#59）；I/O 错误按合约静默；测试覆盖失败路径

Closes #55