### PR TITLE
feat(ironclaw): cutover to dasclaw_llm_provider, drop claw-code-api path-dep (W6-C PR-A.4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -232,18 +232,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
-name = "api"
-version = "0.1.0"
-dependencies = [
- "reqwest 0.12.28",
- "runtime",
- "serde",
- "serde_json",
- "telemetry",
- "tokio",
-]
-
-[[package]]
 name = "ar_archive_writer"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4282,7 +4270,6 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.4",
  "tower-service",
- "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -4632,7 +4619,6 @@ dependencies = [
  "aes-gcm",
  "aho-corasick",
  "anyhow",
- "api",
  "async-trait",
  "aws-config",
  "aws-sdk-bedrockruntime",
@@ -4652,6 +4638,7 @@ dependencies = [
  "dasclaw_apply_patch",
  "dasclaw_exec",
  "dasclaw_hooks",
+ "dasclaw_llm_provider",
  "dasclaw_net_proxy",
  "dasclaw_sandbox",
  "deadpool-postgres",
@@ -6664,14 +6651,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "plugins"
-version = "0.1.0"
-dependencies = [
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "png"
 version = "0.17.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7534,7 +7513,6 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams 0.4.2",
  "web-sys",
- "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -7656,21 +7634,6 @@ dependencies = [
  "spki",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "runtime"
-version = "0.1.0"
-dependencies = [
- "glob",
- "plugins",
- "regex",
- "serde",
- "serde_json",
- "sha2",
- "telemetry",
- "tokio",
- "walkdir",
 ]
 
 [[package]]
@@ -9537,14 +9500,6 @@ dependencies = [
  "dunce",
  "embed-resource",
  "toml 0.9.12+spec-1.1.0",
-]
-
-[[package]]
-name = "telemetry"
-version = "0.1.0"
-dependencies = [
- "serde",
- "serde_json",
 ]
 
 [[package]]

--- a/crates/dasclaw_llm_provider/src/lib.rs
+++ b/crates/dasclaw_llm_provider/src/lib.rs
@@ -4,7 +4,7 @@
 //! claw-code 子仓视为只读参考库，本 crate **重新设计** Anthropic Messages /
 //! OpenAI Chat Completions 兼容层 wire 类型与 client 抽象，不直接消费子仓代码。
 //!
-//! 当前阶段：**PR-A.3 — OpenAI Chat Completions 兼容客户端**
+//! 当前阶段：**PR-A.4 — `ProviderClient` enum dispatcher + ironclaw 切换 path-dep**
 //! - ✅ wire 类型（`types`）—— Anthropic Messages 协议输入/输出/streaming events
 //! - ✅ 强类型错误（`error::ApiError`）—— 拆分 `RateLimited` / `AuthFailed` /
 //!   `ContextWindowExceeded` / `ServerError` / `Transport` / `MalformedSseFrame` 等，
@@ -20,8 +20,11 @@
 //! - ✅ `providers::OpenAiCompatClient` —— `complete()` + xAI / OpenAI / DashScope 三预设；
 //!   复用 `RetryPolicy` 与 `ApiError` 强类型；inline error envelope 兜底；
 //!   `gpt-5*` 模型自动改用 `max_completion_tokens`；reasoning_content 提升为 Thinking block
+//! - ✅ `providers::ProviderClient` —— enum dispatcher（`Anthropic` / `Xai` / `OpenAi` 三变体），
+//!   显式构造、不读 env，`send_message()` 同步入口
+//! - ✅ ironclaw 切换 `claw-code-api` path-dep → `dasclaw_llm_provider`
 //! - 🟡 `OpenAiCompatClient::stream()`：留给 PR-A.3.1（ironclaw 当前 call site 仅用 `send_message`）
-//! - 🟡 删除主仓 `claw-code-api` path-dep：留给 PR-A.4
+//! - 🟡 `ProviderClient::stream_message()` dispatch：依赖 `OpenAiCompatClient::stream()`，同上
 //!
 //! 与 `claw-code-api` 的设计差异（顺势处理架构债，详见 ADR-118 §8.5）：
 //!
@@ -50,8 +53,8 @@ pub use http::{build_http_client, build_http_client_with, ProxyConfig};
 pub use providers::{
     detect_provider_kind, max_tokens_for_model, max_tokens_for_model_with_override,
     metadata_for_model, model_token_limit, resolve_model_alias, AnthropicClient, AnthropicStream,
-    AuthSource, EnvSnapshot, ModelTokenLimit, OpenAiCompatClient, OpenAiCompatConfig, ProviderKind,
-    ProviderMetadata,
+    AuthSource, EnvSnapshot, ModelTokenLimit, OpenAiCompatClient, OpenAiCompatConfig,
+    ProviderClient, ProviderKind, ProviderMetadata,
 };
 pub use retry::{parse_retry_after, RetryPolicy};
 pub use sse::{parse_frame, SseParser};

--- a/crates/dasclaw_llm_provider/src/providers/client.rs
+++ b/crates/dasclaw_llm_provider/src/providers/client.rs
@@ -1,0 +1,94 @@
+//! [`ProviderClient`] —— 跨协议的 enum dispatcher。
+//!
+//! 把 Anthropic Messages / xAI Chat Completions / OpenAI Chat Completions 三种
+//! 协议的 client 统一在一个 enum 下，提供共同的 [`send_message`](ProviderClient::send_message)
+//! 入口（同步 `complete` 调用）。本类型**不读取环境变量**，调用方需用具体变体
+//! 显式构造，符合 [ADR-118 §8.5] 「无 env 副作用」原则。
+//!
+//! # 设计差异（vs `claw-code-api::ProviderClient`）
+//!
+//! - **不提供 `from_model(model)`**：原 `claw-code-api` 的 `from_model` 内部读 env
+//!   构造 client，违反纯函数原则。本 crate 让调用方在应用层做 env 采集 + 显式
+//!   构造，避免库层与进程环境耦合。
+//! - **不提供 `prompt_cache*` / `with_prompt_cache`**：PromptCache 是 `claw-code`
+//!   的应用层概念（依赖 telemetry / runtime）；本 crate 保持纯 HTTP client。
+//! - **不提供 `stream_message` dispatch**：当前 ironclaw call site 仅消费同步
+//!   `send_message`；流式入口留给 PR-A.3.1（[`OpenAiCompatClient::stream`] 落地后）。
+//!
+//! [ADR-118 §8.5]: ../../../docs/plans/architecture-refactor/adr-118-claw-code-readonly-and-self-impl.md
+//! [`OpenAiCompatClient::stream`]: super::openai_compat::OpenAiCompatClient
+
+use crate::error::ApiError;
+use crate::providers::anthropic::AnthropicClient;
+use crate::providers::openai_compat::OpenAiCompatClient;
+use crate::providers::ProviderKind;
+use crate::types::{MessageRequest, MessageResponse};
+
+/// 路由到具体协议 client 的 enum。
+///
+/// 调用方根据模型 / 配置先选定变体，再用 [`send_message`](Self::send_message)
+/// 同步发起请求，下层 client 负责 HTTP / 鉴权 / 重试。
+#[derive(Debug, Clone)]
+pub enum ProviderClient {
+    /// Anthropic Messages API client。
+    Anthropic(AnthropicClient),
+    /// xAI Grok（OpenAI Chat Completions 兼容协议 + 独立 base URL）。
+    Xai(OpenAiCompatClient),
+    /// OpenAI Chat Completions 协议 client（含 OpenAI 自家、DashScope、Groq、
+    /// Kimi、OpenRouter、Tinfoil、Ollama 等所有兼容厂商）。
+    OpenAi(OpenAiCompatClient),
+}
+
+impl ProviderClient {
+    /// 当前 client 走的协议类型。
+    #[must_use]
+    pub const fn provider_kind(&self) -> ProviderKind {
+        match self {
+            Self::Anthropic(_) => ProviderKind::Anthropic,
+            Self::Xai(_) => ProviderKind::Xai,
+            Self::OpenAi(_) => ProviderKind::OpenAi,
+        }
+    }
+
+    /// 同步发送一个消息请求并返回完整响应（非流式）。
+    ///
+    /// 内部按变体 dispatch 到具体 client 的 `complete` 方法；错误透传 [`ApiError`]
+    /// 强类型变体，调用方可精确决策重试 / 重新鉴权。
+    pub async fn send_message(
+        &self,
+        request: &MessageRequest,
+    ) -> Result<MessageResponse, ApiError> {
+        match self {
+            Self::Anthropic(client) => client.complete(request).await,
+            Self::Xai(client) | Self::OpenAi(client) => client.complete(request).await,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::providers::openai_compat::OpenAiCompatConfig;
+
+    #[test]
+    fn provider_kind_matches_variant() {
+        let anthropic = AnthropicClient::new("sk-ant-test").expect("build anthropic");
+        let openai_inner = OpenAiCompatClient::new("sk-openai-test", OpenAiCompatConfig::openai())
+            .expect("build openai");
+        let xai_inner =
+            OpenAiCompatClient::new("xai-test", OpenAiCompatConfig::xai()).expect("build xai");
+
+        assert_eq!(
+            ProviderClient::Anthropic(anthropic).provider_kind(),
+            ProviderKind::Anthropic
+        );
+        assert_eq!(
+            ProviderClient::OpenAi(openai_inner).provider_kind(),
+            ProviderKind::OpenAi
+        );
+        assert_eq!(
+            ProviderClient::Xai(xai_inner).provider_kind(),
+            ProviderKind::Xai
+        );
+    }
+}

--- a/crates/dasclaw_llm_provider/src/providers/mod.rs
+++ b/crates/dasclaw_llm_provider/src/providers/mod.rs
@@ -9,9 +9,11 @@
 //!   实际 HTTP client 在 PR-A.1+ 落地，路由 metadata 与 client 解耦。
 
 pub mod anthropic;
+pub mod client;
 pub mod openai_compat;
 
 pub use anthropic::{AnthropicClient, AnthropicStream, AuthSource};
+pub use client::ProviderClient;
 pub use openai_compat::{OpenAiCompatClient, OpenAiCompatConfig};
 
 /// LLM provider 类型（决定走 Anthropic Messages 协议 / OpenAI Chat Completions 协议 / xAI 协议）。

--- a/desktop-client/ironclaw/Cargo.toml
+++ b/desktop-client/ironclaw/Cargo.toml
@@ -144,9 +144,9 @@ blake3 = "1"
 rand = "0.8"
 subtle = "2"  # Constant-time comparisons for token validation
 
-# Multi-provider LLM support (claw-code-api native client)
-# crate 真实 package 名为 `api`，这里重命名为 claw-code-api 避免泛名冲突。
-claw-code-api = { path = "../../claw-code/rust/crates/api", package = "api" }
+# Multi-provider LLM support (主仓自实现 client，W6-C PR-A.4 起替代 claw-code-api path-dep；
+# claw-code 子仓自此只读保留，详见 ADR-118)
+dasclaw_llm_provider = { path = "../../crates/dasclaw_llm_provider" }
 
 # AWS Bedrock (native Converse API, opt-in via --features bedrock)
 aws-config = { version = "1", features = ["behavior-version-latest"], optional = true }
@@ -229,9 +229,9 @@ harness = false
 default = ["postgres", "libsql", "html-to-markdown"]
 test-support = ["dep:tempfile"]
 # 历史遗留：Phase 2 Step I 之前用来切换 rig-core / claw-code-api 两套 LLM
-# 后端，现在 claw-code-api 是唯一路径，feature 名保留为空 no-op，避免下游
-# （如 desktop-client）触发构建失败。下一次 minor 版本可同步删除该 feature
-# 与 desktop-client/Cargo.toml 中的 passthrough。
+# 后端，W6-C PR-A.4 之后 dasclaw_llm_provider 是唯一路径，feature 名保留为空
+# no-op，避免下游（如 desktop-client）触发构建失败。下一次 minor 版本可同步
+# 删除该 feature 与 desktop-client/Cargo.toml 中的 passthrough。
 claw-code-llm = []
 postgres = [
     "dep:deadpool-postgres",

--- a/desktop-client/ironclaw/src/llm/claw_code_provider.rs
+++ b/desktop-client/ironclaw/src/llm/claw_code_provider.rs
@@ -1,7 +1,11 @@
-//! `ClawCodeLlmProvider` — LLM Provider 基于 `claw-code-api` 的原生客户端。
+//! `ClawCodeLlmProvider` — LLM Provider 基于 `dasclaw_llm_provider` 的原生客户端。
 //!
 //! Phase 2 Step I 完成后，本模块是生产唯一 LLM 路径
 //! （`GithubCopilot` / `CodexChatGpt` 由各自独立 provider 处理）。
+//!
+//! W6-C PR-A.4 完成后，底层 client 切换到主仓自实现的 [`dasclaw_llm_provider`]，
+//! 不再依赖 `claw-code/rust/crates/api` 的 path-dep（claw-code 子仓只读化，详见
+//! [ADR-118](../../../../docs/plans/architecture-refactor/adr-118-claw-code-readonly-and-self-impl.md)）。
 //!
 //! 关键收益：
 //! - `OpenAiCompatClient` 已为各 OpenAI-compat 厂商（DashScope/Kimi/xAI/Ollama）
@@ -10,9 +14,9 @@
 //! - 编译期裁掉大量历史 rig 适配层的异构类型体操。
 
 use async_trait::async_trait;
-use claw_code_api::{
-    AnthropicClient, AuthSource, InputContentBlock, InputMessage, MessageRequest, MessageResponse,
-    OpenAiCompatClient, OpenAiCompatConfig, OutputContentBlock, ProviderClient,
+use dasclaw_llm_provider::{
+    AnthropicClient, ApiError, AuthSource, InputContentBlock, InputMessage, MessageRequest,
+    MessageResponse, OpenAiCompatClient, OpenAiCompatConfig, OutputContentBlock, ProviderClient,
     ToolChoice as ApiToolChoice, ToolDefinition as ApiToolDefinition, ToolResultContentBlock,
 };
 use rust_decimal::Decimal;
@@ -39,19 +43,6 @@ pub struct ClawCodeLlmProvider {
 }
 
 impl ClawCodeLlmProvider {
-    /// 根据模型名自动探测 Provider 类型（OpenAI / Anthropic / xAI / DashScope 等）。
-    pub fn from_model(model: impl Into<String>) -> Result<Self, LlmError> {
-        let configured_model = model.into();
-        let resolved_model = claw_code_api::resolve_model_alias(&configured_model).to_string();
-        let client = ProviderClient::from_model(&configured_model).map_err(map_api_error)?;
-        Ok(Self {
-            client,
-            configured_model,
-            resolved_model,
-            cost_rates: None,
-        })
-    }
-
     /// 覆盖 token 单价（用于 `calculate_cost` / `cost_per_token`）。
     #[must_use]
     pub fn with_cost_rates(mut self, input: Decimal, output: Decimal) -> Self {
@@ -62,7 +53,7 @@ impl ClawCodeLlmProvider {
     /// 从 ironclaw 的 [`RegistryProviderConfig`] 构造一个 Provider。
     ///
     /// 这是 **Step D** 的核心入口，负责把 x-claw 现有的 providers.json 配置
-    /// 映射到 `claw-code-api` 的具体 client：
+    /// 映射到 `dasclaw_llm_provider` 的具体 client：
     ///
     /// | `ProviderProtocol`  | 映射目标                                                    |
     /// |---------------------|-------------------------------------------------------------|
@@ -74,12 +65,13 @@ impl ClawCodeLlmProvider {
     /// 不读取任何环境变量：凭据/URL 都来自显式配置，符合 x-claw 的 keychain 模型。
     pub fn from_registry_config(config: &RegistryProviderConfig) -> Result<Self, LlmError> {
         let configured_model = config.model.clone();
-        let resolved_model = claw_code_api::resolve_model_alias(&configured_model).to_string();
+        let resolved_model =
+            dasclaw_llm_provider::resolve_model_alias(&configured_model).to_string();
 
         let client = match config.protocol {
             ProviderProtocol::Anthropic => build_anthropic_client(config)?,
             ProviderProtocol::OpenAiCompletions => build_openai_compat_client(config)?,
-            ProviderProtocol::Ollama => build_ollama_client(config),
+            ProviderProtocol::Ollama => build_ollama_client(config)?,
             ProviderProtocol::GithubCopilot => {
                 return Err(LlmError::RequestFailed {
                     provider: config.provider_id.clone(),
@@ -107,7 +99,7 @@ impl ClawCodeLlmProvider {
 }
 
 // ============================================================================
-// 请求映射：ironclaw → claw-code-api
+// 请求映射：ironclaw → dasclaw_llm_provider
 // ============================================================================
 
 /// 把 ironclaw 的 `CompletionRequest` 映射为 claw-code-api 的 `MessageRequest`。
@@ -212,8 +204,8 @@ fn map_user_message(m: &ChatMessage) -> InputMessage {
                     content.push(InputContentBlock::Text { text: text.clone() })
                 }
                 ContentPart::ImageUrl { image_url: _ } => {
-                    // claw-code-api 的 InputContentBlock 目前不直接接受 OpenAI image_url，
-                    // 交由未来扩展。此处降级为占位文本以免丢失语义。
+                    // dasclaw_llm_provider 的 InputContentBlock 目前不直接接受 OpenAI
+                    // image_url，交由未来扩展。此处降级为占位文本以免丢失语义。
                     content.push(InputContentBlock::Text {
                         text: "[image]".to_string(),
                     });
@@ -296,7 +288,7 @@ fn map_tool_choice(choice: &str) -> Option<ApiToolChoice> {
 }
 
 // ============================================================================
-// 响应映射：claw-code-api → ironclaw
+// 响应映射：dasclaw_llm_provider → ironclaw
 // ============================================================================
 
 pub(crate) fn map_message_response(resp: MessageResponse) -> ToolCompletionResponse {
@@ -364,9 +356,9 @@ fn map_finish_reason(reason: Option<&str>) -> FinishReason {
     }
 }
 
-fn map_api_error(err: claw_code_api::ApiError) -> LlmError {
+fn map_api_error(err: ApiError) -> LlmError {
     LlmError::RequestFailed {
-        provider: "claw-code-api".to_string(),
+        provider: "dasclaw_llm_provider".to_string(),
         reason: err.to_string(),
     }
 }
@@ -406,24 +398,30 @@ fn build_anthropic_client(config: &RegistryProviderConfig) -> Result<ProviderCli
         }
     };
 
-    let client = AnthropicClient::from_auth(auth).with_base_url(config.base_url.clone());
+    let client = AnthropicClient::with_auth(auth)
+        .map_err(map_api_error)?
+        .with_base_url(config.base_url.clone());
     Ok(ProviderClient::Anthropic(client))
 }
 
 /// 根据模型名自动选 DashScope / xAI / OpenAI 预设；然后 override base_url。
+///
+/// 仅基于模型名做静态映射，不读取环境（`EnvSnapshot::default()` 即可），
+/// 因为 ironclaw 的鉴权一律来自 `RegistryProviderConfig` 的显式配置。
 fn pick_openai_compat_config(model: &str) -> (OpenAiCompatConfig, ProviderVariant) {
-    let resolved = claw_code_api::resolve_model_alias(model);
-    match claw_code_api::detect_provider_kind(&resolved) {
-        claw_code_api::ProviderKind::Xai => (OpenAiCompatConfig::xai(), ProviderVariant::Xai),
-        claw_code_api::ProviderKind::OpenAi => {
+    use dasclaw_llm_provider::{
+        EnvSnapshot, ProviderKind, detect_provider_kind, resolve_model_alias,
+    };
+    let resolved = resolve_model_alias(model);
+    match detect_provider_kind(&resolved, &EnvSnapshot::default()) {
+        ProviderKind::Xai => (OpenAiCompatConfig::xai(), ProviderVariant::Xai),
+        ProviderKind::OpenAi => {
             // 根据模型 metadata 进一步区分 DashScope vs 通用 OpenAI-compat
             // （Groq/Kimi/OpenRouter/Tinfoil 都用 openai() 预设 + 自定义 base_url）
             (OpenAiCompatConfig::openai(), ProviderVariant::OpenAi)
         }
         // Anthropic 不该走到这里；兜底 openai 预设以避免 panic，错误由上层抛出。
-        claw_code_api::ProviderKind::Anthropic => {
-            (OpenAiCompatConfig::openai(), ProviderVariant::OpenAi)
-        }
+        ProviderKind::Anthropic => (OpenAiCompatConfig::openai(), ProviderVariant::OpenAi),
     }
 }
 
@@ -439,20 +437,22 @@ fn build_openai_compat_client(config: &RegistryProviderConfig) -> Result<Provide
     })?;
 
     let (compat_config, variant) = pick_openai_compat_config(&config.model);
-    let client =
-        OpenAiCompatClient::new(api_key, compat_config).with_base_url(config.base_url.clone());
+    let client = OpenAiCompatClient::new(api_key, compat_config)
+        .map_err(map_api_error)?
+        .with_base_url(config.base_url.clone());
     Ok(match variant {
         ProviderVariant::Xai => ProviderClient::Xai(client),
         ProviderVariant::OpenAi => ProviderClient::OpenAi(client),
     })
 }
 
-fn build_ollama_client(config: &RegistryProviderConfig) -> ProviderClient {
+fn build_ollama_client(config: &RegistryProviderConfig) -> Result<ProviderClient, LlmError> {
     // Ollama 不需要 API key；如果用户填了 key（如反向代理鉴权），也传进去。
     let api_key = registry_api_key(config).unwrap_or_default();
     let client = OpenAiCompatClient::new(api_key, OpenAiCompatConfig::openai())
+        .map_err(map_api_error)?
         .with_base_url(config.base_url.clone());
-    ProviderClient::OpenAi(client)
+    Ok(ProviderClient::OpenAi(client))
 }
 
 // ============================================================================
@@ -531,7 +531,7 @@ impl LlmProvider for ClawCodeLlmProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use claw_code_api::Usage;
+    use dasclaw_llm_provider::Usage;
     use serde_json::json;
 
     fn mk_user(text: &str) -> ChatMessage {
@@ -1003,7 +1003,7 @@ mod tests {
     // ========================================================================
 
     use crate::llm::config::{CacheRetention, RegistryProviderConfig};
-    use claw_code_api::ProviderKind;
+    use dasclaw_llm_provider::ProviderKind;
     use secrecy::SecretString;
 
     fn mk_config(

--- a/docs/plans/architecture-refactor/p0-w6c-ironclaw-call-site-inventory.md
+++ b/docs/plans/architecture-refactor/p0-w6c-ironclaw-call-site-inventory.md
@@ -1,0 +1,180 @@
+# P0 W6-C ironclaw 调用面 inventory（PR-A.4 准备）
+
+> **状态**：inventory（只读盘点）。本文件**不做架构决策**，只列事实。
+>
+> **目的**：在 PR-A.4 切换 `desktop-client/ironclaw` 的 `claw-code-api` path-dep 到
+> `dasclaw_llm_provider` 之前，把所有 ironclaw 端依赖 `claw_code_api::*` 的位置、签名、
+> 已移植/未移植状态全列出来，PR-A.4 实施时按本表逐条迁移。
+>
+> **来源**：
+> - Level 1 `semantic_search`：claude code api provider usage send_message stream
+> - Level 2 引用面：`grep_search "claw_code_api"` in `desktop-client/**/*.rs`（11 hit）+ Cargo.toml（5 hit）
+> - Level 3 字面量：`grep` `pub fn (with_|new|from_auth|complete|stream)` 双 client 比对
+>
+> **关联 ADR**：[ADR-118 §5 W6-C](adr-118-claw-code-readonly-and-self-impl.md#5-w6-c) /
+> [§8 实施事实账本](adr-118-claw-code-readonly-and-self-impl.md#8)
+
+## 1. 调用面总图
+
+ironclaw 中**唯一**消费 `claw-code-api` 的文件是 [`desktop-client/ironclaw/src/llm/claw_code_provider.rs`](../../desktop-client/ironclaw/src/llm/claw_code_provider.rs)（1351 LOC）。
+Cargo path-dep 在 [`desktop-client/ironclaw/Cargo.toml`](../../desktop-client/ironclaw/Cargo.toml#L149)：
+
+```toml
+claw-code-api = { path = "../../claw-code/rust/crates/api", package = "api" }
+```
+
+无第二个消费方。
+
+## 2. 引用符号清单（共 16 个）
+
+来源：`claw_code_provider.rs` 第 13-17 行 `use claw_code_api::{...}` 块 + 散落 `claw_code_api::xxx` 调用 + `tests` 块的 `use claw_code_api::Usage` / `use claw_code_api::ProviderKind`。
+
+| # | 符号 | 引用方式 | 在 `dasclaw_llm_provider` 已移植？ | 备注 |
+|---|---|---|---|---|
+| 1 | `AnthropicClient` | type | ✅ PR-A.2 | 字段名/构造方法有差异（见 §3.1） |
+| 2 | `AuthSource` | enum | ✅ PR-A.2 | 三变体齐全（`ApiKey` / `BearerToken` / `ApiKeyAndBearer`） |
+| 3 | `InputContentBlock` | type | ✅ PR-A.0 types | |
+| 4 | `InputMessage` | type | ✅ PR-A.0 types | `role: String`，非 enum |
+| 5 | `MessageRequest` | type | ✅ PR-A.0 types | |
+| 6 | `MessageResponse` | type | ✅ PR-A.0 types | |
+| 7 | `OpenAiCompatClient` | type | ✅ PR-A.3 | `complete()` only，`stream()` 留 PR-A.3.1 |
+| 8 | `OpenAiCompatConfig` | type | ✅ PR-A.3 | `openai()` / `xai()` / `dashscope()` 三预设齐 |
+| 9 | `OutputContentBlock` | type | ✅ PR-A.0 types | |
+| 10 | `ProviderClient` | enum + dispatcher | ❌ **未移植** | **PR-A.4 必须新增**，见 §3.2 |
+| 11 | `ToolChoice` | enum | ✅ PR-A.0 types | ironclaw 重命名为 `ApiToolChoice` |
+| 12 | `ToolDefinition` | struct | ✅ PR-A.0 types | ironclaw 重命名为 `ApiToolDefinition` |
+| 13 | `ToolResultContentBlock` | struct | ✅ PR-A.0 types | |
+| 14 | `ApiError` | error type | ✅ PR-A.0 error | dasclaw 拆变体更细 |
+| 15 | `Usage` | struct | ✅ PR-A.0 types | 测试块用 |
+| 16 | `ProviderKind` | enum | ✅ PR-A.0 providers | 测试块用 |
+
+## 3. 函数 / 方法调用清单
+
+### 3.1 已移植但**签名不兼容**（PR-A.4 必须改 ironclaw 调用方）
+
+| 调用位置（claw_code_provider.rs 行号） | 当前调用 | 目标 dasclaw 等价 | 签名差异 |
+|---|---|---|---|
+| L45, L77, L415 | `claw_code_api::resolve_model_alias(model) -> &'static str` | `dasclaw_llm_provider::resolve_model_alias(model) -> String` | 返回类型 `&'static str` → `String`，调用方已 `.to_string()` 兼容 |
+| L416 | `claw_code_api::detect_provider_kind(&resolved)` | `dasclaw_llm_provider::detect_provider_kind(&resolved, &env)` | **新增 `EnvSnapshot` 参数**：调用方需先 `EnvSnapshot::from_process_env()` 然后传引用 |
+| L411 (`build_anthropic_client`) | `AnthropicClient::from_auth(auth)` 返回 `Self` | `AnthropicClient::with_auth(auth)?` 返回 `Result<Self, ApiError>` | **可错构造**：调用方需 `?` 传播错误并 `map_err(map_api_error)` |
+| L449 (`build_openai_compat_client`) | `OpenAiCompatClient::new(key, config)` 返回 `Self` | `OpenAiCompatClient::new(key, config)?` 返回 `Result<Self, ApiError>` | **可错构造**：同上 |
+| L506, L539（`complete` / `complete_with_tools` 内 `self.client.send_message(&msg_req)`） | 通过 `ProviderClient` enum dispatch 到具体 client 的 `send_message` | 见 §3.2 — `ProviderClient` 还没移植 | **方法名也需考虑**：dasclaw 把 client 单点方法叫 `complete()`，不是 `send_message()` |
+
+### 3.2 未移植：`ProviderClient` enum dispatcher（PR-A.4 必须新增）
+
+claw-code 的 `ProviderClient` 提供三件事，ironclaw 全部依赖：
+
+```rust
+// claw-code/rust/crates/api/src/client.rs:10-104
+pub enum ProviderClient {
+    Anthropic(AnthropicClient),
+    Xai(OpenAiCompatClient),
+    OpenAi(OpenAiCompatClient),
+}
+impl ProviderClient {
+    pub fn from_model(model: &str) -> Result<Self, ApiError> { /* 别名 → kind → 默认 client */ }
+    pub fn from_model_with_anthropic_auth(model, anthropic_auth: Option<AuthSource>) -> Result<Self, ApiError>;
+    pub const fn provider_kind(&self) -> ProviderKind;
+    pub async fn send_message(&self, req: &MessageRequest) -> Result<MessageResponse, ApiError>;
+    pub async fn stream_message(&self, req: &MessageRequest) -> Result<MessageStream, ApiError>;
+    // 还有 prompt_cache 系列，ironclaw 未消费 → PR-A.4 不必移植
+}
+```
+
+ironclaw 实际消费点（`claw_code_provider.rs`）：
+- L46：`ProviderClient::from_model(&configured_model).map_err(map_api_error)?`
+- L412：`ProviderClient::Anthropic(client)` 构造（`build_anthropic_client` 末尾）
+- L455-458：`ProviderClient::Xai(client)` / `ProviderClient::OpenAi(client)` 构造（`build_openai_compat_client`）
+- L464：`ProviderClient::OpenAi(client)`（`build_ollama_client`）
+- L506, L539：`self.client.send_message(&msg_req).await`
+
+**ironclaw 未消费**的：`stream_message` / `provider_kind` / `prompt_cache*` / `from_model_with_anthropic_auth`。
+
+### 3.3 已移植且签名兼容（PR-A.4 改 import path 即可）
+
+| 符号 | claw-code 路径 | dasclaw 路径 |
+|---|---|---|
+| `InputContentBlock` / `InputMessage` / `MessageRequest` / `MessageResponse` / `OutputContentBlock` / `ToolChoice` / `ToolDefinition` / `ToolResultContentBlock` / `Usage` | `claw_code_api::*` | `dasclaw_llm_provider::*`（已 re-export） |
+| `ApiError` | `claw_code_api::ApiError` | `dasclaw_llm_provider::ApiError` |
+| `ProviderKind` | `claw_code_api::ProviderKind` | `dasclaw_llm_provider::ProviderKind` |
+| `AuthSource` | `claw_code_api::AuthSource` | `dasclaw_llm_provider::AuthSource` |
+| `AnthropicClient::with_base_url` / `OpenAiCompatClient::with_base_url` | 同名 | 同名（builder pattern 一致） |
+
+## 4. PR-A.4 必做改动清单（按 file 分块）
+
+### 4.1 `desktop-client/ironclaw/Cargo.toml`
+
+- 删除 `claw-code-api = { path = "../../claw-code/rust/crates/api", package = "api" }`（L149）
+- 新增 `dasclaw_llm_provider = { path = "../../crates/dasclaw_llm_provider" }`
+- 注释（L147-148, L231-232）一并更新或删除
+
+### 4.2 `desktop-client/ironclaw/src/llm/claw_code_provider.rs`
+
+按 §3.1 + §3.2 改：
+
+1. `use` 块全部改 `claw_code_api::` → `dasclaw_llm_provider::`
+2. `from_model` (L46) 调用方：先 `let env = EnvSnapshot::from_process_env();` 再两步调（kind 检测 + 构造），或者**在 dasclaw 增 `ProviderClient::from_model(model)` 兼容方法**
+3. `AnthropicClient::from_auth(auth)` (L411) → `with_auth(auth)?`
+4. `OpenAiCompatClient::new(...)` (L449, L460) 加 `?`
+5. `detect_provider_kind(&resolved)` (L416) 加 `EnvSnapshot` 参数
+6. `client.send_message(&msg_req)` (L506, L539) 改 `client.complete(&msg_req)` 或在 dasclaw `ProviderClient` 上提供 `send_message` alias
+7. 测试块 (L534, L1006) `use` 改路径
+
+### 4.3 选项 A vs 选项 B（PR-A.4 设计决策点，不在本 inventory 决断）
+
+- **选项 A — ironclaw 全面适配 dasclaw 新签名**：调用方写 `EnvSnapshot::from_process_env()`、`with_auth(...)?`、`.complete(...)`，dasclaw 不加任何兼容层。**优点**：dasclaw API 干净；**缺点**：PR-A.4 diff 大。
+- **选项 B — dasclaw 加薄兼容层**：在 dasclaw 提供 `ProviderClient::from_model(&str)`（内部读 env）、`send_message` 作为 `complete` 的 alias、`AnthropicClient::from_auth(auth) -> Self` 内部 unwrap_or_panic。**优点**：PR-A.4 改动小；**缺点**：dasclaw 沾上"无 env 副作用"原则的反例（ADR-118 §8.5 第 2 点明确说 dasclaw 不读 env）。
+
+**推荐**：**选项 A**。ADR-118 §8.5 已经把"无 env 副作用"列为顺势处理的架构债，PR-A.4 一次性还清，比留兼容层后续再拆更彻底。`ProviderClient` enum 仍然在 dasclaw 提供（因 ironclaw 真的需要 enum dispatch），但 `from_model` 改成 `from_model(model, &env)` 显式签名。
+
+## 5. 已确认的非目标（PR-A.4 不做）
+
+1. **`OpenAiCompatClient::stream()`** 移植 — 留 PR-A.3.1，ironclaw 当前 call site 全部 `send_message` (`stream: false`)
+2. **`AnthropicClient::stream()` 在 `ProviderClient::stream_message` 上的 dispatch** — ironclaw 未消费，dasclaw `ProviderClient::stream_message` 不必先实现（PR-A.4 可只暴露 `send_message` dispatch）
+3. **`prompt_cache*` 方法族** — ironclaw 未消费
+4. **`from_env*` 工厂方法**（`AnthropicClient::from_env`、`OpenAiCompatClient::from_env`、`AnthropicClient::from_env_or_saved`）— ironclaw `build_anthropic_client` / `build_openai_compat_client` 都从 `RegistryProviderConfig` 显式构造 `AuthSource`，不走 env，无须移植
+5. **`ProviderClient::with_prompt_cache` / `prompt_cache_stats` / `take_last_prompt_cache_record`** — ironclaw 未消费
+6. **`ProviderClient::from_model_with_anthropic_auth`** — ironclaw 未消费（OAuth 走 `build_anthropic_client` 显式）
+7. **删除 `claw-code` 子仓本身** — ADR-118 §5 已声明 W6-C 后子仓只读保留，不删除
+
+## 6. 验证清单（PR-A.4 本地最低门）
+
+按 [AGENTS.md "本地快速开发节奏"](../../AGENTS.md) **档 2 推荐**（基础库改下游消费方）：
+
+```bash
+# 1. 本 crate
+cargo check -p dasclaw_llm_provider --tests
+cargo nextest run -p dasclaw_llm_provider
+
+# 2. 下游 — 基础库改动必跑
+cargo check --workspace --tests          # ironclaw + desktop-client + admin-backend 全编
+
+# 3. 局部测试
+cargo nextest run -p ironclaw --lib llm
+cargo build -p desktop-client --lib --tests   # link-time / Tauri state 验证
+
+# 4. 标准三件套
+cargo fmt --all
+python3.12 scripts/check_no_panics.py --base origin/xClaw
+cargo clippy --no-deps -p dasclaw_llm_provider --all-targets -- -D warnings
+cargo clippy --no-deps -p ironclaw --all-targets -- -D warnings
+```
+
+## 7. 三层验证证据存档
+
+按 [AGENTS.md 分析工具使用规范](../../AGENTS.md) 要求，本 inventory 是「跨项目对账 + 否定性结论」，已完成三层验证：
+
+- **Level 1 `semantic_search`**：query "ironclaw claude code api provider usage send_message stream" → 命中 `claw_code_provider.rs` / `claw_code_api::*` import 块 / `ProviderClient` 实现 / dasclaw_llm_provider 当前 re-export 状态。
+- **Level 2 `grep_search`**：`claw_code_api` in `desktop-client/**/*.rs` → 11 hit（全部在 `claw_code_provider.rs`）；`claw-code-api|claw_code_api` in `desktop-client/**/Cargo.toml` → 5 hit（仅 ironclaw/Cargo.toml）。
+- **Level 3 `grep_search`**：`pub fn (with_|new|from_auth|complete|stream|base_url)` 在 dasclaw 双 client 与 claw-code 双 client 上分别枚举 → 签名差异表（§3.1）。
+
+**否定性结论 + 双证据**：
+- "ironclaw 未消费 stream_message" — Level 2 grep `stream_message|stream(` in `desktop-client/ironclaw/src/llm/*.rs` 无 hit + Level 1 ADR-118 §8 事实账本表"streaming = ❌（trait 默认）"
+- "ironclaw 未消费 prompt_cache*" — Level 2 grep `prompt_cache` in `desktop-client/ironclaw/src/llm/*.rs` 无 hit
+- "`ProviderClient` 在 dasclaw 不存在" — Level 2 grep `ProviderClient` in `crates/dasclaw_llm_provider/src/**` 无 hit + Level 1 lib.rs re-export 列表无该名
+
+---
+
+**文档版本**：v1（inventory 初稿，伴随 PR-A.4 起草）
+**生成时间**：随 PR-A.4 准备工作创建
+**生成方法**：`semantic_search` → `grep_search` → `read_file` 三层验证后人工汇总


### PR DESCRIPTION
## 背景/目标

ADR-118 §5 W6-C 迁移路线图 **收官步**：把 ironclaw 的 LLM client 后端从 `claw-code-api` path-dep 切换到主仓自实现的 `dasclaw_llm_provider`。完成后 `claw-code/` 子仓不再被主仓引用，可按 ADR-118 进入只读阶段。

> ⚠️ **Stacked PR**：base = `w6c-dasclaw-llm-provider-openai-compat` (PR #156)，**请先 review/merge #156，再看本 PR**。

## 改动范围

- `dasclaw_llm_provider`：新增 `ProviderClient` enum dispatcher（Anthropic/Xai/OpenAi 三协议）
- `desktop-client/ironclaw/Cargo.toml`：替换 path-dep
- `desktop-client/ironclaw/src/llm/claw_code_provider.rs`：11 处替换 + 4 处签名差异适配（`?` 链路）
- 删除 dead code `ClawCodeLlmProvider::from_model`（三层验证 0 外部调用方）
- 调用清单文档 `docs/plans/architecture-refactor/p0-w6c-ironclaw-call-site-inventory.md`

## 非目标（What's NOT in this PR）

- 不实现 `ProviderClient::stream_message`（ironclaw 当前仅用 `send_message`，留 PR-A.5）
- 不实现 `ProviderClient::from_model`（保 dasclaw env 纯净，§8.5）
- 不删除 `claw-code/` 子仓（ADR-118 后续 PR）

## 验证（命令 + 结果）

```text
cargo check -p dasclaw_llm_provider --tests        ✅
cargo check -p ironclaw --lib --tests              ✅
cargo nextest run -p dasclaw_llm_provider          131/131 ✅
cargo nextest run -p ironclaw --lib llm            681/681 ✅
cargo fmt --all                                    ✅
python3.12 scripts/check_no_panics.py --base origin/xClaw   ✅
cargo clippy -p dasclaw_llm_provider --all-targets -- -D warnings ✅
```

ironclaw clippy 34 条警告全部为 **预存遗留**（`web_search.rs` / `worker/job.rs` 等），grep 确认本 PR 改动文件 `claw_code_provider.rs` 无任何 clippy 命中。

## Merge Order

1. PR #154 (PR-A.2 AnthropicClient)
2. PR #156 (PR-A.3 OpenAiCompatClient)
3. **本 PR (PR-A.4 ironclaw cutover)**

Closes #157
Refs: ADR-118 §5 W6-C / §8.5