### PR TITLE
feat(x_claw_agent): inject AGENTS.md into ReasoningContext::system_prompt (#111)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12375,9 +12375,11 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "chrono",
+ "dasclaw_project_docs",
  "ironclaw_common",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 1.0.69",
  "tokio",
  "tracing",

--- a/crates/x_claw_agent/Cargo.toml
+++ b/crates/x_claw_agent/Cargo.toml
@@ -30,6 +30,10 @@ uuid = { version = "1", features = ["v4", "v5", "serde"] }
 ironclaw_common = { path = "../../desktop-client/ironclaw/crates/ironclaw_common", version = "0.1.0" }
 # session_manager 需要 RwLock/Mutex/spawn (fire-and-forget hooks)
 tokio = { version = "1", features = ["sync", "rt", "time"] }
+# Project doc 注入 (#59b / ADR-115): SessionManager 构建期 DI 调用
+# `LayeredProjectDocLoader` + `assemble_section`，不进 hook 系统。
+dasclaw_project_docs = { path = "../dasclaw_project_docs", version = "0.0.0-w1" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt", "sync"] }
+tempfile = "3"

--- a/crates/x_claw_agent/src/lib.rs
+++ b/crates/x_claw_agent/src/lib.rs
@@ -20,6 +20,7 @@ pub mod intent;
 pub mod llm;
 pub mod messages;
 pub mod permissions;
+pub mod project_docs;
 pub mod prompt;
 pub mod reasoning_ctx;
 pub mod response_types;

--- a/crates/x_claw_agent/src/project_docs.rs
+++ b/crates/x_claw_agent/src/project_docs.rs
@@ -1,0 +1,228 @@
+//! Project-doc injection into [`ReasoningContext::system_prompt`].
+//!
+//! Implements W3 issue **#59b** under [ADR-115] (`ProjectDoc` 不进 hook 系统):
+//! at session-construction time the agent runtime calls a
+//! [`ProjectDocLoader`] + [`assemble_section`] and **appends** the result to
+//! the existing `system_prompt`, after the dynamic boundary set by upstream
+//! prompt builders.
+//!
+//! Path C2 (entry-point injection) is chosen over C1 (SessionManager field)
+//! because:
+//!
+//! 1. `cwd` is naturally available at the agentic-loop entry, but not at
+//!    [`SessionManager::get_or_create_session`]; threading `cwd` through the
+//!    user-keyed session API would force every consumer to pick a single
+//!    workspace per user, contradicting the `auto-generated sandbox /
+//!    user-imported workspace_root` model documented on
+//!    [`crate::session::Session`].
+//! 2. [`ReasoningContext`] is the type the prompt is actually read from —
+//!    injecting at the same site eliminates a layer of indirection and keeps
+//!    the operation observable in tests.
+//! 3. ADR-115 forbids both the `dasclaw_hooks` system and any hook handler
+//!    mutating the prompt; an explicit constructor-DI helper satisfies that
+//!    contract by construction.
+//!
+//! Re-export `ProjectDocLoader` so consumers can implement custom loaders
+//! without depending on `dasclaw_project_docs` directly.
+//!
+//! [ADR-115]: ../../../../docs/plans/architecture-refactor/adr-115-project-docs-not-in-hook.md
+
+use std::path::Path;
+
+pub use dasclaw_project_docs::{
+    DocLayer, EmptyProjectDocLoader, LayeredProjectDocLoader, PriorityProjectDocLoader, ProjectDoc,
+    ProjectDocLoader, assemble_section,
+};
+
+use crate::reasoning_ctx::ReasoningContext;
+
+/// Boundary marker placed between an existing `system_prompt` (the "dynamic
+/// boundary" assembled upstream) and the appended project-doc section.
+///
+/// Two newlines mirror the inter-doc separator inside [`assemble_section`]
+/// so the prompt reads as a single contiguous Markdown document. The
+/// constant is exposed for tests asserting boundary behaviour.
+pub const PROJECT_DOCS_BOUNDARY: &str = "\n\n";
+
+/// Load project docs for `cwd` and append the assembled section to
+/// `ctx.system_prompt`.
+///
+/// Returns the byte length of the appended section, or `0` when nothing was
+/// injected (so callers can record a metric without re-doing the work).
+///
+/// # Behaviour
+///
+/// * When the loader returns no docs (or every fragment is empty), the
+///   context is left untouched — no orphan separator is emitted, mirroring
+///   the [`assemble_section`] contract.
+/// * When `ctx.system_prompt` is already populated, the assembled section is
+///   appended after a [`PROJECT_DOCS_BOUNDARY`].
+/// * When `ctx.system_prompt` is empty / unset, the assembled section
+///   becomes the entire prompt (no leading boundary).
+/// * The function never panics on missing files or permission errors —
+///   that's the [`ProjectDocLoader`] trait's contract.
+pub fn inject_project_docs_section(
+    ctx: &mut ReasoningContext,
+    loader: &dyn ProjectDocLoader,
+    cwd: &Path,
+) -> usize {
+    let docs = loader.load(cwd);
+    let Some(section) = assemble_section(&docs) else {
+        return 0;
+    };
+    let appended = section.len();
+    match ctx.system_prompt.as_mut() {
+        Some(existing) if !existing.is_empty() => {
+            existing.push_str(PROJECT_DOCS_BOUNDARY);
+            existing.push_str(&section);
+        }
+        _ => {
+            ctx.system_prompt = Some(section);
+        }
+    }
+    appended
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::path::PathBuf;
+    use tempfile::TempDir;
+
+    /// Build a [`LayeredProjectDocLoader`] whose three layers all resolve
+    /// inside the supplied tempdir, so tests don't touch `$HOME` or escape
+    /// the sandbox.
+    fn loader_for(tmp: &TempDir) -> LayeredProjectDocLoader {
+        LayeredProjectDocLoader::new(
+            Some(tmp.path().join("home")),
+            Some(tmp.path().join("project")),
+        )
+    }
+
+    fn write(path: PathBuf, body: &str) {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).expect("create parent");
+        }
+        fs::write(&path, body).expect("write fixture");
+    }
+
+    #[test]
+    fn req_x_claw_agent_59b_injects_section_when_agents_md_exists() {
+        let tmp = TempDir::new().unwrap();
+        let cwd = tmp.path().join("project");
+        write(cwd.join("AGENTS.md"), "## test instructions");
+
+        let mut ctx = ReasoningContext::new();
+        let appended = inject_project_docs_section(&mut ctx, &loader_for(&tmp), &cwd);
+
+        assert!(appended > 0);
+        let prompt = ctx.system_prompt.expect("prompt populated");
+        assert!(
+            prompt.contains("## test instructions"),
+            "AGENTS.md body must end up in the prompt, got: {prompt}"
+        );
+    }
+
+    #[test]
+    fn req_x_claw_agent_59b_no_injection_when_no_docs() {
+        let tmp = TempDir::new().unwrap();
+        let cwd = tmp.path().join("project");
+        fs::create_dir_all(&cwd).unwrap();
+
+        let mut ctx = ReasoningContext::new();
+        let appended = inject_project_docs_section(&mut ctx, &loader_for(&tmp), &cwd);
+
+        assert_eq!(appended, 0);
+        assert!(
+            ctx.system_prompt.is_none(),
+            "no orphan separator may be emitted when docs are absent"
+        );
+    }
+
+    #[test]
+    fn req_x_claw_agent_59b_appends_after_existing_dynamic_boundary() {
+        let tmp = TempDir::new().unwrap();
+        let cwd = tmp.path().join("project");
+        write(cwd.join("AGENTS.md"), "rule-1");
+
+        let mut ctx = ReasoningContext::new();
+        ctx.system_prompt = Some("base-template".to_string());
+
+        inject_project_docs_section(&mut ctx, &loader_for(&tmp), &cwd);
+
+        let prompt = ctx.system_prompt.unwrap();
+        let expected = format!("base-template{PROJECT_DOCS_BOUNDARY}rule-1");
+        assert_eq!(prompt, expected);
+        // Sanity: project-doc text comes *after* the existing template.
+        let base_idx = prompt.find("base-template").unwrap();
+        let doc_idx = prompt.find("rule-1").unwrap();
+        assert!(
+            base_idx < doc_idx,
+            "project docs must follow dynamic boundary"
+        );
+    }
+
+    #[test]
+    fn req_x_claw_agent_59b_handles_nested_layered_docs() {
+        let tmp = TempDir::new().unwrap();
+        // Layered loader walks `home`, `project`, `cwd` independently.
+        write(tmp.path().join("home/.dasclaw/AGENTS.md"), "user-global");
+        write(tmp.path().join("project/AGENTS.md"), "repo-rule");
+        let cwd = tmp.path().join("project/sub");
+        write(cwd.join("AGENTS.md"), "cwd-rule");
+
+        let mut ctx = ReasoningContext::new();
+        inject_project_docs_section(&mut ctx, &loader_for(&tmp), &cwd);
+
+        let prompt = ctx.system_prompt.expect("prompt populated");
+        for needle in ["user-global", "repo-rule", "cwd-rule"] {
+            assert!(prompt.contains(needle), "missing `{needle}` in: {prompt}");
+        }
+    }
+
+    #[test]
+    fn req_x_claw_agent_59b_empty_existing_prompt_replaced_without_boundary() {
+        let tmp = TempDir::new().unwrap();
+        let cwd = tmp.path().join("project");
+        write(cwd.join("AGENTS.md"), "only");
+
+        let mut ctx = ReasoningContext::new();
+        ctx.system_prompt = Some(String::new());
+
+        inject_project_docs_section(&mut ctx, &loader_for(&tmp), &cwd);
+
+        let prompt = ctx.system_prompt.unwrap();
+        assert_eq!(
+            prompt, "only",
+            "empty existing prompt must not produce a leading boundary"
+        );
+    }
+
+    #[test]
+    fn req_x_claw_agent_59b_empty_loader_is_noop_with_existing_prompt() {
+        let mut ctx = ReasoningContext::new();
+        ctx.system_prompt = Some("base".to_string());
+
+        let appended = inject_project_docs_section(
+            &mut ctx,
+            &EmptyProjectDocLoader,
+            Path::new("/nonexistent"),
+        );
+
+        assert_eq!(appended, 0);
+        assert_eq!(ctx.system_prompt.as_deref(), Some("base"));
+    }
+
+    #[test]
+    fn req_x_claw_agent_59b_reports_appended_byte_count() {
+        let tmp = TempDir::new().unwrap();
+        let cwd = tmp.path().join("project");
+        write(cwd.join("AGENTS.md"), "abcdef");
+
+        let mut ctx = ReasoningContext::new();
+        let appended = inject_project_docs_section(&mut ctx, &loader_for(&tmp), &cwd);
+
+        assert_eq!(appended, "abcdef".len());
+    }
+}

