### PR TITLE
feat(dasclaw_llm_provider): OpenAI prompt cache 字段映射（W6-C PR-A.7）

### DIFF
--- a/crates/dasclaw_llm_provider/src/providers/openai_compat.rs
+++ b/crates/dasclaw_llm_provider/src/providers/openai_compat.rs
@@ -632,18 +632,11 @@ fn normalize_response(
             .finish_reason
             .map(|value| normalize_finish_reason(&value)),
         stop_sequence: None,
-        usage: Usage {
-            input_tokens: response
-                .usage
-                .as_ref()
-                .map_or(0, |usage| usage.prompt_tokens),
-            cache_creation_input_tokens: 0,
-            cache_read_input_tokens: 0,
-            output_tokens: response
-                .usage
-                .as_ref()
-                .map_or(0, |usage| usage.completion_tokens),
-        },
+        usage: response
+            .usage
+            .as_ref()
+            .map(OpenAiUsage::to_dasclaw_usage)
+            .unwrap_or_default(),
         request_id: None,
     })
 }
@@ -707,6 +700,35 @@ struct OpenAiUsage {
     prompt_tokens: u32,
     #[serde(default)]
     completion_tokens: u32,
+    /// OpenAI / DashScope 在 `prompt_tokens_details.cached_tokens` 上报命中
+    /// 上下文缓存的 token 数；映射到 [`Usage::cache_read_input_tokens`]。
+    #[serde(default)]
+    prompt_tokens_details: Option<OpenAiPromptTokensDetails>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenAiPromptTokensDetails {
+    #[serde(default)]
+    cached_tokens: u32,
+}
+
+impl OpenAiUsage {
+    /// 把 OpenAI `usage` 规整为 dasclaw 的 [`Usage`]，按 Anthropic 语义把缓存
+    /// token 从 `input_tokens` 中扣除（OpenAI `prompt_tokens` 含命中缓存部分，
+    /// Anthropic `input_tokens` 仅指未缓存的新 token）。`cache_creation_input_tokens`
+    /// 保持 0：OpenAI 协议不区分新建缓存与命中缓存。
+    fn to_dasclaw_usage(&self) -> Usage {
+        let cached = self
+            .prompt_tokens_details
+            .as_ref()
+            .map_or(0, |details| details.cached_tokens);
+        Usage {
+            input_tokens: self.prompt_tokens.saturating_sub(cached),
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: cached,
+            output_tokens: self.completion_tokens,
+        }
+    }
 }
 
 // ---------- Streaming ----------
@@ -895,24 +917,14 @@ impl StreamState {
                     model: chunk.model.clone().unwrap_or_else(|| self.model.clone()),
                     stop_reason: None,
                     stop_sequence: None,
-                    usage: Usage {
-                        input_tokens: 0,
-                        cache_creation_input_tokens: 0,
-                        cache_read_input_tokens: 0,
-                        output_tokens: 0,
-                    },
+                    usage: Usage::default(),
                     request_id: None,
                 },
             }));
         }
 
         if let Some(usage) = chunk.usage {
-            self.usage = Some(Usage {
-                input_tokens: usage.prompt_tokens,
-                cache_creation_input_tokens: 0,
-                cache_read_input_tokens: 0,
-                output_tokens: usage.completion_tokens,
-            });
+            self.usage = Some(usage.to_dasclaw_usage());
         }
 
         for choice in chunk.choices {
@@ -1017,12 +1029,7 @@ impl StreamState {
                     ),
                     stop_sequence: None,
                 },
-                usage: self.usage.clone().unwrap_or(Usage {
-                    input_tokens: 0,
-                    cache_creation_input_tokens: 0,
-                    cache_read_input_tokens: 0,
-                    output_tokens: 0,
-                }),
+                usage: self.usage.clone().unwrap_or_default(),
             }));
             events.push(StreamEvent::MessageStop(MessageStopEvent {}));
         }

--- a/crates/dasclaw_llm_provider/tests/openai_compat_client.rs
+++ b/crates/dasclaw_llm_provider/tests/openai_compat_client.rs
@@ -229,3 +229,63 @@ async fn inline_error_envelope_in_200_body_is_surfaced() {
         other => panic!("expected Provider, got {other:?}"),
     }
 }
+
+#[tokio::test]
+async fn complete_maps_prompt_tokens_details_cached_tokens() {
+    // OpenAI / DashScope 在 `usage.prompt_tokens_details.cached_tokens` 上报命中
+    // 上下文缓存的 token 数；按 Anthropic 语义，这部分应进入
+    // `cache_read_input_tokens`，并从 `input_tokens` 中扣除。
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": "chatcmpl-cache",
+            "model": "gpt-4o-mini",
+            "choices": [{
+                "index": 0,
+                "message": { "role": "assistant", "content": "ok" },
+                "finish_reason": "stop"
+            }],
+            "usage": {
+                "prompt_tokens": 100,
+                "completion_tokens": 20,
+                "prompt_tokens_details": { "cached_tokens": 80 }
+            }
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = build_client(server.uri(), fast_retry_policy(0)).expect("client constructible");
+    let response = client
+        .complete(&sample_request())
+        .await
+        .expect("request succeeds");
+    assert_eq!(response.usage.input_tokens, 20);
+    assert_eq!(response.usage.cache_read_input_tokens, 80);
+    assert_eq!(response.usage.cache_creation_input_tokens, 0);
+    assert_eq!(response.usage.output_tokens, 20);
+}
+
+#[tokio::test]
+async fn complete_without_prompt_tokens_details_keeps_cache_zero() {
+    // 旧 OpenAI / 不暴露 cache 字段的后端：cache_* 必须保持 0，
+    // input_tokens 直接等于 prompt_tokens，向后兼容。
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(success_body()))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = build_client(server.uri(), fast_retry_policy(0)).expect("client constructible");
+    let response = client
+        .complete(&sample_request())
+        .await
+        .expect("request succeeds");
+    assert_eq!(response.usage.input_tokens, 3);
+    assert_eq!(response.usage.cache_read_input_tokens, 0);
+    assert_eq!(response.usage.cache_creation_input_tokens, 0);
+    assert_eq!(response.usage.output_tokens, 1);
+}

