### PR TITLE
feat(config): introduce JobRuntimeMode enum (ADR-119 F1)

### DIFF
--- a/desktop-client/ironclaw/src/config/job_runtime.rs
+++ b/desktop-client/ironclaw/src/config/job_runtime.rs
@@ -1,0 +1,350 @@
+//! Job runtime mode configuration.
+//!
+//! Per [ADR-119](../../../../docs/plans/architecture-refactor/adr-119-job-runtime-decision-for-desktop-client.md),
+//! desktop clients pick exactly one of:
+//!
+//! - [`JobRuntimeMode::Disabled`] — enterprise default; job tools are not
+//!   exposed and no Docker probe is performed at startup.
+//! - [`JobRuntimeMode::LocalContainer`] — the existing path that delegates
+//!   `create_job` to a local Docker / OrbStack / Colima / Rancher / Podman
+//!   socket via `bollard`.
+//! - [`JobRuntimeMode::Cloud`] — reserved enum slot for a future cloud Job
+//!   service; not implemented in the current code.
+//!
+//! # Backward compatibility
+//!
+//! The legacy `[sandbox] enabled = true` boolean is still honored for
+//! installs whose config predates ADR-119: when no explicit
+//! `[job_runtime]` block is present we derive a mode from the legacy bool
+//! (`true` → `LocalContainer`, `false` → `Disabled`) and emit a single
+//! deprecation warning. F2/F3/F4 (the orchestrator, registry, and audit
+//! follow-ups in ADR-119 §5) will eventually retire the legacy bool.
+
+use std::sync::Once;
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::ConfigError;
+use crate::settings::Settings;
+
+/// Job runtime mode for the desktop client.
+///
+/// Tagged enum on the wire so a future `Cloud` payload can grow without
+/// breaking existing TOML files.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(tag = "mode", rename_all = "snake_case")]
+pub enum JobRuntimeMode {
+    /// Job tooling is unavailable. Enterprise default.
+    ///
+    /// `create_job` and the related discovery tools (`list_jobs`,
+    /// `job_status`, `cancel_job`, `job_events`, `job_prompt`) MUST NOT
+    /// be exposed to the LLM in this mode (enforced by F3, ADR-119 §5).
+    #[default]
+    Disabled,
+    /// Run jobs in a local container via Docker or a Docker-API-compatible
+    /// runtime (Docker Desktop, OrbStack, Colima, Rancher Desktop, Podman
+    /// rootless). Requires the daemon to be reachable at boot; no silent
+    /// fallback to an in-process scheduler (enforced by F2, ADR-119 §5).
+    LocalContainer,
+    /// Route jobs to a managed cloud endpoint. Reserved enum slot — the
+    /// current code does not implement dispatch and rejecting Cloud at
+    /// resolution is intentional until a follow-up ADR fills in auth,
+    /// offline behaviour, and tenant isolation.
+    Cloud {
+        /// Endpoint URL of the managed Job service.
+        endpoint: String,
+    },
+}
+
+impl JobRuntimeMode {
+    /// Lower-case identifier suitable for log fields and the eventual audit
+    /// `runtime_mode` payload (ADR-119 D5).
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Disabled => "disabled",
+            Self::LocalContainer => "local_container",
+            Self::Cloud { .. } => "cloud",
+        }
+    }
+}
+
+/// Resolved job runtime configuration.
+///
+/// Wraps [`JobRuntimeMode`] in a struct so future per-mode tunables can
+/// land without churning every call site that reads `config.job_runtime`.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct JobRuntimeConfig {
+    /// Selected runtime mode.
+    pub mode: JobRuntimeMode,
+}
+
+/// Wire-format settings block for `[job_runtime]` in TOML / DB.
+///
+/// Optional in [`Settings`]; absence triggers the legacy fallback in
+/// [`JobRuntimeConfig::resolve`].
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct JobRuntimeSettings {
+    /// Selected runtime mode. See [`JobRuntimeMode`] for the wire shape.
+    #[serde(flatten)]
+    pub mode: JobRuntimeMode,
+}
+
+static WARNED_LEGACY_SANDBOX_DERIVE: Once = Once::new();
+
+impl JobRuntimeConfig {
+    /// Resolve job runtime configuration from settings.
+    ///
+    /// Priority (highest first):
+    /// 1. `JOB_RUNTIME_MODE` env var (`disabled`, `local_container`,
+    ///    `cloud:<endpoint>`).
+    /// 2. Explicit `[job_runtime]` block in TOML / DB settings.
+    /// 3. Derived from legacy `[sandbox] enabled` for backward compatibility
+    ///    (`true` → `LocalContainer`, `false` → `Disabled`); emits a single
+    ///    deprecation warning when the derivation actually fires.
+    pub(crate) fn resolve(settings: &Settings) -> Result<Self, ConfigError> {
+        if let Some(mode) = parse_env_override()? {
+            return Ok(Self { mode });
+        }
+
+        if let Some(explicit) = settings.job_runtime.as_ref() {
+            if let JobRuntimeMode::Cloud { endpoint } = &explicit.mode
+                && endpoint.trim().is_empty()
+            {
+                return Err(ConfigError::InvalidValue {
+                    key: "job_runtime.endpoint".to_string(),
+                    message: "Cloud mode requires a non-empty endpoint".to_string(),
+                });
+            }
+            return Ok(Self {
+                mode: explicit.mode.clone(),
+            });
+        }
+
+        let mode = if settings.sandbox.enabled {
+            WARNED_LEGACY_SANDBOX_DERIVE.call_once(|| {
+                tracing::warn!(
+                    "[sandbox] enabled = true is deprecated; set [job_runtime] mode = \
+                     \"local_container\" instead. See ADR-119 §5 F1 (xClaw#167)."
+                );
+            });
+            JobRuntimeMode::LocalContainer
+        } else {
+            JobRuntimeMode::Disabled
+        };
+
+        Ok(Self { mode })
+    }
+}
+
+/// Parse the `JOB_RUNTIME_MODE` env var into a [`JobRuntimeMode`].
+///
+/// Accepts:
+/// - `disabled`
+/// - `local_container`
+/// - `cloud:<endpoint>` (URL after the colon, trimmed)
+fn parse_env_override() -> Result<Option<JobRuntimeMode>, ConfigError> {
+    let raw = match std::env::var("JOB_RUNTIME_MODE") {
+        Ok(v) => v,
+        Err(_) => return Ok(None),
+    };
+    let trimmed = raw.trim();
+    let lower = trimmed.to_ascii_lowercase();
+    match lower.as_str() {
+        "disabled" => Ok(Some(JobRuntimeMode::Disabled)),
+        "local_container" => Ok(Some(JobRuntimeMode::LocalContainer)),
+        s if s.starts_with("cloud:") => {
+            let endpoint = trimmed["cloud:".len()..].trim().to_string();
+            if endpoint.is_empty() {
+                return Err(ConfigError::InvalidValue {
+                    key: "JOB_RUNTIME_MODE".to_string(),
+                    message: "cloud mode requires an endpoint after the colon".to_string(),
+                });
+            }
+            Ok(Some(JobRuntimeMode::Cloud { endpoint }))
+        }
+        other => Err(ConfigError::InvalidValue {
+            key: "JOB_RUNTIME_MODE".to_string(),
+            message: format!(
+                "expected one of 'disabled', 'local_container', 'cloud:<endpoint>'; got '{other}'"
+            ),
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::helpers::lock_env;
+    use crate::settings::Settings;
+
+    fn settings_with_sandbox(enabled: bool) -> Settings {
+        let mut s = Settings::default();
+        s.sandbox.enabled = enabled;
+        s.job_runtime = None;
+        s
+    }
+
+    fn clear_env() {
+        // SAFETY: callers hold lock_env() guard.
+        unsafe {
+            std::env::remove_var("JOB_RUNTIME_MODE");
+        }
+    }
+
+    #[test]
+    fn default_mode_is_disabled() {
+        assert_eq!(JobRuntimeMode::default(), JobRuntimeMode::Disabled);
+        assert_eq!(JobRuntimeConfig::default().mode, JobRuntimeMode::Disabled);
+    }
+
+    #[test]
+    fn as_str_matches_audit_payload_contract() {
+        assert_eq!(JobRuntimeMode::Disabled.as_str(), "disabled");
+        assert_eq!(JobRuntimeMode::LocalContainer.as_str(), "local_container");
+        assert_eq!(
+            JobRuntimeMode::Cloud {
+                endpoint: "https://example.com".into()
+            }
+            .as_str(),
+            "cloud"
+        );
+    }
+
+    #[test]
+    fn serde_round_trip_disabled() {
+        let m = JobRuntimeMode::Disabled;
+        let s = toml::to_string(&JobRuntimeSettings { mode: m.clone() }).unwrap();
+        assert!(s.contains("mode = \"disabled\""), "got: {s}");
+        let back: JobRuntimeSettings = toml::from_str(&s).unwrap();
+        assert_eq!(back.mode, m);
+    }
+
+    #[test]
+    fn serde_round_trip_local_container() {
+        let m = JobRuntimeMode::LocalContainer;
+        let s = toml::to_string(&JobRuntimeSettings { mode: m.clone() }).unwrap();
+        assert!(s.contains("mode = \"local_container\""), "got: {s}");
+        let back: JobRuntimeSettings = toml::from_str(&s).unwrap();
+        assert_eq!(back.mode, m);
+    }
+
+    #[test]
+    fn serde_round_trip_cloud() {
+        let m = JobRuntimeMode::Cloud {
+            endpoint: "https://jobs.example.com/v1".to_string(),
+        };
+        let s = toml::to_string(&JobRuntimeSettings { mode: m.clone() }).unwrap();
+        assert!(s.contains("mode = \"cloud\""), "got: {s}");
+        assert!(s.contains("endpoint = \"https://jobs.example.com/v1\""));
+        let back: JobRuntimeSettings = toml::from_str(&s).unwrap();
+        assert_eq!(back.mode, m);
+    }
+
+    #[test]
+    fn legacy_sandbox_true_derives_local_container() {
+        let _guard = lock_env();
+        clear_env();
+        let s = settings_with_sandbox(true);
+        let cfg = JobRuntimeConfig::resolve(&s).unwrap();
+        assert_eq!(cfg.mode, JobRuntimeMode::LocalContainer);
+    }
+
+    #[test]
+    fn legacy_sandbox_false_derives_disabled() {
+        let _guard = lock_env();
+        clear_env();
+        let s = settings_with_sandbox(false);
+        let cfg = JobRuntimeConfig::resolve(&s).unwrap();
+        assert_eq!(cfg.mode, JobRuntimeMode::Disabled);
+    }
+
+    #[test]
+    fn explicit_block_overrides_legacy() {
+        let _guard = lock_env();
+        clear_env();
+        let mut s = Settings::default();
+        s.sandbox.enabled = true;
+        s.job_runtime = Some(JobRuntimeSettings {
+            mode: JobRuntimeMode::Disabled,
+        });
+        let cfg = JobRuntimeConfig::resolve(&s).unwrap();
+        assert_eq!(cfg.mode, JobRuntimeMode::Disabled);
+    }
+
+    #[test]
+    fn explicit_cloud_requires_endpoint() {
+        let _guard = lock_env();
+        clear_env();
+        let mut s = Settings::default();
+        s.job_runtime = Some(JobRuntimeSettings {
+            mode: JobRuntimeMode::Cloud {
+                endpoint: "   ".to_string(),
+            },
+        });
+        let err = JobRuntimeConfig::resolve(&s).unwrap_err();
+        assert!(
+            matches!(err, ConfigError::InvalidValue { ref key, .. } if key == "job_runtime.endpoint")
+        );
+    }
+
+    #[test]
+    fn env_var_override_disabled() {
+        let _guard = lock_env();
+        // SAFETY: under ENV_MUTEX.
+        unsafe {
+            std::env::set_var("JOB_RUNTIME_MODE", "disabled");
+        }
+        let s = settings_with_sandbox(true);
+        let cfg = JobRuntimeConfig::resolve(&s).unwrap();
+        assert_eq!(cfg.mode, JobRuntimeMode::Disabled);
+        clear_env();
+    }
+
+    #[test]
+    fn env_var_override_cloud_with_endpoint() {
+        let _guard = lock_env();
+        // SAFETY: under ENV_MUTEX.
+        unsafe {
+            std::env::set_var("JOB_RUNTIME_MODE", "cloud:https://jobs.example.com/v1");
+        }
+        let s = settings_with_sandbox(false);
+        let cfg = JobRuntimeConfig::resolve(&s).unwrap();
+        assert_eq!(
+            cfg.mode,
+            JobRuntimeMode::Cloud {
+                endpoint: "https://jobs.example.com/v1".to_string(),
+            }
+        );
+        clear_env();
+    }
+
+    #[test]
+    fn env_var_unknown_value_is_error() {
+        let _guard = lock_env();
+        // SAFETY: under ENV_MUTEX.
+        unsafe {
+            std::env::set_var("JOB_RUNTIME_MODE", "bogus");
+        }
+        let s = settings_with_sandbox(false);
+        let err = JobRuntimeConfig::resolve(&s).unwrap_err();
+        assert!(
+            matches!(err, ConfigError::InvalidValue { ref key, .. } if key == "JOB_RUNTIME_MODE")
+        );
+        clear_env();
+    }
+
+    #[test]
+    fn env_var_cloud_without_endpoint_is_error() {
+        let _guard = lock_env();
+        // SAFETY: under ENV_MUTEX.
+        unsafe {
+            std::env::set_var("JOB_RUNTIME_MODE", "cloud:");
+        }
+        let s = settings_with_sandbox(false);
+        let err = JobRuntimeConfig::resolve(&s).unwrap_err();
+        assert!(
+            matches!(err, ConfigError::InvalidValue { ref key, .. } if key == "JOB_RUNTIME_MODE")
+        );
+        clear_env();
+    }
+}

--- a/desktop-client/ironclaw/src/config/mod.rs
+++ b/desktop-client/ironclaw/src/config/mod.rs
@@ -17,6 +17,7 @@ pub(crate) mod embeddings;
 mod heartbeat;
 pub(crate) mod helpers;
 mod hygiene;
+pub mod job_runtime;
 pub(crate) mod llm;
 pub mod relay;
 mod routines;
@@ -47,6 +48,7 @@ pub use self::database::{DatabaseBackend, DatabaseConfig, SslMode, default_libsq
 pub use self::embeddings::{DEFAULT_EMBEDDING_CACHE_SIZE, EmbeddingsConfig};
 pub use self::heartbeat::HeartbeatConfig;
 pub use self::hygiene::HygieneConfig;
+pub use self::job_runtime::{JobRuntimeConfig, JobRuntimeMode, JobRuntimeSettings};
 pub use self::llm::default_session_path;
 pub use self::relay::RelayConfig;
 pub use self::routines::RoutineConfig;
@@ -101,6 +103,8 @@ pub struct Config {
     pub hygiene: HygieneConfig,
     pub routines: RoutineConfig,
     pub sandbox: SandboxModeConfig,
+    /// Job runtime mode (Disabled / LocalContainer / Cloud). See ADR-119.
+    pub job_runtime: JobRuntimeConfig,
     pub claude_code: ClaudeCodeConfig,
     pub skills: SkillsConfig,
     pub transcription: TranscriptionConfig,
@@ -174,6 +178,7 @@ impl Config {
                 enabled: false,
                 ..SandboxModeConfig::default()
             },
+            job_runtime: JobRuntimeConfig::default(),
             claude_code: ClaudeCodeConfig::default(),
             skills: SkillsConfig {
                 enabled: true,
@@ -369,6 +374,7 @@ impl Config {
             hygiene: HygieneConfig::resolve()?,
             routines: RoutineConfig::resolve()?,
             sandbox: SandboxModeConfig::resolve(settings)?,
+            job_runtime: JobRuntimeConfig::resolve(settings)?,
             claude_code: ClaudeCodeConfig::resolve(settings)?,
             skills: SkillsConfig::resolve()?,
             transcription: TranscriptionConfig::resolve(settings)?,

--- a/desktop-client/ironclaw/src/settings.rs
+++ b/desktop-client/ironclaw/src/settings.rs
@@ -193,6 +193,12 @@ pub struct Settings {
     #[serde(default)]
     pub sandbox: SandboxSettings,
 
+    /// Job runtime mode (ADR-119). When omitted, the legacy
+    /// `[sandbox] enabled` boolean is used to derive a mode for backward
+    /// compatibility (see `crate::config::JobRuntimeConfig::resolve`).
+    #[serde(default)]
+    pub job_runtime: Option<crate::config::job_runtime::JobRuntimeSettings>,
+
     /// Safety configuration.
     #[serde(default)]
     pub safety: SafetySettings,


### PR DESCRIPTION
## 背景 / 目标

实现 [ADR-119](https://github.com/Linnanli/xClaw/blob/xClaw/docs/plans/architecture-refactor/adr-119-job-runtime-decision-for-desktop-client.md) §5 F1：在桌面端 ironclaw 的 config 层引入三态枚举 `JobRuntimeMode`（`Disabled` / `LocalContainer` / `Cloud`），替代旧的 `[sandbox] enabled: bool` 二态布尔语义，并保持向后兼容。

后续 F2/F3/F4（#168 #169 #170）会基于本 PR 引入的 `config.job_runtime` 字段实现：编排器 fail-closed、工具可见性过滤、审计字段。本 PR 只完成"配置面建模 + 解析"，**不动行为**。

Closes #167

## 改动范围

### 新增 `desktop-client/ironclaw/src/config/job_runtime.rs`

- `pub enum JobRuntimeMode { Disabled, LocalContainer, Cloud { endpoint } }`
  - `#[derive(Default)]` + `#[default] Disabled`（企业默认）
  - `#[serde(tag = "mode", rename_all = "snake_case")]` — 标签枚举，未来 `Cloud` 扩字段不破坏 TOML
  - `as_str()` 返回 `"disabled"` / `"local_container"` / `"cloud"`，对应 ADR-119 D5 审计 payload 契约
- `pub struct JobRuntimeConfig { mode: JobRuntimeMode }` — 解析后的配置载体
- `pub struct JobRuntimeSettings` — wire 层 settings 块（`#[serde(flatten)] mode`）
- `JobRuntimeConfig::resolve(settings: &Settings)` — 三级优先级解析：
  1. `JOB_RUNTIME_MODE` 环境变量（`disabled` / `local_container` / `cloud:<endpoint>`）
  2. 显式 `[job_runtime]` 块
  3. 旧 `[sandbox] enabled` 推导（`true → LocalContainer` + 一次性 deprecation warning，`false → Disabled`）
- 13 个单测，覆盖：默认值、`as_str` 契约、3 档 serde round-trip、旧 bool 推导（true/false）、显式块覆盖旧值、Cloud 空 endpoint 拒绝、env 覆盖（disabled/cloud/未知/Cloud 缺 endpoint）

### 接线 `desktop-client/ironclaw/src/settings.rs`

新增 `pub job_runtime: Option<JobRuntimeSettings>` 字段（`#[serde(default)]`，缺省走旧 bool 推导路径）。

### 接线 `desktop-client/ironclaw/src/config/mod.rs`

- 声明 `pub mod job_runtime;`
- 重导出 `JobRuntimeConfig` / `JobRuntimeMode` / `JobRuntimeSettings`
- `Config` struct 新增 `pub job_runtime: JobRuntimeConfig` 字段
- `Config::for_testing()` / `Config::build()` 各自填充

### 设计原则（禁补丁式）

- **不**在现有 `SandboxModeConfig` 上加 if 分支或新 flag — 用全新 enum 表达三态决策
- **不**复制 `enabled: bool` 字段 — 旧值通过 `resolve()` 一次性推导，调用点（F2/F3/F4）只读 `JobRuntimeMode`
- 测试通过 `crate::config::helpers::lock_env()` 串行化 env 变更，不引入新依赖（如 `serial_test`）

## 非目标（What's NOT in this PR）

- ❌ 不动 `orchestrator/mod.rs` 的静默降级（→ F2 #168）
- ❌ 不动工具注册器对 6 个 job tool 的可见性（→ F3 #169）
- ❌ 不扩 `AppEvent::JobStarted` 的审计字段（→ F4 #170）
- ❌ 不删 `config.sandbox.image` / `memory_limit_mb` 等字段（仍由 LocalContainer 路径使用）
- ❌ 不实现 `Cloud` 模式的实际派发（保留为枚举槽位，未来 ADR 补 auth / 多租户 / 离线行为）
- ❌ 不动 setup wizard / main.rs 等 7 处 `config.sandbox.enabled` 读取点（待 F2 起统一替换为 `config.job_runtime.mode`）

## 验证

```bash
cargo check -p ironclaw --tests
# Finished `dev` profile [unoptimized + debuginfo] target(s) in 5m 50s

cargo nextest run -p ironclaw -E 'test(config::job_runtime)'
# Summary [7.547s] 13 tests run: 13 passed, 4534 skipped

cargo fmt --all
# (无输出)

python3.12 scripts/check_no_panics.py --base origin/xClaw
# OK: No panic-inducing calls in changed production code.
```

`cargo clippy -p ironclaw -- -D warnings` 本地报 35 处 `collapsible_if` 错误，**全部预先存在于 `origin/xClaw`**（已 git stash 验证：base 35 / branch 35），与本 PR 无关；CI 的 clippy（`Clippy (default)`）按既有 toolchain 运行，预期 PASS（与 #163 / #165 / #166 同 baseline）。

## 风险与回滚

- 旧用户 `[sandbox] enabled = true`（系统默认值）首次启动会看到一行 `tracing::warn!` 提示迁移到 `[job_runtime] mode = "local_container"` — 信息性日志，不改变行为
- 回滚：单 commit revert，不涉及数据库 / 持久化 schema 变更
