### PR TITLE
feat(project-docs): add assemble_section helper (Closes #59)

### DIFF
--- a/crates/dasclaw_project_docs/src/lib.rs
+++ b/crates/dasclaw_project_docs/src/lib.rs
@@ -5,7 +5,11 @@
 //! - #56: 3-layer merge (user / project / cwd)
 //! - #57: recursive upward search to repo root / `$HOME`
 //! - #58: `max_bytes` truncation
-//! - #59: `OnSessionStart` hook injection
+//! - #59 (#59a): `assemble_section` helper — joins layered docs into a
+//!   single `system_prompt` section. Loaded into the prompt at session
+//!   construction time via constructor DI per
+//!   [ADR-115](../../docs/plans/architecture-refactor/adr-115-project-docs-not-in-hook.md);
+//!   never enters the `dasclaw_hooks` system.
 //!
 //! See `docs/plans/architecture-refactor/31-target-architecture.md` §4 and
 //! `32-execution-plan.md` W3 task 3 for the full design.
@@ -118,6 +122,43 @@ impl ProjectDocLoader for PriorityProjectDocLoader {
         }
         Vec::new()
     }
+}
+
+/// Separator inserted between adjacent project-doc fragments when assembling
+/// them into a single `system_prompt` section.
+///
+/// Locked to codex `agents_md.rs::AGENTS_MD_SEPARATOR` so prompt diffs across
+/// `x-claw`, `codex` and `claw-code` stay readable side-by-side.
+pub const PROJECT_DOC_SEPARATOR: &str = "\n\n--- project-doc ---\n\n";
+
+/// Assemble multi-layer project docs into a single `system_prompt` section.
+///
+/// Behaviour (locked by `tests/assemble_section.rs`):
+///
+/// - Returns `None` when `docs` is empty or every fragment has empty content
+///   (so callers never emit an orphan separator into the prompt).
+/// - Preserves the input order — the [`ProjectDocLoader`] trait already
+///   defines load-priority ordering, and re-sorting here would silently
+///   override caller-side composition (e.g. cwd overrides).
+/// - Skips blank fragments mid-list rather than dropping the whole section,
+///   so a missing project-layer doc doesn't create two adjacent separators.
+/// - Does not re-truncate `content`; truncation is `max_bytes`'s job (#58).
+///
+/// Per [ADR-115](../../docs/plans/architecture-refactor/adr-115-project-docs-not-in-hook.md)
+/// this helper is invoked at session-construction time via constructor DI;
+/// it must not be wired into the `dasclaw_hooks` system.
+pub fn assemble_section(docs: &[ProjectDoc]) -> Option<String> {
+    let parts: Vec<&str> = docs
+        .iter()
+        .map(|d| d.content.as_str())
+        .filter(|content| !content.is_empty())
+        .collect();
+
+    if parts.is_empty() {
+        return None;
+    }
+
+    Some(parts.join(PROJECT_DOC_SEPARATOR))
 }
 
 #[cfg(test)]

