### PR TITLE
chore(prompt): remove dead code per ADR-117 D6/D8.4

### DIFF
--- a/desktop-client/ironclaw/src/llm/prompt/dynamic_layer.rs
+++ b/desktop-client/ironclaw/src/llm/prompt/dynamic_layer.rs
@@ -4,9 +4,7 @@
 //! group chat rules, runtime info, environment context, and project doc.
 //!
 //! Composition order is fixed by [ADR-117 §2.3 D8.6]:
-//! skill → channel → ext → conv → group → runtime → environment → project_doc
-//! → admin_policy → token_budget → language_preference. The trailing three
-//! fields are scheduled for removal in PR-3 (ADR-117 D8.4 / issue #137).
+//! skill → channel → ext → conv → group → runtime → environment → project_doc.
 //!
 //! [ADR-117 §2.3 D8.6]: ../../../../docs/plans/architecture-refactor/adr-117-p0c-prompt-builder-unification.md
 
@@ -33,12 +31,6 @@ pub struct DynamicLayerInput {
     /// `.codex/AGENTS.md`. Placeholder field for the post-#55 wiring step
     /// (ADR-117 §2.3 D8.3); current callers leave it `None`.
     pub project_doc: Option<String>,
-    /// Admin-managed policy overrides.
-    pub admin_policy: Option<String>,
-    /// Token budget / quota reminder.
-    pub token_budget: Option<String>,
-    /// User's preferred interaction language.
-    pub language_preference: Option<String>,
 }
 
 /// Build the dynamic (uncached) portion of the system prompt.
@@ -100,31 +92,6 @@ pub fn build(input: &DynamicLayerInput) -> String {
         }
     }
 
-    if let Some(ref policy) = input.admin_policy {
-        if !policy.is_empty() {
-            sections.push(format!(
-                "## Admin Policy\n\n\
-                 The following policies are enforced by the organization administrator.\n\
-                 They take precedence over user preferences but not over safety rules.\n\n\
-                 {policy}"
-            ));
-        }
-    }
-
-    if let Some(ref budget) = input.token_budget {
-        if !budget.is_empty() {
-            sections.push(format!("## Token Budget\n\n{budget}"));
-        }
-    }
-
-    if let Some(ref lang) = input.language_preference {
-        if !lang.is_empty() {
-            sections.push(format!(
-                "## Language\n\nRespond in {lang} unless the user writes in a different language."
-            ));
-        }
-    }
-
     sections.join("\n\n")
 }
 
@@ -151,29 +118,17 @@ mod tests {
     }
 
     #[test]
-    fn test_admin_policy_precedence_note() {
-        let input = DynamicLayerInput {
-            admin_policy: Some("No external API calls.".into()),
-            ..Default::default()
-        };
-        let text = build(&input);
-        assert!(text.contains("Admin Policy"));
-        assert!(text.contains("take precedence"));
-        assert!(text.contains("No external API calls"));
-    }
-
-    #[test]
     fn test_multiple_sections_joined() {
         let input = DynamicLayerInput {
             channel: Some("telegram".into()),
-            language_preference: Some("中文".into()),
+            runtime_info: Some("model=claude".into()),
             ..Default::default()
         };
         let text = build(&input);
         assert!(text.contains("Channel"));
         assert!(text.contains("telegram"));
-        assert!(text.contains("Language"));
-        assert!(text.contains("中文"));
+        assert!(text.contains("Runtime"));
+        assert!(text.contains("model=claude"));
     }
 
     #[test]

--- a/desktop-client/ironclaw/src/llm/prompt/mod.rs
+++ b/desktop-client/ironclaw/src/llm/prompt/mod.rs
@@ -17,8 +17,6 @@ mod static_layer;
 pub use dynamic_layer::DynamicLayerInput;
 pub use static_layer::StaticLayer;
 
-use std::collections::hash_map::DefaultHasher;
-use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 
 use x_claw_agent::PROMPT_CACHE_BOUNDARY;
