### PR TITLE
chore(ci): broaden closes-link exemption to all plan docs

### DIFF
--- a/.github/workflows/pr-closes-issue-check.yml
+++ b/.github/workflows/pr-closes-issue-check.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false
     steps:
-      - name: Detect ADR-only PR (exempt from closes-link)
+      - name: Detect plan-docs-only PR (exempt from closes-link)
         id: exempt
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -21,17 +21,18 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
-          # ADR docs are reference material referenced by other PRs, not implementation
-          # of trackable issues. Exempt PRs whose changes are entirely under
-          # docs/plans/architecture-refactor/adr-*.md from the closes-link check.
+          # Plan docs (ADRs, execution plans, inventories under docs/plans/architecture-refactor/)
+          # are reference material referenced by other PRs, not implementation of trackable
+          # issues. Exempt PRs whose changes are entirely under that directory from the
+          # closes-link check.
           files=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/files" --paginate --jq '.[].filename')
           if [ -z "$files" ]; then
             echo "exempt=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          non_adr=$(printf '%s\n' "$files" | grep -vE '^docs/plans/architecture-refactor/adr-.*\.md$' || true)
-          if [ -z "$non_adr" ]; then
-            echo "All changed files are ADR docs; exempting from closes-link check."
+          non_plan=$(printf '%s\n' "$files" | grep -vE '^docs/plans/architecture-refactor/.*\.md$' || true)
+          if [ -z "$non_plan" ]; then
+            echo "All changed files are plan docs; exempting from closes-link check."
             echo "exempt=true" >> "$GITHUB_OUTPUT"
           else
             echo "exempt=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## 背景 / 目标

PR #145 同时修改 `adr-118-*.md` + `32-execution-plan.md` + `adr-117-*.md`，但 32-execution-plan 不匹配现行 `^adr-.*\.md$` 豁免正则 → 被 `closes-link` workflow 拦下（即使 #145 已链接 issue #147）。

这类「ADR + 配套 32 任务表/库存文档」复合文档 PR 是常态：

- #142 同时改了 31 / 32 / adr-117 三类文档
- #145 同时改了 32 / adr-117 / adr-118
- 未来 W6/W7 同样会出现 ADR 修订 + 执行计划同步的复合 PR

仅豁免 ADR 已不够；放宽到「整个 `docs/plans/architecture-refactor/` 子目录下所有 `.md`」更贴近真实需求。

## 改动范围

`.github/workflows/pr-closes-issue-check.yml` 1 处：

- 步骤名 `Detect ADR-only PR` → `Detect plan-docs-only PR`
- 注释从「ADR docs」拓展为「plan docs (ADRs, execution plans, inventories)」
- 正则 `^docs/plans/architecture-refactor/adr-.*\.md$` → `^docs/plans/architecture-refactor/.*\.md$`
- 变量 `non_adr` → `non_plan`

## 非目标 (What's NOT in this PR)

- 不动闭合关键字判定逻辑（仍要求 `Closes/Fixes/Resolves #N`）
- 不动其他 workflow 文件
- 不放宽其他目录（`docs/` 顶层、`docs/architecture/` 等仍受约束）
- 不动 PR #145 / #146 — 它们已通过 issue #147 / #148 满足现行规则，本 PR 是结构性改进而非补救

## 验证

```bash
# 本地 yaml 语法检查
python3 -c "import yaml; yaml.safe_load(open('.github/workflows/pr-closes-issue-check.yml'))"
# OK，无输出
```

合并后预期：未来「整个变更范围都在 `docs/plans/architecture-refactor/*.md`」的 PR 自动豁免；混合 PR（含其他文件）继续强制 `Closes #N`。

## 关联

Closes #149