--- a/crates/dasclaw_project_docs/tests/assemble_section.rs
+++ b/crates/dasclaw_project_docs/tests/assemble_section.rs
@@ -1,0 +1,96 @@
+//! W3 issue #59a — `assemble_section` helper contract.
+//!
+//! Locks the assembly behaviour of multi-layer project docs into a single
+//! string suitable for injection into the LLM `system_prompt` after the
+//! dynamic boundary. See [ADR-115](../../docs/plans/architecture-refactor/adr-115-project-docs-not-in-hook.md):
+//! this helper is invoked at session-construction time via constructor DI;
+//! it never enters the `dasclaw_hooks` system.
+//!
+//! The separator and ordering match codex `agents_md.rs::AGENTS_MD_SEPARATOR`
+//! (`"\n\n--- project-doc ---\n\n"`) so cross-tool prompt diffs stay readable.
+
+use std::path::PathBuf;
+
+use dasclaw_project_docs::{assemble_section, DocLayer, ProjectDoc, PROJECT_DOC_SEPARATOR};
+
+fn doc(layer: DocLayer, path: &str, content: &str) -> ProjectDoc {
+    ProjectDoc {
+        content: content.to_string(),
+        source_path: PathBuf::from(path),
+        layer,
+        bytes: content.len(),
+    }
+}
+
+#[test]
+fn req_project_docs_59a_separator_matches_codex() {
+    // Locked to codex `AGENTS_MD_SEPARATOR` for cross-tool diff readability.
+    assert_eq!(PROJECT_DOC_SEPARATOR, "\n\n--- project-doc ---\n\n");
+}
+
+#[test]
+fn req_project_docs_59a_empty_slice_returns_none() {
+    // Avoid emitting a stray separator or empty section into the prompt.
+    assert!(assemble_section(&[]).is_none());
+}
+
+#[test]
+fn req_project_docs_59a_only_blank_content_returns_none() {
+    // Blank-content docs (e.g. file existed but was empty after truncation)
+    // must not produce orphan separators.
+    let docs = [doc(DocLayer::UserGlobal, "/u/AGENTS.md", "")];
+    assert!(assemble_section(&docs).is_none());
+}
+
+#[test]
+fn req_project_docs_59a_single_doc_returns_content_verbatim() {
+    // No separator should be added when there is exactly one fragment.
+    let docs = [doc(DocLayer::Project, "/p/AGENTS.md", "be helpful")];
+    assert_eq!(assemble_section(&docs).as_deref(), Some("be helpful"));
+}
+
+#[test]
+fn req_project_docs_59a_three_layer_merge_preserves_input_order() {
+    // The trait contract states `load()` returns docs in load-priority order;
+    // assembly must preserve that order rather than re-sorting by `DocLayer`,
+    // since callers may have already trimmed/reordered (e.g. cwd overrides).
+    let docs = [
+        doc(DocLayer::UserGlobal, "/u/AGENTS.md", "global"),
+        doc(DocLayer::Project, "/p/AGENTS.md", "project"),
+        doc(DocLayer::Cwd, "/p/sub/AGENTS.md", "cwd"),
+    ];
+    let expected = format!("global{sep}project{sep}cwd", sep = PROJECT_DOC_SEPARATOR);
+    assert_eq!(assemble_section(&docs).as_deref(), Some(expected.as_str()));
+}
+
+#[test]
+fn req_project_docs_59a_blank_fragments_are_skipped_not_dropped_around() {
+    // A blank middle fragment must not produce two adjacent separators
+    // (which would confuse the model with empty section headers).
+    let docs = [
+        doc(DocLayer::UserGlobal, "/u/AGENTS.md", "global"),
+        doc(DocLayer::Project, "/p/AGENTS.md", ""),
+        doc(DocLayer::Cwd, "/p/sub/AGENTS.md", "cwd"),
+    ];
+    let expected = format!("global{sep}cwd", sep = PROJECT_DOC_SEPARATOR);
+    assert_eq!(assemble_section(&docs).as_deref(), Some(expected.as_str()));
+}
+
+#[test]
+fn req_project_docs_59a_truncated_content_still_assembles() {
+    // After #58 truncation the `content` may end mid-sentence; `assemble_section`
+    // must not assert on byte-shape and must not re-truncate.
+    let truncated = "a".repeat(8 * 1024);
+    let docs = [doc(DocLayer::Project, "/p/AGENTS.md", &truncated)];
+    let out = assemble_section(&docs).expect("non-empty input must assemble");
+    assert_eq!(out.len(), 8 * 1024);
+}
+
+#[test]
+fn req_project_docs_59a_only_cwd_layer_returns_content_verbatim() {
+    // When only the cwd layer is loaded (e.g. user has no global AGENTS.md
+    // and the loader skipped project layer), output must equal that content
+    // without any separator prefix/suffix.
+    let docs = [doc(DocLayer::Cwd, "/work/AGENTS.md", "cwd-only")];
+    assert_eq!(assemble_section(&docs).as_deref(), Some("cwd-only"));
+}


