### PR TITLE
feat(crates): introduce dasclaw_llm_provider skeleton (PR-A.0, ADR-118)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2461,6 +2461,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dasclaw_llm_provider"
+version = "0.0.0-w6"
+dependencies = [
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "dasclaw_lsp"
 version = "0.0.0-w1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,8 @@ members = [
 	"crates/dasclaw_routines",
 	# W2.6 接线层：组合 sandbox + pty + workspace_cap policy
 	"crates/dasclaw_exec",
+	# W6-C 主仓自实现 LLM provider —— 替代 claw-code-api path-dep（ADR-118 PR-A.0 骨架）
+	"crates/dasclaw_llm_provider",
 	"desktop-client/ironclaw",
 	"desktop-client/ironclaw/crates/ironclaw_common",
 	"desktop-client/ironclaw/crates/ironclaw_safety",

--- a/crates/dasclaw_llm_provider/Cargo.toml
+++ b/crates/dasclaw_llm_provider/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "dasclaw_llm_provider"
+version = "0.0.0-w6"
+edition = "2021"
+description = "Main-repo native LLM provider — replaces claw-code-api path-dep per ADR-118."
+license = "Apache-2.0 OR MIT"
+publish = false
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+thiserror = "1"
+
+[dev-dependencies]
+serde_json = "1"

--- a/crates/dasclaw_llm_provider/src/error.rs
+++ b/crates/dasclaw_llm_provider/src/error.rs
@@ -1,0 +1,267 @@
+//! 强类型化 API error。
+//!
+//! 与 `claw-code-api::ApiError` 的设计差异（ADR-118 §8.5 架构债 #2 顺势处理）：
+//!
+//! - **拆变体**：`RateLimited` / `AuthFailed` / `ContextWindowExceeded` 等单独成变体，
+//!   调用方可精确决策（Retry-After 退避 / 触发 OAuth re-login / 不重试）。
+//! - **保留 trace ID**：`Provider` 变体保留 `request_id` 字段供日志关联。
+//! - **`Display` 不暴露密钥**：实现 `Display` 时只输出错误描述 + trace ID + HTTP 状态，
+//!   不会序列化原始 API key 或鉴权 header（即便错误对象内嵌了原始上下文也不输出）。
+
+use thiserror::Error;
+
+/// 与上游 LLM provider HTTP 调用相关的错误。
+#[derive(Debug, Error)]
+pub enum ApiError {
+    /// 速率限制（HTTP 429）。`retry_after_secs` 来自上游 `Retry-After` header；
+    /// 缺失时上层应使用指数退避默认值。
+    #[error(
+        "rate limited by {provider}{}",
+        retry_after_secs.map_or_else(String::new, |s| format!(" (retry after {s}s)"))
+    )]
+    RateLimited {
+        /// 上游 provider 标识（"anthropic" / "openai" / "xai" / "dashscope" 等）。
+        provider: String,
+        /// 上游建议的等待秒数（`Retry-After` header）。
+        retry_after_secs: Option<u64>,
+        /// 上游 trace ID（如有）。
+        request_id: Option<String>,
+    },
+
+    /// 鉴权失败（HTTP 401 / 403）。调用方应触发重新登录或刷新 token，**不应**直接重试。
+    #[error("authentication failed for {provider}: {reason}")]
+    AuthFailed {
+        /// 上游 provider 标识。
+        provider: String,
+        /// 失败原因（不含密钥）。
+        reason: String,
+        /// 上游 trace ID（如有）。
+        request_id: Option<String>,
+    },
+
+    /// 上下文窗口超限。这是**不可重试**错误 —— 必须由上层裁剪上下文后重发。
+    #[error(
+        "context window exceeded for {model}: \
+         estimated {estimated_total_tokens} tokens (input {estimated_input_tokens} + \
+         requested output {requested_output_tokens}) > limit {context_window_tokens}"
+    )]
+    ContextWindowExceeded {
+        /// canonical 模型名。
+        model: String,
+        /// 估算的输入 token 数。
+        estimated_input_tokens: u32,
+        /// 请求的输出 token 数。
+        requested_output_tokens: u32,
+        /// 估算的总 token 数。
+        estimated_total_tokens: u32,
+        /// 模型上下文窗口限制。
+        context_window_tokens: u32,
+    },
+
+    /// 请求体不合法（HTTP 400）。通常是 client 实现 bug 或上游协议变更。
+    #[error("bad request to {provider}: {reason}")]
+    BadRequest {
+        /// 上游 provider 标识。
+        provider: String,
+        /// 失败原因。
+        reason: String,
+        /// 上游 trace ID（如有）。
+        request_id: Option<String>,
+    },
+
+    /// 上游服务端错误（HTTP 5xx）。上层可重试。
+    #[error("server error from {provider} (HTTP {status}): {reason}")]
+    ServerError {
+        /// 上游 provider 标识。
+        provider: String,
+        /// HTTP 状态码。
+        status: u16,
+        /// 失败原因。
+        reason: String,
+        /// 上游 trace ID（如有）。
+        request_id: Option<String>,
+    },
+
+    /// 其他 provider 端错误（不属于上述任何分类）。
+    #[error("provider error from {provider}: {reason}")]
+    Provider {
+        /// 上游 provider 标识。
+        provider: String,
+        /// 失败原因。
+        reason: String,
+        /// 上游 trace ID（如有）。
+        request_id: Option<String>,
+    },
+
+    /// 传输层错误（网络断开、TLS 失败、连接超时等）。
+    #[error("transport error: {0}")]
+    Transport(String),
+
+    /// JSON 序列化 / 反序列化错误。
+    #[error("serialization error: {0}")]
+    Serialization(String),
+
+    /// 流式响应被异常中断（连接中途断开、SSE 协议错误）。
+    #[error("stream interrupted: {0}")]
+    StreamInterrupted(String),
+
+    /// SSE 帧解析错误（payload 不是合法 SSE 帧 / 字段格式错误）。
+    #[error("malformed SSE frame: {0}")]
+    MalformedSseFrame(String),
+}
+
+impl ApiError {
+    /// 判定错误是否应触发重试。
+    ///
+    /// **可重试**：`RateLimited` / `ServerError` / `Transport` / `StreamInterrupted`。
+    /// **不可重试**：`AuthFailed`（应重新登录）/ `ContextWindowExceeded`（应裁剪上下文）/
+    /// `BadRequest`（client 端 bug）/ `Serialization` / `MalformedSseFrame` / `Provider`（语义未知）。
+    #[must_use]
+    pub const fn is_retryable(&self) -> bool {
+        matches!(
+            self,
+            Self::RateLimited { .. }
+                | Self::ServerError { .. }
+                | Self::Transport(_)
+                | Self::StreamInterrupted(_)
+        )
+    }
+
+    /// 获取 trace ID（如有）。便于上层日志 / 用户报错关联。
+    #[must_use]
+    pub fn request_id(&self) -> Option<&str> {
+        match self {
+            Self::RateLimited { request_id, .. }
+            | Self::AuthFailed { request_id, .. }
+            | Self::BadRequest { request_id, .. }
+            | Self::ServerError { request_id, .. }
+            | Self::Provider { request_id, .. } => request_id.as_deref(),
+            _ => None,
+        }
+    }
+
+    /// 获取 provider 标识（如有）。
+    #[must_use]
+    pub fn provider(&self) -> Option<&str> {
+        match self {
+            Self::RateLimited { provider, .. }
+            | Self::AuthFailed { provider, .. }
+            | Self::BadRequest { provider, .. }
+            | Self::ServerError { provider, .. }
+            | Self::Provider { provider, .. } => Some(provider.as_str()),
+            _ => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rate_limited_is_retryable() {
+        let err = ApiError::RateLimited {
+            provider: "anthropic".into(),
+            retry_after_secs: Some(30),
+            request_id: Some("req_xyz".into()),
+        };
+        assert!(err.is_retryable());
+        assert_eq!(err.provider(), Some("anthropic"));
+        assert_eq!(err.request_id(), Some("req_xyz"));
+    }
+
+    #[test]
+    fn auth_failed_is_not_retryable() {
+        let err = ApiError::AuthFailed {
+            provider: "openai".into(),
+            reason: "invalid api key".into(),
+            request_id: None,
+        };
+        assert!(!err.is_retryable());
+    }
+
+    #[test]
+    fn context_window_exceeded_is_not_retryable() {
+        let err = ApiError::ContextWindowExceeded {
+            model: "claude-opus-4-6".into(),
+            estimated_input_tokens: 200_000,
+            requested_output_tokens: 4000,
+            estimated_total_tokens: 204_000,
+            context_window_tokens: 200_000,
+        };
+        assert!(!err.is_retryable());
+        assert_eq!(err.provider(), None);
+    }
+
+    #[test]
+    fn server_error_is_retryable() {
+        let err = ApiError::ServerError {
+            provider: "anthropic".into(),
+            status: 503,
+            reason: "service unavailable".into(),
+            request_id: None,
+        };
+        assert!(err.is_retryable());
+    }
+
+    #[test]
+    fn bad_request_not_retryable() {
+        let err = ApiError::BadRequest {
+            provider: "openai".into(),
+            reason: "max_tokens required".into(),
+            request_id: None,
+        };
+        assert!(!err.is_retryable());
+    }
+
+    #[test]
+    fn transport_is_retryable() {
+        let err = ApiError::Transport("connection reset".into());
+        assert!(err.is_retryable());
+        assert_eq!(err.provider(), None);
+        assert_eq!(err.request_id(), None);
+    }
+
+    #[test]
+    fn serialization_is_not_retryable() {
+        let err = ApiError::Serialization("expected `,` at line 3".into());
+        assert!(!err.is_retryable());
+    }
+
+    #[test]
+    fn rate_limited_display_includes_retry_after() {
+        let err = ApiError::RateLimited {
+            provider: "anthropic".into(),
+            retry_after_secs: Some(30),
+            request_id: None,
+        };
+        let msg = format!("{err}");
+        assert!(msg.contains("rate limited by anthropic"));
+        assert!(msg.contains("retry after 30s"));
+    }
+
+    #[test]
+    fn rate_limited_display_omits_retry_after_when_none() {
+        let err = ApiError::RateLimited {
+            provider: "openai".into(),
+            retry_after_secs: None,
+            request_id: None,
+        };
+        let msg = format!("{err}");
+        assert_eq!(msg, "rate limited by openai");
+    }
+
+    #[test]
+    fn context_window_display_format_is_actionable() {
+        let err = ApiError::ContextWindowExceeded {
+            model: "claude-opus-4-6".into(),
+            estimated_input_tokens: 198_000,
+            requested_output_tokens: 4_000,
+            estimated_total_tokens: 202_000,
+            context_window_tokens: 200_000,
+        };
+        let msg = format!("{err}");
+        assert!(msg.contains("198000 + requested output 4000"));
+        assert!(msg.contains("> limit 200000"));
+    }
+}

--- a/crates/dasclaw_llm_provider/src/lib.rs
+++ b/crates/dasclaw_llm_provider/src/lib.rs
@@ -1,0 +1,44 @@
+//! `dasclaw_llm_provider` — 主仓自实现的 LLM provider crate
+//!
+//! 本 crate 在 [ADR-118] 定义下，替代主仓对 `claw-code-api` 的 path-dep。
+//! claw-code 子仓视为只读参考库，本 crate **重新设计** Anthropic Messages /
+//! OpenAI Chat Completions 兼容层 wire 类型与 client 抽象，不直接消费子仓代码。
+//!
+//! 当前阶段：**PR-A.0 骨架**
+//! - ✅ wire 类型（`types`）—— Anthropic Messages 协议输入/输出/streaming events
+//! - ✅ 强类型错误（`error::ApiError`）—— 拆分 `RateLimited` / `AuthFailed` /
+//!   `ContextWindowExceeded` / `Http` / `Json` / `Io` / `Provider`，便于上层精确映射
+//! - ✅ `ProviderKind` + 模型别名表 + `metadata_for_model` + `max_tokens_for_model`
+//! - 🟡 `AnthropicClient` / `OpenAiCompatClient`：留给 PR-A.2，本骨架暂未实现
+//!
+//! 与 `claw-code-api` 的设计差异（顺势处理架构债，详见 ADR-118 §8.5）：
+//!
+//! 1. **错误强类型化**：`ApiError` 拆变体，调用方可精确决策重试 / 重新鉴权 / 不重试。
+//!    `claw-code-api::ApiError` 是 all-in-one，调用方靠字符串扫描判断。
+//! 2. **无 env 副作用**：`detect_provider_kind` 接受显式 `EnvSnapshot`，而不是
+//!    内部调 `std::env::var_os`。这让本 crate 完全 pure，便于测试与多租户。
+//! 3. **无 pricing 耦合**：本 crate 只输出 `Usage { input_tokens / output_tokens / ... }`
+//!    四个原始字段，**不计算 USD 成本**。成本计算是 ironclaw 应用层 `costs::model_cost`
+//!    的职责（claw-code-api 反向依赖 `runtime::pricing_for_model` 是层间泄漏，本 crate 不复刻）。
+//!
+//! [ADR-118]: ../docs/plans/architecture-refactor/adr-118-claw-code-readonly-and-self-impl.md
+
+#![deny(unsafe_code)]
+#![warn(missing_docs)]
+
+pub mod error;
+pub mod providers;
+pub mod types;
+
+pub use error::ApiError;
+pub use providers::{
+    detect_provider_kind, max_tokens_for_model, max_tokens_for_model_with_override,
+    metadata_for_model, model_token_limit, resolve_model_alias, EnvSnapshot, ModelTokenLimit,
+    ProviderKind, ProviderMetadata,
+};
+pub use types::{
+    ContentBlockDelta, ContentBlockDeltaEvent, ContentBlockStartEvent, ContentBlockStopEvent,
+    InputContentBlock, InputMessage, MessageDelta, MessageDeltaEvent, MessageRequest,
+    MessageResponse, MessageStartEvent, MessageStopEvent, OutputContentBlock, StreamEvent,
+    ToolChoice, ToolDefinition, ToolResultContentBlock, Usage,
+};

--- a/crates/dasclaw_llm_provider/src/providers/mod.rs
+++ b/crates/dasclaw_llm_provider/src/providers/mod.rs
@@ -1,0 +1,448 @@
+//! Provider 路由：模型别名表、provider 类型推断、token 限制查询。
+//!
+//! 与 `claw-code-api::providers` 的设计差异（ADR-118 §8.5 顺势处理）：
+//!
+//! - **无 env 副作用**：[`detect_provider_kind`] 接受显式 [`EnvSnapshot`]，**不调** `std::env`。
+//!   调用方负责采集环境（一次 `EnvSnapshot::from_process_env()`）后传入，
+//!   便于多租户场景把不同租户的环境注入同一进程，也便于测试。
+//! - **职责单一**：本模块只做"模型名 → provider 类型"的纯函数映射，不做 HTTP / SSE。
+//!   实际 HTTP client 在 PR-A.1+ 落地，路由 metadata 与 client 解耦。
+
+/// LLM provider 类型（决定走 Anthropic Messages 协议 / OpenAI Chat Completions 协议 / xAI 协议）。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ProviderKind {
+    /// Anthropic Messages API。
+    Anthropic,
+    /// xAI Grok（OpenAI Chat Completions 兼容，但 base URL / model 名空间独立）。
+    Xai,
+    /// OpenAI Chat Completions 协议（含 OpenAI 自家、Kimi、Qwen/DashScope、Groq、OpenRouter、
+    /// Tinfoil、Ollama 等所有兼容厂商）。
+    OpenAi,
+}
+
+/// 单条模型路由元数据。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ProviderMetadata {
+    /// 走哪种协议。
+    pub provider: ProviderKind,
+    /// 鉴权 env var 名。
+    pub auth_env: &'static str,
+    /// Base URL override env var 名。
+    pub base_url_env: &'static str,
+    /// 默认 base URL（当 `base_url_env` 未设置时使用）。
+    pub default_base_url: &'static str,
+}
+
+/// 模型 token 限制。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ModelTokenLimit {
+    /// 单次响应最大输出 token 数。
+    pub max_output_tokens: u32,
+    /// 上下文窗口（输入 + 输出）token 总限制。
+    pub context_window_tokens: u32,
+}
+
+/// 调用方采集的环境快照。无 IO 副作用，便于测试与多租户。
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct EnvSnapshot {
+    /// `ANTHROPIC_API_KEY` 是否设置（值不重要，只关心是否存在）。
+    pub anthropic_api_key_present: bool,
+    /// `OPENAI_API_KEY` 是否设置。
+    pub openai_api_key_present: bool,
+    /// `OPENAI_BASE_URL` 是否设置。
+    pub openai_base_url_present: bool,
+    /// `XAI_API_KEY` 是否设置。
+    pub xai_api_key_present: bool,
+    /// `DASHSCOPE_API_KEY` 是否设置。
+    pub dashscope_api_key_present: bool,
+}
+
+impl EnvSnapshot {
+    /// 从当前进程环境采集快照（**唯一**调用 `std::env` 的地方）。
+    #[must_use]
+    pub fn from_process_env() -> Self {
+        Self {
+            anthropic_api_key_present: std::env::var_os("ANTHROPIC_API_KEY").is_some(),
+            openai_api_key_present: std::env::var_os("OPENAI_API_KEY").is_some(),
+            openai_base_url_present: std::env::var_os("OPENAI_BASE_URL").is_some(),
+            xai_api_key_present: std::env::var_os("XAI_API_KEY").is_some(),
+            dashscope_api_key_present: std::env::var_os("DASHSCOPE_API_KEY").is_some(),
+        }
+    }
+}
+
+// 默认 base URL 常量。集中在此便于审查；client 实现复用同一组常量。
+mod base_url {
+    pub(super) const ANTHROPIC: &str = "https://api.anthropic.com";
+    pub(super) const OPENAI: &str = "https://api.openai.com/v1";
+    pub(super) const XAI: &str = "https://api.x.ai/v1";
+    pub(super) const DASHSCOPE: &str = "https://dashscope.aliyuncs.com/compatible-mode/v1";
+}
+
+/// 模型别名 → canonical 模型名映射（已小写化的 alias）。
+///
+/// canonical 名是上游 API 实际接受的模型 ID。Alias 是用户友好缩写。
+const MODEL_ALIASES: &[(&str, &str)] = &[
+    ("opus", "claude-opus-4-6"),
+    ("sonnet", "claude-sonnet-4-6"),
+    ("haiku", "claude-haiku-4-5-20251213"),
+    ("grok", "grok-3"),
+    ("grok-3", "grok-3"),
+    ("grok-mini", "grok-3-mini"),
+    ("grok-3-mini", "grok-3-mini"),
+    ("grok-2", "grok-2"),
+    ("kimi", "kimi-k2.5"),
+];
+
+/// 解析模型别名 → canonical 模型名。
+///
+/// 大小写不敏感、去前后空格。无别名时原样返回（去空格）。
+#[must_use]
+pub fn resolve_model_alias(model: &str) -> String {
+    let trimmed = model.trim();
+    let lower = trimmed.to_ascii_lowercase();
+    MODEL_ALIASES
+        .iter()
+        .find_map(|(alias, canonical)| (*alias == lower).then_some((*canonical).to_string()))
+        .unwrap_or_else(|| trimmed.to_string())
+}
+
+/// 根据模型名（canonical 或 alias）推断 provider 元数据。
+///
+/// 路由优先级：
+/// 1. canonical 名前缀匹配（`claude` → Anthropic / `grok` → Xai）
+/// 2. provider-namespaced 前缀（`openai/` / `gpt-` → OpenAi / `qwen/` / `qwen-` → DashScope /
+///    `kimi/` / `kimi-` → DashScope）
+/// 3. 不匹配返回 `None`，由 [`detect_provider_kind`] 走 env-sniff 兜底。
+#[must_use]
+pub fn metadata_for_model(model: &str) -> Option<ProviderMetadata> {
+    let canonical = resolve_model_alias(model);
+
+    if canonical.starts_with("claude") {
+        return Some(ProviderMetadata {
+            provider: ProviderKind::Anthropic,
+            auth_env: "ANTHROPIC_API_KEY",
+            base_url_env: "ANTHROPIC_BASE_URL",
+            default_base_url: base_url::ANTHROPIC,
+        });
+    }
+    if canonical.starts_with("grok") {
+        return Some(ProviderMetadata {
+            provider: ProviderKind::Xai,
+            auth_env: "XAI_API_KEY",
+            base_url_env: "XAI_BASE_URL",
+            default_base_url: base_url::XAI,
+        });
+    }
+    // 显式 provider 前缀（`openai/gpt-...` 或 `gpt-...`）。
+    // 必须在 env-sniff 之前命中，否则 `ANTHROPIC_API_KEY` 存在时会误路由到 Anthropic。
+    if canonical.starts_with("openai/") || canonical.starts_with("gpt-") {
+        return Some(ProviderMetadata {
+            provider: ProviderKind::OpenAi,
+            auth_env: "OPENAI_API_KEY",
+            base_url_env: "OPENAI_BASE_URL",
+            default_base_url: base_url::OPENAI,
+        });
+    }
+    // 阿里 DashScope 兼容模式：qwen-* / qwen/* / kimi-* / kimi/* 都走 OpenAI-compat 协议
+    // 但 base URL 与 auth env 与原生 OpenAI 不同。
+    if canonical.starts_with("qwen/")
+        || canonical.starts_with("qwen-")
+        || canonical.starts_with("kimi/")
+        || canonical.starts_with("kimi-")
+    {
+        return Some(ProviderMetadata {
+            provider: ProviderKind::OpenAi,
+            auth_env: "DASHSCOPE_API_KEY",
+            base_url_env: "DASHSCOPE_BASE_URL",
+            default_base_url: base_url::DASHSCOPE,
+        });
+    }
+    None
+}
+
+/// 推断 provider 类型。
+///
+/// 路由策略（按优先级降序）：
+/// 1. 模型名命中 [`metadata_for_model`] → 直接返回对应 [`ProviderKind`]
+/// 2. `OPENAI_BASE_URL` + `OPENAI_API_KEY` 都存在 → `OpenAi`
+///    （用户显式配置了 OpenAI-compat endpoint，比 Anthropic 兜底优先 ——
+///    覆盖 Ollama / vLLM / LM Studio 等本地 model 名无前缀场景）
+/// 3. `ANTHROPIC_API_KEY` 存在 → `Anthropic`
+/// 4. `OPENAI_API_KEY` 存在 → `OpenAi`
+/// 5. `XAI_API_KEY` 存在 → `Xai`
+/// 6. 仅 `OPENAI_BASE_URL` 存在（无 key，部分本地 endpoint 不要求 auth）→ `OpenAi`
+/// 7. 兜底 → `Anthropic`
+#[must_use]
+pub fn detect_provider_kind(model: &str, env: &EnvSnapshot) -> ProviderKind {
+    if let Some(metadata) = metadata_for_model(model) {
+        return metadata.provider;
+    }
+    if env.openai_base_url_present && env.openai_api_key_present {
+        return ProviderKind::OpenAi;
+    }
+    if env.anthropic_api_key_present {
+        return ProviderKind::Anthropic;
+    }
+    if env.openai_api_key_present {
+        return ProviderKind::OpenAi;
+    }
+    if env.xai_api_key_present {
+        return ProviderKind::Xai;
+    }
+    if env.openai_base_url_present {
+        return ProviderKind::OpenAi;
+    }
+    ProviderKind::Anthropic
+}
+
+/// 查询模型 token 限制。
+///
+/// 仅返回**已知**模型的官方限制；未知模型返回 `None`，由 [`max_tokens_for_model`] 兜底。
+#[must_use]
+pub fn model_token_limit(model: &str) -> Option<ModelTokenLimit> {
+    let canonical = resolve_model_alias(model);
+    match canonical.as_str() {
+        "claude-opus-4-6" => Some(ModelTokenLimit {
+            max_output_tokens: 32_000,
+            context_window_tokens: 200_000,
+        }),
+        "claude-sonnet-4-6" | "claude-haiku-4-5-20251213" => Some(ModelTokenLimit {
+            max_output_tokens: 64_000,
+            context_window_tokens: 200_000,
+        }),
+        "grok-3" | "grok-3-mini" => Some(ModelTokenLimit {
+            max_output_tokens: 64_000,
+            context_window_tokens: 131_072,
+        }),
+        _ => None,
+    }
+}
+
+/// 查询模型最大输出 token 数（带兜底）。
+///
+/// 已知模型走 [`model_token_limit`]；未知模型按 canonical 名包含 `opus` 兜底 32K，否则 64K。
+#[must_use]
+pub fn max_tokens_for_model(model: &str) -> u32 {
+    if let Some(limit) = model_token_limit(model) {
+        return limit.max_output_tokens;
+    }
+    let canonical = resolve_model_alias(model);
+    if canonical.contains("opus") {
+        32_000
+    } else {
+        64_000
+    }
+}
+
+/// 查询模型最大输出 token 数（允许插件/调用方覆盖）。
+#[must_use]
+pub fn max_tokens_for_model_with_override(model: &str, plugin_override: Option<u32>) -> u32 {
+    plugin_override.unwrap_or_else(|| max_tokens_for_model(model))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn alias_opus_resolves_to_canonical() {
+        assert_eq!(resolve_model_alias("opus"), "claude-opus-4-6");
+        assert_eq!(resolve_model_alias("OPUS"), "claude-opus-4-6");
+        assert_eq!(resolve_model_alias("  opus  "), "claude-opus-4-6");
+    }
+
+    #[test]
+    fn alias_sonnet_haiku_resolve() {
+        assert_eq!(resolve_model_alias("sonnet"), "claude-sonnet-4-6");
+        assert_eq!(resolve_model_alias("haiku"), "claude-haiku-4-5-20251213");
+    }
+
+    #[test]
+    fn alias_grok_resolves() {
+        assert_eq!(resolve_model_alias("grok"), "grok-3");
+        assert_eq!(resolve_model_alias("grok-3"), "grok-3");
+        assert_eq!(resolve_model_alias("grok-mini"), "grok-3-mini");
+        assert_eq!(resolve_model_alias("grok-3-mini"), "grok-3-mini");
+        assert_eq!(resolve_model_alias("grok-2"), "grok-2");
+    }
+
+    #[test]
+    fn alias_kimi_resolves() {
+        assert_eq!(resolve_model_alias("kimi"), "kimi-k2.5");
+    }
+
+    #[test]
+    fn unknown_model_returned_as_is_after_trim() {
+        assert_eq!(resolve_model_alias("  custom-model-x  "), "custom-model-x");
+    }
+
+    #[test]
+    fn metadata_claude_routes_to_anthropic() {
+        let m = metadata_for_model("opus").expect("metadata");
+        assert_eq!(m.provider, ProviderKind::Anthropic);
+        assert_eq!(m.auth_env, "ANTHROPIC_API_KEY");
+        assert_eq!(m.default_base_url, "https://api.anthropic.com");
+    }
+
+    #[test]
+    fn metadata_grok_routes_to_xai() {
+        let m = metadata_for_model("grok-3").expect("metadata");
+        assert_eq!(m.provider, ProviderKind::Xai);
+        assert_eq!(m.auth_env, "XAI_API_KEY");
+    }
+
+    #[test]
+    fn metadata_openai_namespace_prefix() {
+        let m = metadata_for_model("openai/gpt-4.1-mini").expect("metadata");
+        assert_eq!(m.provider, ProviderKind::OpenAi);
+        assert_eq!(m.auth_env, "OPENAI_API_KEY");
+    }
+
+    #[test]
+    fn metadata_gpt_prefix_routes_to_openai() {
+        let m = metadata_for_model("gpt-4o").expect("metadata");
+        assert_eq!(m.provider, ProviderKind::OpenAi);
+    }
+
+    #[test]
+    fn metadata_qwen_routes_to_dashscope() {
+        let m = metadata_for_model("qwen-max").expect("metadata");
+        assert_eq!(m.provider, ProviderKind::OpenAi);
+        assert_eq!(m.auth_env, "DASHSCOPE_API_KEY");
+        assert!(m.default_base_url.contains("dashscope"));
+    }
+
+    #[test]
+    fn metadata_kimi_alias_routes_to_dashscope() {
+        // alias "kimi" 在 MODEL_ALIASES 中解析为 "kimi-k2.5"，命中 kimi- 前缀
+        let m = metadata_for_model("kimi").expect("metadata");
+        assert_eq!(m.provider, ProviderKind::OpenAi);
+        assert_eq!(m.auth_env, "DASHSCOPE_API_KEY");
+    }
+
+    #[test]
+    fn metadata_unknown_returns_none() {
+        assert!(metadata_for_model("custom-model-x").is_none());
+    }
+
+    #[test]
+    fn detect_recognized_model_short_circuits_env() {
+        // 即便 env 全空，已知模型也能走 metadata_for_model 路由
+        let env = EnvSnapshot::default();
+        assert_eq!(detect_provider_kind("opus", &env), ProviderKind::Anthropic);
+        assert_eq!(detect_provider_kind("grok-3", &env), ProviderKind::Xai);
+        assert_eq!(detect_provider_kind("gpt-4o", &env), ProviderKind::OpenAi);
+    }
+
+    #[test]
+    fn detect_unknown_model_with_anthropic_key_falls_to_anthropic() {
+        let env = EnvSnapshot {
+            anthropic_api_key_present: true,
+            ..EnvSnapshot::default()
+        };
+        assert_eq!(
+            detect_provider_kind("custom-x", &env),
+            ProviderKind::Anthropic
+        );
+    }
+
+    #[test]
+    fn detect_openai_base_url_plus_key_overrides_anthropic_fallback() {
+        // 用户显式配置了 OpenAI-compat endpoint —— 应优先于 Anthropic 兜底
+        let env = EnvSnapshot {
+            anthropic_api_key_present: true,
+            openai_api_key_present: true,
+            openai_base_url_present: true,
+            ..EnvSnapshot::default()
+        };
+        assert_eq!(
+            detect_provider_kind("qwen2.5-coder:7b", &env),
+            ProviderKind::OpenAi
+        );
+    }
+
+    #[test]
+    fn detect_only_openai_base_url_routes_openai() {
+        // 本地 endpoint（Ollama 等）不要求 API key
+        let env = EnvSnapshot {
+            openai_base_url_present: true,
+            ..EnvSnapshot::default()
+        };
+        assert_eq!(
+            detect_provider_kind("local-model", &env),
+            ProviderKind::OpenAi
+        );
+    }
+
+    #[test]
+    fn detect_xai_key_only() {
+        let env = EnvSnapshot {
+            xai_api_key_present: true,
+            ..EnvSnapshot::default()
+        };
+        assert_eq!(detect_provider_kind("custom-x", &env), ProviderKind::Xai);
+    }
+
+    #[test]
+    fn detect_no_env_falls_to_anthropic() {
+        let env = EnvSnapshot::default();
+        assert_eq!(
+            detect_provider_kind("custom-x", &env),
+            ProviderKind::Anthropic
+        );
+    }
+
+    #[test]
+    fn token_limit_opus_32k_output_200k_window() {
+        let limit = model_token_limit("opus").expect("limit");
+        assert_eq!(limit.max_output_tokens, 32_000);
+        assert_eq!(limit.context_window_tokens, 200_000);
+    }
+
+    #[test]
+    fn token_limit_sonnet_haiku_64k_output_200k_window() {
+        let s = model_token_limit("sonnet").expect("limit");
+        assert_eq!(s.max_output_tokens, 64_000);
+        assert_eq!(s.context_window_tokens, 200_000);
+
+        let h = model_token_limit("haiku").expect("limit");
+        assert_eq!(h.max_output_tokens, 64_000);
+    }
+
+    #[test]
+    fn token_limit_grok_64k_output_131k_window() {
+        let limit = model_token_limit("grok").expect("limit");
+        assert_eq!(limit.max_output_tokens, 64_000);
+        assert_eq!(limit.context_window_tokens, 131_072);
+    }
+
+    #[test]
+    fn token_limit_unknown_returns_none() {
+        assert!(model_token_limit("custom-x").is_none());
+    }
+
+    #[test]
+    fn max_tokens_unknown_opus_substr_falls_to_32k() {
+        // 未在 model_token_limit 表中、但 canonical 含 "opus" 字串 → 32K 兜底
+        assert_eq!(max_tokens_for_model("custom-opus-future"), 32_000);
+    }
+
+    #[test]
+    fn max_tokens_unknown_other_falls_to_64k() {
+        assert_eq!(max_tokens_for_model("totally-unknown-model"), 64_000);
+    }
+
+    #[test]
+    fn max_tokens_with_override_uses_override_when_some() {
+        assert_eq!(
+            max_tokens_for_model_with_override("opus", Some(8_000)),
+            8_000
+        );
+    }
+
+    #[test]
+    fn max_tokens_with_override_falls_back_when_none() {
+        assert_eq!(max_tokens_for_model_with_override("opus", None), 32_000);
+    }
+}

