### PR TITLE
feat(migration): dasclaw migrate subcommand (ADR-114 B-II)

### DIFF
--- a/desktop-client/ironclaw/src/cli/migrate.rs
+++ b/desktop-client/ironclaw/src/cli/migrate.rs
@@ -1,0 +1,84 @@
+//! `dasclaw migrate` CLI subcommand — ADR-114 B-Ⅱ (issue #107).
+//!
+//! Thin wrapper over [`crate::migration`] that resolves the user's home
+//! directory and prints a human-readable summary.
+
+use clap::Args;
+
+use crate::migration::{self, MigrateOptions, MigrationReport};
+
+#[derive(Args, Debug, Clone)]
+pub struct MigrateCommand {
+    /// Print the migration plan without writing anything to disk.
+    #[arg(long)]
+    pub dry_run: bool,
+
+    /// Re-run even when the destination already carries the migration marker.
+    /// Existing destination files are *still* never overwritten — `--force`
+    /// only resumes filling in gaps from the legacy directory.
+    #[arg(long)]
+    pub force: bool,
+}
+
+pub fn run_migrate_command(cmd: MigrateCommand) -> anyhow::Result<()> {
+    let home =
+        dirs::home_dir().ok_or_else(|| anyhow::anyhow!("could not determine home directory"))?;
+
+    let opts = MigrateOptions {
+        dry_run: cmd.dry_run,
+        force: cmd.force,
+    };
+    let report = migration::migrate(&home, opts)?;
+    print_report(&report);
+    Ok(())
+}
+
+fn print_report(report: &MigrationReport) {
+    let mode = if report.dry_run { "[dry-run] " } else { "" };
+    println!(
+        "{mode}migrate: {} -> {}",
+        report.source.display(),
+        report.destination.display()
+    );
+
+    if report.source_missing {
+        println!("  source does not exist; nothing to migrate");
+        return;
+    }
+    if report.already_migrated {
+        println!(
+            "  destination already carries `{}`; pass --force to resume",
+            migration::MIGRATED_MARKER
+        );
+        return;
+    }
+
+    println!("  copied: {} file(s)", report.copied.len());
+    for path in &report.copied {
+        println!("    + {}", path.display());
+    }
+    if !report.skipped_existing.is_empty() {
+        println!(
+            "  skipped (destination already has them): {} file(s)",
+            report.skipped_existing.len()
+        );
+        for path in &report.skipped_existing {
+            println!("    = {}", path.display());
+        }
+    }
+    if report.dry_run {
+        println!("  (dry-run: no files were written)");
+    } else {
+        println!(
+            "  marker written to {}",
+            report
+                .destination
+                .join(migration::MIGRATED_MARKER)
+                .display()
+        );
+        println!(
+            "  legacy directory preserved at {} — delete manually when ready",
+            report.source.display()
+        );
+    }
+}

--- a/desktop-client/ironclaw/src/cli/mod.rs
+++ b/desktop-client/ironclaw/src/cli/mod.rs
@@ -25,6 +25,7 @@ pub mod import;
 mod logs;
 mod mcp;
 pub mod memory;
+mod migrate;
 mod models;
 pub mod oauth_defaults;
 mod pairing;
@@ -46,6 +47,7 @@ pub use logs::{LogsCommand, run_logs_command};
 pub use mcp::{McpCommand, run_mcp_command};
 pub use memory::MemoryCommand;
 pub use memory::run_memory_command_with_db;
+pub use migrate::{MigrateCommand, run_migrate_command};
 pub use models::{ModelsCommand, run_models_command};
 pub use pairing::{PairingCommand, run_pairing_command, run_pairing_command_with_store};
 pub use registry::{RegistryCommand, run_registry_command};
@@ -247,6 +249,13 @@ pub enum Command {
         long_about = "Displays health and diagnostics info.\nExample: ironclaw status"
     )]
     Status,
