### PR TITLE
feat(dasclaw_llm_provider): OpenAiCompat 流式 + ProviderStream 分发器（W6-C PR-A.5）

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -232,18 +232,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
-name = "api"
-version = "0.1.0"
-dependencies = [
- "reqwest 0.12.28",
- "runtime",
- "serde",
- "serde_json",
- "telemetry",
- "tokio",
-]
-
-[[package]]
 name = "ar_archive_writer"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4282,7 +4270,6 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.4",
  "tower-service",
- "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -4632,7 +4619,6 @@ dependencies = [
  "aes-gcm",
  "aho-corasick",
  "anyhow",
- "api",
  "async-trait",
  "aws-config",
  "aws-sdk-bedrockruntime",
@@ -4652,6 +4638,7 @@ dependencies = [
  "dasclaw_apply_patch",
  "dasclaw_exec",
  "dasclaw_hooks",
+ "dasclaw_llm_provider",
  "dasclaw_net_proxy",
  "dasclaw_sandbox",
  "deadpool-postgres",
@@ -6664,14 +6651,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "plugins"
-version = "0.1.0"
-dependencies = [
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "png"
 version = "0.17.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7534,7 +7513,6 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams 0.4.2",
  "web-sys",
- "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -7656,21 +7634,6 @@ dependencies = [
  "spki",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "runtime"
-version = "0.1.0"
-dependencies = [
- "glob",
- "plugins",
- "regex",
- "serde",
- "serde_json",
- "sha2",
- "telemetry",
- "tokio",
- "walkdir",
 ]
 
 [[package]]
@@ -9537,14 +9500,6 @@ dependencies = [
  "dunce",
  "embed-resource",
  "toml 0.9.12+spec-1.1.0",
-]
-
-[[package]]
-name = "telemetry"
-version = "0.1.0"
-dependencies = [
- "serde",
- "serde_json",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2469,6 +2469,7 @@ dependencies = [
  "serde_json",
  "thiserror 1.0.69",
  "tokio",
+ "wiremock",
 ]
 
 [[package]]

--- a/crates/dasclaw_llm_provider/Cargo.toml
+++ b/crates/dasclaw_llm_provider/Cargo.toml
@@ -14,7 +14,9 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "1"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls-native-roots"] }
+tokio = { version = "1", default-features = false, features = ["time"] }
 
 [dev-dependencies]
 serde_json = "1"
-tokio = { version = "1", features = ["macros", "rt"] }
+tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread", "time"] }
+wiremock = "0.6"

--- a/crates/dasclaw_llm_provider/src/lib.rs
+++ b/crates/dasclaw_llm_provider/src/lib.rs
@@ -54,7 +54,7 @@ pub use providers::{
     detect_provider_kind, max_tokens_for_model, max_tokens_for_model_with_override,
     metadata_for_model, model_token_limit, resolve_model_alias, AnthropicClient, AnthropicStream,
     AuthSource, EnvSnapshot, ModelTokenLimit, OpenAiCompatClient, OpenAiCompatConfig,
-    ProviderClient, ProviderKind, ProviderMetadata,
+    OpenAiCompatStream, ProviderClient, ProviderKind, ProviderMetadata, ProviderStream,
 };
 pub use retry::{parse_retry_after, RetryPolicy};
 pub use sse::{parse_frame, SseParser};

--- a/crates/dasclaw_llm_provider/src/lib.rs
+++ b/crates/dasclaw_llm_provider/src/lib.rs
@@ -4,7 +4,7 @@
 //! claw-code 子仓视为只读参考库，本 crate **重新设计** Anthropic Messages /
 //! OpenAI Chat Completions 兼容层 wire 类型与 client 抽象，不直接消费子仓代码。
 //!
-//! 当前阶段：**PR-A.3 — OpenAI Chat Completions 兼容客户端**
+//! 当前阶段：**PR-A.4 — `ProviderClient` enum dispatcher + ironclaw 切换 path-dep**
 //! - ✅ wire 类型（`types`）—— Anthropic Messages 协议输入/输出/streaming events
 //! - ✅ 强类型错误（`error::ApiError`）—— 拆分 `RateLimited` / `AuthFailed` /
 //!   `ContextWindowExceeded` / `ServerError` / `Transport` / `MalformedSseFrame` 等，
@@ -20,8 +20,11 @@
 //! - ✅ `providers::OpenAiCompatClient` —— `complete()` + xAI / OpenAI / DashScope 三预设；
 //!   复用 `RetryPolicy` 与 `ApiError` 强类型；inline error envelope 兜底；
 //!   `gpt-5*` 模型自动改用 `max_completion_tokens`；reasoning_content 提升为 Thinking block
+//! - ✅ `providers::ProviderClient` —— enum dispatcher（`Anthropic` / `Xai` / `OpenAi` 三变体），
+//!   显式构造、不读 env，`send_message()` 同步入口
+//! - ✅ ironclaw 切换 `claw-code-api` path-dep → `dasclaw_llm_provider`
 //! - 🟡 `OpenAiCompatClient::stream()`：留给 PR-A.3.1（ironclaw 当前 call site 仅用 `send_message`）
-//! - 🟡 删除主仓 `claw-code-api` path-dep：留给 PR-A.4
+//! - 🟡 `ProviderClient::stream_message()` dispatch：依赖 `OpenAiCompatClient::stream()`，同上
 //!
 //! 与 `claw-code-api` 的设计差异（顺势处理架构债，详见 ADR-118 §8.5）：
 //!
@@ -50,8 +53,8 @@ pub use http::{build_http_client, build_http_client_with, ProxyConfig};
 pub use providers::{
     detect_provider_kind, max_tokens_for_model, max_tokens_for_model_with_override,
     metadata_for_model, model_token_limit, resolve_model_alias, AnthropicClient, AnthropicStream,
-    AuthSource, EnvSnapshot, ModelTokenLimit, OpenAiCompatClient, OpenAiCompatConfig, ProviderKind,
-    ProviderMetadata,
+    AuthSource, EnvSnapshot, ModelTokenLimit, OpenAiCompatClient, OpenAiCompatConfig,
+    ProviderClient, ProviderKind, ProviderMetadata,
 };
 pub use retry::{parse_retry_after, RetryPolicy};
 pub use sse::{parse_frame, SseParser};

--- a/crates/dasclaw_llm_provider/src/lib.rs
+++ b/crates/dasclaw_llm_provider/src/lib.rs
@@ -4,7 +4,7 @@
 //! claw-code 子仓视为只读参考库，本 crate **重新设计** Anthropic Messages /
 //! OpenAI Chat Completions 兼容层 wire 类型与 client 抽象，不直接消费子仓代码。
 //!
-//! 当前阶段：**PR-A.2 — Anthropic Messages 客户端 + 重试策略**
+//! 当前阶段：**PR-A.3 — OpenAI Chat Completions 兼容客户端**
 //! - ✅ wire 类型（`types`）—— Anthropic Messages 协议输入/输出/streaming events
 //! - ✅ 强类型错误（`error::ApiError`）—— 拆分 `RateLimited` / `AuthFailed` /
 //!   `ContextWindowExceeded` / `ServerError` / `Transport` / `MalformedSseFrame` 等，
@@ -17,7 +17,10 @@
 //!   （**改进**：claw-code 完全忽略 `Retry-After`，本 crate 优先采纳上游建议）
 //! - ✅ `providers::AnthropicClient` —— `complete()` / `stream()` + 状态码精确映射到
 //!   `ApiError` 各变体；`AuthSource` 支持 `ApiKey` / `BearerToken` / 双 header
-//! - 🟡 `OpenAiCompatClient`：留给 PR-A.3
+//! - ✅ `providers::OpenAiCompatClient` —— `complete()` + xAI / OpenAI / DashScope 三预设；
+//!   复用 `RetryPolicy` 与 `ApiError` 强类型；inline error envelope 兜底；
+//!   `gpt-5*` 模型自动改用 `max_completion_tokens`；reasoning_content 提升为 Thinking block
+//! - 🟡 `OpenAiCompatClient::stream()`：留给 PR-A.3.1（ironclaw 当前 call site 仅用 `send_message`）
 //! - 🟡 删除主仓 `claw-code-api` path-dep：留给 PR-A.4
 //!
 //! 与 `claw-code-api` 的设计差异（顺势处理架构债，详见 ADR-118 §8.5）：
@@ -47,7 +50,8 @@ pub use http::{build_http_client, build_http_client_with, ProxyConfig};
 pub use providers::{
     detect_provider_kind, max_tokens_for_model, max_tokens_for_model_with_override,
     metadata_for_model, model_token_limit, resolve_model_alias, AnthropicClient, AnthropicStream,
-    AuthSource, EnvSnapshot, ModelTokenLimit, ProviderKind, ProviderMetadata,
+    AuthSource, EnvSnapshot, ModelTokenLimit, OpenAiCompatClient, OpenAiCompatConfig, ProviderKind,
+    ProviderMetadata,
 };
 pub use retry::{parse_retry_after, RetryPolicy};
 pub use sse::{parse_frame, SseParser};

--- a/crates/dasclaw_llm_provider/src/lib.rs
+++ b/crates/dasclaw_llm_provider/src/lib.rs
@@ -4,7 +4,7 @@
 //! claw-code 子仓视为只读参考库，本 crate **重新设计** Anthropic Messages /
 //! OpenAI Chat Completions 兼容层 wire 类型与 client 抽象，不直接消费子仓代码。
 //!
-//! 当前阶段：**PR-A.1 — HTTP transport + SSE 解析器原语**
+//! 当前阶段：**PR-A.2 — Anthropic Messages 客户端 + 重试策略**
 //! - ✅ wire 类型（`types`）—— Anthropic Messages 协议输入/输出/streaming events
 //! - ✅ 强类型错误（`error::ApiError`）—— 拆分 `RateLimited` / `AuthFailed` /
 //!   `ContextWindowExceeded` / `ServerError` / `Transport` / `MalformedSseFrame` 等，
@@ -13,8 +13,12 @@
 //! - ✅ `http::ProxyConfig` + `http::build_http_client_with` —— `reqwest::Client`
 //!   构造 + 代理（HTTP/HTTPS/统一 URL/no_proxy）支持，纯函数 + 显式 env 入口
 //! - ✅ `sse::SseParser` + `sse::parse_frame` —— 增量 SSE 帧解析器，识别 ping/DONE/comment
-//! - 🟡 `AnthropicClient` / `OpenAiCompatClient`：留给 PR-A.2 / PR-A.3，本 PR 暂未实现
-//! - 🟡 重试策略 + Retry-After 解析：随 PR-A.2 client 一并落地
+//! - ✅ `retry::RetryPolicy` —— 指数退避 + 抖动 + `Retry-After` 头部尊重
+//!   （**改进**：claw-code 完全忽略 `Retry-After`，本 crate 优先采纳上游建议）
+//! - ✅ `providers::AnthropicClient` —— `complete()` / `stream()` + 状态码精确映射到
+//!   `ApiError` 各变体；`AuthSource` 支持 `ApiKey` / `BearerToken` / 双 header
+//! - 🟡 `OpenAiCompatClient`：留给 PR-A.3
+//! - 🟡 删除主仓 `claw-code-api` path-dep：留给 PR-A.4
 //!
 //! 与 `claw-code-api` 的设计差异（顺势处理架构债，详见 ADR-118 §8.5）：
 //!
@@ -34,6 +38,7 @@
 pub mod error;
 pub mod http;
 pub mod providers;
+pub mod retry;
 pub mod sse;
 pub mod types;
 
@@ -41,9 +46,10 @@ pub use error::ApiError;
 pub use http::{build_http_client, build_http_client_with, ProxyConfig};
 pub use providers::{
     detect_provider_kind, max_tokens_for_model, max_tokens_for_model_with_override,
-    metadata_for_model, model_token_limit, resolve_model_alias, EnvSnapshot, ModelTokenLimit,
-    ProviderKind, ProviderMetadata,
+    metadata_for_model, model_token_limit, resolve_model_alias, AnthropicClient, AnthropicStream,
+    AuthSource, EnvSnapshot, ModelTokenLimit, ProviderKind, ProviderMetadata,
 };
+pub use retry::{parse_retry_after, RetryPolicy};
 pub use sse::{parse_frame, SseParser};
 pub use types::{
     ContentBlockDelta, ContentBlockDeltaEvent, ContentBlockStartEvent, ContentBlockStopEvent,

--- a/crates/dasclaw_llm_provider/src/providers/anthropic.rs
+++ b/crates/dasclaw_llm_provider/src/providers/anthropic.rs
@@ -1,0 +1,529 @@
+//! Anthropic Messages API 客户端。
+//!
+//! 实现 [Anthropic Messages API] 的 `/v1/messages` 端点，提供同步 [`complete`]
+//! 与流式 [`stream`] 两种调用模式。基于 [`crate::http::build_http_client_with`]
+//! 与 [`crate::sse::SseParser`] 原语。
+//!
+//! # 与 `claw-code-api::providers::anthropic` 的差异
+//!
+//! 1. **去除应用层耦合**：本 crate 不依赖 `runtime` / `telemetry` / `prompt_cache`，
+//!    `AnthropicClient` 不挂 `SessionTracer` / `PromptCache` 字段，纯 HTTP 客户端。
+//!    PromptCache / 会话追踪由上层 ironclaw 在调用方包装。
+//! 2. **错误强类型化**：HTTP 状态码精确分发到 `ApiError` 各变体（`RateLimited`、
+//!    `AuthFailed`、`ContextWindowExceeded`、`BadRequest`、`ServerError`、`Provider`），
+//!    上层免去字符串扫描。
+//! 3. **尊重 `Retry-After`**：429 响应携带 `Retry-After` 时优先采纳上游建议（受
+//!    `RetryPolicy::max_backoff` 约束）；claw-code 完全忽略此头部。
+//! 4. **OAuth 解耦**：本 PR 仅支持 `ApiKey` / `BearerToken` 静态凭据；OAuth flow
+//!    由后续 PR 单独承载，避免 client 主体逻辑被凭据轮转撑大。
+//!
+//! [Anthropic Messages API]: https://docs.anthropic.com/en/api/messages
+//! [`complete`]: AnthropicClient::complete
+//! [`stream`]: AnthropicClient::stream
+
+use std::collections::VecDeque;
+use std::time::Duration;
+
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
+
+use crate::error::ApiError;
+use crate::retry::{parse_retry_after, RetryPolicy};
+use crate::sse::SseParser;
+use crate::types::{MessageRequest, MessageResponse, StreamEvent};
+
+const ANTHROPIC_PROVIDER: &str = "anthropic";
+
+/// Anthropic API 默认 base URL。
+pub const DEFAULT_BASE_URL: &str = "https://api.anthropic.com";
+
+/// Anthropic API 版本号头部值。
+pub const ANTHROPIC_VERSION: &str = "2023-06-01";
+
+const REQUEST_ID_HEADER: &str = "request-id";
+const ALT_REQUEST_ID_HEADER: &str = "x-request-id";
+const RETRY_AFTER_HEADER: &str = "retry-after";
+
+/// Anthropic 客户端鉴权来源。
+///
+/// 同时携带 `ApiKey` 与 `BearerToken` 时，两者**都会**附加到请求（`x-api-key`
+/// 头 + `Authorization: Bearer` 头），与 claw-code 行为一致。
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AuthSource {
+    /// 无凭据 — 仅用于探针请求或测试 mock 场景。
+    None,
+    /// `sk-ant-*` 形式 API Key（走 `x-api-key` 头）。
+    ApiKey(String),
+    /// OAuth bearer token（走 `Authorization: Bearer` 头）。
+    BearerToken(String),
+    /// 两者都提供（部分企业网关需要双 header）。
+    ApiKeyAndBearer {
+        /// `sk-ant-*` API Key。
+        api_key: String,
+        /// OAuth bearer token。
+        bearer_token: String,
+    },
+}
+
+impl AuthSource {
+    fn apply(&self, builder: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
+        let mut builder = builder;
+        if let Some(api_key) = self.api_key() {
+            builder = builder.header("x-api-key", api_key);
+        }
+        if let Some(token) = self.bearer_token() {
+            builder = builder.bearer_auth(token);
+        }
+        builder
+    }
+
+    fn api_key(&self) -> Option<&str> {
+        match self {
+            Self::ApiKey(key) | Self::ApiKeyAndBearer { api_key: key, .. } => Some(key),
+            Self::None | Self::BearerToken(_) => None,
+        }
+    }
+
+    fn bearer_token(&self) -> Option<&str> {
+        match self {
+            Self::BearerToken(token)
+            | Self::ApiKeyAndBearer {
+                bearer_token: token,
+                ..
+            } => Some(token),
+            Self::None | Self::ApiKey(_) => None,
+        }
+    }
+}
+
+/// Anthropic Messages API 客户端。
+#[derive(Debug, Clone)]
+pub struct AnthropicClient {
+    http: reqwest::Client,
+    auth: AuthSource,
+    base_url: String,
+    retry_policy: RetryPolicy,
+}
+
+impl AnthropicClient {
+    /// 用 API Key 构造客户端，使用默认 `reqwest::Client` 与默认 [`RetryPolicy`]。
+    pub fn new(api_key: impl Into<String>) -> Result<Self, ApiError> {
+        Self::with_auth(AuthSource::ApiKey(api_key.into()))
+    }
+
+    /// 显式传入 [`AuthSource`]；其余字段取默认。
+    pub fn with_auth(auth: AuthSource) -> Result<Self, ApiError> {
+        Ok(Self {
+            http: crate::http::build_http_client_with(&crate::http::ProxyConfig::default())?,
+            auth,
+            base_url: DEFAULT_BASE_URL.to_string(),
+            retry_policy: RetryPolicy::default(),
+        })
+    }
+
+    /// 注入预构造的 `reqwest::Client`（例如已配置代理的客户端）。
+    #[must_use]
+    pub fn with_http_client(mut self, http: reqwest::Client) -> Self {
+        self.http = http;
+        self
+    }
+
+    /// 覆盖 base URL（如自托管网关 / Vertex / Bedrock 兼容前端）。
+    #[must_use]
+    pub fn with_base_url(mut self, base_url: impl Into<String>) -> Self {
+        self.base_url = base_url.into();
+        self
+    }
+
+    /// 覆盖默认 [`RetryPolicy`]。
+    #[must_use]
+    pub fn with_retry_policy(mut self, policy: RetryPolicy) -> Self {
+        self.retry_policy = policy;
+        self
+    }
+
+    /// 当前 base URL（只读）。
+    #[must_use]
+    pub fn base_url(&self) -> &str {
+        &self.base_url
+    }
+
+    /// 同步（非流式）发送消息请求。
+    ///
+    /// 内部强制将 `request.stream` 改写为 `false`。
+    pub async fn complete(&self, request: &MessageRequest) -> Result<MessageResponse, ApiError> {
+        let request = MessageRequest {
+            stream: false,
+            ..request.clone()
+        };
+        let response = self.send_with_retry(&request).await?;
+        let request_id = request_id_from_headers(response.headers());
+        let body = response
+            .text()
+            .await
+            .map_err(|err| ApiError::Transport(err.to_string()))?;
+        let mut parsed: MessageResponse =
+            serde_json::from_str(&body).map_err(|err| ApiError::Provider {
+                provider: ANTHROPIC_PROVIDER.to_string(),
+                reason: format!(
+                    "failed to deserialize MessageResponse for model={}: {}",
+                    request.model, err
+                ),
+                request_id: request_id.clone(),
+            })?;
+        if parsed.request_id.is_none() {
+            parsed.request_id = request_id;
+        }
+        Ok(parsed)
+    }
+
+    /// 流式发送消息请求；返回 [`AnthropicStream`] 增量推送 SSE 事件。
+    ///
+    /// 内部强制将 `request.stream` 改写为 `true`。
+    pub async fn stream(&self, request: &MessageRequest) -> Result<AnthropicStream, ApiError> {
+        let request = MessageRequest {
+            stream: true,
+            ..request.clone()
+        };
+        let response = self.send_with_retry(&request).await?;
+        let request_id = request_id_from_headers(response.headers());
+        Ok(AnthropicStream {
+            request_id,
+            response,
+            parser: SseParser::new().with_context(ANTHROPIC_PROVIDER, request.model.clone()),
+            pending: VecDeque::new(),
+            done: false,
+        })
+    }
+
+    async fn send_with_retry(
+        &self,
+        request: &MessageRequest,
+    ) -> Result<reqwest::Response, ApiError> {
+        let mut attempt: u32 = 0;
+        loop {
+            let outcome = self.send_once(request).await;
+            match outcome {
+                Ok(response) => return Ok(response),
+                Err(error) => {
+                    let retryable = error.is_retryable();
+                    if !retryable || attempt >= self.retry_policy.max_retries {
+                        return Err(error);
+                    }
+                    let suggested = retry_after_from_error(&error);
+                    attempt += 1;
+                    let delay = self
+                        .retry_policy
+                        .delay_for_attempt(attempt, suggested)
+                        .ok_or_else(|| ApiError::Provider {
+                            provider: ANTHROPIC_PROVIDER.to_string(),
+                            reason: format!("retry backoff overflow at attempt {attempt}"),
+                            request_id: error.request_id().map(ToOwned::to_owned),
+                        })?;
+                    tokio::time::sleep(delay).await;
+                }
+            }
+        }
+    }
+
+    async fn send_once(&self, request: &MessageRequest) -> Result<reqwest::Response, ApiError> {
+        let url = format!("{}/v1/messages", self.base_url.trim_end_matches('/'));
+        let builder = self
+            .http
+            .post(&url)
+            .header("content-type", "application/json")
+            .header("anthropic-version", ANTHROPIC_VERSION);
+        let builder = self.auth.apply(builder);
+        let response = builder
+            .json(request)
+            .send()
+            .await
+            .map_err(|err| ApiError::Transport(err.to_string()))?;
+        expect_success(response).await
+    }
+}
+
+/// Anthropic 流式响应；由 [`AnthropicClient::stream`] 创建。
+#[derive(Debug)]
+pub struct AnthropicStream {
+    request_id: Option<String>,
+    response: reqwest::Response,
+    parser: SseParser,
+    pending: VecDeque<StreamEvent>,
+    done: bool,
+}
+
+impl AnthropicStream {
+    /// 上游返回的 trace ID（如有）。
+    #[must_use]
+    pub fn request_id(&self) -> Option<&str> {
+        self.request_id.as_deref()
+    }
+
+    /// 增量拉取下一个 [`StreamEvent`]；流结束时返回 `Ok(None)`。
+    pub async fn next_event(&mut self) -> Result<Option<StreamEvent>, ApiError> {
+        loop {
+            if let Some(event) = self.pending.pop_front() {
+                return Ok(Some(event));
+            }
+            if self.done {
+                let trailing = self.parser.finish()?;
+                if trailing.is_empty() {
+                    return Ok(None);
+                }
+                self.pending.extend(trailing);
+                continue;
+            }
+            match self
+                .response
+                .chunk()
+                .await
+                .map_err(|err| ApiError::StreamInterrupted(err.to_string()))?
+            {
+                Some(chunk) => {
+                    self.pending.extend(self.parser.push(&chunk)?);
+                }
+                None => {
+                    self.done = true;
+                }
+            }
+        }
+    }
+}
+
+fn request_id_from_headers(headers: &HeaderMap) -> Option<String> {
+    headers
+        .get(REQUEST_ID_HEADER)
+        .or_else(|| headers.get(ALT_REQUEST_ID_HEADER))
+        .and_then(|value| value.to_str().ok())
+        .map(ToOwned::to_owned)
+}
+
+fn retry_after_from_error(error: &ApiError) -> Option<Duration> {
+    match error {
+        ApiError::RateLimited {
+            retry_after_secs: Some(secs),
+            ..
+        } => Some(Duration::from_secs(*secs)),
+        _ => None,
+    }
+}
+
+async fn expect_success(response: reqwest::Response) -> Result<reqwest::Response, ApiError> {
+    let status = response.status();
+    if status.is_success() {
+        return Ok(response);
+    }
+
+    let request_id = request_id_from_headers(response.headers());
+    let retry_after = response
+        .headers()
+        .get(RETRY_AFTER_HEADER)
+        .and_then(|value| value.to_str().ok())
+        .and_then(parse_retry_after);
+
+    let body = response.text().await.unwrap_or_default();
+    let parsed_message = parse_anthropic_error_message(&body);
+    let reason = parsed_message
+        .clone()
+        .unwrap_or_else(|| truncate_body(&body));
+
+    Err(map_status_to_api_error(
+        status,
+        reason,
+        retry_after,
+        request_id,
+    ))
+}
+
+fn map_status_to_api_error(
+    status: StatusCode,
+    reason: String,
+    retry_after: Option<Duration>,
+    request_id: Option<String>,
+) -> ApiError {
+    let provider = ANTHROPIC_PROVIDER.to_string();
+    match status.as_u16() {
+        429 => ApiError::RateLimited {
+            provider,
+            retry_after_secs: retry_after.map(|d| d.as_secs()),
+            request_id,
+        },
+        401 | 403 => ApiError::AuthFailed {
+            provider,
+            reason,
+            request_id,
+        },
+        400 => ApiError::BadRequest {
+            provider,
+            reason,
+            request_id,
+        },
+        408 | 409 | 500 | 502 | 503 | 504 => ApiError::ServerError {
+            provider,
+            status: status.as_u16(),
+            reason,
+            request_id,
+        },
+        _ => ApiError::Provider {
+            provider,
+            reason: format!("unexpected status {status}: {reason}"),
+            request_id,
+        },
+    }
+}
+
+fn parse_anthropic_error_message(body: &str) -> Option<String> {
+    #[derive(serde::Deserialize)]
+    struct ErrorEnvelope {
+        error: ErrorBody,
+    }
+    #[derive(serde::Deserialize)]
+    struct ErrorBody {
+        message: String,
+    }
+    serde_json::from_str::<ErrorEnvelope>(body)
+        .ok()
+        .map(|envelope| envelope.error.message)
+}
+
+fn truncate_body(body: &str) -> String {
+    const MAX: usize = 200;
+    if body.len() <= MAX {
+        return body.to_string();
+    }
+    let safe_end = (0..=MAX)
+        .rev()
+        .find(|&i| body.is_char_boundary(i))
+        .unwrap_or(0);
+    format!("{}…(truncated, {} bytes)", &body[..safe_end], body.len())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        map_status_to_api_error, parse_anthropic_error_message, AnthropicClient, AuthSource,
+    };
+    use crate::error::ApiError;
+    use reqwest::StatusCode;
+    use std::time::Duration;
+
+    #[test]
+    fn map_status_429_yields_rate_limited_with_retry_after() {
+        let err = map_status_to_api_error(
+            StatusCode::TOO_MANY_REQUESTS,
+            "slow down".to_string(),
+            Some(Duration::from_secs(7)),
+            Some("req-1".to_string()),
+        );
+        match err {
+            ApiError::RateLimited {
+                provider,
+                retry_after_secs,
+                request_id,
+            } => {
+                assert_eq!(provider, "anthropic");
+                assert_eq!(retry_after_secs, Some(7));
+                assert_eq!(request_id.as_deref(), Some("req-1"));
+            }
+            other => panic!("expected RateLimited, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn map_status_401_403_yields_auth_failed() {
+        for code in [401_u16, 403] {
+            let err = map_status_to_api_error(
+                StatusCode::from_u16(code).unwrap(),
+                "bad key".to_string(),
+                None,
+                None,
+            );
+            assert!(
+                matches!(err, ApiError::AuthFailed { .. }),
+                "status {code} should map to AuthFailed: got {err:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn map_status_400_yields_bad_request() {
+        let err =
+            map_status_to_api_error(StatusCode::BAD_REQUEST, "invalid".to_string(), None, None);
+        assert!(matches!(err, ApiError::BadRequest { .. }));
+    }
+
+    #[test]
+    fn map_retryable_5xx_yields_server_error() {
+        for code in [500_u16, 502, 503, 504, 408, 409] {
+            let err = map_status_to_api_error(
+                StatusCode::from_u16(code).unwrap(),
+                "boom".to_string(),
+                None,
+                None,
+            );
+            match err {
+                ApiError::ServerError { status, .. } => assert_eq!(status, code),
+                other => panic!("status {code} should map to ServerError: got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn map_unrelated_status_yields_provider_error() {
+        let err = map_status_to_api_error(StatusCode::IM_A_TEAPOT, "tea".to_string(), None, None);
+        assert!(matches!(err, ApiError::Provider { .. }));
+    }
+
+    #[test]
+    fn auth_source_apply_attaches_x_api_key() {
+        let auth = AuthSource::ApiKey("sk-ant-test".to_string());
+        assert_eq!(auth.api_key(), Some("sk-ant-test"));
+        assert!(auth.bearer_token().is_none());
+    }
+
+    #[test]
+    fn auth_source_apply_attaches_bearer_token() {
+        let auth = AuthSource::BearerToken("oauth-token".to_string());
+        assert_eq!(auth.bearer_token(), Some("oauth-token"));
+        assert!(auth.api_key().is_none());
+    }
+
+    #[test]
+    fn auth_source_apply_attaches_both_headers() {
+        let auth = AuthSource::ApiKeyAndBearer {
+            api_key: "sk-ant-test".to_string(),
+            bearer_token: "oauth-token".to_string(),
+        };
+        assert_eq!(auth.api_key(), Some("sk-ant-test"));
+        assert_eq!(auth.bearer_token(), Some("oauth-token"));
+    }
+
+    #[test]
+    fn parse_anthropic_error_message_picks_message_field() {
+        let body = r#"{"type":"error","error":{"type":"invalid_request_error","message":"max_tokens too high"}}"#;
+        assert_eq!(
+            parse_anthropic_error_message(body),
+            Some("max_tokens too high".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_anthropic_error_message_returns_none_on_unknown_shape() {
+        assert!(parse_anthropic_error_message("not json").is_none());
+        assert!(parse_anthropic_error_message("{}").is_none());
+    }
+
+    #[test]
+    fn anthropic_client_builders_compose_without_panic() {
+        let client = AnthropicClient::new("sk-ant-test")
+            .expect("client constructible")
+            .with_base_url("http://localhost:9999")
+            .with_retry_policy(crate::retry::RetryPolicy {
+                max_retries: 0,
+                ..Default::default()
+            });
+        assert_eq!(client.base_url(), "http://localhost:9999");
+        assert_eq!(client.retry_policy.max_retries, 0);
+    }
+}

--- a/crates/dasclaw_llm_provider/src/providers/client.rs
+++ b/crates/dasclaw_llm_provider/src/providers/client.rs
@@ -12,17 +12,15 @@
 //!   构造，避免库层与进程环境耦合。
 //! - **不提供 `prompt_cache*` / `with_prompt_cache`**：PromptCache 是 `claw-code`
 //!   的应用层概念（依赖 telemetry / runtime）；本 crate 保持纯 HTTP client。
-//! - **不提供 `stream_message` dispatch**：当前 ironclaw call site 仅消费同步
-//!   `send_message`；流式入口留给 PR-A.3.1（[`OpenAiCompatClient::stream`] 落地后）。
 //!
 //! [ADR-118 §8.5]: ../../../docs/plans/architecture-refactor/adr-118-claw-code-readonly-and-self-impl.md
 //! [`OpenAiCompatClient::stream`]: super::openai_compat::OpenAiCompatClient
 
 use crate::error::ApiError;
-use crate::providers::anthropic::AnthropicClient;
-use crate::providers::openai_compat::OpenAiCompatClient;
+use crate::providers::anthropic::{AnthropicClient, AnthropicStream};
+use crate::providers::openai_compat::{OpenAiCompatClient, OpenAiCompatStream};
 use crate::providers::ProviderKind;
-use crate::types::{MessageRequest, MessageResponse};
+use crate::types::{MessageRequest, MessageResponse, StreamEvent};
 
 /// 路由到具体协议 client 的 enum。
 ///
@@ -61,6 +59,59 @@ impl ProviderClient {
         match self {
             Self::Anthropic(client) => client.complete(request).await,
             Self::Xai(client) | Self::OpenAi(client) => client.complete(request).await,
+        }
+    }
+
+    /// 流式发送一个消息请求，返回统一的 [`ProviderStream`]，后续可反复调用
+    /// [`ProviderStream::next_event`] 增量拉取 [`StreamEvent`]。
+    ///
+    /// 各后端差异被全部抻在这一层：Anthropic 本身就是 Anthropic-风格事件，
+    /// OpenAI / xAI 后端在 [`OpenAiCompatStream`] 内部把 `chat.completion.chunk`
+    /// 翻译为 Anthropic 事件 —— 上层 ironclaw 只面对 [`StreamEvent`]。
+    pub async fn stream_message(
+        &self,
+        request: &MessageRequest,
+    ) -> Result<ProviderStream, ApiError> {
+        match self {
+            Self::Anthropic(client) => client.stream(request).await.map(ProviderStream::Anthropic),
+            Self::Xai(client) => client
+                .stream(request)
+                .await
+                .map(ProviderStream::OpenAiCompat),
+            Self::OpenAi(client) => client
+                .stream(request)
+                .await
+                .map(ProviderStream::OpenAiCompat),
+        }
+    }
+}
+
+/// 跨后端统一的流式响应 —— [`ProviderClient::stream_message`] 的返回类型。
+///
+/// 两个变体均提供同名 `next_event()` 与 `request_id()`，调用方不需区分后端。
+#[derive(Debug)]
+pub enum ProviderStream {
+    /// Anthropic Messages API 原生流。
+    Anthropic(AnthropicStream),
+    /// OpenAI Chat Completions 兼容流（包含 OpenAI / xAI / DashScope 等）。
+    OpenAiCompat(OpenAiCompatStream),
+}
+
+impl ProviderStream {
+    /// 增量拉取下一个 [`StreamEvent`]；流结束时返回 `Ok(None)`。
+    pub async fn next_event(&mut self) -> Result<Option<StreamEvent>, ApiError> {
+        match self {
+            Self::Anthropic(stream) => stream.next_event().await,
+            Self::OpenAiCompat(stream) => stream.next_event().await,
+        }
+    }
+
+    /// 上游返回的 trace ID（如有）。
+    #[must_use]
+    pub fn request_id(&self) -> Option<&str> {
+        match self {
+            Self::Anthropic(stream) => stream.request_id(),
+            Self::OpenAiCompat(stream) => stream.request_id(),
         }
     }
 }

--- a/crates/dasclaw_llm_provider/src/providers/client.rs
+++ b/crates/dasclaw_llm_provider/src/providers/client.rs
@@ -1,0 +1,94 @@
+//! [`ProviderClient`] —— 跨协议的 enum dispatcher。
+//!
+//! 把 Anthropic Messages / xAI Chat Completions / OpenAI Chat Completions 三种
+//! 协议的 client 统一在一个 enum 下，提供共同的 [`send_message`](ProviderClient::send_message)
+//! 入口（同步 `complete` 调用）。本类型**不读取环境变量**，调用方需用具体变体
+//! 显式构造，符合 [ADR-118 §8.5] 「无 env 副作用」原则。
+//!
+//! # 设计差异（vs `claw-code-api::ProviderClient`）
+//!
+//! - **不提供 `from_model(model)`**：原 `claw-code-api` 的 `from_model` 内部读 env
+//!   构造 client，违反纯函数原则。本 crate 让调用方在应用层做 env 采集 + 显式
+//!   构造，避免库层与进程环境耦合。
+//! - **不提供 `prompt_cache*` / `with_prompt_cache`**：PromptCache 是 `claw-code`
+//!   的应用层概念（依赖 telemetry / runtime）；本 crate 保持纯 HTTP client。
+//! - **不提供 `stream_message` dispatch**：当前 ironclaw call site 仅消费同步
+//!   `send_message`；流式入口留给 PR-A.3.1（[`OpenAiCompatClient::stream`] 落地后）。
+//!
+//! [ADR-118 §8.5]: ../../../docs/plans/architecture-refactor/adr-118-claw-code-readonly-and-self-impl.md
+//! [`OpenAiCompatClient::stream`]: super::openai_compat::OpenAiCompatClient
+
+use crate::error::ApiError;
+use crate::providers::anthropic::AnthropicClient;
+use crate::providers::openai_compat::OpenAiCompatClient;
+use crate::providers::ProviderKind;
+use crate::types::{MessageRequest, MessageResponse};
+
+/// 路由到具体协议 client 的 enum。
+///
+/// 调用方根据模型 / 配置先选定变体，再用 [`send_message`](Self::send_message)
+/// 同步发起请求，下层 client 负责 HTTP / 鉴权 / 重试。
+#[derive(Debug, Clone)]
+pub enum ProviderClient {
+    /// Anthropic Messages API client。
+    Anthropic(AnthropicClient),
+    /// xAI Grok（OpenAI Chat Completions 兼容协议 + 独立 base URL）。
+    Xai(OpenAiCompatClient),
+    /// OpenAI Chat Completions 协议 client（含 OpenAI 自家、DashScope、Groq、
+    /// Kimi、OpenRouter、Tinfoil、Ollama 等所有兼容厂商）。
+    OpenAi(OpenAiCompatClient),
+}
+
+impl ProviderClient {
+    /// 当前 client 走的协议类型。
+    #[must_use]
+    pub const fn provider_kind(&self) -> ProviderKind {
+        match self {
+            Self::Anthropic(_) => ProviderKind::Anthropic,
+            Self::Xai(_) => ProviderKind::Xai,
+            Self::OpenAi(_) => ProviderKind::OpenAi,
+        }
+    }
+
+    /// 同步发送一个消息请求并返回完整响应（非流式）。
+    ///
+    /// 内部按变体 dispatch 到具体 client 的 `complete` 方法；错误透传 [`ApiError`]
+    /// 强类型变体，调用方可精确决策重试 / 重新鉴权。
+    pub async fn send_message(
+        &self,
+        request: &MessageRequest,
+    ) -> Result<MessageResponse, ApiError> {
+        match self {
+            Self::Anthropic(client) => client.complete(request).await,
+            Self::Xai(client) | Self::OpenAi(client) => client.complete(request).await,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::providers::openai_compat::OpenAiCompatConfig;
+
+    #[test]
+    fn provider_kind_matches_variant() {
+        let anthropic = AnthropicClient::new("sk-ant-test").expect("build anthropic");
+        let openai_inner = OpenAiCompatClient::new("sk-openai-test", OpenAiCompatConfig::openai())
+            .expect("build openai");
+        let xai_inner =
+            OpenAiCompatClient::new("xai-test", OpenAiCompatConfig::xai()).expect("build xai");
+
+        assert_eq!(
+            ProviderClient::Anthropic(anthropic).provider_kind(),
+            ProviderKind::Anthropic
+        );
+        assert_eq!(
+            ProviderClient::OpenAi(openai_inner).provider_kind(),
+            ProviderKind::OpenAi
+        );
+        assert_eq!(
+            ProviderClient::Xai(xai_inner).provider_kind(),
+            ProviderKind::Xai
+        );
+    }
+}

--- a/crates/dasclaw_llm_provider/src/providers/mod.rs
+++ b/crates/dasclaw_llm_provider/src/providers/mod.rs
@@ -9,9 +9,11 @@
 //!   实际 HTTP client 在 PR-A.1+ 落地，路由 metadata 与 client 解耦。
 
 pub mod anthropic;
+pub mod client;
 pub mod openai_compat;
 
 pub use anthropic::{AnthropicClient, AnthropicStream, AuthSource};
+pub use client::ProviderClient;
 pub use openai_compat::{OpenAiCompatClient, OpenAiCompatConfig};
 
 /// LLM provider 类型（决定走 Anthropic Messages 协议 / OpenAI Chat Completions 协议 / xAI 协议）。

--- a/crates/dasclaw_llm_provider/src/providers/mod.rs
+++ b/crates/dasclaw_llm_provider/src/providers/mod.rs
@@ -13,8 +13,8 @@ pub mod client;
 pub mod openai_compat;
 
 pub use anthropic::{AnthropicClient, AnthropicStream, AuthSource};
-pub use client::ProviderClient;
-pub use openai_compat::{OpenAiCompatClient, OpenAiCompatConfig};
+pub use client::{ProviderClient, ProviderStream};
+pub use openai_compat::{OpenAiCompatClient, OpenAiCompatConfig, OpenAiCompatStream};
 
 /// LLM provider 类型（决定走 Anthropic Messages 协议 / OpenAI Chat Completions 协议 / xAI 协议）。
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/crates/dasclaw_llm_provider/src/providers/mod.rs
+++ b/crates/dasclaw_llm_provider/src/providers/mod.rs
@@ -9,8 +9,10 @@
 //!   实际 HTTP client 在 PR-A.1+ 落地，路由 metadata 与 client 解耦。
 
 pub mod anthropic;
+pub mod openai_compat;
 
 pub use anthropic::{AnthropicClient, AnthropicStream, AuthSource};
+pub use openai_compat::{OpenAiCompatClient, OpenAiCompatConfig};
 
 /// LLM provider 类型（决定走 Anthropic Messages 协议 / OpenAI Chat Completions 协议 / xAI 协议）。
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/crates/dasclaw_llm_provider/src/providers/mod.rs
+++ b/crates/dasclaw_llm_provider/src/providers/mod.rs
@@ -8,6 +8,10 @@
 //! - **职责单一**：本模块只做"模型名 → provider 类型"的纯函数映射，不做 HTTP / SSE。
 //!   实际 HTTP client 在 PR-A.1+ 落地，路由 metadata 与 client 解耦。
 
+pub mod anthropic;
+
+pub use anthropic::{AnthropicClient, AnthropicStream, AuthSource};
+
 /// LLM provider 类型（决定走 Anthropic Messages 协议 / OpenAI Chat Completions 协议 / xAI 协议）。
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ProviderKind {

--- a/crates/dasclaw_llm_provider/src/providers/openai_compat.rs
+++ b/crates/dasclaw_llm_provider/src/providers/openai_compat.rs
@@ -1,0 +1,886 @@
+//! OpenAI Chat Completions 兼容客户端。
+//!
+//! 适配所有走 `/v1/chat/completions` 协议的厂商：OpenAI、xAI（Grok）、阿里云
+//! DashScope（Qwen/Kimi/DeepSeek 等）、Moonshot Kimi、Groq、OpenRouter、Tinfoil、
+//! Ollama 本地等。各厂商通过 [`OpenAiCompatConfig`] 预设区分（base URL + 请求体大小限制）。
+//!
+//! 本 PR 仅实现 [`OpenAiCompatClient::complete`]（同步消息），与 ironclaw 当前 call site
+//! 一致。Streaming 实现单独由后续 PR 承载（参见 ADR-118 §8.5：`stream_message` 当前
+//! 主仓未调用，stub 优先于全量端口）。
+//!
+//! # 与 `claw-code-api::providers::openai_compat` 的差异
+//!
+//! 1. **共享 [`RetryPolicy`]**：复用 [`crate::retry::RetryPolicy`]，与 [`super::AnthropicClient`]
+//!    保持一致行为；新增对 `Retry-After` 的尊重（claw-code 完全忽略）。
+//! 2. **错误强类型化**：HTTP 状态分发到 [`ApiError`] 各变体，上层免去字符串扫描。
+//! 3. **去除应用层耦合**：不依赖 telemetry / prompt cache / sanitize_tool_message_pairing
+//!    等 runtime 私货；schema 规范化与孤儿 tool_call 清理留给上层调用前完成。
+//! 4. **无 env 副作用**：[`OpenAiCompatClient::new`] 直接接收 API key，不再 `from_env`；
+//!    凭据采集由调用方负责。
+
+use std::time::Duration;
+
+use reqwest::header::HeaderMap;
+use reqwest::StatusCode;
+use serde::Deserialize;
+use serde_json::{json, Value};
+
+use crate::error::ApiError;
+use crate::retry::{parse_retry_after, RetryPolicy};
+use crate::types::{
+    InputContentBlock, InputMessage, MessageRequest, MessageResponse, OutputContentBlock,
+    ToolChoice, ToolDefinition, ToolResultContentBlock, Usage,
+};
+
+const REQUEST_ID_HEADER: &str = "request-id";
+const ALT_REQUEST_ID_HEADER: &str = "x-request-id";
+const RETRY_AFTER_HEADER: &str = "retry-after";
+
+/// xAI 默认 base URL。
+pub const DEFAULT_XAI_BASE_URL: &str = "https://api.x.ai/v1";
+/// OpenAI 默认 base URL。
+pub const DEFAULT_OPENAI_BASE_URL: &str = "https://api.openai.com/v1";
+/// 阿里云 DashScope 兼容模式默认 base URL。
+pub const DEFAULT_DASHSCOPE_BASE_URL: &str = "https://dashscope.aliyuncs.com/compatible-mode/v1";
+
+const XAI_MAX_REQUEST_BODY_BYTES: usize = 52_428_800; // 50MB
+const OPENAI_MAX_REQUEST_BODY_BYTES: usize = 104_857_600; // 100MB
+const DASHSCOPE_MAX_REQUEST_BODY_BYTES: usize = 6_291_456; // 6MB（DashScope 实测限制）
+
+/// OpenAI-compat 客户端的厂商预设。
+///
+/// 通过 [`Self::openai`] / [`Self::xai`] / [`Self::dashscope`] 三个 const 构造器获得；
+/// 调用方可经 [`OpenAiCompatClient::with_base_url`] 覆盖 `default_base_url` 以指向自托管端点。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct OpenAiCompatConfig {
+    /// 厂商名（用于错误消息与遥测）。
+    pub provider_name: &'static str,
+    /// 默认 base URL（不含尾部 `/`）。
+    pub default_base_url: &'static str,
+    /// 请求体最大字节数（厂商侧硬限制）。
+    pub max_request_body_bytes: usize,
+}
+
+impl OpenAiCompatConfig {
+    /// xAI Grok 预设（`https://api.x.ai/v1`）。
+    #[must_use]
+    pub const fn xai() -> Self {
+        Self {
+            provider_name: "xai",
+            default_base_url: DEFAULT_XAI_BASE_URL,
+            max_request_body_bytes: XAI_MAX_REQUEST_BODY_BYTES,
+        }
+    }
+
+    /// OpenAI 预设（`https://api.openai.com/v1`）。
+    #[must_use]
+    pub const fn openai() -> Self {
+        Self {
+            provider_name: "openai",
+            default_base_url: DEFAULT_OPENAI_BASE_URL,
+            max_request_body_bytes: OPENAI_MAX_REQUEST_BODY_BYTES,
+        }
+    }
+
+    /// 阿里云 DashScope 兼容模式预设（Qwen / DeepSeek / Kimi 等）。
+    #[must_use]
+    pub const fn dashscope() -> Self {
+        Self {
+            provider_name: "dashscope",
+            default_base_url: DEFAULT_DASHSCOPE_BASE_URL,
+            max_request_body_bytes: DASHSCOPE_MAX_REQUEST_BODY_BYTES,
+        }
+    }
+}
+
+/// OpenAI Chat Completions 兼容客户端。
+#[derive(Debug, Clone)]
+pub struct OpenAiCompatClient {
+    http: reqwest::Client,
+    api_key: String,
+    config: OpenAiCompatConfig,
+    base_url: String,
+    retry_policy: RetryPolicy,
+}
+
+impl OpenAiCompatClient {
+    /// 用 API key + 厂商预设构造客户端。
+    pub fn new(api_key: impl Into<String>, config: OpenAiCompatConfig) -> Result<Self, ApiError> {
+        Ok(Self {
+            http: crate::http::build_http_client_with(&crate::http::ProxyConfig::default())?,
+            api_key: api_key.into(),
+            config,
+            base_url: config.default_base_url.to_string(),
+            retry_policy: RetryPolicy::default(),
+        })
+    }
+
+    /// 注入预构造的 `reqwest::Client`（如已配置代理 / 自定义 TLS）。
+    #[must_use]
+    pub fn with_http_client(mut self, http: reqwest::Client) -> Self {
+        self.http = http;
+        self
+    }
+
+    /// 覆盖 base URL。
+    #[must_use]
+    pub fn with_base_url(mut self, base_url: impl Into<String>) -> Self {
+        self.base_url = base_url.into();
+        self
+    }
+
+    /// 覆盖默认 [`RetryPolicy`]。
+    #[must_use]
+    pub fn with_retry_policy(mut self, policy: RetryPolicy) -> Self {
+        self.retry_policy = policy;
+        self
+    }
+
+    /// 当前 base URL（只读）。
+    #[must_use]
+    pub fn base_url(&self) -> &str {
+        &self.base_url
+    }
+
+    /// 当前厂商预设（只读）。
+    #[must_use]
+    pub const fn config(&self) -> OpenAiCompatConfig {
+        self.config
+    }
+
+    /// 同步（非流式）发送消息请求。
+    ///
+    /// 内部强制将 `request.stream` 改写为 `false`；将 [`MessageRequest`]
+    /// 翻译为 OpenAI Chat Completions 协议体后投递，再把响应映射回
+    /// [`MessageResponse`]。
+    pub async fn complete(&self, request: &MessageRequest) -> Result<MessageResponse, ApiError> {
+        let request = MessageRequest {
+            stream: false,
+            ..request.clone()
+        };
+        let payload = build_chat_completion_request(&request, self.config);
+        check_request_body_size(&payload, self.config)?;
+
+        let response = self.send_with_retry(&payload).await?;
+        let request_id = request_id_from_headers(response.headers());
+        let body = response
+            .text()
+            .await
+            .map_err(|err| ApiError::Transport(err.to_string()))?;
+
+        // 部分 OpenAI-compat 后端把错误塞回 200 体的 `error` 字段而不是 HTTP 状态。
+        if let Some(err) = detect_inline_error(&body, self.config.provider_name, &request_id) {
+            return Err(err);
+        }
+
+        let parsed: ChatCompletionResponse =
+            serde_json::from_str(&body).map_err(|err| ApiError::Provider {
+                provider: self.config.provider_name.to_string(),
+                reason: format!(
+                    "failed to deserialize ChatCompletionResponse for model={}: {}",
+                    request.model, err
+                ),
+                request_id: request_id.clone(),
+            })?;
+
+        let mut normalized = normalize_response(&request.model, parsed)?;
+        if normalized.request_id.is_none() {
+            normalized.request_id = request_id;
+        }
+        Ok(normalized)
+    }
+
+    async fn send_with_retry(&self, payload: &Value) -> Result<reqwest::Response, ApiError> {
+        let mut attempt: u32 = 0;
+        loop {
+            let outcome = self.send_once(payload).await;
+            match outcome {
+                Ok(response) => return Ok(response),
+                Err(error) => {
+                    let retryable = error.is_retryable();
+                    if !retryable || attempt >= self.retry_policy.max_retries {
+                        return Err(error);
+                    }
+                    let suggested = retry_after_from_error(&error);
+                    attempt += 1;
+                    let delay = self
+                        .retry_policy
+                        .delay_for_attempt(attempt, suggested)
+                        .ok_or_else(|| ApiError::Provider {
+                            provider: self.config.provider_name.to_string(),
+                            reason: format!("retry backoff overflow at attempt {attempt}"),
+                            request_id: error.request_id().map(ToOwned::to_owned),
+                        })?;
+                    tokio::time::sleep(delay).await;
+                }
+            }
+        }
+    }
+
+    async fn send_once(&self, payload: &Value) -> Result<reqwest::Response, ApiError> {
+        let url = chat_completions_endpoint(&self.base_url);
+        let response = self
+            .http
+            .post(&url)
+            .header("content-type", "application/json")
+            .bearer_auth(&self.api_key)
+            .json(payload)
+            .send()
+            .await
+            .map_err(|err| ApiError::Transport(err.to_string()))?;
+        expect_success(response, self.config.provider_name).await
+    }
+}
+
+fn retry_after_from_error(error: &ApiError) -> Option<Duration> {
+    match error {
+        ApiError::RateLimited {
+            retry_after_secs: Some(secs),
+            ..
+        } => Some(Duration::from_secs(*secs)),
+        _ => None,
+    }
+}
+
+fn request_id_from_headers(headers: &HeaderMap) -> Option<String> {
+    headers
+        .get(REQUEST_ID_HEADER)
+        .or_else(|| headers.get(ALT_REQUEST_ID_HEADER))
+        .and_then(|value| value.to_str().ok())
+        .map(ToOwned::to_owned)
+}
+
+fn chat_completions_endpoint(base_url: &str) -> String {
+    let trimmed = base_url.trim_end_matches('/');
+    if trimmed.ends_with("/chat/completions") {
+        trimmed.to_string()
+    } else {
+        format!("{trimmed}/chat/completions")
+    }
+}
+
+async fn expect_success(
+    response: reqwest::Response,
+    provider: &'static str,
+) -> Result<reqwest::Response, ApiError> {
+    let status = response.status();
+    if status.is_success() {
+        return Ok(response);
+    }
+
+    let request_id = request_id_from_headers(response.headers());
+    let retry_after = response
+        .headers()
+        .get(RETRY_AFTER_HEADER)
+        .and_then(|value| value.to_str().ok())
+        .and_then(parse_retry_after);
+
+    let body = response.text().await.unwrap_or_default();
+    let parsed_message = parse_openai_error_message(&body);
+    let reason = parsed_message.unwrap_or_else(|| truncate_body(&body));
+
+    Err(map_status_to_api_error(
+        provider,
+        status,
+        reason,
+        retry_after,
+        request_id,
+    ))
+}
+
+fn map_status_to_api_error(
+    provider: &'static str,
+    status: StatusCode,
+    reason: String,
+    retry_after: Option<Duration>,
+    request_id: Option<String>,
+) -> ApiError {
+    let provider = provider.to_string();
+    match status.as_u16() {
+        429 => ApiError::RateLimited {
+            provider,
+            retry_after_secs: retry_after.map(|d| d.as_secs()),
+            request_id,
+        },
+        401 | 403 => ApiError::AuthFailed {
+            provider,
+            reason,
+            request_id,
+        },
+        400 => ApiError::BadRequest {
+            provider,
+            reason,
+            request_id,
+        },
+        408 | 409 | 500 | 502 | 503 | 504 => ApiError::ServerError {
+            provider,
+            status: status.as_u16(),
+            reason,
+            request_id,
+        },
+        _ => ApiError::Provider {
+            provider,
+            reason: format!("unexpected status {status}: {reason}"),
+            request_id,
+        },
+    }
+}
+
+fn detect_inline_error(
+    body: &str,
+    provider: &'static str,
+    request_id: &Option<String>,
+) -> Option<ApiError> {
+    let raw: Value = serde_json::from_str(body).ok()?;
+    let err_obj = raw.get("error")?;
+    let message = err_obj
+        .get("message")
+        .and_then(Value::as_str)
+        .unwrap_or("provider returned an error")
+        .to_string();
+    Some(ApiError::Provider {
+        provider: provider.to_string(),
+        reason: message,
+        request_id: request_id.clone(),
+    })
+}
+
+fn parse_openai_error_message(body: &str) -> Option<String> {
+    let raw: Value = serde_json::from_str(body).ok()?;
+    raw.get("error")
+        .and_then(|err| err.get("message"))
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned)
+}
+
+fn truncate_body(body: &str) -> String {
+    const MAX: usize = 200;
+    if body.len() <= MAX {
+        return body.to_string();
+    }
+    let safe_end = (0..=MAX)
+        .rev()
+        .find(|&i| body.is_char_boundary(i))
+        .unwrap_or(0);
+    format!("{}…(truncated, {} bytes)", &body[..safe_end], body.len())
+}
+
+fn check_request_body_size(payload: &Value, config: OpenAiCompatConfig) -> Result<(), ApiError> {
+    let estimated = serde_json::to_vec(payload).map(|v| v.len()).unwrap_or(0);
+    if estimated > config.max_request_body_bytes {
+        return Err(ApiError::BadRequest {
+            provider: config.provider_name.to_string(),
+            reason: format!(
+                "request body {estimated} bytes exceeds {} max {} bytes",
+                config.provider_name, config.max_request_body_bytes
+            ),
+            request_id: None,
+        });
+    }
+    Ok(())
+}
+
+/// 把 [`MessageRequest`] 翻译成 OpenAI Chat Completions 协议体。
+///
+/// 公开仅为了基准测试与契约测试需要；正常调用走 [`OpenAiCompatClient::complete`]。
+#[must_use]
+pub fn build_chat_completion_request(
+    request: &MessageRequest,
+    _config: OpenAiCompatConfig,
+) -> Value {
+    let mut messages = Vec::new();
+    if let Some(system) = request.system.as_ref().filter(|value| !value.is_empty()) {
+        messages.push(json!({ "role": "system", "content": system }));
+    }
+    for message in &request.messages {
+        messages.extend(translate_message(message));
+    }
+
+    // gpt-5* 系列改用 max_completion_tokens；其余沿用 max_tokens。
+    let max_tokens_key = if request.model.starts_with("gpt-5") {
+        "max_completion_tokens"
+    } else {
+        "max_tokens"
+    };
+
+    let mut payload = json!({
+        "model": request.model,
+        max_tokens_key: request.max_tokens,
+        "messages": messages,
+        "stream": request.stream,
+    });
+
+    if let Some(tools) = &request.tools {
+        payload["tools"] =
+            Value::Array(tools.iter().map(openai_tool_definition).collect::<Vec<_>>());
+    }
+    if let Some(tool_choice) = &request.tool_choice {
+        payload["tool_choice"] = openai_tool_choice(tool_choice);
+    }
+
+    // Reasoning models（o1 / o3 / o4 / grok-3-mini）拒绝 sampling 参数；本 crate
+    // 不在 wire 层做静默过滤——上层调用方应根据模型选择性传入。
+    if let Some(temperature) = request.temperature {
+        payload["temperature"] = json!(temperature);
+    }
+    if let Some(top_p) = request.top_p {
+        payload["top_p"] = json!(top_p);
+    }
+    if let Some(frequency_penalty) = request.frequency_penalty {
+        payload["frequency_penalty"] = json!(frequency_penalty);
+    }
+    if let Some(presence_penalty) = request.presence_penalty {
+        payload["presence_penalty"] = json!(presence_penalty);
+    }
+    if let Some(stop) = request.stop.as_ref().filter(|s| !s.is_empty()) {
+        payload["stop"] = json!(stop);
+    }
+    if let Some(effort) = &request.reasoning_effort {
+        payload["reasoning_effort"] = json!(effort);
+    }
+
+    payload
+}
+
+fn translate_message(message: &InputMessage) -> Vec<Value> {
+    match message.role.as_str() {
+        "assistant" => translate_assistant_message(&message.content),
+        _ => translate_user_message(&message.content),
+    }
+}
+
+fn translate_assistant_message(blocks: &[InputContentBlock]) -> Vec<Value> {
+    let mut text = String::new();
+    let mut tool_calls = Vec::new();
+    for block in blocks {
+        match block {
+            InputContentBlock::Text { text: value } => text.push_str(value),
+            InputContentBlock::ToolUse { id, name, input } => tool_calls.push(json!({
+                "id": id,
+                "type": "function",
+                "function": {
+                    "name": name,
+                    "arguments": input.to_string(),
+                }
+            })),
+            InputContentBlock::ToolResult { .. } => {}
+        }
+    }
+    if text.is_empty() && tool_calls.is_empty() {
+        return Vec::new();
+    }
+    let mut msg = json!({
+        "role": "assistant",
+        "content": (!text.is_empty()).then_some(text),
+    });
+    if !tool_calls.is_empty() {
+        msg["tool_calls"] = json!(tool_calls);
+    }
+    vec![msg]
+}
+
+fn translate_user_message(blocks: &[InputContentBlock]) -> Vec<Value> {
+    blocks
+        .iter()
+        .filter_map(|block| match block {
+            InputContentBlock::Text { text } => Some(json!({ "role": "user", "content": text })),
+            InputContentBlock::ToolResult {
+                tool_use_id,
+                content,
+                is_error,
+            } => Some(json!({
+                "role": "tool",
+                "tool_call_id": tool_use_id,
+                "content": flatten_tool_result_content(content),
+                "is_error": *is_error,
+            })),
+            InputContentBlock::ToolUse { .. } => None,
+        })
+        .collect()
+}
+
+fn flatten_tool_result_content(content: &[ToolResultContentBlock]) -> String {
+    let total_len: usize = content
+        .iter()
+        .map(|block| match block {
+            ToolResultContentBlock::Text { text } => text.len(),
+            ToolResultContentBlock::Json { value } => value.to_string().len(),
+        })
+        .sum();
+    let capacity = total_len + content.len().saturating_sub(1);
+    let mut result = String::with_capacity(capacity);
+    for (i, block) in content.iter().enumerate() {
+        if i > 0 {
+            result.push('\n');
+        }
+        match block {
+            ToolResultContentBlock::Text { text } => result.push_str(text),
+            ToolResultContentBlock::Json { value } => result.push_str(&value.to_string()),
+        }
+    }
+    result
+}
+
+fn openai_tool_definition(tool: &ToolDefinition) -> Value {
+    json!({
+        "type": "function",
+        "function": {
+            "name": tool.name,
+            "description": tool.description,
+            "parameters": tool.input_schema,
+        }
+    })
+}
+
+fn openai_tool_choice(tool_choice: &ToolChoice) -> Value {
+    match tool_choice {
+        ToolChoice::Auto => Value::String("auto".to_string()),
+        ToolChoice::Any => Value::String("required".to_string()),
+        ToolChoice::Tool { name } => json!({
+            "type": "function",
+            "function": { "name": name },
+        }),
+    }
+}
+
+fn normalize_response(
+    request_model: &str,
+    response: ChatCompletionResponse,
+) -> Result<MessageResponse, ApiError> {
+    let choice = response
+        .choices
+        .into_iter()
+        .next()
+        .ok_or_else(|| ApiError::Provider {
+            provider: "openai".to_string(),
+            reason: "chat completion response missing choices".to_string(),
+            request_id: None,
+        })?;
+
+    let mut content = Vec::new();
+    if let Some(reasoning) = choice
+        .message
+        .reasoning_content
+        .filter(|value| !value.is_empty())
+    {
+        content.push(OutputContentBlock::Thinking {
+            thinking: reasoning,
+            signature: None,
+        });
+    }
+    if let Some(text) = choice.message.content.filter(|value| !value.is_empty()) {
+        content.push(OutputContentBlock::Text { text });
+    }
+    for tool_call in choice.message.tool_calls {
+        content.push(OutputContentBlock::ToolUse {
+            id: tool_call.id,
+            name: tool_call.function.name,
+            input: parse_tool_arguments(&tool_call.function.arguments),
+        });
+    }
+
+    let model = if response.model.is_empty() {
+        request_model.to_string()
+    } else {
+        response.model
+    };
+
+    Ok(MessageResponse {
+        id: response.id,
+        kind: "message".to_string(),
+        role: choice.message.role,
+        content,
+        model,
+        stop_reason: choice
+            .finish_reason
+            .map(|value| normalize_finish_reason(&value)),
+        stop_sequence: None,
+        usage: Usage {
+            input_tokens: response
+                .usage
+                .as_ref()
+                .map_or(0, |usage| usage.prompt_tokens),
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 0,
+            output_tokens: response
+                .usage
+                .as_ref()
+                .map_or(0, |usage| usage.completion_tokens),
+        },
+        request_id: None,
+    })
+}
+
+fn parse_tool_arguments(arguments: &str) -> Value {
+    serde_json::from_str(arguments).unwrap_or_else(|_| json!({ "raw": arguments }))
+}
+
+fn normalize_finish_reason(value: &str) -> String {
+    match value {
+        "stop" => "end_turn",
+        "tool_calls" => "tool_use",
+        other => other,
+    }
+    .to_string()
+}
+
+#[derive(Debug, Deserialize)]
+struct ChatCompletionResponse {
+    id: String,
+    #[serde(default)]
+    model: String,
+    choices: Vec<ChatChoice>,
+    #[serde(default)]
+    usage: Option<OpenAiUsage>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ChatChoice {
+    message: ChatMessage,
+    #[serde(default)]
+    finish_reason: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ChatMessage {
+    role: String,
+    #[serde(default)]
+    content: Option<String>,
+    #[serde(default)]
+    reasoning_content: Option<String>,
+    #[serde(default)]
+    tool_calls: Vec<ResponseToolCall>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ResponseToolCall {
+    id: String,
+    function: ResponseToolFunction,
+}
+
+#[derive(Debug, Deserialize)]
+struct ResponseToolFunction {
+    name: String,
+    arguments: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenAiUsage {
+    #[serde(default)]
+    prompt_tokens: u32,
+    #[serde(default)]
+    completion_tokens: u32,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{InputMessage, MessageRequest};
+
+    #[test]
+    fn presets_have_distinct_provider_names() {
+        assert_eq!(OpenAiCompatConfig::openai().provider_name, "openai");
+        assert_eq!(OpenAiCompatConfig::xai().provider_name, "xai");
+        assert_eq!(OpenAiCompatConfig::dashscope().provider_name, "dashscope");
+    }
+
+    #[test]
+    fn chat_completions_endpoint_appends_path() {
+        assert_eq!(
+            chat_completions_endpoint("https://api.openai.com/v1"),
+            "https://api.openai.com/v1/chat/completions"
+        );
+        assert_eq!(
+            chat_completions_endpoint("https://api.openai.com/v1/"),
+            "https://api.openai.com/v1/chat/completions"
+        );
+    }
+
+    #[test]
+    fn chat_completions_endpoint_idempotent_when_already_present() {
+        assert_eq!(
+            chat_completions_endpoint("https://gateway.example.com/v1/chat/completions"),
+            "https://gateway.example.com/v1/chat/completions"
+        );
+    }
+
+    #[test]
+    fn build_request_uses_max_completion_tokens_for_gpt_5() {
+        let request = MessageRequest {
+            model: "gpt-5-mini".to_string(),
+            max_tokens: 32,
+            messages: vec![InputMessage::user_text("hi")],
+            ..MessageRequest::default()
+        };
+        let payload = build_chat_completion_request(&request, OpenAiCompatConfig::openai());
+        assert!(payload.get("max_completion_tokens").is_some());
+        assert!(payload.get("max_tokens").is_none());
+    }
+
+    #[test]
+    fn build_request_uses_max_tokens_for_other_models() {
+        let request = MessageRequest {
+            model: "gpt-4o".to_string(),
+            max_tokens: 32,
+            messages: vec![InputMessage::user_text("hi")],
+            ..MessageRequest::default()
+        };
+        let payload = build_chat_completion_request(&request, OpenAiCompatConfig::openai());
+        assert!(payload.get("max_tokens").is_some());
+        assert!(payload.get("max_completion_tokens").is_none());
+    }
+
+    #[test]
+    fn build_request_emits_system_message_when_present() {
+        let request = MessageRequest {
+            model: "gpt-4o".to_string(),
+            max_tokens: 16,
+            messages: vec![InputMessage::user_text("hi")],
+            system: Some("you are a tester".to_string()),
+            ..MessageRequest::default()
+        };
+        let payload = build_chat_completion_request(&request, OpenAiCompatConfig::openai());
+        let messages = payload["messages"].as_array().expect("messages array");
+        assert_eq!(messages[0]["role"], "system");
+        assert_eq!(messages[0]["content"], "you are a tester");
+        assert_eq!(messages[1]["role"], "user");
+    }
+
+    #[test]
+    fn translate_assistant_keeps_text_and_tool_calls() {
+        let msg = InputMessage {
+            role: "assistant".to_string(),
+            content: vec![
+                InputContentBlock::Text {
+                    text: "calling".to_string(),
+                },
+                InputContentBlock::ToolUse {
+                    id: "call_1".to_string(),
+                    name: "lookup".to_string(),
+                    input: json!({ "q": "foo" }),
+                },
+            ],
+        };
+        let translated = translate_message(&msg);
+        assert_eq!(translated.len(), 1);
+        assert_eq!(translated[0]["role"], "assistant");
+        assert_eq!(translated[0]["content"], "calling");
+        assert_eq!(translated[0]["tool_calls"][0]["id"], "call_1");
+        assert_eq!(translated[0]["tool_calls"][0]["function"]["name"], "lookup");
+    }
+
+    #[test]
+    fn translate_user_handles_tool_result() {
+        let msg = InputMessage {
+            role: "user".to_string(),
+            content: vec![InputContentBlock::ToolResult {
+                tool_use_id: "call_1".to_string(),
+                content: vec![ToolResultContentBlock::Text {
+                    text: "result".to_string(),
+                }],
+                is_error: false,
+            }],
+        };
+        let translated = translate_message(&msg);
+        assert_eq!(translated.len(), 1);
+        assert_eq!(translated[0]["role"], "tool");
+        assert_eq!(translated[0]["tool_call_id"], "call_1");
+        assert_eq!(translated[0]["content"], "result");
+    }
+
+    #[test]
+    fn map_status_429_yields_rate_limited() {
+        let err = map_status_to_api_error(
+            "openai",
+            StatusCode::TOO_MANY_REQUESTS,
+            "slow".to_string(),
+            Some(Duration::from_secs(3)),
+            Some("req-1".to_string()),
+        );
+        match err {
+            ApiError::RateLimited {
+                provider,
+                retry_after_secs,
+                ..
+            } => {
+                assert_eq!(provider, "openai");
+                assert_eq!(retry_after_secs, Some(3));
+            }
+            other => panic!("expected RateLimited, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn map_status_401_yields_auth_failed() {
+        let err = map_status_to_api_error(
+            "openai",
+            StatusCode::UNAUTHORIZED,
+            "bad key".to_string(),
+            None,
+            None,
+        );
+        assert!(matches!(err, ApiError::AuthFailed { .. }));
+    }
+
+    #[test]
+    fn map_status_500_yields_server_error() {
+        let err = map_status_to_api_error(
+            "openai",
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "boom".to_string(),
+            None,
+            None,
+        );
+        assert!(matches!(err, ApiError::ServerError { status: 500, .. }));
+    }
+
+    #[test]
+    fn detect_inline_error_recognizes_envelope() {
+        let body = r#"{"error":{"message":"insufficient quota","type":"billing"}}"#;
+        let err = detect_inline_error(body, "openai", &Some("req-9".to_string())).expect("error");
+        match err {
+            ApiError::Provider {
+                provider, reason, ..
+            } => {
+                assert_eq!(provider, "openai");
+                assert_eq!(reason, "insufficient quota");
+            }
+            other => panic!("expected Provider, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn check_request_body_size_rejects_oversized() {
+        let huge = json!({ "blob": "x".repeat(10 * 1024 * 1024) });
+        let result = check_request_body_size(&huge, OpenAiCompatConfig::dashscope());
+        assert!(matches!(result, Err(ApiError::BadRequest { .. })));
+    }
+
+    #[test]
+    fn normalize_response_promotes_reasoning_to_thinking_block() {
+        let body = json!({
+            "id": "chatcmpl-1",
+            "model": "qwen-max",
+            "choices": [{
+                "message": {
+                    "role": "assistant",
+                    "content": "answer",
+                    "reasoning_content": "step 1, step 2"
+                },
+                "finish_reason": "stop"
+            }],
+            "usage": { "prompt_tokens": 5, "completion_tokens": 10 }
+        });
+        let parsed: ChatCompletionResponse = serde_json::from_value(body).expect("parses");
+        let resp = normalize_response("qwen-max", parsed).expect("normalizes");
+        assert_eq!(resp.content.len(), 2);
+        assert!(matches!(
+            resp.content[0],
+            OutputContentBlock::Thinking { .. }
+        ));
+        assert!(matches!(resp.content[1], OutputContentBlock::Text { .. }));
+        assert_eq!(resp.stop_reason.as_deref(), Some("end_turn"));
+        assert_eq!(resp.usage.input_tokens, 5);
+        assert_eq!(resp.usage.output_tokens, 10);
+    }
+}

--- a/crates/dasclaw_llm_provider/src/providers/openai_compat.rs
+++ b/crates/dasclaw_llm_provider/src/providers/openai_compat.rs
@@ -4,9 +4,11 @@
 //! DashScope（Qwen/Kimi/DeepSeek 等）、Moonshot Kimi、Groq、OpenRouter、Tinfoil、
 //! Ollama 本地等。各厂商通过 [`OpenAiCompatConfig`] 预设区分（base URL + 请求体大小限制）。
 //!
-//! 本 PR 仅实现 [`OpenAiCompatClient::complete`]（同步消息），与 ironclaw 当前 call site
-//! 一致。Streaming 实现单独由后续 PR 承载（参见 ADR-118 §8.5：`stream_message` 当前
-//! 主仓未调用，stub 优先于全量端口）。
+//! 本 client 同时实现 [`OpenAiCompatClient::complete`]（同步消息）与
+//! [`OpenAiCompatClient::stream`]（流式消息）。流式实现把 OpenAI 增量
+//! `chat.completion.chunk` 协议映射为 Anthropic 风格的 [`StreamEvent`] 序列
+//! （`message_start` / `content_block_*` / `message_delta` / `message_stop`），
+//! 让上层 ironclaw 用一套事件模型消费两类后端。
 //!
 //! # 与 `claw-code-api::providers::openai_compat` 的差异
 //!
@@ -18,6 +20,7 @@
 //! 4. **无 env 副作用**：[`OpenAiCompatClient::new`] 直接接收 API key，不再 `from_env`；
 //!    凭据采集由调用方负责。
 
+use std::collections::{BTreeMap, VecDeque};
 use std::time::Duration;
 
 use reqwest::header::HeaderMap;
@@ -28,7 +31,9 @@ use serde_json::{json, Value};
 use crate::error::ApiError;
 use crate::retry::{parse_retry_after, RetryPolicy};
 use crate::types::{
-    InputContentBlock, InputMessage, MessageRequest, MessageResponse, OutputContentBlock,
+    ContentBlockDelta, ContentBlockDeltaEvent, ContentBlockStartEvent, ContentBlockStopEvent,
+    InputContentBlock, InputMessage, MessageDelta, MessageDeltaEvent, MessageRequest,
+    MessageResponse, MessageStartEvent, MessageStopEvent, OutputContentBlock, StreamEvent,
     ToolChoice, ToolDefinition, ToolResultContentBlock, Usage,
 };
 
@@ -188,6 +193,38 @@ impl OpenAiCompatClient {
             normalized.request_id = request_id;
         }
         Ok(normalized)
+    }
+
+    /// 流式发送消息请求；返回 [`OpenAiCompatStream`] 增量推送 Anthropic 风格的
+    /// [`StreamEvent`] 序列。
+    ///
+    /// 内部强制将 `request.stream` 改写为 `true`，并把 OpenAI 增量
+    /// `chat.completion.chunk` 协议（`data: {...}\n\n` SSE 帧 + `[DONE]` 哨兵）
+    /// 翻译为 Anthropic 6 类事件（`message_start` / `content_block_*` /
+    /// `message_delta` / `message_stop`）。
+    ///
+    /// Tool 调用增量遵循 OpenAI 协议：每个 tool call 用 `index` 区分，名称在
+    /// 第一帧给出，arguments 由后续帧逐片拼接 — 本实现把它映射为
+    /// `content_block_start { tool_use, input: {} }` + 多次 `input_json_delta`
+    /// + `content_block_stop`，与 Anthropic 一致。
+    pub async fn stream(&self, request: &MessageRequest) -> Result<OpenAiCompatStream, ApiError> {
+        let request = MessageRequest {
+            stream: true,
+            ..request.clone()
+        };
+        let payload = build_chat_completion_request(&request, self.config);
+        check_request_body_size(&payload, self.config)?;
+
+        let response = self.send_with_retry(&payload).await?;
+        let request_id = request_id_from_headers(response.headers());
+        Ok(OpenAiCompatStream {
+            request_id,
+            response,
+            parser: OpenAiSseParser::new(self.config.provider_name, request.model.clone()),
+            pending: VecDeque::new(),
+            done: false,
+            state: StreamState::new(request.model.clone()),
+        })
     }
 
     async fn send_with_retry(&self, payload: &Value) -> Result<reqwest::Response, ApiError> {
@@ -670,6 +707,447 @@ struct OpenAiUsage {
     prompt_tokens: u32,
     #[serde(default)]
     completion_tokens: u32,
+}
+
+// ---------- Streaming ----------
+
+/// OpenAI Chat Completions 流式响应；由 [`OpenAiCompatClient::stream`] 创建。
+///
+/// 增量协议为 OpenAI `chat.completion.chunk` 序列（`data: {...}\n\n` SSE 帧 +
+/// `[DONE]` 哨兵），但本类型对外暴露 Anthropic 风格的 [`StreamEvent`]——上层
+/// ironclaw 用同一套 `next_event()` 消费 anthropic / openai_compat 两类后端。
+#[derive(Debug)]
+pub struct OpenAiCompatStream {
+    request_id: Option<String>,
+    response: reqwest::Response,
+    parser: OpenAiSseParser,
+    pending: VecDeque<StreamEvent>,
+    done: bool,
+    state: StreamState,
+}
+
+impl OpenAiCompatStream {
+    /// 上游返回的 trace ID（如有）。
+    #[must_use]
+    pub fn request_id(&self) -> Option<&str> {
+        self.request_id.as_deref()
+    }
+
+    /// 增量拉取下一个 [`StreamEvent`]；流结束时返回 `Ok(None)`。
+    ///
+    /// 内部状态机：先消费 HTTP body 字节 → SSE 帧 → `ChatCompletionChunk` →
+    /// 经 [`StreamState::ingest_chunk`] 翻译为 Anthropic 风格事件队列。
+    pub async fn next_event(&mut self) -> Result<Option<StreamEvent>, ApiError> {
+        loop {
+            if let Some(event) = self.pending.pop_front() {
+                return Ok(Some(event));
+            }
+            if self.done {
+                let trailing = self.state.finish()?;
+                if trailing.is_empty() {
+                    return Ok(None);
+                }
+                self.pending.extend(trailing);
+                continue;
+            }
+            match self
+                .response
+                .chunk()
+                .await
+                .map_err(|err| ApiError::StreamInterrupted(err.to_string()))?
+            {
+                Some(bytes) => {
+                    for chunk in self.parser.push(&bytes)? {
+                        self.pending.extend(self.state.ingest_chunk(chunk)?);
+                    }
+                }
+                None => {
+                    self.done = true;
+                }
+            }
+        }
+    }
+}
+
+/// OpenAI 形态 SSE 解析器：识别 `data: {...}\n\n` 帧与 `data: [DONE]` 哨兵。
+///
+/// 与 [`crate::sse::SseParser`]（Anthropic 形态：`event: foo\ndata: {...}`）的差异：
+/// OpenAI 不带 `event:` 字段，所有事件都是裸 JSON chunk；只有一个
+/// `[DONE]` 哨兵字符串作为流结束标记（不是 JSON）。
+#[derive(Debug)]
+struct OpenAiSseParser {
+    provider: &'static str,
+    model: String,
+    buffer: Vec<u8>,
+}
+
+impl OpenAiSseParser {
+    fn new(provider: &'static str, model: String) -> Self {
+        Self {
+            provider,
+            model,
+            buffer: Vec::new(),
+        }
+    }
+
+    fn push(&mut self, chunk: &[u8]) -> Result<Vec<ChatCompletionChunk>, ApiError> {
+        self.buffer.extend_from_slice(chunk);
+        let mut events = Vec::new();
+        while let Some(frame) = take_frame(&mut self.buffer) {
+            if let Some(event) = self.parse_frame(&frame)? {
+                events.push(event);
+            }
+        }
+        Ok(events)
+    }
+
+    fn parse_frame(&self, frame: &str) -> Result<Option<ChatCompletionChunk>, ApiError> {
+        let mut payload = String::new();
+        for line in frame.split('\n') {
+            let line = line.strip_prefix('\r').unwrap_or(line);
+            let line = line.trim_end_matches('\r');
+            if line.is_empty() || line.starts_with(':') {
+                continue;
+            }
+            let Some(rest) = line.strip_prefix("data:") else {
+                continue;
+            };
+            let value = rest.strip_prefix(' ').unwrap_or(rest);
+            if value == "[DONE]" {
+                return Ok(None);
+            }
+            if !payload.is_empty() {
+                payload.push('\n');
+            }
+            payload.push_str(value);
+        }
+        if payload.is_empty() {
+            return Ok(None);
+        }
+        serde_json::from_str::<ChatCompletionChunk>(&payload)
+            .map(Some)
+            .map_err(|err| {
+                ApiError::MalformedSseFrame(format!(
+                    "{}: failed to deserialize chat.completion.chunk for model={}: {err}",
+                    self.provider, self.model
+                ))
+            })
+    }
+}
+
+/// 从 buffer 中切出下一个 SSE 帧（以 `\n\n` 为分隔；兼容 `\r\n\r\n`）。
+fn take_frame(buffer: &mut Vec<u8>) -> Option<String> {
+    let needle_lf = b"\n\n";
+    let needle_crlf = b"\r\n\r\n";
+    let lf_idx = buffer.windows(needle_lf.len()).position(|w| w == needle_lf);
+    let crlf_idx = buffer
+        .windows(needle_crlf.len())
+        .position(|w| w == needle_crlf);
+    let (split_at, sep_len) = match (lf_idx, crlf_idx) {
+        (Some(lf), Some(crlf)) if crlf <= lf => (crlf, needle_crlf.len()),
+        (Some(lf), _) => (lf, needle_lf.len()),
+        (None, Some(crlf)) => (crlf, needle_crlf.len()),
+        (None, None) => return None,
+    };
+    let frame_bytes: Vec<u8> = buffer.drain(..split_at).collect();
+    buffer.drain(..sep_len);
+    Some(String::from_utf8_lossy(&frame_bytes).into_owned())
+}
+
+/// 把 OpenAI `chat.completion.chunk` 流翻译成 Anthropic 风格 [`StreamEvent`] 序列的状态机。
+#[allow(clippy::struct_excessive_bools)]
+#[derive(Debug)]
+struct StreamState {
+    model: String,
+    message_started: bool,
+    text_started: bool,
+    text_finished: bool,
+    finished: bool,
+    stop_reason: Option<String>,
+    usage: Option<Usage>,
+    tool_calls: BTreeMap<u32, ToolCallState>,
+}
+
+impl StreamState {
+    fn new(model: String) -> Self {
+        Self {
+            model,
+            message_started: false,
+            text_started: false,
+            text_finished: false,
+            finished: false,
+            stop_reason: None,
+            usage: None,
+            tool_calls: BTreeMap::new(),
+        }
+    }
+
+    fn ingest_chunk(&mut self, chunk: ChatCompletionChunk) -> Result<Vec<StreamEvent>, ApiError> {
+        let mut events = Vec::new();
+        if !self.message_started {
+            self.message_started = true;
+            events.push(StreamEvent::MessageStart(MessageStartEvent {
+                message: MessageResponse {
+                    id: chunk.id.clone(),
+                    kind: "message".to_string(),
+                    role: "assistant".to_string(),
+                    content: Vec::new(),
+                    model: chunk.model.clone().unwrap_or_else(|| self.model.clone()),
+                    stop_reason: None,
+                    stop_sequence: None,
+                    usage: Usage {
+                        input_tokens: 0,
+                        cache_creation_input_tokens: 0,
+                        cache_read_input_tokens: 0,
+                        output_tokens: 0,
+                    },
+                    request_id: None,
+                },
+            }));
+        }
+
+        if let Some(usage) = chunk.usage {
+            self.usage = Some(Usage {
+                input_tokens: usage.prompt_tokens,
+                cache_creation_input_tokens: 0,
+                cache_read_input_tokens: 0,
+                output_tokens: usage.completion_tokens,
+            });
+        }
+
+        for choice in chunk.choices {
+            if let Some(content) = choice.delta.content.filter(|value| !value.is_empty()) {
+                if !self.text_started {
+                    self.text_started = true;
+                    events.push(StreamEvent::ContentBlockStart(ContentBlockStartEvent {
+                        index: 0,
+                        content_block: OutputContentBlock::Text {
+                            text: String::new(),
+                        },
+                    }));
+                }
+                events.push(StreamEvent::ContentBlockDelta(ContentBlockDeltaEvent {
+                    index: 0,
+                    delta: ContentBlockDelta::TextDelta { text: content },
+                }));
+            }
+
+            for tool_call in choice.delta.tool_calls {
+                let state = self.tool_calls.entry(tool_call.index).or_default();
+                state.apply(tool_call);
+                let block_index = state.block_index();
+                if !state.started {
+                    if let Some(start_event) = state.start_event() {
+                        state.started = true;
+                        events.push(StreamEvent::ContentBlockStart(start_event));
+                    } else {
+                        continue;
+                    }
+                }
+                if let Some(delta_event) = state.delta_event() {
+                    events.push(StreamEvent::ContentBlockDelta(delta_event));
+                }
+                if choice.finish_reason.as_deref() == Some("tool_calls") && !state.stopped {
+                    state.stopped = true;
+                    events.push(StreamEvent::ContentBlockStop(ContentBlockStopEvent {
+                        index: block_index,
+                    }));
+                }
+            }
+
+            if let Some(finish_reason) = choice.finish_reason {
+                self.stop_reason = Some(normalize_finish_reason(&finish_reason));
+                if finish_reason == "tool_calls" {
+                    for state in self.tool_calls.values_mut() {
+                        if state.started && !state.stopped {
+                            state.stopped = true;
+                            events.push(StreamEvent::ContentBlockStop(ContentBlockStopEvent {
+                                index: state.block_index(),
+                            }));
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(events)
+    }
+
+    /// 在底层 HTTP body 结束时收尾：补 `content_block_stop` / `message_delta` /
+    /// `message_stop`。幂等 — 多次调用只在第一次产出事件。
+    fn finish(&mut self) -> Result<Vec<StreamEvent>, ApiError> {
+        if self.finished {
+            return Ok(Vec::new());
+        }
+        self.finished = true;
+
+        let mut events = Vec::new();
+        if self.text_started && !self.text_finished {
+            self.text_finished = true;
+            events.push(StreamEvent::ContentBlockStop(ContentBlockStopEvent {
+                index: 0,
+            }));
+        }
+
+        for state in self.tool_calls.values_mut() {
+            if !state.started {
+                if let Some(start_event) = state.start_event() {
+                    state.started = true;
+                    events.push(StreamEvent::ContentBlockStart(start_event));
+                    if let Some(delta_event) = state.delta_event() {
+                        events.push(StreamEvent::ContentBlockDelta(delta_event));
+                    }
+                }
+            }
+            if state.started && !state.stopped {
+                state.stopped = true;
+                events.push(StreamEvent::ContentBlockStop(ContentBlockStopEvent {
+                    index: state.block_index(),
+                }));
+            }
+        }
+
+        if self.message_started {
+            events.push(StreamEvent::MessageDelta(MessageDeltaEvent {
+                delta: MessageDelta {
+                    stop_reason: Some(
+                        self.stop_reason
+                            .clone()
+                            .unwrap_or_else(|| "end_turn".to_string()),
+                    ),
+                    stop_sequence: None,
+                },
+                usage: self.usage.clone().unwrap_or(Usage {
+                    input_tokens: 0,
+                    cache_creation_input_tokens: 0,
+                    cache_read_input_tokens: 0,
+                    output_tokens: 0,
+                }),
+            }));
+            events.push(StreamEvent::MessageStop(MessageStopEvent {}));
+        }
+        Ok(events)
+    }
+}
+
+/// 单个 OpenAI tool call 的累积状态。
+///
+/// OpenAI 流式协议中，同一个 tool call 跨多个 chunk 切片：第一个 chunk 给出 `id` +
+/// `function.name`，后续 chunk 仅切片 `function.arguments`。`block_index` 取
+/// `openai_index + 1`，把索引 0 留给可能存在的 text content block。
+#[derive(Debug, Default)]
+struct ToolCallState {
+    openai_index: u32,
+    id: Option<String>,
+    name: Option<String>,
+    arguments: String,
+    emitted_len: usize,
+    started: bool,
+    stopped: bool,
+}
+
+impl ToolCallState {
+    fn apply(&mut self, tool_call: DeltaToolCall) {
+        self.openai_index = tool_call.index;
+        if let Some(id) = tool_call.id {
+            self.id = Some(id);
+        }
+        if let Some(name) = tool_call.function.name {
+            self.name = Some(name);
+        }
+        if let Some(arguments) = tool_call.function.arguments {
+            self.arguments.push_str(&arguments);
+        }
+    }
+
+    const fn block_index(&self) -> u32 {
+        self.openai_index + 1
+    }
+
+    fn start_event(&self) -> Option<ContentBlockStartEvent> {
+        let name = self.name.clone()?;
+        let id = self
+            .id
+            .clone()
+            .unwrap_or_else(|| format!("tool_call_{}", self.openai_index));
+        Some(ContentBlockStartEvent {
+            index: self.block_index(),
+            content_block: OutputContentBlock::ToolUse {
+                id,
+                name,
+                input: json!({}),
+            },
+        })
+    }
+
+    fn delta_event(&mut self) -> Option<ContentBlockDeltaEvent> {
+        if self.emitted_len >= self.arguments.len() {
+            return None;
+        }
+        let delta = self.arguments[self.emitted_len..].to_string();
+        self.emitted_len = self.arguments.len();
+        Some(ContentBlockDeltaEvent {
+            index: self.block_index(),
+            delta: ContentBlockDelta::InputJsonDelta {
+                partial_json: delta,
+            },
+        })
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct ChatCompletionChunk {
+    id: String,
+    #[serde(default)]
+    model: Option<String>,
+    #[serde(default)]
+    choices: Vec<ChunkChoice>,
+    #[serde(default)]
+    usage: Option<OpenAiUsage>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ChunkChoice {
+    delta: ChunkDelta,
+    #[serde(default)]
+    finish_reason: Option<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct ChunkDelta {
+    #[serde(default)]
+    content: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_null_as_empty_vec")]
+    tool_calls: Vec<DeltaToolCall>,
+}
+
+#[derive(Debug, Deserialize)]
+struct DeltaToolCall {
+    #[serde(default)]
+    index: u32,
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    function: DeltaFunction,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct DeltaFunction {
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    arguments: Option<String>,
+}
+
+/// 部分 OpenAI-compat 厂商把 `tool_calls` 显式写成 `null` 而不是省略字段或用 `[]`。
+/// `#[serde(default)]` 仅处理缺失键，处理不了显式 null —— 本反序列化器把
+/// `null` 视为 `[]`。
+fn deserialize_null_as_empty_vec<'de, D, T>(deserializer: D) -> Result<Vec<T>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+    T: serde::Deserialize<'de>,
+{
+    Ok(Option::<Vec<T>>::deserialize(deserializer)?.unwrap_or_default())
 }
 
 #[cfg(test)]

--- a/crates/dasclaw_llm_provider/src/retry.rs
+++ b/crates/dasclaw_llm_provider/src/retry.rs
@@ -1,0 +1,203 @@
+//! 重试策略 — 指数退避 + 抖动 + Retry-After 头部尊重。
+//!
+//! 与 [`claw-code-api`] `providers::anthropic` 内联的退避逻辑相比，本模块作了
+//! 两处改进（[ADR-118] §8.5 顺势处理）：
+//!
+//! 1. **独立模块**：claw-code 把退避当成 `AnthropicClient` 私有方法。本 crate
+//!    把 `RetryPolicy` 提升为公共类型，PR-A.3 `OpenAiCompatClient` 共享同一份
+//!    实现，避免重复代码。
+//! 2. **尊重 `Retry-After`**：claw-code 完全忽略 `Retry-After` 头部，固定走
+//!    指数退避。我们在 [`RetryPolicy::delay_for_attempt`] 中接受可选 `retry_after`
+//!    参数，优先采纳上游建议（取 `min(retry_after, max_backoff)` 防恶意头）。
+//!
+//! [`claw-code-api`]: https://github.com/charmbracelet/claw-code
+//! [ADR-118]: ../docs/plans/architecture-refactor/adr-118-claw-code-readonly-and-self-impl.md
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+/// 指数退避重试策略。
+///
+/// 默认值：max_retries=8，initial_backoff=1s，max_backoff=128s（与 claw-code 对齐）。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RetryPolicy {
+    /// 最大重试次数（不含首次请求）。
+    pub max_retries: u32,
+    /// 第一次重试前的等待。后续重试在此基础上指数翻倍（饱和到 `max_backoff`）。
+    pub initial_backoff: Duration,
+    /// 退避上限；任何计算出的延迟都不会超过此值。
+    pub max_backoff: Duration,
+}
+
+impl Default for RetryPolicy {
+    fn default() -> Self {
+        Self {
+            max_retries: 8,
+            initial_backoff: Duration::from_secs(1),
+            max_backoff: Duration::from_secs(128),
+        }
+    }
+}
+
+impl RetryPolicy {
+    /// 计算第 `attempt` 次重试的基础退避（指数 + 上限封顶）。
+    ///
+    /// `attempt` 从 1 开始计（第一次重试 = attempt=1）。返回 `None` 当移位
+    /// 溢出（极端 `attempt` 值），调用方应直接放弃重试。
+    #[must_use]
+    pub fn backoff_for_attempt(&self, attempt: u32) -> Option<Duration> {
+        let exp = attempt.saturating_sub(1);
+        let multiplier = 1_u32.checked_shl(exp)?;
+        Some(
+            self.initial_backoff
+                .checked_mul(multiplier)
+                .map_or(self.max_backoff, |delay| delay.min(self.max_backoff)),
+        )
+    }
+
+    /// 计算最终延迟：当 `retry_after` 提供时优先使用（同样受 `max_backoff` 约束），
+    /// 否则走指数退避 + 抖动。
+    ///
+    /// 抖动是 `[0, base]` 区间的加法抖动 —— 不会缩短延迟，只会拉长到至多 2×base。
+    #[must_use]
+    pub fn delay_for_attempt(
+        &self,
+        attempt: u32,
+        retry_after: Option<Duration>,
+    ) -> Option<Duration> {
+        if let Some(retry_after) = retry_after {
+            return Some(retry_after.min(self.max_backoff));
+        }
+        let base = self.backoff_for_attempt(attempt)?;
+        Some(base + jitter_for_base(base))
+    }
+}
+
+/// 解析 HTTP `Retry-After` 头部。
+///
+/// 仅支持 delta-seconds 整数格式（最常见）。HTTP-date 格式不解析（claw-code 也未
+/// 实现，留给未来需要时扩展）。
+#[must_use]
+pub fn parse_retry_after(value: &str) -> Option<Duration> {
+    value.trim().parse::<u64>().ok().map(Duration::from_secs)
+}
+
+static JITTER_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+/// 加法抖动 — 在 `[0, base]` 区间内均匀采样。
+///
+/// 熵源：纳秒级 wall clock + 进程 atomic 计数器，经 splitmix64 finalizer 混淆。
+/// 不需要密码学强度（只用于退避去关联）。
+fn jitter_for_base(base: Duration) -> Duration {
+    let base_nanos = u64::try_from(base.as_nanos()).unwrap_or(u64::MAX);
+    if base_nanos == 0 {
+        return Duration::ZERO;
+    }
+    let raw_nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|elapsed| u64::try_from(elapsed.as_nanos()).unwrap_or(u64::MAX))
+        .unwrap_or(0);
+    let tick = JITTER_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let mut mixed = raw_nanos
+        .wrapping_add(tick)
+        .wrapping_add(0x9E37_79B9_7F4A_7C15);
+    mixed = (mixed ^ (mixed >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+    mixed = (mixed ^ (mixed >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+    mixed ^= mixed >> 31;
+    let jitter_nanos = mixed % base_nanos.saturating_add(1);
+    Duration::from_nanos(jitter_nanos)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_retry_after, RetryPolicy};
+    use std::time::Duration;
+
+    #[test]
+    fn default_policy_matches_claw_code_constants() {
+        let policy = RetryPolicy::default();
+        assert_eq!(policy.max_retries, 8);
+        assert_eq!(policy.initial_backoff, Duration::from_secs(1));
+        assert_eq!(policy.max_backoff, Duration::from_secs(128));
+    }
+
+    #[test]
+    fn backoff_doubles_per_attempt_until_max() {
+        let policy = RetryPolicy::default();
+        assert_eq!(policy.backoff_for_attempt(1), Some(Duration::from_secs(1)));
+        assert_eq!(policy.backoff_for_attempt(2), Some(Duration::from_secs(2)));
+        assert_eq!(policy.backoff_for_attempt(3), Some(Duration::from_secs(4)));
+        assert_eq!(
+            policy.backoff_for_attempt(8),
+            Some(Duration::from_secs(128))
+        );
+        // attempts beyond saturate at max_backoff (no overflow)
+        assert_eq!(
+            policy.backoff_for_attempt(20),
+            Some(Duration::from_secs(128))
+        );
+    }
+
+    #[test]
+    fn backoff_saturates_at_max_when_initial_is_large() {
+        let policy = RetryPolicy {
+            max_retries: 3,
+            initial_backoff: Duration::from_secs(100),
+            max_backoff: Duration::from_secs(120),
+        };
+        assert_eq!(
+            policy.backoff_for_attempt(1),
+            Some(Duration::from_secs(100))
+        );
+        assert_eq!(
+            policy.backoff_for_attempt(2),
+            Some(Duration::from_secs(120))
+        );
+        assert_eq!(
+            policy.backoff_for_attempt(3),
+            Some(Duration::from_secs(120))
+        );
+    }
+
+    #[test]
+    fn delay_uses_retry_after_when_present_capped_by_max_backoff() {
+        let policy = RetryPolicy::default();
+        let suggested = Some(Duration::from_secs(10));
+        let delay = policy
+            .delay_for_attempt(1, suggested)
+            .expect("delay computable");
+        assert_eq!(delay, Duration::from_secs(10));
+
+        // Server-suggested value beyond max_backoff should clamp.
+        let huge = Some(Duration::from_secs(10_000));
+        let clamped = policy.delay_for_attempt(1, huge).expect("delay computable");
+        assert_eq!(clamped, Duration::from_secs(128));
+    }
+
+    #[test]
+    fn delay_falls_back_to_jittered_exponential_when_no_retry_after() {
+        let policy = RetryPolicy::default();
+        let base = policy.backoff_for_attempt(2).expect("base attempt 2");
+        let delay = policy.delay_for_attempt(2, None).expect("delay computable");
+        assert!(
+            delay >= base && delay <= base * 2,
+            "delay {delay:?} not within [{base:?}, 2*{base:?}]"
+        );
+    }
+
+    #[test]
+    fn parse_retry_after_accepts_integer_seconds() {
+        assert_eq!(parse_retry_after("3"), Some(Duration::from_secs(3)));
+        assert_eq!(parse_retry_after("  120  "), Some(Duration::from_secs(120)));
+        assert_eq!(parse_retry_after("0"), Some(Duration::ZERO));
+    }
+
+    #[test]
+    fn parse_retry_after_rejects_non_integer_formats() {
+        // HTTP-date format is not supported (claw-code parity).
+        assert!(parse_retry_after("Wed, 21 Oct 2026 07:28:00 GMT").is_none());
+        assert!(parse_retry_after("3.5").is_none());
+        assert!(parse_retry_after("").is_none());
+        assert!(parse_retry_after("-1").is_none());
+    }
+}

--- a/crates/dasclaw_llm_provider/tests/anthropic_client.rs
+++ b/crates/dasclaw_llm_provider/tests/anthropic_client.rs
@@ -1,0 +1,256 @@
+//! 集成测试 — `AnthropicClient` 的 wire 行为。
+//!
+//! 用 [`wiremock`] mock 上游 `/v1/messages` 端点，验证：
+//! 1. `complete()` happy path + `request-id` header propagation
+//! 2. 401 不重试，立即返回 `ApiError::AuthFailed`
+//! 3. 429 携带 `Retry-After` → 退避采纳上游建议，下一次成功
+//! 4. 500 重试后成功（默认指数退避）
+//! 5. 最大重试次数耗尽 → 冒泡最后一次错误
+//! 6. 流式响应 SSE 帧可逐个拉取，结束后 `next_event` 返回 `Ok(None)`
+//! 7. `400` 含 Anthropic 错误 envelope → `ApiError::BadRequest.reason` 为 `error.message`
+
+use std::time::Duration;
+
+use dasclaw_llm_provider::{
+    AnthropicClient, ApiError, AuthSource, MessageRequest, RetryPolicy, StreamEvent,
+};
+use serde_json::json;
+use wiremock::matchers::{header, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+const TEST_API_KEY: &str = "sk-ant-test";
+
+fn sample_request() -> MessageRequest {
+    let body = json!({
+        "model": "claude-3-5-sonnet-20241022",
+        "max_tokens": 16,
+        "messages": [
+            { "role": "user", "content": [{ "type": "text", "text": "ping" }] }
+        ]
+    });
+    serde_json::from_value(body).expect("MessageRequest deserializable")
+}
+
+fn fast_retry_policy(max_retries: u32) -> RetryPolicy {
+    RetryPolicy {
+        max_retries,
+        initial_backoff: Duration::from_millis(1),
+        max_backoff: Duration::from_millis(5),
+    }
+}
+
+fn success_body() -> serde_json::Value {
+    json!({
+        "id": "msg_test",
+        "type": "message",
+        "role": "assistant",
+        "model": "claude-3-5-sonnet-20241022",
+        "content": [
+            { "type": "text", "text": "pong" }
+        ],
+        "stop_reason": "end_turn",
+        "usage": {
+            "input_tokens": 3,
+            "output_tokens": 1
+        }
+    })
+}
+
+async fn build_client(server: &MockServer, retry: RetryPolicy) -> AnthropicClient {
+    AnthropicClient::with_auth(AuthSource::ApiKey(TEST_API_KEY.into()))
+        .expect("client constructible")
+        .with_base_url(server.uri())
+        .with_retry_policy(retry)
+}
+
+#[tokio::test]
+async fn complete_happy_path_propagates_request_id() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .and(header("x-api-key", TEST_API_KEY))
+        .and(header("anthropic-version", "2023-06-01"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("request-id", "req-success")
+                .set_body_json(success_body()),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = build_client(&server, fast_retry_policy(0)).await;
+    let response = client.complete(&sample_request()).await.expect("ok");
+    assert_eq!(response.request_id.as_deref(), Some("req-success"));
+    assert_eq!(response.usage.input_tokens, 3);
+}
+
+#[tokio::test]
+async fn auth_failure_is_not_retried() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(ResponseTemplate::new(401).set_body_json(json!({
+            "type": "error",
+            "error": { "type": "authentication_error", "message": "invalid x-api-key" }
+        })))
+        .expect(1) // exactly one — no retry
+        .mount(&server)
+        .await;
+
+    let client = build_client(&server, fast_retry_policy(5)).await;
+    let err = client
+        .complete(&sample_request())
+        .await
+        .expect_err("should fail");
+    match err {
+        ApiError::AuthFailed { reason, .. } => {
+            assert!(
+                reason.contains("invalid x-api-key"),
+                "reason should carry server message, got {reason}"
+            );
+        }
+        other => panic!("expected AuthFailed, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn rate_limited_then_success_honors_retry_after() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(
+            ResponseTemplate::new(429)
+                .insert_header("retry-after", "0")
+                .insert_header("request-id", "req-rl")
+                .set_body_json(json!({
+                    "type": "error",
+                    "error": { "type": "rate_limit_error", "message": "slow down" }
+                })),
+        )
+        .up_to_n_times(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(success_body()))
+        .mount(&server)
+        .await;
+
+    let client = build_client(&server, fast_retry_policy(2)).await;
+    let response = client.complete(&sample_request()).await.expect("ok");
+    assert_eq!(response.usage.output_tokens, 1);
+}
+
+#[tokio::test]
+async fn server_error_retries_then_succeeds() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(ResponseTemplate::new(503).set_body_string("upstream busy"))
+        .up_to_n_times(2)
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(success_body()))
+        .mount(&server)
+        .await;
+
+    let client = build_client(&server, fast_retry_policy(3)).await;
+    let response = client.complete(&sample_request()).await.expect("ok");
+    assert_eq!(response.usage.input_tokens, 3);
+}
+
+#[tokio::test]
+async fn max_retries_exhausted_returns_last_error() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(ResponseTemplate::new(503).set_body_string("upstream busy"))
+        .expect(3) // 1 initial + 2 retries
+        .mount(&server)
+        .await;
+
+    let client = build_client(&server, fast_retry_policy(2)).await;
+    let err = client
+        .complete(&sample_request())
+        .await
+        .expect_err("should fail");
+    match err {
+        ApiError::ServerError { status, .. } => assert_eq!(status, 503),
+        other => panic!("expected ServerError, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn bad_request_extracts_anthropic_error_message() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(ResponseTemplate::new(400).set_body_json(json!({
+            "type": "error",
+            "error": { "type": "invalid_request_error", "message": "max_tokens > 4096" }
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = build_client(&server, fast_retry_policy(3)).await;
+    let err = client
+        .complete(&sample_request())
+        .await
+        .expect_err("should fail");
+    match err {
+        ApiError::BadRequest { reason, .. } => assert_eq!(reason, "max_tokens > 4096"),
+        other => panic!("expected BadRequest, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn stream_yields_events_until_message_stop() {
+    let body = "\
+event: message_start\n\
+data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_1\",\"type\":\"message\",\"role\":\"assistant\",\"model\":\"claude-3-5-sonnet-20241022\",\"content\":[],\"stop_reason\":null,\"usage\":{\"input_tokens\":3,\"output_tokens\":0}}}\n\
+\n\
+event: content_block_start\n\
+data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n\
+\n\
+event: content_block_delta\n\
+data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"pong\"}}\n\
+\n\
+event: content_block_stop\n\
+data: {\"type\":\"content_block_stop\",\"index\":0}\n\
+\n\
+event: message_delta\n\
+data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":1}}\n\
+\n\
+event: message_stop\n\
+data: {\"type\":\"message_stop\"}\n\
+\n";
+
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "text/event-stream")
+                .insert_header("request-id", "req-stream")
+                .set_body_string(body),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = build_client(&server, fast_retry_policy(0)).await;
+    let mut stream = client.stream(&sample_request()).await.expect("ok");
+    assert_eq!(stream.request_id(), Some("req-stream"));
+
+    let mut events = Vec::new();
+    while let Some(event) = stream.next_event().await.expect("event") {
+        events.push(event);
+    }
+    assert_eq!(events.len(), 6, "expected 6 events, got {events:?}");
+    assert!(matches!(events[0], StreamEvent::MessageStart(_)));
+    assert!(matches!(events[5], StreamEvent::MessageStop(_)));
+}

--- a/crates/dasclaw_llm_provider/tests/anthropic_client.rs
+++ b/crates/dasclaw_llm_provider/tests/anthropic_client.rs
@@ -12,7 +12,7 @@
 use std::time::Duration;
 
 use dasclaw_llm_provider::{
-    AnthropicClient, ApiError, AuthSource, MessageRequest, RetryPolicy, StreamEvent,
+    AnthropicClient, ApiError, AuthSource, InputMessage, MessageRequest, RetryPolicy, StreamEvent,
 };
 use serde_json::json;
 use wiremock::matchers::{header, method, path};
@@ -21,14 +21,12 @@ use wiremock::{Mock, MockServer, ResponseTemplate};
 const TEST_API_KEY: &str = "sk-ant-test";
 
 fn sample_request() -> MessageRequest {
-    let body = json!({
-        "model": "claude-3-5-sonnet-20241022",
-        "max_tokens": 16,
-        "messages": [
-            { "role": "user", "content": [{ "type": "text", "text": "ping" }] }
-        ]
-    });
-    serde_json::from_value(body).expect("MessageRequest deserializable")
+    MessageRequest {
+        model: "claude-3-5-sonnet-20241022".to_string(),
+        max_tokens: 16,
+        messages: vec![InputMessage::user_text("ping")],
+        ..MessageRequest::default()
+    }
 }
 
 fn fast_retry_policy(max_retries: u32) -> RetryPolicy {
@@ -56,11 +54,12 @@ fn success_body() -> serde_json::Value {
     })
 }
 
-async fn build_client(server: &MockServer, retry: RetryPolicy) -> AnthropicClient {
-    AnthropicClient::with_auth(AuthSource::ApiKey(TEST_API_KEY.into()))
-        .expect("client constructible")
-        .with_base_url(server.uri())
-        .with_retry_policy(retry)
+fn build_client(server_uri: String, retry: RetryPolicy) -> Result<AnthropicClient, ApiError> {
+    Ok(
+        AnthropicClient::with_auth(AuthSource::ApiKey(TEST_API_KEY.into()))?
+            .with_base_url(server_uri)
+            .with_retry_policy(retry),
+    )
 }
 
 #[tokio::test]
@@ -79,7 +78,7 @@ async fn complete_happy_path_propagates_request_id() {
         .mount(&server)
         .await;
 
-    let client = build_client(&server, fast_retry_policy(0)).await;
+    let client = build_client(server.uri(), fast_retry_policy(0)).expect("client constructible");
     let response = client.complete(&sample_request()).await.expect("ok");
     assert_eq!(response.request_id.as_deref(), Some("req-success"));
     assert_eq!(response.usage.input_tokens, 3);
@@ -98,7 +97,7 @@ async fn auth_failure_is_not_retried() {
         .mount(&server)
         .await;
 
-    let client = build_client(&server, fast_retry_policy(5)).await;
+    let client = build_client(server.uri(), fast_retry_policy(5)).expect("client constructible");
     let err = client
         .complete(&sample_request())
         .await
@@ -137,7 +136,7 @@ async fn rate_limited_then_success_honors_retry_after() {
         .mount(&server)
         .await;
 
-    let client = build_client(&server, fast_retry_policy(2)).await;
+    let client = build_client(server.uri(), fast_retry_policy(2)).expect("client constructible");
     let response = client.complete(&sample_request()).await.expect("ok");
     assert_eq!(response.usage.output_tokens, 1);
 }
@@ -157,7 +156,7 @@ async fn server_error_retries_then_succeeds() {
         .mount(&server)
         .await;
 
-    let client = build_client(&server, fast_retry_policy(3)).await;
+    let client = build_client(server.uri(), fast_retry_policy(3)).expect("client constructible");
     let response = client.complete(&sample_request()).await.expect("ok");
     assert_eq!(response.usage.input_tokens, 3);
 }
@@ -172,7 +171,7 @@ async fn max_retries_exhausted_returns_last_error() {
         .mount(&server)
         .await;
 
-    let client = build_client(&server, fast_retry_policy(2)).await;
+    let client = build_client(server.uri(), fast_retry_policy(2)).expect("client constructible");
     let err = client
         .complete(&sample_request())
         .await
@@ -196,7 +195,7 @@ async fn bad_request_extracts_anthropic_error_message() {
         .mount(&server)
         .await;
 
-    let client = build_client(&server, fast_retry_policy(3)).await;
+    let client = build_client(server.uri(), fast_retry_policy(3)).expect("client constructible");
     let err = client
         .complete(&sample_request())
         .await
@@ -242,7 +241,7 @@ data: {\"type\":\"message_stop\"}\n\
         .mount(&server)
         .await;
 
-    let client = build_client(&server, fast_retry_policy(0)).await;
+    let client = build_client(server.uri(), fast_retry_policy(0)).expect("client constructible");
     let mut stream = client.stream(&sample_request()).await.expect("ok");
     assert_eq!(stream.request_id(), Some("req-stream"));
 

--- a/crates/dasclaw_llm_provider/tests/openai_compat_client.rs
+++ b/crates/dasclaw_llm_provider/tests/openai_compat_client.rs
@@ -1,0 +1,231 @@
+//! `OpenAiCompatClient` 集成测试 — 走 wiremock 模拟 `/v1/chat/completions`，
+//! 覆盖 happy path / 鉴权失败 / 限流退避 / 服务端错误重试 / 重试耗尽 /
+//! 400 错误信封解析 / inline error envelope 兜底。
+
+use std::time::Duration;
+
+use dasclaw_llm_provider::{
+    ApiError, InputMessage, MessageRequest, OpenAiCompatClient, OpenAiCompatConfig, RetryPolicy,
+};
+use serde_json::json;
+use wiremock::matchers::{header, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+const TEST_API_KEY: &str = "sk-test";
+
+fn sample_request() -> MessageRequest {
+    MessageRequest {
+        model: "gpt-4o-mini".to_string(),
+        max_tokens: 16,
+        messages: vec![InputMessage::user_text("ping")],
+        ..MessageRequest::default()
+    }
+}
+
+fn fast_retry_policy(max_retries: u32) -> RetryPolicy {
+    RetryPolicy {
+        max_retries,
+        initial_backoff: Duration::from_millis(1),
+        max_backoff: Duration::from_millis(5),
+    }
+}
+
+fn success_body() -> serde_json::Value {
+    json!({
+        "id": "chatcmpl-test",
+        "object": "chat.completion",
+        "model": "gpt-4o-mini",
+        "choices": [{
+            "index": 0,
+            "message": {
+                "role": "assistant",
+                "content": "pong"
+            },
+            "finish_reason": "stop"
+        }],
+        "usage": { "prompt_tokens": 3, "completion_tokens": 1 }
+    })
+}
+
+fn build_client(server_uri: String, retry: RetryPolicy) -> Result<OpenAiCompatClient, ApiError> {
+    Ok(
+        OpenAiCompatClient::new(TEST_API_KEY, OpenAiCompatConfig::openai())?
+            .with_base_url(server_uri)
+            .with_retry_policy(retry),
+    )
+}
+
+#[tokio::test]
+async fn complete_happy_path_propagates_request_id() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .and(header(
+            "authorization",
+            format!("Bearer {TEST_API_KEY}").as_str(),
+        ))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("request-id", "req-happy")
+                .set_body_json(success_body()),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = build_client(server.uri(), fast_retry_policy(0)).expect("client constructible");
+    let response = client
+        .complete(&sample_request())
+        .await
+        .expect("request succeeds");
+    assert_eq!(response.id, "chatcmpl-test");
+    assert_eq!(response.request_id.as_deref(), Some("req-happy"));
+    assert_eq!(response.stop_reason.as_deref(), Some("end_turn"));
+}
+
+#[tokio::test]
+async fn auth_failure_is_not_retried() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(ResponseTemplate::new(401).set_body_json(json!({
+            "error": { "message": "invalid api key" }
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = build_client(server.uri(), fast_retry_policy(5)).expect("client constructible");
+    let error = client
+        .complete(&sample_request())
+        .await
+        .expect_err("auth fails");
+    match error {
+        ApiError::AuthFailed { reason, .. } => {
+            assert!(reason.contains("invalid api key"), "{reason}");
+        }
+        other => panic!("expected AuthFailed, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn rate_limited_then_success_honors_retry_after() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(
+            ResponseTemplate::new(429)
+                .insert_header("retry-after", "0")
+                .set_body_json(json!({ "error": { "message": "slow down" } })),
+        )
+        .up_to_n_times(1)
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(success_body()))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = build_client(server.uri(), fast_retry_policy(2)).expect("client constructible");
+    let response = client
+        .complete(&sample_request())
+        .await
+        .expect("eventually succeeds");
+    assert_eq!(response.id, "chatcmpl-test");
+}
+
+#[tokio::test]
+async fn server_error_retries_then_succeeds() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(ResponseTemplate::new(503))
+        .up_to_n_times(2)
+        .expect(2)
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(success_body()))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = build_client(server.uri(), fast_retry_policy(3)).expect("client constructible");
+    let response = client
+        .complete(&sample_request())
+        .await
+        .expect("eventually succeeds");
+    assert_eq!(response.id, "chatcmpl-test");
+}
+
+#[tokio::test]
+async fn max_retries_exhausted_returns_last_error() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(ResponseTemplate::new(500))
+        .expect(3) // initial + 2 retries
+        .mount(&server)
+        .await;
+
+    let client = build_client(server.uri(), fast_retry_policy(2)).expect("client constructible");
+    let error = client
+        .complete(&sample_request())
+        .await
+        .expect_err("retries exhausted");
+    assert!(matches!(error, ApiError::ServerError { status: 500, .. }));
+}
+
+#[tokio::test]
+async fn bad_request_extracts_openai_error_message() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(ResponseTemplate::new(400).set_body_json(json!({
+            "error": { "message": "unknown parameter foo" }
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = build_client(server.uri(), fast_retry_policy(3)).expect("client constructible");
+    let error = client
+        .complete(&sample_request())
+        .await
+        .expect_err("bad request");
+    match error {
+        ApiError::BadRequest { reason, .. } => {
+            assert!(reason.contains("unknown parameter foo"), "{reason}");
+        }
+        other => panic!("expected BadRequest, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn inline_error_envelope_in_200_body_is_surfaced() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "error": { "message": "insufficient quota", "type": "billing" }
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = build_client(server.uri(), fast_retry_policy(0)).expect("client constructible");
+    let error = client
+        .complete(&sample_request())
+        .await
+        .expect_err("inline error surfaces");
+    match error {
+        ApiError::Provider { reason, .. } => {
+            assert!(reason.contains("insufficient quota"), "{reason}");
+        }
+        other => panic!("expected Provider, got {other:?}"),
+    }
+}

--- a/crates/dasclaw_llm_provider/tests/openai_compat_streaming.rs
+++ b/crates/dasclaw_llm_provider/tests/openai_compat_streaming.rs
@@ -1,0 +1,248 @@
+//! `OpenAiCompatClient::stream` 集成测试 — 走 wiremock 模拟 `/v1/chat/completions`
+//! 的 SSE 响应（`text/event-stream`，每帧 `data: {...}\n\n`，以 `data: [DONE]` 收尾），
+//! 验证 `OpenAiCompatStream::next_event` 把 OpenAI `chat.completion.chunk` 协议正确
+//! 翻译为 Anthropic 风格 [`StreamEvent`] 序列。
+
+use dasclaw_llm_provider::{
+    ContentBlockDelta, InputMessage, MessageRequest, OpenAiCompatClient, OpenAiCompatConfig,
+    OutputContentBlock, ProviderClient, RetryPolicy, StreamEvent,
+};
+use std::time::Duration;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+const TEST_API_KEY: &str = "sk-test";
+const SSE_CONTENT_TYPE: &str = "text/event-stream";
+
+fn sample_request() -> MessageRequest {
+    MessageRequest {
+        model: "gpt-4o-mini".to_string(),
+        max_tokens: 64,
+        messages: vec![InputMessage::user_text("hello")],
+        stream: true,
+        ..MessageRequest::default()
+    }
+}
+
+fn build_client(server_uri: String) -> OpenAiCompatClient {
+    OpenAiCompatClient::new(TEST_API_KEY, OpenAiCompatConfig::openai())
+        .expect("client constructible")
+        .with_base_url(server_uri)
+        .with_retry_policy(RetryPolicy {
+            max_retries: 0,
+            initial_backoff: Duration::from_millis(1),
+            max_backoff: Duration::from_millis(2),
+        })
+}
+
+/// 把多帧 `data: {json}\n\n` + `data: [DONE]\n\n` 拼成 SSE body。
+fn sse_body(frames: &[&str]) -> String {
+    let mut out = String::new();
+    for frame in frames {
+        out.push_str("data: ");
+        out.push_str(frame);
+        out.push_str("\n\n");
+    }
+    out.push_str("data: [DONE]\n\n");
+    out
+}
+
+async fn drain_stream(client: &OpenAiCompatClient, request: &MessageRequest) -> Vec<StreamEvent> {
+    let mut stream = client.stream(request).await.expect("stream begins");
+    let mut events = Vec::new();
+    while let Some(event) = stream.next_event().await.expect("next_event yields ok") {
+        events.push(event);
+    }
+    events
+}
+
+#[tokio::test]
+async fn stream_text_chunks_yield_anthropic_event_sequence() {
+    let server = MockServer::start().await;
+    let body = sse_body(&[
+        r#"{"id":"chatcmpl-1","model":"gpt-4o-mini","choices":[{"index":0,"delta":{"role":"assistant","content":"He"},"finish_reason":null}]}"#,
+        r#"{"id":"chatcmpl-1","model":"gpt-4o-mini","choices":[{"index":0,"delta":{"content":"llo"},"finish_reason":null}]}"#,
+        r#"{"id":"chatcmpl-1","model":"gpt-4o-mini","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":5,"completion_tokens":2}}"#,
+    ]);
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", SSE_CONTENT_TYPE)
+                .insert_header("request-id", "req-stream-text")
+                .set_body_string(body),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = build_client(server.uri());
+    let events = drain_stream(&client, &sample_request()).await;
+
+    assert!(matches!(events.first(), Some(StreamEvent::MessageStart(_))));
+    assert!(matches!(
+        events.get(1),
+        Some(StreamEvent::ContentBlockStart(_))
+    ));
+
+    let text: String = events
+        .iter()
+        .filter_map(|e| match e {
+            StreamEvent::ContentBlockDelta(delta) => match &delta.delta {
+                ContentBlockDelta::TextDelta { text } => Some(text.as_str()),
+                _ => None,
+            },
+            _ => None,
+        })
+        .collect();
+    assert_eq!(text, "Hello");
+
+    let last_two = &events[events.len() - 2..];
+    assert!(matches!(last_two[0], StreamEvent::MessageDelta(_)));
+    assert!(matches!(last_two[1], StreamEvent::MessageStop(_)));
+
+    let stop_reason = match &last_two[0] {
+        StreamEvent::MessageDelta(ev) => ev.delta.stop_reason.as_deref(),
+        _ => None,
+    };
+    assert_eq!(stop_reason, Some("end_turn"));
+}
+
+#[tokio::test]
+async fn stream_tool_call_accumulates_input_json_delta() {
+    let server = MockServer::start().await;
+    let body = sse_body(&[
+        // 第一帧：tool call 元信息 + 第一段 arguments
+        r#"{"id":"c-1","model":"gpt-4o-mini","choices":[{"index":0,"delta":{"role":"assistant","tool_calls":[{"index":0,"id":"call_1","function":{"name":"get_weather","arguments":"{\"loc"}}]},"finish_reason":null}]}"#,
+        // 第二帧：剩余 arguments
+        r#"{"id":"c-1","model":"gpt-4o-mini","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"ation\":\"SH\"}"}}]},"finish_reason":null}]}"#,
+        // 第三帧：finish
+        r#"{"id":"c-1","model":"gpt-4o-mini","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":12,"completion_tokens":7}}"#,
+    ]);
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", SSE_CONTENT_TYPE)
+                .set_body_string(body),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = build_client(server.uri());
+    let events = drain_stream(&client, &sample_request()).await;
+
+    // ContentBlockStart for ToolUse with name + id
+    let start = events
+        .iter()
+        .find_map(|e| match e {
+            StreamEvent::ContentBlockStart(ev) => match &ev.content_block {
+                OutputContentBlock::ToolUse { id, name, .. } => Some((id.clone(), name.clone())),
+                _ => None,
+            },
+            _ => None,
+        })
+        .expect("tool_use start emitted");
+    assert_eq!(start.0, "call_1");
+    assert_eq!(start.1, "get_weather");
+
+    // 拼接所有 InputJsonDelta，校验完整 arguments
+    let arguments: String = events
+        .iter()
+        .filter_map(|e| match e {
+            StreamEvent::ContentBlockDelta(delta) => match &delta.delta {
+                ContentBlockDelta::InputJsonDelta { partial_json } => Some(partial_json.as_str()),
+                _ => None,
+            },
+            _ => None,
+        })
+        .collect();
+    assert_eq!(arguments, r#"{"location":"SH"}"#);
+
+    // ContentBlockStop with index = 1（block_index = openai_index + 1）
+    let stop_idx = events.iter().rev().find_map(|e| match e {
+        StreamEvent::ContentBlockStop(ev) => Some(ev.index),
+        _ => None,
+    });
+    assert_eq!(stop_idx, Some(1));
+
+    let stop_reason = events.iter().rev().find_map(|e| match e {
+        StreamEvent::MessageDelta(ev) => ev.delta.stop_reason.clone(),
+        _ => None,
+    });
+    assert_eq!(stop_reason.as_deref(), Some("tool_use"));
+}
+
+#[tokio::test]
+async fn stream_tolerates_explicit_null_tool_calls() {
+    // DashScope/Qwen 等部分后端会把 `tool_calls: null` 发出来，serde `default`
+    // 单独处理不了显式 null，本测试守护 `deserialize_null_as_empty_vec` 行为。
+    let server = MockServer::start().await;
+    let body = sse_body(&[
+        r#"{"id":"c-2","model":"qwen-max","choices":[{"index":0,"delta":{"role":"assistant","content":"ok","tool_calls":null},"finish_reason":null}]}"#,
+        r#"{"id":"c-2","model":"qwen-max","choices":[{"index":0,"delta":{"content":null,"tool_calls":null},"finish_reason":"stop"}]}"#,
+    ]);
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", SSE_CONTENT_TYPE)
+                .set_body_string(body),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = build_client(server.uri());
+    let events = drain_stream(&client, &sample_request()).await;
+    let text: String = events
+        .iter()
+        .filter_map(|e| match e {
+            StreamEvent::ContentBlockDelta(delta) => match &delta.delta {
+                ContentBlockDelta::TextDelta { text } => Some(text.as_str()),
+                _ => None,
+            },
+            _ => None,
+        })
+        .collect();
+    assert_eq!(text, "ok");
+}
+
+#[tokio::test]
+async fn stream_dispatch_through_provider_client_returns_same_events() {
+    // ProviderClient::stream_message 的 dispatcher 行为：OpenAi 变体应走
+    // OpenAiCompatStream 路径，与直连一致。
+    let server = MockServer::start().await;
+    let body = sse_body(&[
+        r#"{"id":"c-3","model":"gpt-4o-mini","choices":[{"index":0,"delta":{"role":"assistant","content":"hi"},"finish_reason":null}]}"#,
+        r#"{"id":"c-3","model":"gpt-4o-mini","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}"#,
+    ]);
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", SSE_CONTENT_TYPE)
+                .set_body_string(body),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let inner = build_client(server.uri());
+    let provider = ProviderClient::OpenAi(inner);
+    let mut stream = provider
+        .stream_message(&sample_request())
+        .await
+        .expect("dispatch ok");
+
+    let mut text = String::new();
+    while let Some(event) = stream.next_event().await.expect("next ok") {
+        if let StreamEvent::ContentBlockDelta(delta) = event {
+            if let ContentBlockDelta::TextDelta { text: chunk } = delta.delta {
+                text.push_str(&chunk);
+            }
+        }
+    }
+    assert_eq!(text, "hi");
+}

--- a/crates/dasclaw_llm_provider/tests/openai_compat_streaming.rs
+++ b/crates/dasclaw_llm_provider/tests/openai_compat_streaming.rs
@@ -4,8 +4,8 @@
 //! 翻译为 Anthropic 风格 [`StreamEvent`] 序列。
 
 use dasclaw_llm_provider::{
-    ContentBlockDelta, InputMessage, MessageRequest, OpenAiCompatClient, OpenAiCompatConfig,
-    OutputContentBlock, ProviderClient, RetryPolicy, StreamEvent,
+    ApiError, ContentBlockDelta, InputMessage, MessageRequest, OpenAiCompatClient,
+    OpenAiCompatConfig, OutputContentBlock, ProviderClient, RetryPolicy, StreamEvent,
 };
 use std::time::Duration;
 use wiremock::matchers::{method, path};
@@ -24,15 +24,16 @@ fn sample_request() -> MessageRequest {
     }
 }
 
-fn build_client(server_uri: String) -> OpenAiCompatClient {
-    OpenAiCompatClient::new(TEST_API_KEY, OpenAiCompatConfig::openai())
-        .expect("client constructible")
-        .with_base_url(server_uri)
-        .with_retry_policy(RetryPolicy {
-            max_retries: 0,
-            initial_backoff: Duration::from_millis(1),
-            max_backoff: Duration::from_millis(2),
-        })
+fn build_client(server_uri: String) -> Result<OpenAiCompatClient, ApiError> {
+    Ok(
+        OpenAiCompatClient::new(TEST_API_KEY, OpenAiCompatConfig::openai())?
+            .with_base_url(server_uri)
+            .with_retry_policy(RetryPolicy {
+                max_retries: 0,
+                initial_backoff: Duration::from_millis(1),
+                max_backoff: Duration::from_millis(2),
+            }),
+    )
 }
 
 /// 把多帧 `data: {json}\n\n` + `data: [DONE]\n\n` 拼成 SSE body。
@@ -47,13 +48,16 @@ fn sse_body(frames: &[&str]) -> String {
     out
 }
 
-async fn drain_stream(client: &OpenAiCompatClient, request: &MessageRequest) -> Vec<StreamEvent> {
-    let mut stream = client.stream(request).await.expect("stream begins");
+async fn drain_stream(
+    client: &OpenAiCompatClient,
+    request: &MessageRequest,
+) -> Result<Vec<StreamEvent>, ApiError> {
+    let mut stream = client.stream(request).await?;
     let mut events = Vec::new();
-    while let Some(event) = stream.next_event().await.expect("next_event yields ok") {
+    while let Some(event) = stream.next_event().await? {
         events.push(event);
     }
-    events
+    Ok(events)
 }
 
 #[tokio::test]
@@ -76,8 +80,10 @@ async fn stream_text_chunks_yield_anthropic_event_sequence() {
         .mount(&server)
         .await;
 
-    let client = build_client(server.uri());
-    let events = drain_stream(&client, &sample_request()).await;
+    let client = build_client(server.uri()).expect("client constructible");
+    let events = drain_stream(&client, &sample_request())
+        .await
+        .expect("stream drains");
 
     assert!(matches!(events.first(), Some(StreamEvent::MessageStart(_))));
     assert!(matches!(
@@ -130,8 +136,10 @@ async fn stream_tool_call_accumulates_input_json_delta() {
         .mount(&server)
         .await;
 
-    let client = build_client(server.uri());
-    let events = drain_stream(&client, &sample_request()).await;
+    let client = build_client(server.uri()).expect("client constructible");
+    let events = drain_stream(&client, &sample_request())
+        .await
+        .expect("stream drains");
 
     // ContentBlockStart for ToolUse with name + id
     let start = events
@@ -194,8 +202,10 @@ async fn stream_tolerates_explicit_null_tool_calls() {
         .mount(&server)
         .await;
 
-    let client = build_client(server.uri());
-    let events = drain_stream(&client, &sample_request()).await;
+    let client = build_client(server.uri()).expect("client constructible");
+    let events = drain_stream(&client, &sample_request())
+        .await
+        .expect("stream drains");
     let text: String = events
         .iter()
         .filter_map(|e| match e {
@@ -229,7 +239,7 @@ async fn stream_dispatch_through_provider_client_returns_same_events() {
         .mount(&server)
         .await;
 
-    let inner = build_client(server.uri());
+    let inner = build_client(server.uri()).expect("client constructible");
     let provider = ProviderClient::OpenAi(inner);
     let mut stream = provider
         .stream_message(&sample_request())

--- a/desktop-client/ironclaw/Cargo.toml
+++ b/desktop-client/ironclaw/Cargo.toml
@@ -144,9 +144,9 @@ blake3 = "1"
 rand = "0.8"
 subtle = "2"  # Constant-time comparisons for token validation
 
-# Multi-provider LLM support (claw-code-api native client)
-# crate 真实 package 名为 `api`，这里重命名为 claw-code-api 避免泛名冲突。
-claw-code-api = { path = "../../claw-code/rust/crates/api", package = "api" }
+# Multi-provider LLM support (主仓自实现 client，W6-C PR-A.4 起替代 claw-code-api path-dep；
+# claw-code 子仓自此只读保留，详见 ADR-118)
+dasclaw_llm_provider = { path = "../../crates/dasclaw_llm_provider" }
 
 # AWS Bedrock (native Converse API, opt-in via --features bedrock)
 aws-config = { version = "1", features = ["behavior-version-latest"], optional = true }
@@ -229,9 +229,9 @@ harness = false
 default = ["postgres", "libsql", "html-to-markdown"]
 test-support = ["dep:tempfile"]
 # 历史遗留：Phase 2 Step I 之前用来切换 rig-core / claw-code-api 两套 LLM
-# 后端，现在 claw-code-api 是唯一路径，feature 名保留为空 no-op，避免下游
-# （如 desktop-client）触发构建失败。下一次 minor 版本可同步删除该 feature
-# 与 desktop-client/Cargo.toml 中的 passthrough。
+# 后端，W6-C PR-A.4 之后 dasclaw_llm_provider 是唯一路径，feature 名保留为空
+# no-op，避免下游（如 desktop-client）触发构建失败。下一次 minor 版本可同步
+# 删除该 feature 与 desktop-client/Cargo.toml 中的 passthrough。
 claw-code-llm = []
 postgres = [
     "dep:deadpool-postgres",

--- a/desktop-client/ironclaw/src/llm/claw_code_provider.rs
+++ b/desktop-client/ironclaw/src/llm/claw_code_provider.rs
@@ -1,7 +1,11 @@
-//! `ClawCodeLlmProvider` — LLM Provider 基于 `claw-code-api` 的原生客户端。
+//! `ClawCodeLlmProvider` — LLM Provider 基于 `dasclaw_llm_provider` 的原生客户端。
 //!
 //! Phase 2 Step I 完成后，本模块是生产唯一 LLM 路径
 //! （`GithubCopilot` / `CodexChatGpt` 由各自独立 provider 处理）。
+//!
+//! W6-C PR-A.4 完成后，底层 client 切换到主仓自实现的 [`dasclaw_llm_provider`]，
+//! 不再依赖 `claw-code/rust/crates/api` 的 path-dep（claw-code 子仓只读化，详见
+//! [ADR-118](../../../../docs/plans/architecture-refactor/adr-118-claw-code-readonly-and-self-impl.md)）。
 //!
 //! 关键收益：
 //! - `OpenAiCompatClient` 已为各 OpenAI-compat 厂商（DashScope/Kimi/xAI/Ollama）
@@ -10,9 +14,9 @@
 //! - 编译期裁掉大量历史 rig 适配层的异构类型体操。
 
 use async_trait::async_trait;
-use claw_code_api::{
-    AnthropicClient, AuthSource, InputContentBlock, InputMessage, MessageRequest, MessageResponse,
-    OpenAiCompatClient, OpenAiCompatConfig, OutputContentBlock, ProviderClient,
+use dasclaw_llm_provider::{
+    AnthropicClient, ApiError, AuthSource, InputContentBlock, InputMessage, MessageRequest,
+    MessageResponse, OpenAiCompatClient, OpenAiCompatConfig, OutputContentBlock, ProviderClient,
     ToolChoice as ApiToolChoice, ToolDefinition as ApiToolDefinition, ToolResultContentBlock,
 };
 use rust_decimal::Decimal;
@@ -39,19 +43,6 @@ pub struct ClawCodeLlmProvider {
 }
 
 impl ClawCodeLlmProvider {
-    /// 根据模型名自动探测 Provider 类型（OpenAI / Anthropic / xAI / DashScope 等）。
-    pub fn from_model(model: impl Into<String>) -> Result<Self, LlmError> {
-        let configured_model = model.into();
-        let resolved_model = claw_code_api::resolve_model_alias(&configured_model).to_string();
-        let client = ProviderClient::from_model(&configured_model).map_err(map_api_error)?;
-        Ok(Self {
-            client,
-            configured_model,
-            resolved_model,
-            cost_rates: None,
-        })
-    }
-
     /// 覆盖 token 单价（用于 `calculate_cost` / `cost_per_token`）。
     #[must_use]
     pub fn with_cost_rates(mut self, input: Decimal, output: Decimal) -> Self {
@@ -62,7 +53,7 @@ impl ClawCodeLlmProvider {
     /// 从 ironclaw 的 [`RegistryProviderConfig`] 构造一个 Provider。
     ///
     /// 这是 **Step D** 的核心入口，负责把 x-claw 现有的 providers.json 配置
-    /// 映射到 `claw-code-api` 的具体 client：
+    /// 映射到 `dasclaw_llm_provider` 的具体 client：
     ///
     /// | `ProviderProtocol`  | 映射目标                                                    |
     /// |---------------------|-------------------------------------------------------------|
@@ -74,12 +65,13 @@ impl ClawCodeLlmProvider {
     /// 不读取任何环境变量：凭据/URL 都来自显式配置，符合 x-claw 的 keychain 模型。
     pub fn from_registry_config(config: &RegistryProviderConfig) -> Result<Self, LlmError> {
         let configured_model = config.model.clone();
-        let resolved_model = claw_code_api::resolve_model_alias(&configured_model).to_string();
+        let resolved_model =
+            dasclaw_llm_provider::resolve_model_alias(&configured_model).to_string();
 
         let client = match config.protocol {
             ProviderProtocol::Anthropic => build_anthropic_client(config)?,
             ProviderProtocol::OpenAiCompletions => build_openai_compat_client(config)?,
-            ProviderProtocol::Ollama => build_ollama_client(config),
+            ProviderProtocol::Ollama => build_ollama_client(config)?,
             ProviderProtocol::GithubCopilot => {
                 return Err(LlmError::RequestFailed {
                     provider: config.provider_id.clone(),
@@ -107,7 +99,7 @@ impl ClawCodeLlmProvider {
 }
 
 // ============================================================================
-// 请求映射：ironclaw → claw-code-api
+// 请求映射：ironclaw → dasclaw_llm_provider
 // ============================================================================
 
 /// 把 ironclaw 的 `CompletionRequest` 映射为 claw-code-api 的 `MessageRequest`。
@@ -212,8 +204,8 @@ fn map_user_message(m: &ChatMessage) -> InputMessage {
                     content.push(InputContentBlock::Text { text: text.clone() })
                 }
                 ContentPart::ImageUrl { image_url: _ } => {
-                    // claw-code-api 的 InputContentBlock 目前不直接接受 OpenAI image_url，
-                    // 交由未来扩展。此处降级为占位文本以免丢失语义。
+                    // dasclaw_llm_provider 的 InputContentBlock 目前不直接接受 OpenAI
+                    // image_url，交由未来扩展。此处降级为占位文本以免丢失语义。
                     content.push(InputContentBlock::Text {
                         text: "[image]".to_string(),
                     });
@@ -296,7 +288,7 @@ fn map_tool_choice(choice: &str) -> Option<ApiToolChoice> {
 }
 
 // ============================================================================
-// 响应映射：claw-code-api → ironclaw
+// 响应映射：dasclaw_llm_provider → ironclaw
 // ============================================================================
 
 pub(crate) fn map_message_response(resp: MessageResponse) -> ToolCompletionResponse {
@@ -364,9 +356,9 @@ fn map_finish_reason(reason: Option<&str>) -> FinishReason {
     }
 }
 
-fn map_api_error(err: claw_code_api::ApiError) -> LlmError {
+fn map_api_error(err: ApiError) -> LlmError {
     LlmError::RequestFailed {
-        provider: "claw-code-api".to_string(),
+        provider: "dasclaw_llm_provider".to_string(),
         reason: err.to_string(),
     }
 }
@@ -406,24 +398,30 @@ fn build_anthropic_client(config: &RegistryProviderConfig) -> Result<ProviderCli
         }
     };
 
-    let client = AnthropicClient::from_auth(auth).with_base_url(config.base_url.clone());
+    let client = AnthropicClient::with_auth(auth)
+        .map_err(map_api_error)?
+        .with_base_url(config.base_url.clone());
     Ok(ProviderClient::Anthropic(client))
 }
 
 /// 根据模型名自动选 DashScope / xAI / OpenAI 预设；然后 override base_url。
+///
+/// 仅基于模型名做静态映射，不读取环境（`EnvSnapshot::default()` 即可），
+/// 因为 ironclaw 的鉴权一律来自 `RegistryProviderConfig` 的显式配置。
 fn pick_openai_compat_config(model: &str) -> (OpenAiCompatConfig, ProviderVariant) {
-    let resolved = claw_code_api::resolve_model_alias(model);
-    match claw_code_api::detect_provider_kind(&resolved) {
-        claw_code_api::ProviderKind::Xai => (OpenAiCompatConfig::xai(), ProviderVariant::Xai),
-        claw_code_api::ProviderKind::OpenAi => {
+    use dasclaw_llm_provider::{
+        EnvSnapshot, ProviderKind, detect_provider_kind, resolve_model_alias,
+    };
+    let resolved = resolve_model_alias(model);
+    match detect_provider_kind(&resolved, &EnvSnapshot::default()) {
+        ProviderKind::Xai => (OpenAiCompatConfig::xai(), ProviderVariant::Xai),
+        ProviderKind::OpenAi => {
             // 根据模型 metadata 进一步区分 DashScope vs 通用 OpenAI-compat
             // （Groq/Kimi/OpenRouter/Tinfoil 都用 openai() 预设 + 自定义 base_url）
             (OpenAiCompatConfig::openai(), ProviderVariant::OpenAi)
         }
         // Anthropic 不该走到这里；兜底 openai 预设以避免 panic，错误由上层抛出。
-        claw_code_api::ProviderKind::Anthropic => {
-            (OpenAiCompatConfig::openai(), ProviderVariant::OpenAi)
-        }
+        ProviderKind::Anthropic => (OpenAiCompatConfig::openai(), ProviderVariant::OpenAi),
     }
 }
 
@@ -439,20 +437,22 @@ fn build_openai_compat_client(config: &RegistryProviderConfig) -> Result<Provide
     })?;
 
     let (compat_config, variant) = pick_openai_compat_config(&config.model);
-    let client =
-        OpenAiCompatClient::new(api_key, compat_config).with_base_url(config.base_url.clone());
+    let client = OpenAiCompatClient::new(api_key, compat_config)
+        .map_err(map_api_error)?
+        .with_base_url(config.base_url.clone());
     Ok(match variant {
         ProviderVariant::Xai => ProviderClient::Xai(client),
         ProviderVariant::OpenAi => ProviderClient::OpenAi(client),
     })
 }
 
-fn build_ollama_client(config: &RegistryProviderConfig) -> ProviderClient {
+fn build_ollama_client(config: &RegistryProviderConfig) -> Result<ProviderClient, LlmError> {
     // Ollama 不需要 API key；如果用户填了 key（如反向代理鉴权），也传进去。
     let api_key = registry_api_key(config).unwrap_or_default();
     let client = OpenAiCompatClient::new(api_key, OpenAiCompatConfig::openai())
+        .map_err(map_api_error)?
         .with_base_url(config.base_url.clone());
-    ProviderClient::OpenAi(client)
+    Ok(ProviderClient::OpenAi(client))
 }
 
 // ============================================================================
@@ -531,7 +531,7 @@ impl LlmProvider for ClawCodeLlmProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use claw_code_api::Usage;
+    use dasclaw_llm_provider::Usage;
     use serde_json::json;
 
     fn mk_user(text: &str) -> ChatMessage {
@@ -1003,7 +1003,7 @@ mod tests {
     // ========================================================================
 
     use crate::llm::config::{CacheRetention, RegistryProviderConfig};
-    use claw_code_api::ProviderKind;
+    use dasclaw_llm_provider::ProviderKind;
     use secrecy::SecretString;
 
     fn mk_config(

--- a/docs/plans/architecture-refactor/p0-w6c-ironclaw-call-site-inventory.md
+++ b/docs/plans/architecture-refactor/p0-w6c-ironclaw-call-site-inventory.md
@@ -1,0 +1,180 @@
+# P0 W6-C ironclaw 调用面 inventory（PR-A.4 准备）
+
+> **状态**：inventory（只读盘点）。本文件**不做架构决策**，只列事实。
+>
+> **目的**：在 PR-A.4 切换 `desktop-client/ironclaw` 的 `claw-code-api` path-dep 到
+> `dasclaw_llm_provider` 之前，把所有 ironclaw 端依赖 `claw_code_api::*` 的位置、签名、
+> 已移植/未移植状态全列出来，PR-A.4 实施时按本表逐条迁移。
+>
+> **来源**：
+> - Level 1 `semantic_search`：claude code api provider usage send_message stream
+> - Level 2 引用面：`grep_search "claw_code_api"` in `desktop-client/**/*.rs`（11 hit）+ Cargo.toml（5 hit）
+> - Level 3 字面量：`grep` `pub fn (with_|new|from_auth|complete|stream)` 双 client 比对
+>
+> **关联 ADR**：[ADR-118 §5 W6-C](adr-118-claw-code-readonly-and-self-impl.md#5-w6-c) /
+> [§8 实施事实账本](adr-118-claw-code-readonly-and-self-impl.md#8)
+
+## 1. 调用面总图
+
+ironclaw 中**唯一**消费 `claw-code-api` 的文件是 [`desktop-client/ironclaw/src/llm/claw_code_provider.rs`](../../desktop-client/ironclaw/src/llm/claw_code_provider.rs)（1351 LOC）。
+Cargo path-dep 在 [`desktop-client/ironclaw/Cargo.toml`](../../desktop-client/ironclaw/Cargo.toml#L149)：
+
+```toml
+claw-code-api = { path = "../../claw-code/rust/crates/api", package = "api" }
+```
+
+无第二个消费方。
+
+## 2. 引用符号清单（共 16 个）
+
+来源：`claw_code_provider.rs` 第 13-17 行 `use claw_code_api::{...}` 块 + 散落 `claw_code_api::xxx` 调用 + `tests` 块的 `use claw_code_api::Usage` / `use claw_code_api::ProviderKind`。
+
+| # | 符号 | 引用方式 | 在 `dasclaw_llm_provider` 已移植？ | 备注 |
+|---|---|---|---|---|
+| 1 | `AnthropicClient` | type | ✅ PR-A.2 | 字段名/构造方法有差异（见 §3.1） |
+| 2 | `AuthSource` | enum | ✅ PR-A.2 | 三变体齐全（`ApiKey` / `BearerToken` / `ApiKeyAndBearer`） |
+| 3 | `InputContentBlock` | type | ✅ PR-A.0 types | |
+| 4 | `InputMessage` | type | ✅ PR-A.0 types | `role: String`，非 enum |
+| 5 | `MessageRequest` | type | ✅ PR-A.0 types | |
+| 6 | `MessageResponse` | type | ✅ PR-A.0 types | |
+| 7 | `OpenAiCompatClient` | type | ✅ PR-A.3 | `complete()` only，`stream()` 留 PR-A.3.1 |
+| 8 | `OpenAiCompatConfig` | type | ✅ PR-A.3 | `openai()` / `xai()` / `dashscope()` 三预设齐 |
+| 9 | `OutputContentBlock` | type | ✅ PR-A.0 types | |
+| 10 | `ProviderClient` | enum + dispatcher | ❌ **未移植** | **PR-A.4 必须新增**，见 §3.2 |
+| 11 | `ToolChoice` | enum | ✅ PR-A.0 types | ironclaw 重命名为 `ApiToolChoice` |
+| 12 | `ToolDefinition` | struct | ✅ PR-A.0 types | ironclaw 重命名为 `ApiToolDefinition` |
+| 13 | `ToolResultContentBlock` | struct | ✅ PR-A.0 types | |
+| 14 | `ApiError` | error type | ✅ PR-A.0 error | dasclaw 拆变体更细 |
+| 15 | `Usage` | struct | ✅ PR-A.0 types | 测试块用 |
+| 16 | `ProviderKind` | enum | ✅ PR-A.0 providers | 测试块用 |
+
+## 3. 函数 / 方法调用清单
+
+### 3.1 已移植但**签名不兼容**（PR-A.4 必须改 ironclaw 调用方）
+
+| 调用位置（claw_code_provider.rs 行号） | 当前调用 | 目标 dasclaw 等价 | 签名差异 |
+|---|---|---|---|
+| L45, L77, L415 | `claw_code_api::resolve_model_alias(model) -> &'static str` | `dasclaw_llm_provider::resolve_model_alias(model) -> String` | 返回类型 `&'static str` → `String`，调用方已 `.to_string()` 兼容 |
+| L416 | `claw_code_api::detect_provider_kind(&resolved)` | `dasclaw_llm_provider::detect_provider_kind(&resolved, &env)` | **新增 `EnvSnapshot` 参数**：调用方需先 `EnvSnapshot::from_process_env()` 然后传引用 |
+| L411 (`build_anthropic_client`) | `AnthropicClient::from_auth(auth)` 返回 `Self` | `AnthropicClient::with_auth(auth)?` 返回 `Result<Self, ApiError>` | **可错构造**：调用方需 `?` 传播错误并 `map_err(map_api_error)` |
+| L449 (`build_openai_compat_client`) | `OpenAiCompatClient::new(key, config)` 返回 `Self` | `OpenAiCompatClient::new(key, config)?` 返回 `Result<Self, ApiError>` | **可错构造**：同上 |
+| L506, L539（`complete` / `complete_with_tools` 内 `self.client.send_message(&msg_req)`） | 通过 `ProviderClient` enum dispatch 到具体 client 的 `send_message` | 见 §3.2 — `ProviderClient` 还没移植 | **方法名也需考虑**：dasclaw 把 client 单点方法叫 `complete()`，不是 `send_message()` |
+
+### 3.2 未移植：`ProviderClient` enum dispatcher（PR-A.4 必须新增）
+
+claw-code 的 `ProviderClient` 提供三件事，ironclaw 全部依赖：
+
+```rust
+// claw-code/rust/crates/api/src/client.rs:10-104
+pub enum ProviderClient {
+    Anthropic(AnthropicClient),
+    Xai(OpenAiCompatClient),
+    OpenAi(OpenAiCompatClient),
+}
+impl ProviderClient {
+    pub fn from_model(model: &str) -> Result<Self, ApiError> { /* 别名 → kind → 默认 client */ }
+    pub fn from_model_with_anthropic_auth(model, anthropic_auth: Option<AuthSource>) -> Result<Self, ApiError>;
+    pub const fn provider_kind(&self) -> ProviderKind;
+    pub async fn send_message(&self, req: &MessageRequest) -> Result<MessageResponse, ApiError>;
+    pub async fn stream_message(&self, req: &MessageRequest) -> Result<MessageStream, ApiError>;
+    // 还有 prompt_cache 系列，ironclaw 未消费 → PR-A.4 不必移植
+}
+```
+
+ironclaw 实际消费点（`claw_code_provider.rs`）：
+- L46：`ProviderClient::from_model(&configured_model).map_err(map_api_error)?`
+- L412：`ProviderClient::Anthropic(client)` 构造（`build_anthropic_client` 末尾）
+- L455-458：`ProviderClient::Xai(client)` / `ProviderClient::OpenAi(client)` 构造（`build_openai_compat_client`）
+- L464：`ProviderClient::OpenAi(client)`（`build_ollama_client`）
+- L506, L539：`self.client.send_message(&msg_req).await`
+
+**ironclaw 未消费**的：`stream_message` / `provider_kind` / `prompt_cache*` / `from_model_with_anthropic_auth`。
+
+### 3.3 已移植且签名兼容（PR-A.4 改 import path 即可）
+
+| 符号 | claw-code 路径 | dasclaw 路径 |
+|---|---|---|
+| `InputContentBlock` / `InputMessage` / `MessageRequest` / `MessageResponse` / `OutputContentBlock` / `ToolChoice` / `ToolDefinition` / `ToolResultContentBlock` / `Usage` | `claw_code_api::*` | `dasclaw_llm_provider::*`（已 re-export） |
+| `ApiError` | `claw_code_api::ApiError` | `dasclaw_llm_provider::ApiError` |
+| `ProviderKind` | `claw_code_api::ProviderKind` | `dasclaw_llm_provider::ProviderKind` |
+| `AuthSource` | `claw_code_api::AuthSource` | `dasclaw_llm_provider::AuthSource` |
+| `AnthropicClient::with_base_url` / `OpenAiCompatClient::with_base_url` | 同名 | 同名（builder pattern 一致） |
+
+## 4. PR-A.4 必做改动清单（按 file 分块）
+
+### 4.1 `desktop-client/ironclaw/Cargo.toml`
+
+- 删除 `claw-code-api = { path = "../../claw-code/rust/crates/api", package = "api" }`（L149）
+- 新增 `dasclaw_llm_provider = { path = "../../crates/dasclaw_llm_provider" }`
+- 注释（L147-148, L231-232）一并更新或删除
+
+### 4.2 `desktop-client/ironclaw/src/llm/claw_code_provider.rs`
+
+按 §3.1 + §3.2 改：
+
+1. `use` 块全部改 `claw_code_api::` → `dasclaw_llm_provider::`
+2. `from_model` (L46) 调用方：先 `let env = EnvSnapshot::from_process_env();` 再两步调（kind 检测 + 构造），或者**在 dasclaw 增 `ProviderClient::from_model(model)` 兼容方法**
+3. `AnthropicClient::from_auth(auth)` (L411) → `with_auth(auth)?`
+4. `OpenAiCompatClient::new(...)` (L449, L460) 加 `?`
+5. `detect_provider_kind(&resolved)` (L416) 加 `EnvSnapshot` 参数
+6. `client.send_message(&msg_req)` (L506, L539) 改 `client.complete(&msg_req)` 或在 dasclaw `ProviderClient` 上提供 `send_message` alias
+7. 测试块 (L534, L1006) `use` 改路径
+
+### 4.3 选项 A vs 选项 B（PR-A.4 设计决策点，不在本 inventory 决断）
+
+- **选项 A — ironclaw 全面适配 dasclaw 新签名**：调用方写 `EnvSnapshot::from_process_env()`、`with_auth(...)?`、`.complete(...)`，dasclaw 不加任何兼容层。**优点**：dasclaw API 干净；**缺点**：PR-A.4 diff 大。
+- **选项 B — dasclaw 加薄兼容层**：在 dasclaw 提供 `ProviderClient::from_model(&str)`（内部读 env）、`send_message` 作为 `complete` 的 alias、`AnthropicClient::from_auth(auth) -> Self` 内部 unwrap_or_panic。**优点**：PR-A.4 改动小；**缺点**：dasclaw 沾上"无 env 副作用"原则的反例（ADR-118 §8.5 第 2 点明确说 dasclaw 不读 env）。
+
+**推荐**：**选项 A**。ADR-118 §8.5 已经把"无 env 副作用"列为顺势处理的架构债，PR-A.4 一次性还清，比留兼容层后续再拆更彻底。`ProviderClient` enum 仍然在 dasclaw 提供（因 ironclaw 真的需要 enum dispatch），但 `from_model` 改成 `from_model(model, &env)` 显式签名。
+
+## 5. 已确认的非目标（PR-A.4 不做）
+
+1. **`OpenAiCompatClient::stream()`** 移植 — 留 PR-A.3.1，ironclaw 当前 call site 全部 `send_message` (`stream: false`)
+2. **`AnthropicClient::stream()` 在 `ProviderClient::stream_message` 上的 dispatch** — ironclaw 未消费，dasclaw `ProviderClient::stream_message` 不必先实现（PR-A.4 可只暴露 `send_message` dispatch）
+3. **`prompt_cache*` 方法族** — ironclaw 未消费
+4. **`from_env*` 工厂方法**（`AnthropicClient::from_env`、`OpenAiCompatClient::from_env`、`AnthropicClient::from_env_or_saved`）— ironclaw `build_anthropic_client` / `build_openai_compat_client` 都从 `RegistryProviderConfig` 显式构造 `AuthSource`，不走 env，无须移植
+5. **`ProviderClient::with_prompt_cache` / `prompt_cache_stats` / `take_last_prompt_cache_record`** — ironclaw 未消费
+6. **`ProviderClient::from_model_with_anthropic_auth`** — ironclaw 未消费（OAuth 走 `build_anthropic_client` 显式）
+7. **删除 `claw-code` 子仓本身** — ADR-118 §5 已声明 W6-C 后子仓只读保留，不删除
+
+## 6. 验证清单（PR-A.4 本地最低门）
+
+按 [AGENTS.md "本地快速开发节奏"](../../AGENTS.md) **档 2 推荐**（基础库改下游消费方）：
+
+```bash
+# 1. 本 crate
+cargo check -p dasclaw_llm_provider --tests
+cargo nextest run -p dasclaw_llm_provider
+
+# 2. 下游 — 基础库改动必跑
+cargo check --workspace --tests          # ironclaw + desktop-client + admin-backend 全编
+
+# 3. 局部测试
+cargo nextest run -p ironclaw --lib llm
+cargo build -p desktop-client --lib --tests   # link-time / Tauri state 验证
+
+# 4. 标准三件套
+cargo fmt --all
+python3.12 scripts/check_no_panics.py --base origin/xClaw
+cargo clippy --no-deps -p dasclaw_llm_provider --all-targets -- -D warnings
+cargo clippy --no-deps -p ironclaw --all-targets -- -D warnings
+```
+
+## 7. 三层验证证据存档
+
+按 [AGENTS.md 分析工具使用规范](../../AGENTS.md) 要求，本 inventory 是「跨项目对账 + 否定性结论」，已完成三层验证：
+
+- **Level 1 `semantic_search`**：query "ironclaw claude code api provider usage send_message stream" → 命中 `claw_code_provider.rs` / `claw_code_api::*` import 块 / `ProviderClient` 实现 / dasclaw_llm_provider 当前 re-export 状态。
+- **Level 2 `grep_search`**：`claw_code_api` in `desktop-client/**/*.rs` → 11 hit（全部在 `claw_code_provider.rs`）；`claw-code-api|claw_code_api` in `desktop-client/**/Cargo.toml` → 5 hit（仅 ironclaw/Cargo.toml）。
+- **Level 3 `grep_search`**：`pub fn (with_|new|from_auth|complete|stream|base_url)` 在 dasclaw 双 client 与 claw-code 双 client 上分别枚举 → 签名差异表（§3.1）。
+
+**否定性结论 + 双证据**：
+- "ironclaw 未消费 stream_message" — Level 2 grep `stream_message|stream(` in `desktop-client/ironclaw/src/llm/*.rs` 无 hit + Level 1 ADR-118 §8 事实账本表"streaming = ❌（trait 默认）"
+- "ironclaw 未消费 prompt_cache*" — Level 2 grep `prompt_cache` in `desktop-client/ironclaw/src/llm/*.rs` 无 hit
+- "`ProviderClient` 在 dasclaw 不存在" — Level 2 grep `ProviderClient` in `crates/dasclaw_llm_provider/src/**` 无 hit + Level 1 lib.rs re-export 列表无该名
+
+---
+
+**文档版本**：v1（inventory 初稿，伴随 PR-A.4 起草）
+**生成时间**：随 PR-A.4 准备工作创建
+**生成方法**：`semantic_search` → `grep_search` → `read_file` 三层验证后人工汇总


### PR DESCRIPTION
## 背景 / 目标

依据 [ADR-118 §8.5](docs/plans/architecture-refactor/adr-118-llm-provider-decoupling.md)，在 `dasclaw_llm_provider` 中实现 OpenAI Chat Completions SSE 流式 → Anthropic `StreamEvent` 序列的翻译，完成流式能力在 dasclaw 端的交付。

这是 PR-A.4（#158, ironclaw cutover）之上的 **stacked PR**：base = `w6c-dasclaw-llm-provider-ironclaw-cutover`，**先合并 #158 再合并本 PR**。

## 改动范围

**`crates/dasclaw_llm_provider/src/providers/openai_compat.rs`**
- 新公共方法 `OpenAiCompatClient::stream(&MessageRequest) -> Result<OpenAiCompatStream, ApiError>`
- 新公共类型 `OpenAiCompatStream`：`next_event()` 异步循环，吸收 SSE → chunks → events，pending VecDeque 缓冲
- 内部 `OpenAiSseParser`：帧切分（`\n\n` / `\r\n\r\n`），剥离 `data:` 前缀，识别 `[DONE]` 哨兵
- 内部 `StreamState`（BTreeMap<u32, ToolCallState>）+ `ToolCallState`：
  - `block_index = openai_index + 1`（文本块固定占用 0）
  - `apply` 累积 id/name/arguments，`start_event` 发出 `ContentBlockStart`，`delta_event` 用 `emitted_len` 切片发出 `InputJsonDelta`
- `finish_reason` → `stop_reason` 映射（stop→end_turn / length→max_tokens / tool_calls→tool_use / content_filter→stop / function_call→tool_use）
- chunk 类型：`ChatCompletionChunk` / `ChunkChoice` / `ChunkDelta` / `DeltaToolCall` / `DeltaFunction`
- `deserialize_null_as_empty_vec` 容错 DashScope `tool_calls: null`

**`crates/dasclaw_llm_provider/src/providers/client.rs`**
- 新方法 `ProviderClient::stream_message(&self, request) -> Result<ProviderStream, ApiError>`
- 新公共枚举 `ProviderStream { Anthropic(AnthropicStream), OpenAiCompat(OpenAiCompatStream) }`，统一暴露 `next_event()` 与 `request_id()`

**`crates/dasclaw_llm_provider/src/providers/mod.rs` / `lib.rs`**
- 重导出 `OpenAiCompatStream` / `ProviderStream`
- lib.rs 状态块更新 PR-A.4 → PR-A.5

**`crates/dasclaw_llm_provider/tests/openai_compat_streaming.rs`** (新增)
- 4 个 wiremock SSE 集成测试

## 非目标（What's NOT in this PR）

- ❌ ironclaw 侧 `supports_streaming = true` 切换（留给 **PR-A.6**）
- ❌ prompt cache 字段填充（留给后续 PR）
- ❌ Anthropic 流式实现（已存在，本 PR 仅做 dispatcher 包装）
- ❌ claw-code/ 目录改动（受 ADR-118 §2 readonly 守卫保护，#160）

## 验证

```bash
cargo nextest run -p dasclaw_llm_provider --test openai_compat_streaming
# 4/4 PASS（17.97s）

cargo nextest run -p dasclaw_llm_provider
# Summary [84.076s] 135 tests run: 135 passed, 0 skipped

cargo fmt --all                                    # OK
python3.12 scripts/check_no_panics.py --base origin/xClaw
# OK: No panic-inducing calls in changed production code.
cargo clippy --no-deps -p dasclaw_llm_provider --all-targets -- -D warnings
# Finished, no warnings
```

测试覆盖：
- `stream_text_chunks_yield_anthropic_event_sequence`：文本累积（"He"+"llo"="Hello" / stop→end_turn / 完整 6 事件序列）
- `stream_tool_call_accumulates_input_json_delta`：tool_call 跨 chunk 拼接（`{"loc` + `ation":"SH"}` / tool_calls→tool_use / block_index=1）
- `stream_tolerates_explicit_null_tool_calls`：DashScope `"tool_calls":null` 容错
- `stream_dispatch_through_provider_client_returns_same_events`：`ProviderClient::OpenAi` 路由验证

Closes #162
