### PR TITLE
feat(adr-118): mark claw-code/ readonly + CI guard (W6-C wrap-up)

### DIFF
--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -132,15 +132,32 @@ jobs:
         BASE="${{ github.event.pull_request.base.sha }}"
         python3 scripts/check_no_panics.py --base "$BASE" --head HEAD
 
+  claw-code-readonly:
+    name: claw-code/ readonly guard (ADR-118)
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v6
+      with:
+        submodules: recursive
+        fetch-depth: 0
+    - uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+    - name: Reject changes inside claw-code/ outside of whitelist
+      run: |
+        BASE="${{ github.event.pull_request.base.sha }}"
+        python3 scripts/check_claw_code_readonly.py --base "$BASE" --head HEAD
+
   # Roll-up job for branch protection
   code-style:
     name: Code Style (fmt + clippy + deny)
     runs-on: ubuntu-latest
     if: always()
-    needs: [format, clippy, clippy-windows, deny-check, no-panics]
+    needs: [format, clippy, clippy-windows, deny-check, no-panics, claw-code-readonly]
     steps:
       - run: |
-          if [[ "${{ needs.format.result }}" != "success" || "${{ needs.clippy.result }}" != "success" || "${{ needs.deny-check.result }}" != "success" || "${{ needs.no-panics.result }}" != "success" ]]; then
+          if [[ "${{ needs.format.result }}" != "success" || "${{ needs.clippy.result }}" != "success" || "${{ needs.deny-check.result }}" != "success" || "${{ needs.no-panics.result }}" != "success" || "${{ needs.claw-code-readonly.result }}" != "success" ]]; then
             echo "One or more jobs failed"
             exit 1
           fi

--- a/scripts/check_claw_code_readonly.py
+++ b/scripts/check_claw_code_readonly.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3.12
+"""
+ADR-118 红线守卫：claw-code/ 子仓只读化检查。
+
+W6-C PR-A.4 完成后（#158 merged），主仓代码不再依赖 claw-code/ 路径下
+的任何 crate（path-dep 已替换为 `crates/dasclaw_llm_provider/`）。
+本守卫从父仓角度禁止 PR 修改 `claw-code` submodule pointer——任何
+能力端口都应通过 `dasclaw_*` 自实现路径完成，不应再 bump 子仓 commit。
+
+使用方法（本地）：
+    python3.12 scripts/check_claw_code_readonly.py --base origin/xClaw
+
+使用方法（CI）：
+    python3 scripts/check_claw_code_readonly.py --base "$BASE" --head HEAD
+
+例外：
+    无白名单。如确需破例（例：补一个安全 critical 的 fix 到子仓），
+    应先在主仓提交一个修订 ADR-118 的 PR 显式开闸，再 bump pointer。
+"""
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+
+GUARDED_SUBMODULE: str = "claw-code"
+
+
+def changed_paths(base: str, head: str) -> list[str]:
+    """返回 base..head 之间发生变更的路径（含 submodule 路径条目）。"""
+    out = subprocess.run(
+        ["git", "diff", "--name-only", f"{base}..{head}"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return [line for line in out.stdout.splitlines() if line]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base", required=True, help="base ref (e.g. origin/xClaw)")
+    parser.add_argument("--head", default="HEAD", help="head ref (default: HEAD)")
+    args = parser.parse_args()
+
+    paths = changed_paths(args.base, args.head)
+    if GUARDED_SUBMODULE in paths:
+        sys.stderr.write(
+            "ERROR: claw-code/ submodule pointer 已被改动；ADR-118 已将该子仓\n"
+            "标记为只读，禁止 bump pointer。\n\n"
+            "如需端口能力到主仓，请走 dasclaw_* crate 自实现路径，参考：\n"
+            "  docs/plans/architecture-refactor/adr-118-claw-code-readonly-and-self-impl.md\n\n"
+            "如确需破例修订 ADR-118 重新开闸，请先提交独立 PR 修改 ADR，\n"
+            "再 bump submodule pointer。\n"
+        )
+        return 1
+
+    print("OK: claw-code submodule pointer unchanged.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 背景/目标

ADR-118 §2 决策核心：W6-C PR-A.4（#158）完成后，主仓代码不再依赖 `claw-code/` 子仓。本 PR 把该决策从"约定"升级为"CI 红线"——任何 PR 若 bump `claw-code` submodule pointer 都会被守卫拦截。

本 PR 与 stacked PR-A 链 (#154 / #156 / #158) **完全独立**，不依赖任何上游 PR，可独立 review/merge。

## 改动范围

- 新增 `scripts/check_claw_code_readonly.py`（父仓视角的 submodule pointer 守卫）
- `.github/workflows/code_style.yml`：增加 `claw-code-readonly` job + 接入 `code-style` roll-up

## 非目标（What's NOT in this PR）

- 不在子仓内加 `.READONLY` 标记（claw-code 是 submodule，父仓不跟踪其内部文件，加了也不被父仓 commit）
- 不修改 `claw-code/README.md`（同上理由）
- 不删除子仓（保留作为只读参考材料，符合 ADR-118 §2）
- 不修改 `.gitmodules`

## 验证（命令 + 结果）

```text
python3.12 scripts/check_claw_code_readonly.py --base origin/xClaw   ✅ (OK)
python3.12 scripts/check_no_panics.py --base origin/xClaw            ✅

# 反向验证（人工伪造 submodule bump，确认守卫拦截）：
cd claw-code && git checkout HEAD~1 && cd ..
git add claw-code && git commit -m "tmp"
python3.12 scripts/check_claw_code_readonly.py --base HEAD~1 --head HEAD
# → EXIT=1 + 中文错误说明 ✅
```

Closes #159
Refs: ADR-118 §2 / §5.2