### PR DESCRIPTION
## 背景 / 目标

实现 `dasclaw_project_docs::assemble_section(&[ProjectDoc]) -> Option<String>` helper：把多层项目文档（user_global / project / cwd）拼装成一段可注入到 LLM `system_prompt`（dynamic boundary 之后）的字符串。

按 [ADR-115](docs/plans/architecture-refactor/adr-115-project-docs-not-in-hook.md)：本 helper 由 `SessionManager` 在 session 创建时**构建期 DI** 直接调用，**完全不进 `dasclaw_hooks` 系统**。session 内不可变（与 codex / claw-code / ironclaw 三参考库一致）。

Closes #59

## 改动范围

- `crates/dasclaw_project_docs/src/lib.rs`：
  - 新增 `pub const PROJECT_DOC_SEPARATOR: &str = "\n\n--- project-doc ---\n\n"`（与 codex `AGENTS_MD_SEPARATOR` 锁定一致）
  - 新增 `pub fn assemble_section(docs: &[ProjectDoc]) -> Option<String>`
  - 模块文档：路线指针由"#59 OnSessionStart hook injection"改为"#59a assemble_section helper + ADR-115"
- `crates/dasclaw_project_docs/tests/assemble_section.rs`（新文件，8 个 `req_project_docs_59a_*` 测试）

## 路线说明（与 issue 原文偏差）

issue body 写"`pub fn assemble_section(doc: &LayeredProjectDoc) -> Option<String>`"，但实际代码库当前状态：
- `LayeredProjectDoc` 类型尚未存在（`#55-#58` 未合并）
- 当前公开 surface 是 `ProjectDocLoader::load(&self, cwd: &Path) -> Vec<ProjectDoc>`

因此 helper 签名落地为 `&[ProjectDoc]`（`load()` 输出的自然消费类型），与 issue 意图等价。`#55-#58` 后续若引入 `LayeredProjectDoc` 包装类型，可在其上加便捷方法 `to_section()` 内部调用本 helper，无需改动本 helper 公共契约。

## 行为契约（由测试锁定）

| 输入 | 输出 |
|---|---|
| `&[]` | `None` |
| 全 `content == ""` | `None` |
| 单条非空 | 该 content 原样（无分隔符） |
| 多条（含中间空条） | 跳过空条后用 `PROJECT_DOC_SEPARATOR` join |
| 已截断 content（#58） | 不再截断，原样拼装 |

输入顺序保留（由 `ProjectDocLoader::load()` 契约定义为 load-priority），不重新排序。

## 非目标 (What's NOT in this PR)

- 不接入 SessionManager / agentic_loop（#111 = #59b）
- 不实现 `LayeredProjectDoc` 类型（#56 / #58）
- 不动 `dasclaw_hooks` crate
- 不在 `dasclaw_project_docs/Cargo.toml` 添加 `dasclaw_hooks` 依赖（ADR-115 §4.1 禁止）
- 不动 issue body / ADR 文档（已在 PR #112 完成）

## 验证

```bash
cargo nextest run -p dasclaw_project_docs
# 13 tests run: 13 passed, 0 skipped (8 new + 5 existing)

cargo clippy --no-deps -p dasclaw_project_docs --all-targets -- -D warnings
# Finished — no warnings

cargo fmt --all
python3.12 scripts/check_no_panics.py --base origin/xClaw
# OK: No panic-inducing calls in changed production code.
```

## Cross-cuts

- **ADR-114 类 A**：本 PR 无新增 `.ironclaw` 字面量
- **ADR-115**：纯 helper，不进 hook 系统；不在 Cargo.toml 增加 hooks 依赖
- 不依赖 PR #112（ADR-115 文档）合并先后

## 后续

- #111 (#59b)：SessionManager 构建期 DI 注入 — 消费本 helper
- 当 `LayeredProjectDoc` 包装类型在 #56 / #58 引入时，可加便捷方法 `to_section()`
