### PR TITLE
ci(closes-link): exempt ADR-only PRs (Closes #116)

### DIFF
--- a/.github/workflows/pr-closes-issue-check.yml
+++ b/.github/workflows/pr-closes-issue-check.yml
@@ -6,13 +6,38 @@ on:
 
 permissions:
   pull-requests: read
+  contents: read
 
 jobs:
   closes-link:
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false
     steps:
+      - name: Detect ADR-only PR (exempt from closes-link)
+        id: exempt
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          # ADR docs are reference material referenced by other PRs, not implementation
+          # of trackable issues. Exempt PRs whose changes are entirely under
+          # docs/plans/architecture-refactor/adr-*.md from the closes-link check.
+          files=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/files" --paginate --jq '.[].filename')
+          if [ -z "$files" ]; then
+            echo "exempt=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          non_adr=$(printf '%s\n' "$files" | grep -vE '^docs/plans/architecture-refactor/adr-.*\.md$' || true)
+          if [ -z "$non_adr" ]; then
+            echo "All changed files are ADR docs; exempting from closes-link check."
+            echo "exempt=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exempt=false" >> "$GITHUB_OUTPUT"
+          fi
       - name: Require Closes/Fixes/Resolves #N in PR body
+        if: steps.exempt.outputs.exempt != 'true'
         env:
           BODY: ${{ github.event.pull_request.body }}
         run: |


### PR DESCRIPTION
## 背景 / 目标

`pr-closes-issue-check.yml` 工作流要求每个 PR body 必须包含 `Closes/Fixes/Resolves #<issue>`，让 board 状态机能在合并时推进。

但纯 ADR 文档 PR（#104 ADR-114、#112 ADR-115）是被其他实现 PR 引用的**源材料**，不是某个 tracking issue 的实现，因此不存在可以 `Closes` 的 issue，CI 必然红。

Closes #116

## 改动范围

- `.github/workflows/pr-closes-issue-check.yml`
  - 新增 pre-step：调用 GitHub API `repos/{owner}/{repo}/pulls/{pr}/files` 获取 PR 文件列表
  - 若全部文件匹配 `docs/plans/architecture-refactor/adr-.*\.md` 正则，则把 `exempt=true` 写到 step output
  - 原 `Require Closes/Fixes/Resolves` step 加 `if: steps.exempt.outputs.exempt != 'true'`
- 在 `permissions` 加 `contents: read`（gh api 需要）

## 非目标（What's NOT in this PR）

- ❌ 修改混合 PR（ADR + 代码）的检查（仍要求 Closes #N）
- ❌ 修改其他 docs 路径的豁免（仅限 ADR 路径，约束最小化）
- ❌ 直接给 #104 / #112 加 `Closes`（治标不治本）

## 验证

- 本地 yamllint 干净（无新增语法）
- CI 自检：本 PR 自身**不**全部位于 ADR 路径（改 `.github/workflows/`），所以 closes-link 仍会要求 `Closes #N` → body 已含 `Closes #116`
- 合并后效果：#104 / #112 触发 `synchronize` 或 `edited` 后会被新逻辑放行

## 风险 / 后续步骤

- 风险：`gh api` 在缺权限时会失败 → 已显式声明 `permissions: contents: read`
- 后续：合并后人工触发 #104 / #112 的 closes-link 重跑（push 空 commit 或 edit body 任意字符）

## Skill 自审

- code-quality-audit: 单一职责（豁免判定），无补丁式逻辑；shell `grep -vE` + `[ -z ]` 简洁清晰；无新增依赖
- code-review-expert: 安全 — `permissions` 仅 read；`gh api` 输出经 `--jq` 过滤；正则锚定 `^...$` 防止路径欺骗；fallback `[ -z "$files" ]` 时不豁免（fail-safe）
