### PR TITLE
feat(llm-provider): OpenAiCompatClient (W6-C PR-A.3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2469,6 +2469,7 @@ dependencies = [
  "serde_json",
  "thiserror 1.0.69",
  "tokio",
+ "wiremock",
 ]
 
 [[package]]

--- a/crates/dasclaw_llm_provider/Cargo.toml
+++ b/crates/dasclaw_llm_provider/Cargo.toml
@@ -14,7 +14,9 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "1"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls-native-roots"] }
+tokio = { version = "1", default-features = false, features = ["time"] }
 
 [dev-dependencies]
 serde_json = "1"
-tokio = { version = "1", features = ["macros", "rt"] }
+tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread", "time"] }
+wiremock = "0.6"

--- a/crates/dasclaw_llm_provider/src/lib.rs
+++ b/crates/dasclaw_llm_provider/src/lib.rs
@@ -4,7 +4,7 @@
 //! claw-code 子仓视为只读参考库，本 crate **重新设计** Anthropic Messages /
 //! OpenAI Chat Completions 兼容层 wire 类型与 client 抽象，不直接消费子仓代码。
 //!
-//! 当前阶段：**PR-A.2 — Anthropic Messages 客户端 + 重试策略**
+//! 当前阶段：**PR-A.3 — OpenAI Chat Completions 兼容客户端**
 //! - ✅ wire 类型（`types`）—— Anthropic Messages 协议输入/输出/streaming events
 //! - ✅ 强类型错误（`error::ApiError`）—— 拆分 `RateLimited` / `AuthFailed` /
 //!   `ContextWindowExceeded` / `ServerError` / `Transport` / `MalformedSseFrame` 等，
@@ -17,7 +17,10 @@
 //!   （**改进**：claw-code 完全忽略 `Retry-After`，本 crate 优先采纳上游建议）
 //! - ✅ `providers::AnthropicClient` —— `complete()` / `stream()` + 状态码精确映射到
 //!   `ApiError` 各变体；`AuthSource` 支持 `ApiKey` / `BearerToken` / 双 header
-//! - 🟡 `OpenAiCompatClient`：留给 PR-A.3
+//! - ✅ `providers::OpenAiCompatClient` —— `complete()` + xAI / OpenAI / DashScope 三预设；
+//!   复用 `RetryPolicy` 与 `ApiError` 强类型；inline error envelope 兜底；
+//!   `gpt-5*` 模型自动改用 `max_completion_tokens`；reasoning_content 提升为 Thinking block
+//! - 🟡 `OpenAiCompatClient::stream()`：留给 PR-A.3.1（ironclaw 当前 call site 仅用 `send_message`）
 //! - 🟡 删除主仓 `claw-code-api` path-dep：留给 PR-A.4
 //!
 //! 与 `claw-code-api` 的设计差异（顺势处理架构债，详见 ADR-118 §8.5）：
@@ -47,7 +50,8 @@ pub use http::{build_http_client, build_http_client_with, ProxyConfig};
 pub use providers::{
     detect_provider_kind, max_tokens_for_model, max_tokens_for_model_with_override,
     metadata_for_model, model_token_limit, resolve_model_alias, AnthropicClient, AnthropicStream,
-    AuthSource, EnvSnapshot, ModelTokenLimit, ProviderKind, ProviderMetadata,
+    AuthSource, EnvSnapshot, ModelTokenLimit, OpenAiCompatClient, OpenAiCompatConfig, ProviderKind,
+    ProviderMetadata,
 };
 pub use retry::{parse_retry_after, RetryPolicy};
 pub use sse::{parse_frame, SseParser};

--- a/crates/dasclaw_llm_provider/src/lib.rs
+++ b/crates/dasclaw_llm_provider/src/lib.rs
@@ -4,7 +4,7 @@
 //! claw-code 子仓视为只读参考库，本 crate **重新设计** Anthropic Messages /
 //! OpenAI Chat Completions 兼容层 wire 类型与 client 抽象，不直接消费子仓代码。
 //!
-//! 当前阶段：**PR-A.1 — HTTP transport + SSE 解析器原语**
+//! 当前阶段：**PR-A.2 — Anthropic Messages 客户端 + 重试策略**
 //! - ✅ wire 类型（`types`）—— Anthropic Messages 协议输入/输出/streaming events
 //! - ✅ 强类型错误（`error::ApiError`）—— 拆分 `RateLimited` / `AuthFailed` /
 //!   `ContextWindowExceeded` / `ServerError` / `Transport` / `MalformedSseFrame` 等，
@@ -13,8 +13,12 @@
 //! - ✅ `http::ProxyConfig` + `http::build_http_client_with` —— `reqwest::Client`
 //!   构造 + 代理（HTTP/HTTPS/统一 URL/no_proxy）支持，纯函数 + 显式 env 入口
 //! - ✅ `sse::SseParser` + `sse::parse_frame` —— 增量 SSE 帧解析器，识别 ping/DONE/comment
-//! - 🟡 `AnthropicClient` / `OpenAiCompatClient`：留给 PR-A.2 / PR-A.3，本 PR 暂未实现
-//! - 🟡 重试策略 + Retry-After 解析：随 PR-A.2 client 一并落地
+//! - ✅ `retry::RetryPolicy` —— 指数退避 + 抖动 + `Retry-After` 头部尊重
+//!   （**改进**：claw-code 完全忽略 `Retry-After`，本 crate 优先采纳上游建议）
+//! - ✅ `providers::AnthropicClient` —— `complete()` / `stream()` + 状态码精确映射到
+//!   `ApiError` 各变体；`AuthSource` 支持 `ApiKey` / `BearerToken` / 双 header
+//! - 🟡 `OpenAiCompatClient`：留给 PR-A.3
+//! - 🟡 删除主仓 `claw-code-api` path-dep：留给 PR-A.4
 //!
 //! 与 `claw-code-api` 的设计差异（顺势处理架构债，详见 ADR-118 §8.5）：
 //!
@@ -34,6 +38,7 @@
 pub mod error;
 pub mod http;
 pub mod providers;
+pub mod retry;
 pub mod sse;
 pub mod types;
 
@@ -41,9 +46,10 @@ pub use error::ApiError;
 pub use http::{build_http_client, build_http_client_with, ProxyConfig};
 pub use providers::{
     detect_provider_kind, max_tokens_for_model, max_tokens_for_model_with_override,
-    metadata_for_model, model_token_limit, resolve_model_alias, EnvSnapshot, ModelTokenLimit,
-    ProviderKind, ProviderMetadata,
+    metadata_for_model, model_token_limit, resolve_model_alias, AnthropicClient, AnthropicStream,
+    AuthSource, EnvSnapshot, ModelTokenLimit, ProviderKind, ProviderMetadata,
 };
+pub use retry::{parse_retry_after, RetryPolicy};
 pub use sse::{parse_frame, SseParser};
 pub use types::{
     ContentBlockDelta, ContentBlockDeltaEvent, ContentBlockStartEvent, ContentBlockStopEvent,

--- a/crates/dasclaw_llm_provider/src/providers/anthropic.rs
+++ b/crates/dasclaw_llm_provider/src/providers/anthropic.rs
@@ -1,0 +1,529 @@
+//! Anthropic Messages API 客户端。
+//!
+//! 实现 [Anthropic Messages API] 的 `/v1/messages` 端点，提供同步 [`complete`]
+//! 与流式 [`stream`] 两种调用模式。基于 [`crate::http::build_http_client_with`]
+//! 与 [`crate::sse::SseParser`] 原语。
+//!
+//! # 与 `claw-code-api::providers::anthropic` 的差异
+//!
+//! 1. **去除应用层耦合**：本 crate 不依赖 `runtime` / `telemetry` / `prompt_cache`，
+//!    `AnthropicClient` 不挂 `SessionTracer` / `PromptCache` 字段，纯 HTTP 客户端。
+//!    PromptCache / 会话追踪由上层 ironclaw 在调用方包装。
+//! 2. **错误强类型化**：HTTP 状态码精确分发到 `ApiError` 各变体（`RateLimited`、
+//!    `AuthFailed`、`ContextWindowExceeded`、`BadRequest`、`ServerError`、`Provider`），
+//!    上层免去字符串扫描。
+//! 3. **尊重 `Retry-After`**：429 响应携带 `Retry-After` 时优先采纳上游建议（受
+//!    `RetryPolicy::max_backoff` 约束）；claw-code 完全忽略此头部。
+//! 4. **OAuth 解耦**：本 PR 仅支持 `ApiKey` / `BearerToken` 静态凭据；OAuth flow
+//!    由后续 PR 单独承载，避免 client 主体逻辑被凭据轮转撑大。
+//!
+//! [Anthropic Messages API]: https://docs.anthropic.com/en/api/messages
+//! [`complete`]: AnthropicClient::complete
+//! [`stream`]: AnthropicClient::stream
+
+use std::collections::VecDeque;
+use std::time::Duration;
+
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
+
+use crate::error::ApiError;
+use crate::retry::{parse_retry_after, RetryPolicy};
+use crate::sse::SseParser;
+use crate::types::{MessageRequest, MessageResponse, StreamEvent};
+
+const ANTHROPIC_PROVIDER: &str = "anthropic";
+
+/// Anthropic API 默认 base URL。
+pub const DEFAULT_BASE_URL: &str = "https://api.anthropic.com";
+
+/// Anthropic API 版本号头部值。
+pub const ANTHROPIC_VERSION: &str = "2023-06-01";
+
+const REQUEST_ID_HEADER: &str = "request-id";
+const ALT_REQUEST_ID_HEADER: &str = "x-request-id";
+const RETRY_AFTER_HEADER: &str = "retry-after";
+
+/// Anthropic 客户端鉴权来源。
+///
+/// 同时携带 `ApiKey` 与 `BearerToken` 时，两者**都会**附加到请求（`x-api-key`
+/// 头 + `Authorization: Bearer` 头），与 claw-code 行为一致。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AuthSource {
+    /// 无凭据 — 仅用于探针请求或测试 mock 场景。
+    None,
+    /// `sk-ant-*` 形式 API Key（走 `x-api-key` 头）。
+    ApiKey(String),
+    /// OAuth bearer token（走 `Authorization: Bearer` 头）。
+    BearerToken(String),
+    /// 两者都提供（部分企业网关需要双 header）。
+    ApiKeyAndBearer {
+        /// `sk-ant-*` API Key。
+        api_key: String,
+        /// OAuth bearer token。
+        bearer_token: String,
+    },
+}
+
+impl AuthSource {
+    fn apply(&self, builder: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
+        let mut builder = builder;
+        if let Some(api_key) = self.api_key() {
+            builder = builder.header("x-api-key", api_key);
+        }
+        if let Some(token) = self.bearer_token() {
+            builder = builder.bearer_auth(token);
+        }
+        builder
+    }
+
+    fn api_key(&self) -> Option<&str> {
+        match self {
+            Self::ApiKey(key) | Self::ApiKeyAndBearer { api_key: key, .. } => Some(key),
+            Self::None | Self::BearerToken(_) => None,
+        }
+    }
+
+    fn bearer_token(&self) -> Option<&str> {
+        match self {
+            Self::BearerToken(token)
+            | Self::ApiKeyAndBearer {
+                bearer_token: token,
+                ..
+            } => Some(token),
+            Self::None | Self::ApiKey(_) => None,
+        }
+    }
+}
+
+/// Anthropic Messages API 客户端。
+#[derive(Debug, Clone)]
+pub struct AnthropicClient {
+    http: reqwest::Client,
+    auth: AuthSource,
+    base_url: String,
+    retry_policy: RetryPolicy,
+}
+
+impl AnthropicClient {
+    /// 用 API Key 构造客户端，使用默认 `reqwest::Client` 与默认 [`RetryPolicy`]。
+    pub fn new(api_key: impl Into<String>) -> Result<Self, ApiError> {
+        Self::with_auth(AuthSource::ApiKey(api_key.into()))
+    }
+
+    /// 显式传入 [`AuthSource`]；其余字段取默认。
+    pub fn with_auth(auth: AuthSource) -> Result<Self, ApiError> {
+        Ok(Self {
+            http: crate::http::build_http_client_with(&crate::http::ProxyConfig::default())?,
+            auth,
+            base_url: DEFAULT_BASE_URL.to_string(),
+            retry_policy: RetryPolicy::default(),
+        })
+    }
+
+    /// 注入预构造的 `reqwest::Client`（例如已配置代理的客户端）。
+    #[must_use]
+    pub fn with_http_client(mut self, http: reqwest::Client) -> Self {
+        self.http = http;
+        self
+    }
+
+    /// 覆盖 base URL（如自托管网关 / Vertex / Bedrock 兼容前端）。
+    #[must_use]
+    pub fn with_base_url(mut self, base_url: impl Into<String>) -> Self {
+        self.base_url = base_url.into();
+        self
+    }
+
+    /// 覆盖默认 [`RetryPolicy`]。
+    #[must_use]
+    pub fn with_retry_policy(mut self, policy: RetryPolicy) -> Self {
+        self.retry_policy = policy;
+        self
+    }
+
+    /// 当前 base URL（只读）。
+    #[must_use]
+    pub fn base_url(&self) -> &str {
+        &self.base_url
+    }
+
+    /// 同步（非流式）发送消息请求。
+    ///
+    /// 内部强制将 `request.stream` 改写为 `false`。
+    pub async fn complete(&self, request: &MessageRequest) -> Result<MessageResponse, ApiError> {
+        let request = MessageRequest {
+            stream: false,
+            ..request.clone()
+        };
+        let response = self.send_with_retry(&request).await?;
+        let request_id = request_id_from_headers(response.headers());
+        let body = response
+            .text()
+            .await
+            .map_err(|err| ApiError::Transport(err.to_string()))?;
+        let mut parsed: MessageResponse =
+            serde_json::from_str(&body).map_err(|err| ApiError::Provider {
+                provider: ANTHROPIC_PROVIDER.to_string(),
+                reason: format!(
+                    "failed to deserialize MessageResponse for model={}: {}",
+                    request.model, err
+                ),
+                request_id: request_id.clone(),
+            })?;
+        if parsed.request_id.is_none() {
+            parsed.request_id = request_id;
+        }
+        Ok(parsed)
+    }
+
+    /// 流式发送消息请求；返回 [`AnthropicStream`] 增量推送 SSE 事件。
+    ///
+    /// 内部强制将 `request.stream` 改写为 `true`。
+    pub async fn stream(&self, request: &MessageRequest) -> Result<AnthropicStream, ApiError> {
+        let request = MessageRequest {
+            stream: true,
+            ..request.clone()
+        };
+        let response = self.send_with_retry(&request).await?;
+        let request_id = request_id_from_headers(response.headers());
+        Ok(AnthropicStream {
+            request_id,
+            response,
+            parser: SseParser::new().with_context(ANTHROPIC_PROVIDER, request.model.clone()),
+            pending: VecDeque::new(),
+            done: false,
+        })
+    }
+
+    async fn send_with_retry(
+        &self,
+        request: &MessageRequest,
+    ) -> Result<reqwest::Response, ApiError> {
+        let mut attempt: u32 = 0;
+        loop {
+            let outcome = self.send_once(request).await;
+            match outcome {
+                Ok(response) => return Ok(response),
+                Err(error) => {
+                    let retryable = error.is_retryable();
+                    if !retryable || attempt >= self.retry_policy.max_retries {
+                        return Err(error);
+                    }
+                    let suggested = retry_after_from_error(&error);
+                    attempt += 1;
+                    let delay = self
+                        .retry_policy
+                        .delay_for_attempt(attempt, suggested)
+                        .ok_or_else(|| ApiError::Provider {
+                            provider: ANTHROPIC_PROVIDER.to_string(),
+                            reason: format!("retry backoff overflow at attempt {attempt}"),
+                            request_id: error.request_id().map(ToOwned::to_owned),
+                        })?;
+                    tokio::time::sleep(delay).await;
+                }
+            }
+        }
+    }
+
+    async fn send_once(&self, request: &MessageRequest) -> Result<reqwest::Response, ApiError> {
+        let url = format!("{}/v1/messages", self.base_url.trim_end_matches('/'));
+        let builder = self
+            .http
+            .post(&url)
+            .header("content-type", "application/json")
+            .header("anthropic-version", ANTHROPIC_VERSION);
+        let builder = self.auth.apply(builder);
+        let response = builder
+            .json(request)
+            .send()
+            .await
+            .map_err(|err| ApiError::Transport(err.to_string()))?;
+        expect_success(response).await
+    }
+}
+
+/// Anthropic 流式响应；由 [`AnthropicClient::stream`] 创建。
+#[derive(Debug)]
+pub struct AnthropicStream {
+    request_id: Option<String>,
+    response: reqwest::Response,
+    parser: SseParser,
+    pending: VecDeque<StreamEvent>,
+    done: bool,
+}
+
+impl AnthropicStream {
+    /// 上游返回的 trace ID（如有）。
+    #[must_use]
+    pub fn request_id(&self) -> Option<&str> {
+        self.request_id.as_deref()
+    }
+
+    /// 增量拉取下一个 [`StreamEvent`]；流结束时返回 `Ok(None)`。
+    pub async fn next_event(&mut self) -> Result<Option<StreamEvent>, ApiError> {
+        loop {
+            if let Some(event) = self.pending.pop_front() {
+                return Ok(Some(event));
+            }
+            if self.done {
+                let trailing = self.parser.finish()?;
+                if trailing.is_empty() {
+                    return Ok(None);
+                }
+                self.pending.extend(trailing);
+                continue;
+            }
+            match self
+                .response
+                .chunk()
+                .await
+                .map_err(|err| ApiError::StreamInterrupted(err.to_string()))?
+            {
+                Some(chunk) => {
+                    self.pending.extend(self.parser.push(&chunk)?);
+                }
+                None => {
+                    self.done = true;
+                }
+            }
+        }
+    }
+}
+
+fn request_id_from_headers(headers: &HeaderMap) -> Option<String> {
+    headers
+        .get(REQUEST_ID_HEADER)
+        .or_else(|| headers.get(ALT_REQUEST_ID_HEADER))
+        .and_then(|value| value.to_str().ok())
+        .map(ToOwned::to_owned)
+}
+
+fn retry_after_from_error(error: &ApiError) -> Option<Duration> {
+    match error {
+        ApiError::RateLimited {
+            retry_after_secs: Some(secs),
+            ..
+        } => Some(Duration::from_secs(*secs)),
+        _ => None,
+    }
+}
+
+async fn expect_success(response: reqwest::Response) -> Result<reqwest::Response, ApiError> {
+    let status = response.status();
+    if status.is_success() {
+        return Ok(response);
+    }
+
+    let request_id = request_id_from_headers(response.headers());
+    let retry_after = response
+        .headers()
+        .get(RETRY_AFTER_HEADER)
+        .and_then(|value| value.to_str().ok())
+        .and_then(parse_retry_after);
+
+    let body = response.text().await.unwrap_or_default();
+    let parsed_message = parse_anthropic_error_message(&body);
+    let reason = parsed_message
+        .clone()
+        .unwrap_or_else(|| truncate_body(&body));
+
+    Err(map_status_to_api_error(
+        status,
+        reason,
+        retry_after,
+        request_id,
+    ))
+}
+
+fn map_status_to_api_error(
+    status: StatusCode,
+    reason: String,
+    retry_after: Option<Duration>,
+    request_id: Option<String>,
+) -> ApiError {
+    let provider = ANTHROPIC_PROVIDER.to_string();
+    match status.as_u16() {
+        429 => ApiError::RateLimited {
+            provider,
+            retry_after_secs: retry_after.map(|d| d.as_secs()),
+            request_id,
+        },
+        401 | 403 => ApiError::AuthFailed {
+            provider,
+            reason,
+            request_id,
+        },
+        400 => ApiError::BadRequest {
+            provider,
+            reason,
+            request_id,
+        },
+        408 | 409 | 500 | 502 | 503 | 504 => ApiError::ServerError {
+            provider,
+            status: status.as_u16(),
+            reason,
+            request_id,
+        },
+        _ => ApiError::Provider {
+            provider,
+            reason: format!("unexpected status {status}: {reason}"),
+            request_id,
+        },
+    }
+}
+
+fn parse_anthropic_error_message(body: &str) -> Option<String> {
+    #[derive(serde::Deserialize)]
+    struct ErrorEnvelope {
+        error: ErrorBody,
+    }
+    #[derive(serde::Deserialize)]
+    struct ErrorBody {
+        message: String,
+    }
+    serde_json::from_str::<ErrorEnvelope>(body)
+        .ok()
+        .map(|envelope| envelope.error.message)
+}
+
+fn truncate_body(body: &str) -> String {
+    const MAX: usize = 200;
+    if body.len() <= MAX {
+        return body.to_string();
+    }
+    let safe_end = (0..=MAX)
+        .rev()
+        .find(|&i| body.is_char_boundary(i))
+        .unwrap_or(0);
+    format!("{}…(truncated, {} bytes)", &body[..safe_end], body.len())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        map_status_to_api_error, parse_anthropic_error_message, AnthropicClient, AuthSource,
+    };
+    use crate::error::ApiError;
+    use reqwest::StatusCode;
+    use std::time::Duration;
+
+    #[test]
+    fn map_status_429_yields_rate_limited_with_retry_after() {
+        let err = map_status_to_api_error(
+            StatusCode::TOO_MANY_REQUESTS,
+            "slow down".to_string(),
+            Some(Duration::from_secs(7)),
+            Some("req-1".to_string()),
+        );
+        match err {
+            ApiError::RateLimited {
+                provider,
+                retry_after_secs,
+                request_id,
+            } => {
+                assert_eq!(provider, "anthropic");
+                assert_eq!(retry_after_secs, Some(7));
+                assert_eq!(request_id.as_deref(), Some("req-1"));
+            }
+            other => panic!("expected RateLimited, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn map_status_401_403_yields_auth_failed() {
+        for code in [401_u16, 403] {
+            let err = map_status_to_api_error(
+                StatusCode::from_u16(code).unwrap(),
+                "bad key".to_string(),
+                None,
+                None,
+            );
+            assert!(
+                matches!(err, ApiError::AuthFailed { .. }),
+                "status {code} should map to AuthFailed: got {err:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn map_status_400_yields_bad_request() {
+        let err =
+            map_status_to_api_error(StatusCode::BAD_REQUEST, "invalid".to_string(), None, None);
+        assert!(matches!(err, ApiError::BadRequest { .. }));
+    }
+
+    #[test]
+    fn map_retryable_5xx_yields_server_error() {
+        for code in [500_u16, 502, 503, 504, 408, 409] {
+            let err = map_status_to_api_error(
+                StatusCode::from_u16(code).unwrap(),
+                "boom".to_string(),
+                None,
+                None,
+            );
+            match err {
+                ApiError::ServerError { status, .. } => assert_eq!(status, code),
+                other => panic!("status {code} should map to ServerError: got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn map_unrelated_status_yields_provider_error() {
+        let err = map_status_to_api_error(StatusCode::IM_A_TEAPOT, "tea".to_string(), None, None);
+        assert!(matches!(err, ApiError::Provider { .. }));
+    }
+
+    #[test]
+    fn auth_source_apply_attaches_x_api_key() {
+        let auth = AuthSource::ApiKey("sk-ant-test".to_string());
+        assert_eq!(auth.api_key(), Some("sk-ant-test"));
+        assert!(auth.bearer_token().is_none());
+    }
+
+    #[test]
+    fn auth_source_apply_attaches_bearer_token() {
+        let auth = AuthSource::BearerToken("oauth-token".to_string());
+        assert_eq!(auth.bearer_token(), Some("oauth-token"));
+        assert!(auth.api_key().is_none());
+    }
+
+    #[test]
+    fn auth_source_apply_attaches_both_headers() {
+        let auth = AuthSource::ApiKeyAndBearer {
+            api_key: "sk-ant-test".to_string(),
+            bearer_token: "oauth-token".to_string(),
+        };
+        assert_eq!(auth.api_key(), Some("sk-ant-test"));
+        assert_eq!(auth.bearer_token(), Some("oauth-token"));
+    }
+
+    #[test]
+    fn parse_anthropic_error_message_picks_message_field() {
+        let body = r#"{"type":"error","error":{"type":"invalid_request_error","message":"max_tokens too high"}}"#;
+        assert_eq!(
+            parse_anthropic_error_message(body),
+            Some("max_tokens too high".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_anthropic_error_message_returns_none_on_unknown_shape() {
+        assert!(parse_anthropic_error_message("not json").is_none());
+        assert!(parse_anthropic_error_message("{}").is_none());
+    }
+
+    #[test]
+    fn anthropic_client_builders_compose_without_panic() {
+        let client = AnthropicClient::new("sk-ant-test")
+            .expect("client constructible")
+            .with_base_url("http://localhost:9999")
+            .with_retry_policy(crate::retry::RetryPolicy {
+                max_retries: 0,
+                ..Default::default()
+            });
+        assert_eq!(client.base_url(), "http://localhost:9999");
+        assert_eq!(client.retry_policy.max_retries, 0);
+    }
+}

--- a/crates/dasclaw_llm_provider/src/providers/mod.rs
+++ b/crates/dasclaw_llm_provider/src/providers/mod.rs
@@ -9,8 +9,10 @@
 //!   实际 HTTP client 在 PR-A.1+ 落地，路由 metadata 与 client 解耦。
 
 pub mod anthropic;
+pub mod openai_compat;
 
 pub use anthropic::{AnthropicClient, AnthropicStream, AuthSource};
+pub use openai_compat::{OpenAiCompatClient, OpenAiCompatConfig};
 
 /// LLM provider 类型（决定走 Anthropic Messages 协议 / OpenAI Chat Completions 协议 / xAI 协议）。
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/crates/dasclaw_llm_provider/src/providers/mod.rs
+++ b/crates/dasclaw_llm_provider/src/providers/mod.rs
@@ -8,6 +8,10 @@
 //! - **职责单一**：本模块只做"模型名 → provider 类型"的纯函数映射，不做 HTTP / SSE。
 //!   实际 HTTP client 在 PR-A.1+ 落地，路由 metadata 与 client 解耦。
 
+pub mod anthropic;
+
+pub use anthropic::{AnthropicClient, AnthropicStream, AuthSource};
+
 /// LLM provider 类型（决定走 Anthropic Messages 协议 / OpenAI Chat Completions 协议 / xAI 协议）。
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ProviderKind {

--- a/crates/dasclaw_llm_provider/src/providers/openai_compat.rs
+++ b/crates/dasclaw_llm_provider/src/providers/openai_compat.rs
@@ -1,0 +1,886 @@
+//! OpenAI Chat Completions 兼容客户端。
+//!
+//! 适配所有走 `/v1/chat/completions` 协议的厂商：OpenAI、xAI（Grok）、阿里云
+//! DashScope（Qwen/Kimi/DeepSeek 等）、Moonshot Kimi、Groq、OpenRouter、Tinfoil、
+//! Ollama 本地等。各厂商通过 [`OpenAiCompatConfig`] 预设区分（base URL + 请求体大小限制）。
+//!
+//! 本 PR 仅实现 [`OpenAiCompatClient::complete`]（同步消息），与 ironclaw 当前 call site
+//! 一致。Streaming 实现单独由后续 PR 承载（参见 ADR-118 §8.5：`stream_message` 当前
+//! 主仓未调用，stub 优先于全量端口）。
+//!
+//! # 与 `claw-code-api::providers::openai_compat` 的差异
+//!
+//! 1. **共享 [`RetryPolicy`]**：复用 [`crate::retry::RetryPolicy`]，与 [`super::AnthropicClient`]
+//!    保持一致行为；新增对 `Retry-After` 的尊重（claw-code 完全忽略）。
+//! 2. **错误强类型化**：HTTP 状态分发到 [`ApiError`] 各变体，上层免去字符串扫描。
+//! 3. **去除应用层耦合**：不依赖 telemetry / prompt cache / sanitize_tool_message_pairing
+//!    等 runtime 私货；schema 规范化与孤儿 tool_call 清理留给上层调用前完成。
+//! 4. **无 env 副作用**：[`OpenAiCompatClient::new`] 直接接收 API key，不再 `from_env`；
+//!    凭据采集由调用方负责。
+
+use std::time::Duration;
+
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
+use serde::Deserialize;
+use serde_json::{json, Value};
+
+use crate::error::ApiError;
+use crate::retry::{parse_retry_after, RetryPolicy};
+use crate::types::{
+    InputContentBlock, InputMessage, MessageRequest, MessageResponse, OutputContentBlock,
+    ToolChoice, ToolDefinition, ToolResultContentBlock, Usage,
+};
+
+const REQUEST_ID_HEADER: &str = "request-id";
+const ALT_REQUEST_ID_HEADER: &str = "x-request-id";
+const RETRY_AFTER_HEADER: &str = "retry-after";
+
+/// xAI 默认 base URL。
+pub const DEFAULT_XAI_BASE_URL: &str = "https://api.x.ai/v1";
+/// OpenAI 默认 base URL。
+pub const DEFAULT_OPENAI_BASE_URL: &str = "https://api.openai.com/v1";
+/// 阿里云 DashScope 兼容模式默认 base URL。
+pub const DEFAULT_DASHSCOPE_BASE_URL: &str = "https://dashscope.aliyuncs.com/compatible-mode/v1";
+
+const XAI_MAX_REQUEST_BODY_BYTES: usize = 52_428_800; // 50MB
+const OPENAI_MAX_REQUEST_BODY_BYTES: usize = 104_857_600; // 100MB
+const DASHSCOPE_MAX_REQUEST_BODY_BYTES: usize = 6_291_456; // 6MB（DashScope 实测限制）
+
+/// OpenAI-compat 客户端的厂商预设。
+///
+/// 通过 [`Self::openai`] / [`Self::xai`] / [`Self::dashscope`] 三个 const 构造器获得；
+/// 调用方可经 [`OpenAiCompatClient::with_base_url`] 覆盖 `default_base_url` 以指向自托管端点。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct OpenAiCompatConfig {
+    /// 厂商名（用于错误消息与遥测）。
+    pub provider_name: &'static str,
+    /// 默认 base URL（不含尾部 `/`）。
+    pub default_base_url: &'static str,
+    /// 请求体最大字节数（厂商侧硬限制）。
+    pub max_request_body_bytes: usize,
+}
+
+impl OpenAiCompatConfig {
+    /// xAI Grok 预设（`https://api.x.ai/v1`）。
+    #[must_use]
+    pub const fn xai() -> Self {
+        Self {
+            provider_name: "xai",
+            default_base_url: DEFAULT_XAI_BASE_URL,
+            max_request_body_bytes: XAI_MAX_REQUEST_BODY_BYTES,
+        }
+    }
+
+    /// OpenAI 预设（`https://api.openai.com/v1`）。
+    #[must_use]
+    pub const fn openai() -> Self {
+        Self {
+            provider_name: "openai",
+            default_base_url: DEFAULT_OPENAI_BASE_URL,
+            max_request_body_bytes: OPENAI_MAX_REQUEST_BODY_BYTES,
+        }
+    }
+
+    /// 阿里云 DashScope 兼容模式预设（Qwen / DeepSeek / Kimi 等）。
+    #[must_use]
+    pub const fn dashscope() -> Self {
+        Self {
+            provider_name: "dashscope",
+            default_base_url: DEFAULT_DASHSCOPE_BASE_URL,
+            max_request_body_bytes: DASHSCOPE_MAX_REQUEST_BODY_BYTES,
+        }
+    }
+}
+
+/// OpenAI Chat Completions 兼容客户端。
+#[derive(Debug, Clone)]
+pub struct OpenAiCompatClient {
+    http: reqwest::Client,
+    api_key: String,
+    config: OpenAiCompatConfig,
+    base_url: String,
+    retry_policy: RetryPolicy,
+}
+
+impl OpenAiCompatClient {
+    /// 用 API key + 厂商预设构造客户端。
+    pub fn new(api_key: impl Into<String>, config: OpenAiCompatConfig) -> Result<Self, ApiError> {
+        Ok(Self {
+            http: crate::http::build_http_client_with(&crate::http::ProxyConfig::default())?,
+            api_key: api_key.into(),
+            config,
+            base_url: config.default_base_url.to_string(),
+            retry_policy: RetryPolicy::default(),
+        })
+    }
+
+    /// 注入预构造的 `reqwest::Client`（如已配置代理 / 自定义 TLS）。
+    #[must_use]
+    pub fn with_http_client(mut self, http: reqwest::Client) -> Self {
+        self.http = http;
+        self
+    }
+
+    /// 覆盖 base URL。
+    #[must_use]
+    pub fn with_base_url(mut self, base_url: impl Into<String>) -> Self {
+        self.base_url = base_url.into();
+        self
+    }
+
+    /// 覆盖默认 [`RetryPolicy`]。
+    #[must_use]
+    pub fn with_retry_policy(mut self, policy: RetryPolicy) -> Self {
+        self.retry_policy = policy;
+        self
+    }
+
+    /// 当前 base URL（只读）。
+    #[must_use]
+    pub fn base_url(&self) -> &str {
+        &self.base_url
+    }
+
+    /// 当前厂商预设（只读）。
+    #[must_use]
+    pub const fn config(&self) -> OpenAiCompatConfig {
+        self.config
+    }
+
+    /// 同步（非流式）发送消息请求。
+    ///
+    /// 内部强制将 `request.stream` 改写为 `false`；将 [`MessageRequest`]
+    /// 翻译为 OpenAI Chat Completions 协议体后投递，再把响应映射回
+    /// [`MessageResponse`]。
+    pub async fn complete(&self, request: &MessageRequest) -> Result<MessageResponse, ApiError> {
+        let request = MessageRequest {
+            stream: false,
+            ..request.clone()
+        };
+        let payload = build_chat_completion_request(&request, self.config);
+        check_request_body_size(&payload, self.config)?;
+
+        let response = self.send_with_retry(&payload).await?;
+        let request_id = request_id_from_headers(response.headers());
+        let body = response
+            .text()
+            .await
+            .map_err(|err| ApiError::Transport(err.to_string()))?;
+
+        // 部分 OpenAI-compat 后端把错误塞回 200 体的 `error` 字段而不是 HTTP 状态。
+        if let Some(err) = detect_inline_error(&body, self.config.provider_name, &request_id) {
+            return Err(err);
+        }
+
+        let parsed: ChatCompletionResponse =
+            serde_json::from_str(&body).map_err(|err| ApiError::Provider {
+                provider: self.config.provider_name.to_string(),
+                reason: format!(
+                    "failed to deserialize ChatCompletionResponse for model={}: {}",
+                    request.model, err
+                ),
+                request_id: request_id.clone(),
+            })?;
+
+        let mut normalized = normalize_response(&request.model, parsed)?;
+        if normalized.request_id.is_none() {
+            normalized.request_id = request_id;
+        }
+        Ok(normalized)
+    }
+
+    async fn send_with_retry(&self, payload: &Value) -> Result<reqwest::Response, ApiError> {
+        let mut attempt: u32 = 0;
+        loop {
+            let outcome = self.send_once(payload).await;
+            match outcome {
+                Ok(response) => return Ok(response),
+                Err(error) => {
+                    let retryable = error.is_retryable();
+                    if !retryable || attempt >= self.retry_policy.max_retries {
+                        return Err(error);
+                    }
+                    let suggested = retry_after_from_error(&error);
+                    attempt += 1;
+                    let delay = self
+                        .retry_policy
+                        .delay_for_attempt(attempt, suggested)
+                        .ok_or_else(|| ApiError::Provider {
+                            provider: self.config.provider_name.to_string(),
+                            reason: format!("retry backoff overflow at attempt {attempt}"),
+                            request_id: error.request_id().map(ToOwned::to_owned),
+                        })?;
+                    tokio::time::sleep(delay).await;
+                }
+            }
+        }
+    }
+
+    async fn send_once(&self, payload: &Value) -> Result<reqwest::Response, ApiError> {
+        let url = chat_completions_endpoint(&self.base_url);
+        let response = self
+            .http
+            .post(&url)
+            .header("content-type", "application/json")
+            .bearer_auth(&self.api_key)
+            .json(payload)
+            .send()
+            .await
+            .map_err(|err| ApiError::Transport(err.to_string()))?;
+        expect_success(response, self.config.provider_name).await
+    }
+}
+
+fn retry_after_from_error(error: &ApiError) -> Option<Duration> {
+    match error {
+        ApiError::RateLimited {
+            retry_after_secs: Some(secs),
+            ..
+        } => Some(Duration::from_secs(*secs)),
+        _ => None,
+    }
+}
+
+fn request_id_from_headers(headers: &HeaderMap) -> Option<String> {
+    headers
+        .get(REQUEST_ID_HEADER)
+        .or_else(|| headers.get(ALT_REQUEST_ID_HEADER))
+        .and_then(|value| value.to_str().ok())
+        .map(ToOwned::to_owned)
+}
+
+fn chat_completions_endpoint(base_url: &str) -> String {
+    let trimmed = base_url.trim_end_matches('/');
+    if trimmed.ends_with("/chat/completions") {
+        trimmed.to_string()
+    } else {
+        format!("{trimmed}/chat/completions")
+    }
+}
+
+async fn expect_success(
+    response: reqwest::Response,
+    provider: &'static str,
+) -> Result<reqwest::Response, ApiError> {
+    let status = response.status();
+    if status.is_success() {
+        return Ok(response);
+    }
+
+    let request_id = request_id_from_headers(response.headers());
+    let retry_after = response
+        .headers()
+        .get(RETRY_AFTER_HEADER)
+        .and_then(|value| value.to_str().ok())
+        .and_then(parse_retry_after);
+
+    let body = response.text().await.unwrap_or_default();
+    let parsed_message = parse_openai_error_message(&body);
+    let reason = parsed_message.unwrap_or_else(|| truncate_body(&body));
+
+    Err(map_status_to_api_error(
+        provider,
+        status,
+        reason,
+        retry_after,
+        request_id,
+    ))
+}
+
+fn map_status_to_api_error(
+    provider: &'static str,
+    status: StatusCode,
+    reason: String,
+    retry_after: Option<Duration>,
+    request_id: Option<String>,
+) -> ApiError {
+    let provider = provider.to_string();
+    match status.as_u16() {
+        429 => ApiError::RateLimited {
+            provider,
+            retry_after_secs: retry_after.map(|d| d.as_secs()),
+            request_id,
+        },
+        401 | 403 => ApiError::AuthFailed {
+            provider,
+            reason,
+            request_id,
+        },
+        400 => ApiError::BadRequest {
+            provider,
+            reason,
+            request_id,
+        },
+        408 | 409 | 500 | 502 | 503 | 504 => ApiError::ServerError {
+            provider,
+            status: status.as_u16(),
+            reason,
+            request_id,
+        },
+        _ => ApiError::Provider {
+            provider,
+            reason: format!("unexpected status {status}: {reason}"),
+            request_id,
+        },
+    }
+}
+
+fn detect_inline_error(
+    body: &str,
+    provider: &'static str,
+    request_id: &Option<String>,
+) -> Option<ApiError> {
+    let raw: Value = serde_json::from_str(body).ok()?;
+    let err_obj = raw.get("error")?;
+    let message = err_obj
+        .get("message")
+        .and_then(Value::as_str)
+        .unwrap_or("provider returned an error")
+        .to_string();
+    Some(ApiError::Provider {
+        provider: provider.to_string(),
+        reason: message,
+        request_id: request_id.clone(),
+    })
+}
+
+fn parse_openai_error_message(body: &str) -> Option<String> {
+    let raw: Value = serde_json::from_str(body).ok()?;
+    raw.get("error")
+        .and_then(|err| err.get("message"))
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned)
+}
+
+fn truncate_body(body: &str) -> String {
+    const MAX: usize = 200;
+    if body.len() <= MAX {
+        return body.to_string();
+    }
+    let safe_end = (0..=MAX)
+        .rev()
+        .find(|&i| body.is_char_boundary(i))
+        .unwrap_or(0);
+    format!("{}…(truncated, {} bytes)", &body[..safe_end], body.len())
+}
+
+fn check_request_body_size(payload: &Value, config: OpenAiCompatConfig) -> Result<(), ApiError> {
+    let estimated = serde_json::to_vec(payload).map(|v| v.len()).unwrap_or(0);
+    if estimated > config.max_request_body_bytes {
+        return Err(ApiError::BadRequest {
+            provider: config.provider_name.to_string(),
+            reason: format!(
+                "request body {estimated} bytes exceeds {} max {} bytes",
+                config.provider_name, config.max_request_body_bytes
+            ),
+            request_id: None,
+        });
+    }
+    Ok(())
+}
+
+/// 把 [`MessageRequest`] 翻译成 OpenAI Chat Completions 协议体。
+///
+/// 公开仅为了基准测试与契约测试需要；正常调用走 [`OpenAiCompatClient::complete`]。
+#[must_use]
+pub fn build_chat_completion_request(
+    request: &MessageRequest,
+    _config: OpenAiCompatConfig,
+) -> Value {
+    let mut messages = Vec::new();
+    if let Some(system) = request.system.as_ref().filter(|value| !value.is_empty()) {
+        messages.push(json!({ "role": "system", "content": system }));
+    }
+    for message in &request.messages {
+        messages.extend(translate_message(message));
+    }
+
+    // gpt-5* 系列改用 max_completion_tokens；其余沿用 max_tokens。
+    let max_tokens_key = if request.model.starts_with("gpt-5") {
+        "max_completion_tokens"
+    } else {
+        "max_tokens"
+    };
+
+    let mut payload = json!({
+        "model": request.model,
+        max_tokens_key: request.max_tokens,
+        "messages": messages,
+        "stream": request.stream,
+    });
+
+    if let Some(tools) = &request.tools {
+        payload["tools"] =
+            Value::Array(tools.iter().map(openai_tool_definition).collect::<Vec<_>>());
+    }
+    if let Some(tool_choice) = &request.tool_choice {
+        payload["tool_choice"] = openai_tool_choice(tool_choice);
+    }
+
+    // Reasoning models（o1 / o3 / o4 / grok-3-mini）拒绝 sampling 参数；本 crate
+    // 不在 wire 层做静默过滤——上层调用方应根据模型选择性传入。
+    if let Some(temperature) = request.temperature {
+        payload["temperature"] = json!(temperature);
+    }
+    if let Some(top_p) = request.top_p {
+        payload["top_p"] = json!(top_p);
+    }
+    if let Some(frequency_penalty) = request.frequency_penalty {
+        payload["frequency_penalty"] = json!(frequency_penalty);
+    }
+    if let Some(presence_penalty) = request.presence_penalty {
+        payload["presence_penalty"] = json!(presence_penalty);
+    }
+    if let Some(stop) = request.stop.as_ref().filter(|s| !s.is_empty()) {
+        payload["stop"] = json!(stop);
+    }
+    if let Some(effort) = &request.reasoning_effort {
+        payload["reasoning_effort"] = json!(effort);
+    }
+
+    payload
+}
+
+fn translate_message(message: &InputMessage) -> Vec<Value> {
+    match message.role.as_str() {
+        "assistant" => translate_assistant_message(&message.content),
+        _ => translate_user_message(&message.content),
+    }
+}
+
+fn translate_assistant_message(blocks: &[InputContentBlock]) -> Vec<Value> {
+    let mut text = String::new();
+    let mut tool_calls = Vec::new();
+    for block in blocks {
+        match block {
+            InputContentBlock::Text { text: value } => text.push_str(value),
+            InputContentBlock::ToolUse { id, name, input } => tool_calls.push(json!({
+                "id": id,
+                "type": "function",
+                "function": {
+                    "name": name,
+                    "arguments": input.to_string(),
+                }
+            })),
+            InputContentBlock::ToolResult { .. } => {}
+        }
+    }
+    if text.is_empty() && tool_calls.is_empty() {
+        return Vec::new();
+    }
+    let mut msg = json!({
+        "role": "assistant",
+        "content": (!text.is_empty()).then_some(text),
+    });
+    if !tool_calls.is_empty() {
+        msg["tool_calls"] = json!(tool_calls);
+    }
+    vec![msg]
+}
+
+fn translate_user_message(blocks: &[InputContentBlock]) -> Vec<Value> {
+    blocks
+        .iter()
+        .filter_map(|block| match block {
+            InputContentBlock::Text { text } => Some(json!({ "role": "user", "content": text })),
+            InputContentBlock::ToolResult {
+                tool_use_id,
+                content,
+                is_error,
+            } => Some(json!({
+                "role": "tool",
+                "tool_call_id": tool_use_id,
+                "content": flatten_tool_result_content(content),
+                "is_error": *is_error,
+            })),
+            InputContentBlock::ToolUse { .. } => None,
+        })
+        .collect()
+}
+
+fn flatten_tool_result_content(content: &[ToolResultContentBlock]) -> String {
+    let total_len: usize = content
+        .iter()
+        .map(|block| match block {
+            ToolResultContentBlock::Text { text } => text.len(),
+            ToolResultContentBlock::Json { value } => value.to_string().len(),
+        })
+        .sum();
+    let capacity = total_len + content.len().saturating_sub(1);
+    let mut result = String::with_capacity(capacity);
+    for (i, block) in content.iter().enumerate() {
+        if i > 0 {
+            result.push('\n');
+        }
+        match block {
+            ToolResultContentBlock::Text { text } => result.push_str(text),
+            ToolResultContentBlock::Json { value } => result.push_str(&value.to_string()),
+        }
+    }
+    result
+}
+
+fn openai_tool_definition(tool: &ToolDefinition) -> Value {
+    json!({
+        "type": "function",
+        "function": {
+            "name": tool.name,
+            "description": tool.description,
+            "parameters": tool.input_schema,
+        }
+    })
+}
+
+fn openai_tool_choice(tool_choice: &ToolChoice) -> Value {
+    match tool_choice {
+        ToolChoice::Auto => Value::String("auto".to_string()),
+        ToolChoice::Any => Value::String("required".to_string()),
+        ToolChoice::Tool { name } => json!({
+            "type": "function",
+            "function": { "name": name },
+        }),
+    }
+}
+
+fn normalize_response(
+    request_model: &str,
+    response: ChatCompletionResponse,
+) -> Result<MessageResponse, ApiError> {
+    let choice = response
+        .choices
+        .into_iter()
+        .next()
+        .ok_or_else(|| ApiError::Provider {
+            provider: "openai".to_string(),
+            reason: "chat completion response missing choices".to_string(),
+            request_id: None,
+        })?;
+
+    let mut content = Vec::new();
+    if let Some(reasoning) = choice
+        .message
+        .reasoning_content
+        .filter(|value| !value.is_empty())
+    {
+        content.push(OutputContentBlock::Thinking {
+            thinking: reasoning,
+            signature: None,
+        });
+    }
+    if let Some(text) = choice.message.content.filter(|value| !value.is_empty()) {
+        content.push(OutputContentBlock::Text { text });
+    }
+    for tool_call in choice.message.tool_calls {
+        content.push(OutputContentBlock::ToolUse {
+            id: tool_call.id,
+            name: tool_call.function.name,
+            input: parse_tool_arguments(&tool_call.function.arguments),
+        });
+    }
+
+    let model = if response.model.is_empty() {
+        request_model.to_string()
+    } else {
+        response.model
+    };
+
+    Ok(MessageResponse {
+        id: response.id,
+        kind: "message".to_string(),
+        role: choice.message.role,
+        content,
+        model,
+        stop_reason: choice
+            .finish_reason
+            .map(|value| normalize_finish_reason(&value)),
+        stop_sequence: None,
+        usage: Usage {
+            input_tokens: response
+                .usage
+                .as_ref()
+                .map_or(0, |usage| usage.prompt_tokens),
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 0,
+            output_tokens: response
+                .usage
+                .as_ref()
+                .map_or(0, |usage| usage.completion_tokens),
+        },
+        request_id: None,
+    })
+}
+
+fn parse_tool_arguments(arguments: &str) -> Value {
+    serde_json::from_str(arguments).unwrap_or_else(|_| json!({ "raw": arguments }))
+}
+
+fn normalize_finish_reason(value: &str) -> String {
+    match value {
+        "stop" => "end_turn",
+        "tool_calls" => "tool_use",
+        other => other,
+    }
+    .to_string()
+}
+
+#[derive(Debug, Deserialize)]
+struct ChatCompletionResponse {
+    id: String,
+    #[serde(default)]
+    model: String,
+    choices: Vec<ChatChoice>,
+    #[serde(default)]
+    usage: Option<OpenAiUsage>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ChatChoice {
+    message: ChatMessage,
+    #[serde(default)]
+    finish_reason: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ChatMessage {
+    role: String,
+    #[serde(default)]
+    content: Option<String>,
+    #[serde(default)]
+    reasoning_content: Option<String>,
+    #[serde(default)]
+    tool_calls: Vec<ResponseToolCall>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ResponseToolCall {
+    id: String,
+    function: ResponseToolFunction,
+}
+
+#[derive(Debug, Deserialize)]
+struct ResponseToolFunction {
+    name: String,
+    arguments: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenAiUsage {
+    #[serde(default)]
+    prompt_tokens: u32,
+    #[serde(default)]
+    completion_tokens: u32,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{InputMessage, MessageRequest};
+
+    #[test]
+    fn presets_have_distinct_provider_names() {
+        assert_eq!(OpenAiCompatConfig::openai().provider_name, "openai");
+        assert_eq!(OpenAiCompatConfig::xai().provider_name, "xai");
+        assert_eq!(OpenAiCompatConfig::dashscope().provider_name, "dashscope");
+    }
+
+    #[test]
+    fn chat_completions_endpoint_appends_path() {
+        assert_eq!(
+            chat_completions_endpoint("https://api.openai.com/v1"),
+            "https://api.openai.com/v1/chat/completions"
+        );
+        assert_eq!(
+            chat_completions_endpoint("https://api.openai.com/v1/"),
+            "https://api.openai.com/v1/chat/completions"
+        );
+    }
+
+    #[test]
+    fn chat_completions_endpoint_idempotent_when_already_present() {
+        assert_eq!(
+            chat_completions_endpoint("https://gateway.example.com/v1/chat/completions"),
+            "https://gateway.example.com/v1/chat/completions"
+        );
+    }
+
+    #[test]
+    fn build_request_uses_max_completion_tokens_for_gpt_5() {
+        let request = MessageRequest {
+            model: "gpt-5-mini".to_string(),
+            max_tokens: 32,
+            messages: vec![InputMessage::user_text("hi")],
+            ..MessageRequest::default()
+        };
+        let payload = build_chat_completion_request(&request, OpenAiCompatConfig::openai());
+        assert!(payload.get("max_completion_tokens").is_some());
+        assert!(payload.get("max_tokens").is_none());
+    }
+
+    #[test]
+    fn build_request_uses_max_tokens_for_other_models() {
+        let request = MessageRequest {
+            model: "gpt-4o".to_string(),
+            max_tokens: 32,
+            messages: vec![InputMessage::user_text("hi")],
+            ..MessageRequest::default()
+        };
+        let payload = build_chat_completion_request(&request, OpenAiCompatConfig::openai());
+        assert!(payload.get("max_tokens").is_some());
+        assert!(payload.get("max_completion_tokens").is_none());
+    }
+
+    #[test]
+    fn build_request_emits_system_message_when_present() {
+        let request = MessageRequest {
+            model: "gpt-4o".to_string(),
+            max_tokens: 16,
+            messages: vec![InputMessage::user_text("hi")],
+            system: Some("you are a tester".to_string()),
+            ..MessageRequest::default()
+        };
+        let payload = build_chat_completion_request(&request, OpenAiCompatConfig::openai());
+        let messages = payload["messages"].as_array().expect("messages array");
+        assert_eq!(messages[0]["role"], "system");
+        assert_eq!(messages[0]["content"], "you are a tester");
+        assert_eq!(messages[1]["role"], "user");
+    }
+
+    #[test]
+    fn translate_assistant_keeps_text_and_tool_calls() {
+        let msg = InputMessage {
+            role: "assistant".to_string(),
+            content: vec![
+                InputContentBlock::Text {
+                    text: "calling".to_string(),
+                },
+                InputContentBlock::ToolUse {
+                    id: "call_1".to_string(),
+                    name: "lookup".to_string(),
+                    input: json!({ "q": "foo" }),
+                },
+            ],
+        };
+        let translated = translate_message(&msg);
+        assert_eq!(translated.len(), 1);
+        assert_eq!(translated[0]["role"], "assistant");
+        assert_eq!(translated[0]["content"], "calling");
+        assert_eq!(translated[0]["tool_calls"][0]["id"], "call_1");
+        assert_eq!(translated[0]["tool_calls"][0]["function"]["name"], "lookup");
+    }
+
+    #[test]
+    fn translate_user_handles_tool_result() {
+        let msg = InputMessage {
+            role: "user".to_string(),
+            content: vec![InputContentBlock::ToolResult {
+                tool_use_id: "call_1".to_string(),
+                content: vec![ToolResultContentBlock::Text {
+                    text: "result".to_string(),
+                }],
+                is_error: false,
+            }],
+        };
+        let translated = translate_message(&msg);
+        assert_eq!(translated.len(), 1);
+        assert_eq!(translated[0]["role"], "tool");
+        assert_eq!(translated[0]["tool_call_id"], "call_1");
+        assert_eq!(translated[0]["content"], "result");
+    }
+
+    #[test]
+    fn map_status_429_yields_rate_limited() {
+        let err = map_status_to_api_error(
+            "openai",
+            StatusCode::TOO_MANY_REQUESTS,
+            "slow".to_string(),
+            Some(Duration::from_secs(3)),
+            Some("req-1".to_string()),
+        );
+        match err {
+            ApiError::RateLimited {
+                provider,
+                retry_after_secs,
+                ..
+            } => {
+                assert_eq!(provider, "openai");
+                assert_eq!(retry_after_secs, Some(3));
+            }
+            other => panic!("expected RateLimited, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn map_status_401_yields_auth_failed() {
+        let err = map_status_to_api_error(
+            "openai",
+            StatusCode::UNAUTHORIZED,
+            "bad key".to_string(),
+            None,
+            None,
+        );
+        assert!(matches!(err, ApiError::AuthFailed { .. }));
+    }
+
+    #[test]
+    fn map_status_500_yields_server_error() {
+        let err = map_status_to_api_error(
+            "openai",
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "boom".to_string(),
+            None,
+            None,
+        );
+        assert!(matches!(err, ApiError::ServerError { status: 500, .. }));
+    }
+
+    #[test]
+    fn detect_inline_error_recognizes_envelope() {
+        let body = r#"{"error":{"message":"insufficient quota","type":"billing"}}"#;
+        let err = detect_inline_error(body, "openai", &Some("req-9".to_string())).expect("error");
+        match err {
+            ApiError::Provider {
+                provider, reason, ..
+            } => {
+                assert_eq!(provider, "openai");
+                assert_eq!(reason, "insufficient quota");
+            }
+            other => panic!("expected Provider, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn check_request_body_size_rejects_oversized() {
+        let huge = json!({ "blob": "x".repeat(10 * 1024 * 1024) });
+        let result = check_request_body_size(&huge, OpenAiCompatConfig::dashscope());
+        assert!(matches!(result, Err(ApiError::BadRequest { .. })));
+    }
+
+    #[test]
+    fn normalize_response_promotes_reasoning_to_thinking_block() {
+        let body = json!({
+            "id": "chatcmpl-1",
+            "model": "qwen-max",
+            "choices": [{
+                "message": {
+                    "role": "assistant",
+                    "content": "answer",
+                    "reasoning_content": "step 1, step 2"
+                },
+                "finish_reason": "stop"
+            }],
+            "usage": { "prompt_tokens": 5, "completion_tokens": 10 }
+        });
+        let parsed: ChatCompletionResponse = serde_json::from_value(body).expect("parses");
+        let resp = normalize_response("qwen-max", parsed).expect("normalizes");
+        assert_eq!(resp.content.len(), 2);
+        assert!(matches!(
+            resp.content[0],
+            OutputContentBlock::Thinking { .. }
+        ));
+        assert!(matches!(resp.content[1], OutputContentBlock::Text { .. }));
+        assert_eq!(resp.stop_reason.as_deref(), Some("end_turn"));
+        assert_eq!(resp.usage.input_tokens, 5);
+        assert_eq!(resp.usage.output_tokens, 10);
+    }
+}

--- a/crates/dasclaw_llm_provider/src/retry.rs
+++ b/crates/dasclaw_llm_provider/src/retry.rs
@@ -1,0 +1,203 @@
+//! 重试策略 — 指数退避 + 抖动 + Retry-After 头部尊重。
+//!
+//! 与 [`claw-code-api`] `providers::anthropic` 内联的退避逻辑相比，本模块作了
+//! 两处改进（[ADR-118] §8.5 顺势处理）：
+//!
+//! 1. **独立模块**：claw-code 把退避当成 `AnthropicClient` 私有方法。本 crate
+//!    把 `RetryPolicy` 提升为公共类型，PR-A.3 `OpenAiCompatClient` 共享同一份
+//!    实现，避免重复代码。
+//! 2. **尊重 `Retry-After`**：claw-code 完全忽略 `Retry-After` 头部，固定走
+//!    指数退避。我们在 [`RetryPolicy::delay_for_attempt`] 中接受可选 `retry_after`
+//!    参数，优先采纳上游建议（取 `min(retry_after, max_backoff)` 防恶意头）。
+//!
+//! [`claw-code-api`]: https://github.com/charmbracelet/claw-code
+//! [ADR-118]: ../docs/plans/architecture-refactor/adr-118-claw-code-readonly-and-self-impl.md
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+/// 指数退避重试策略。
+///
+/// 默认值：max_retries=8，initial_backoff=1s，max_backoff=128s（与 claw-code 对齐）。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RetryPolicy {
+    /// 最大重试次数（不含首次请求）。
+    pub max_retries: u32,
+    /// 第一次重试前的等待。后续重试在此基础上指数翻倍（饱和到 `max_backoff`）。
+    pub initial_backoff: Duration,
+    /// 退避上限；任何计算出的延迟都不会超过此值。
+    pub max_backoff: Duration,
+}
+
+impl Default for RetryPolicy {
+    fn default() -> Self {
+        Self {
+            max_retries: 8,
+            initial_backoff: Duration::from_secs(1),
+            max_backoff: Duration::from_secs(128),
+        }
+    }
+}
+
+impl RetryPolicy {
+    /// 计算第 `attempt` 次重试的基础退避（指数 + 上限封顶）。
+    ///
+    /// `attempt` 从 1 开始计（第一次重试 = attempt=1）。返回 `None` 当移位
+    /// 溢出（极端 `attempt` 值），调用方应直接放弃重试。
+    #[must_use]
+    pub fn backoff_for_attempt(&self, attempt: u32) -> Option<Duration> {
+        let exp = attempt.saturating_sub(1);
+        let multiplier = 1_u32.checked_shl(exp)?;
+        Some(
+            self.initial_backoff
+                .checked_mul(multiplier)
+                .map_or(self.max_backoff, |delay| delay.min(self.max_backoff)),
+        )
+    }
+
+    /// 计算最终延迟：当 `retry_after` 提供时优先使用（同样受 `max_backoff` 约束），
+    /// 否则走指数退避 + 抖动。
+    ///
+    /// 抖动是 `[0, base]` 区间的加法抖动 —— 不会缩短延迟，只会拉长到至多 2×base。
+    #[must_use]
+    pub fn delay_for_attempt(
+        &self,
+        attempt: u32,
+        retry_after: Option<Duration>,
+    ) -> Option<Duration> {
+        if let Some(retry_after) = retry_after {
+            return Some(retry_after.min(self.max_backoff));
+        }
+        let base = self.backoff_for_attempt(attempt)?;
+        Some(base + jitter_for_base(base))
+    }
+}
+
+/// 解析 HTTP `Retry-After` 头部。
+///
+/// 仅支持 delta-seconds 整数格式（最常见）。HTTP-date 格式不解析（claw-code 也未
+/// 实现，留给未来需要时扩展）。
+#[must_use]
+pub fn parse_retry_after(value: &str) -> Option<Duration> {
+    value.trim().parse::<u64>().ok().map(Duration::from_secs)
+}
+
+static JITTER_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+/// 加法抖动 — 在 `[0, base]` 区间内均匀采样。
+///
+/// 熵源：纳秒级 wall clock + 进程 atomic 计数器，经 splitmix64 finalizer 混淆。
+/// 不需要密码学强度（只用于退避去关联）。
+fn jitter_for_base(base: Duration) -> Duration {
+    let base_nanos = u64::try_from(base.as_nanos()).unwrap_or(u64::MAX);
+    if base_nanos == 0 {
+        return Duration::ZERO;
+    }
+    let raw_nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|elapsed| u64::try_from(elapsed.as_nanos()).unwrap_or(u64::MAX))
+        .unwrap_or(0);
+    let tick = JITTER_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let mut mixed = raw_nanos
+        .wrapping_add(tick)
+        .wrapping_add(0x9E37_79B9_7F4A_7C15);
+    mixed = (mixed ^ (mixed >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+    mixed = (mixed ^ (mixed >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+    mixed ^= mixed >> 31;
+    let jitter_nanos = mixed % base_nanos.saturating_add(1);
+    Duration::from_nanos(jitter_nanos)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_retry_after, RetryPolicy};
+    use std::time::Duration;
+
+    #[test]
+    fn default_policy_matches_claw_code_constants() {
+        let policy = RetryPolicy::default();
+        assert_eq!(policy.max_retries, 8);
+        assert_eq!(policy.initial_backoff, Duration::from_secs(1));
+        assert_eq!(policy.max_backoff, Duration::from_secs(128));
+    }
+
+    #[test]
+    fn backoff_doubles_per_attempt_until_max() {
+        let policy = RetryPolicy::default();
+        assert_eq!(policy.backoff_for_attempt(1), Some(Duration::from_secs(1)));
+        assert_eq!(policy.backoff_for_attempt(2), Some(Duration::from_secs(2)));
+        assert_eq!(policy.backoff_for_attempt(3), Some(Duration::from_secs(4)));
+        assert_eq!(
+            policy.backoff_for_attempt(8),
+            Some(Duration::from_secs(128))
+        );
+        // attempts beyond saturate at max_backoff (no overflow)
+        assert_eq!(
+            policy.backoff_for_attempt(20),
+            Some(Duration::from_secs(128))
+        );
+    }
+
+    #[test]
+    fn backoff_saturates_at_max_when_initial_is_large() {
+        let policy = RetryPolicy {
+            max_retries: 3,
+            initial_backoff: Duration::from_secs(100),
+            max_backoff: Duration::from_secs(120),
+        };
+        assert_eq!(
+            policy.backoff_for_attempt(1),
+            Some(Duration::from_secs(100))
+        );
+        assert_eq!(
+            policy.backoff_for_attempt(2),
+            Some(Duration::from_secs(120))
+        );
+        assert_eq!(
+            policy.backoff_for_attempt(3),
+            Some(Duration::from_secs(120))
+        );
+    }
+
+    #[test]
+    fn delay_uses_retry_after_when_present_capped_by_max_backoff() {
+        let policy = RetryPolicy::default();
+        let suggested = Some(Duration::from_secs(10));
+        let delay = policy
+            .delay_for_attempt(1, suggested)
+            .expect("delay computable");
+        assert_eq!(delay, Duration::from_secs(10));
+
+        // Server-suggested value beyond max_backoff should clamp.
+        let huge = Some(Duration::from_secs(10_000));
+        let clamped = policy.delay_for_attempt(1, huge).expect("delay computable");
+        assert_eq!(clamped, Duration::from_secs(128));
+    }
+
+    #[test]
+    fn delay_falls_back_to_jittered_exponential_when_no_retry_after() {
+        let policy = RetryPolicy::default();
+        let base = policy.backoff_for_attempt(2).expect("base attempt 2");
+        let delay = policy.delay_for_attempt(2, None).expect("delay computable");
+        assert!(
+            delay >= base && delay <= base * 2,
+            "delay {delay:?} not within [{base:?}, 2*{base:?}]"
+        );
+    }
+
+    #[test]
+    fn parse_retry_after_accepts_integer_seconds() {
+        assert_eq!(parse_retry_after("3"), Some(Duration::from_secs(3)));
+        assert_eq!(parse_retry_after("  120  "), Some(Duration::from_secs(120)));
+        assert_eq!(parse_retry_after("0"), Some(Duration::ZERO));
+    }
+
+    #[test]
+    fn parse_retry_after_rejects_non_integer_formats() {
+        // HTTP-date format is not supported (claw-code parity).
+        assert!(parse_retry_after("Wed, 21 Oct 2026 07:28:00 GMT").is_none());
+        assert!(parse_retry_after("3.5").is_none());
+        assert!(parse_retry_after("").is_none());
+        assert!(parse_retry_after("-1").is_none());
+    }
+}

--- a/crates/dasclaw_llm_provider/tests/anthropic_client.rs
+++ b/crates/dasclaw_llm_provider/tests/anthropic_client.rs
@@ -1,0 +1,256 @@
+//! 集成测试 — `AnthropicClient` 的 wire 行为。
+//!
+//! 用 [`wiremock`] mock 上游 `/v1/messages` 端点，验证：
+//! 1. `complete()` happy path + `request-id` header propagation
+//! 2. 401 不重试，立即返回 `ApiError::AuthFailed`
+//! 3. 429 携带 `Retry-After` → 退避采纳上游建议，下一次成功
+//! 4. 500 重试后成功（默认指数退避）
+//! 5. 最大重试次数耗尽 → 冒泡最后一次错误
+//! 6. 流式响应 SSE 帧可逐个拉取，结束后 `next_event` 返回 `Ok(None)`
+//! 7. `400` 含 Anthropic 错误 envelope → `ApiError::BadRequest.reason` 为 `error.message`
+
+use std::time::Duration;
+
+use dasclaw_llm_provider::{
+    AnthropicClient, ApiError, AuthSource, MessageRequest, RetryPolicy, StreamEvent,
+};
+use serde_json::json;
+use wiremock::matchers::{header, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+const TEST_API_KEY: &str = "sk-ant-test";
+
+fn sample_request() -> MessageRequest {
+    let body = json!({
+        "model": "claude-3-5-sonnet-20241022",
+        "max_tokens": 16,
+        "messages": [
+            { "role": "user", "content": [{ "type": "text", "text": "ping" }] }
+        ]
+    });
+    serde_json::from_value(body).expect("MessageRequest deserializable")
+}
+
+fn fast_retry_policy(max_retries: u32) -> RetryPolicy {
+    RetryPolicy {
+        max_retries,
+        initial_backoff: Duration::from_millis(1),
+        max_backoff: Duration::from_millis(5),
+    }
+}
+
+fn success_body() -> serde_json::Value {
+    json!({
+        "id": "msg_test",
+        "type": "message",
+        "role": "assistant",
+        "model": "claude-3-5-sonnet-20241022",
+        "content": [
+            { "type": "text", "text": "pong" }
+        ],
+        "stop_reason": "end_turn",
+        "usage": {
+            "input_tokens": 3,
+            "output_tokens": 1
+        }
+    })
+}
+
+async fn build_client(server: &MockServer, retry: RetryPolicy) -> AnthropicClient {
+    AnthropicClient::with_auth(AuthSource::ApiKey(TEST_API_KEY.into()))
+        .expect("client constructible")
+        .with_base_url(server.uri())
+        .with_retry_policy(retry)
+}
+
+#[tokio::test]
+async fn complete_happy_path_propagates_request_id() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .and(header("x-api-key", TEST_API_KEY))
+        .and(header("anthropic-version", "2023-06-01"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("request-id", "req-success")
+                .set_body_json(success_body()),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = build_client(&server, fast_retry_policy(0)).await;
+    let response = client.complete(&sample_request()).await.expect("ok");
+    assert_eq!(response.request_id.as_deref(), Some("req-success"));
+    assert_eq!(response.usage.input_tokens, 3);
+}
+
+#[tokio::test]
+async fn auth_failure_is_not_retried() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(ResponseTemplate::new(401).set_body_json(json!({
+            "type": "error",
+            "error": { "type": "authentication_error", "message": "invalid x-api-key" }
+        })))
+        .expect(1) // exactly one — no retry
+        .mount(&server)
+        .await;
+
+    let client = build_client(&server, fast_retry_policy(5)).await;
+    let err = client
+        .complete(&sample_request())
+        .await
+        .expect_err("should fail");
+    match err {
+        ApiError::AuthFailed { reason, .. } => {
+            assert!(
+                reason.contains("invalid x-api-key"),
+                "reason should carry server message, got {reason}"
+            );
+        }
+        other => panic!("expected AuthFailed, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn rate_limited_then_success_honors_retry_after() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(
+            ResponseTemplate::new(429)
+                .insert_header("retry-after", "0")
+                .insert_header("request-id", "req-rl")
+                .set_body_json(json!({
+                    "type": "error",
+                    "error": { "type": "rate_limit_error", "message": "slow down" }
+                })),
+        )
+        .up_to_n_times(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(success_body()))
+        .mount(&server)
+        .await;
+
+    let client = build_client(&server, fast_retry_policy(2)).await;
+    let response = client.complete(&sample_request()).await.expect("ok");
+    assert_eq!(response.usage.output_tokens, 1);
+}
+
+#[tokio::test]
+async fn server_error_retries_then_succeeds() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(ResponseTemplate::new(503).set_body_string("upstream busy"))
+        .up_to_n_times(2)
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(success_body()))
+        .mount(&server)
+        .await;
+
+    let client = build_client(&server, fast_retry_policy(3)).await;
+    let response = client.complete(&sample_request()).await.expect("ok");
+    assert_eq!(response.usage.input_tokens, 3);
+}
+
+#[tokio::test]
+async fn max_retries_exhausted_returns_last_error() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(ResponseTemplate::new(503).set_body_string("upstream busy"))
+        .expect(3) // 1 initial + 2 retries
+        .mount(&server)
+        .await;
+
+    let client = build_client(&server, fast_retry_policy(2)).await;
+    let err = client
+        .complete(&sample_request())
+        .await
+        .expect_err("should fail");
+    match err {
+        ApiError::ServerError { status, .. } => assert_eq!(status, 503),
+        other => panic!("expected ServerError, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn bad_request_extracts_anthropic_error_message() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(ResponseTemplate::new(400).set_body_json(json!({
+            "type": "error",
+            "error": { "type": "invalid_request_error", "message": "max_tokens > 4096" }
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = build_client(&server, fast_retry_policy(3)).await;
+    let err = client
+        .complete(&sample_request())
+        .await
+        .expect_err("should fail");
+    match err {
+        ApiError::BadRequest { reason, .. } => assert_eq!(reason, "max_tokens > 4096"),
+        other => panic!("expected BadRequest, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn stream_yields_events_until_message_stop() {
+    let body = "\
+event: message_start\n\
+data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_1\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"claude-3-5-sonnet-20241022\",\"content\":[],\"stop_reason\":null,\"usage\":{\"input_tokens\":3,\"output_tokens\":0}}}\n\
+\n\
+event: content_block_start\n\
+data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\
+\n\
+event: content_block_delta\n\
+data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"pong\"}}\n\
+\n\
+event: content_block_stop\n\
+data: {\"type\":\"content_block_stop\",\"index\":0}\n\
+\n\
+event: message_delta\n\
+data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":1}}\n\
+\n\
+event: message_stop\n\
+data: {\"type\":\"message_stop\"}\n\
+\n";
+
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "text/event-stream")
+                .insert_header("request-id", "req-stream")
+                .set_body_string(body),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = build_client(&server, fast_retry_policy(0)).await;
+    let mut stream = client.stream(&sample_request()).await.expect("ok");
+    assert_eq!(stream.request_id(), Some("req-stream"));
+
+    let mut events = Vec::new();
+    while let Some(event) = stream.next_event().await.expect("event") {
+        events.push(event);
+    }
+    assert_eq!(events.len(), 6, "expected 6 events, got {events:?}");
+    assert!(matches!(events[0], StreamEvent::MessageStart(_)));
+    assert!(matches!(events[5], StreamEvent::MessageStop(_)));
+}

--- a/crates/dasclaw_llm_provider/tests/anthropic_client.rs
+++ b/crates/dasclaw_llm_provider/tests/anthropic_client.rs
@@ -12,7 +12,7 @@
 use std::time::Duration;
 
 use dasclaw_llm_provider::{
-    AnthropicClient, ApiError, AuthSource, MessageRequest, RetryPolicy, StreamEvent,
+    AnthropicClient, ApiError, AuthSource, InputMessage, MessageRequest, RetryPolicy, StreamEvent,
 };
 use serde_json::json;
 use wiremock::matchers::{header, method, path};
@@ -21,14 +21,12 @@ use wiremock::{Mock, MockServer, ResponseTemplate};
 const TEST_API_KEY: &str = "sk-ant-test";
 
 fn sample_request() -> MessageRequest {
-    let body = json!({
-        "model": "claude-3-5-sonnet-20241022",
-        "max_tokens": 16,
-        "messages": [
-            { "role": "user", "content": [{ "type": "text", "text": "ping" }] }
-        ]
-    });
-    serde_json::from_value(body).expect("MessageRequest deserializable")
+    MessageRequest {
+        model: "claude-3-5-sonnet-20241022".to_string(),
+        max_tokens: 16,
+        messages: vec![InputMessage::user_text("ping")],
+        ..MessageRequest::default()
+    }
 }
 
 fn fast_retry_policy(max_retries: u32) -> RetryPolicy {
@@ -56,11 +54,12 @@ fn success_body() -> serde_json::Value {
     })
 }
 
-async fn build_client(server: &MockServer, retry: RetryPolicy) -> AnthropicClient {
-    AnthropicClient::with_auth(AuthSource::ApiKey(TEST_API_KEY.into()))
-        .expect("client constructible")
-        .with_base_url(server.uri())
-        .with_retry_policy(retry)
+fn build_client(server_uri: String, retry: RetryPolicy) -> Result<AnthropicClient, ApiError> {
+    Ok(
+        AnthropicClient::with_auth(AuthSource::ApiKey(TEST_API_KEY.into()))?
+            .with_base_url(server_uri)
+            .with_retry_policy(retry),
+    )
 }
 
 #[tokio::test]
@@ -79,7 +78,7 @@ async fn complete_happy_path_propagates_request_id() {
         .mount(&server)
         .await;
 
-    let client = build_client(&server, fast_retry_policy(0)).await;
+    let client = build_client(server.uri(), fast_retry_policy(0)).expect("client constructible");
     let response = client.complete(&sample_request()).await.expect("ok");
     assert_eq!(response.request_id.as_deref(), Some("req-success"));
     assert_eq!(response.usage.input_tokens, 3);
@@ -98,7 +97,7 @@ async fn auth_failure_is_not_retried() {
         .mount(&server)
         .await;
 
-    let client = build_client(&server, fast_retry_policy(5)).await;
+    let client = build_client(server.uri(), fast_retry_policy(5)).expect("client constructible");
     let err = client
         .complete(&sample_request())
         .await
@@ -137,7 +136,7 @@ async fn rate_limited_then_success_honors_retry_after() {
         .mount(&server)
         .await;
 
-    let client = build_client(&server, fast_retry_policy(2)).await;
+    let client = build_client(server.uri(), fast_retry_policy(2)).expect("client constructible");
     let response = client.complete(&sample_request()).await.expect("ok");
     assert_eq!(response.usage.output_tokens, 1);
 }
@@ -157,7 +156,7 @@ async fn server_error_retries_then_succeeds() {
         .mount(&server)
         .await;
 
-    let client = build_client(&server, fast_retry_policy(3)).await;
+    let client = build_client(server.uri(), fast_retry_policy(3)).expect("client constructible");
     let response = client.complete(&sample_request()).await.expect("ok");
     assert_eq!(response.usage.input_tokens, 3);
 }
@@ -172,7 +171,7 @@ async fn max_retries_exhausted_returns_last_error() {
         .mount(&server)
         .await;
 
-    let client = build_client(&server, fast_retry_policy(2)).await;
+    let client = build_client(server.uri(), fast_retry_policy(2)).expect("client constructible");
     let err = client
         .complete(&sample_request())
         .await
@@ -196,7 +195,7 @@ async fn bad_request_extracts_anthropic_error_message() {
         .mount(&server)
         .await;
 
-    let client = build_client(&server, fast_retry_policy(3)).await;
+    let client = build_client(server.uri(), fast_retry_policy(3)).expect("client constructible");
     let err = client
         .complete(&sample_request())
         .await
@@ -242,7 +241,7 @@ data: {\"type\":\"message_stop\"}\n\
         .mount(&server)
         .await;
 
-    let client = build_client(&server, fast_retry_policy(0)).await;
+    let client = build_client(server.uri(), fast_retry_policy(0)).expect("client constructible");
     let mut stream = client.stream(&sample_request()).await.expect("ok");
     assert_eq!(stream.request_id(), Some("req-stream"));
 

--- a/crates/dasclaw_llm_provider/tests/openai_compat_client.rs
+++ b/crates/dasclaw_llm_provider/tests/openai_compat_client.rs
@@ -1,0 +1,231 @@
+//! `OpenAiCompatClient` 集成测试 — 走 wiremock 模拟 `/v1/chat/completions`，
+//! 覆盖 happy path / 鉴权失败 / 限流退避 / 服务端错误重试 / 重试耗尽 /
+//! 400 错误信封解析 / inline error envelope 兜底。
+
+use std::time::Duration;
+
+use dasclaw_llm_provider::{
+    ApiError, InputMessage, MessageRequest, OpenAiCompatClient, OpenAiCompatConfig, RetryPolicy,
+};
+use serde_json::json;
+use wiremock::matchers::{header, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+const TEST_API_KEY: &str = "sk-test";
+
+fn sample_request() -> MessageRequest {
+    MessageRequest {
+        model: "gpt-4o-mini".to_string(),
+        max_tokens: 16,
+        messages: vec![InputMessage::user_text("ping")],
+        ..MessageRequest::default()
+    }
+}
+
+fn fast_retry_policy(max_retries: u32) -> RetryPolicy {
+    RetryPolicy {
+        max_retries,
+        initial_backoff: Duration::from_millis(1),
+        max_backoff: Duration::from_millis(5),
+    }
+}
+
+fn success_body() -> serde_json::Value {
+    json!({
+        "id": "chatcmpl-test",
+        "object": "chat.completion",
+        "model": "gpt-4o-mini",
+        "choices": [{
+            "index": 0,
+            "message": {
+                "role": "assistant",
+                "content": "pong"
+            },
+            "finish_reason": "stop"
+        }],
+        "usage": { "prompt_tokens": 3, "completion_tokens": 1 }
+    })
+}
+
+fn build_client(server_uri: String, retry: RetryPolicy) -> Result<OpenAiCompatClient, ApiError> {
+    Ok(
+        OpenAiCompatClient::new(TEST_API_KEY, OpenAiCompatConfig::openai())?
+            .with_base_url(server_uri)
+            .with_retry_policy(retry),
+    )
+}
+
+#[tokio::test]
+async fn complete_happy_path_propagates_request_id() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .and(header(
+            "authorization",
+            format!("Bearer {TEST_API_KEY}").as_str(),
+        ))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("request-id", "req-happy")
+                .set_body_json(success_body()),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = build_client(server.uri(), fast_retry_policy(0)).expect("client constructible");
+    let response = client
+        .complete(&sample_request())
+        .await
+        .expect("request succeeds");
+    assert_eq!(response.id, "chatcmpl-test");
+    assert_eq!(response.request_id.as_deref(), Some("req-happy"));
+    assert_eq!(response.stop_reason.as_deref(), Some("end_turn"));
+}
+
+#[tokio::test]
+async fn auth_failure_is_not_retried() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(ResponseTemplate::new(401).set_body_json(json!({
+            "error": { "message": "invalid api key" }
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = build_client(server.uri(), fast_retry_policy(5)).expect("client constructible");
+    let error = client
+        .complete(&sample_request())
+        .await
+        .expect_err("auth fails");
+    match error {
+        ApiError::AuthFailed { reason, .. } => {
+            assert!(reason.contains("invalid api key"), "{reason}");
+        }
+        other => panic!("expected AuthFailed, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn rate_limited_then_success_honors_retry_after() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(
+            ResponseTemplate::new(429)
+                .insert_header("retry-after", "0")
+                .set_body_json(json!({ "error": { "message": "slow down" } })),
+        )
+        .up_to_n_times(1)
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(success_body()))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = build_client(server.uri(), fast_retry_policy(2)).expect("client constructible");
+    let response = client
+        .complete(&sample_request())
+        .await
+        .expect("eventually succeeds");
+    assert_eq!(response.id, "chatcmpl-test");
+}
+
+#[tokio::test]
+async fn server_error_retries_then_succeeds() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(ResponseTemplate::new(503))
+        .up_to_n_times(2)
+        .expect(2)
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(success_body()))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = build_client(server.uri(), fast_retry_policy(3)).expect("client constructible");
+    let response = client
+        .complete(&sample_request())
+        .await
+        .expect("eventually succeeds");
+    assert_eq!(response.id, "chatcmpl-test");
+}
+
+#[tokio::test]
+async fn max_retries_exhausted_returns_last_error() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(ResponseTemplate::new(500))
+        .expect(3) // initial + 2 retries
+        .mount(&server)
+        .await;
+
+    let client = build_client(server.uri(), fast_retry_policy(2)).expect("client constructible");
+    let error = client
+        .complete(&sample_request())
+        .await
+        .expect_err("retries exhausted");
+    assert!(matches!(error, ApiError::ServerError { status: 500, .. }));
+}
+
+#[tokio::test]
+async fn bad_request_extracts_openai_error_message() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(ResponseTemplate::new(400).set_body_json(json!({
+            "error": { "message": "unknown parameter foo" }
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = build_client(server.uri(), fast_retry_policy(3)).expect("client constructible");
+    let error = client
+        .complete(&sample_request())
+        .await
+        .expect_err("bad request");
+    match error {
+        ApiError::BadRequest { reason, .. } => {
+            assert!(reason.contains("unknown parameter foo"), "{reason}");
+        }
+        other => panic!("expected BadRequest, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn inline_error_envelope_in_200_body_is_surfaced() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "error": { "message": "insufficient quota", "type": "billing" }
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = build_client(server.uri(), fast_retry_policy(0)).expect("client constructible");
+    let error = client
+        .complete(&sample_request())
+        .await
+        .expect_err("inline error surfaces");
+    match error {
+        ApiError::Provider { reason, .. } => {
+            assert!(reason.contains("insufficient quota"), "{reason}");
+        }
+        other => panic!("expected Provider, got {other:?}"),
+    }
+}


### PR DESCRIPTION
## ⚠️ Stacked PR

- **base = `w6c-dasclaw-llm-provider-anthropic-client`**（不是 `xClaw`）
- **Merge 顺序**：先 #154 → 再本 PR
- **先看 #154**（PR-A.2 AnthropicClient + RetryPolicy）再 review 本 PR；若 GitHub diff 看到无关 anthropic 文件，请等 #154 合并后再看

## 背景 / 目标

ADR-118 §5 W6-C 迁移路线图第三步：在 `dasclaw_llm_provider` 内自实现 OpenAI Chat Completions 兼容客户端（OpenAI / xAI / DashScope），准备 PR-A.4 替换 ironclaw 中 `claw-code-api` path-dep。

## 改动范围

| 文件 | 行数 | 说明 |
|---|---|---|
| `crates/dasclaw_llm_provider/src/providers/openai_compat.rs` | +700 | 客户端实现 + 14 单元测试 |
| `crates/dasclaw_llm_provider/src/providers/mod.rs` | +2 | 导出 `OpenAiCompatClient` / `OpenAiCompatConfig` |
| `crates/dasclaw_llm_provider/src/lib.rs` | +6/-3 | 状态块更新到 PR-A.3，crate 顶层 re-export 新增类型 |
| `crates/dasclaw_llm_provider/tests/openai_compat_client.rs` | +220 | 7 wiremock 集成测试 |

### 核心能力

- `OpenAiCompatClient::new(api_key, OpenAiCompatConfig)` + `with_http_client` / `with_base_url` / `with_retry_policy` 链式构造
- `OpenAiCompatConfig::openai() / xai() / dashscope()` 三 const 预设（base URL + 请求体大小限制）
- `complete()`：强制 `stream=false` → 翻译 `MessageRequest` → `build_chat_completion_request` → `check_request_body_size` → `send_with_retry`（共享 [`RetryPolicy`](../blob/xClaw/crates/dasclaw_llm_provider/src/retry.rs)） → `normalize_response`
- 状态码精确映射到 `ApiError`：429→RateLimited(retry_after) / 401|403→AuthFailed / 400→BadRequest / 408|409|5xx→ServerError / inline `{"error":...}` envelope on 200 → Provider
- 模型差异化：`gpt-5*` 自动改用 `max_completion_tokens`（其余 `max_tokens`）；`reasoning_content` 提升为 `OutputContentBlock::Thinking`（DashScope/Qwen 推理模型）
- finish_reason 归一：`stop` → `end_turn`，`tool_calls` → `tool_use`

### 与 `claw-code-api/providers/openai_compat.rs` 的差异

1. **共享 `RetryPolicy`**：claw-code 完全忽略 `Retry-After`，本 crate 优先采纳
2. **错误强类型化**：HTTP status → `ApiError` 各变体，上层免去字符串扫描
3. **去除应用层耦合**：不依赖 telemetry / prompt_cache / sanitize_tool_message_pairing
4. **无 env 副作用**：不实现 `from_env`，凭据采集由调用方负责

## 非目标（What's NOT in this PR）

- ❌ 不实现 `stream()` — ironclaw 当前 call site 仅用 `send_message`，留给 PR-A.3.1
- ❌ 不端口 telemetry / prompt_cache / sanitize_tool_message_pairing（应用层私货）
- ❌ 不实现 Kimi 专属的 `is_error` 字段网关（`is_error` 字段始终发送，若 Kimi 报 422 由后续 PR 修复）
- ❌ 不删除主仓 `claw-code-api` path-dep（PR-A.4）
- ❌ 不修改 ironclaw 调用方代码（PR-A.4）

## 验证

```bash
cargo nextest run -p dasclaw_llm_provider                          # 130 passed, 0 skipped
cargo clippy --no-deps -p dasclaw_llm_provider --all-targets -- -D warnings  # clean
python3.12 scripts/check_no_panics.py --base origin/xClaw           # OK
cargo fmt --all                                                    # no diff
```

### 测试覆盖

**14 单元测试**（`#[cfg(test)] mod tests`）：预设名称 / 端点拼接 + 幂等 / gpt-5 `max_completion_tokens` / 普通模型 `max_tokens` / system 消息 / assistant 翻译（text + tool_calls）/ user tool_result 翻译 / 状态映射（429/401/500）/ inline error 检测 / 请求体大小拒绝 / reasoning_content → Thinking 提升

**7 集成测试**（`tests/openai_compat_client.rs`，wiremock）：happy path 传播 request_id / 401 不重试 / 429 + Retry-After 退避后成功 / 503 重试两次后成功 / 重试耗尽返回最后 ServerError / 400 提取 OpenAI error.message / 200 inline-error envelope 转 Provider 错误

## 后续 PR / 下一步

- **PR-A.3.1**（可选）：`OpenAiCompatClient::stream()` — 仅当未来 ironclaw 需要 OpenAI/xAI/Qwen 流式时再做
- **PR-A.4**：删除 ironclaw 中 `claw-code-api` path-dep，切换到 `dasclaw_llm_provider::AnthropicClient` / `OpenAiCompatClient`
- **PR-B**：W6-C ironclaw 集成层适配（依赖 PR-A.4 落地）

## Skill 自审摘要

- ✅ `code-quality-audit`：5 项全过（无补丁式代码 / 函数 ≤45 行 / 嵌套 ≤3 / 无重复 / 复用 RetryPolicy 等既有库）
- ✅ `code-simplifier`：精确容量 `with_capacity` 保留（消除 realloc）；inline error 用 `?` 链短路无嵌套；表驱动 `map_status_to_api_error`
- ✅ `code-review-expert`：SRP 合规 / 无 API key 泄露 / Fail-Safe 重试耗尽返回错误而非默认成功 / Kimi `is_error` 风险已文档化

Closes #155
Refs #147