--- a/crates/x_claw_agent/tests/project_docs_adr115.rs
+++ b/crates/x_claw_agent/tests/project_docs_adr115.rs
@@ -1,0 +1,59 @@
+//! ADR-115 red-line test: ensure the project-doc injection path never
+//! reaches into the [`dasclaw_hooks`] system.
+//!
+//! The check is intentionally a build-time / source-grep test rather than a
+//! runtime assertion, because ADR-115 forbids *any* coupling — including a
+//! latent dependency we'd later forget to delete. If you find yourself
+//! adding a `dasclaw_hooks` import to satisfy a feature request, stop and
+//! re-read ADR-115 § "为什么不进 hook 系统".
+
+use std::fs;
+use std::path::PathBuf;
+
+fn project_docs_source() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/project_docs.rs")
+}
+
+#[test]
+fn req_x_claw_agent_59b_adr115_no_dasclaw_hooks_reference() {
+    let body = fs::read_to_string(project_docs_source())
+        .expect("project_docs.rs must exist for #59b injection path");
+
+    // Strip line comments and block comments before scanning so an ADR-115
+    // explanatory comment that mentions the symbol doesn't fail the test.
+    let stripped = strip_comments(&body);
+
+    assert!(
+        !stripped.contains("dasclaw_hooks"),
+        "ADR-115 violation: project_docs.rs must not reference `dasclaw_hooks` \
+         (found a non-comment occurrence). The injection path is constructor \
+         DI only."
+    );
+}
+
+fn strip_comments(src: &str) -> String {
+    let mut out = String::with_capacity(src.len());
+    let bytes = src.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        // Block comment
+        if i + 1 < bytes.len() && bytes[i] == b'/' && bytes[i + 1] == b'*' {
+            i += 2;
+            while i + 1 < bytes.len() && !(bytes[i] == b'*' && bytes[i + 1] == b'/') {
+                i += 1;
+            }
+            i = (i + 2).min(bytes.len());
+            continue;
+        }
+        // Line comment (covers both `//` and `///`)
+        if i + 1 < bytes.len() && bytes[i] == b'/' && bytes[i + 1] == b'/' {
+            while i < bytes.len() && bytes[i] != b'\n' {
+                i += 1;
+            }
+            continue;
+        }
+        out.push(bytes[i] as char);
+        i += 1;
+    }
+    out
+}


