### PR TITLE
feat(project-docs): land per-doc max_bytes truncation (Closes #58)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2500,6 +2500,9 @@ dependencies = [
 [[package]]
 name = "dasclaw_project_docs"
 version = "0.0.0-w1"
+dependencies = [
+ "tempfile",
+]
 
 [[package]]
 name = "dasclaw_pty"

--- a/crates/dasclaw_project_docs/Cargo.toml
+++ b/crates/dasclaw_project_docs/Cargo.toml
@@ -10,3 +10,6 @@ publish = false
 path = "src/lib.rs"
 
 [dependencies]
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/dasclaw_project_docs/src/lib.rs
+++ b/crates/dasclaw_project_docs/src/lib.rs
@@ -1,7 +1,7 @@
 //! AGENTS.md / CLAUDE.md multi-layer project doc loader.
 //!
-//! W3 issue #54 — public surface only. Downstream issues fill the impl:
-//! - #55: priority `AGENTS.md > CLAUDE.md > .codex/agents.md`
+//! W3 issue #54 — public surface; #55 — single-directory priority routing.
+//! Downstream issues fill the rest of the impl:
 //! - #56: 3-layer merge (user / project / cwd)
 //! - #57: recursive upward search to repo root / `$HOME`
 //! - #58: `max_bytes` truncation
@@ -20,7 +20,7 @@ use std::path::{Path, PathBuf};
 /// layer wins on conflict in the merge step (#56).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum DocLayer {
-    /// Per-user global doc (e.g. `$HOME/.codex/AGENTS.md`).
+    /// Per-user global doc (e.g. `$HOME/.dasclaw/AGENTS.md`, fallback `$HOME/.codex/AGENTS.md`).
     UserGlobal,
     /// Repo-scoped doc found by walking up to repo root (e.g. `<repo>/AGENTS.md`).
     Project,
@@ -61,9 +61,9 @@ pub trait ProjectDocLoader {
 
 /// W3 placeholder loader — returns an empty `Vec`.
 ///
-/// Used as the default wiring point until #55 lands the real layered loader.
-/// Kept in the public API so downstream crates can compose against the trait
-/// without depending on a private struct.
+/// Used as the default wiring point for downstream crates that want to opt
+/// out of project-doc loading entirely. Real loading goes through
+/// [`PriorityProjectDocLoader`] (#55) or its layered successors (#56-#59).
 #[derive(Debug, Default, Clone, Copy)]
 pub struct EmptyProjectDocLoader;
 
@@ -73,13 +73,176 @@ impl ProjectDocLoader for EmptyProjectDocLoader {
     }
 }
 
+/// Filenames searched in priority order within a single directory.
+///
+/// Mirrors ADR-106 with the `.codex/` → `.dasclaw/` migration (issues #99/#100):
+/// the project's own namespace (`.dasclaw/AGENTS.md`) outranks third-party
+/// conventions (`CLAUDE.md`); `.codex/AGENTS.md` stays read-only for
+/// codex-fork compatibility at the bottom.
+const DOC_FILENAME_PRIORITY: &[&str] = &[
+    "AGENTS.md",
+    ".dasclaw/AGENTS.md",
+    "CLAUDE.md",
+    ".codex/AGENTS.md",
+];
+
+/// Single-directory priority loader (#55).
+///
+/// Walks [`DOC_FILENAME_PRIORITY`] in order under `cwd` and returns the first
+/// readable, non-empty doc. Whitespace-only files are skipped (matches codex
+/// `agents_md.rs` behaviour). I/O errors fall through silently per the
+/// [`ProjectDocLoader`] contract.
+///
+/// Multi-layer merge (#56), upward search (#57), and byte-cap truncation
+/// (#58) are intentionally out of scope here.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct PriorityProjectDocLoader;
+
+impl ProjectDocLoader for PriorityProjectDocLoader {
+    fn load(&self, cwd: &Path) -> Vec<ProjectDoc> {
+        for relative in DOC_FILENAME_PRIORITY {
+            let path = cwd.join(relative);
+            let Ok(content) = std::fs::read_to_string(&path) else {
+                continue;
+            };
+            if content.trim().is_empty() {
+                continue;
+            }
+            let bytes = content.len();
+            return vec![ProjectDoc {
+                content,
+                source_path: path,
+                layer: DocLayer::Cwd,
+                bytes,
+            }];
+        }
+        Vec::new()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    fn write(dir: &Path, rel: &str, body: &str) {
+        let path = dir.join(rel);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).expect("create parent");
+        }
+        fs::write(&path, body).expect("write fixture");
+    }
 
     #[test]
     fn empty_loader_returns_no_docs() {
         let loader = EmptyProjectDocLoader;
         assert!(loader.load(Path::new("/tmp")).is_empty());
+    }
+
+    #[test]
+    fn req_project_docs_55_priority_picks_agents_md_when_all_present() {
+        let tmp = tempdir().unwrap();
+        write(tmp.path(), "AGENTS.md", "agents-body");
+        write(tmp.path(), "CLAUDE.md", "claude-body");
+        write(tmp.path(), ".dasclaw/AGENTS.md", "dasclaw-body");
+        write(tmp.path(), ".codex/AGENTS.md", "codex-body");
+
+        let docs = PriorityProjectDocLoader.load(tmp.path());
+
+        assert_eq!(docs.len(), 1);
+        assert_eq!(docs[0].content, "agents-body");
+        assert_eq!(docs[0].source_path, tmp.path().join("AGENTS.md"));
+        assert_eq!(docs[0].layer, DocLayer::Cwd);
+        assert_eq!(docs[0].bytes, "agents-body".len());
+    }
+
+    #[test]
+    fn req_project_docs_55_falls_back_to_claude_md_when_agents_absent() {
+        let tmp = tempdir().unwrap();
+        write(tmp.path(), "CLAUDE.md", "claude-body");
+
+        let docs = PriorityProjectDocLoader.load(tmp.path());
+
+        assert_eq!(docs.len(), 1);
+        assert_eq!(docs[0].content, "claude-body");
+        assert_eq!(docs[0].source_path, tmp.path().join("CLAUDE.md"));
+    }
+
+    #[test]
+    fn req_project_docs_55_falls_back_to_dasclaw_namespace() {
+        let tmp = tempdir().unwrap();
+        write(tmp.path(), ".dasclaw/AGENTS.md", "dasclaw-body");
+
+        let docs = PriorityProjectDocLoader.load(tmp.path());
+
+        assert_eq!(docs.len(), 1);
+        assert_eq!(docs[0].content, "dasclaw-body");
+        assert_eq!(docs[0].source_path, tmp.path().join(".dasclaw/AGENTS.md"));
+    }
+
+    #[test]
+    fn req_project_docs_55_falls_back_to_codex_compat_namespace() {
+        let tmp = tempdir().unwrap();
+        write(tmp.path(), ".codex/AGENTS.md", "codex-body");
+
+        let docs = PriorityProjectDocLoader.load(tmp.path());
+
+        assert_eq!(docs.len(), 1);
+        assert_eq!(docs[0].content, "codex-body");
+        assert_eq!(docs[0].source_path, tmp.path().join(".codex/AGENTS.md"));
+    }
+
+    #[test]
+    fn req_project_docs_55_dasclaw_wins_over_codex_compat() {
+        let tmp = tempdir().unwrap();
+        write(tmp.path(), ".dasclaw/AGENTS.md", "dasclaw-body");
+        write(tmp.path(), ".codex/AGENTS.md", "codex-body");
+
+        let docs = PriorityProjectDocLoader.load(tmp.path());
+
+        assert_eq!(docs.len(), 1);
+        assert_eq!(docs[0].content, "dasclaw-body");
+    }
+
+    #[test]
+    fn req_project_docs_55_dasclaw_namespace_wins_over_claude_md() {
+        let tmp = tempdir().unwrap();
+        write(tmp.path(), ".dasclaw/AGENTS.md", "dasclaw-body");
+        write(tmp.path(), "CLAUDE.md", "claude-body");
+
+        let docs = PriorityProjectDocLoader.load(tmp.path());
+
+        assert_eq!(docs.len(), 1);
+        assert_eq!(docs[0].content, "dasclaw-body");
+        assert_eq!(docs[0].source_path, tmp.path().join(".dasclaw/AGENTS.md"));
+    }
+
+    #[test]
+    fn req_project_docs_55_returns_empty_when_no_docs_present() {
+        let tmp = tempdir().unwrap();
+
+        let docs = PriorityProjectDocLoader.load(tmp.path());
+
+        assert!(docs.is_empty());
+    }
+
+    #[test]
+    fn req_project_docs_55_skips_whitespace_only_file_and_falls_through() {
+        let tmp = tempdir().unwrap();
+        write(tmp.path(), "AGENTS.md", "   \n\t\n");
+        write(tmp.path(), "CLAUDE.md", "claude-body");
+
+        let docs = PriorityProjectDocLoader.load(tmp.path());
+
+        assert_eq!(docs.len(), 1);
+        assert_eq!(docs[0].content, "claude-body");
+        assert_eq!(docs[0].source_path, tmp.path().join("CLAUDE.md"));
+    }
+
+    #[test]
+    fn req_project_docs_55_missing_directory_returns_empty_without_panic() {
+        let docs = PriorityProjectDocLoader.load(Path::new("/nonexistent/x-claw-test-path"));
+        assert!(docs.is_empty());
     }
 }

