### PR TITLE
feat(orchestrator): fail-closed boot on JobRuntimeMode dispatch (ADR-119 F2)

### DIFF
--- a/desktop-client/ironclaw/src/config/job_runtime.rs
+++ b/desktop-client/ironclaw/src/config/job_runtime.rs
@@ -1,0 +1,350 @@
+//! Job runtime mode configuration.
+//!
+//! Per [ADR-119](../../../../docs/plans/architecture-refactor/adr-119-job-runtime-decision-for-desktop-client.md),
+//! desktop clients pick exactly one of:
+//!
+//! - [`JobRuntimeMode::Disabled`] — enterprise default; job tools are not
+//!   exposed and no Docker probe is performed at startup.
+//! - [`JobRuntimeMode::LocalContainer`] — the existing path that delegates
+//!   `create_job` to a local Docker / OrbStack / Colima / Rancher / Podman
+//!   socket via `bollard`.
+//! - [`JobRuntimeMode::Cloud`] — reserved enum slot for a future cloud Job
+//!   service; not implemented in the current code.
+//!
+//! # Backward compatibility
+//!
+//! The legacy `[sandbox] enabled = true` boolean is still honored for
+//! installs whose config predates ADR-119: when no explicit
+//! `[job_runtime]` block is present we derive a mode from the legacy bool
+//! (`true` → `LocalContainer`, `false` → `Disabled`) and emit a single
+//! deprecation warning. F2/F3/F4 (the orchestrator, registry, and audit
+//! follow-ups in ADR-119 §5) will eventually retire the legacy bool.
+
+use std::sync::Once;
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::ConfigError;
+use crate::settings::Settings;
+
+/// Job runtime mode for the desktop client.
+///
+/// Tagged enum on the wire so a future `Cloud` payload can grow without
+/// breaking existing TOML files.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(tag = "mode", rename_all = "snake_case")]
+pub enum JobRuntimeMode {
+    /// Job tooling is unavailable. Enterprise default.
+    ///
+    /// `create_job` and the related discovery tools (`list_jobs`,
+    /// `job_status`, `cancel_job`, `job_events`, `job_prompt`) MUST NOT
+    /// be exposed to the LLM in this mode (enforced by F3, ADR-119 §5).
+    #[default]
+    Disabled,
+    /// Run jobs in a local container via Docker or a Docker-API-compatible
+    /// runtime (Docker Desktop, OrbStack, Colima, Rancher Desktop, Podman
+    /// rootless). Requires the daemon to be reachable at boot; no silent
+    /// fallback to an in-process scheduler (enforced by F2, ADR-119 §5).
+    LocalContainer,
+    /// Route jobs to a managed cloud endpoint. Reserved enum slot — the
+    /// current code does not implement dispatch and rejecting Cloud at
+    /// resolution is intentional until a follow-up ADR fills in auth,
+    /// offline behaviour, and tenant isolation.
+    Cloud {
+        /// Endpoint URL of the managed Job service.
+        endpoint: String,
+    },
+}
+
+impl JobRuntimeMode {
+    /// Lower-case identifier suitable for log fields and the eventual audit
+    /// `runtime_mode` payload (ADR-119 D5).
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Disabled => "disabled",
+            Self::LocalContainer => "local_container",
+            Self::Cloud { .. } => "cloud",
+        }
+    }
+}
+
+/// Resolved job runtime configuration.
+///
+/// Wraps [`JobRuntimeMode`] in a struct so future per-mode tunables can
+/// land without churning every call site that reads `config.job_runtime`.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct JobRuntimeConfig {
+    /// Selected runtime mode.
+    pub mode: JobRuntimeMode,
+}
+
+/// Wire-format settings block for `[job_runtime]` in TOML / DB.
+///
+/// Optional in [`Settings`]; absence triggers the legacy fallback in
+/// [`JobRuntimeConfig::resolve`].
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct JobRuntimeSettings {
+    /// Selected runtime mode. See [`JobRuntimeMode`] for the wire shape.
+    #[serde(flatten)]
+    pub mode: JobRuntimeMode,
+}
+
+static WARNED_LEGACY_SANDBOX_DERIVE: Once = Once::new();
+
+impl JobRuntimeConfig {
+    /// Resolve job runtime configuration from settings.
+    ///
+    /// Priority (highest first):
+    /// 1. `JOB_RUNTIME_MODE` env var (`disabled`, `local_container`,
+    ///    `cloud:<endpoint>`).
+    /// 2. Explicit `[job_runtime]` block in TOML / DB settings.
+    /// 3. Derived from legacy `[sandbox] enabled` for backward compatibility
+    ///    (`true` → `LocalContainer`, `false` → `Disabled`); emits a single
+    ///    deprecation warning when the derivation actually fires.
+    pub(crate) fn resolve(settings: &Settings) -> Result<Self, ConfigError> {
+        if let Some(mode) = parse_env_override()? {
+            return Ok(Self { mode });
+        }
+
+        if let Some(explicit) = settings.job_runtime.as_ref() {
+            if let JobRuntimeMode::Cloud { endpoint } = &explicit.mode
+                && endpoint.trim().is_empty()
+            {
+                return Err(ConfigError::InvalidValue {
+                    key: "job_runtime.endpoint".to_string(),
+                    message: "Cloud mode requires a non-empty endpoint".to_string(),
+                });
+            }
+            return Ok(Self {
+                mode: explicit.mode.clone(),
+            });
+        }
+
+        let mode = if settings.sandbox.enabled {
+            WARNED_LEGACY_SANDBOX_DERIVE.call_once(|| {
+                tracing::warn!(
+                    "[sandbox] enabled = true is deprecated; set [job_runtime] mode = \
+                     \"local_container\" instead. See ADR-119 §5 F1 (xClaw#167)."
+                );
+            });
+            JobRuntimeMode::LocalContainer
+        } else {
+            JobRuntimeMode::Disabled
+        };
+
+        Ok(Self { mode })
+    }
+}
+
+/// Parse the `JOB_RUNTIME_MODE` env var into a [`JobRuntimeMode`].
+///
+/// Accepts:
+/// - `disabled`
+/// - `local_container`
+/// - `cloud:<endpoint>` (URL after the colon, trimmed)
+fn parse_env_override() -> Result<Option<JobRuntimeMode>, ConfigError> {
+    let raw = match std::env::var("JOB_RUNTIME_MODE") {
+        Ok(v) => v,
+        Err(_) => return Ok(None),
+    };
+    let trimmed = raw.trim();
+    let lower = trimmed.to_ascii_lowercase();
+    match lower.as_str() {
+        "disabled" => Ok(Some(JobRuntimeMode::Disabled)),
+        "local_container" => Ok(Some(JobRuntimeMode::LocalContainer)),
+        s if s.starts_with("cloud:") => {
+            let endpoint = trimmed["cloud:".len()..].trim().to_string();
+            if endpoint.is_empty() {
+                return Err(ConfigError::InvalidValue {
+                    key: "JOB_RUNTIME_MODE".to_string(),
+                    message: "cloud mode requires an endpoint after the colon".to_string(),
+                });
+            }
+            Ok(Some(JobRuntimeMode::Cloud { endpoint }))
+        }
+        other => Err(ConfigError::InvalidValue {
+            key: "JOB_RUNTIME_MODE".to_string(),
+            message: format!(
+                "expected one of 'disabled', 'local_container', 'cloud:<endpoint>'; got '{other}'"
+            ),
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::helpers::lock_env;
+    use crate::settings::Settings;
+
+    fn settings_with_sandbox(enabled: bool) -> Settings {
+        let mut s = Settings::default();
+        s.sandbox.enabled = enabled;
+        s.job_runtime = None;
+        s
+    }
+
+    fn clear_env() {
+        // SAFETY: callers hold lock_env() guard.
+        unsafe {
+            std::env::remove_var("JOB_RUNTIME_MODE");
+        }
+    }
+
+    #[test]
+    fn default_mode_is_disabled() {
+        assert_eq!(JobRuntimeMode::default(), JobRuntimeMode::Disabled);
+        assert_eq!(JobRuntimeConfig::default().mode, JobRuntimeMode::Disabled);
+    }
+
+    #[test]
+    fn as_str_matches_audit_payload_contract() {
+        assert_eq!(JobRuntimeMode::Disabled.as_str(), "disabled");
+        assert_eq!(JobRuntimeMode::LocalContainer.as_str(), "local_container");
+        assert_eq!(
+            JobRuntimeMode::Cloud {
+                endpoint: "https://example.com".into()
+            }
+            .as_str(),
+            "cloud"
+        );
+    }
+
+    #[test]
+    fn serde_round_trip_disabled() {
+        let m = JobRuntimeMode::Disabled;
+        let s = toml::to_string(&JobRuntimeSettings { mode: m.clone() }).unwrap();
+        assert!(s.contains("mode = \"disabled\""), "got: {s}");
+        let back: JobRuntimeSettings = toml::from_str(&s).unwrap();
+        assert_eq!(back.mode, m);
+    }
+
+    #[test]
+    fn serde_round_trip_local_container() {
+        let m = JobRuntimeMode::LocalContainer;
+        let s = toml::to_string(&JobRuntimeSettings { mode: m.clone() }).unwrap();
+        assert!(s.contains("mode = \"local_container\""), "got: {s}");
+        let back: JobRuntimeSettings = toml::from_str(&s).unwrap();
+        assert_eq!(back.mode, m);
+    }
+
+    #[test]
+    fn serde_round_trip_cloud() {
+        let m = JobRuntimeMode::Cloud {
+            endpoint: "https://jobs.example.com/v1".to_string(),
+        };
+        let s = toml::to_string(&JobRuntimeSettings { mode: m.clone() }).unwrap();
+        assert!(s.contains("mode = \"cloud\""), "got: {s}");
+        assert!(s.contains("endpoint = \"https://jobs.example.com/v1\""));
+        let back: JobRuntimeSettings = toml::from_str(&s).unwrap();
+        assert_eq!(back.mode, m);
+    }
+
+    #[test]
+    fn legacy_sandbox_true_derives_local_container() {
+        let _guard = lock_env();
+        clear_env();
+        let s = settings_with_sandbox(true);
+        let cfg = JobRuntimeConfig::resolve(&s).unwrap();
+        assert_eq!(cfg.mode, JobRuntimeMode::LocalContainer);
+    }
+
+    #[test]
+    fn legacy_sandbox_false_derives_disabled() {
+        let _guard = lock_env();
+        clear_env();
+        let s = settings_with_sandbox(false);
+        let cfg = JobRuntimeConfig::resolve(&s).unwrap();
+        assert_eq!(cfg.mode, JobRuntimeMode::Disabled);
+    }
+
+    #[test]
+    fn explicit_block_overrides_legacy() {
+        let _guard = lock_env();
+        clear_env();
+        let mut s = Settings::default();
+        s.sandbox.enabled = true;
+        s.job_runtime = Some(JobRuntimeSettings {
+            mode: JobRuntimeMode::Disabled,
+        });
+        let cfg = JobRuntimeConfig::resolve(&s).unwrap();
+        assert_eq!(cfg.mode, JobRuntimeMode::Disabled);
+    }
+
+    #[test]
+    fn explicit_cloud_requires_endpoint() {
+        let _guard = lock_env();
+        clear_env();
+        let mut s = Settings::default();
+        s.job_runtime = Some(JobRuntimeSettings {
+            mode: JobRuntimeMode::Cloud {
+                endpoint: "   ".to_string(),
+            },
+        });
+        let err = JobRuntimeConfig::resolve(&s).unwrap_err();
+        assert!(
+            matches!(err, ConfigError::InvalidValue { ref key, .. } if key == "job_runtime.endpoint")
+        );
+    }
+
+    #[test]
+    fn env_var_override_disabled() {
+        let _guard = lock_env();
+        // SAFETY: under ENV_MUTEX.
+        unsafe {
+            std::env::set_var("JOB_RUNTIME_MODE", "disabled");
+        }
+        let s = settings_with_sandbox(true);
+        let cfg = JobRuntimeConfig::resolve(&s).unwrap();
+        assert_eq!(cfg.mode, JobRuntimeMode::Disabled);
+        clear_env();
+    }
+
+    #[test]
+    fn env_var_override_cloud_with_endpoint() {
+        let _guard = lock_env();
+        // SAFETY: under ENV_MUTEX.
+        unsafe {
+            std::env::set_var("JOB_RUNTIME_MODE", "cloud:https://jobs.example.com/v1");
+        }
+        let s = settings_with_sandbox(false);
+        let cfg = JobRuntimeConfig::resolve(&s).unwrap();
+        assert_eq!(
+            cfg.mode,
+            JobRuntimeMode::Cloud {
+                endpoint: "https://jobs.example.com/v1".to_string(),
+            }
+        );
+        clear_env();
+    }
+
+    #[test]
+    fn env_var_unknown_value_is_error() {
+        let _guard = lock_env();
+        // SAFETY: under ENV_MUTEX.
+        unsafe {
+            std::env::set_var("JOB_RUNTIME_MODE", "bogus");
+        }
+        let s = settings_with_sandbox(false);
+        let err = JobRuntimeConfig::resolve(&s).unwrap_err();
+        assert!(
+            matches!(err, ConfigError::InvalidValue { ref key, .. } if key == "JOB_RUNTIME_MODE")
+        );
+        clear_env();
+    }
+
+    #[test]
+    fn env_var_cloud_without_endpoint_is_error() {
+        let _guard = lock_env();
+        // SAFETY: under ENV_MUTEX.
+        unsafe {
+            std::env::set_var("JOB_RUNTIME_MODE", "cloud:");
+        }
+        let s = settings_with_sandbox(false);
+        let err = JobRuntimeConfig::resolve(&s).unwrap_err();
+        assert!(
+            matches!(err, ConfigError::InvalidValue { ref key, .. } if key == "JOB_RUNTIME_MODE")
+        );
+        clear_env();
+    }
+}

--- a/desktop-client/ironclaw/src/config/mod.rs
+++ b/desktop-client/ironclaw/src/config/mod.rs
@@ -17,6 +17,7 @@ pub(crate) mod embeddings;
 mod heartbeat;
 pub(crate) mod helpers;
 mod hygiene;
+pub mod job_runtime;
 pub(crate) mod llm;
 pub mod relay;
 mod routines;
@@ -47,6 +48,7 @@ pub use self::database::{DatabaseBackend, DatabaseConfig, SslMode, default_libsq
 pub use self::embeddings::{DEFAULT_EMBEDDING_CACHE_SIZE, EmbeddingsConfig};
 pub use self::heartbeat::HeartbeatConfig;
 pub use self::hygiene::HygieneConfig;
+pub use self::job_runtime::{JobRuntimeConfig, JobRuntimeMode, JobRuntimeSettings};
 pub use self::llm::default_session_path;
 pub use self::relay::RelayConfig;
 pub use self::routines::RoutineConfig;
@@ -101,6 +103,8 @@ pub struct Config {
     pub hygiene: HygieneConfig,
     pub routines: RoutineConfig,
     pub sandbox: SandboxModeConfig,
+    /// Job runtime mode (Disabled / LocalContainer / Cloud). See ADR-119.
+    pub job_runtime: JobRuntimeConfig,
     pub claude_code: ClaudeCodeConfig,
     pub skills: SkillsConfig,
     pub transcription: TranscriptionConfig,
@@ -174,6 +178,7 @@ impl Config {
                 enabled: false,
                 ..SandboxModeConfig::default()
             },
+            job_runtime: JobRuntimeConfig::default(),
             claude_code: ClaudeCodeConfig::default(),
             skills: SkillsConfig {
                 enabled: true,
@@ -369,6 +374,7 @@ impl Config {
             hygiene: HygieneConfig::resolve()?,
             routines: RoutineConfig::resolve()?,
             sandbox: SandboxModeConfig::resolve(settings)?,
+            job_runtime: JobRuntimeConfig::resolve(settings)?,
             claude_code: ClaudeCodeConfig::resolve(settings)?,
             skills: SkillsConfig::resolve()?,
             transcription: TranscriptionConfig::resolve(settings)?,

--- a/desktop-client/ironclaw/src/main.rs
+++ b/desktop-client/ironclaw/src/main.rs
@@ -365,7 +365,13 @@ async fn async_main() -> anyhow::Result<()> {
         components.db.as_ref(),
         components.secrets_store.as_ref(),
     )
-    .await;
+    .await
+    .map_err(|e| {
+        // ADR-119 F2: fail-closed boot — surface the error to the user
+        // instead of silently downgrading the runtime.
+        tracing::error!("Orchestrator setup refused to start: {e}");
+        anyhow::anyhow!("orchestrator setup failed: {e}")
+    })?;
     let container_job_manager = orch.container_job_manager;
     let job_event_tx = orch.job_event_tx;
     let prompt_queue = orch.prompt_queue;

--- a/desktop-client/ironclaw/src/orchestrator/mod.rs
+++ b/desktop-client/ironclaw/src/orchestrator/mod.rs
@@ -68,99 +68,161 @@ pub struct OrchestratorSetup {
     pub docker_status: crate::sandbox::DockerStatus,
 }
 
+/// Errors returned by [`setup_orchestrator`] when the orchestrator cannot
+/// be brought up safely (ADR-119 F2 — fail-closed boot).
+///
+/// Replacing the historical silent downgrade: if the operator configures
+/// `JobRuntimeMode::LocalContainer` we MUST refuse to boot rather than
+/// quietly running the agent without a working sandbox.
+#[derive(Debug, thiserror::Error)]
+pub enum OrchestratorSetupError {
+    /// `JobRuntimeMode::LocalContainer` requires Docker but it is not
+    /// installed on this host.
+    #[error(
+        "JobRuntimeMode::LocalContainer requires Docker but it is not installed. {hint}\n\
+         Hint: set [job_runtime] mode = \"disabled\" or install Docker."
+    )]
+    DockerNotInstalled { hint: String },
+
+    /// `JobRuntimeMode::LocalContainer` requires Docker but the daemon is
+    /// not currently running.
+    #[error(
+        "JobRuntimeMode::LocalContainer requires Docker but the daemon is not running. {hint}\n\
+         Hint: start Docker or set [job_runtime] mode = \"disabled\"."
+    )]
+    DockerNotRunning { hint: String },
+
+    /// `JobRuntimeMode::Cloud` is reserved for a future ADR; refuse to
+    /// boot rather than silently behaving like `Disabled`.
+    #[error(
+        "JobRuntimeMode::Cloud (endpoint = {endpoint:?}) is not yet implemented. \
+         Use mode = \"disabled\" or mode = \"local_container\"."
+    )]
+    CloudNotImplemented { endpoint: String },
+}
+
 /// Detect Docker availability, create the container job manager, and start
 /// the orchestrator internal API in the background.
+///
+/// Dispatches on [`crate::config::JobRuntimeMode`] (ADR-119 F2):
+/// - `Disabled`     → skip docker probe, return empty setup
+/// - `LocalContainer` → require working Docker, else fail-closed with
+///   [`OrchestratorSetupError::DockerNotInstalled`] / `DockerNotRunning`
+/// - `Cloud { .. }` → reserved; fails with [`OrchestratorSetupError::CloudNotImplemented`]
 pub async fn setup_orchestrator(
     config: &crate::config::Config,
     llm: &Arc<dyn LlmProvider>,
     db: Option<&Arc<dyn Database>>,
     secrets_store: Option<&Arc<dyn SecretsStore + Send + Sync>>,
-) -> OrchestratorSetup {
+) -> Result<OrchestratorSetup, OrchestratorSetupError> {
     let prompt_queue = Arc::new(Mutex::new(
         HashMap::<Uuid, VecDeque<api::PendingPrompt>>::new(),
     ));
 
-    let docker_status = if config.sandbox.enabled {
-        let detection = crate::sandbox::check_docker().await;
-        match detection.status {
-            crate::sandbox::DockerStatus::Available => {
-                tracing::info!("Docker is available");
-            }
-            crate::sandbox::DockerStatus::NotInstalled => {
-                tracing::warn!(
-                    "Docker is not installed -- sandbox disabled for this session. {}",
-                    detection.platform.install_hint()
-                );
-            }
-            crate::sandbox::DockerStatus::NotRunning => {
-                tracing::warn!(
-                    "Docker is installed but not running -- sandbox disabled for this session. {}",
-                    detection.platform.start_hint()
-                );
-            }
-            crate::sandbox::DockerStatus::Disabled => {}
+    match &config.job_runtime.mode {
+        crate::config::JobRuntimeMode::Disabled => Ok(OrchestratorSetup {
+            container_job_manager: None,
+            job_event_tx: None,
+            prompt_queue,
+            docker_status: crate::sandbox::DockerStatus::Disabled,
+        }),
+        crate::config::JobRuntimeMode::LocalContainer => {
+            setup_local_container(config, llm, db, secrets_store, prompt_queue).await
         }
-        detection.status
-    } else {
-        crate::sandbox::DockerStatus::Disabled
+        crate::config::JobRuntimeMode::Cloud { endpoint } => {
+            Err(OrchestratorSetupError::CloudNotImplemented {
+                endpoint: endpoint.clone(),
+            })
+        }
+    }
+}
+
+/// Build the local-container orchestrator (probe Docker, spawn API,
+/// construct `ContainerJobManager`). Fails closed when Docker is
+/// unavailable.
+async fn setup_local_container(
+    config: &crate::config::Config,
+    llm: &Arc<dyn LlmProvider>,
+    db: Option<&Arc<dyn Database>>,
+    secrets_store: Option<&Arc<dyn SecretsStore + Send + Sync>>,
+    prompt_queue: Arc<Mutex<HashMap<Uuid, VecDeque<api::PendingPrompt>>>>,
+) -> Result<OrchestratorSetup, OrchestratorSetupError> {
+    let detection = crate::sandbox::check_docker().await;
+    let docker_status = detection.status;
+    match docker_status {
+        crate::sandbox::DockerStatus::Available => {
+            tracing::info!("Docker is available");
+        }
+        crate::sandbox::DockerStatus::NotInstalled => {
+            return Err(OrchestratorSetupError::DockerNotInstalled {
+                hint: detection.platform.install_hint().to_string(),
+            });
+        }
+        crate::sandbox::DockerStatus::NotRunning => {
+            return Err(OrchestratorSetupError::DockerNotRunning {
+                hint: detection.platform.start_hint().to_string(),
+            });
+        }
+        crate::sandbox::DockerStatus::Disabled => {
+            // Should not happen: setup_local_container is only entered
+            // for JobRuntimeMode::LocalContainer. Treat as fail-closed.
+            return Err(OrchestratorSetupError::DockerNotRunning {
+                hint: "internal: docker probe returned Disabled in LocalContainer mode".to_string(),
+            });
+        }
+    }
+
+    let (tx, _) = broadcast::channel(256);
+    let job_event_tx = Some(tx);
+
+    let token_store = TokenStore::new();
+    let orchestrator_port = resolve_orchestrator_port();
+    let job_config = ContainerJobConfig {
+        image: config.sandbox.image.clone(),
+        memory_limit_mb: config.sandbox.memory_limit_mb,
+        cpu_shares: config.sandbox.cpu_shares,
+        orchestrator_port,
+        claude_code_api_key: std::env::var("ANTHROPIC_API_KEY").ok(),
+        claude_code_oauth_token: crate::config::ClaudeCodeConfig::extract_oauth_token(),
+        claude_code_model: config.claude_code.model.clone(),
+        claude_code_max_turns: config.claude_code.max_turns,
+        claude_code_memory_limit_mb: config.claude_code.memory_limit_mb,
+        claude_code_allowed_tools: config.claude_code.allowed_tools.clone(),
+    };
+    let jm = Arc::new(ContainerJobManager::new(job_config, token_store.clone()));
+
+    let orchestrator_state = api::OrchestratorState {
+        llm: Arc::clone(llm),
+        job_manager: Arc::clone(&jm),
+        token_store,
+        job_event_tx: job_event_tx.clone(),
+        prompt_queue: Arc::clone(&prompt_queue),
+        store: db.cloned(),
+        secrets_store: secrets_store.cloned(),
+        user_id: "default".to_string(),
+        job_owner_cache: Arc::new(std::sync::RwLock::new(std::collections::HashMap::new())),
     };
 
-    let (job_event_tx, container_job_manager) = if config.sandbox.enabled && docker_status.is_ok() {
-        let (tx, _) = broadcast::channel(256);
-        let job_event_tx = Some(tx);
-
-        let token_store = TokenStore::new();
-        let orchestrator_port = resolve_orchestrator_port();
-        let job_config = ContainerJobConfig {
-            image: config.sandbox.image.clone(),
-            memory_limit_mb: config.sandbox.memory_limit_mb,
-            cpu_shares: config.sandbox.cpu_shares,
-            orchestrator_port,
-            claude_code_api_key: std::env::var("ANTHROPIC_API_KEY").ok(),
-            claude_code_oauth_token: crate::config::ClaudeCodeConfig::extract_oauth_token(),
-            claude_code_model: config.claude_code.model.clone(),
-            claude_code_max_turns: config.claude_code.max_turns,
-            claude_code_memory_limit_mb: config.claude_code.memory_limit_mb,
-            claude_code_allowed_tools: config.claude_code.allowed_tools.clone(),
-        };
-        let jm = Arc::new(ContainerJobManager::new(job_config, token_store.clone()));
-
-        let orchestrator_state = api::OrchestratorState {
-            llm: Arc::clone(llm),
-            job_manager: Arc::clone(&jm),
-            token_store,
-            job_event_tx: job_event_tx.clone(),
-            prompt_queue: Arc::clone(&prompt_queue),
-            store: db.cloned(),
-            secrets_store: secrets_store.cloned(),
-            user_id: "default".to_string(),
-            job_owner_cache: Arc::new(std::sync::RwLock::new(std::collections::HashMap::new())),
-        };
-
-        tokio::spawn(async move {
-            if let Err(e) = OrchestratorApi::start(orchestrator_state, orchestrator_port).await {
-                tracing::error!("Orchestrator API failed: {}", e);
-            }
-        });
-
-        if config.claude_code.enabled {
-            tracing::info!(
-                "Claude Code sandbox mode available (model: {}, max_turns: {})",
-                config.claude_code.model,
-                config.claude_code.max_turns
-            );
+    tokio::spawn(async move {
+        if let Err(e) = OrchestratorApi::start(orchestrator_state, orchestrator_port).await {
+            tracing::error!("Orchestrator API failed: {}", e);
         }
-        (job_event_tx, Some(jm))
-    } else {
-        (None, None)
-    };
+    });
 
-    OrchestratorSetup {
-        container_job_manager,
+    if config.claude_code.enabled {
+        tracing::info!(
+            "Claude Code sandbox mode available (model: {}, max_turns: {})",
+            config.claude_code.model,
+            config.claude_code.max_turns
+        );
+    }
+
+    Ok(OrchestratorSetup {
+        container_job_manager: Some(jm),
         job_event_tx,
         prompt_queue,
         docker_status,
-    }
+    })
 }
 
 #[cfg(test)]
@@ -193,5 +255,78 @@ mod tests {
 
         // Cleanup
         unsafe { std::env::remove_var("ORCHESTRATOR_PORT") };
+    }
+
+    // ─── ADR-119 F2: fail-closed boot dispatch ────────────────────────────
+
+    fn build_test_config(mode: crate::config::JobRuntimeMode) -> crate::config::Config {
+        let tmp = std::env::temp_dir().join(format!("ironclaw-orch-test-{}", uuid::Uuid::new_v4()));
+        let mut cfg = crate::config::Config::for_testing(
+            tmp.join("db.sqlite"),
+            tmp.join("skills"),
+            tmp.join("installed_skills"),
+        );
+        cfg.job_runtime = crate::config::JobRuntimeConfig { mode };
+        cfg
+    }
+
+    #[tokio::test]
+    async fn req_adr119_f2_disabled_mode_returns_empty_setup_without_docker_probe() {
+        // When mode = Disabled the orchestrator must NOT probe Docker
+        // and must succeed even on hosts where Docker is missing.
+        let cfg = build_test_config(crate::config::JobRuntimeMode::Disabled);
+        let llm: Arc<dyn LlmProvider> = Arc::new(crate::testing::StubLlm::new("noop"));
+        let setup = match setup_orchestrator(&cfg, &llm, None, None).await {
+            Ok(s) => s,
+            Err(e) => panic!("Disabled mode must succeed, got error: {e}"),
+        };
+        assert!(setup.container_job_manager.is_none());
+        assert!(setup.job_event_tx.is_none());
+        assert!(matches!(
+            setup.docker_status,
+            crate::sandbox::DockerStatus::Disabled
+        ));
+    }
+
+    #[tokio::test]
+    async fn req_adr119_f2_cloud_mode_fails_closed_with_endpoint_in_error() {
+        // Cloud is reserved for a future ADR; setup must refuse to boot.
+        let cfg = build_test_config(crate::config::JobRuntimeMode::Cloud {
+            endpoint: "https://jobs.example.com/v1".to_string(),
+        });
+        let llm: Arc<dyn LlmProvider> = Arc::new(crate::testing::StubLlm::new("noop"));
+        match setup_orchestrator(&cfg, &llm, None, None).await {
+            Ok(_) => panic!("Cloud mode must fail-closed"),
+            Err(OrchestratorSetupError::CloudNotImplemented { endpoint }) => {
+                assert_eq!(endpoint, "https://jobs.example.com/v1");
+            }
+            Err(other) => panic!("expected CloudNotImplemented, got {other}"),
+        }
+    }
+
+    #[test]
+    fn req_adr119_f2_docker_not_installed_error_renders_actionable_hint() {
+        // The Display impl must mention BOTH the platform-specific install
+        // hint and the "set mode = disabled" workaround so operators can
+        // self-recover from the log alone.
+        let err = OrchestratorSetupError::DockerNotInstalled {
+            hint: "Install Docker Desktop from https://docker.com".to_string(),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("LocalContainer"), "msg = {msg}");
+        assert!(msg.contains("not installed"), "msg = {msg}");
+        assert!(msg.contains("Install Docker Desktop"), "msg = {msg}");
+        assert!(msg.contains("disabled"), "msg = {msg}");
+    }
+
+    #[test]
+    fn req_adr119_f2_docker_not_running_error_renders_actionable_hint() {
+        let err = OrchestratorSetupError::DockerNotRunning {
+            hint: "Run `open -a Docker`".to_string(),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("not running"), "msg = {msg}");
+        assert!(msg.contains("open -a Docker"), "msg = {msg}");
+        assert!(msg.contains("disabled"), "msg = {msg}");
     }
 }

--- a/desktop-client/ironclaw/src/settings.rs
+++ b/desktop-client/ironclaw/src/settings.rs
@@ -193,6 +193,12 @@ pub struct Settings {
     #[serde(default)]
     pub sandbox: SandboxSettings,
 
+    /// Job runtime mode (ADR-119). When omitted, the legacy
+    /// `[sandbox] enabled` boolean is used to derive a mode for backward
+    /// compatibility (see `crate::config::JobRuntimeConfig::resolve`).
+    #[serde(default)]
+    pub job_runtime: Option<crate::config::job_runtime::JobRuntimeSettings>,
+
     /// Safety configuration.
     #[serde(default)]
     pub safety: SafetySettings,


### PR DESCRIPTION
## 背景 / 目标

ADR-119 §5 F2 — orchestrator boot 在 `JobRuntimeMode::LocalContainer` + Docker 不可用时 **fail-closed**(拒绝启动),取代历史上的"静默降级"行为。

旧逻辑:Docker 缺失时 `tracing::warn!` 一行后继续启动,留给 LLM 一个**没有 sandbox 的运行时**——既违反操作员声明,也让审计日志失去意义。新逻辑按 `JobRuntimeMode` 三态精确分发,任何"无法兑现声明"的情况都返回错误,主进程退出。

Closes #168
Stacked on #171 (ADR-119 F1)。

## 改动范围

- `desktop-client/ironclaw/src/orchestrator/mod.rs`
  - 新增错误类型 `OrchestratorSetupError`(thiserror):
    - `DockerNotInstalled { hint }` — 平台相关的安装提示 + "set mode = disabled" 建议
    - `DockerNotRunning { hint }` — 平台相关的启动提示
    - `CloudNotImplemented { endpoint }` — Cloud 模式留待未来 ADR,显式拒绝启动
  - `setup_orchestrator(...)` 签名改为 `Result<OrchestratorSetup, OrchestratorSetupError>`
  - 主体改为 `match config.job_runtime.mode`:
    - `Disabled` → 不探测 Docker,直接返回空 setup(`docker_status = Disabled`)
    - `LocalContainer` → 委托给新的 `setup_local_container(...)`,Docker 不可用即 `Err`
    - `Cloud { endpoint }` → 立即返回 `CloudNotImplemented`
  - 新增 4 个单测(`req_adr119_f2_*`)覆盖 Disabled 通路、Cloud 拒绝、两种 Docker 错误的可读性
- `desktop-client/ironclaw/src/main.rs`
  - 调用方加 `.map_err(...)?`,把 setup 错误向上传播,主进程因此**优雅退出**而非半启动

## 非目标(What's NOT in this PR)

- 移除旧的 `[sandbox]` 配置(由 F1/F4 的 deprecation 路径完成)
- F4 审计字段(`AppEvent::JobStarted` 增 `runtime_mode` 等,#170)
- Cloud 调度具体实现(留待未来 ADR,本 PR 仅 fail-closed)
- 修改 `DockerStatus` 枚举(继续返回供下游观测代码使用)

## 验证

```bash
$ cargo check -p ironclaw --tests
    Finished `dev` profile in 4.25s

$ cargo nextest run -p ironclaw -E 'test(req_adr119_f2)'
     Summary [2.823s] 4 tests run: 4 passed, 4547 skipped
       PASS req_adr119_f2_disabled_mode_returns_empty_setup_without_docker_probe
       PASS req_adr119_f2_cloud_mode_fails_closed_with_endpoint_in_error
       PASS req_adr119_f2_docker_not_installed_error_renders_actionable_hint
       PASS req_adr119_f2_docker_not_running_error_renders_actionable_hint

$ cargo fmt --all
$ python3.12 scripts/check_no_panics.py --base origin/xClaw
OK: No panic-inducing calls in changed production code.
```

## Stacked PR

- **base 分支**:`w6-f1-job-runtime-mode-config`(stacked on #171)
- **合并顺序**:#171 → 本 PR → #172
- **审阅顺序**:先看 #171(F1),再看本 PR