### PR DESCRIPTION
# [W3] #59b · SessionManager 接入 assemble_section 注入 system_prompt

**Source**: docs/plans/architecture-refactor/Issue #111
**ADR**: [adr-115-project-docs-not-in-hook.md](../docs/plans/architecture-refactor/adr-115-project-docs-not-in-hook.md)

## 背景 / 目标

W2 已落地 `dasclaw_project_docs` crate（PriorityProjectDocLoader / LayeredProjectDocLoader / `assemble_section`）。W3 #59b 需要把它接入 agent 运行时——按 ADR-115 红线：**构建期 DI**，**绝不进 `dasclaw_hooks` 系统**。

本 PR 把 ProjectDoc 段拼接到 `ReasoningContext.system_prompt`（dynamic boundary 之后），第一次 LLM 请求即可读到 AGENTS.md / CLAUDE.md 内容。

## 路径选择：C2（agentic_loop / ReasoningContext 入口）

Issue 列出两条候选路径，本 PR 选 **C2** 而非 C1（SessionManager 字段）：

1. **`cwd` 在 SessionManager 不天然可得**：`get_or_create_session(user_id)` 是用户级 API，单用户多 workspace 是常态（auto-generated sandbox vs imported workspace_root，见 `Session` 注释）。把 `cwd` 塞进用户级方法会强制每用户单 workspace，与 `Session.workspace_root` 模型矛盾。
2. **`ReasoningContext` 才是 prompt 真正被读取的地方**：在 prompt 构造点注入消除一层间接，测试与生产路径完全对称。
3. **最小耦合**：不改 `Session` schema、不改 `SessionManager` 公开签名，只新增一个明确的 helper。后续若需要持久化注入元数据，可在不破坏现有调用点的前提下平滑迁移到 C1。
4. ADR-115 红线在 C1/C2 下要求一致（不入 hook 系统），路径选择只影响代码组织。