--- a/crates/dasclaw_project_docs/src/lib.rs
+++ b/crates/dasclaw_project_docs/src/lib.rs
@@ -1,8 +1,7 @@
 //! AGENTS.md / CLAUDE.md multi-layer project doc loader.
 //!
-//! W3 issue #54 — public surface; #55 — single-directory priority routing.
-//! Downstream issues fill the rest of the impl:
-//! - #56: 3-layer merge (user / project / cwd)
+//! W3 issues #54 (trait surface), #55 (single-dir priority), #56 (3-layer merge).
+//! Downstream:
 //! - #57: recursive upward search to repo root / `$HOME`
 //! - #58: `max_bytes` truncation
 //! - #59: `OnSessionStart` hook injection
@@ -73,7 +72,7 @@ impl ProjectDocLoader for EmptyProjectDocLoader {
     }
 }
 
-/// Filenames searched in priority order within a single directory.
+/// Filenames searched in priority order within a project / cwd directory.
 ///
 /// Mirrors ADR-106 with the `.codex/` → `.dasclaw/` migration (issues #99/#100):
 /// the project's own namespace (`.dasclaw/AGENTS.md`) outranks third-party
@@ -86,11 +85,42 @@ const DOC_FILENAME_PRIORITY: &[&str] = &[
     ".codex/AGENTS.md",
 ];
 
+/// User-global filename priority chain (relative to `$HOME`).
+///
+/// Mirrors ADR-106 dual-read: `~/.dasclaw/AGENTS.md` is the new primary,
+/// `~/.codex/AGENTS.md` retained for codex-fork compatibility.
+const USER_GLOBAL_FILENAME_PRIORITY: &[&str] = &[".dasclaw/AGENTS.md", ".codex/AGENTS.md"];
+
+/// Read a single doc, skipping unreadable / whitespace-only files.
+///
+/// Centralises the “best-effort, never panic” I/O policy mandated by the
+/// [`ProjectDocLoader`] trait contract. Whitespace-only files are skipped to
+/// match codex `agents_md.rs` behaviour.
+fn read_doc_at(path: PathBuf, layer: DocLayer) -> Option<ProjectDoc> {
+    let content = std::fs::read_to_string(&path).ok()?;
+    if content.trim().is_empty() {
+        return None;
+    }
+    let bytes = content.len();
+    Some(ProjectDoc {
+        content,
+        source_path: path,
+        layer,
+        bytes,
+    })
+}
+
+/// Walk a filename priority chain under `base`, returning the first match.
+fn first_priority_doc(base: &Path, chain: &[&str], layer: DocLayer) -> Option<ProjectDoc> {
+    chain
+        .iter()
+        .find_map(|relative| read_doc_at(base.join(relative), layer))
+}
+
 /// Single-directory priority loader (#55).
 ///
 /// Walks [`DOC_FILENAME_PRIORITY`] in order under `cwd` and returns the first
