### PR TITLE
docs(adr): adr-117 p0c prompt builder unification

### DIFF
--- a/docs/plans/architecture-refactor/adr-117-p0c-prompt-builder-unification.md
+++ b/docs/plans/architecture-refactor/adr-117-p0c-prompt-builder-unification.md
@@ -1,0 +1,227 @@
+# ADR-117: P0-C Prompt Builder 统一（吸收 claw-code 至 LayeredPromptBuilder）
+
+- **Status**: Proposed
+- **Date**: 2026-04-30
+- **Approver**: pending
+- **Issue**: [#130](https://github.com/Linnanli/xClaw/issues/130)（W3/B P0-C — Prompt Builder 统一）
+- **Closes**: #130
+- **Related**:
+  - [p0c-prompt-builder-inventory.md](p0c-prompt-builder-inventory.md)（事实底盘 + §11 16 个待决问题，本 ADR 是其封顶）
+  - [adr-112-compatibility-evaluation.md §5](adr-112-compatibility-evaluation.md)（W3-A Phase 0 P0-1 boundary literal 统一前置）
+  - [adr-113-hook-engine-unification.md §2.4](adr-113-hook-engine-unification.md)（反跨界原则 — 解释为什么 ProjectDoc 不走 hook）
+  - [adr-115-project-docs-not-in-hook.md](adr-115-project-docs-not-in-hook.md)（构建期 DI / project_doc 字段对齐）
+  - [openai-cache-augmentation-issue-draft.md](openai-cache-augmentation-issue-draft.md)（P1 后续，不阻塞本 ADR）
+  - 未来 P1 issue：Anthropic provider 实现 cache_control 切分（本 ADR §6 R-1 风险条目登记）
+- **Numbering note**: 仓库 inventory + draft 早期文件提到的「ADR-114 prompt builder 统一」实际编号让位至 117（114 已被 [adr-114-dasclaw-rebrand.md](adr-114-dasclaw-rebrand.md) 占用，115/116 也已分别预留）。同步将 `openai-cache-augmentation-issue-draft.md` 中 3 处「ADR-114」更正为「ADR-117」。
+
+---
+
+## 1. Context
+
+### 1.1 三参考库 + 一 fork 的 prompt 装配现状
+
+依据 [p0c-prompt-builder-inventory.md](p0c-prompt-builder-inventory.md) §1–§3：
+
+| 项目 | 装配入口 | 模式 | 装配产物 |
+|---|---|---|---|
+| `claw-code` | `SystemPromptBuilder` + `load_system_prompt`（[runtime/src/prompt.rs](../../claw-code/rust/crates/runtime/src/prompt.rs)） | 9 段构建器，永远 emit `__SYSTEM_PROMPT_DYNAMIC_BOUNDARY__` 裸字面量 | `Vec<String>` |
+| `desktop-client/ironclaw` (本仓库 fork) | `LayeredPromptBuilder`（[desktop-client/ironclaw/src/llm/prompt/mod.rs](../../desktop-client/ironclaw/src/llm/prompt/mod.rs)） | 静态/动态二层 + `static_hash: u64` + `with_cache_boundary(is_anthropic)` 条件 emit `<!-- {boundary} -->` HTML 注释 | `String` |
+| `codex-cli-main` | `Session::build_initial_context`（无独立 builder type） | inline composition：top-level `instructions` API 字段 + developer/contextual_user 多 message item | typed `Vec<TurnContextItem>` |
+| `ironclaw-main`（legacy server） | `Workspace::system_prompt()` 不透明字符串 + 64KB HTTP cap | 无 builder | `String` |
+
+W3-A Phase 0 P0-1（[ADR-112 §5](adr-112-compatibility-evaluation.md)）已统一**字面量**（`x_claw_agent::PROMPT_CACHE_BOUNDARY`），但**装配代码**仍在两处并行：claw-code 的 `SystemPromptBuilder` 与 fork 的 `LayeredPromptBuilder`。
+
+### 1.2 #130 / W3/B 验收要求
+
+issue #130 要求 W3/B 阶段**统一 prompt builder 装配路径**，作为 ADR-101 吸收式重构的 P0-C 节点。判定材料 = inventory §11 的 16 个待决问题。
+
+### 1.3 三层验证已完成的关键负向断言
+
+inventory §10 + 本 ADR 起草过程的三层验证（semantic_search → vscode_listCodeUsages → grep）确认：
+
+1. **boundary marker 在所有 provider 端无消费方**：grep 全仓 `cache_control` 在 desktop-client/ironclaw、claw-code、ironclaw-main 的 provider 适配层 0 命中。当前 marker 的实际行为是 **inert HTML comment**，Anthropic prompt cache 命中率 = 0。
+2. **`DynamicLayerInput.admin_policy` / `token_budget` / `language_preference` 是 0 caller 死字段**：`git log -S` 确认仅一次 P0-1 commit（3f45d54）引入；`vscode_listCodeUsages` + `rg` 全仓 0 调用方。三参考库（codex / claw-code / ironclaw-main）均无对应概念。
+3. **codex 装配模型与 ironclaw 不可融合**：codex 走 Responses API 顶层 `instructions` 字段 + developer/contextual_user 多消息项，无 inline boundary；不能直接借鉴，但可作为未来 P1 优化方向。
+4. **inventory 35/36/37 三份 capability inventory 均未拍 composition 顺序**：D8 决策属真空地带，由本 ADR 一次性定义。
+5. **`claw-code-api` 依赖 `claw-code/rust/crates/runtime` 仅用于 OAuth/usage/config**，与 `runtime::prompt` 模块无耦合 → 删除 `runtime/src/prompt.rs` 不破 desktop-client 编译。
+6. **`claw-code/rust/crates/rusty-claude-cli` 是 desktop-client 的死代码**：grep workflows + Cargo.toml + lockfile 0 命中。
+
+---
+
+## 2. Decision
+
+### 2.1 总方针
+
+**保留 desktop-client/ironclaw 的 `LayeredPromptBuilder` 为唯一装配路径**；**删除 claw-code 的 `SystemPromptBuilder`**；其需要的能力（环境段、project doc 段）以**字段化**形式吸收进 `DynamicLayerInput`，**不引入新模块**。
+
+### 2.2 十项细决策（D1–D10）
+
+| # | 决策 | 选项 | 备注 |
+|---|---|---|---|
+| **D1** | 统一目标 | **B — 吸收到 LayeredPromptBuilder** | 不另起新 crate；与 ADR-101 吸收式重构总方针一致 |
+| **D2** | boundary 字面量来源 | **B' — 通过 `x_claw_agent::PROMPT_CACHE_BOUNDARY` 单源** | claw-code 端的同名常量随 D5 删除一并消失 |
+| **D3** | 吸收范围 | **Absorb a/b/c/d/e/g/i** | inventory §11 的待决问题 a/b/c/d/e/g/i 由本 ADR 给出最终选择 |
+| **D4** | `IRONCLAW_PROMPT_LAYERING` 环境变量 | **C — 删除** | P0-1 已默认启用并删除；本 ADR 仅追认 |
+| **D5** | `claw-code/rust/crates/runtime/src/prompt.rs` | **drop — 整文件删除** | desktop-client 不依赖 `runtime::prompt`，且 `claw-code-api` 不再需要 |
+| **D6** | `LayeredPromptBuilder.static_hash` + `static_changed` 旗标 | **Y — 删除** | 该 hash 字段无消费者，prefix cache 真正依赖的是字节稳定性，而非业务层 hash 比较 |
+| **D7** | 删除半径 | **档 1 保守 — 仅删 `runtime/src/prompt.rs` + `rusty-claude-cli/`** | 不删整个 `claw-code` 子树。`claw-code-api` 仍提供 OAuth/usage/config 给 desktop-client；agent loop 已独立 |
+| **D8** | composition 顺序 | 见 §2.3（6 个子决策） | inventory 35/36/37 真空地带，本 ADR 一次性拍板 |
+| **D9** | 测试不变量 | 见 §2.4（5 个子决策） | 删 3 加 5；不引入快照测试；不设覆盖率门槛 |
+| **D10** | 落地序列 | **三段 PR** + 立即删除 + 单 commit revert | 见 §4 |
+
+### 2.3 D8 — composition 顺序（6 子决策）
+
+| # | 子决策 | 取值 | 理由 |
+|---|---|---|---|
+| **D8.1** | identity（workspace AGENTS.md / SOUL.md / IDENTITY.md）所属层 | **静态层尾部 `--- {identity}`** 不变；项目级文档以 `DynamicLayerInput.project_doc` **占位字段**迎接 [#55 ProjectDocLoader](https://github.com/Linnanli/xClaw/issues/55)（已 closed）的产出 | identity 是「我是谁」恒定身份；project_doc 是「项目的指令」按 cwd 变化 — 两者生命周期不同 |
+| **D8.2** | 新增 `## Environment` 段格式 | **Markdown**：`## Environment\n\ncwd: {path}\ndate: {date}\nplatform: {os}` | 维持 dynamic 层全 Markdown，避免 codex 的 XML（`<environment_context>`）与 Markdown 混排 |
+| **D8.3** | `project_doc` 字段是否本 ADR 立即接入 ProjectDocLoader | **A — 暂不接 + 字段预留** | [#55 ProjectDocLoader](https://github.com/Linnanli/xClaw/issues/55) 本体已 closed（loader 逻辑实现完），但接入 `LayeredPromptBuilder` 的字段赋值工作属后续 issue；本 ADR 仅预留 `Option<String>` 接口面，避免将来反复改 schema |
+| **D8.4** | `admin_policy` / `token_budget` / `language_preference` 三字段 | **B — 删除** | 三层验证证实 0 caller、0 上游对应、P0-1 死占位；未来正确路径已分别登记到 [#137](https://github.com/Linnanli/xClaw/issues/137) |
+| **D8.5** | 静态层内部顺序 | **保持现状** | preamble → response_format → guidelines → safety → tools → tool_style → identity；inventory §3.1 已稳定 |
+| **D8.6** | 动态层内部顺序 | **保持现状基础上插入新段** | skill → channel → ext → conv → group → runtime → **environment（新）** → **project_doc（新占位）** |
+
+#### 2.3.1 最终 `DynamicLayerInput` 字段形态
+
+```rust
+pub struct DynamicLayerInput {
+    pub skill_context: Option<String>,
+    pub channel: Option<String>,
+    pub extensions_guidance: Option<String>,
+    pub conversation_context: Option<String>,
+    pub group_guidance: Option<String>,
+    pub runtime_info: Option<String>,
+    pub environment: Option<String>,    // D8.2 新增
+    pub project_doc: Option<String>,    // D8.3 占位（#55 loader 已 closed；接入字段赋值是后续 issue）
+}
+```
+
+删除字段：`admin_policy` / `token_budget` / `language_preference`（D8.4）。
+
+### 2.4 D9 — 测试不变量（5 子决策）
+
+| # | 子决策 | 取值 |
+|---|---|---|
+| **D9.1** | 删除测试 | `test_admin_policy_precedence_note`（dynamic_layer.rs）+ `test_static_hash_*` 系列（mod.rs）共 3 项 |
+| **D9.2** | 新增功能测试 | `test_environment_section_renders`（验证 `## Environment` Markdown 正确组装） + `test_project_doc_field_default_empty`（占位字段在 `None` 时不 emit） |
+| **D9.3** | 新增 provider 通用性测试 | `test_openai_compat_prompt_serializes` + `test_anthropic_compat_prompt_serializes` —— 锁定「inert HTML comment 在所有 provider 都是合法静态字节，不破坏序列化」 |
+| **D9.4** | 顺序断言形式 | **B — `text.find()` 相对位置断言**（不引入 `insta` 快照）。理由：prompt 文本会随产品迭代频繁修订，快照会变成「狼来了」噪声；位置断言锁的是不变量本身（`environment 早于 project_doc`），不锁文案 |
+| **D9.5** | 覆盖率门槛 | **C — 不设** | x-claw 已有 TDD + Rust 类型 + 多层 CI gate 作为强约束；覆盖率门槛是弱代理（Goodhart 风险），不写 |
+
+净测试变化：**+5 / -3**。
+
+---
+
+## 3. Consequences
+
+### 3.1 正面
+
+- 装配路径单源化：`Reasoning::build_system_prompt_with_tools` → `LayeredPromptBuilder::build` → `String`，可被任意 provider 透传
+- `DynamicLayerInput` 形态契合 codex `EnvironmentContext` 概念（cwd/date/platform），未来若接 #55 ProjectDocLoader 不需要再改 schema
+- 删除 ~600 LOC 死代码（runtime/src/prompt.rs ~920 行 + rusty-claude-cli + 3 个 dynamic 字段 + hash 系列）
+- ADR-115 的「构建期 DI」原则得到字段化承接（`project_doc: Option<String>`）
+
+### 3.2 负面 / 成本
+
+- 删除 `claw-code/rust/crates/runtime/src/prompt.rs` 后，`claw-code` 子项目的 standalone 用途（如果有）失去 system prompt 装配能力 → 但本仓库不依赖该路径，可接受
+- 跨 crate 删除 PR（PR-3）需要 `cargo check -p claw-code-api` 双重验证
+
+### 3.3 风险
+
+| # | 风险 | 缓解 |
+|---|---|---|
+| **R-1** | **boundary marker 全 provider 无消费**（核心遗留问题） | 本 ADR **不在范围内**修复 — 单独 P1 issue「Anthropic provider 接入 `cache_control` 切分」；本 ADR §1.3 已记录该负向事实底盘 |
+| **R-2** | PR-3 删 `rusty-claude-cli` 破 CI workflow | PR-3 必须先 `grep -r "rusty-claude-cli" .github/workflows/` 0 命中 |
+| **R-3** | PR-3 删 `runtime/src/prompt.rs` 破 `claw-code-api` 编译 | PR-3 必须 `cargo check -p claw-code-api` 通过 |
+| **R-4** | `## Environment` 段格式与 #55 ProjectDocLoader 将来要求冲突 | `project_doc` 字段已预留；#55 实施时仅填字段，不改格式 |
+| **R-5** | `admin_policy` / `token_budget` / `language_preference` 误删（万一上游 fork 或某 milestone 真要用） | 已三层验证 0 caller，且未来正确路径登记到 [#137](https://github.com/Linnanli/xClaw/issues/137)（admin_policy → ironclaw_safety fail-safe / token_budget → context/compact / language_preference → ChannelAdapter）；删除是字段重构，不是能力删除 |
+
+---
+
+## 4. 落地序列（D10）
+
+### 4.1 三段 PR
+
+| PR | 标题 | base | closes | 内容 | LOC | 风险 |
+|---|---|---|---|---|---|---|
+| **PR-1** | `docs(adr): adr-117 p0c prompt builder unification` | xClaw | — | 仅本文档 | +~400 / -0 | 0 |
+| **PR-2** | `feat(prompt): implement adr-117 d8 composition order` | PR-1 合并后 xClaw | — | `DynamicLayerInput.environment` + `project_doc` 字段；`dynamic_layer.rs` render；`reasoning.rs` 喂 `EnvironmentContext::current()` 数据；新增 5 测试 | +~80 / -5 | 低 |
+| **PR-3** | `chore(prompt): remove dead code per adr-117 d5/d6/d7/d8.4` | PR-2 合并后 xClaw | **#130** | 删 `admin_policy`/`token_budget`/`language_preference` 字段 + `dynamic_layer.rs` 对应 render；删 `LayeredPromptBuilder.static_hash` + `static_changed` + hash 测试；删 `claw-code/rust/crates/runtime/src/prompt.rs`（D5）；删 `claw-code/rust/crates/rusty-claude-cli/`（D7）；同步 `runtime/lib.rs` 的 `pub use` | +~10 / -~600 | 中 |
+
+### 4.2 每 PR 必跑验证
+
+依据 [.github/copilot-instructions.md](../../.github/copilot-instructions.md) 第 3 节本地管线：
+
+```bash
+cargo check -p ironclaw --tests
+cargo nextest run -p ironclaw --lib llm::prompt
+cargo fmt --all
+python3.12 scripts/check_no_panics.py --base origin/xClaw
+cargo clippy --no-deps -p ironclaw --all-targets -- -D warnings
+```
+
+PR-3 额外：
+
+```bash
+cargo check -p claw-code-api                                   # 不破依赖
+grep -r "rusty_claude_cli\|runtime::prompt" --include='*.rs'   # 无残留引用
+grep -r "rusty-claude-cli" .github/workflows/                  # 无 workflow 引用
+```
+
+### 4.3 删除时机
+
+**立即删除**，无 deprecate 期：三层验证已确认 0 caller，无外部 fork 依赖路径需要给迁移窗口。
+
+### 4.4 回滚策略
+
+**单 commit revert**。不引入 `IRONCLAW_PROMPT_V2` 之类 feature flag——feature flag 即「补丁式代码」，违反 [AGENTS.md](../../AGENTS.md) 红线。
+
+---
+
+## 5. Enforcement
+
+### 5.1 PR body 必填项
+
+按 [.github/copilot-instructions.md](../../.github/copilot-instructions.md) 第 4 节：每个 PR body 必须包含 4 块（背景/目标 / 改动范围 / What's NOT in this PR / 验证）。stacked PR（PR-2 / PR-3）必须额外注明 base 不是 `xClaw` 与 merge 顺序。
+
+### 5.2 范围外（What's NOT in this PR）
+
+- **不修复 boundary marker 无 provider 消费**（R-1，单独 P1 issue）
+- **不接入 #55 ProjectDocLoader**（仅占位字段）
+- **不删除整个 `claw-code` 子树**（D7 档 1 保守，仅删 `runtime/src/prompt.rs` + `rusty-claude-cli/`）
+- **不重新设计 codex-style top-level `instructions` 装配**（与本仓库 ChatMessage::system 单串模型不兼容，留待后续 ADR）
+- **不引入 `insta` 快照测试**（D9.4）
+- **不设覆盖率门槛**（D9.5）
+
+---
+
+## 6. 验证
+
+### 6.1 三层验证账本
+
+inventory [§10](p0c-prompt-builder-inventory.md) + 本 ADR 起草过程已完成：
+
+- **Tier 1 semantic_search**：定位 `LayeredPromptBuilder` / `SystemPromptBuilder` / `Session::build_initial_context` 三处装配
+- **Tier 2 vscode_listCodeUsages**：`admin_policy` / `token_budget` / `language_preference` 0 调用方；`runtime::prompt` 在 desktop-client 0 调用方
+- **Tier 3 grep_search / rg**：
+  - `cache_control` 在 desktop-client/ironclaw、claw-code、ironclaw-main provider 层 0 命中（R-1 事实底盘）
+  - `git log -S` 确认 admin_policy 等三字段仅 P0-1 commit（3f45d54）引入
+  - `rusty-claude-cli` 在 workflows / Cargo / lockfile 0 命中
+
+### 6.2 关联 issue
+
+- **#130**：本 ADR 实施 PR-3 closes
+- **#55**：[CLOSED] ProjectDocLoader loader 实现本体已完；将其输出接入 `DynamicLayerInput.project_doc` 字段赋值属后续 issue
+- **#137**：admin_policy / token_budget / language_preference 三字段未来正确路径追踪
+- **未来 P1（待开 issue）**：Anthropic provider 实现 `cache_control` 切分（R-1）
+
+---
+
+## 7. 关键术语
+
+| 术语 | 含义 |
+|---|---|
+| **静态层** | 与 cwd / 用户输入无关、跨 session 字节稳定的前缀（identity / response_format / guidelines / safety / tools） |
+| **动态层** | 跨 session 变化的后缀（skill / channel / runtime / environment / project_doc） |
+| **boundary marker** | `<!-- __SYSTEM_PROMPT_DYNAMIC_BOUNDARY__ -->`，HTML 注释包裹的字面量，理论用途为辅助 provider 端做 prefix cache 切分；当前**实际为 inert HTML 注释**（无 provider 消费） |
+| **inert** | 模型可读但语义中立——HTML 注释对所有主流 LLM provider 都是合法静态字节 |
+| **provider 通用性** | 同一 prompt 串可作为 `ChatMessage::system` 内容透传给 OpenAI / Anthropic / Gemini / Bedrock / Copilot 等任意 provider 而不破坏其请求 schema |

--- a/docs/plans/architecture-refactor/openai-cache-augmentation-issue-draft.md
+++ b/docs/plans/architecture-refactor/openai-cache-augmentation-issue-draft.md
@@ -1,0 +1,111 @@
+# Issue 草案：feat(llm): OpenAI provider 接入服务端 prompt cache（prompt_cache_key + cached_tokens）
+
+> Status: Draft
+> Priority: P1
+> 关联 ADR: 不阻塞 [ADR-117](adr-117-p0c-prompt-builder-unification.md)（P0-C prompt builder 统一）；建议在 ADR-117 合并后启动
+> Source: P0-C/W3/B 决策讨论（#130）副产品
+
+## 背景 / 问题
+
+当前 desktop（`desktop-client/ironclaw/src/llm/`）的 OpenAI provider 路径在 LLM cache 能力上有两个明确缺口：
+
+### 缺口 1：请求侧未注入 `prompt_cache_key`
+
+`openai_codex_provider.rs` 与 registry openai-protocol 路径都没有给 OpenAI Responses API 发 `prompt_cache_key` 字段（`grep -r prompt_cache_key desktop-client/` 0 处匹配）。
+OpenAI 服务端虽然会自动尝试 cache，但若没有 stable cache key，命中率受 hash 抖动影响明显。
+
+参考实现：[`codex-cli-main/codex-rs/core/src/client.rs:878`](../../codex-cli-main/codex-rs/core/src/client.rs#L878)
+
+```rust
+prompt_cache_key: Some(self.client.state.conversation_id.to_string()),
+```
+
+仅 3 行即生效。
+
+### 缺口 2：响应侧 `cached_tokens` 写死为 0
+
+[`desktop-client/ironclaw/src/llm/openai_codex_provider.rs:270-271, 323-324`](../../desktop-client/ironclaw/src/llm/openai_codex_provider.rs#L270)：
+
+```rust
+cache_read_input_tokens: 0,
+cache_creation_input_tokens: 0,
+```
+
+两处硬编码 — 即使 OpenAI 服务端真的命中了 cache 并在 `usage.prompt_tokens_details.cached_tokens` 里报告了缓存命中数，desktop 完全看不到。后果：
+
+- 计费统计不准（cache 命中实际省了 token 但 metric 不知道）
+- `PromptCacheMonitor` 对 OpenAI 路径完全失效（永远看到 0）
+- 用户优化 prompt 时无 OpenAI 反馈
+
+## 现状对比矩阵
+
+| Provider | CachedProvider 客户端 | 服务端 prompt_cache_key | cached_tokens 解析 | Monitor 可见 |
+|---|---|---|---|---|
+| Anthropic | ✅ | ✅ ephemeral marker | ✅ | ✅ |
+| OpenAI codex | ✅ | ❌ | ❌ 写死 0 | ❌ |
+| OpenAI compat (registry) | ✅ | ❌ | ❌ | ❌ |
+
+## 范围
+
+**P1，不阻塞**。与 P0-C / [ADR-117](adr-117-p0c-prompt-builder-unification.md) prompt builder 统一**完全正交**，建议在 ADR-117 合并后启动。
+
+## 改动清单
+
+### 1. 注入 `prompt_cache_key`
+
+- `desktop-client/ironclaw/src/llm/openai_codex_provider.rs`：构造 OpenAI Responses API request 时填 `prompt_cache_key = session_id.to_string()`
+- registry openai-protocol provider：同步注入
+- 决策点：用 session_id 还是 conversation_id？建议 session_id（与 codex 等价但避免 desktop 已有 session/conversation 二级概念冲突）
+
+### 2. 解析响应 `cached_tokens`
+
+- `openai_codex_provider.rs:270/271/323/324`：从 OpenAI Responses API 响应的 `usage.prompt_tokens_details.cached_tokens` 读取
+- 映射规则：
+  - `cache_read_input_tokens` ← `usage.prompt_tokens_details.cached_tokens`
+  - `cache_creation_input_tokens` 保持 0（OpenAI 无 ephemeral 写入概念，符合协议本质）
+
+### 3. PromptCacheMonitor 通用化
+
+- `desktop-client/ironclaw/src/llm/observability/prompt_cache.rs`：保持现有 record 接口；OpenAI 路径填 `cache_creation_input_tokens=0` 即可（最小改动方案）
+- 不需要新增 `provider_kind` 字段（避免 API 变更）
+
+### 4. 测试
+
+- mock-openai-service 路径增加 cache hit 测试（mock 服务返回 `usage.prompt_tokens_details.cached_tokens > 0`）
+- 新增集成测试 `req_llm_openai_cache_001`：连续两次相同 prompt → 第二次 `cache_read_input_tokens > 0`
+- 单测：`prompt_cache_key` 正确从 session_id 派生
+
+## 不做（避免范围蔓延）
+
+- 不动 LayeredPromptBuilder（属 [ADR-117](adr-117-p0c-prompt-builder-unification.md) / P0-C）
+- 不引入 OpenAI Responses API 全套迁移（仅 cache 字段）
+- 不改 CacheRetention enum（OpenAI 无 TTL 客户端控制）
+- 不增加 CachedProvider TTL 跟随 provider（保持 1h 默认）
+
+## 验证
+
+```bash
+cargo nextest run -p ironclaw llm::openai
+cargo nextest run -p ironclaw llm::observability::prompt_cache
+```
+
+集成验证：连续相同 prompt 两次 → `tracing::info!` 日志可见 `cache_read_input_tokens > 0`。
+
+## 收益估算
+
+- OpenAI 用户场景下 token 计费可见性恢复
+- `PromptCacheMonitor` 命中率指标对 OpenAI 路径可用
+- 长会话场景理论 token 节省（依赖 OpenAI 服务端策略，预计 30-60% input token 减少）
+
+## 复制 codex / 自研比例
+
+- 复制部分：`prompt_cache_key` 注入逻辑（约 3 行）+ `cached_tokens` 字段读取（约 5 行）
+- 自研部分：在 desktop 多 provider trait + `PromptCacheMonitor` 观测体系下集成（约 100-200 行）
+- desktop 比 codex 更好的部分：多 provider 抽象 + `CachedProvider`（response_cache.rs）客户端响应缓存 + Monitor 可观测性
+
+## 来源参考
+
+- codex 实现：[`codex-cli-main/codex-rs/core/src/client.rs:878`](../../codex-cli-main/codex-rs/core/src/client.rs#L878)（prompt_cache_key 注入）
+- desktop 现状：[`desktop-client/ironclaw/src/llm/openai_codex_provider.rs:270-271, 323-324`](../../desktop-client/ironclaw/src/llm/openai_codex_provider.rs#L270)
+- 客户端缓存层（已有，无需改动）：[`desktop-client/ironclaw/src/llm/response_cache.rs`](../../desktop-client/ironclaw/src/llm/response_cache.rs)
+- Monitor：[`desktop-client/ironclaw/src/llm/observability/prompt_cache.rs`](../../desktop-client/ironclaw/src/llm/observability/prompt_cache.rs)


### PR DESCRIPTION
## 背景 / 目标

P0-C / W3/B（issue #130）要求统一 prompt builder 装配路径。本 PR **仅落地 ADR-117 决策文档**，是 P0-C 三段 stacked PR 的第 1/3 段：

- **PR-1（本 PR）** = ADR 决策文档 + companion 编号同步（不闭 issue）
- **PR-2** = `feat(prompt): implement ADR-117 D8 composition order`（加 environment + project_doc 字段）
- **PR-3** = `chore(prompt): remove dead code per ADR-117 D5/D6/D7/D8.4`（**closes #130 + #131**）

ADR-117 是对 [p0c-prompt-builder-inventory.md](https://github.com/Linnanli/xClaw/blob/w3-issue-130-prompt-builder-adr-117/docs/plans/architecture-refactor/p0c-prompt-builder-inventory.md) §11 列出的 16 个待决问题的封顶决策（D1–D10，含 D8 6 子决策 + D9 5 子决策）。

> ⚠️ **Stacked PR**：base 不是 `xClaw`，而是 `w3-issue-129-prompt-builder-inventory`（PR #136）。merge 顺序：**先看并合并 #136 → 再看本 PR**。本 PR 在 #136 合并后会 rebase 到 `xClaw`。

## 改动范围

| 文件 | 改动 | 行数 |
|---|---|---|
| `docs/plans/architecture-refactor/adr-117-p0c-prompt-builder-unification.md` | **新建** ADR 文档（7 节：Context / Decision D1–D10 / Consequences / 落地序列 / Enforcement / 验证 / 关键术语） | +227 |
| `docs/plans/architecture-refactor/openai-cache-augmentation-issue-draft.md` | **新建**（封装本次会话工作区中已有的 draft；同步 3 处 ADR-114 → ADR-117 编号更正） | +111 |

**编号说明**：早期 inventory + draft 提到的「ADR-114 prompt builder」实际编号让位至 **117**（114 已被 [adr-114-dasclaw-rebrand.md](https://github.com/Linnanli/xClaw/blob/xClaw/docs/plans/architecture-refactor/adr-114-dasclaw-rebrand.md) 占用，115 占于 [adr-115-project-docs-not-in-hook.md](https://github.com/Linnanli/xClaw/blob/xClaw/docs/plans/architecture-refactor/adr-115-project-docs-not-in-hook.md)，116 由 [adr-112 §6](https://github.com/Linnanli/xClaw/blob/xClaw/docs/plans/architecture-refactor/adr-112-compatibility-evaluation.md) 预告 Tier 2 合规清单占用）。

## D1–D10 速览

- **D1=B** 吸收到 LayeredPromptBuilder（删 SystemPromptBuilder）
- **D2=B'** 单源 boundary literal via `x_claw_agent::PROMPT_CACHE_BOUNDARY`
- **D3** Absorb a/b/c/d/e/g/i（inventory §11）
- **D4=C** 删 `IRONCLAW_PROMPT_LAYERING` 环境变量（P0-1 已删，本 ADR 追认）
- **D5** drop `claw-code/rust/crates/runtime/src/prompt.rs`
- **D6=Y** 删 `LayeredPromptBuilder.static_hash` + `static_changed`
- **D7 档 1 保守** 仅删 `runtime/src/prompt.rs` + `rusty-claude-cli/`，保 `claw-code` 子树
- **D8** composition 顺序：identity 静态、`project_doc` 占位字段、`## Environment` Markdown、删 `admin_policy`/`token_budget`/`language_preference`（追踪 #137）
- **D9** 测试：删 3 加 5；不引入 `insta` 快照；不设覆盖率门槛
- **D10** 三段 PR 落地（本 PR 是 1/3）

## What's NOT in this PR

- ❌ **不修代码**：本 PR 仅文档；代码改动在 PR-2 / PR-3
- ❌ **不闭任何 issue**：closes #130 + #131 留给 PR-3
- ❌ **不修复 R-1 boundary marker 无 provider 消费**（P1，独立 issue 待开）
- ❌ **不接入 [#55 ProjectDocLoader](https://github.com/Linnanli/xClaw/issues/55)**（仅在 D8.3 预留 `project_doc` 字段）
- ❌ **不删除整个 `claw-code` 子树**（D7 档 1 保守）
- ❌ **不重新设计 codex-style top-level `instructions` 装配**（与 ChatMessage::system 单串模型不兼容，留待后续 ADR）
- ❌ **不引入 `insta` 快照测试**（D9.4）
- ❌ **不设覆盖率门槛**（D9.5）

## 验证（命令 + 结果）

ADR 是纯文档，本 PR 无代码改动。按 [.github/copilot-instructions.md](https://github.com/Linnanli/xClaw/blob/xClaw/.github/copilot-instructions.md) 第 3 节，纯文档 PR 仅需：

```bash
$ python3.12 scripts/check_no_panics.py --base origin/xClaw
# 文档 PR 不影响（无 .rs 改动）

$ git diff --stat origin/w3-issue-129-prompt-builder-inventory..HEAD
 .../adr-117-p0c-prompt-builder-unification.md      | 227 +++++++++++++++++++++
 .../openai-cache-augmentation-issue-draft.md       | 111 ++++++++++
 2 files changed, 338 insertions(+)
```

三层验证账本（已记录于 ADR-117 §6.1）：
- **Tier 1 semantic_search**：定位 `LayeredPromptBuilder` / `SystemPromptBuilder` / `Session::build_initial_context` 三处装配
- **Tier 2 vscode_listCodeUsages**：`admin_policy` / `token_budget` / `language_preference` / `runtime::prompt` 0 调用方
- **Tier 3 grep_search**：`cache_control` 在 desktop-client/ironclaw + claw-code + ironclaw-main provider 层 0 命中（R-1 事实底盘）；`git log -S` 确认三死字段仅 P0-1 commit 引入；`rusty-claude-cli` 在 workflows / Cargo / lockfile 0 命中

## 关联 issue

- **#130**（P0-C/W3/B 决策 ADR）— 本 PR 不闭，留给 PR-3
- **#131**（P0-C/W3/C 实施）— 不闭，留给 PR-3
- **#137**（admin_policy/token_budget/language_preference 未来正确路径追踪）— ADR §2.3 D8.4 + §6.2 链接
- **#89**（P1 prompt builder ownership ADR）— 与本 ADR 互不冲突；本 ADR D7 档 1 保守保留 LayeredPromptBuilder 当前位置，长期 ownership 留 #89
- **#55**（ProjectDocLoader，CLOSED）— `project_doc` 字段为后续接入预留
- **未来 P1 issue**（待开）— Anthropic provider 实现 `cache_control` 切分（ADR-117 R-1）