调用方在已经构建好 `ReasoningContext` 后、`run_agentic_loop` 前调用一次 `inject_project_docs_section(&mut ctx, &loader, &cwd)` 即可。

## 改动范围

- `crates/x_claw_agent/src/project_docs.rs`（新）：
  - `pub fn inject_project_docs_section(ctx, loader, cwd) -> usize`：load → assemble → append（已有 prompt 用 `\n\n` 边界，否则直接赋值）。空 docs / 空 section 完全 no-op，绝不输出孤立分隔符。
  - re-export `ProjectDoc{,Loader}` / `assemble_section` / `LayeredProjectDocLoader` / `PriorityProjectDocLoader` / `EmptyProjectDocLoader`。
- `crates/x_claw_agent/tests/project_docs_adr115.rs`（新）：源码 grep 红线测试——`project_docs.rs` 里**剥离注释后**禁止出现 `dasclaw_hooks`，从源头堵死 hook 耦合。
- `crates/x_claw_agent/Cargo.toml`：`dasclaw_project_docs = { path = ..., version = "0.0.0-w1" }`，dev-dep 加 `tempfile = "3"`。
- `crates/x_claw_agent/src/lib.rs`：`pub mod project_docs;`。

## 非目标（What's NOT in this PR）

- ❌ **不**改 `SessionManager` / `Session` 公开签名（C1 推迟到有需求驱动时再做）。
- ❌ **不**改 `agentic_loop::run_agentic_loop` 签名——helper 由调用方在外面调用，避免 plumbing 蔓延到核心 loop。
- ❌ **不**接入 desktop-client / admin-backend 的真实 prompt 装配代码（W3-W4 后续 issue 负责整合调用点；本 PR 只交付可被调用的 helper + 测试用例）。
- ❌ **不**做 metrics / tracing 接线（仅返回 `usize` 供调用方统计）。
- ❌ **不**碰 ADR-114 dual-read（与 #119 隔离）。
- ❌ **不**触碰 `dasclaw_hooks` 任何代码（ADR-115 红线）。