--- a/crates/dasclaw_llm_provider/tests/openai_compat_streaming.rs
+++ b/crates/dasclaw_llm_provider/tests/openai_compat_streaming.rs
@@ -256,3 +256,42 @@ async fn stream_dispatch_through_provider_client_returns_same_events() {
     }
     assert_eq!(text, "hi");
 }
+
+#[tokio::test]
+async fn stream_message_delta_carries_cache_read_input_tokens() {
+    // 流式收尾的 `usage` 帧含 `prompt_tokens_details.cached_tokens` 时，必须
+    // 透传到 MessageDelta 事件的 `usage.cache_read_input_tokens`，并按
+    // Anthropic 语义把缓存 token 从 `input_tokens` 中扣除。
+    let server = MockServer::start().await;
+    let body = sse_body(&[
+        r#"{"id":"c-cache","model":"gpt-4o-mini","choices":[{"index":0,"delta":{"role":"assistant","content":"ok"},"finish_reason":null}]}"#,
+        r#"{"id":"c-cache","model":"gpt-4o-mini","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":100,"completion_tokens":2,"prompt_tokens_details":{"cached_tokens":75}}}"#,
+    ]);
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", SSE_CONTENT_TYPE)
+                .set_body_string(body),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let client = build_client(server.uri()).expect("client constructible");
+    let events = drain_stream(&client, &sample_request())
+        .await
+        .expect("stream drains");
+    let usage = events
+        .iter()
+        .rev()
+        .find_map(|e| match e {
+            StreamEvent::MessageDelta(ev) => Some(ev.usage.clone()),
+            _ => None,
+        })
+        .expect("message_delta carries usage");
+    assert_eq!(usage.input_tokens, 25);
+    assert_eq!(usage.cache_read_input_tokens, 75);
+    assert_eq!(usage.cache_creation_input_tokens, 0);
+    assert_eq!(usage.output_tokens, 2);
+}


### PR DESCRIPTION
## 背景 / 目标

ADR-118 §8 要求 `dasclaw_llm_provider` 暴露统一的 prompt cache 计数。OpenAI / DashScope 通过 `usage.prompt_tokens_details.cached_tokens` 上报命中的上下文缓存 token；先前 OpenAI-compat provider 把 `prompt_tokens` 直接塞进 `Usage.input_tokens`，`cache_read_input_tokens` 永远为 0，与 Anthropic provider 行为不一致。

本 PR 让 OpenAI-compat 路径按 Anthropic 语义产出 `Usage`：

| Anthropic 字段 | OpenAI 来源 |
| --- | --- |
| `input_tokens` | `prompt_tokens - prompt_tokens_details.cached_tokens`（`saturating_sub`） |
| `cache_read_input_tokens` | `prompt_tokens_details.cached_tokens` |
| `cache_creation_input_tokens` | `0`（OpenAI 协议无对应字段） |
| `output_tokens` | `completion_tokens` |

## 改动范围

- `crates/dasclaw_llm_provider/src/providers/openai_compat.rs`
  - `OpenAiUsage` 增字段 `prompt_tokens_details: Option<OpenAiPromptTokensDetails>`
  - 新增 `OpenAiPromptTokensDetails { cached_tokens: u32 }`
  - 新增 `impl OpenAiUsage::to_dasclaw_usage()` 统一映射
  - complete 路径与 streaming 路径都改走 `to_dasclaw_usage()`
  - finish/MessageStart 默认 usage 改用 `Usage::default()`，去除零字面量样板
- `crates/dasclaw_llm_provider/tests/openai_compat_client.rs`
  - 新增 `complete_maps_prompt_tokens_details_cached_tokens`
  - 新增 `complete_without_prompt_tokens_details_keeps_cache_zero`（向后兼容）
- `crates/dasclaw_llm_provider/tests/openai_compat_streaming.rs`
  - 新增 `stream_message_delta_carries_cache_read_input_tokens`

## 非目标（What's NOT in this PR）

- ❌ 不动 ironclaw `supports_streaming`（属于 PR-A.6 ironclaw cutover 独立切片）
- ❌ 不动 Anthropic 直连 provider（已经原生 cache_*）
- ❌ 不引入 USD 成本计算（仍由 ironclaw `costs::model_cost` 负责）
- ❌ 不改 `Usage` 公共类型签名（types.rs 未触碰）

## 验证

```bash
cargo nextest run -p dasclaw_llm_provider          # 138 passed, 0 skipped
cargo fmt --all                                    # clean
python3.12 scripts/check_no_panics.py --base origin/xClaw
# OK: No panic-inducing calls in changed production code.
cargo clippy --no-deps -p dasclaw_llm_provider --all-targets -- -D warnings
# Finished `dev` profile (0 warnings)
```

新增 3 条 TDD 测试覆盖：含 `prompt_tokens_details` → cache 按预期切片；不含字段 → cache_*=0、`input_tokens=prompt_tokens`，向后兼容。

## 后续

- 等 PR-A.6 ironclaw cutover 完成后，整个 W6-C ADR-118 收敛阶段闭合
- DashScope / Qwen 等 OpenAI-compat 后端无需额外改动，自动受益于本映射

Closes #164
