### PR TITLE
feat(hooks): emit lifecycle trace log at HookRegistry::run dispatch (#60)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2449,6 +2449,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tracing",
+ "tracing-test",
  "x_claw_agent",
 ]
 

--- a/crates/dasclaw_hooks/Cargo.toml
+++ b/crates/dasclaw_hooks/Cargo.toml
@@ -23,3 +23,7 @@ tracing = "0.1"
 # Reexport `x_claw_agent` trait seams so `dasclaw_hooks` becomes the single
 # front-door for both event-style hooks and trait-seam hooks. See ADR-113.
 x_claw_agent = { path = "../x_claw_agent", version = "0.1.0" }
+
+[dev-dependencies]
+tokio = { version = "1", features = ["sync", "macros", "time", "rt", "rt-multi-thread"] }
+tracing-test = { version = "0.2", features = ["no-env-filter"] }

--- a/crates/dasclaw_hooks/src/hook.rs
+++ b/crates/dasclaw_hooks/src/hook.rs
@@ -87,6 +87,21 @@ impl HookEvent {
         }
     }
 
+    /// Variant tag used as the `event_type` field in lifecycle trace logs.
+    ///
+    /// Distinct from [`HookPoint::as_str`] so consumers can disambiguate the
+    /// event shape from the lifecycle slot it triggered.
+    pub fn event_kind(&self) -> &'static str {
+        match self {
+            HookEvent::Inbound { .. } => "Inbound",
+            HookEvent::ToolCall { .. } => "ToolCall",
+            HookEvent::Outbound { .. } => "Outbound",
+            HookEvent::SessionStart { .. } => "SessionStart",
+            HookEvent::SessionEnd { .. } => "SessionEnd",
+            HookEvent::ResponseTransform { .. } => "ResponseTransform",
+        }
+    }
+
     /// Apply a modification string to the event's primary content field.
     pub fn apply_modification(&mut self, modified: &str) {
         match self {

--- a/crates/dasclaw_hooks/src/registry.rs
+++ b/crates/dasclaw_hooks/src/registry.rs
@@ -80,6 +80,7 @@ impl HookRegistry {
     /// - Timeout/error handling respects each hook's `failure_mode`.
     pub async fn run(&self, event: &HookEvent) -> Result<HookOutcome, HookError> {
         let point = event.hook_point();
+        let event_kind = event.event_kind();
         let ctx = HookContext::default();
 
         // Clone matching hooks and drop the read guard before executing.
@@ -94,6 +95,16 @@ impl HookRegistry {
                 .collect()
         };
 
+        // ADR-113 single-instrumentation point: every lifecycle dispatch emits
+        // one log line so e2e runs always show all 6 trigger points, even
+        // when no hooks are registered (W3 #60).
+        tracing::debug!(
+            hook_point = %point.as_str(),
+            event_type = %event_kind,
+            matching_hooks = matching.len(),
+            "lifecycle fired"
+        );
+
         if matching.is_empty() {
             return Ok(HookOutcome::ok());
         }
@@ -102,6 +113,13 @@ impl HookRegistry {
 
         for hook in &matching {
             let timeout = hook.timeout();
+
+            tracing::debug!(
+                hook_name = %hook.name(),
+                hook_point = %point.as_str(),
+                event_type = %event_kind,
+                "hook executing"
+            );
 
             let result = tokio::time::timeout(timeout, hook.execute(&current_event, &ctx)).await;
 

--- a/crates/dasclaw_hooks/tests/lifecycle_trace_log.rs
+++ b/crates/dasclaw_hooks/tests/lifecycle_trace_log.rs
@@ -1,0 +1,181 @@
+//! W3 #60 — lifecycle trace log instrumentation contract.
+//!
+//! Verifies that every one of the 6 hook lifecycle trigger points emits a
+//! `tracing` event from [`HookRegistry::run`], so an end-to-end run produces
+//! one log line per fired event regardless of whether matching hooks are
+//! installed.
+//!
+//! Acceptance pinned by these tests:
+//! - Each lifecycle point emits a log carrying `hook_point` + `event_type`.
+//! - When a hook is matched, a per-hook log additionally carries `hook_name`.
+//! - Firing all 6 [`HookEvent`] variants produces 6 distinct lifecycle lines.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use dasclaw_hooks::{
+    Hook, HookContext, HookError, HookEvent, HookFailureMode, HookOutcome, HookPoint, HookRegistry,
+};
+use tracing_test::traced_test;
+
+const ALL_POINTS: &[HookPoint] = &[
+    HookPoint::BeforeInbound,
+    HookPoint::BeforeToolCall,
+    HookPoint::BeforeOutbound,
+    HookPoint::OnSessionStart,
+    HookPoint::OnSessionEnd,
+    HookPoint::TransformResponse,
+];
+
+/// Minimal pass-through hook bound to all six lifecycle points.
+struct AllPointsHook;
+
+#[async_trait]
+impl Hook for AllPointsHook {
+    fn name(&self) -> &str {
+        "all_points_hook"
+    }
+
+    fn hook_points(&self) -> &[HookPoint] {
+        ALL_POINTS
+    }
+
+    fn timeout(&self) -> Duration {
+        Duration::from_secs(1)
+    }
+
+    fn failure_mode(&self) -> HookFailureMode {
+        HookFailureMode::FailOpen
+    }
+
+    async fn execute(
+        &self,
+        _event: &HookEvent,
+        _ctx: &HookContext,
+    ) -> Result<HookOutcome, HookError> {
+        Ok(HookOutcome::ok())
+    }
+}
+
+fn all_six_events() -> Vec<HookEvent> {
+    vec![
+        HookEvent::Inbound {
+            user_id: "u".into(),
+            channel: "c".into(),
+            content: "in".into(),
+            thread_id: None,
+        },
+        HookEvent::ToolCall {
+            tool_name: "shell".into(),
+            parameters: serde_json::json!({}),
+            user_id: "u".into(),
+            context: "chat".into(),
+        },
+        HookEvent::Outbound {
+            user_id: "u".into(),
+            channel: "c".into(),
+            content: "out".into(),
+            thread_id: None,
+        },
+        HookEvent::SessionStart {
+            user_id: "u".into(),
+            session_id: "s".into(),
+        },
+        HookEvent::SessionEnd {
+            user_id: "u".into(),
+            session_id: "s".into(),
+        },
+        HookEvent::ResponseTransform {
+            user_id: "u".into(),
+            thread_id: "t".into(),
+            response: "r".into(),
+        },
+    ]
+}
+
+/// Empty registry still emits a lifecycle log for each fired event so an e2e
+/// pass produces 6 distinct log lines (one per HookPoint).
+#[tokio::test]
+#[traced_test]
+async fn req_hooks_60_lifecycle_log_emitted_for_all_six_points() {
+    let registry = HookRegistry::new();
+
+    for event in all_six_events() {
+        registry
+            .run(&event)
+            .await
+            .expect("empty registry returns Ok");
+    }
+
+    // Every HookPoint must appear at least once in the log stream.
+    for point in [
+        HookPoint::BeforeInbound,
+        HookPoint::BeforeToolCall,
+        HookPoint::BeforeOutbound,
+        HookPoint::OnSessionStart,
+        HookPoint::OnSessionEnd,
+        HookPoint::TransformResponse,
+    ] {
+        let needle = format!("hook_point={}", point.as_str());
+        assert!(
+            logs_contain(&needle),
+            "expected lifecycle log to mention `{needle}`"
+        );
+    }
+}
+
+/// Lifecycle log must include `event_type` so consumers can filter by event
+/// shape without relying on `hook_point` alone.
+#[tokio::test]
+#[traced_test]
+async fn req_hooks_60_lifecycle_log_includes_event_type_field() {
+    let registry = HookRegistry::new();
+
+    registry
+        .run(&HookEvent::Inbound {
+            user_id: "u".into(),
+            channel: "c".into(),
+            content: "hi".into(),
+            thread_id: None,
+        })
+        .await
+        .expect("ok");
+
+    assert!(
+        logs_contain("event_type=Inbound"),
+        "lifecycle log must include event_type=Inbound"
+    );
+}
+
+/// When a matching hook is installed, the per-hook execution log must carry
+/// `hook_name` plus the same `hook_point` / `event_type` fields.
+#[tokio::test]
+#[traced_test]
+async fn req_hooks_60_per_hook_log_includes_hook_name_and_event_type() {
+    let registry = HookRegistry::new();
+    registry.register(Arc::new(AllPointsHook)).await;
+
+    registry
+        .run(&HookEvent::ToolCall {
+            tool_name: "shell".into(),
+            parameters: serde_json::json!({"cmd": "ls"}),
+            user_id: "u".into(),
+            context: "chat".into(),
+        })
+        .await
+        .expect("ok");
+
+    assert!(
+        logs_contain("hook_name=all_points_hook"),
+        "per-hook log must carry hook_name field"
+    );
+    assert!(
+        logs_contain("event_type=ToolCall"),
+        "per-hook log must carry event_type field"
+    );
+    assert!(
+        logs_contain("hook_point=beforeToolCall"),
+        "per-hook log must carry hook_point field"
+    );
+}


### PR DESCRIPTION
## 背景 / 目标

W3 #60 — Hooks 6 个 lifecycle 触发链路缺乏可观测的 trace log，e2e 跑一次看不到完整的触发证据。本 PR 在 \`HookRegistry::run()\` 中央分发点（ADR-113 唯一入口）添加 \`tracing\` instrumentation，使每个生命周期触发都产生一条带 \`hook_point + event_type\` 的日志，并在每个匹配 hook 执行前再追加一条带 \`hook_name\` 的日志。

## 改动范围

- \`crates/dasclaw_hooks/src/hook.rs\`: 新增 \`HookEvent::event_kind() -> &'static str\`，返回变体名（Inbound / ToolCall / Outbound / SessionStart / SessionEnd / ResponseTransform），与 \`hook_point()\` 区分用途。
- \`crates/dasclaw_hooks/src/registry.rs::run()\`: 在分发入口加 1 条 \`debug!\`（lifecycle fired，含 hook_point + event_type + matching_hooks），在 for-loop 内每个 hook 执行前加 1 条 \`debug!\`（hook executing，含 hook_name + hook_point + event_type）。**无新分支、无 flag、无补丁式追加**，单点 instrumentation 一次覆盖 6 个 lifecycle。
- \`crates/dasclaw_hooks/Cargo.toml\`: 添加 dev-dep \`tracing-test = \"0.2\"\`（仓库既有约定，已在 \`desktop-client/ironclaw\` / \`codex-rs\` 使用）+ tokio rt-multi-thread。
- \`crates/dasclaw_hooks/tests/lifecycle_trace_log.rs\`: 新增 3 条 e2e/contract 测试（TDD 红→绿）。

## 非目标

- 不改 hook trait / Hook 注册 API / HookOutcome 语义。
- 不动现有 \`Hook rejected\` / \`Hook modified content\` / \`Hook failed\` / \`Hook timed out\` 4 条已有日志（保留）。
- 不改 log level 默认值（沿用 \`debug!\`，与已有 hook 行为日志同 level）。
- 不引入 OpenTelemetry / span / metric——仅 \`tracing\` event。

## 验证

\`\`\`bash
# RED → GREEN
cargo nextest run -p dasclaw_hooks --test lifecycle_trace_log
#   3 tests run: 3 passed

# 无回归
cargo nextest run -p dasclaw_hooks
#   42 tests run: 42 passed

# 质量门禁
cargo fmt --all
python3.12 scripts/check_no_panics.py --base origin/xClaw
#   OK: No panic-inducing calls in changed production code.
cargo clippy --no-deps -p dasclaw_hooks --all-targets -- -D warnings
#   Finished, 0 warnings
\`\`\`

测试覆盖：
1. \`req_hooks_60_lifecycle_log_emitted_for_all_six_points\` — 空 registry 也对 6 个 HookEvent 变体各发一条 lifecycle fired 日志（核心 e2e 验收）。
2. \`req_hooks_60_lifecycle_log_includes_event_type_field\` — 日志带 \`event_type=Inbound\` 字段。
3. \`req_hooks_60_per_hook_log_includes_hook_name_and_event_type\` — 注册 hook 后产生 \`hook executing\` 日志，含 \`hook_name + hook_point + event_type\` 三字段（满足 #60 验收"至少含 hook_name + event_type"）。

## 安全 / 兼容

- 日志字段 (\`hook_point\` enum 字符串、\`event_type\` 静态字符串、\`hook_name\` 开发者自定义、\`matching_hooks\` 计数) 均无用户输入或 PII。
- 所有日志 \`debug!\` level，默认生产配置（INFO）不输出，不增加日志体积。
- 无 public API 变更（\`event_kind\` 是新增 inherent method，向后兼容）。

## 后续 / 下一步

- ADR-113 中央化 instrumentation 已就位，后续 \`info!\` 级别 audit log（如 fail-closed 拒绝事件）可在同一 dispatch 点扩展。

Closes #60