--- a/crates/dasclaw_llm_provider/src/types.rs
+++ b/crates/dasclaw_llm_provider/src/types.rs
@@ -1,0 +1,541 @@
+//! Wire 类型 — Anthropic Messages 协议输入 / 输出 / streaming events。
+//!
+//! 设计原则：
+//! - **纯数据**：所有类型都是 `serde` derive，不依赖任何 IO 或运行时副作用。
+//! - **不计算成本**：`Usage` 只暴露 4 个原始 token 字段（input/output/cache_read/cache_creation）。
+//!   成本计算是上层应用职责，本 crate 不耦合 pricing 表。
+//! - **`#[serde(skip_serializing_if = ...)]`**：所有可选字段在 None 时不写入 JSON，
+//!   避免向上游 Anthropic / OpenAI-compat API 发送多余字段触发 schema 校验失败。
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// Anthropic Messages API 请求体。
+///
+/// 字段对齐 [Anthropic Messages API](https://docs.anthropic.com/en/api/messages)
+/// 与 OpenAI Chat Completions 兼容层（temperature / top_p / penalties / stop / reasoning_effort
+/// 在 OpenAI 系厂商生效；Anthropic 仅识别 temperature / top_p / stop_sequences，其它字段后端
+/// 静默忽略）。
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+pub struct MessageRequest {
+    /// 模型名（可以是别名如 "opus" / "sonnet"，由 [`super::resolve_model_alias`] 解析为 canonical 名）。
+    pub model: String,
+    /// 最大输出 token 数。Anthropic 协议必填字段；OpenAI-compat 等价于 `max_tokens`。
+    pub max_tokens: u32,
+    /// 多轮消息历史（不含 system —— system 单独走 [`Self::system`] 字段）。
+    pub messages: Vec<InputMessage>,
+    /// System prompt。Anthropic 协议是顶层字段，OpenAI-compat 走第一条 `role=system` message
+    /// （由 client 实现负责适配，wire 层统一暴露此字段）。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub system: Option<String>,
+    /// 工具定义。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tools: Option<Vec<ToolDefinition>>,
+    /// 工具选择策略。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_choice: Option<ToolChoice>,
+    /// 是否流式返回。SSE 流由 client 实现处理。
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub stream: bool,
+    /// Sampling temperature（[0, 1]）。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub temperature: Option<f64>,
+    /// Nucleus sampling top-p（[0, 1]）。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub top_p: Option<f64>,
+    /// Frequency penalty（OpenAI-compat 特有，Anthropic 忽略）。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub frequency_penalty: Option<f64>,
+    /// Presence penalty（OpenAI-compat 特有，Anthropic 忽略）。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub presence_penalty: Option<f64>,
+    /// Stop sequences。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stop: Option<Vec<String>>,
+    /// Reasoning effort：`"low"` / `"medium"` / `"high"`，OpenAI o-系列等 reasoning models 适用。
+    /// 后端不支持时静默忽略。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reasoning_effort: Option<String>,
+}
+
+impl MessageRequest {
+    /// 设置 `stream = true` 并返回自身，便于链式调用。
+    #[must_use]
+    pub fn with_streaming(mut self) -> Self {
+        self.stream = true;
+        self
+    }
+}
+
+/// 单条对话消息。
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct InputMessage {
+    /// 角色：`"user"` / `"assistant"` / `"system"`。
+    pub role: String,
+    /// 消息内容块。允许混合文本 + tool_use + tool_result。
+    pub content: Vec<InputContentBlock>,
+}
+
+impl InputMessage {
+    /// 构造单段纯文本 user message。
+    #[must_use]
+    pub fn user_text(text: impl Into<String>) -> Self {
+        Self {
+            role: "user".to_string(),
+            content: vec![InputContentBlock::Text { text: text.into() }],
+        }
+    }
+
+    /// 构造 tool_result user message（Anthropic 协议要求 tool_result 必须挂在 role=user 上）。
+    #[must_use]
+    pub fn user_tool_result(
+        tool_use_id: impl Into<String>,
+        content: impl Into<String>,
+        is_error: bool,
+    ) -> Self {
+        Self {
+            role: "user".to_string(),
+            content: vec![InputContentBlock::ToolResult {
+                tool_use_id: tool_use_id.into(),
+                content: vec![ToolResultContentBlock::Text {
+                    text: content.into(),
+                }],
+                is_error,
+            }],
+        }
+    }
+}
+
+/// 请求侧 content block。
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum InputContentBlock {
+    /// 纯文本。
+    Text {
+        /// 文本内容。
+        text: String,
+    },
+    /// 工具调用（assistant 历史消息中的 tool_use）。
+    ToolUse {
+        /// 工具调用 ID（assistant 端生成，后续 tool_result 必须引用）。
+        id: String,
+        /// 工具名。
+        name: String,
+        /// 工具入参 JSON。
+        input: Value,
+    },
+    /// 工具结果（必须挂在 role=user 上）。
+    ToolResult {
+        /// 引用对应 [`Self::ToolUse::id`]。
+        tool_use_id: String,
+        /// 结果内容块（通常单段 Text，复杂场景可多段）。
+        content: Vec<ToolResultContentBlock>,
+        /// 是否表示工具执行失败。
+        #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+        is_error: bool,
+    },
+}
+
+/// 工具结果内嵌 content block。
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ToolResultContentBlock {
+    /// 文本结果。
+    Text {
+        /// 文本内容。
+        text: String,
+    },
+    /// JSON 结果（Anthropic 协议扩展）。
+    Json {
+        /// JSON 值。
+        value: Value,
+    },
+}
+
+/// 工具定义。
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ToolDefinition {
+    /// 工具名（必须满足 `^[a-zA-Z0-9_-]+$`，由 client 校验）。
+    pub name: String,
+    /// 工具描述（提示 LLM 何时使用）。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// JSON Schema 定义入参。
+    pub input_schema: Value,
+}
+
+/// 工具选择策略。
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ToolChoice {
+    /// LLM 自行决定是否调用工具。
+    Auto,
+    /// 必须调用某个工具（不限定哪一个）。
+    Any,
+    /// 必须调用指定工具。
+    Tool {
+        /// 强制调用的工具名。
+        name: String,
+    },
+}
+
+/// Anthropic Messages API 响应体。
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MessageResponse {
+    /// 消息 ID（Anthropic 端 `msg_xxx`）。
+    pub id: String,
+    /// 消息类型，固定 `"message"`。
+    #[serde(rename = "type")]
+    pub kind: String,
+    /// 角色，固定 `"assistant"`。
+    pub role: String,
+    /// 输出 content blocks。
+    pub content: Vec<OutputContentBlock>,
+    /// 实际生成所用的模型 canonical 名。
+    pub model: String,
+    /// 终止原因：`"end_turn"` / `"max_tokens"` / `"stop_sequence"` / `"tool_use"` / `"refusal"`。
+    #[serde(default)]
+    pub stop_reason: Option<String>,
+    /// 命中的 stop sequence（如有）。
+    #[serde(default)]
+    pub stop_sequence: Option<String>,
+    /// Token 使用量。
+    #[serde(default)]
+    pub usage: Usage,
+    /// 上游 trace ID（Anthropic 响应头 `request-id`，client 实现负责注入）。
+    #[serde(default)]
+    pub request_id: Option<String>,
+}
+
+impl MessageResponse {
+    /// 总 token 数（input + output + cache_creation + cache_read）。
+    #[must_use]
+    pub const fn total_tokens(&self) -> u32 {
+        self.usage.total_tokens()
+    }
+}
+
+/// 响应侧 content block。
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum OutputContentBlock {
+    /// 纯文本。
+    Text {
+        /// 文本内容。
+        text: String,
+    },
+    /// 工具调用（assistant 想调用工具）。
+    ToolUse {
+        /// 工具调用 ID（assistant 端生成，后续 tool_result 必须引用此 ID）。
+        id: String,
+        /// 工具名。
+        name: String,
+        /// 工具入参 JSON。
+        input: Value,
+    },
+    /// Extended thinking 输出（Claude Opus / Sonnet 4.x 专属）。
+    Thinking {
+        /// 思考过程文本。
+        #[serde(default)]
+        thinking: String,
+        /// 签名（验签时需保留原样回传）。
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        signature: Option<String>,
+    },
+    /// Redacted thinking 输出（Anthropic 隐私策略下被遮蔽的思考块，data 是不透明 blob）。
+    RedactedThinking {
+        /// 不透明 redacted 数据，回传时必须原样保留。
+        data: Value,
+    },
+}
+
+/// Token 使用量原始字段。
+///
+/// **本 crate 不计算 USD 成本** —— 成本计算是上层应用职责（如 ironclaw 端
+/// `costs::model_cost`）。本类型只暴露 4 个原始 token 计数。
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Usage {
+    /// 输入 token 数。
+    #[serde(default)]
+    pub input_tokens: u32,
+    /// 提示词缓存写入 token 数（首次写入 prefix cache 时计费）。
+    #[serde(default)]
+    pub cache_creation_input_tokens: u32,
+    /// 提示词缓存命中 token 数（命中后续请求 prefix cache 时折扣）。
+    #[serde(default)]
+    pub cache_read_input_tokens: u32,
+    /// 输出 token 数。
+    #[serde(default)]
+    pub output_tokens: u32,
+}
+
+impl Usage {
+    /// 总 token 数（4 个字段相加）。
+    #[must_use]
+    pub const fn total_tokens(&self) -> u32 {
+        self.input_tokens
+            + self.output_tokens
+            + self.cache_creation_input_tokens
+            + self.cache_read_input_tokens
+    }
+}
+
+// ---------- Streaming events ----------
+
+/// `message_start` SSE 事件。
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MessageStartEvent {
+    /// 完整消息壳（content 此时为空，后续 ContentBlockStart/Delta/Stop 流式填充）。
+    pub message: MessageResponse,
+}
+
+/// `message_delta` SSE 事件。
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MessageDeltaEvent {
+    /// 增量字段（stop_reason / stop_sequence）。
+    pub delta: MessageDelta,
+    /// 累计 token 使用量。
+    #[serde(default)]
+    pub usage: Usage,
+}
+
+/// `message_delta` 内嵌增量字段。
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MessageDelta {
+    /// 终止原因。
+    #[serde(default)]
+    pub stop_reason: Option<String>,
+    /// 命中的 stop sequence。
+    #[serde(default)]
+    pub stop_sequence: Option<String>,
+}
+
+/// `content_block_start` SSE 事件。
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ContentBlockStartEvent {
+    /// content blocks 数组中的索引。
+    pub index: u32,
+    /// 起始 content block。
+    pub content_block: OutputContentBlock,
+}
+
+/// `content_block_delta` SSE 事件。
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ContentBlockDeltaEvent {
+    /// content blocks 数组中的索引。
+    pub index: u32,
+    /// 增量内容。
+    pub delta: ContentBlockDelta,
+}
+
+/// `content_block_delta` 内嵌增量类型。
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ContentBlockDelta {
+    /// 文本增量。
+    TextDelta {
+        /// 增量文本。
+        text: String,
+    },
+    /// Tool input JSON 增量（partial JSON，需上层拼接后整体反序列化）。
+    InputJsonDelta {
+        /// 部分 JSON 字符串。
+        partial_json: String,
+    },
+    /// Thinking 文本增量。
+    ThinkingDelta {
+        /// 增量思考文本。
+        thinking: String,
+    },
+    /// Thinking 签名（验签字段，Anthropic 必须原样回传）。
+    SignatureDelta {
+        /// 签名值。
+        signature: String,
+    },
+}
+
+/// `content_block_stop` SSE 事件。
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ContentBlockStopEvent {
+    /// content blocks 数组中的索引。
+    pub index: u32,
+}
+
+/// `message_stop` SSE 事件（无字段）。
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MessageStopEvent {}
+
+/// SSE 流事件枚举（按 Anthropic streaming 协议 6 种事件类型）。
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum StreamEvent {
+    /// `message_start`。
+    MessageStart(MessageStartEvent),
+    /// `message_delta`。
+    MessageDelta(MessageDeltaEvent),
+    /// `content_block_start`。
+    ContentBlockStart(ContentBlockStartEvent),
+    /// `content_block_delta`。
+    ContentBlockDelta(ContentBlockDeltaEvent),
+    /// `content_block_stop`。
+    ContentBlockStop(ContentBlockStopEvent),
+    /// `message_stop`。
+    MessageStop(MessageStopEvent),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn usage_total_tokens_sums_all_four_fields() {
+        let usage = Usage {
+            input_tokens: 10,
+            cache_creation_input_tokens: 2,
+            cache_read_input_tokens: 3,
+            output_tokens: 4,
+        };
+        assert_eq!(usage.total_tokens(), 19);
+    }
+
+    #[test]
+    fn usage_default_is_all_zero() {
+        let usage = Usage::default();
+        assert_eq!(usage.total_tokens(), 0);
+    }
+
+    #[test]
+    fn input_message_user_text_helper() {
+        let msg = InputMessage::user_text("hello");
+        assert_eq!(msg.role, "user");
+        assert_eq!(msg.content.len(), 1);
+        match &msg.content[0] {
+            InputContentBlock::Text { text } => assert_eq!(text, "hello"),
+            other => unreachable!("expected Text variant, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn input_message_user_tool_result_helper() {
+        let msg = InputMessage::user_tool_result("tool_42", "result body", true);
+        assert_eq!(msg.role, "user");
+        assert_eq!(msg.content.len(), 1);
+        match &msg.content[0] {
+            InputContentBlock::ToolResult {
+                tool_use_id,
+                content,
+                is_error,
+            } => {
+                assert_eq!(tool_use_id, "tool_42");
+                assert_eq!(content.len(), 1);
+                assert!(is_error);
+                match &content[0] {
+                    ToolResultContentBlock::Text { text } => assert_eq!(text, "result body"),
+                    other => unreachable!("expected Text variant, got {other:?}"),
+                }
+            }
+            other => unreachable!("expected ToolResult variant, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn message_request_omits_none_fields_in_json() {
+        let req = MessageRequest {
+            model: "claude-opus-4-6".to_string(),
+            max_tokens: 100,
+            messages: vec![InputMessage::user_text("hi")],
+            ..Default::default()
+        };
+        let json = serde_json::to_value(&req).expect("serialize");
+        let obj = json.as_object().expect("object");
+        // None 字段不应出现
+        assert!(!obj.contains_key("system"));
+        assert!(!obj.contains_key("tools"));
+        assert!(!obj.contains_key("tool_choice"));
+        assert!(!obj.contains_key("temperature"));
+        assert!(!obj.contains_key("top_p"));
+        assert!(!obj.contains_key("frequency_penalty"));
+        assert!(!obj.contains_key("presence_penalty"));
+        assert!(!obj.contains_key("stop"));
+        assert!(!obj.contains_key("reasoning_effort"));
+        // false stream 也省略
+        assert!(!obj.contains_key("stream"));
+        // 必填字段在
+        assert_eq!(
+            obj.get("model").and_then(|v| v.as_str()),
+            Some("claude-opus-4-6")
+        );
+        assert_eq!(obj.get("max_tokens").and_then(|v| v.as_u64()), Some(100));
+    }
+
+    #[test]
+    fn message_request_with_streaming_sets_stream_true() {
+        let req = MessageRequest {
+            model: "m".into(),
+            max_tokens: 1,
+            messages: vec![],
+            ..Default::default()
+        }
+        .with_streaming();
+        assert!(req.stream);
+        let json = serde_json::to_value(&req).expect("serialize");
+        assert_eq!(json.get("stream").and_then(|v| v.as_bool()), Some(true));
+    }
+
+    #[test]
+    fn tool_choice_serializes_with_type_tag() {
+        let auto = serde_json::to_value(ToolChoice::Auto).expect("serialize");
+        assert_eq!(auto.get("type").and_then(|v| v.as_str()), Some("auto"));
+
+        let any = serde_json::to_value(ToolChoice::Any).expect("serialize");
+        assert_eq!(any.get("type").and_then(|v| v.as_str()), Some("any"));
+
+        let tool =
+            serde_json::to_value(ToolChoice::Tool { name: "foo".into() }).expect("serialize");
+        assert_eq!(tool.get("type").and_then(|v| v.as_str()), Some("tool"));
+        assert_eq!(tool.get("name").and_then(|v| v.as_str()), Some("foo"));
+    }
+
+    #[test]
+    fn output_content_block_thinking_roundtrip() {
+        let original = OutputContentBlock::Thinking {
+            thinking: "step by step".into(),
+            signature: Some("sig_abc".into()),
+        };
+        let json = serde_json::to_value(&original).expect("serialize");
+        assert_eq!(json.get("type").and_then(|v| v.as_str()), Some("thinking"));
+        let back: OutputContentBlock = serde_json::from_value(json).expect("deserialize");
+        assert_eq!(back, original);
+    }
+
+    #[test]
+    fn message_response_total_tokens_delegates_to_usage() {
+        let resp = MessageResponse {
+            id: "msg_1".into(),
+            kind: "message".into(),
+            role: "assistant".into(),
+            content: vec![],
+            model: "claude-opus-4-6".into(),
+            stop_reason: Some("end_turn".into()),
+            stop_sequence: None,
+            usage: Usage {
+                input_tokens: 5,
+                cache_creation_input_tokens: 1,
+                cache_read_input_tokens: 2,
+                output_tokens: 7,
+            },
+            request_id: None,
+        };
+        assert_eq!(resp.total_tokens(), 15);
+    }
+
+    #[test]
+    fn stream_event_message_stop_serializes_as_tagged_unit() {
+        let ev = StreamEvent::MessageStop(MessageStopEvent {});
+        let json = serde_json::to_value(&ev).expect("serialize");
+        assert_eq!(
+            json.get("type").and_then(|v| v.as_str()),
+            Some("message_stop")
+        );
+    }
+}

--- a/crates/dasclaw_llm_provider/tests/types_roundtrip.rs
+++ b/crates/dasclaw_llm_provider/tests/types_roundtrip.rs
@@ -1,0 +1,235 @@
+//! 集成测试：wire 类型 JSON round-trip。
+//!
+//! 这些测试把代表性 wire 数据走 `serde_json::to_value` → `from_value` 一轮，
+//! 验证 `#[serde(tag = "type")]` 标签、`skip_serializing_if` 行为、字段命名都符合
+//! Anthropic Messages 协议规范。
+
+use dasclaw_llm_provider::{
+    ContentBlockDelta, ContentBlockDeltaEvent, InputContentBlock, InputMessage, MessageRequest,
+    MessageResponse, OutputContentBlock, StreamEvent, ToolChoice, ToolDefinition,
+    ToolResultContentBlock, Usage,
+};
+use serde_json::json;
+
+#[test]
+fn input_message_text_roundtrip() {
+    let msg = InputMessage::user_text("hello world");
+    let json = serde_json::to_value(&msg).expect("serialize");
+    let back: InputMessage = serde_json::from_value(json).expect("deserialize");
+    assert_eq!(back, msg);
+}
+
+#[test]
+fn input_message_tool_use_roundtrip() {
+    let msg = InputMessage {
+        role: "assistant".into(),
+        content: vec![InputContentBlock::ToolUse {
+            id: "toolu_abc".into(),
+            name: "read_file".into(),
+            input: json!({ "path": "/etc/hosts" }),
+        }],
+    };
+    let json = serde_json::to_value(&msg).expect("serialize");
+    assert_eq!(json["content"][0]["type"], "tool_use");
+    let back: InputMessage = serde_json::from_value(json).expect("deserialize");
+    assert_eq!(back, msg);
+}
+
+#[test]
+fn input_message_tool_result_roundtrip() {
+    let msg = InputMessage::user_tool_result("toolu_abc", "file contents", false);
+    let json = serde_json::to_value(&msg).expect("serialize");
+    assert_eq!(json["content"][0]["type"], "tool_result");
+    // is_error: false 应被 skip_serializing_if 省略
+    assert!(json["content"][0].get("is_error").is_none());
+    let back: InputMessage = serde_json::from_value(json).expect("deserialize");
+    assert_eq!(back, msg);
+}
+
+#[test]
+fn tool_result_with_error_includes_is_error_field() {
+    let msg = InputMessage::user_tool_result("toolu_abc", "denied", true);
+    let json = serde_json::to_value(&msg).expect("serialize");
+    assert_eq!(json["content"][0]["is_error"], true);
+}
+
+#[test]
+fn tool_definition_roundtrip() {
+    let tool = ToolDefinition {
+        name: "read_file".into(),
+        description: Some("Read a file".into()),
+        input_schema: json!({
+            "type": "object",
+            "properties": { "path": { "type": "string" } },
+            "required": ["path"]
+        }),
+    };
+    let json = serde_json::to_value(&tool).expect("serialize");
+    let back: ToolDefinition = serde_json::from_value(json).expect("deserialize");
+    assert_eq!(back, tool);
+}
+
+#[test]
+fn tool_choice_three_variants_roundtrip() {
+    for tc in [
+        ToolChoice::Auto,
+        ToolChoice::Any,
+        ToolChoice::Tool {
+            name: "read_file".into(),
+        },
+    ] {
+        let json = serde_json::to_value(&tc).expect("serialize");
+        let back: ToolChoice = serde_json::from_value(json).expect("deserialize");
+        assert_eq!(back, tc);
+    }
+}
+
+#[test]
+fn full_message_request_roundtrip() {
+    let req = MessageRequest {
+        model: "claude-opus-4-6".into(),
+        max_tokens: 4096,
+        messages: vec![InputMessage::user_text("hi")],
+        system: Some("You are helpful.".into()),
+        tools: Some(vec![ToolDefinition {
+            name: "search".into(),
+            description: None,
+            input_schema: json!({"type": "object"}),
+        }]),
+        tool_choice: Some(ToolChoice::Auto),
+        stream: true,
+        temperature: Some(0.7),
+        top_p: Some(0.9),
+        frequency_penalty: None,
+        presence_penalty: None,
+        stop: Some(vec!["</end>".into()]),
+        reasoning_effort: Some("high".into()),
+    };
+    let json = serde_json::to_value(&req).expect("serialize");
+    let back: MessageRequest = serde_json::from_value(json).expect("deserialize");
+    assert_eq!(back, req);
+}
+
+#[test]
+fn message_response_with_thinking_block_roundtrip() {
+    let resp = MessageResponse {
+        id: "msg_xyz".into(),
+        kind: "message".into(),
+        role: "assistant".into(),
+        content: vec![
+            OutputContentBlock::Thinking {
+                thinking: "Let me think...".into(),
+                signature: Some("sig_abc".into()),
+            },
+            OutputContentBlock::Text {
+                text: "Hello!".into(),
+            },
+            OutputContentBlock::ToolUse {
+                id: "toolu_42".into(),
+                name: "search".into(),
+                input: json!({"q": "rust"}),
+            },
+        ],
+        model: "claude-opus-4-6".into(),
+        stop_reason: Some("tool_use".into()),
+        stop_sequence: None,
+        usage: Usage {
+            input_tokens: 100,
+            cache_creation_input_tokens: 10,
+            cache_read_input_tokens: 50,
+            output_tokens: 30,
+        },
+        request_id: Some("req_abc".into()),
+    };
+    let json = serde_json::to_value(&resp).expect("serialize");
+    let back: MessageResponse = serde_json::from_value(json).expect("deserialize");
+    assert_eq!(back, resp);
+}
+
+#[test]
+fn redacted_thinking_preserves_opaque_blob() {
+    let block = OutputContentBlock::RedactedThinking {
+        data: json!({"opaque": [1, 2, 3], "version": "v1"}),
+    };
+    let json = serde_json::to_value(&block).expect("serialize");
+    assert_eq!(json["type"], "redacted_thinking");
+    let back: OutputContentBlock = serde_json::from_value(json).expect("deserialize");
+    assert_eq!(back, block);
+}
+
+#[test]
+fn tool_result_content_block_json_variant_roundtrip() {
+    let block = ToolResultContentBlock::Json {
+        value: json!({"result": "ok"}),
+    };
+    let json = serde_json::to_value(&block).expect("serialize");
+    assert_eq!(json["type"], "json");
+    let back: ToolResultContentBlock = serde_json::from_value(json).expect("deserialize");
+    assert_eq!(back, block);
+}
+
+#[test]
+fn stream_event_message_start_tagged_correctly() {
+    let ev = StreamEvent::MessageStart(dasclaw_llm_provider::MessageStartEvent {
+        message: MessageResponse {
+            id: "msg_1".into(),
+            kind: "message".into(),
+            role: "assistant".into(),
+            content: vec![],
+            model: "claude-sonnet-4-6".into(),
+            stop_reason: None,
+            stop_sequence: None,
+            usage: Usage::default(),
+            request_id: None,
+        },
+    });
+    let json = serde_json::to_value(&ev).expect("serialize");
+    assert_eq!(json["type"], "message_start");
+    let back: StreamEvent = serde_json::from_value(json).expect("deserialize");
+    assert_eq!(back, ev);
+}
+
+#[test]
+fn stream_event_content_block_delta_text_delta() {
+    let ev = StreamEvent::ContentBlockDelta(ContentBlockDeltaEvent {
+        index: 0,
+        delta: ContentBlockDelta::TextDelta {
+            text: "hello".into(),
+        },
+    });
+    let json = serde_json::to_value(&ev).expect("serialize");
+    assert_eq!(json["type"], "content_block_delta");
+    assert_eq!(json["delta"]["type"], "text_delta");
+    let back: StreamEvent = serde_json::from_value(json).expect("deserialize");
+    assert_eq!(back, ev);
+}
+
+#[test]
+fn stream_event_input_json_delta_for_partial_tool_input() {
+    let ev = StreamEvent::ContentBlockDelta(ContentBlockDeltaEvent {
+        index: 1,
+        delta: ContentBlockDelta::InputJsonDelta {
+            partial_json: r#"{"path":"#.into(),
+        },
+    });
+    let json = serde_json::to_value(&ev).expect("serialize");
+    assert_eq!(json["delta"]["type"], "input_json_delta");
+    let back: StreamEvent = serde_json::from_value(json).expect("deserialize");
+    assert_eq!(back, ev);
+}
+
+#[test]
+fn message_request_default_omits_optional_fields() {
+    let req = MessageRequest {
+        model: "claude-sonnet-4-6".into(),
+        max_tokens: 100,
+        messages: vec![InputMessage::user_text("hi")],
+        ..MessageRequest::default()
+    };
+    let json = serde_json::to_string(&req).expect("serialize");
+    assert!(!json.contains("system"));
+    assert!(!json.contains("tools"));
+    assert!(!json.contains("tool_choice"));
+    assert!(!json.contains("temperature"));
+    assert!(!json.contains("stream"));
+}


### PR DESCRIPTION
feat(crates): introduce dasclaw_llm_provider skeleton (PR-A.0, ADR-118)

新建 crates/dasclaw_llm_provider —— 主仓自实现 LLM provider crate
骨架，替代 desktop-client/ironclaw 对 claw-code-api 的 path-dep。

## 改动范围（PR-A.0 骨架，~1200 行原创代码）

- `crates/dasclaw_llm_provider/Cargo.toml`：deps serde / serde_json /
  thiserror。HTTP / SSE / async runtime 留给 PR-A.1。
- `src/lib.rs`：模块声明 + selective re-export，`#![deny(unsafe_code)]`
  + `#![warn(missing_docs)]`。
- `src/types.rs`：Anthropic Messages 协议 wire 类型 13 个
  （MessageRequest 13 字段 / InputMessage / 3×InputContentBlock /
  ToolDefinition / 3×ToolChoice / MessageResponse / 4×OutputContentBlock
  含 Thinking + RedactedThinking / Usage 4 字段 / 6 种 SSE StreamEvent /
  4×ContentBlockDelta）。
- `src/error.rs`：强类型 ApiError —— RateLimited / AuthFailed /
  ContextWindowExceeded / BadRequest / ServerError / Provider /
  Transport / Serialization / StreamInterrupted / MalformedSseFrame，
  附 `is_retryable()` / `provider()` / `request_id()` 查询方法。
- `src/providers/mod.rs`：ProviderKind（Anthropic/Xai/OpenAi）+
  9 条模型别名表 + metadata_for_model 路由（含 openai/ / qwen/ /
  kimi/ namespace 前缀） + EnvSnapshot 显式 env 快照 +
  detect_provider_kind / model_token_limit / max_tokens_for_model
  / max_tokens_for_model_with_override。
- `tests/types_roundtrip.rs`：14 项 JSON round-trip 集成测试。

## 与 claw-code-api 的设计差异（顺势处理 ADR-118 §8.5 架构债）

1. **错误强类型化**：拆 10 变体。调用方可精确决策（重试 / 重新登录 /
   裁剪上下文）。claw-code-api 是 all-in-one Display 字符串扫描。
2. **无 env 副作用**：detect_provider_kind 接受显式 EnvSnapshot 而非
   `std::env::var_os`。本 crate 完全 pure，便于多租户 / 单元测试。
3. **无 pricing 耦合**：Usage 只暴露 4 个原始 token 字段，**不计算
   USD 成本**。成本计算是 ironclaw 应用层 `costs::model_cost` 的职责
   （claw-code-api 反向依赖 `runtime::pricing_for_model` 是层间泄漏）。

## 非目标（What's NOT in this PR）

- ❌ HTTP client / reqwest 接入 → PR-A.1
- ❌ SSE parser → PR-A.1
- ❌ AnthropicClient 实现（1717 LOC 等价工作量） → PR-A.2
- ❌ OpenAiCompatClient 实现（2235 LOC 等价工作量） → PR-A.3
- ❌ desktop-client/ironclaw 切换 → PR-A.4（删除 path-dep 即在此 PR 完成）
- ❌ 删除 claw-code submodule → 永不（ADR-118 §2 只读化）

## 验证

```
cargo check -p dasclaw_llm_provider --tests   # OK 13.84s
cargo nextest run -p dasclaw_llm_provider     # 60 passed, 0 failed, 0 skipped
cargo clippy --no-deps -p dasclaw_llm_provider --all-targets -- -D warnings  # OK
cargo fmt --all                                # OK
python3.12 scripts/check_no_panics.py --base origin/xClaw  # OK: No panic-inducing calls
```

## 关联

- Source: docs/plans/architecture-refactor/adr-118-claw-code-readonly-and-self-impl.md §5.2 + §8.6
- Stacked on: #145 (ADR-118 doc PR)

## Skills 自查（AGENTS.md 强制项）

- code-simplifier：✅ 全部模块单一职责、无 dead branches、无 flag 切换
  逻辑、无 try-add-and-fallback 补丁式代码、所有公开 API 都有 doc。
- code-review-expert：✅ 强类型错误 + pure function 设计 / 无 unwrap
  expect panic（生产代码）/ 60 个单元 + 集成测试覆盖正负样本 /
  serde skip_serializing_if 行为单独验证 / EnvSnapshot pattern 解决
  env 副作用调试难题。



Closes #148
