### PR TITLE
feat(tools): hide job tools when JobRuntimeMode=Disabled (ADR-119 F3)

### DIFF
--- a/desktop-client/ironclaw/src/config/job_runtime.rs
+++ b/desktop-client/ironclaw/src/config/job_runtime.rs
@@ -1,0 +1,350 @@
+//! Job runtime mode configuration.
+//!
+//! Per [ADR-119](../../../../docs/plans/architecture-refactor/adr-119-job-runtime-decision-for-desktop-client.md),
+//! desktop clients pick exactly one of:
+//!
+//! - [`JobRuntimeMode::Disabled`] — enterprise default; job tools are not
+//!   exposed and no Docker probe is performed at startup.
+//! - [`JobRuntimeMode::LocalContainer`] — the existing path that delegates
+//!   `create_job` to a local Docker / OrbStack / Colima / Rancher / Podman
+//!   socket via `bollard`.
+//! - [`JobRuntimeMode::Cloud`] — reserved enum slot for a future cloud Job
+//!   service; not implemented in the current code.
+//!
+//! # Backward compatibility
+//!
+//! The legacy `[sandbox] enabled = true` boolean is still honored for
+//! installs whose config predates ADR-119: when no explicit
+//! `[job_runtime]` block is present we derive a mode from the legacy bool
+//! (`true` → `LocalContainer`, `false` → `Disabled`) and emit a single
+//! deprecation warning. F2/F3/F4 (the orchestrator, registry, and audit
+//! follow-ups in ADR-119 §5) will eventually retire the legacy bool.
+
+use std::sync::Once;
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::ConfigError;
+use crate::settings::Settings;
+
+/// Job runtime mode for the desktop client.
+///
+/// Tagged enum on the wire so a future `Cloud` payload can grow without
+/// breaking existing TOML files.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(tag = "mode", rename_all = "snake_case")]
+pub enum JobRuntimeMode {
+    /// Job tooling is unavailable. Enterprise default.
+    ///
+    /// `create_job` and the related discovery tools (`list_jobs`,
+    /// `job_status`, `cancel_job`, `job_events`, `job_prompt`) MUST NOT
+    /// be exposed to the LLM in this mode (enforced by F3, ADR-119 §5).
+    #[default]
+    Disabled,
+    /// Run jobs in a local container via Docker or a Docker-API-compatible
+    /// runtime (Docker Desktop, OrbStack, Colima, Rancher Desktop, Podman
+    /// rootless). Requires the daemon to be reachable at boot; no silent
+    /// fallback to an in-process scheduler (enforced by F2, ADR-119 §5).
+    LocalContainer,
+    /// Route jobs to a managed cloud endpoint. Reserved enum slot — the
+    /// current code does not implement dispatch and rejecting Cloud at
+    /// resolution is intentional until a follow-up ADR fills in auth,
+    /// offline behaviour, and tenant isolation.
+    Cloud {
+        /// Endpoint URL of the managed Job service.
+        endpoint: String,
+    },
+}
+
+impl JobRuntimeMode {
+    /// Lower-case identifier suitable for log fields and the eventual audit
+    /// `runtime_mode` payload (ADR-119 D5).
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Disabled => "disabled",
+            Self::LocalContainer => "local_container",
+            Self::Cloud { .. } => "cloud",
+        }
+    }
+}
+
+/// Resolved job runtime configuration.
+///
+/// Wraps [`JobRuntimeMode`] in a struct so future per-mode tunables can
+/// land without churning every call site that reads `config.job_runtime`.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct JobRuntimeConfig {
+    /// Selected runtime mode.
+    pub mode: JobRuntimeMode,
+}
+
+/// Wire-format settings block for `[job_runtime]` in TOML / DB.
+///
+/// Optional in [`Settings`]; absence triggers the legacy fallback in
+/// [`JobRuntimeConfig::resolve`].
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct JobRuntimeSettings {
+    /// Selected runtime mode. See [`JobRuntimeMode`] for the wire shape.
+    #[serde(flatten)]
+    pub mode: JobRuntimeMode,
+}
+
+static WARNED_LEGACY_SANDBOX_DERIVE: Once = Once::new();
+
+impl JobRuntimeConfig {
+    /// Resolve job runtime configuration from settings.
+    ///
+    /// Priority (highest first):
+    /// 1. `JOB_RUNTIME_MODE` env var (`disabled`, `local_container`,
+    ///    `cloud:<endpoint>`).
+    /// 2. Explicit `[job_runtime]` block in TOML / DB settings.
+    /// 3. Derived from legacy `[sandbox] enabled` for backward compatibility
+    ///    (`true` → `LocalContainer`, `false` → `Disabled`); emits a single
+    ///    deprecation warning when the derivation actually fires.
+    pub(crate) fn resolve(settings: &Settings) -> Result<Self, ConfigError> {
+        if let Some(mode) = parse_env_override()? {
+            return Ok(Self { mode });
+        }
+
+        if let Some(explicit) = settings.job_runtime.as_ref() {
+            if let JobRuntimeMode::Cloud { endpoint } = &explicit.mode
+                && endpoint.trim().is_empty()
+            {
+                return Err(ConfigError::InvalidValue {
+                    key: "job_runtime.endpoint".to_string(),
+                    message: "Cloud mode requires a non-empty endpoint".to_string(),
+                });
+            }
+            return Ok(Self {
+                mode: explicit.mode.clone(),
+            });
+        }
+
+        let mode = if settings.sandbox.enabled {
+            WARNED_LEGACY_SANDBOX_DERIVE.call_once(|| {
+                tracing::warn!(
+                    "[sandbox] enabled = true is deprecated; set [job_runtime] mode = \
+                     \"local_container\" instead. See ADR-119 §5 F1 (xClaw#167)."
+                );
+            });
+            JobRuntimeMode::LocalContainer
+        } else {
+            JobRuntimeMode::Disabled
+        };
+
+        Ok(Self { mode })
+    }
+}
+
+/// Parse the `JOB_RUNTIME_MODE` env var into a [`JobRuntimeMode`].
+///
+/// Accepts:
+/// - `disabled`
+/// - `local_container`
+/// - `cloud:<endpoint>` (URL after the colon, trimmed)
+fn parse_env_override() -> Result<Option<JobRuntimeMode>, ConfigError> {
+    let raw = match std::env::var("JOB_RUNTIME_MODE") {
+        Ok(v) => v,
+        Err(_) => return Ok(None),
+    };
+    let trimmed = raw.trim();
+    let lower = trimmed.to_ascii_lowercase();
+    match lower.as_str() {
+        "disabled" => Ok(Some(JobRuntimeMode::Disabled)),
+        "local_container" => Ok(Some(JobRuntimeMode::LocalContainer)),
+        s if s.starts_with("cloud:") => {
+            let endpoint = trimmed["cloud:".len()..].trim().to_string();
+            if endpoint.is_empty() {
+                return Err(ConfigError::InvalidValue {
+                    key: "JOB_RUNTIME_MODE".to_string(),
+                    message: "cloud mode requires an endpoint after the colon".to_string(),
+                });
+            }
+            Ok(Some(JobRuntimeMode::Cloud { endpoint }))
+        }
+        other => Err(ConfigError::InvalidValue {
+            key: "JOB_RUNTIME_MODE".to_string(),
+            message: format!(
+                "expected one of 'disabled', 'local_container', 'cloud:<endpoint>'; got '{other}'"
+            ),
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::helpers::lock_env;
+    use crate::settings::Settings;
+
+    fn settings_with_sandbox(enabled: bool) -> Settings {
+        let mut s = Settings::default();
+        s.sandbox.enabled = enabled;
+        s.job_runtime = None;
+        s
+    }
+
+    fn clear_env() {
+        // SAFETY: callers hold lock_env() guard.
+        unsafe {
+            std::env::remove_var("JOB_RUNTIME_MODE");
+        }
+    }
+
+    #[test]
+    fn default_mode_is_disabled() {
+        assert_eq!(JobRuntimeMode::default(), JobRuntimeMode::Disabled);
+        assert_eq!(JobRuntimeConfig::default().mode, JobRuntimeMode::Disabled);
+    }
+
+    #[test]
+    fn as_str_matches_audit_payload_contract() {
+        assert_eq!(JobRuntimeMode::Disabled.as_str(), "disabled");
+        assert_eq!(JobRuntimeMode::LocalContainer.as_str(), "local_container");
+        assert_eq!(
+            JobRuntimeMode::Cloud {
+                endpoint: "https://example.com".into()
+            }
+            .as_str(),
+            "cloud"
+        );
+    }
+
+    #[test]
+    fn serde_round_trip_disabled() {
+        let m = JobRuntimeMode::Disabled;
+        let s = toml::to_string(&JobRuntimeSettings { mode: m.clone() }).unwrap();
+        assert!(s.contains("mode = \"disabled\""), "got: {s}");
+        let back: JobRuntimeSettings = toml::from_str(&s).unwrap();
+        assert_eq!(back.mode, m);
+    }
+
+    #[test]
+    fn serde_round_trip_local_container() {
+        let m = JobRuntimeMode::LocalContainer;
+        let s = toml::to_string(&JobRuntimeSettings { mode: m.clone() }).unwrap();
+        assert!(s.contains("mode = \"local_container\""), "got: {s}");
+        let back: JobRuntimeSettings = toml::from_str(&s).unwrap();
+        assert_eq!(back.mode, m);
+    }
+
+    #[test]
+    fn serde_round_trip_cloud() {
+        let m = JobRuntimeMode::Cloud {
+            endpoint: "https://jobs.example.com/v1".to_string(),
+        };
+        let s = toml::to_string(&JobRuntimeSettings { mode: m.clone() }).unwrap();
+        assert!(s.contains("mode = \"cloud\""), "got: {s}");
+        assert!(s.contains("endpoint = \"https://jobs.example.com/v1\""));
+        let back: JobRuntimeSettings = toml::from_str(&s).unwrap();
+        assert_eq!(back.mode, m);
+    }
+
+    #[test]
+    fn legacy_sandbox_true_derives_local_container() {
+        let _guard = lock_env();
+        clear_env();
+        let s = settings_with_sandbox(true);
+        let cfg = JobRuntimeConfig::resolve(&s).unwrap();
+        assert_eq!(cfg.mode, JobRuntimeMode::LocalContainer);
+    }
+
+    #[test]
+    fn legacy_sandbox_false_derives_disabled() {
+        let _guard = lock_env();
+        clear_env();
+        let s = settings_with_sandbox(false);
+        let cfg = JobRuntimeConfig::resolve(&s).unwrap();
+        assert_eq!(cfg.mode, JobRuntimeMode::Disabled);
+    }
+
+    #[test]
+    fn explicit_block_overrides_legacy() {
+        let _guard = lock_env();
+        clear_env();
+        let mut s = Settings::default();
+        s.sandbox.enabled = true;
+        s.job_runtime = Some(JobRuntimeSettings {
+            mode: JobRuntimeMode::Disabled,
+        });
+        let cfg = JobRuntimeConfig::resolve(&s).unwrap();
+        assert_eq!(cfg.mode, JobRuntimeMode::Disabled);
+    }
+
+    #[test]
+    fn explicit_cloud_requires_endpoint() {
+        let _guard = lock_env();
+        clear_env();
+        let mut s = Settings::default();
+        s.job_runtime = Some(JobRuntimeSettings {
+            mode: JobRuntimeMode::Cloud {
+                endpoint: "   ".to_string(),
+            },
+        });
+        let err = JobRuntimeConfig::resolve(&s).unwrap_err();
+        assert!(
+            matches!(err, ConfigError::InvalidValue { ref key, .. } if key == "job_runtime.endpoint")
+        );
+    }
+
+    #[test]
+    fn env_var_override_disabled() {
+        let _guard = lock_env();
+        // SAFETY: under ENV_MUTEX.
+        unsafe {
+            std::env::set_var("JOB_RUNTIME_MODE", "disabled");
+        }
+        let s = settings_with_sandbox(true);
+        let cfg = JobRuntimeConfig::resolve(&s).unwrap();
+        assert_eq!(cfg.mode, JobRuntimeMode::Disabled);
+        clear_env();
+    }
+
+    #[test]
+    fn env_var_override_cloud_with_endpoint() {
+        let _guard = lock_env();
+        // SAFETY: under ENV_MUTEX.
+        unsafe {
+            std::env::set_var("JOB_RUNTIME_MODE", "cloud:https://jobs.example.com/v1");
+        }
+        let s = settings_with_sandbox(false);
+        let cfg = JobRuntimeConfig::resolve(&s).unwrap();
+        assert_eq!(
+            cfg.mode,
+            JobRuntimeMode::Cloud {
+                endpoint: "https://jobs.example.com/v1".to_string(),
+            }
+        );
+        clear_env();
+    }
+
+    #[test]
+    fn env_var_unknown_value_is_error() {
+        let _guard = lock_env();
+        // SAFETY: under ENV_MUTEX.
+        unsafe {
+            std::env::set_var("JOB_RUNTIME_MODE", "bogus");
+        }
+        let s = settings_with_sandbox(false);
+        let err = JobRuntimeConfig::resolve(&s).unwrap_err();
+        assert!(
+            matches!(err, ConfigError::InvalidValue { ref key, .. } if key == "JOB_RUNTIME_MODE")
+        );
+        clear_env();
+    }
+
+    #[test]
+    fn env_var_cloud_without_endpoint_is_error() {
+        let _guard = lock_env();
+        // SAFETY: under ENV_MUTEX.
+        unsafe {
+            std::env::set_var("JOB_RUNTIME_MODE", "cloud:");
+        }
+        let s = settings_with_sandbox(false);
+        let err = JobRuntimeConfig::resolve(&s).unwrap_err();
+        assert!(
+            matches!(err, ConfigError::InvalidValue { ref key, .. } if key == "JOB_RUNTIME_MODE")
+        );
+        clear_env();
+    }
+}

--- a/desktop-client/ironclaw/src/config/mod.rs
+++ b/desktop-client/ironclaw/src/config/mod.rs
@@ -17,6 +17,7 @@ pub(crate) mod embeddings;
 mod heartbeat;
 pub(crate) mod helpers;
 mod hygiene;
+pub mod job_runtime;
 pub(crate) mod llm;
 pub mod relay;
 mod routines;
@@ -47,6 +48,7 @@ pub use self::database::{DatabaseBackend, DatabaseConfig, SslMode, default_libsq
 pub use self::embeddings::{DEFAULT_EMBEDDING_CACHE_SIZE, EmbeddingsConfig};
 pub use self::heartbeat::HeartbeatConfig;
 pub use self::hygiene::HygieneConfig;
+pub use self::job_runtime::{JobRuntimeConfig, JobRuntimeMode, JobRuntimeSettings};
 pub use self::llm::default_session_path;
 pub use self::relay::RelayConfig;
 pub use self::routines::RoutineConfig;
@@ -101,6 +103,8 @@ pub struct Config {
     pub hygiene: HygieneConfig,
     pub routines: RoutineConfig,
     pub sandbox: SandboxModeConfig,
+    /// Job runtime mode (Disabled / LocalContainer / Cloud). See ADR-119.
+    pub job_runtime: JobRuntimeConfig,
     pub claude_code: ClaudeCodeConfig,
     pub skills: SkillsConfig,
     pub transcription: TranscriptionConfig,
@@ -174,6 +178,7 @@ impl Config {
                 enabled: false,
                 ..SandboxModeConfig::default()
             },
+            job_runtime: JobRuntimeConfig::default(),
             claude_code: ClaudeCodeConfig::default(),
             skills: SkillsConfig {
                 enabled: true,
@@ -369,6 +374,7 @@ impl Config {
             hygiene: HygieneConfig::resolve()?,
             routines: RoutineConfig::resolve()?,
             sandbox: SandboxModeConfig::resolve(settings)?,
+            job_runtime: JobRuntimeConfig::resolve(settings)?,
             claude_code: ClaudeCodeConfig::resolve(settings)?,
             skills: SkillsConfig::resolve()?,
             transcription: TranscriptionConfig::resolve(settings)?,

--- a/desktop-client/ironclaw/src/main.rs
+++ b/desktop-client/ironclaw/src/main.rs
@@ -582,20 +582,28 @@ async fn async_main() -> anyhow::Result<()> {
             mode: BootstrapMode::Orchestrator {
                 allow_local_tools: config.agent.allow_local_tools,
             },
-            job_config: Some(JobToolsConfig {
-                context_manager: Arc::clone(&components.context_manager),
-                scheduler_slot: Some(scheduler_slot.clone()),
-                job_manager: container_job_manager.clone(),
-                store: components.db.clone(),
-                job_event_tx: job_event_tx.clone(),
-                inject_tx: Some(channels.inject_sender()),
-                prompt_queue: if config.sandbox.enabled {
-                    Some(Arc::clone(&prompt_queue))
-                } else {
-                    None
+            // ADR-119 F3: when JobRuntimeMode::Disabled, do not pass
+            // JobToolsConfig at all so the registry skips registering
+            // create_job / list_jobs / job_status / cancel_job /
+            // job_events / job_prompt entirely. The LLM never sees these
+            // 6 tool definitions in Disabled mode.
+            job_config: ironclaw::tools::bootstrap::job_tools_for_mode(
+                &config.job_runtime.mode,
+                || JobToolsConfig {
+                    context_manager: Arc::clone(&components.context_manager),
+                    scheduler_slot: Some(scheduler_slot.clone()),
+                    job_manager: container_job_manager.clone(),
+                    store: components.db.clone(),
+                    job_event_tx: job_event_tx.clone(),
+                    inject_tx: Some(channels.inject_sender()),
+                    prompt_queue: if config.sandbox.enabled {
+                        Some(Arc::clone(&prompt_queue))
+                    } else {
+                        None
+                    },
+                    secrets_store: components.secrets_store.clone(),
                 },
-                secrets_store: components.secrets_store.clone(),
-            }),
+            ),
             ..Default::default()
         })
         .await?;

--- a/desktop-client/ironclaw/src/settings.rs
+++ b/desktop-client/ironclaw/src/settings.rs
@@ -193,6 +193,12 @@ pub struct Settings {
     #[serde(default)]
     pub sandbox: SandboxSettings,
 
+    /// Job runtime mode (ADR-119). When omitted, the legacy
+    /// `[sandbox] enabled` boolean is used to derive a mode for backward
+    /// compatibility (see `crate::config::JobRuntimeConfig::resolve`).
+    #[serde(default)]
+    pub job_runtime: Option<crate::config::job_runtime::JobRuntimeSettings>,
+
     /// Safety configuration.
     #[serde(default)]
     pub safety: SafetySettings,

--- a/desktop-client/ironclaw/src/tools/bootstrap.rs
+++ b/desktop-client/ironclaw/src/tools/bootstrap.rs
@@ -141,6 +141,32 @@ impl JobToolsConfig {
     }
 }
 
+/// Decide whether to register the job-tool group based on the resolved
+/// [`crate::config::JobRuntimeMode`] (ADR-119 F3).
+///
+/// Returns `Some(builder())` when the runtime mode allows job dispatch
+/// (`LocalContainer` or `Cloud`), or `None` when the runtime is
+/// [`crate::config::JobRuntimeMode::Disabled`] — in which case the
+/// registry skips registration of the 6 job tools entirely so the LLM
+/// never sees their definitions.
+///
+/// The `builder` closure is only invoked in the non-disabled case, so
+/// callers can place expensive `Arc::clone` calls inside it without
+/// paying the cost when job tools are off.
+pub fn job_tools_for_mode<F>(
+    mode: &crate::config::JobRuntimeMode,
+    builder: F,
+) -> Option<JobToolsConfig>
+where
+    F: FnOnce() -> JobToolsConfig,
+{
+    match mode {
+        crate::config::JobRuntimeMode::Disabled => None,
+        crate::config::JobRuntimeMode::LocalContainer
+        | crate::config::JobRuntimeMode::Cloud { .. } => Some(builder()),
+    }
+}
+
 /// Configuration bundle for `register_image_tools`.
 #[derive(Debug, Clone, Default)]
 pub struct ImageApiConfig {
@@ -346,5 +372,57 @@ mod tests {
         // can be added without breaking the trait derive contract.
         let err = BootstrapError::Other("boom".to_string());
         assert_eq!(err.to_string(), "bootstrap error: boom");
+    }
+
+    // ─── ADR-119 F3: job_tools_for_mode dispatch ──────────────────────────
+
+    #[test]
+    fn req_adr119_f3_disabled_returns_none_and_skips_builder() {
+        use crate::config::JobRuntimeMode;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let calls = AtomicUsize::new(0);
+        let result = job_tools_for_mode(&JobRuntimeMode::Disabled, || {
+            calls.fetch_add(1, Ordering::SeqCst);
+            unreachable!("builder must not run when mode is Disabled");
+        });
+        assert!(result.is_none(), "Disabled mode must yield None");
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            0,
+            "builder must not be invoked when mode is Disabled (lazy gate contract)"
+        );
+    }
+
+    #[test]
+    fn req_adr119_f3_local_container_invokes_builder() {
+        use crate::config::JobRuntimeMode;
+        use crate::context::ContextManager;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let calls = AtomicUsize::new(0);
+        let result = job_tools_for_mode(&JobRuntimeMode::LocalContainer, || {
+            calls.fetch_add(1, Ordering::SeqCst);
+            JobToolsConfig::new(Arc::new(ContextManager::new(8)))
+        });
+        assert!(result.is_some(), "LocalContainer mode must yield Some");
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn req_adr119_f3_cloud_invokes_builder() {
+        use crate::config::JobRuntimeMode;
+        use crate::context::ContextManager;
+
+        let result = job_tools_for_mode(
+            &JobRuntimeMode::Cloud {
+                endpoint: "https://jobs.example.com".to_string(),
+            },
+            || JobToolsConfig::new(Arc::new(ContextManager::new(8))),
+        );
+        assert!(
+            result.is_some(),
+            "Cloud mode must yield Some (dispatch reserved for future ADR)"
+        );
     }
 }


### PR DESCRIPTION
## 背景 / 目标

ADR-119 §5 F3 — 当 `JobRuntimeMode::Disabled` 时,完全不向 LLM 暴露 6 个 job 工具(`create_job` / `list_jobs` / `job_status` / `cancel_job` / `job_events` / `job_prompt`)。

之前 `main.rs` 在 orchestrator bootstrap 处无条件传入 `Some(JobToolsConfig { ... })`,即使容器运行时禁用,job 工具仍会被注册并展示给 LLM。本 PR 修复该可见性漏洞。

Closes #169

## 改动范围

- `desktop-client/ironclaw/src/tools/bootstrap.rs`
  - 新增 `pub fn job_tools_for_mode(mode, builder) -> Option<JobToolsConfig>`:基于 `JobRuntimeMode` 决定是否构造 `JobToolsConfig`,`Disabled` 返回 `None` 且 **不调用 builder**(惰性契约,避免无谓的 `Arc::clone`)
  - 新增 3 个单测(`req_adr119_f3_*`)覆盖三种 mode 分支,`Disabled` 分支用 `unreachable!()` 验证 builder 不被调用
- `desktop-client/ironclaw/src/main.rs` orchestrator bootstrap 处:`job_config` 改为 `job_tools_for_mode(&config.job_runtime.mode, || JobToolsConfig { ... })`,无 flag 切换、无补丁式 `if`
- 复用已有的 `registry.rs` 分发逻辑(`job_config: None` → 跳过 6 个工具的 `register_*`),无需改 registry

## 非目标(What's NOT in this PR)

- F2(orchestrator fail-closed boot,#168)— 另开 PR
- F4(`AppEvent::JobStarted` 增加审计字段,#170)— 另开 PR
- 修改 `register_job_tools` 内部逻辑(已在 PR #2 完成,本 PR 复用)
- 任何 `Cloud` 路由调度(留待未来 ADR)

## 验证

```bash
$ cargo check -p ironclaw --tests
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 3m 36s

$ cargo nextest run -p ironclaw -E 'test(req_adr119_f3) | test(req_p02_pr4) | test(req_p02_pr2)'
     Summary [10.467s] 15 tests run: 15 passed (1 leaky), 4535 skipped
       PASS req_adr119_f3_disabled_returns_none_and_skips_builder
       PASS req_adr119_f3_local_container_invokes_builder
       PASS req_adr119_f3_cloud_invokes_builder
       PASS req_p02_pr4_b_job_config_absent_skips_job_tools  ← 已有回归测试,确认 None→不注册

$ cargo fmt --all
$ python3.12 scripts/check_no_panics.py --base origin/xClaw
OK: No panic-inducing calls in changed production code.
```

## Stacked PR

- **base 分支**:`w6-f1-job-runtime-mode-config`(stacked on #171)
- **合并顺序**:先 #171,再本 PR;#171 合并后我会 rebase 到 `xClaw`
- **审阅顺序**:先看 #171(F1 引入 `JobRuntimeMode` enum),再看本 PR(F3 消费该 enum)