-/// readable, non-empty doc. Whitespace-only files are skipped (matches codex
-/// `agents_md.rs` behaviour). I/O errors fall through silently per the
+/// readable, non-empty doc. I/O errors fall through silently per the
 /// [`ProjectDocLoader`] contract.
 ///
 /// Multi-layer merge (#56), upward search (#57), and byte-cap truncation
@@ -100,23 +130,68 @@ pub struct PriorityProjectDocLoader;
 
 impl ProjectDocLoader for PriorityProjectDocLoader {
     fn load(&self, cwd: &Path) -> Vec<ProjectDoc> {
-        for relative in DOC_FILENAME_PRIORITY {
-            let path = cwd.join(relative);
-            let Ok(content) = std::fs::read_to_string(&path) else {
-                continue;
-            };
-            if content.trim().is_empty() {
-                continue;
-            }
-            let bytes = content.len();
-            return vec![ProjectDoc {
-                content,
-                source_path: path,
-                layer: DocLayer::Cwd,
-                bytes,
-            }];
+        first_priority_doc(cwd, DOC_FILENAME_PRIORITY, DocLayer::Cwd)
+            .map(|doc| vec![doc])
+            .unwrap_or_default()
+    }
+}
+
+/// 3-layer merge loader (#56).
+///
+/// Emits up to 3 docs in load order: `UserGlobal` → `Project` → `Cwd`.
+/// Each layer reuses [`DOC_FILENAME_PRIORITY`] (or
+/// [`USER_GLOBAL_FILENAME_PRIORITY`] for the user-global layer) and skips
+/// empty / unreadable files. When `cwd` is the same path as `project_root`
+/// the duplicate `Cwd` emit is suppressed so callers see a single
+/// `Project`-layer doc instead of two copies.
+///
+/// `user_home` and `project_root` are optional so callers can disable the
+/// upper layers without composing a different loader (e.g. ephemeral /
+/// non-repo `cwd`s in tests). Recursive upward search to find
+/// `project_root` is the responsibility of issue #57.
+#[derive(Debug, Default, Clone)]
+pub struct LayeredProjectDocLoader {
+    user_home: Option<PathBuf>,
+    project_root: Option<PathBuf>,
+}
+
+impl LayeredProjectDocLoader {
+    /// Construct a layered loader with explicit user-home and project-root paths.
+    pub fn new(user_home: Option<PathBuf>, project_root: Option<PathBuf>) -> Self {
+        Self {
+            user_home,
+            project_root,
         }
-        Vec::new()
+    }
+}
+
+impl ProjectDocLoader for LayeredProjectDocLoader {
+    fn load(&self, cwd: &Path) -> Vec<ProjectDoc> {
+        let mut docs = Vec::with_capacity(3);
+
+        let user_doc = self.user_home.as_deref().and_then(|home| {
+            first_priority_doc(home, USER_GLOBAL_FILENAME_PRIORITY, DocLayer::UserGlobal)
+        });
+        if let Some(doc) = user_doc {
+            docs.push(doc);
+        }
+
+        let project_doc = self
+            .project_root
+            .as_deref()
+            .and_then(|root| first_priority_doc(root, DOC_FILENAME_PRIORITY, DocLayer::Project));
+        if let Some(doc) = project_doc {
+            docs.push(doc);
+        }
+
+        let cwd_is_project_root = self.project_root.as_deref() == Some(cwd);
+        if !cwd_is_project_root {
+            if let Some(doc) = first_priority_doc(cwd, DOC_FILENAME_PRIORITY, DocLayer::Cwd) {
+                docs.push(doc);
+            }
+        }
+
+        docs
     }
 }
 
@@ -244,5 +319,161 @@ mod tests {
     fn req_project_docs_55_missing_directory_returns_empty_without_panic() {
         let docs = PriorityProjectDocLoader.load(Path::new("/nonexistent/x-claw-test-path"));
         assert!(docs.is_empty());
+    }
+
+    // ───────────────────────── #56 LayeredProjectDocLoader ─────────────────────────
+
+    #[test]
+    fn req_project_docs_56_three_layers_emit_in_order() {
+        let home = tempdir().unwrap();
+        let project = tempdir().unwrap();
+        let cwd = project.path().join("subdir");
+        fs::create_dir_all(&cwd).unwrap();
+
+        write(home.path(), ".dasclaw/AGENTS.md", "user-body");
+        write(project.path(), "AGENTS.md", "project-body");
+        write(&cwd, "AGENTS.md", "cwd-body");
+
+        let loader = LayeredProjectDocLoader::new(
+            Some(home.path().to_path_buf()),
+            Some(project.path().to_path_buf()),
+        );
+        let docs = loader.load(&cwd);
+
+        assert_eq!(docs.len(), 3);
+        assert_eq!(docs[0].layer, DocLayer::UserGlobal);
+        assert_eq!(docs[0].content, "user-body");
+        assert_eq!(docs[1].layer, DocLayer::Project);
+        assert_eq!(docs[1].content, "project-body");
+        assert_eq!(docs[2].layer, DocLayer::Cwd);
+        assert_eq!(docs[2].content, "cwd-body");
+    }
+
+    #[test]
+    fn req_project_docs_56_user_plus_project_two_layers() {
+        let home = tempdir().unwrap();
+        let project = tempdir().unwrap();
+        let cwd = project.path().join("subdir");
+        fs::create_dir_all(&cwd).unwrap();
+
+        write(home.path(), ".dasclaw/AGENTS.md", "user-body");
+        write(project.path(), "AGENTS.md", "project-body");
+        // No doc at cwd.
+
+        let loader = LayeredProjectDocLoader::new(
+            Some(home.path().to_path_buf()),
+            Some(project.path().to_path_buf()),
+        );
+        let docs = loader.load(&cwd);
+
+        assert_eq!(docs.len(), 2);
+        assert_eq!(docs[0].layer, DocLayer::UserGlobal);
+        assert_eq!(docs[1].layer, DocLayer::Project);
+    }
+
+    #[test]
+    fn req_project_docs_56_project_plus_cwd_skips_missing_user() {
+        let project = tempdir().unwrap();
+        let cwd = project.path().join("subdir");
+        fs::create_dir_all(&cwd).unwrap();
+
+        write(project.path(), "AGENTS.md", "project-body");
+        write(&cwd, "AGENTS.md", "cwd-body");
+
+        let loader = LayeredProjectDocLoader::new(None, Some(project.path().to_path_buf()));
+        let docs = loader.load(&cwd);
+
+        assert_eq!(docs.len(), 2);
+        assert_eq!(docs[0].layer, DocLayer::Project);
+        assert_eq!(docs[1].layer, DocLayer::Cwd);
+    }
+
+    #[test]
+    fn req_project_docs_56_cwd_only_when_no_user_no_project() {
+        let cwd = tempdir().unwrap();
+        write(cwd.path(), "AGENTS.md", "cwd-body");
+
+        let loader = LayeredProjectDocLoader::new(None, None);
+        let docs = loader.load(cwd.path());
+
+        assert_eq!(docs.len(), 1);
+        assert_eq!(docs[0].layer, DocLayer::Cwd);
+    }
+
+    #[test]
+    fn req_project_docs_56_returns_empty_when_no_docs_anywhere() {
+        let home = tempdir().unwrap();
+        let project = tempdir().unwrap();
+        let cwd = project.path().join("subdir");
+        fs::create_dir_all(&cwd).unwrap();
+
+        let loader = LayeredProjectDocLoader::new(
+            Some(home.path().to_path_buf()),
+            Some(project.path().to_path_buf()),
+        );
+        assert!(loader.load(&cwd).is_empty());
+    }
+
+    #[test]
+    fn req_project_docs_56_cwd_equal_to_project_root_dedups_to_single_project_doc() {
+        let project = tempdir().unwrap();
+        write(project.path(), "AGENTS.md", "project-body");
+
+        let loader = LayeredProjectDocLoader::new(None, Some(project.path().to_path_buf()));
+        let docs = loader.load(project.path());
+
+        assert_eq!(docs.len(), 1);
+        assert_eq!(docs[0].layer, DocLayer::Project);
+        assert_eq!(docs[0].content, "project-body");
+    }
+
+    #[test]
+    fn req_project_docs_56_user_global_dasclaw_wins_over_codex_compat() {
+        let home = tempdir().unwrap();
+        let cwd = tempdir().unwrap();
+        write(home.path(), ".dasclaw/AGENTS.md", "user-dasclaw");
+        write(home.path(), ".codex/AGENTS.md", "user-codex");
+
+        let loader = LayeredProjectDocLoader::new(Some(home.path().to_path_buf()), None);
+        let docs = loader.load(cwd.path());
+
+        let user_docs: Vec<_> = docs
+            .iter()
+            .filter(|d| d.layer == DocLayer::UserGlobal)
+            .collect();
+        assert_eq!(user_docs.len(), 1);
+        assert_eq!(user_docs[0].content, "user-dasclaw");
+    }
+
+    #[test]
+    fn req_project_docs_56_user_global_falls_back_to_codex_compat() {
+        let home = tempdir().unwrap();
+        let cwd = tempdir().unwrap();
+        write(home.path(), ".codex/AGENTS.md", "user-codex");
+
+        let loader = LayeredProjectDocLoader::new(Some(home.path().to_path_buf()), None);
+        let docs = loader.load(cwd.path());
+
+        assert_eq!(docs.len(), 1);
+        assert_eq!(docs[0].layer, DocLayer::UserGlobal);
+        assert_eq!(docs[0].content, "user-codex");
+        assert_eq!(docs[0].source_path, home.path().join(".codex/AGENTS.md"));
+    }
+
+    #[test]
+    fn req_project_docs_56_project_layer_uses_full_priority_chain() {
+        let project = tempdir().unwrap();
+        // Only CLAUDE.md at project root — should still emit at Project layer.
+        write(project.path(), "CLAUDE.md", "claude-project");
+        let cwd = project.path().join("subdir");
+        fs::create_dir_all(&cwd).unwrap();
+
+        let loader = LayeredProjectDocLoader::new(None, Some(project.path().to_path_buf()));
+        let docs = loader.load(&cwd);
+
+        assert_eq!(docs.len(), 1);
+        assert_eq!(docs[0].layer, DocLayer::Project);
+        assert_eq!(docs[0].content, "claude-project");
+        assert_eq!(docs[0].source_path, project.path().join("CLAUDE.md"));
     }
 }

--- a/crates/dasclaw_project_docs/src/lib.rs
+++ b/crates/dasclaw_project_docs/src/lib.rs
@@ -1,10 +1,13 @@
 //! AGENTS.md / CLAUDE.md multi-layer project doc loader.
 //!
-//! W3 issues #54 (trait surface), #55 (single-dir priority), #56 (3-layer merge).
+//! W3 issues #54 (trait surface), #55 (single-dir priority), #56 (3-layer merge),
+//! #58 (`max_bytes` truncation).
 //! Downstream:
-//! - #57: recursive upward search to repo root / `$HOME`
-//! - #58: `max_bytes` truncation
 //! - #59: `OnSessionStart` hook injection
+//!
+//! Note: #57 (recursive upward search) was closed as obsolete — desktop-client
+//! uses an explicit session-level `workspace_root` (auto-generated sandbox or
+//! user-imported), so cwd ≈ project_root and walk-up is unnecessary.
 //!
 //! See `docs/plans/architecture-refactor/31-target-architecture.md` §4 and
 //! `32-execution-plan.md` W3 task 3 for the full design.
@@ -91,13 +94,48 @@ const DOC_FILENAME_PRIORITY: &[&str] = &[
 /// `~/.codex/AGENTS.md` retained for codex-fork compatibility.
 const USER_GLOBAL_FILENAME_PRIORITY: &[&str] = &[".dasclaw/AGENTS.md", ".codex/AGENTS.md"];
 
+/// Default per-doc byte cap (#58). Mirrors codex `project_doc_max_bytes` default of 8 KiB.
+pub const DEFAULT_PROJECT_DOC_MAX_BYTES: usize = 8 * 1024;
+
+/// Truncate `content` to at most `max_bytes`, preserving complete lines.
+///
+/// If the content fits within the cap it is returned as-is. Otherwise the
+/// longest prefix of complete lines (terminated by `\n`) that fits in
+/// `max_bytes` is kept. If even the first line is longer than `max_bytes`
+/// the prefix is cut at the largest valid UTF-8 char boundary `<= max_bytes`,
+/// guaranteeing a valid `String` without panicking on multi-byte chars.
+fn truncate_to_max_bytes(content: String, max_bytes: usize) -> String {
+    if content.len() <= max_bytes {
+        return content;
+    }
+    let mut out = String::with_capacity(max_bytes);
+    for line in content.split_inclusive('\n') {
+        if out.len() + line.len() > max_bytes {
+            break;
+        }
+        out.push_str(line);
+    }
+    if !out.is_empty() {
+        return out;
+    }
+    // Single line wider than cap: trim back to a UTF-8 boundary.
+    let mut end = max_bytes.min(content.len());
+    while end > 0 && !content.is_char_boundary(end) {
+        end -= 1;
+    }
+    content[..end].to_string()
+}
+
 /// Read a single doc, skipping unreadable / whitespace-only files.
 ///
 /// Centralises the “best-effort, never panic” I/O policy mandated by the
 /// [`ProjectDocLoader`] trait contract. Whitespace-only files are skipped to
-/// match codex `agents_md.rs` behaviour.
-fn read_doc_at(path: PathBuf, layer: DocLayer) -> Option<ProjectDoc> {
-    let content = std::fs::read_to_string(&path).ok()?;
+/// match codex `agents_md.rs` behaviour. `max_bytes` (#58) caps the doc body
+/// at line boundaries before whitespace check, mirroring codex
+/// `project_doc_max_bytes`.
+fn read_doc_at(path: PathBuf, layer: DocLayer, max_bytes: usize) -> Option<ProjectDoc> {
+    let raw = std::fs::read_to_string(&path).ok()?;
+    let content = truncate_to_max_bytes(raw, max_bytes);
     if content.trim().is_empty() {
         return None;
     }
@@ -111,32 +149,54 @@ fn read_doc_at(path: PathBuf, layer: DocLayer) -> Option<ProjectDoc> {
 }
 
 /// Walk a filename priority chain under `base`, returning the first match.
-fn first_priority_doc(base: &Path, chain: &[&str], layer: DocLayer) -> Option<ProjectDoc> {
+fn first_priority_doc(
+    base: &Path,
+    chain: &[&str],
+    layer: DocLayer,
+    max_bytes: usize,
+) -> Option<ProjectDoc> {
     chain
         .iter()
-        .find_map(|relative| read_doc_at(base.join(relative), layer))
+        .find_map(|relative| read_doc_at(base.join(relative), layer, max_bytes))
 }
 
 /// Single-directory priority loader (#55).
 ///
 /// Walks [`DOC_FILENAME_PRIORITY`] in order under `cwd` and returns the first
 /// readable, non-empty doc. I/O errors fall through silently per the
-/// [`ProjectDocLoader`] contract.
+/// [`ProjectDocLoader`] contract. Doc bodies are truncated at `max_bytes`
+/// line-boundaries (#58, default [`DEFAULT_PROJECT_DOC_MAX_BYTES`]).
 ///
-/// Multi-layer merge (#56), upward search (#57), and byte-cap truncation
-/// (#58) are intentionally out of scope here.
-#[derive(Debug, Default, Clone, Copy)]
-pub struct PriorityProjectDocLoader;
+/// Multi-layer merge is provided by [`LayeredProjectDocLoader`] (#56).
+#[derive(Debug, Clone)]
+pub struct PriorityProjectDocLoader {
+    max_bytes: usize,
+}
+
+impl Default for PriorityProjectDocLoader {
+    fn default() -> Self {
+        Self {
+            max_bytes: DEFAULT_PROJECT_DOC_MAX_BYTES,
+        }
+    }
+}
+
+impl PriorityProjectDocLoader {
+    /// Construct a loader with a custom per-doc byte cap (#58).
+    pub fn with_max_bytes(max_bytes: usize) -> Self {
+        Self { max_bytes }
+    }
+}
 
 impl ProjectDocLoader for PriorityProjectDocLoader {
     fn load(&self, cwd: &Path) -> Vec<ProjectDoc> {
-        first_priority_doc(cwd, DOC_FILENAME_PRIORITY, DocLayer::Cwd)
+        first_priority_doc(cwd, DOC_FILENAME_PRIORITY, DocLayer::Cwd, self.max_bytes)
             .map(|doc| vec![doc])
             .unwrap_or_default()
     }
 }
 
-/// 3-layer merge loader (#56).
+/// 3-layer merge loader (#56) with per-doc byte cap (#58).
 ///
 /// Emits up to 3 docs in load order: `UserGlobal` → `Project` → `Cwd`.
 /// Each layer reuses [`DOC_FILENAME_PRIORITY`] (or
@@ -147,21 +207,42 @@ impl ProjectDocLoader for PriorityProjectDocLoader {
 ///
 /// `user_home` and `project_root` are optional so callers can disable the
 /// upper layers without composing a different loader (e.g. ephemeral /
-/// non-repo `cwd`s in tests). Recursive upward search to find
-/// `project_root` is the responsibility of issue #57.
-#[derive(Debug, Default, Clone)]
+/// non-repo `cwd`s in tests).
+#[derive(Debug, Clone)]
 pub struct LayeredProjectDocLoader {
     user_home: Option<PathBuf>,
     project_root: Option<PathBuf>,
+    max_bytes: usize,
+}
+
+impl Default for LayeredProjectDocLoader {
+    fn default() -> Self {
+        Self {
+            user_home: None,
+            project_root: None,
+            max_bytes: DEFAULT_PROJECT_DOC_MAX_BYTES,
+        }
+    }
 }
 
 impl LayeredProjectDocLoader {
     /// Construct a layered loader with explicit user-home and project-root paths.
+    ///
+    /// Uses [`DEFAULT_PROJECT_DOC_MAX_BYTES`] as the per-doc byte cap; call
+    /// [`Self::with_max_bytes`] to override.
     pub fn new(user_home: Option<PathBuf>, project_root: Option<PathBuf>) -> Self {
         Self {
             user_home,
             project_root,
+            max_bytes: DEFAULT_PROJECT_DOC_MAX_BYTES,
         }
+    }
+
+    /// Override the per-doc byte cap (#58).
+    #[must_use]
+    pub fn with_max_bytes(mut self, max_bytes: usize) -> Self {
+        self.max_bytes = max_bytes;
+        self
     }
 }
 
@@ -170,23 +251,34 @@ impl ProjectDocLoader for LayeredProjectDocLoader {
         let mut docs = Vec::with_capacity(3);
 
         let user_doc = self.user_home.as_deref().and_then(|home| {
-            first_priority_doc(home, USER_GLOBAL_FILENAME_PRIORITY, DocLayer::UserGlobal)
+            first_priority_doc(
+                home,
+                USER_GLOBAL_FILENAME_PRIORITY,
+                DocLayer::UserGlobal,
+                self.max_bytes,
+            )
         });
         if let Some(doc) = user_doc {
             docs.push(doc);
         }
 
-        let project_doc = self
-            .project_root
-            .as_deref()
-            .and_then(|root| first_priority_doc(root, DOC_FILENAME_PRIORITY, DocLayer::Project));
+        let project_doc = self.project_root.as_deref().and_then(|root| {
+            first_priority_doc(
+                root,
+                DOC_FILENAME_PRIORITY,
+                DocLayer::Project,
+                self.max_bytes,
+            )
+        });
         if let Some(doc) = project_doc {
             docs.push(doc);
         }
 
         let cwd_is_project_root = self.project_root.as_deref() == Some(cwd);
         if !cwd_is_project_root {
-            if let Some(doc) = first_priority_doc(cwd, DOC_FILENAME_PRIORITY, DocLayer::Cwd) {
+            if let Some(doc) =
+                first_priority_doc(cwd, DOC_FILENAME_PRIORITY, DocLayer::Cwd, self.max_bytes)
+            {
                 docs.push(doc);
             }
         }
@@ -223,7 +315,7 @@ mod tests {
         write(tmp.path(), ".dasclaw/AGENTS.md", "dasclaw-body");
         write(tmp.path(), ".codex/AGENTS.md", "codex-body");
 
-        let docs = PriorityProjectDocLoader.load(tmp.path());
+        let docs = PriorityProjectDocLoader::default().load(tmp.path());
 
         assert_eq!(docs.len(), 1);
         assert_eq!(docs[0].content, "agents-body");
@@ -237,7 +329,7 @@ mod tests {
         let tmp = tempdir().unwrap();
         write(tmp.path(), "CLAUDE.md", "claude-body");
 
-        let docs = PriorityProjectDocLoader.load(tmp.path());
+        let docs = PriorityProjectDocLoader::default().load(tmp.path());
 
         assert_eq!(docs.len(), 1);
         assert_eq!(docs[0].content, "claude-body");
@@ -249,7 +341,7 @@ mod tests {
         let tmp = tempdir().unwrap();
         write(tmp.path(), ".dasclaw/AGENTS.md", "dasclaw-body");
 
-        let docs = PriorityProjectDocLoader.load(tmp.path());
+        let docs = PriorityProjectDocLoader::default().load(tmp.path());
 
         assert_eq!(docs.len(), 1);
         assert_eq!(docs[0].content, "dasclaw-body");
@@ -261,7 +353,7 @@ mod tests {
         let tmp = tempdir().unwrap();
         write(tmp.path(), ".codex/AGENTS.md", "codex-body");
 
-        let docs = PriorityProjectDocLoader.load(tmp.path());
+        let docs = PriorityProjectDocLoader::default().load(tmp.path());
 
         assert_eq!(docs.len(), 1);
         assert_eq!(docs[0].content, "codex-body");
@@ -274,7 +366,7 @@ mod tests {
         write(tmp.path(), ".dasclaw/AGENTS.md", "dasclaw-body");
         write(tmp.path(), ".codex/AGENTS.md", "codex-body");
 
-        let docs = PriorityProjectDocLoader.load(tmp.path());
+        let docs = PriorityProjectDocLoader::default().load(tmp.path());
 
         assert_eq!(docs.len(), 1);
         assert_eq!(docs[0].content, "dasclaw-body");
@@ -286,7 +378,7 @@ mod tests {
         write(tmp.path(), ".dasclaw/AGENTS.md", "dasclaw-body");
         write(tmp.path(), "CLAUDE.md", "claude-body");
 
-        let docs = PriorityProjectDocLoader.load(tmp.path());
+        let docs = PriorityProjectDocLoader::default().load(tmp.path());
 
         assert_eq!(docs.len(), 1);
         assert_eq!(docs[0].content, "dasclaw-body");
@@ -297,7 +389,7 @@ mod tests {
     fn req_project_docs_55_returns_empty_when_no_docs_present() {
         let tmp = tempdir().unwrap();
 
-        let docs = PriorityProjectDocLoader.load(tmp.path());
+        let docs = PriorityProjectDocLoader::default().load(tmp.path());
 
         assert!(docs.is_empty());
     }
@@ -308,7 +400,7 @@ mod tests {
         write(tmp.path(), "AGENTS.md", "   \n\t\n");
         write(tmp.path(), "CLAUDE.md", "claude-body");
 
-        let docs = PriorityProjectDocLoader.load(tmp.path());
+        let docs = PriorityProjectDocLoader::default().load(tmp.path());
 
         assert_eq!(docs.len(), 1);
         assert_eq!(docs[0].content, "claude-body");
@@ -317,7 +409,8 @@ mod tests {
 
     #[test]
     fn req_project_docs_55_missing_directory_returns_empty_without_panic() {
-        let docs = PriorityProjectDocLoader.load(Path::new("/nonexistent/x-claw-test-path"));
+        let docs =
+            PriorityProjectDocLoader::default().load(Path::new("/nonexistent/x-claw-test-path"));
         assert!(docs.is_empty());
     }
 
@@ -475,5 +568,112 @@ mod tests {
         assert_eq!(docs[0].layer, DocLayer::Project);
         assert_eq!(docs[0].content, "claude-project");
         assert_eq!(docs[0].source_path, project.path().join("CLAUDE.md"));
+    }
+
+    // -------------------- #58 max_bytes truncation --------------------
+
+    fn make_lined_body(line_count: usize, line_body: &str) -> String {
+        let mut s = String::new();
+        for _ in 0..line_count {
+            s.push_str(line_body);
+            s.push('\n');
+        }
+        s
+    }
+
+    #[test]
+    fn req_project_docs_58_default_cap_is_8_kib() {
+        assert_eq!(DEFAULT_PROJECT_DOC_MAX_BYTES, 8 * 1024);
+    }
+
+    #[test]
+    fn req_project_docs_58_under_cap_returned_verbatim() {
+        let tmp = tempdir().unwrap();
+        // ~5 KiB body of 64-byte lines (64 * 80 = 5120).
+        let body = make_lined_body(80, &"a".repeat(63));
+        assert!(body.len() < DEFAULT_PROJECT_DOC_MAX_BYTES);
+        write(tmp.path(), "AGENTS.md", &body);
+
+        let docs = PriorityProjectDocLoader::default().load(tmp.path());
+
+        assert_eq!(docs.len(), 1);
+        assert_eq!(docs[0].content, body);
+        assert_eq!(docs[0].bytes, body.len());
+    }
+
+    #[test]
+    fn req_project_docs_58_over_cap_truncated_at_line_boundary() {
+        let tmp = tempdir().unwrap();
+        // ~10 KiB body of 64-byte lines: 160 lines * 64 = 10240.
+        let body = make_lined_body(160, &"b".repeat(63));
+        assert!(body.len() > DEFAULT_PROJECT_DOC_MAX_BYTES);
+        write(tmp.path(), "AGENTS.md", &body);
+
+        let docs = PriorityProjectDocLoader::default().load(tmp.path());
+
+        assert_eq!(docs.len(), 1);
+        let content = &docs[0].content;
+        assert!(content.len() <= DEFAULT_PROJECT_DOC_MAX_BYTES);
+        // Last char must be '\n' — i.e. the last surviving line is complete.
+        assert_eq!(content.as_bytes().last().copied(), Some(b'\n'));
+        assert_eq!(docs[0].bytes, content.len());
+    }
+
+    #[test]
+    fn req_project_docs_58_with_max_bytes_override_applied() {
+        let tmp = tempdir().unwrap();
+        // 4 lines of 100 bytes each = 400 bytes; cap to 250 -> exactly 2 lines.
+        let body = make_lined_body(4, &"c".repeat(99));
+        write(tmp.path(), "AGENTS.md", &body);
+
+        let docs = PriorityProjectDocLoader::with_max_bytes(250).load(tmp.path());
+
+        assert_eq!(docs.len(), 1);
+        let content = &docs[0].content;
+        assert!(content.len() <= 250);
+        assert_eq!(content.matches('\n').count(), 2);
+    }
+
+    #[test]
+    fn req_project_docs_58_layered_loader_truncates_each_layer() {
+        let home = tempdir().unwrap();
+        let project = tempdir().unwrap();
+        let body = make_lined_body(4, &"d".repeat(99)); // 400 bytes
+        write(home.path(), ".dasclaw/AGENTS.md", &body);
+        write(project.path(), "AGENTS.md", &body);
+
+        let loader = LayeredProjectDocLoader::new(
+            Some(home.path().to_path_buf()),
+            Some(project.path().to_path_buf()),
+        )
+        .with_max_bytes(150); // 1 line of 100 bytes fits, 2nd would overflow
+
+        let docs = loader.load(project.path());
+
+        assert_eq!(docs.len(), 2);
+        for doc in &docs {
+            assert!(doc.content.len() <= 150);
+            assert_eq!(doc.content.matches('\n').count(), 1);
+        }
+    }
+
+    #[test]
+    fn req_project_docs_58_single_line_over_cap_keeps_utf8_boundary() {
+        let tmp = tempdir().unwrap();
+        // 4-byte UTF-8 char repeated -> 100 chars * 4 bytes = 400 bytes, no '\n'.
+        let body = "🦀".repeat(100);
+        assert_eq!(body.len(), 400);
+        write(tmp.path(), "AGENTS.md", &body);
+
+        let docs = PriorityProjectDocLoader::with_max_bytes(150).load(tmp.path());
+
+        assert_eq!(docs.len(), 1);
+        let content = &docs[0].content;
+        assert!(content.len() <= 150);
+        // Must remain valid UTF-8 (round-trip without panic).
+        let _: &str = content.as_str();
+        // 150 / 4 = 37.5 → 37 crabs → 148 bytes.
+        assert_eq!(content.chars().count(), 37);
+        assert_eq!(content.len(), 148);
     }
 }

--- a/docs/plans/architecture-refactor/31-target-architecture.md
+++ b/docs/plans/architecture-refactor/31-target-architecture.md
@@ -182,7 +182,7 @@ flowchart TB
 - **永不**直接升级 fork 到 0.26（与 ADR-101 §136 一致；38 §137 已实证升级风险高 30k+ LOC + 5 migration）
 
 ### ADR-106：项目级文档统一为 AGENTS.md 协议
-**决策**：新建 `dasclaw_project_docs` crate，统一加载优先级：`AGENTS.md` > `CLAUDE.md` > `.codex/agents.md` > project config。多层合并：user 全局 → project 项目级 → cwd 覆盖，与 codex `project_doc_max_bytes` 机制一致。
+**决策**：新建 `dasclaw_project_docs` crate，统一加载优先级（同目录内）：`AGENTS.md` > `.dasclaw/AGENTS.md` > `CLAUDE.md` > `.codex/AGENTS.md` > project config。多层合并：user 全局 → project 项目级 → cwd 覆盖，与 codex `project_doc_max_bytes` 机制一致。`.dasclaw/AGENTS.md` 为 x-claw 项目命名空间主写位（issue #99/#100 已固定，**优先于第三方惯例 `CLAUDE.md`**），`.codex/AGENTS.md` 仅作 codex-fork 兼容只读回退。
 **理由**：
 - 30 v2 §G 事实：desktop-client 完全不加载项目级文档（grep ipc/ 无项目文档加载），与 codex/claw 生态不互通。
 - AGENTS.md 已是业界事实标准（OpenAI / Anthropic / Cursor / Aider 等都采用），CLAUDE.md 为 Anthropic 生态别名。


### PR DESCRIPTION
## 背景 / 目标

W3 任务 3.5：单层 `max_bytes` 截断（默认 8 KiB，按行），与 codex `project_doc_max_bytes` 对齐。

## 改动范围

- `crates/dasclaw_project_docs/src/lib.rs`：
  - 新增 `pub const DEFAULT_PROJECT_DOC_MAX_BYTES: usize = 8 * 1024`
  - 新增 `truncate_to_max_bytes(content, max_bytes) -> String`：按 `\n` 切完整行；单行超长 fallback 到 `char_boundary` 截断（保 UTF-8 不 panic）
  - `read_doc_at` 加 `max_bytes` 参数，截断在 trim-empty 检查之前
  - `PriorityProjectDocLoader`:unit struct → `{ max_bytes }`，新增 `Default`（8 KiB）+ `with_max_bytes(n)` builder
  - `LayeredProjectDocLoader` 增 `max_bytes` 字段 + `with_max_bytes(n)` builder（保留原 `new(...)` 签名，默认 8 KiB）
  - 模块 doc 注释更新：标注 #57 已关闭（obsolete by sandbox model）
- 测试调用 `PriorityProjectDocLoader.load(...)` → `PriorityProjectDocLoader::default().load(...)`

## 非目标（What's NOT in this PR）

- ❌ #57 上行 walk-up（已关闭：desktop-client 显式 workspace_root 模型不需要）
- ❌ #59 OnSessionStart hook 注入
- ❌ 调用方接入：本 PR 仅在 crate 内提供能力，consumer wiring 由后续 PR 落地
- ❌ 多层 max_bytes 总量上限（codex 也只做单文件 cap，符合本 issue 范围）

## 验证

```bash
cargo nextest run -p dasclaw_project_docs  # 29/29 pass（含 6 个新增 #58 测试）
cargo clippy --no-deps -p dasclaw_project_docs --all-targets -- -D warnings  # clean
python3.12 scripts/check_no_panics.py --base origin/xClaw  # OK
cargo fmt --all  # clean
```

新增测试：
- `req_project_docs_58_default_cap_is_8_kib` —— 默认 8 KiB 锁定
- `req_project_docs_58_under_cap_returned_verbatim` —— 5 KiB 原样保留
- `req_project_docs_58_over_cap_truncated_at_line_boundary` —— 10 KiB → ≤ 8 KiB，最后字节必为 `\n`
- `req_project_docs_58_with_max_bytes_override_applied` —— `with_max_bytes(250)` → 恰 2 行（100B × 2 = 200B 适合，第三行会爆）
- `req_project_docs_58_layered_loader_truncates_each_layer` —— Layered 双层各自截断
- `req_project_docs_58_single_line_over_cap_keeps_utf8_boundary` —— `🦀 × 100`（4 字节 UTF-8）单行超长，回退到 `char_boundary` 不 panic

## Stacked PR 信息

- **Base**: `feat/w3-56-layered-project-doc-loader`（PR #102），**不是 `xClaw`**
- **Merge 顺序**：先 #101 → #102 → 本 PR
- **建议 review 顺序**：先看 #101，再 #102，最后本 PR

## Skill 自审摘要

- **code-quality-audit**: 无补丁式代码（新增字段 + builder，非 if-flag 切换）；新 helper `truncate_to_max_bytes` 单一职责；行数 `read_doc_at` 19 行 / `truncate_to_max_bytes` 21 行，均 < 50；嵌套深度 ≤ 2；零 unwrap/expect/panic（`assert!` 仅在 `#[cfg(test)]` 出现）
- **code-simplifier**: helper 命名清晰；UTF-8 fallback 用 `is_char_boundary` 单点循环替代手工 codepoint scan；reuse `read_doc_at` + `first_priority_doc` 在两 loader 间零重复
- **code-review-expert**: SOLID — 截断职责放在 `read_doc_at` 单点，符合 SRP；`max_bytes` 通过依赖注入而非全局，符合 OCP；安全 — 不 panic on 任何文件大小或编码；性能 — `split_inclusive` 是 O(n) 一遍过；契约 — `bytes` 字段始终等于 `content.len()`（截断后），doc 注释已强调

## 后续步骤

- **#59** OnSessionStart hook 注入（本 PR 直接 stack）
- **下游接入**：在 W3 后续阶段把 `LayeredProjectDocLoader` 接入 desktop-client session 启动路径

Closes #58