+
+    /// Migrate legacy `~/.ironclaw/` data into `~/.dasclaw/` (ADR-114 B-Ⅱ).
+    #[command(
+        about = "Migrate ~/.ironclaw -> ~/.dasclaw",
+        long_about = "Copies files from the legacy ~/.ironclaw directory into ~/.dasclaw.\nNever overwrites existing destination files; safe to re-run.\nExamples:\n  dasclaw migrate --dry-run   # Preview the plan\n  dasclaw migrate             # Copy missing files and write marker\n  dasclaw migrate --force     # Resume after a previous successful run"
+    )]
+    Migrate(MigrateCommand),
 
     /// Generate shell completion scripts
     #[command(

--- a/desktop-client/ironclaw/src/cli/snapshots/ironclaw__cli__tests__help_output_without_import.snap
+++ b/desktop-client/ironclaw/src/cli/snapshots/ironclaw__cli__tests__help_output_without_import.snap
@@ -1,5 +1,5 @@
 ---
-source: src/cli/mod.rs
+source: desktop-client/ironclaw/src/cli/mod.rs
 expression: help
 ---
 Secure personal AI assistant that protects your data and expands its capabilities
@@ -24,6 +24,7 @@ Commands:
   doctor      Run diagnostics
   logs        View and manage gateway logs
   status      Show system status
+  migrate     Migrate ~/.ironclaw -> ~/.dasclaw
   completion  Generate completions
   login       Authenticate with a provider
   help        Print this message or the help of the given subcommand(s)

--- a/desktop-client/ironclaw/src/cli/snapshots/ironclaw__cli__tests__long_help_output_without_import.snap
+++ b/desktop-client/ironclaw/src/cli/snapshots/ironclaw__cli__tests__long_help_output_without_import.snap
@@ -1,5 +1,5 @@
 ---
-source: src/cli/mod.rs
+source: desktop-client/ironclaw/src/cli/mod.rs
 expression: help
 ---
 IronClaw is a secure AI assistant. Use 'ironclaw <subcommand> --help' for details.
@@ -27,6 +27,7 @@ Commands:
   doctor      Run diagnostics
   logs        View and manage gateway logs
   status      Show system status
+  migrate     Migrate ~/.ironclaw -> ~/.dasclaw
   completion  Generate completions
   login       Authenticate with a provider
   help        Print this message or the help of the given subcommand(s)

--- a/desktop-client/ironclaw/src/lib.rs
+++ b/desktop-client/ironclaw/src/lib.rs
@@ -57,6 +57,7 @@ pub mod hook_bootstrap;
 #[cfg(feature = "import")]
 pub mod import;
 pub mod llm;
+pub mod migration;
 pub mod observability;
 pub mod orchestrator;
 pub mod pairing;

--- a/desktop-client/ironclaw/src/main.rs
+++ b/desktop-client/ironclaw/src/main.rs
@@ -156,6 +156,10 @@ async fn async_main() -> anyhow::Result<()> {
             init_cli_tracing();
             return run_status_command().await;
         }
