### PR TITLE
feat(dasclaw_llm_provider): HTTP transport + SSE parser primitives (W6-C PR-A.1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2464,9 +2464,11 @@ dependencies = [
 name = "dasclaw_llm_provider"
 version = "0.0.0-w6"
 dependencies = [
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
+ "tokio",
 ]
 
 [[package]]

--- a/crates/dasclaw_llm_provider/Cargo.toml
+++ b/crates/dasclaw_llm_provider/Cargo.toml
@@ -13,6 +13,8 @@ path = "src/lib.rs"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "1"
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls-native-roots"] }
 
 [dev-dependencies]
 serde_json = "1"
+tokio = { version = "1", features = ["macros", "rt"] }

--- a/crates/dasclaw_llm_provider/src/http.rs
+++ b/crates/dasclaw_llm_provider/src/http.rs
@@ -1,0 +1,301 @@
+//! HTTP transport 层 — `reqwest::Client` 构造 + 代理配置。
+//!
+//! 本模块在 [ADR-118] 定义下，为后续 PR-A.2 / PR-A.3 的 `AnthropicClient` /
+//! `OpenAiCompatClient` 提供共享的传输层基础。
+//!
+//! # 与 `claw-code-api::http_client` 的差异
+//!
+//! 1. **纯函数化**：`ProxyConfig::from_lookup` 接受闭包查询，不直接调用
+//!    `std::env::var`。`ProxyConfig::from_process_env` 是显式命名的副作用入口，
+//!    便于上层多租户 / 测试隔离。
+//! 2. **错误统一映射**：`reqwest` 错误统一映射为 [`ApiError::Transport`]，
+//!    上游 `claw-code-api::ApiError::Http` 是独立变体。我们不引入 `Http` 变体，
+//!    保持 `ApiError` 的语义简洁（10 个变体 → 不增加）。
+//!
+//! [ADR-118]: ../docs/plans/architecture-refactor/adr-118-claw-code-readonly-and-self-impl.md
+
+use crate::error::ApiError;
+
+const HTTP_PROXY_KEYS: [&str; 2] = ["HTTP_PROXY", "http_proxy"];
+const HTTPS_PROXY_KEYS: [&str; 2] = ["HTTPS_PROXY", "https_proxy"];
+const NO_PROXY_KEYS: [&str; 2] = ["NO_PROXY", "no_proxy"];
+
+/// 出站 HTTP 客户端的代理环境快照。
+///
+/// 当 `proxy_url` 设置时，作为 HTTP/HTTPS 流量的 catch-all 代理，优先级高于
+/// 按 scheme 分别设置的 `http_proxy` / `https_proxy` 字段。
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ProxyConfig {
+    /// HTTP 流量代理 URL（来自 `HTTP_PROXY` / `http_proxy`）。
+    pub http_proxy: Option<String>,
+    /// HTTPS 流量代理 URL（来自 `HTTPS_PROXY` / `https_proxy`）。
+    pub https_proxy: Option<String>,
+    /// 不走代理的 host 列表（来自 `NO_PROXY` / `no_proxy`）。
+    pub no_proxy: Option<String>,
+    /// 显式配置的统一代理 URL；优先级高于 `http_proxy` / `https_proxy`。
+    pub proxy_url: Option<String>,
+}
+
+impl ProxyConfig {
+    /// 从进程环境变量读取代理配置（**有副作用**，仅供应用启动期使用）。
+    ///
+    /// 测试 / 多租户场景请改用 [`ProxyConfig::from_lookup`] 或
+    /// 直接构造结构体字段。
+    #[must_use]
+    pub fn from_process_env() -> Self {
+        Self::from_lookup(|key| std::env::var(key).ok())
+    }
+
+    /// 从纯 lookup 闭包读取代理配置；不触碰进程环境。
+    ///
+    /// 同一 scheme 优先大写、再回退小写。空字符串视作未设置。
+    pub fn from_lookup<F>(mut lookup: F) -> Self
+    where
+        F: FnMut(&str) -> Option<String>,
+    {
+        Self {
+            http_proxy: first_non_empty(&HTTP_PROXY_KEYS, &mut lookup),
+            https_proxy: first_non_empty(&HTTPS_PROXY_KEYS, &mut lookup),
+            no_proxy: first_non_empty(&NO_PROXY_KEYS, &mut lookup),
+            proxy_url: None,
+        }
+    }
+
+    /// 从单一 URL 构造统一代理配置；HTTP 与 HTTPS 共用同一目标。
+    #[must_use]
+    pub fn from_proxy_url(url: impl Into<String>) -> Self {
+        Self {
+            proxy_url: Some(url.into()),
+            ..Self::default()
+        }
+    }
+
+    /// 是否未配置任何代理。
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.proxy_url.is_none() && self.http_proxy.is_none() && self.https_proxy.is_none()
+    }
+}
+
+fn first_non_empty<F>(keys: &[&str], lookup: &mut F) -> Option<String>
+where
+    F: FnMut(&str) -> Option<String>,
+{
+    keys.iter()
+        .find_map(|key| lookup(key).filter(|value| !value.is_empty()))
+}
+
+/// 使用进程环境构造 `reqwest::Client`。
+///
+/// 仅 `HTTP_PROXY` / `HTTPS_PROXY` / `NO_PROXY` 任一未设置或为空时，行为与
+/// `reqwest::Client::new()` 一致。
+///
+/// **副作用**：调用 `std::env::var`。多租户 / 测试请改用
+/// [`build_http_client_with`]。
+pub fn build_http_client() -> Result<reqwest::Client, ApiError> {
+    build_http_client_with(&ProxyConfig::from_process_env())
+}
+
+/// 显式 [`ProxyConfig`] 版本；不读进程环境，**纯函数**。
+///
+/// `proxy_url` 字段优先级高于 `http_proxy` / `https_proxy`：当 `proxy_url` 设
+/// 置时，HTTP 与 HTTPS 流量都走它。
+pub fn build_http_client_with(config: &ProxyConfig) -> Result<reqwest::Client, ApiError> {
+    let mut builder = reqwest::Client::builder().no_proxy();
+
+    let no_proxy = config
+        .no_proxy
+        .as_deref()
+        .and_then(reqwest::NoProxy::from_string);
+
+    let (http_proxy_url, https_url) = match config.proxy_url.as_deref() {
+        Some(unified) => (Some(unified), Some(unified)),
+        None => (config.http_proxy.as_deref(), config.https_proxy.as_deref()),
+    };
+
+    if let Some(url) = https_url {
+        let mut proxy = reqwest::Proxy::https(url).map_err(transport_error)?;
+        if let Some(filter) = no_proxy.clone() {
+            proxy = proxy.no_proxy(Some(filter));
+        }
+        builder = builder.proxy(proxy);
+    }
+
+    if let Some(url) = http_proxy_url {
+        let mut proxy = reqwest::Proxy::http(url).map_err(transport_error)?;
+        if let Some(filter) = no_proxy.clone() {
+            proxy = proxy.no_proxy(Some(filter));
+        }
+        builder = builder.proxy(proxy);
+    }
+
+    builder.build().map_err(transport_error)
+}
+
+fn transport_error(err: reqwest::Error) -> ApiError {
+    ApiError::Transport(err.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::{build_http_client_with, ProxyConfig};
+
+    fn config_from_map(pairs: &[(&str, &str)]) -> ProxyConfig {
+        let map: HashMap<String, String> = pairs
+            .iter()
+            .map(|(key, value)| ((*key).to_string(), (*value).to_string()))
+            .collect();
+        ProxyConfig::from_lookup(|key| map.get(key).cloned())
+    }
+
+    #[test]
+    fn proxy_config_is_empty_when_no_env_vars_are_set() {
+        let config = config_from_map(&[]);
+        assert!(config.is_empty());
+        assert_eq!(config, ProxyConfig::default());
+    }
+
+    #[test]
+    fn proxy_config_reads_uppercase_http_https_and_no_proxy() {
+        let pairs = [
+            ("HTTP_PROXY", "http://proxy.internal:3128"),
+            ("HTTPS_PROXY", "http://secure.internal:3129"),
+            ("NO_PROXY", "localhost,127.0.0.1,.corp"),
+        ];
+        let config = config_from_map(&pairs);
+        assert_eq!(
+            config.http_proxy.as_deref(),
+            Some("http://proxy.internal:3128")
+        );
+        assert_eq!(
+            config.https_proxy.as_deref(),
+            Some("http://secure.internal:3129")
+        );
+        assert_eq!(
+            config.no_proxy.as_deref(),
+            Some("localhost,127.0.0.1,.corp")
+        );
+        assert!(!config.is_empty());
+    }
+
+    #[test]
+    fn proxy_config_falls_back_to_lowercase_keys() {
+        let pairs = [
+            ("http_proxy", "http://lower.internal:3128"),
+            ("https_proxy", "http://lower-secure.internal:3129"),
+            ("no_proxy", ".lower"),
+        ];
+        let config = config_from_map(&pairs);
+        assert_eq!(
+            config.http_proxy.as_deref(),
+            Some("http://lower.internal:3128")
+        );
+        assert_eq!(
+            config.https_proxy.as_deref(),
+            Some("http://lower-secure.internal:3129")
+        );
+        assert_eq!(config.no_proxy.as_deref(), Some(".lower"));
+    }
+
+    #[test]
+    fn proxy_config_prefers_uppercase_over_lowercase_when_both_set() {
+        let pairs = [
+            ("HTTP_PROXY", "http://upper.internal:3128"),
+            ("http_proxy", "http://lower.internal:3128"),
+        ];
+        let config = config_from_map(&pairs);
+        assert_eq!(
+            config.http_proxy.as_deref(),
+            Some("http://upper.internal:3128")
+        );
+    }
+
+    #[test]
+    fn proxy_config_treats_empty_strings_as_unset() {
+        let pairs = [("HTTP_PROXY", ""), ("http_proxy", "")];
+        let config = config_from_map(&pairs);
+        assert!(config.http_proxy.is_none());
+    }
+
+    #[test]
+    fn build_http_client_succeeds_when_no_proxy_is_configured() {
+        let config = ProxyConfig::default();
+        let result = build_http_client_with(&config);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn build_http_client_succeeds_with_valid_http_and_https_proxies() {
+        let config = ProxyConfig {
+            http_proxy: Some("http://proxy.internal:3128".to_string()),
+            https_proxy: Some("http://secure.internal:3129".to_string()),
+            no_proxy: Some("localhost,127.0.0.1".to_string()),
+            proxy_url: None,
+        };
+        let result = build_http_client_with(&config);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn build_http_client_returns_transport_error_for_invalid_proxy_url() {
+        let config = ProxyConfig {
+            http_proxy: None,
+            https_proxy: Some("not a url".to_string()),
+            no_proxy: None,
+            proxy_url: None,
+        };
+        let result = build_http_client_with(&config);
+        let error = result.expect_err("invalid proxy URL must be reported as a build failure");
+        assert!(
+            matches!(error, crate::error::ApiError::Transport(_)),
+            "expected ApiError::Transport for invalid proxy URL, got: {error:?}"
+        );
+    }
+
+    #[test]
+    fn from_proxy_url_sets_unified_field_and_leaves_per_scheme_empty() {
+        let config = ProxyConfig::from_proxy_url("http://unified.internal:3128");
+        assert_eq!(
+            config.proxy_url.as_deref(),
+            Some("http://unified.internal:3128")
+        );
+        assert!(config.http_proxy.is_none());
+        assert!(config.https_proxy.is_none());
+        assert!(!config.is_empty());
+    }
+
+    #[test]
+    fn build_http_client_succeeds_with_unified_proxy_url() {
+        let config = ProxyConfig {
+            proxy_url: Some("http://unified.internal:3128".to_string()),
+            no_proxy: Some("localhost".to_string()),
+            ..ProxyConfig::default()
+        };
+        let result = build_http_client_with(&config);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn proxy_url_takes_precedence_over_per_scheme_fields() {
+        let config = ProxyConfig {
+            http_proxy: Some("http://per-scheme.internal:1111".to_string()),
+            https_proxy: Some("http://per-scheme.internal:2222".to_string()),
+            no_proxy: None,
+            proxy_url: Some("http://unified.internal:3128".to_string()),
+        };
+        let result = build_http_client_with(&config);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn build_http_client_returns_transport_error_for_invalid_unified_proxy_url() {
+        let config = ProxyConfig::from_proxy_url("not a url");
+        let result = build_http_client_with(&config);
+        assert!(
+            matches!(result, Err(crate::error::ApiError::Transport(_))),
+            "invalid unified proxy URL should fail: {result:?}"
+        );
+    }
+}

--- a/crates/dasclaw_llm_provider/src/lib.rs
+++ b/crates/dasclaw_llm_provider/src/lib.rs
@@ -4,12 +4,17 @@
 //! claw-code 子仓视为只读参考库，本 crate **重新设计** Anthropic Messages /
 //! OpenAI Chat Completions 兼容层 wire 类型与 client 抽象，不直接消费子仓代码。
 //!
-//! 当前阶段：**PR-A.0 骨架**
+//! 当前阶段：**PR-A.1 — HTTP transport + SSE 解析器原语**
 //! - ✅ wire 类型（`types`）—— Anthropic Messages 协议输入/输出/streaming events
 //! - ✅ 强类型错误（`error::ApiError`）—— 拆分 `RateLimited` / `AuthFailed` /
-//!   `ContextWindowExceeded` / `Http` / `Json` / `Io` / `Provider`，便于上层精确映射
+//!   `ContextWindowExceeded` / `ServerError` / `Transport` / `MalformedSseFrame` 等，
+//!   便于上层精确映射
 //! - ✅ `ProviderKind` + 模型别名表 + `metadata_for_model` + `max_tokens_for_model`
-//! - 🟡 `AnthropicClient` / `OpenAiCompatClient`：留给 PR-A.2，本骨架暂未实现
+//! - ✅ `http::ProxyConfig` + `http::build_http_client_with` —— `reqwest::Client`
+//!   构造 + 代理（HTTP/HTTPS/统一 URL/no_proxy）支持，纯函数 + 显式 env 入口
+//! - ✅ `sse::SseParser` + `sse::parse_frame` —— 增量 SSE 帧解析器，识别 ping/DONE/comment
+//! - 🟡 `AnthropicClient` / `OpenAiCompatClient`：留给 PR-A.2 / PR-A.3，本 PR 暂未实现
+//! - 🟡 重试策略 + Retry-After 解析：随 PR-A.2 client 一并落地
 //!
 //! 与 `claw-code-api` 的设计差异（顺势处理架构债，详见 ADR-118 §8.5）：
 //!
@@ -27,15 +32,19 @@
 #![warn(missing_docs)]
 
 pub mod error;
+pub mod http;
 pub mod providers;
+pub mod sse;
 pub mod types;
 
 pub use error::ApiError;
+pub use http::{build_http_client, build_http_client_with, ProxyConfig};
 pub use providers::{
     detect_provider_kind, max_tokens_for_model, max_tokens_for_model_with_override,
     metadata_for_model, model_token_limit, resolve_model_alias, EnvSnapshot, ModelTokenLimit,
     ProviderKind, ProviderMetadata,
 };
+pub use sse::{parse_frame, SseParser};
 pub use types::{
     ContentBlockDelta, ContentBlockDeltaEvent, ContentBlockStartEvent, ContentBlockStopEvent,
     InputContentBlock, InputMessage, MessageDelta, MessageDeltaEvent, MessageRequest,

--- a/crates/dasclaw_llm_provider/src/sse.rs
+++ b/crates/dasclaw_llm_provider/src/sse.rs
@@ -1,0 +1,356 @@
+//! SSE 帧解析器 — 把 `data: ...` 行流解析为 [`StreamEvent`]。
+//!
+//! 本解析器是同步、增量、零异步依赖的字节缓冲器，由上层（PR-A.2 / PR-A.3）的
+//! `reqwest::Response` 字节流驱动。设计参考 Anthropic Messages SSE 协议
+//! （`event: ` + `data: ` + 空行帧分隔），同时兼容 `: keepalive` 注释行
+//! 与 `data: [DONE]` 终止标识。
+//!
+//! # 与 `claw-code-api::sse` 的差异
+//!
+//! 1. **JSON 错误映射**：本 crate 的 [`ApiError`] 没有专用的 `JsonDeserialize`
+//!    变体；不可解析的 SSE 帧统一映射为 [`ApiError::MalformedSseFrame`]，错误
+//!    消息内嵌 provider / model / payload 截断（≤ 200 字节，避免泄漏密钥）。
+//! 2. **provider/model 上下文可选**：未携带上下文时占位为 `"unknown"`，
+//!    上层可通过 [`SseParser::with_context`] 显式注入。
+//!
+//! [ApiError]: crate::error::ApiError
+//! [StreamEvent]: crate::types::StreamEvent
+
+use crate::error::ApiError;
+use crate::types::StreamEvent;
+
+/// SSE 流增量解析器。
+///
+/// 内部维护字节缓冲，按 `\n\n` 或 `\r\n\r\n` 切帧；不完整帧保留至下次 `push`。
+#[derive(Debug, Default)]
+pub struct SseParser {
+    buffer: Vec<u8>,
+    provider: Option<String>,
+    model: Option<String>,
+}
+
+impl SseParser {
+    /// 构造无上下文的解析器（错误消息中 provider/model 显示为 `"unknown"`）。
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// 注入 provider 名与 model 名，仅用于增强 `MalformedSseFrame` 错误信息。
+    #[must_use]
+    pub fn with_context(mut self, provider: impl Into<String>, model: impl Into<String>) -> Self {
+        self.provider = Some(provider.into());
+        self.model = Some(model.into());
+        self
+    }
+
+    /// 推送一段字节，返回本次能完整解析出的 [`StreamEvent`] 列表。
+    ///
+    /// 不完整帧自动保留至下次 `push`。`event: ping` 与 `data: [DONE]` 会被静默丢弃。
+    pub fn push(&mut self, chunk: &[u8]) -> Result<Vec<StreamEvent>, ApiError> {
+        self.buffer.extend_from_slice(chunk);
+        let mut events = Vec::new();
+
+        while let Some(frame) = self.next_frame() {
+            if let Some(event) = self.parse_frame_with_context(&frame)? {
+                events.push(event);
+            }
+        }
+
+        Ok(events)
+    }
+
+    /// 流结束时调用 — 把缓冲区残留作为最后一帧解析。
+    pub fn finish(&mut self) -> Result<Vec<StreamEvent>, ApiError> {
+        if self.buffer.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let trailing = std::mem::take(&mut self.buffer);
+        match self.parse_frame_with_context(&String::from_utf8_lossy(&trailing))? {
+            Some(event) => Ok(vec![event]),
+            None => Ok(Vec::new()),
+        }
+    }
+
+    fn parse_frame_with_context(&self, frame: &str) -> Result<Option<StreamEvent>, ApiError> {
+        let provider = self.provider.as_deref().unwrap_or("unknown");
+        let model = self.model.as_deref().unwrap_or("unknown");
+        parse_frame_with_provider(frame, provider, model)
+    }
+
+    fn next_frame(&mut self) -> Option<String> {
+        let separator = self
+            .buffer
+            .windows(2)
+            .position(|window| window == b"\n\n")
+            .map(|position| (position, 2))
+            .or_else(|| {
+                self.buffer
+                    .windows(4)
+                    .position(|window| window == b"\r\n\r\n")
+                    .map(|position| (position, 4))
+            })?;
+
+        let (position, separator_len) = separator;
+        let frame = self
+            .buffer
+            .drain(..position + separator_len)
+            .collect::<Vec<_>>();
+        let frame_len = frame.len().saturating_sub(separator_len);
+        Some(String::from_utf8_lossy(&frame[..frame_len]).into_owned())
+    }
+}
+
+/// 解析单帧（不带 provider/model 上下文）；内部测试和无上下文调用方使用。
+pub fn parse_frame(frame: &str) -> Result<Option<StreamEvent>, ApiError> {
+    parse_frame_with_provider(frame, "unknown", "unknown")
+}
+
+fn parse_frame_with_provider(
+    frame: &str,
+    provider: &str,
+    model: &str,
+) -> Result<Option<StreamEvent>, ApiError> {
+    let trimmed = frame.trim();
+    if trimmed.is_empty() {
+        return Ok(None);
+    }
+
+    let mut data_lines = Vec::new();
+    let mut event_name: Option<&str> = None;
+
+    for line in trimmed.lines() {
+        if line.starts_with(':') {
+            continue;
+        }
+        if let Some(name) = line.strip_prefix("event:") {
+            event_name = Some(name.trim());
+            continue;
+        }
+        if let Some(data) = line.strip_prefix("data:") {
+            data_lines.push(data.trim_start());
+        }
+    }
+
+    if matches!(event_name, Some("ping")) {
+        return Ok(None);
+    }
+
+    if data_lines.is_empty() {
+        return Ok(None);
+    }
+
+    let payload = data_lines.join("\n");
+    if payload == "[DONE]" {
+        return Ok(None);
+    }
+
+    serde_json::from_str::<StreamEvent>(&payload)
+        .map(Some)
+        .map_err(|error| {
+            let truncated = truncate_for_error(&payload);
+            ApiError::MalformedSseFrame(format!(
+                "{provider} model={model} payload={truncated}: {error}"
+            ))
+        })
+}
+
+/// 截断 payload 到 ≤ 200 字节，避免错误消息泄漏完整 prompt / 密钥片段。
+fn truncate_for_error(payload: &str) -> String {
+    const MAX: usize = 200;
+    if payload.len() <= MAX {
+        return payload.to_string();
+    }
+    let safe_end = (0..=MAX)
+        .rev()
+        .find(|&i| payload.is_char_boundary(i))
+        .unwrap_or(0);
+    format!(
+        "{}…(truncated, {} bytes)",
+        &payload[..safe_end],
+        payload.len()
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_frame, SseParser};
+    use crate::types::{
+        ContentBlockDelta, ContentBlockDeltaEvent, ContentBlockStartEvent, MessageDelta,
+        MessageDeltaEvent, MessageStopEvent, OutputContentBlock, StreamEvent, Usage,
+    };
+
+    #[test]
+    fn parses_single_content_block_start_frame() {
+        let frame = concat!(
+            "event: content_block_start\n",
+            "data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"Hi\"}}\n\n"
+        );
+        let event = parse_frame(frame).expect("frame should parse");
+        assert_eq!(
+            event,
+            Some(StreamEvent::ContentBlockStart(ContentBlockStartEvent {
+                index: 0,
+                content_block: OutputContentBlock::Text {
+                    text: "Hi".to_string(),
+                },
+            }))
+        );
+    }
+
+    #[test]
+    fn parses_chunked_stream_buffering_partial_frame() {
+        let mut parser = SseParser::new();
+        let first = b"event: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"Hel";
+        let second = b"lo\"}}\n\n";
+
+        let early = parser.push(first).expect("first chunk should buffer");
+        assert!(early.is_empty(), "partial frame must not yield events yet");
+        let events = parser.push(second).expect("second chunk should parse");
+        assert_eq!(
+            events,
+            vec![StreamEvent::ContentBlockDelta(ContentBlockDeltaEvent {
+                index: 0,
+                delta: ContentBlockDelta::TextDelta {
+                    text: "Hello".to_string(),
+                },
+            })]
+        );
+    }
+
+    #[test]
+    fn ignores_keepalive_comments_ping_events_and_done_marker() {
+        let mut parser = SseParser::new();
+        let payload = concat!(
+            ": keepalive\n",
+            "event: ping\n",
+            "data: {\"type\":\"ping\"}\n\n",
+            "event: message_delta\n",
+            "data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"tool_use\",\"stop_sequence\":null},\"usage\":{\"input_tokens\":1,\"output_tokens\":2}}\n\n",
+            "event: message_stop\n",
+            "data: {\"type\":\"message_stop\"}\n\n",
+            "data: [DONE]\n\n"
+        );
+        let events = parser
+            .push(payload.as_bytes())
+            .expect("parser should succeed");
+        assert_eq!(
+            events,
+            vec![
+                StreamEvent::MessageDelta(MessageDeltaEvent {
+                    delta: MessageDelta {
+                        stop_reason: Some("tool_use".to_string()),
+                        stop_sequence: None,
+                    },
+                    usage: Usage {
+                        input_tokens: 1,
+                        cache_creation_input_tokens: 0,
+                        cache_read_input_tokens: 0,
+                        output_tokens: 2,
+                    },
+                }),
+                StreamEvent::MessageStop(MessageStopEvent {}),
+            ]
+        );
+    }
+
+    #[test]
+    fn ignores_data_less_event_frames() {
+        let frame = "event: ping\n\n";
+        let event = parse_frame(frame).expect("frame should parse");
+        assert!(event.is_none());
+    }
+
+    #[test]
+    fn supports_crlf_separator() {
+        let mut parser = SseParser::new();
+        let payload = b"event: message_stop\r\ndata: {\"type\":\"message_stop\"}\r\n\r\n";
+        let events = parser.push(payload).expect("crlf parser should succeed");
+        assert_eq!(events, vec![StreamEvent::MessageStop(MessageStopEvent {})]);
+    }
+
+    #[test]
+    fn malformed_json_returns_malformed_sse_frame_error_with_context() {
+        let frame = "event: message_delta\ndata: {not valid json}\n\n";
+        let err = parse_frame(frame).expect_err("invalid JSON must fail");
+        match err {
+            crate::error::ApiError::MalformedSseFrame(msg) => {
+                assert!(msg.contains("unknown"), "expect provider context: {msg}");
+                assert!(msg.contains("model="), "expect model context: {msg}");
+            }
+            other => panic!("expected MalformedSseFrame, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parser_with_context_includes_provider_and_model_in_error() {
+        let mut parser = SseParser::new().with_context("anthropic", "claude-sonnet-4-6");
+        let frame = b"event: bogus\ndata: {not valid json}\n\n";
+        let err = parser.push(frame).expect_err("invalid JSON must fail");
+        match err {
+            crate::error::ApiError::MalformedSseFrame(msg) => {
+                assert!(
+                    msg.contains("anthropic"),
+                    "context provider missing in: {msg}"
+                );
+                assert!(
+                    msg.contains("claude-sonnet-4-6"),
+                    "context model missing in: {msg}"
+                );
+            }
+            other => panic!("expected MalformedSseFrame, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn finish_drains_trailing_partial_frame_when_terminated_without_double_newline() {
+        let mut parser = SseParser::new();
+        // Frame missing the terminating \n\n: parser should buffer it.
+        let payload = b"event: message_stop\ndata: {\"type\":\"message_stop\"}";
+        let early = parser.push(payload).expect("partial push should buffer");
+        assert!(early.is_empty());
+        let final_events = parser.finish().expect("finish should drain");
+        assert_eq!(
+            final_events,
+            vec![StreamEvent::MessageStop(MessageStopEvent {})]
+        );
+    }
+
+    #[test]
+    fn finish_on_empty_buffer_yields_nothing() {
+        let mut parser = SseParser::new();
+        let events = parser.finish().expect("empty finish ok");
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn empty_frame_returns_none() {
+        let event = parse_frame("").expect("empty frame should parse");
+        assert!(event.is_none());
+    }
+
+    #[test]
+    fn truncated_payload_stays_within_size_bound() {
+        // Build a long invalid payload to test the truncation path of error formatting.
+        let big = format!("event: x\ndata: {{ {} }}\n\n", "x".repeat(500));
+        let err = parse_frame(&big).expect_err("invalid JSON must fail");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("truncated"),
+            "should mention truncation: {msg}"
+        );
+    }
+
+    #[test]
+    fn multiple_data_lines_concatenate_with_newline() {
+        // Anthropic MCP and some providers split JSON across multiple data: lines.
+        let frame = concat!(
+            "event: message_stop\n",
+            "data: {\"type\":\n",
+            "data: \"message_stop\"}\n\n"
+        );
+        let event = parse_frame(frame).expect("multiline data should parse");
+        assert_eq!(event, Some(StreamEvent::MessageStop(MessageStopEvent {})));
+    }
+}


### PR DESCRIPTION
## 背景 / 目标

ADR-118 §5 第二步：在 `dasclaw_llm_provider`（PR-A.0 #146 已合并骨架）之上落地
**HTTP 传输层 + SSE 解析器原语**。这两个模块不依赖任何具体 provider 协议，是 PR-A.2
（`AnthropicClient`）/ PR-A.3（`OpenAiCompatClient`）的共享基础。

按 ADR-118 §8.5「顺势处理架构债」原则，相对 `claw-code-api::http_client` /
`claw-code-api::sse` 做了两处改进：

1. **HTTP — 纯函数化**：`ProxyConfig::from_lookup<F>` 接受闭包查询代理 env，不再触碰
   `std::env::var`。`from_process_env` 是显式命名的副作用入口，便于多租户 / 测试隔离。
2. **SSE — 错误强类型化 + 上下文化**：解析失败统一映射为 `ApiError::MalformedSseFrame`
   并内嵌 `provider` / `model` / 截断的 payload（≤ 200 字节，避免泄漏密钥）。
   不复刻 claw-code 的 `JsonDeserialize` 字符串错误。

`Closes #151`

## 改动范围

- `crates/dasclaw_llm_provider/src/http.rs`（**新增** ~280 LOC，含 11 个单测）
  - `ProxyConfig`（http_proxy / https_proxy / no_proxy / proxy_url）
  - `from_lookup<F>` / `from_process_env` / `from_proxy_url` / `is_empty`
  - `build_http_client()` / `build_http_client_with(&ProxyConfig)`
  - `proxy_url` 优先级高于按 scheme 字段；`NoProxy::from_string` 过滤；HTTP/HTTPS 双轨
- `crates/dasclaw_llm_provider/src/sse.rs`（**新增** ~270 LOC，含 12 个单测）
  - `SseParser`：增量字节缓冲 + `\n\n` / `\r\n\r\n` 双分隔符
  - 跳过 `:` 注释行 / `event: ping` / `data: [DONE]`；多行 `data:` 自动 `\n` 拼接
  - `with_context(provider, model)` 注入；错误消息 payload 截断到 ≤ 200 字节
- `crates/dasclaw_llm_provider/Cargo.toml`：`+ reqwest 0.12`（rustls-tls-native-roots, json）；
  dev `+ tokio` (macros + rt) 留给后续 client 测试
- `crates/dasclaw_llm_provider/src/lib.rs`：注册 `pub mod http; pub mod sse;` + re-exports；
  状态块从「PR-A.0 骨架」更新为「PR-A.1」

## 非目标（What's NOT in this PR）

- ❌ `AnthropicClient` / `OpenAiCompatClient` —— 留给 PR-A.2 / PR-A.3
- ❌ 重试策略 + Retry-After 解析 —— 随 PR-A.2 client 一并落地，避免本 PR 体积膨胀
- ❌ 真实网络 IO 测试（mockito / wiremock）—— 引入到 PR-A.2 client 落地时再加
- ❌ `claw-code-api` 路径依赖删除 —— 留给 PR-A.4

## 验证（命令 + 结果）

```text
$ cargo check -p dasclaw_llm_provider --tests
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 25s

$ cargo nextest run -p dasclaw_llm_provider
    Summary [37.188s] 84 tests run: 84 passed (1 leaky), 0 skipped
    （+23 个新增单测：11 在 http::tests，12 在 sse::tests）

$ cargo fmt --all
    （无差异）

$ cargo clippy --no-deps -p dasclaw_llm_provider --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 3.14s
    （0 warnings）

$ python3.12 scripts/check_no_panics.py --base origin/xClaw
    OK: No panic-inducing calls in changed production code.
```

## 后续

- PR-A.2：`AnthropicClient`（complete + stream）、Retry-After 退避、`messages` endpoint
- PR-A.3：`OpenAiCompatClient`（OpenAI / xAI / Dashscope / OpenRouter / DeepSeek）
- PR-A.4：切换 ironclaw 引用从 `claw-code-api::*` → `dasclaw_llm_provider::*` + 删除 path-dep