@@ -37,22 +35,19 @@ fn cache_boundary_section() -> String {
 pub struct LayeredPrompt {
     /// The fully assembled system prompt string.
     pub text: String,
-    /// Whether the static layer was rebuilt (hash changed).
-    pub static_changed: bool,
 }
 
 /// Builds system prompts with static/dynamic separation.
 ///
-/// The static layer is computed once and cached in an `Arc<String>`.
-/// It is only rebuilt when the `static_hash` changes (tool set change,
-/// config change, etc.).
-///
-/// The dynamic layer is rebuilt every call from the provided `DynamicLayerInput`.
+/// The static layer is computed once at construction and cached in an
+/// `Arc<String>`. The dynamic layer is rebuilt every call from the provided
+/// [`DynamicLayerInput`]. Provider-side prefix caching relies on byte-level
+/// stability of the static prefix, not on a builder-side hash; see ADR-117
+/// §2.2 D6 for why the previous `static_hash` / `refresh_static` machinery
+/// was removed.
 pub struct LayeredPromptBuilder {
     /// Cached static layer text.
     static_layer: Arc<String>,
-    /// Hash of the inputs that produced `static_layer`.
-    static_hash: u64,
     /// Whether the model supports Anthropic-style cache control.
     supports_cache_boundary: bool,
 }
@@ -61,10 +56,8 @@ impl LayeredPromptBuilder {
     /// Create a new builder with the given tool definitions and static config.
     pub fn new(tools: &[ToolDefinition], static_config: &StaticLayerConfig) -> Self {
         let static_text = StaticLayer::build(tools, static_config);
-        let hash = Self::compute_hash(tools, static_config);
         Self {
             static_layer: Arc::new(static_text),
-            static_hash: hash,
             supports_cache_boundary: false,
         }
     }
@@ -73,22 +66,6 @@ impl LayeredPromptBuilder {
     pub fn with_cache_boundary(mut self, enabled: bool) -> Self {
         self.supports_cache_boundary = enabled;
         self
-    }
-
-    /// Rebuild the static layer only if inputs have changed.
-    /// Returns `true` if the layer was actually rebuilt.
-    pub fn refresh_static(
-        &mut self,
-        tools: &[ToolDefinition],
-        static_config: &StaticLayerConfig,
-    ) -> bool {
-        let new_hash = Self::compute_hash(tools, static_config);
-        if new_hash == self.static_hash {
-            return false;
-        }
-        self.static_layer = Arc::new(StaticLayer::build(tools, static_config));
-        self.static_hash = new_hash;
-        true
     }
 
     /// Build the full system prompt by combining static + dynamic layers.
@@ -106,32 +83,12 @@ impl LayeredPromptBuilder {
             format!("{}\n\n{}", self.static_layer, dynamic_text)
         };
 
-        LayeredPrompt {
-            text,
-            static_changed: false,
-        }
-    }
-
-    /// Get the current static layer hash.
-    pub fn static_hash(&self) -> u64 {
-        self.static_hash
-    }
-
-    fn compute_hash(tools: &[ToolDefinition], config: &StaticLayerConfig) -> u64 {
-        let mut hasher = DefaultHasher::new();
-        for t in tools {
-            t.name.hash(&mut hasher);
-            t.description.hash(&mut hasher);
-        }
-        config.identity.hash(&mut hasher);
-        config.has_native_thinking.hash(&mut hasher);
-        config.model_name.hash(&mut hasher);
-        hasher.finish()
+        LayeredPrompt { text }
     }
 }
 
 /// Configuration inputs for the static layer that rarely change.
-#[derive(Debug, Clone, Hash)]
+#[derive(Debug, Clone, Default)]
 pub struct StaticLayerConfig {
     /// Workspace identity prompt (AGENTS.md + SOUL.md + IDENTITY.md etc.).
     pub identity: String,
@@ -139,16 +96,6 @@ pub struct StaticLayerConfig {
     pub model_name: String,
     /// Whether the model has native thinking (Qwen3, DeepSeek-R1).
     pub has_native_thinking: bool,
-}
-
-impl Default for StaticLayerConfig {
-    fn default() -> Self {
-        Self {
-            identity: String::new(),
-            model_name: String::new(),
-            has_native_thinking: false,
-        }
-    }
 }
 
 #[cfg(test)]
@@ -176,50 +123,6 @@ mod tests {
             model_name: "claude-sonnet-4-20250514".into(),
             has_native_thinking: false,
         }
-    }
-
-    #[test]
-    fn test_static_hash_stable_for_same_inputs() {
-        let tools = sample_tools();
-        let config = sample_config();
-        let b1 = LayeredPromptBuilder::new(&tools, &config);
-        let b2 = LayeredPromptBuilder::new(&tools, &config);
-        assert_eq!(b1.static_hash(), b2.static_hash());
-    }
-
-    #[test]
-    fn test_static_hash_changes_on_tool_change() {
-        let config = sample_config();
-        let tools1 = sample_tools();
-        let tools2 = vec![ToolDefinition {
-            name: "grep_search".into(),
-            description: "Search files".into(),
-            parameters: serde_json::json!({}),
-        }];
-        let b1 = LayeredPromptBuilder::new(&tools1, &config);
-        let b2 = LayeredPromptBuilder::new(&tools2, &config);
-        assert_ne!(b1.static_hash(), b2.static_hash());
-    }
-
-    #[test]
-    fn test_refresh_static_returns_false_when_unchanged() {
-        let tools = sample_tools();
-        let config = sample_config();
-        let mut builder = LayeredPromptBuilder::new(&tools, &config);
-        assert!(!builder.refresh_static(&tools, &config));
-    }
-
-    #[test]
-    fn test_refresh_static_returns_true_when_tools_change() {
-        let tools = sample_tools();
-        let config = sample_config();
-        let mut builder = LayeredPromptBuilder::new(&tools, &config);
-        let new_tools = vec![ToolDefinition {
-            name: "git_status".into(),
-            description: "Git status".into(),
-            parameters: serde_json::json!({}),
-        }];
-        assert!(builder.refresh_static(&new_tools, &config));
     }
 
     #[test]

--- a/desktop-client/ironclaw/tests/parity_gate_p1.rs
+++ b/desktop-client/ironclaw/tests/parity_gate_p1.rs
@@ -502,7 +502,7 @@ fn fp_021_prompt_cache_hit_rate_above_80() {
 fn fp_022_dynamic_layer_preserves_static_cache() {
     let tools = sample_tools();
     let config = sample_config();
-    let mut builder = LayeredPromptBuilder::new(&tools, &config);
+    let builder = LayeredPromptBuilder::new(&tools, &config);
 
     // Static layer should not change when only dynamic content changes
     let dynamic_v1 = DynamicLayerInput {
@@ -516,12 +516,6 @@ fn fp_022_dynamic_layer_preserves_static_cache() {
 
     let prompt_v1 = builder.build(&dynamic_v1);
     let prompt_v2 = builder.build(&dynamic_v2);
-
-    // Static hash should remain the same
-    assert!(
-        !builder.refresh_static(&tools, &config),
-        "FP-022: refresh_static with same tools/config should return false"
-    );
 
     // Both prompts should contain their respective dynamic content
     assert!(


### PR DESCRIPTION
## 背景 / 目标

落地 ADR-117 §2.2/§2.3 中已锁定的死代码清理（D6 / D8.4）：
- **D6**：移除 `LayeredPromptBuilder` 上的 `static_hash` / `compute_hash` / `refresh_static` / `static_hash()` getter，以及 `LayeredPrompt.static_changed` 字段。Provider 端前缀缓存依赖**字节级稳定性**而非 builder 端 hash；prefix-stability 已由 [parity_gate_p1.rs](desktop-client/ironclaw/tests/parity_gate_p1.rs) 中按 `PROMPT_CACHE_BOUNDARY` split 比对前缀的断言守住。
- **D8.4**：移除 `DynamicLayerInput` 上的 `admin_policy` / `token_budget` / `language_preference` 三个字段及其 `## Admin Policy` / `## Token Budget` / `## Language` 渲染段；这些在当前架构中没有任何调用方写入（grep 验证）。

`Closes #130`

PR-2（#141, ADR-117 §2.3 D8.2/D8.3 — composition order + environment + project_doc 占位）须先合入；本 PR 基于 PR-2 分支后继续。`### 合并顺序`：先 #141，再本 PR。如果 PR-2 已合入 `xClaw`，请将本 PR 的 base 调整为 `xClaw` 后再合并。

## 改动范围

仅 desktop-client/ironclaw（parent repo 内可控范围）：

- [desktop-client/ironclaw/src/llm/prompt/mod.rs](desktop-client/ironclaw/src/llm/prompt/mod.rs) — D6：删 `static_hash` / `compute_hash` / `refresh_static` / `static_hash()` / `LayeredPrompt.static_changed`；`StaticLayerConfig` 改用 `#[derive(Default)]`；删 4 个对应的 hash 测试。
- [desktop-client/ironclaw/src/llm/prompt/dynamic_layer.rs](desktop-client/ironclaw/src/llm/prompt/dynamic_layer.rs) — D8.4：删 3 个字段 + 3 段渲染；删 `test_admin_policy_precedence_note`；`test_multiple_sections_joined` 改用现存字段 `runtime_info` 复核多段拼接。
- [desktop-client/ironclaw/tests/parity_gate_p1.rs](desktop-client/ironclaw/tests/parity_gate_p1.rs) — 删 `assert!(!builder.refresh_static(...))` 这条无效自证；其下基于 `PROMPT_CACHE_BOUNDARY` split 的前缀比对已是 FP-022 真正的不变量。

## What's NOT in this PR

ADR-117 §2.2 D5 + D7 涉及到的 **claw-code 子仓**清理——
- 删除 `claw-code/rust/crates/runtime/src/prompt.rs`
- 删除 `claw-code/rust/crates/rusty-claude-cli/`
- `claw-code/rust/crates/runtime/src/{lib,conversation}.rs` 的对应 import/test 收尾

—— **不包含在本 PR**。`claw-code` 是带独立 remote 的 git submodule（`url = ...xclaw-claw-code.git`, `branch = x-claw`），需要独立提一个子仓 PR 后再 bump parent 的 submodule pointer。本 PR 仅落桌面客户端这一段。子仓清理将在跟进 issue 中完成（届时再回来更新 submodule reference 并复核 #130 闭环条件）。

其他不动：
- `crates/x_claw_agent/src/prompt.rs` 中对老 `SystemPromptBuilder` 的 doc comment 引用——纯文字注释，无运行期依赖，留待子仓清理后一并修订。
- `claw-code/rust/crates/tools/src/lib.rs`、`claw-code/.github/workflows/release.yml` 中对 `rusty-claude-cli` 的引用——属于 D7 子仓清理范围，不在本 PR。

## 验证

```bash
$ cargo nextest run -p ironclaw --lib llm::prompt
Summary [   7.323s] 16 tests run: 16 passed, 3991 skipped

$ cargo nextest run -p ironclaw --test parity_gate_p1 fp_022
Summary [   0.819s] 1 test run: 1 passed, 39 skipped

$ cargo fmt --all
(no diff)

$ python3.12 scripts/check_no_panics.py --base origin/xClaw
OK: No panic-inducing calls in changed production code.

$ cargo clippy --no-deps -p ironclaw --all-targets -- -D warnings 2>&1 | grep "^error: " | wc -l
34       # 注：与 origin/xClaw 基线相比净 -3（删除三个 collapsible_if 段）
$ # 落到本 PR 改动文件的 lint 全部沿用既有风格（`collapsible_if`），未引入新 lint。
```

## ADR / 文档对照

- ADR-117 §2.2 D6 — drop `static_hash` & `static_changed`：本 PR 落地。
- ADR-117 §2.3 D8.4 — drop legacy admin/token/language fields：本 PR 落地。
- ADR-117 §2.2 D5 / §2.2 D7 — submodule 范围，跟进 PR 处理。