+        Some(Command::Migrate(migrate_cmd)) => {
+            init_cli_tracing();
+            return ironclaw::cli::run_migrate_command(migrate_cmd.clone());
+        }
         Some(Command::Completion(completion)) => {
             init_cli_tracing();
             return completion.run();

--- a/desktop-client/ironclaw/src/migration.rs
+++ b/desktop-client/ironclaw/src/migration.rs
@@ -1,0 +1,462 @@
+//! `~/.ironclaw/` → `~/.dasclaw/` data migration helper.
+//!
+//! Implements ADR-114 §2.2 类 B-Ⅱ (issue #107). Conservative scope for the
+//! first cut:
+//!
+//! * **Copy semantics, never move** — the legacy `~/.ironclaw/` directory is
+//!   preserved as an implicit backup. Users decide when to delete it.
+//! * **Skip-existing on the destination** — files that already exist under
+//!   `~/.dasclaw/` are *never* overwritten; the migrator only fills in gaps.
+//! * **Idempotent** — a `.migrated_from_ironclaw` marker is written into the
+//!   destination once a successful pass completes; re-runs are no-ops unless
+//!   `force` is set.
+//! * **Fail-safe** — any I/O error aborts before the marker is written, so a
+//!   partial copy will be retried on the next invocation.
+//!
+//! Out of scope for this PR (tracked by ADR-114 B-Ⅲ–Ⅴ red-line tickets):
+//!
+//! * macOS Keychain rename (`com.ironclaw.*` → `com.dasclaw.*`) — B-Ⅳ #109.
+//! * Rewriting absolute paths embedded inside config files (e.g. an explicit
+//!   `/Users/x/.ironclaw/...` string in `settings.json`) — separate issue.
+//! * `--symlink` and move modes mentioned in the issue body — deferred until
+//!   the copy path has soaked.
+
+use std::path::{Path, PathBuf};
+
+/// Marker file written to the destination once a successful migration pass
+/// completes. Its presence makes subsequent runs a no-op (unless `force` is
+/// set), which is what makes the helper safe to call from bootstrap.
+pub const MIGRATED_MARKER: &str = ".migrated_from_ironclaw";
+
+/// Caller-controlled options for [`migrate_with_paths`].
+#[derive(Debug, Clone, Copy, Default)]
+pub struct MigrateOptions {
+    /// Compute the report without touching the filesystem.
+    pub dry_run: bool,
+    /// Re-run even when the destination already carries the marker. Still
+    /// **does not** overwrite existing files at the destination — only
+    /// resumes filling gaps.
+    pub force: bool,
+}
+
+/// Outcome of a migration call. Suitable for both human-friendly CLI output
+/// and assertions in tests.
+#[derive(Debug, Clone)]
+pub struct MigrationReport {
+    pub source: PathBuf,
+    pub destination: PathBuf,
+    /// Files copied (or that *would have been* copied in `dry_run`). Paths
+    /// are relative to the source root.
+    pub copied: Vec<PathBuf>,
+    /// Files skipped because the destination already had them. Paths are
+    /// relative to the source root.
+    pub skipped_existing: Vec<PathBuf>,
+    /// True when the source did not exist — treated as success because the
+    /// helper is safe to call unconditionally from bootstrap.
+    pub source_missing: bool,
+    /// True when the destination already carried the marker and `force` was
+    /// not set; the migrator returned without copying anything.
+    pub already_migrated: bool,
+    /// Mirrors [`MigrateOptions::dry_run`] for callers inspecting the report.
+    pub dry_run: bool,
+}
+
+impl MigrationReport {
+    fn new(source: &Path, destination: &Path, dry_run: bool) -> Self {
+        Self {
+            source: source.to_path_buf(),
+            destination: destination.to_path_buf(),
+            copied: Vec::new(),
+            skipped_existing: Vec::new(),
+            source_missing: false,
+            already_migrated: false,
+            dry_run,
+        }
+    }
+}
+
+/// Errors surfaced from the migration helper. Wraps the offending path so the
+/// CLI can render an actionable message.
+#[derive(Debug, thiserror::Error)]
+pub enum MigrationError {
+    #[error("I/O error at {path}: {source}")]
+    Io {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+}
+
+fn io<P: Into<PathBuf>>(path: P) -> impl FnOnce(std::io::Error) -> MigrationError {
+    let path = path.into();
+    move |source| MigrationError::Io { path, source }
+}
+
+/// Migrate `~/.ironclaw/` under `home` into `~/.dasclaw/`.
+///
+/// Convenience wrapper around [`migrate_with_paths`] that derives the legacy
+/// and rebranded directory names from a home directory. Tests prefer the
+/// explicit-path variant so they can target a `tempdir`.
+pub fn migrate(home: &Path, opts: MigrateOptions) -> Result<MigrationReport, MigrationError> {
+    let source = home.join(".ironclaw");
+    let destination = home.join(".dasclaw");
+    migrate_with_paths(&source, &destination, opts)
+}
+
+/// Migrate `source` into `destination`. See module-level docs for the full
+/// contract. Both paths are taken explicitly so tests can drive the helper
+/// against a `tempdir` without mutating `$HOME`.
+pub fn migrate_with_paths(
+    source: &Path,
+    destination: &Path,
+    opts: MigrateOptions,
+) -> Result<MigrationReport, MigrationError> {
+    let mut report = MigrationReport::new(source, destination, opts.dry_run);
+
+    if !source.exists() {
+        report.source_missing = true;
+        return Ok(report);
+    }
+
+    let marker = destination.join(MIGRATED_MARKER);
+    if marker.exists() && !opts.force {
+        report.already_migrated = true;
+        return Ok(report);
+    }
+
+    if !opts.dry_run {
+        std::fs::create_dir_all(destination).map_err(io(destination))?;
+    }
+
+    copy_dir_recursive(source, destination, source, &mut report, opts.dry_run)?;
+
+    if !opts.dry_run {
+        write_marker(&marker, source)?;
+    }
+
+    Ok(report)
+}
+
+fn copy_dir_recursive(
+    src_root: &Path,
+    dst_root: &Path,
+    cur: &Path,
+    report: &mut MigrationReport,
+    dry_run: bool,
+) -> Result<(), MigrationError> {
+    let entries = std::fs::read_dir(cur).map_err(io(cur))?;
+    for entry in entries {
+        let entry = entry.map_err(io(cur))?;
+        let path = entry.path();
+        let dst = remap_path(src_root, dst_root, &path);
+        let rel = relative_to(src_root, &path);
+
+        let file_type = entry.file_type().map_err(io(&path))?;
+        if file_type.is_dir() {
+            if !dry_run {
+                std::fs::create_dir_all(&dst).map_err(io(&dst))?;
+            }
+            copy_dir_recursive(src_root, dst_root, &path, report, dry_run)?;
+        } else if dst.exists() {
+            report.skipped_existing.push(rel);
+        } else {
+            if !dry_run {
+                std::fs::copy(&path, &dst).map_err(io(&dst))?;
+            }
+            report.copied.push(rel);
+        }
+    }
+    Ok(())
+}
+
+fn remap_path(src_root: &Path, dst_root: &Path, path: &Path) -> PathBuf {
+    let rel = path.strip_prefix(src_root).unwrap_or(path);
+    dst_root.join(rel)
+}
+
+fn relative_to(root: &Path, path: &Path) -> PathBuf {
+    path.strip_prefix(root).unwrap_or(path).to_path_buf()
+}
+
+fn write_marker(marker: &Path, source: &Path) -> Result<(), MigrationError> {
+    let body = format!(
+        "Migrated from {} on {}\n",
+        source.display(),
+        chrono::Utc::now().to_rfc3339()
+    );
+    std::fs::write(marker, body).map_err(io(marker))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn write(path: &Path, body: &str) {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).expect("create parent");
+        }
+        std::fs::write(path, body).expect("write file");
+    }
+
+    fn run(src: &Path, dst: &Path, opts: MigrateOptions) -> MigrationReport {
+        migrate_with_paths(src, dst, opts).expect("migrate")
+    }
+
+    #[test]
+    fn req_adr_114_bii_source_missing_is_noop() {
+        let tmp = TempDir::new().unwrap();
+        let src = tmp.path().join(".ironclaw");
+        let dst = tmp.path().join(".dasclaw");
+
+        let report = run(&src, &dst, MigrateOptions::default());
+
+        assert!(report.source_missing);
+        assert!(report.copied.is_empty());
+        assert!(!dst.exists(), "destination should not be created");
+    }
+
+    #[test]
+    fn req_adr_114_bii_copies_files_when_destination_empty() {
+        let tmp = TempDir::new().unwrap();
+        let src = tmp.path().join(".ironclaw");
+        let dst = tmp.path().join(".dasclaw");
+        write(&src.join(".env"), "DATABASE_URL=foo");
+        write(&src.join("settings.json"), "{}");
+        write(&src.join("projects/a/state.json"), "{}");
+
+        let report = run(&src, &dst, MigrateOptions::default());
+
+        assert!(!report.source_missing);
+        assert_eq!(report.copied.len(), 3);
+        assert!(report.skipped_existing.is_empty());
+        assert_eq!(
+            std::fs::read_to_string(dst.join(".env")).unwrap(),
+            "DATABASE_URL=foo"
+        );
+        assert_eq!(
+            std::fs::read_to_string(dst.join("settings.json")).unwrap(),
+            "{}"
+        );
+        assert!(dst.join("projects/a/state.json").exists());
+    }
+
+    #[test]
+    fn req_adr_114_bii_writes_marker_after_success() {
+        let tmp = TempDir::new().unwrap();
+        let src = tmp.path().join(".ironclaw");
+        let dst = tmp.path().join(".dasclaw");
+        write(&src.join(".env"), "x=1");
+
+        run(&src, &dst, MigrateOptions::default());
+
+        let marker = dst.join(MIGRATED_MARKER);
+        assert!(marker.exists());
+        let body = std::fs::read_to_string(&marker).unwrap();
+        assert!(body.contains(&src.display().to_string()));
+    }
+
+    #[test]
+    fn req_adr_114_bii_idempotent_when_marker_present() {
+        let tmp = TempDir::new().unwrap();
+        let src = tmp.path().join(".ironclaw");
+        let dst = tmp.path().join(".dasclaw");
+        write(&src.join(".env"), "x=1");
+        std::fs::create_dir_all(&dst).unwrap();
+        std::fs::write(dst.join(MIGRATED_MARKER), "stamp").unwrap();
+
+        let report = run(&src, &dst, MigrateOptions::default());
+
+        assert!(report.already_migrated);
+        assert!(report.copied.is_empty());
+        assert!(!dst.join(".env").exists(), "second run must not copy");
+    }
+
+    #[test]
+    fn req_adr_114_bii_force_resumes_after_marker() {
+        let tmp = TempDir::new().unwrap();
+        let src = tmp.path().join(".ironclaw");
+        let dst = tmp.path().join(".dasclaw");
+        write(&src.join(".env"), "x=1");
+        write(&src.join("new.json"), "{}");
+        std::fs::create_dir_all(&dst).unwrap();
+        std::fs::write(dst.join(MIGRATED_MARKER), "stamp").unwrap();
+        // Pretend a previous run already brought over `.env`.
+        write(&dst.join(".env"), "x=1");
+
+        let report = run(
+            &src,
+            &dst,
+            MigrateOptions {
+                force: true,
+                ..MigrateOptions::default()
+            },
+        );
+
+        assert!(!report.already_migrated);
+        let copied: Vec<_> = report
+            .copied
+            .iter()
+            .map(|p| p.to_string_lossy().into_owned())
+            .collect();
+        assert!(copied.contains(&"new.json".to_string()));
+        let skipped: Vec<_> = report
+            .skipped_existing
+            .iter()
+            .map(|p| p.to_string_lossy().into_owned())
+            .collect();
+        assert!(
+            skipped.contains(&".env".to_string()),
+            "existing .env must be left alone"
+        );
+    }
+
+    #[test]
+    fn req_adr_114_bii_dry_run_does_not_touch_disk() {
+        let tmp = TempDir::new().unwrap();
+        let src = tmp.path().join(".ironclaw");
+        let dst = tmp.path().join(".dasclaw");
+        write(&src.join(".env"), "x=1");
+        write(&src.join("projects/a.txt"), "hi");
+
+        let report = run(
+            &src,
+            &dst,
+            MigrateOptions {
+                dry_run: true,
+                ..MigrateOptions::default()
+            },
+        );
+
+        assert!(report.dry_run);
+        assert_eq!(report.copied.len(), 2);
+        assert!(!dst.exists(), "dry-run must not create destination");
+    }
+
+    #[test]
+    fn req_adr_114_bii_skips_existing_files() {
+        let tmp = TempDir::new().unwrap();
+        let src = tmp.path().join(".ironclaw");
+        let dst = tmp.path().join(".dasclaw");
+        write(&src.join(".env"), "old=1");
+        write(&src.join("only-source.json"), "{}");
+        write(&dst.join(".env"), "new=2");
+
+        let report = run(&src, &dst, MigrateOptions::default());
+
+        let copied: Vec<_> = report
+            .copied
+            .iter()
+            .map(|p| p.to_string_lossy().into_owned())
+            .collect();
+        let skipped: Vec<_> = report
+            .skipped_existing
+            .iter()
+            .map(|p| p.to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(copied, vec!["only-source.json".to_string()]);
+        assert_eq!(skipped, vec![".env".to_string()]);
+        assert_eq!(std::fs::read_to_string(dst.join(".env")).unwrap(), "new=2");
+    }
+
+    #[test]
+    fn req_adr_114_bii_preserves_source() {
+        let tmp = TempDir::new().unwrap();
+        let src = tmp.path().join(".ironclaw");
+        let dst = tmp.path().join(".dasclaw");
+        write(&src.join(".env"), "x=1");
+
+        run(&src, &dst, MigrateOptions::default());
+
+        assert!(
+            src.join(".env").exists(),
+            "source must remain intact (copy semantics)"
+        );
+    }
+
+    #[test]
+    fn req_adr_114_bii_recursive_subdirs() {
+        let tmp = TempDir::new().unwrap();
+        let src = tmp.path().join(".ironclaw");
+        let dst = tmp.path().join(".dasclaw");
+        write(&src.join("channels/telegram/cfg.json"), "{}");
+        write(&src.join("tools/wasm/foo.wasm"), "WASM");
+        write(&src.join("projects/p/sub/deep.txt"), "deep");
+
+        let report = run(&src, &dst, MigrateOptions::default());
+
+        assert_eq!(report.copied.len(), 3);
+        assert!(dst.join("channels/telegram/cfg.json").exists());
+        assert!(dst.join("tools/wasm/foo.wasm").exists());
+        assert_eq!(
+            std::fs::read_to_string(dst.join("projects/p/sub/deep.txt")).unwrap(),
+            "deep"
+        );
+    }
+
+    #[test]
+    fn req_adr_114_bii_dry_run_does_not_write_marker() {
+        let tmp = TempDir::new().unwrap();
+        let src = tmp.path().join(".ironclaw");
+        let dst = tmp.path().join(".dasclaw");
+        write(&src.join(".env"), "x=1");
+
+        run(
+            &src,
+            &dst,
+            MigrateOptions {
+                dry_run: true,
+                ..MigrateOptions::default()
+            },
+        );
+
+        assert!(!dst.join(MIGRATED_MARKER).exists());
+    }
+
+    #[test]
+    fn req_adr_114_bii_empty_source_still_marks_destination() {
+        let tmp = TempDir::new().unwrap();
+        let src = tmp.path().join(".ironclaw");
+        let dst = tmp.path().join(".dasclaw");
+        std::fs::create_dir_all(&src).unwrap();
+
+        let report = run(&src, &dst, MigrateOptions::default());
+
+        assert!(report.copied.is_empty());
+        assert!(report.skipped_existing.is_empty());
+        assert!(dst.join(MIGRATED_MARKER).exists());
+    }
+
+    #[test]
+    fn req_adr_114_bii_marker_not_written_on_io_error() {
+        let tmp = TempDir::new().unwrap();
+        let src = tmp.path().join(".ironclaw");
+        // Create destination as a *file* to force `create_dir_all` to fail.
+        let dst = tmp.path().join(".dasclaw");
+        write(&src.join(".env"), "x=1");
+        std::fs::write(&dst, "blocking-file").unwrap();
+
+        let err = migrate_with_paths(&src, &dst, MigrateOptions::default()).unwrap_err();
+        let MigrationError::Io { .. } = err;
+        // Marker file lives under the (would-be) destination dir; confirm we
+        // never rewrote it.
+        assert!(
+            !dst.is_dir(),
+            "destination should not be coerced into a dir"
+        );
+    }
+
+    #[test]
+    fn req_adr_114_bii_migrate_helper_uses_home_subdirs() {
+        let tmp = TempDir::new().unwrap();
+        let home = tmp.path();
+        write(&home.join(".ironclaw/.env"), "x=1");
+
+        let report = migrate(home, MigrateOptions::default()).unwrap();
+
+        assert_eq!(report.source, home.join(".ironclaw"));
+        assert_eq!(report.destination, home.join(".dasclaw"));
+        assert!(home.join(".dasclaw/.env").exists());
+        assert!(home.join(".dasclaw").join(MIGRATED_MARKER).exists());
+    }
+}


### PR DESCRIPTION
## 背景 / 目标

实现 ADR-114 §2.2 类 B-Ⅱ（issue #107）：提供 `dasclaw migrate` CLI，把遗留 `~/.ironclaw/` 下的用户数据搬到新的 `~/.dasclaw/`。

ADR-114 B-Ⅰ（双读 + deprecation warn，#114）已合并；本 PR 是用户从老目录迁移到新目录的入口。

## 改动范围

- `desktop-client/ironclaw/src/migration.rs`（新）— 纯文件系统 helper：
  - `migrate(home, opts)` / `migrate_with_paths(src, dst, opts)`
  - **copy 语义**：从不 move；旧目录保留作为隐式备份
  - **永不覆盖**：目标已有的文件原样保留，只补缺
  - **幂等**：写 `.migrated_from_ironclaw` 标记，重跑即 no-op（除非 `--force`）
  - **fail-safe**：标记在所有 copy 完成之后才写，部分失败可重试
- `desktop-client/ironclaw/src/cli/migrate.rs`（新）— `MigrateCommand` clap wrapper，提供 `--dry-run` / `--force` 与人类可读的 plan 输出
- `desktop-client/ironclaw/src/cli/mod.rs` — 注册 `Command::Migrate(MigrateCommand)`
- `desktop-client/ironclaw/src/lib.rs` — 暴露 `pub mod migration`
- `desktop-client/ironclaw/src/main.rs` — 在 agent setup 之前 dispatch `Command::Migrate`

## 非目标（What's NOT in this PR）

按 ADR-114 红线纪律刻意延后：

- macOS Keychain `com.ironclaw.*` → `com.dasclaw.*` 重命名 → ADR-114 B-Ⅳ（#109）
- `settings.json` 内嵌绝对路径 `/Users/x/.ironclaw/...` 的字符串重写 → 单开 issue
- `--symlink` 模式与 move 语义 → 等 copy 路径稳定后再开切片
- service / launchd plist 中的服务名 → ADR-114 B-Ⅳ
- 跨用户 / 跨主机迁移 → 永不在本助手范畴

## 验证

```
# 单测（13 个 req_adr_114_bii_* + 既有 bootstrap 套件）
$ cargo nextest run -p ironclaw --lib migration
Summary [8.702s] 16 tests run: 16 passed, 3991 skipped

# 主二进制编译
$ cargo check -p ironclaw --bin ironclaw
Finished `dev` profile [unoptimized + debuginfo] target(s) in 3m 44s

# fmt + 反 panic 红线
$ cargo fmt --all && python3.12 scripts/check_no_panics.py --base origin/xClaw
OK: No panic-inducing calls in changed production code.

# clippy（本 PR 新代码 0 warning；workspace 中其它文件遗留 36 个错误与本 PR 无关）
$ cargo clippy --no-deps -p ironclaw --all-targets 2>&1 | grep -E "src/migration|src/cli/migrate"
(empty)
```

测试覆盖的 12+ 边界场景（issue 验收清单）：
1. 旧目录不存在 → no-op（`source_missing`）
2. 目标空 → 全部 copy
3. 写迁移标记
4. 标记已存在 → 跳过整轮
5. `--force` 跳过标记，仍不覆盖目标已有文件
6. `--dry-run` 不动磁盘
7. 跳过目标已有文件
8. 保留源目录（copy 而非 move）
9. 递归子目录
10. dry-run 不写标记
11. 空源目录仍写标记
12. I/O 失败时不写标记
13. `migrate(home, ..)` wrapper 用 `.ironclaw` / `.dasclaw` 子目录

## Skills 自查

- **code-quality-audit**：无 `unwrap`/`expect`/`panic`（仅 `#[cfg(test)]` 内部）；`MigrationError::Io` 带路径（actionable）；marker 写在最后，partial-failure 可重试。
- **code-simplifier**：单一 `copy_dir_recursive` helper；`MigrateOptions: Copy`；无重复代码。
- **code-review-expert**：ADR-114 B-Ⅰ 契约未动；非目标显式列出；测试名 `req_adr_114_bii_*` 可追溯到 ADR。

Closes #107
