### PR TITLE
feat(llm-provider): AnthropicClient + RetryPolicy with Retry-After honor (W6-C PR-A.2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2469,6 +2469,7 @@ dependencies = [
  "serde_json",
  "thiserror 1.0.69",
  "tokio",
+ "wiremock",
 ]
 
 [[package]]

--- a/crates/dasclaw_llm_provider/Cargo.toml
+++ b/crates/dasclaw_llm_provider/Cargo.toml
@@ -14,7 +14,9 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "1"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls-native-roots"] }
+tokio = { version = "1", default-features = false, features = ["time"] }
 
 [dev-dependencies]
 serde_json = "1"
-tokio = { version = "1", features = ["macros", "rt"] }
+tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread", "time"] }
+wiremock = "0.6"

--- a/crates/dasclaw_llm_provider/src/lib.rs
+++ b/crates/dasclaw_llm_provider/src/lib.rs
@@ -4,7 +4,7 @@
 //! claw-code 子仓视为只读参考库，本 crate **重新设计** Anthropic Messages /
 //! OpenAI Chat Completions 兼容层 wire 类型与 client 抽象，不直接消费子仓代码。
 //!
-//! 当前阶段：**PR-A.1 — HTTP transport + SSE 解析器原语**
+//! 当前阶段：**PR-A.2 — Anthropic Messages 客户端 + 重试策略**
 //! - ✅ wire 类型（`types`）—— Anthropic Messages 协议输入/输出/streaming events
 //! - ✅ 强类型错误（`error::ApiError`）—— 拆分 `RateLimited` / `AuthFailed` /
 //!   `ContextWindowExceeded` / `ServerError` / `Transport` / `MalformedSseFrame` 等，
@@ -13,8 +13,12 @@
 //! - ✅ `http::ProxyConfig` + `http::build_http_client_with` —— `reqwest::Client`
 //!   构造 + 代理（HTTP/HTTPS/统一 URL/no_proxy）支持，纯函数 + 显式 env 入口
 //! - ✅ `sse::SseParser` + `sse::parse_frame` —— 增量 SSE 帧解析器，识别 ping/DONE/comment
-//! - 🟡 `AnthropicClient` / `OpenAiCompatClient`：留给 PR-A.2 / PR-A.3，本 PR 暂未实现
-//! - 🟡 重试策略 + Retry-After 解析：随 PR-A.2 client 一并落地
+//! - ✅ `retry::RetryPolicy` —— 指数退避 + 抖动 + `Retry-After` 头部尊重
+//!   （**改进**：claw-code 完全忽略 `Retry-After`，本 crate 优先采纳上游建议）
+//! - ✅ `providers::AnthropicClient` —— `complete()` / `stream()` + 状态码精确映射到
+//!   `ApiError` 各变体；`AuthSource` 支持 `ApiKey` / `BearerToken` / 双 header
+//! - 🟡 `OpenAiCompatClient`：留给 PR-A.3
+//! - 🟡 删除主仓 `claw-code-api` path-dep：留给 PR-A.4
 //!
 //! 与 `claw-code-api` 的设计差异（顺势处理架构债，详见 ADR-118 §8.5）：
 //!
@@ -34,6 +38,7 @@
 pub mod error;
 pub mod http;
 pub mod providers;
+pub mod retry;
 pub mod sse;
 pub mod types;
 
@@ -41,9 +46,10 @@ pub use error::ApiError;
 pub use http::{build_http_client, build_http_client_with, ProxyConfig};
 pub use providers::{
     detect_provider_kind, max_tokens_for_model, max_tokens_for_model_with_override,
-    metadata_for_model, model_token_limit, resolve_model_alias, EnvSnapshot, ModelTokenLimit,
-    ProviderKind, ProviderMetadata,
+    metadata_for_model, model_token_limit, resolve_model_alias, AnthropicClient, AnthropicStream,
+    AuthSource, EnvSnapshot, ModelTokenLimit, ProviderKind, ProviderMetadata,
 };
+pub use retry::{parse_retry_after, RetryPolicy};
 pub use sse::{parse_frame, SseParser};
 pub use types::{
     ContentBlockDelta, ContentBlockDeltaEvent, ContentBlockStartEvent, ContentBlockStopEvent,

--- a/crates/dasclaw_llm_provider/src/providers/anthropic.rs
+++ b/crates/dasclaw_llm_provider/src/providers/anthropic.rs
@@ -1,0 +1,529 @@
+//! Anthropic Messages API 客户端。
+//!
+//! 实现 [Anthropic Messages API] 的 `/v1/messages` 端点，提供同步 [`complete`]
+//! 与流式 [`stream`] 两种调用模式。基于 [`crate::http::build_http_client_with`]
+//! 与 [`crate::sse::SseParser`] 原语。
+//!
+//! # 与 `claw-code-api::providers::anthropic` 的差异
+//!
+//! 1. **去除应用层耦合**：本 crate 不依赖 `runtime` / `telemetry` / `prompt_cache`，
+//!    `AnthropicClient` 不挂 `SessionTracer` / `PromptCache` 字段，纯 HTTP 客户端。
+//!    PromptCache / 会话追踪由上层 ironclaw 在调用方包装。
+//! 2. **错误强类型化**：HTTP 状态码精确分发到 `ApiError` 各变体（`RateLimited`、
+//!    `AuthFailed`、`ContextWindowExceeded`、`BadRequest`、`ServerError`、`Provider`），
+//!    上层免去字符串扫描。
+//! 3. **尊重 `Retry-After`**：429 响应携带 `Retry-After` 时优先采纳上游建议（受
+//!    `RetryPolicy::max_backoff` 约束）；claw-code 完全忽略此头部。
+//! 4. **OAuth 解耦**：本 PR 仅支持 `ApiKey` / `BearerToken` 静态凭据；OAuth flow
+//!    由后续 PR 单独承载，避免 client 主体逻辑被凭据轮转撑大。
+//!
+//! [Anthropic Messages API]: https://docs.anthropic.com/en/api/messages
+//! [`complete`]: AnthropicClient::complete
+//! [`stream`]: AnthropicClient::stream
+
+use std::collections::VecDeque;
+use std::time::Duration;
+
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
+
+use crate::error::ApiError;
+use crate::retry::{parse_retry_after, RetryPolicy};
+use crate::sse::SseParser;
+use crate::types::{MessageRequest, MessageResponse, StreamEvent};
+
+const ANTHROPIC_PROVIDER: &str = "anthropic";
+
+/// Anthropic API 默认 base URL。
+pub const DEFAULT_BASE_URL: &str = "https://api.anthropic.com";
+
+/// Anthropic API 版本号头部值。
+pub const ANTHROPIC_VERSION: &str = "2023-06-01";
+
+const REQUEST_ID_HEADER: &str = "request-id";
+const ALT_REQUEST_ID_HEADER: &str = "x-request-id";
+const RETRY_AFTER_HEADER: &str = "retry-after";
+
+/// Anthropic 客户端鉴权来源。
+///
+/// 同时携带 `ApiKey` 与 `BearerToken` 时，两者**都会**附加到请求（`x-api-key`
+/// 头 + `Authorization: Bearer` 头），与 claw-code 行为一致。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AuthSource {
+    /// 无凭据 — 仅用于探针请求或测试 mock 场景。
+    None,
+    /// `sk-ant-*` 形式 API Key（走 `x-api-key` 头）。
+    ApiKey(String),
+    /// OAuth bearer token（走 `Authorization: Bearer` 头）。
+    BearerToken(String),
+    /// 两者都提供（部分企业网关需要双 header）。
+    ApiKeyAndBearer {
+        /// `sk-ant-*` API Key。
+        api_key: String,
+        /// OAuth bearer token。
+        bearer_token: String,
+    },
+}
+
+impl AuthSource {
+    fn apply(&self, builder: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
+        let mut builder = builder;
+        if let Some(api_key) = self.api_key() {
+            builder = builder.header("x-api-key", api_key);
+        }
+        if let Some(token) = self.bearer_token() {
+            builder = builder.bearer_auth(token);
+        }
+        builder
+    }
+
+    fn api_key(&self) -> Option<&str> {
+        match self {
+            Self::ApiKey(key) | Self::ApiKeyAndBearer { api_key: key, .. } => Some(key),
+            Self::None | Self::BearerToken(_) => None,
+        }
+    }
+
+    fn bearer_token(&self) -> Option<&str> {
+        match self {
+            Self::BearerToken(token)
+            | Self::ApiKeyAndBearer {
+                bearer_token: token,
+                ..
+            } => Some(token),
+            Self::None | Self::ApiKey(_) => None,
+        }
+    }
+}
+
+/// Anthropic Messages API 客户端。
+#[derive(Debug, Clone)]
+pub struct AnthropicClient {
+    http: reqwest::Client,
+    auth: AuthSource,
+    base_url: String,
+    retry_policy: RetryPolicy,
+}
+
+impl AnthropicClient {
+    /// 用 API Key 构造客户端，使用默认 `reqwest::Client` 与默认 [`RetryPolicy`]。
+    pub fn new(api_key: impl Into<String>) -> Result<Self, ApiError> {
+        Self::with_auth(AuthSource::ApiKey(api_key.into()))
+    }
+
+    /// 显式传入 [`AuthSource`]；其余字段取默认。
+    pub fn with_auth(auth: AuthSource) -> Result<Self, ApiError> {
+        Ok(Self {
+            http: crate::http::build_http_client_with(&crate::http::ProxyConfig::default())?,
+            auth,
+            base_url: DEFAULT_BASE_URL.to_string(),
+            retry_policy: RetryPolicy::default(),
+        })
+    }
+
+    /// 注入预构造的 `reqwest::Client`（例如已配置代理的客户端）。
+    #[must_use]
+    pub fn with_http_client(mut self, http: reqwest::Client) -> Self {
+        self.http = http;
+        self
+    }
+
+    /// 覆盖 base URL（如自托管网关 / Vertex / Bedrock 兼容前端）。
+    #[must_use]
+    pub fn with_base_url(mut self, base_url: impl Into<String>) -> Self {
+        self.base_url = base_url.into();
+        self
+    }
+
+    /// 覆盖默认 [`RetryPolicy`]。
+    #[must_use]
+    pub fn with_retry_policy(mut self, policy: RetryPolicy) -> Self {
+        self.retry_policy = policy;
+        self
+    }
+
+    /// 当前 base URL（只读）。
+    #[must_use]
+    pub fn base_url(&self) -> &str {
+        &self.base_url
+    }
+
+    /// 同步（非流式）发送消息请求。
+    ///
+    /// 内部强制将 `request.stream` 改写为 `false`。
+    pub async fn complete(&self, request: &MessageRequest) -> Result<MessageResponse, ApiError> {
+        let request = MessageRequest {
+            stream: false,
+            ..request.clone()
+        };
+        let response = self.send_with_retry(&request).await?;
+        let request_id = request_id_from_headers(response.headers());
+        let body = response
+            .text()
+            .await
+            .map_err(|err| ApiError::Transport(err.to_string()))?;
+        let mut parsed: MessageResponse =
+            serde_json::from_str(&body).map_err(|err| ApiError::Provider {
+                provider: ANTHROPIC_PROVIDER.to_string(),
+                reason: format!(
+                    "failed to deserialize MessageResponse for model={}: {}",
+                    request.model, err
+                ),
+                request_id: request_id.clone(),
+            })?;
+        if parsed.request_id.is_none() {
+            parsed.request_id = request_id;
+        }
+        Ok(parsed)
+    }
+
+    /// 流式发送消息请求；返回 [`AnthropicStream`] 增量推送 SSE 事件。
+    ///
+    /// 内部强制将 `request.stream` 改写为 `true`。
+    pub async fn stream(&self, request: &MessageRequest) -> Result<AnthropicStream, ApiError> {
+        let request = MessageRequest {
+            stream: true,
+            ..request.clone()
+        };
+        let response = self.send_with_retry(&request).await?;
+        let request_id = request_id_from_headers(response.headers());
+        Ok(AnthropicStream {
+            request_id,
+            response,
+            parser: SseParser::new().with_context(ANTHROPIC_PROVIDER, request.model.clone()),
+            pending: VecDeque::new(),
+            done: false,
+        })
+    }
+
+    async fn send_with_retry(
+        &self,
+        request: &MessageRequest,
+    ) -> Result<reqwest::Response, ApiError> {
+        let mut attempt: u32 = 0;
+        loop {
+            let outcome = self.send_once(request).await;
+            match outcome {
+                Ok(response) => return Ok(response),
+                Err(error) => {
+                    let retryable = error.is_retryable();
+                    if !retryable || attempt >= self.retry_policy.max_retries {
+                        return Err(error);
+                    }
+                    let suggested = retry_after_from_error(&error);
+                    attempt += 1;
+                    let delay = self
+                        .retry_policy
+                        .delay_for_attempt(attempt, suggested)
+                        .ok_or_else(|| ApiError::Provider {
+                            provider: ANTHROPIC_PROVIDER.to_string(),
+                            reason: format!("retry backoff overflow at attempt {attempt}"),
+                            request_id: error.request_id().map(ToOwned::to_owned),
+                        })?;
+                    tokio::time::sleep(delay).await;
+                }
+            }
+        }
+    }
+
+    async fn send_once(&self, request: &MessageRequest) -> Result<reqwest::Response, ApiError> {
+        let url = format!("{}/v1/messages", self.base_url.trim_end_matches('/'));
+        let builder = self
+            .http
+            .post(&url)
+            .header("content-type", "application/json")
+            .header("anthropic-version", ANTHROPIC_VERSION);
+        let builder = self.auth.apply(builder);
+        let response = builder
+            .json(request)
+            .send()
+            .await
+            .map_err(|err| ApiError::Transport(err.to_string()))?;
+        expect_success(response).await
+    }
+}
+
+/// Anthropic 流式响应；由 [`AnthropicClient::stream`] 创建。
+#[derive(Debug)]
+pub struct AnthropicStream {
+    request_id: Option<String>,
+    response: reqwest::Response,
+    parser: SseParser,
+    pending: VecDeque<StreamEvent>,
+    done: bool,
+}
+
+impl AnthropicStream {
+    /// 上游返回的 trace ID（如有）。
+    #[must_use]
+    pub fn request_id(&self) -> Option<&str> {
+        self.request_id.as_deref()
+    }
+
+    /// 增量拉取下一个 [`StreamEvent`]；流结束时返回 `Ok(None)`。
+    pub async fn next_event(&mut self) -> Result<Option<StreamEvent>, ApiError> {
+        loop {
+            if let Some(event) = self.pending.pop_front() {
+                return Ok(Some(event));
+            }
+            if self.done {
+                let trailing = self.parser.finish()?;
+                if trailing.is_empty() {
+                    return Ok(None);
+                }
+                self.pending.extend(trailing);
+                continue;
+            }
+            match self
+                .response
+                .chunk()
+                .await
+                .map_err(|err| ApiError::StreamInterrupted(err.to_string()))?
+            {
+                Some(chunk) => {
+                    self.pending.extend(self.parser.push(&chunk)?);
+                }
+                None => {
+                    self.done = true;
+                }
+            }
+        }
+    }
+}
+
+fn request_id_from_headers(headers: &HeaderMap) -> Option<String> {
+    headers
+        .get(REQUEST_ID_HEADER)
+        .or_else(|| headers.get(ALT_REQUEST_ID_HEADER))
+        .and_then(|value| value.to_str().ok())
+        .map(ToOwned::to_owned)
+}
+
+fn retry_after_from_error(error: &ApiError) -> Option<Duration> {
+    match error {
+        ApiError::RateLimited {
+            retry_after_secs: Some(secs),
+            ..
+        } => Some(Duration::from_secs(*secs)),
+        _ => None,
+    }
+}
+
+async fn expect_success(response: reqwest::Response) -> Result<reqwest::Response, ApiError> {
+    let status = response.status();
+    if status.is_success() {
+        return Ok(response);
+    }
+
+    let request_id = request_id_from_headers(response.headers());
+    let retry_after = response
+        .headers()
+        .get(RETRY_AFTER_HEADER)
+        .and_then(|value| value.to_str().ok())
+        .and_then(parse_retry_after);
+
+    let body = response.text().await.unwrap_or_default();
+    let parsed_message = parse_anthropic_error_message(&body);
+    let reason = parsed_message
+        .clone()
+        .unwrap_or_else(|| truncate_body(&body));
+
+    Err(map_status_to_api_error(
+        status,
+        reason,
+        retry_after,
+        request_id,
+    ))
+}
+
+fn map_status_to_api_error(
+    status: StatusCode,
+    reason: String,
+    retry_after: Option<Duration>,
+    request_id: Option<String>,
+) -> ApiError {
+    let provider = ANTHROPIC_PROVIDER.to_string();
+    match status.as_u16() {
+        429 => ApiError::RateLimited {
+            provider,
+            retry_after_secs: retry_after.map(|d| d.as_secs()),
+            request_id,
+        },
+        401 | 403 => ApiError::AuthFailed {
+            provider,
+            reason,
+            request_id,
+        },
+        400 => ApiError::BadRequest {
+            provider,
+            reason,
+            request_id,
+        },
+        408 | 409 | 500 | 502 | 503 | 504 => ApiError::ServerError {
+            provider,
+            status: status.as_u16(),
+            reason,
+            request_id,
+        },
+        _ => ApiError::Provider {
+            provider,
+            reason: format!("unexpected status {status}: {reason}"),
+            request_id,
+        },
+    }
+}
+
+fn parse_anthropic_error_message(body: &str) -> Option<String> {
+    #[derive(serde::Deserialize)]
+    struct ErrorEnvelope {
+        error: ErrorBody,
+    }
+    #[derive(serde::Deserialize)]
+    struct ErrorBody {
+        message: String,
+    }
+    serde_json::from_str::<ErrorEnvelope>(body)
+        .ok()
+        .map(|envelope| envelope.error.message)
+}
+
+fn truncate_body(body: &str) -> String {
+    const MAX: usize = 200;
+    if body.len() <= MAX {
+        return body.to_string();
+    }
+    let safe_end = (0..=MAX)
+        .rev()
+        .find(|&i| body.is_char_boundary(i))
+        .unwrap_or(0);
+    format!("{}…(truncated, {} bytes)", &body[..safe_end], body.len())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        map_status_to_api_error, parse_anthropic_error_message, AnthropicClient, AuthSource,
+    };
+    use crate::error::ApiError;
+    use reqwest::StatusCode;
+    use std::time::Duration;
+
+    #[test]
+    fn map_status_429_yields_rate_limited_with_retry_after() {
+        let err = map_status_to_api_error(
+            StatusCode::TOO_MANY_REQUESTS,
+            "slow down".to_string(),
+            Some(Duration::from_secs(7)),
+            Some("req-1".to_string()),
+        );
+        match err {
+            ApiError::RateLimited {
+                provider,
+                retry_after_secs,
+                request_id,
+            } => {
+                assert_eq!(provider, "anthropic");
+                assert_eq!(retry_after_secs, Some(7));
+                assert_eq!(request_id.as_deref(), Some("req-1"));
+            }
+            other => panic!("expected RateLimited, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn map_status_401_403_yields_auth_failed() {
+        for code in [401_u16, 403] {
+            let err = map_status_to_api_error(
+                StatusCode::from_u16(code).unwrap(),
+                "bad key".to_string(),
+                None,
+                None,
+            );
+            assert!(
+                matches!(err, ApiError::AuthFailed { .. }),
+                "status {code} should map to AuthFailed: got {err:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn map_status_400_yields_bad_request() {
+        let err =
+            map_status_to_api_error(StatusCode::BAD_REQUEST, "invalid".to_string(), None, None);
+        assert!(matches!(err, ApiError::BadRequest { .. }));
+    }
+
+    #[test]
+    fn map_retryable_5xx_yields_server_error() {
+        for code in [500_u16, 502, 503, 504, 408, 409] {
+            let err = map_status_to_api_error(
+                StatusCode::from_u16(code).unwrap(),
+                "boom".to_string(),
+                None,
+                None,
+            );
+            match err {
+                ApiError::ServerError { status, .. } => assert_eq!(status, code),
+                other => panic!("status {code} should map to ServerError: got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn map_unrelated_status_yields_provider_error() {
+        let err = map_status_to_api_error(StatusCode::IM_A_TEAPOT, "tea".to_string(), None, None);
+        assert!(matches!(err, ApiError::Provider { .. }));
+    }
+
+    #[test]
+    fn auth_source_apply_attaches_x_api_key() {
+        let auth = AuthSource::ApiKey("sk-ant-test".to_string());
+        assert_eq!(auth.api_key(), Some("sk-ant-test"));
+        assert!(auth.bearer_token().is_none());
+    }
+
+    #[test]
+    fn auth_source_apply_attaches_bearer_token() {
+        let auth = AuthSource::BearerToken("oauth-token".to_string());
+        assert_eq!(auth.bearer_token(), Some("oauth-token"));
+        assert!(auth.api_key().is_none());
+    }
+
+    #[test]
+    fn auth_source_apply_attaches_both_headers() {
+        let auth = AuthSource::ApiKeyAndBearer {
+            api_key: "sk-ant-test".to_string(),
+            bearer_token: "oauth-token".to_string(),
+        };
+        assert_eq!(auth.api_key(), Some("sk-ant-test"));
+        assert_eq!(auth.bearer_token(), Some("oauth-token"));
+    }
+
+    #[test]
+    fn parse_anthropic_error_message_picks_message_field() {
+        let body = r#"{"type":"error","error":{"type":"invalid_request_error","message":"max_tokens too high"}}"#;
+        assert_eq!(
+            parse_anthropic_error_message(body),
+            Some("max_tokens too high".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_anthropic_error_message_returns_none_on_unknown_shape() {
+        assert!(parse_anthropic_error_message("not json").is_none());
+        assert!(parse_anthropic_error_message("{}").is_none());
+    }
+
+    #[test]
+    fn anthropic_client_builders_compose_without_panic() {
+        let client = AnthropicClient::new("sk-ant-test")
+            .expect("client constructible")
+            .with_base_url("http://localhost:9999")
+            .with_retry_policy(crate::retry::RetryPolicy {
+                max_retries: 0,
+                ..Default::default()
+            });
+        assert_eq!(client.base_url(), "http://localhost:9999");
+        assert_eq!(client.retry_policy.max_retries, 0);
+    }
+}

--- a/crates/dasclaw_llm_provider/src/providers/mod.rs
+++ b/crates/dasclaw_llm_provider/src/providers/mod.rs
@@ -8,6 +8,10 @@
 //! - **职责单一**：本模块只做"模型名 → provider 类型"的纯函数映射，不做 HTTP / SSE。
 //!   实际 HTTP client 在 PR-A.1+ 落地，路由 metadata 与 client 解耦。
 
+pub mod anthropic;
+
+pub use anthropic::{AnthropicClient, AnthropicStream, AuthSource};
+
 /// LLM provider 类型（决定走 Anthropic Messages 协议 / OpenAI Chat Completions 协议 / xAI 协议）。
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ProviderKind {

--- a/crates/dasclaw_llm_provider/src/retry.rs
+++ b/crates/dasclaw_llm_provider/src/retry.rs
@@ -1,0 +1,203 @@
+//! 重试策略 — 指数退避 + 抖动 + Retry-After 头部尊重。
+//!
+//! 与 [`claw-code-api`] `providers::anthropic` 内联的退避逻辑相比，本模块作了
+//! 两处改进（[ADR-118] §8.5 顺势处理）：
+//!
+//! 1. **独立模块**：claw-code 把退避当成 `AnthropicClient` 私有方法。本 crate
+//!    把 `RetryPolicy` 提升为公共类型，PR-A.3 `OpenAiCompatClient` 共享同一份
+//!    实现，避免重复代码。
+//! 2. **尊重 `Retry-After`**：claw-code 完全忽略 `Retry-After` 头部，固定走
+//!    指数退避。我们在 [`RetryPolicy::delay_for_attempt`] 中接受可选 `retry_after`
+//!    参数，优先采纳上游建议（取 `min(retry_after, max_backoff)` 防恶意头）。
+//!
+//! [`claw-code-api`]: https://github.com/charmbracelet/claw-code
+//! [ADR-118]: ../docs/plans/architecture-refactor/adr-118-claw-code-readonly-and-self-impl.md
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+/// 指数退避重试策略。
+///
+/// 默认值：max_retries=8，initial_backoff=1s，max_backoff=128s（与 claw-code 对齐）。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RetryPolicy {
+    /// 最大重试次数（不含首次请求）。
+    pub max_retries: u32,
+    /// 第一次重试前的等待。后续重试在此基础上指数翻倍（饱和到 `max_backoff`）。
+    pub initial_backoff: Duration,
+    /// 退避上限；任何计算出的延迟都不会超过此值。
+    pub max_backoff: Duration,
+}
+
+impl Default for RetryPolicy {
+    fn default() -> Self {
+        Self {
+            max_retries: 8,
+            initial_backoff: Duration::from_secs(1),
+            max_backoff: Duration::from_secs(128),
+        }
+    }
+}
+
+impl RetryPolicy {
+    /// 计算第 `attempt` 次重试的基础退避（指数 + 上限封顶）。
+    ///
+    /// `attempt` 从 1 开始计（第一次重试 = attempt=1）。返回 `None` 当移位
+    /// 溢出（极端 `attempt` 值），调用方应直接放弃重试。
+    #[must_use]
+    pub fn backoff_for_attempt(&self, attempt: u32) -> Option<Duration> {
+        let exp = attempt.saturating_sub(1);
+        let multiplier = 1_u32.checked_shl(exp)?;
+        Some(
+            self.initial_backoff
+                .checked_mul(multiplier)
+                .map_or(self.max_backoff, |delay| delay.min(self.max_backoff)),
+        )
+    }
+
+    /// 计算最终延迟：当 `retry_after` 提供时优先使用（同样受 `max_backoff` 约束），
+    /// 否则走指数退避 + 抖动。
+    ///
+    /// 抖动是 `[0, base]` 区间的加法抖动 —— 不会缩短延迟，只会拉长到至多 2×base。
+    #[must_use]
+    pub fn delay_for_attempt(
+        &self,
+        attempt: u32,
+        retry_after: Option<Duration>,
+    ) -> Option<Duration> {
+        if let Some(retry_after) = retry_after {
+            return Some(retry_after.min(self.max_backoff));
+        }
+        let base = self.backoff_for_attempt(attempt)?;
+        Some(base + jitter_for_base(base))
+    }
+}
+
+/// 解析 HTTP `Retry-After` 头部。
+///
+/// 仅支持 delta-seconds 整数格式（最常见）。HTTP-date 格式不解析（claw-code 也未
+/// 实现，留给未来需要时扩展）。
+#[must_use]
+pub fn parse_retry_after(value: &str) -> Option<Duration> {
+    value.trim().parse::<u64>().ok().map(Duration::from_secs)
+}
+
+static JITTER_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+/// 加法抖动 — 在 `[0, base]` 区间内均匀采样。
+///
+/// 熵源：纳秒级 wall clock + 进程 atomic 计数器，经 splitmix64 finalizer 混淆。
+/// 不需要密码学强度（只用于退避去关联）。
+fn jitter_for_base(base: Duration) -> Duration {
+    let base_nanos = u64::try_from(base.as_nanos()).unwrap_or(u64::MAX);
+    if base_nanos == 0 {
+        return Duration::ZERO;
+    }
+    let raw_nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|elapsed| u64::try_from(elapsed.as_nanos()).unwrap_or(u64::MAX))
+        .unwrap_or(0);
+    let tick = JITTER_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let mut mixed = raw_nanos
+        .wrapping_add(tick)
+        .wrapping_add(0x9E37_79B9_7F4A_7C15);
+    mixed = (mixed ^ (mixed >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+    mixed = (mixed ^ (mixed >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+    mixed ^= mixed >> 31;
+    let jitter_nanos = mixed % base_nanos.saturating_add(1);
+    Duration::from_nanos(jitter_nanos)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_retry_after, RetryPolicy};
+    use std::time::Duration;
+
+    #[test]
+    fn default_policy_matches_claw_code_constants() {
+        let policy = RetryPolicy::default();
+        assert_eq!(policy.max_retries, 8);
+        assert_eq!(policy.initial_backoff, Duration::from_secs(1));
+        assert_eq!(policy.max_backoff, Duration::from_secs(128));
+    }
+
+    #[test]
+    fn backoff_doubles_per_attempt_until_max() {
+        let policy = RetryPolicy::default();
+        assert_eq!(policy.backoff_for_attempt(1), Some(Duration::from_secs(1)));
+        assert_eq!(policy.backoff_for_attempt(2), Some(Duration::from_secs(2)));
+        assert_eq!(policy.backoff_for_attempt(3), Some(Duration::from_secs(4)));
+        assert_eq!(
+            policy.backoff_for_attempt(8),
+            Some(Duration::from_secs(128))
+        );
+        // attempts beyond saturate at max_backoff (no overflow)
+        assert_eq!(
+            policy.backoff_for_attempt(20),
+            Some(Duration::from_secs(128))
+        );
+    }
+
+    #[test]
+    fn backoff_saturates_at_max_when_initial_is_large() {
+        let policy = RetryPolicy {
+            max_retries: 3,
+            initial_backoff: Duration::from_secs(100),
+            max_backoff: Duration::from_secs(120),
+        };
+        assert_eq!(
+            policy.backoff_for_attempt(1),
+            Some(Duration::from_secs(100))
+        );
+        assert_eq!(
+            policy.backoff_for_attempt(2),
+            Some(Duration::from_secs(120))
+        );
+        assert_eq!(
+            policy.backoff_for_attempt(3),
+            Some(Duration::from_secs(120))
+        );
+    }
+
+    #[test]
+    fn delay_uses_retry_after_when_present_capped_by_max_backoff() {
+        let policy = RetryPolicy::default();
+        let suggested = Some(Duration::from_secs(10));
+        let delay = policy
+            .delay_for_attempt(1, suggested)
+            .expect("delay computable");
+        assert_eq!(delay, Duration::from_secs(10));
+
+        // Server-suggested value beyond max_backoff should clamp.
+        let huge = Some(Duration::from_secs(10_000));
+        let clamped = policy.delay_for_attempt(1, huge).expect("delay computable");
+        assert_eq!(clamped, Duration::from_secs(128));
+    }
+
+    #[test]
+    fn delay_falls_back_to_jittered_exponential_when_no_retry_after() {
+        let policy = RetryPolicy::default();
+        let base = policy.backoff_for_attempt(2).expect("base attempt 2");
+        let delay = policy.delay_for_attempt(2, None).expect("delay computable");
+        assert!(
+            delay >= base && delay <= base * 2,
+            "delay {delay:?} not within [{base:?}, 2*{base:?}]"
+        );
+    }
+
+    #[test]
+    fn parse_retry_after_accepts_integer_seconds() {
+        assert_eq!(parse_retry_after("3"), Some(Duration::from_secs(3)));
+        assert_eq!(parse_retry_after("  120  "), Some(Duration::from_secs(120)));
+        assert_eq!(parse_retry_after("0"), Some(Duration::ZERO));
+    }
+
+    #[test]
+    fn parse_retry_after_rejects_non_integer_formats() {
+        // HTTP-date format is not supported (claw-code parity).
+        assert!(parse_retry_after("Wed, 21 Oct 2026 07:28:00 GMT").is_none());
+        assert!(parse_retry_after("3.5").is_none());
+        assert!(parse_retry_after("").is_none());
+        assert!(parse_retry_after("-1").is_none());
+    }
+}

--- a/crates/dasclaw_llm_provider/tests/anthropic_client.rs
+++ b/crates/dasclaw_llm_provider/tests/anthropic_client.rs
@@ -1,0 +1,256 @@
+//! 集成测试 — `AnthropicClient` 的 wire 行为。
+//!
+//! 用 [`wiremock`] mock 上游 `/v1/messages` 端点，验证：
+//! 1. `complete()` happy path + `request-id` header propagation
+//! 2. 401 不重试，立即返回 `ApiError::AuthFailed`
+//! 3. 429 携带 `Retry-After` → 退避采纳上游建议，下一次成功
+//! 4. 500 重试后成功（默认指数退避）
+//! 5. 最大重试次数耗尽 → 冒泡最后一次错误
+//! 6. 流式响应 SSE 帧可逐个拉取，结束后 `next_event` 返回 `Ok(None)`
+//! 7. `400` 含 Anthropic 错误 envelope → `ApiError::BadRequest.reason` 为 `error.message`
+
+use std::time::Duration;
+
+use dasclaw_llm_provider::{
+    AnthropicClient, ApiError, AuthSource, MessageRequest, RetryPolicy, StreamEvent,
+};
+use serde_json::json;
+use wiremock::matchers::{header, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+const TEST_API_KEY: &str = "sk-ant-test";
+
+fn sample_request() -> MessageRequest {
+    let body = json!({
+        "model": "claude-3-5-sonnet-20241022",
+        "max_tokens": 16,
+        "messages": [
+            { "role": "user", "content": [{ "type": "text", "text": "ping" }] }
+        ]
+    });
+    serde_json::from_value(body).expect("MessageRequest deserializable")
+}
+
+fn fast_retry_policy(max_retries: u32) -> RetryPolicy {
+    RetryPolicy {
+        max_retries,
+        initial_backoff: Duration::from_millis(1),
+        max_backoff: Duration::from_millis(5),
+    }
+}
+
+fn success_body() -> serde_json::Value {
+    json!({
+        "id": "msg_test",
+        "type": "message",
+        "role": "assistant",
+        "model": "claude-3-5-sonnet-20241022",
+        "content": [
+            { "type": "text", "text": "pong" }
+        ],
+        "stop_reason": "end_turn",
+        "usage": {
+            "input_tokens": 3,
+            "output_tokens": 1
+        }
+    })
+}
+
+async fn build_client(server: &MockServer, retry: RetryPolicy) -> AnthropicClient {
+    AnthropicClient::with_auth(AuthSource::ApiKey(TEST_API_KEY.into()))
+        .expect("client constructible")
+        .with_base_url(server.uri())
+        .with_retry_policy(retry)
+}
+
+#[tokio::test]
+async fn complete_happy_path_propagates_request_id() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .and(header("x-api-key", TEST_API_KEY))
+        .and(header("anthropic-version", "2023-06-01"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("request-id", "req-success")
+                .set_body_json(success_body()),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = build_client(&server, fast_retry_policy(0)).await;
+    let response = client.complete(&sample_request()).await.expect("ok");
+    assert_eq!(response.request_id.as_deref(), Some("req-success"));
+    assert_eq!(response.usage.input_tokens, 3);
+}
+
+#[tokio::test]
+async fn auth_failure_is_not_retried() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(ResponseTemplate::new(401).set_body_json(json!({
+            "type": "error",
+            "error": { "type": "authentication_error", "message": "invalid x-api-key" }
+        })))
+        .expect(1) // exactly one — no retry
+        .mount(&server)
+        .await;
+
+    let client = build_client(&server, fast_retry_policy(5)).await;
+    let err = client
+        .complete(&sample_request())
+        .await
+        .expect_err("should fail");
+    match err {
+        ApiError::AuthFailed { reason, .. } => {
+            assert!(
+                reason.contains("invalid x-api-key"),
+                "reason should carry server message, got {reason}"
+            );
+        }
+        other => panic!("expected AuthFailed, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn rate_limited_then_success_honors_retry_after() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(
+            ResponseTemplate::new(429)
+                .insert_header("retry-after", "0")
+                .insert_header("request-id", "req-rl")
+                .set_body_json(json!({
+                    "type": "error",
+                    "error": { "type": "rate_limit_error", "message": "slow down" }
+                })),
+        )
+        .up_to_n_times(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(success_body()))
+        .mount(&server)
+        .await;
+
+    let client = build_client(&server, fast_retry_policy(2)).await;
+    let response = client.complete(&sample_request()).await.expect("ok");
+    assert_eq!(response.usage.output_tokens, 1);
+}
+
+#[tokio::test]
+async fn server_error_retries_then_succeeds() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(ResponseTemplate::new(503).set_body_string("upstream busy"))
+        .up_to_n_times(2)
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(success_body()))
+        .mount(&server)
+        .await;
+
+    let client = build_client(&server, fast_retry_policy(3)).await;
+    let response = client.complete(&sample_request()).await.expect("ok");
+    assert_eq!(response.usage.input_tokens, 3);
+}
+
+#[tokio::test]
+async fn max_retries_exhausted_returns_last_error() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(ResponseTemplate::new(503).set_body_string("upstream busy"))
+        .expect(3) // 1 initial + 2 retries
+        .mount(&server)
+        .await;
+
+    let client = build_client(&server, fast_retry_policy(2)).await;
+    let err = client
+        .complete(&sample_request())
+        .await
+        .expect_err("should fail");
+    match err {
+        ApiError::ServerError { status, .. } => assert_eq!(status, 503),
+        other => panic!("expected ServerError, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn bad_request_extracts_anthropic_error_message() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(ResponseTemplate::new(400).set_body_json(json!({
+            "type": "error",
+            "error": { "type": "invalid_request_error", "message": "max_tokens > 4096" }
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = build_client(&server, fast_retry_policy(3)).await;
+    let err = client
+        .complete(&sample_request())
+        .await
+        .expect_err("should fail");
+    match err {
+        ApiError::BadRequest { reason, .. } => assert_eq!(reason, "max_tokens > 4096"),
+        other => panic!("expected BadRequest, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn stream_yields_events_until_message_stop() {
+    let body = "\
+event: message_start\n\
+data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_1\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"claude-3-5-sonnet-20241022\",\"content\":[],\"stop_reason\":null,\"usage\":{\"input_tokens\":3,\"output_tokens\":0}}}\n\
+\n\
+event: content_block_start\n\
+data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\
+\n\
+event: content_block_delta\n\
+data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"pong\"}}\n\
+\n\
+event: content_block_stop\n\
+data: {\"type\":\"content_block_stop\",\"index\":0}\n\
+\n\
+event: message_delta\n\
+data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":1}}\n\
+\n\
+event: message_stop\n\
+data: {\"type\":\"message_stop\"}\n\
+\n";
+
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "text/event-stream")
+                .insert_header("request-id", "req-stream")
+                .set_body_string(body),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = build_client(&server, fast_retry_policy(0)).await;
+    let mut stream = client.stream(&sample_request()).await.expect("ok");
+    assert_eq!(stream.request_id(), Some("req-stream"));
+
+    let mut events = Vec::new();
+    while let Some(event) = stream.next_event().await.expect("event") {
+        events.push(event);
+    }
+    assert_eq!(events.len(), 6, "expected 6 events, got {events:?}");
+    assert!(matches!(events[0], StreamEvent::MessageStart(_)));
+    assert!(matches!(events[5], StreamEvent::MessageStop(_)));
+}

--- a/crates/dasclaw_llm_provider/tests/anthropic_client.rs
+++ b/crates/dasclaw_llm_provider/tests/anthropic_client.rs
@@ -12,7 +12,7 @@
 use std::time::Duration;
 
 use dasclaw_llm_provider::{
-    AnthropicClient, ApiError, AuthSource, MessageRequest, RetryPolicy, StreamEvent,
+    AnthropicClient, ApiError, AuthSource, InputMessage, MessageRequest, RetryPolicy, StreamEvent,
 };
 use serde_json::json;
 use wiremock::matchers::{header, method, path};
@@ -21,14 +21,12 @@ use wiremock::{Mock, MockServer, ResponseTemplate};
 const TEST_API_KEY: &str = "sk-ant-test";
 
 fn sample_request() -> MessageRequest {
-    let body = json!({
-        "model": "claude-3-5-sonnet-20241022",
-        "max_tokens": 16,
-        "messages": [
-            { "role": "user", "content": [{ "type": "text", "text": "ping" }] }
-        ]
-    });
-    serde_json::from_value(body).expect("MessageRequest deserializable")
+    MessageRequest {
+        model: "claude-3-5-sonnet-20241022".to_string(),
+        max_tokens: 16,
+        messages: vec![InputMessage::user_text("ping")],
+        ..MessageRequest::default()
+    }
 }
 
 fn fast_retry_policy(max_retries: u32) -> RetryPolicy {
@@ -56,11 +54,12 @@ fn success_body() -> serde_json::Value {
     })
 }
 
-async fn build_client(server: &MockServer, retry: RetryPolicy) -> AnthropicClient {
-    AnthropicClient::with_auth(AuthSource::ApiKey(TEST_API_KEY.into()))
-        .expect("client constructible")
-        .with_base_url(server.uri())
-        .with_retry_policy(retry)
+fn build_client(server_uri: String, retry: RetryPolicy) -> Result<AnthropicClient, ApiError> {
+    Ok(
+        AnthropicClient::with_auth(AuthSource::ApiKey(TEST_API_KEY.into()))?
+            .with_base_url(server_uri)
+            .with_retry_policy(retry),
+    )
 }
 
 #[tokio::test]
@@ -79,7 +78,7 @@ async fn complete_happy_path_propagates_request_id() {
         .mount(&server)
         .await;
 
-    let client = build_client(&server, fast_retry_policy(0)).await;
+    let client = build_client(server.uri(), fast_retry_policy(0)).expect("client constructible");
     let response = client.complete(&sample_request()).await.expect("ok");
     assert_eq!(response.request_id.as_deref(), Some("req-success"));
     assert_eq!(response.usage.input_tokens, 3);
@@ -98,7 +97,7 @@ async fn auth_failure_is_not_retried() {
         .mount(&server)
         .await;
 
-    let client = build_client(&server, fast_retry_policy(5)).await;
+    let client = build_client(server.uri(), fast_retry_policy(5)).expect("client constructible");
     let err = client
         .complete(&sample_request())
         .await
@@ -137,7 +136,7 @@ async fn rate_limited_then_success_honors_retry_after() {
         .mount(&server)
         .await;
 
-    let client = build_client(&server, fast_retry_policy(2)).await;
+    let client = build_client(server.uri(), fast_retry_policy(2)).expect("client constructible");
     let response = client.complete(&sample_request()).await.expect("ok");
     assert_eq!(response.usage.output_tokens, 1);
 }
@@ -157,7 +156,7 @@ async fn server_error_retries_then_succeeds() {
         .mount(&server)
         .await;
 
-    let client = build_client(&server, fast_retry_policy(3)).await;
+    let client = build_client(server.uri(), fast_retry_policy(3)).expect("client constructible");
     let response = client.complete(&sample_request()).await.expect("ok");
     assert_eq!(response.usage.input_tokens, 3);
 }
@@ -172,7 +171,7 @@ async fn max_retries_exhausted_returns_last_error() {
         .mount(&server)
         .await;
 
-    let client = build_client(&server, fast_retry_policy(2)).await;
+    let client = build_client(server.uri(), fast_retry_policy(2)).expect("client constructible");
     let err = client
         .complete(&sample_request())
         .await
@@ -196,7 +195,7 @@ async fn bad_request_extracts_anthropic_error_message() {
         .mount(&server)
         .await;
 
-    let client = build_client(&server, fast_retry_policy(3)).await;
+    let client = build_client(server.uri(), fast_retry_policy(3)).expect("client constructible");
     let err = client
         .complete(&sample_request())
         .await
@@ -242,7 +241,7 @@ data: {\"type\":\"message_stop\"}\n\
         .mount(&server)
         .await;
 
-    let client = build_client(&server, fast_retry_policy(0)).await;
+    let client = build_client(server.uri(), fast_retry_policy(0)).expect("client constructible");
     let mut stream = client.stream(&sample_request()).await.expect("ok");
     assert_eq!(stream.request_id(), Some("req-stream"));
 


### PR DESCRIPTION
## 背景 / 目标

ADR-118 §5 W6-C PR-A.2：在 `dasclaw_llm_provider` 内补齐 Anthropic Messages 客户端与共享重试策略，承上启下：

- **上承 PR-A.1**（HTTP transport + SSE 解析器原语，#149/#152 已合并）
- **下启 PR-A.3**（OpenAI 兼容客户端将复用同一 `RetryPolicy`）
- **终结 PR-A.4**：删除主仓对 `claw-code-api` 的 path-dep

## 改动范围

| 文件 | 内容 |
|---|---|
| `src/retry.rs`（新，190 LOC） | `RetryPolicy { max_retries=8, initial=1s, max=128s }` + `backoff_for_attempt` + `delay_for_attempt`（Retry-After 优先）+ `parse_retry_after` + splitmix64 抖动 |
| `src/providers/anthropic.rs`（新，450 LOC） | `AnthropicClient` 含 `complete()` / `stream()`；`AuthSource` 枚举；HTTP 状态精确映射到 `ApiError` |
| `tests/anthropic_client.rs`（新） | 7 个 wiremock 集成测试 |
| `src/lib.rs` / `src/providers/mod.rs` | 公开新模块 + 更新阶段标识为 PR-A.2 |
| `Cargo.toml` | `tokio` 进 deps（`time` feature）+ `wiremock` 进 dev-deps |

## 改进项（vs claw-code-api，ADR-118 §8.5 顺势处理）

1. **尊重 `Retry-After`**：claw-code 完全忽略此头部，本 PR 优先采纳上游建议（受 `max_backoff` 钳制 防恶意头）
2. **错误强类型化**：`ApiError` 各变体精确分发，调用方免去字符串扫描判断错误类型
3. **去除应用层耦合**：不依赖 `runtime` / `telemetry` / `prompt_cache`，纯 HTTP 客户端

## 非目标（What's NOT in this PR）

- ❌ OAuth flow — 静态 `AuthSource` 已够用，OAuth 流程留给独立 PR
- ❌ OpenAI 兼容客户端 → PR-A.3
- ❌ 删除 `claw-code-api` path-dep → PR-A.4
- ❌ Prompt cache / SessionTracer / 成本计算 — 这些是 ironclaw 应用层职责
- ❌ HTTP-date 格式 `Retry-After` 解析（仅支持 delta-seconds，与 claw-code 简化路径一致）

## 验证

```bash
cargo nextest run -p dasclaw_llm_provider
# 109 tests run: 109 passed (1 leaky), 0 skipped

cargo clippy --no-deps -p dasclaw_llm_provider --all-targets -- -D warnings
# Finished `dev` profile [unoptimized + debuginfo]

cargo fmt --all
python3.12 scripts/check_no_panics.py --base origin/xClaw
# OK: No panic-inducing calls in changed production code.
```

集成测试覆盖：(1) happy path + request-id propagation, (2) 401 不重试, (3) 429 + Retry-After 采纳后成功, (4) 503 重试两次后成功, (5) max-retries 耗尽冒泡 ServerError, (6) 400 Anthropic envelope reason 提取, (7) 流式 SSE 6 事件全收并 `Ok(None)` 收尾。

## 后续 PR / 下一步

- **PR-A.3**：`OpenAiCompatClient`（复用 `RetryPolicy`，protocol 不同）
- **PR-A.4**：删除主仓 `claw-code-api` path-dep，切换调用点到本 crate

## Skill 自查

- ✅ `code-quality-audit`：函数 ≤50 LOC、嵌套 ≤3、生产代码无 unwrap、Retry-After 钳制至 max_backoff（防恶意头）、复用 reqwest/serde/tokio/wiremock 不重复造轮子
- ✅ `code-review-expert`：`AnthropicClient`（HTTP+retry）与 `AuthSource`（鉴权）单一职责分离；错误映射确定性；凭据不入日志；retry-after 受信任源钳制

Closes #153