## 验证

```bash
cargo check -p x_claw_agent --tests                        # ✅
cargo nextest run -p x_claw_agent project_docs             # ✅ 7/7 (单测)
cargo nextest run -p x_claw_agent --test project_docs_adr115  # ✅ 1/1 (ADR-115 red-line)
cargo nextest run -p x_claw_agent                          # ✅ 238/238
cargo fmt --all                                            # ✅
python3.12 scripts/check_no_panics.py --base origin/xClaw  # ✅ OK
cargo clippy --no-deps -p x_claw_agent --all-targets -- -D warnings  # ✅ no warnings
```

测试用例（全部 `req_x_claw_agent_59b_*`，符合 AGENTS.md 命名规约）：

| 用例 | 断言 |
| --- | --- |
| `injects_section_when_agents_md_exists` | tmpdir 含 AGENTS.md → prompt 含其内容 |
| `no_injection_when_no_docs` | 无 docs → `system_prompt` 保持 `None`，无孤立分隔符 |
| `appends_after_existing_dynamic_boundary` | 已有 prompt → 追加在 dynamic boundary 之后，顺序正确 |
| `handles_nested_layered_docs` | LayeredProjectDocLoader 三层（home / repo / cwd）全部合并 |
| `empty_existing_prompt_replaced_without_boundary` | 空字符串 prompt → 不产生前导边界 |
| `empty_loader_is_noop_with_existing_prompt` | EmptyProjectDocLoader → 完全 no-op |
| `reports_appended_byte_count` | 返回值等于 section 字节数（供调用方度量） |
| `adr115_no_dasclaw_hooks_reference` (integration) | 源码 grep（剥离注释）不含 `dasclaw_hooks` |

## Skills 自查（AGENTS.md 强制）

- **code-quality-audit**：模块边界清晰；`inject_*` 单一职责；返回 `usize` 而非 bool 让调用方决定是否度量；空状态语义靠类型（`Option<String>`）+ 文档锁死。
- **code-simplifier**：未引入新枚举 / 状态机；helper 不持有任何状态；无 unsafe，无 panic。
- **code-review-expert**：路径选择 C2 在 PR 头部显式记录；ADR-115 红线由独立 source-grep 测试守门；命名遵循 `req_<module>_<id>_<desc>`；非目标列出 5 项防止 scope creep。

Closes #111
