### PR TITLE
feat(audit): enrich AppEvent::JobStarted with runtime_mode + credential metadata (ADR-119 F4)

### DIFF
--- a/desktop-client/ironclaw/crates/ironclaw_common/src/event.rs
+++ b/desktop-client/ironclaw/crates/ironclaw_common/src/event.rs
@@ -85,6 +85,25 @@ pub enum AppEvent {
         job_id: String,
         title: String,
         browse_url: String,
+        /// ADR-119 F4 — audit field. Resolved [`JobRuntimeMode`] as the
+        /// stable string "disabled" / "local_container" / "cloud" (D5
+        /// audit contract). Stored as `String` so this crate stays
+        /// independent of the `ironclaw` desktop crate where the enum
+        /// lives.
+        #[serde(default)]
+        runtime_mode: String,
+        /// ADR-119 F4 — container image used to launch the worker
+        /// (LocalContainer only). `None` for `Disabled` / `Cloud`.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        image: Option<String>,
+        /// ADR-119 F4 — remote scheduler endpoint (`Cloud` only).
+        /// `None` for `Disabled` / `LocalContainer`.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        endpoint: Option<String>,
+        /// ADR-119 F4 — names of credentials granted to this job by the
+        /// orchestrator. Empty when no grants were attached.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        credential_grants: Vec<String>,
     },
     #[serde(rename = "approval_needed")]
     ApprovalNeeded {
@@ -286,6 +305,10 @@ mod tests {
                 job_id: String::new(),
                 title: String::new(),
                 browse_url: String::new(),
+                runtime_mode: String::new(),
+                image: None,
+                endpoint: None,
+                credential_grants: Vec::new(),
             },
             AppEvent::ApprovalNeeded {
                 request_id: String::new(),
@@ -389,5 +412,109 @@ mod tests {
         let json = serde_json::to_string(&original).unwrap();
         let deserialized: AppEvent = serde_json::from_str(&json).unwrap();
         assert_eq!(deserialized.event_type(), "response");
+    }
+
+    /// ADR-119 F4 — `JobStarted` must round-trip with the new audit fields
+    /// populated end-to-end.
+    #[test]
+    fn req_adr119_f4_job_started_round_trip_includes_audit_fields() {
+        let original = AppEvent::JobStarted {
+            job_id: "job-1".to_string(),
+            title: "build docs".to_string(),
+            browse_url: "/projects/xyz".to_string(),
+            runtime_mode: "local_container".to_string(),
+            image: Some("ironclaw/worker:1.2.3".to_string()),
+            endpoint: None,
+            credential_grants: vec!["github_token".to_string()],
+        };
+        let json = serde_json::to_string(&original).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed["type"], "job_started");
+        assert_eq!(parsed["runtime_mode"], "local_container");
+        assert_eq!(parsed["image"], "ironclaw/worker:1.2.3");
+        assert_eq!(parsed["credential_grants"][0], "github_token");
+        // Endpoint is omitted (skip_serializing_if Option::is_none).
+        assert!(parsed.get("endpoint").is_none());
+
+        let restored: AppEvent = serde_json::from_str(&json).unwrap();
+        match restored {
+            AppEvent::JobStarted {
+                runtime_mode,
+                image,
+                endpoint,
+                credential_grants,
+                ..
+            } => {
+                assert_eq!(runtime_mode, "local_container");
+                assert_eq!(image.as_deref(), Some("ironclaw/worker:1.2.3"));
+                assert_eq!(endpoint, None);
+                assert_eq!(credential_grants, vec!["github_token".to_string()]);
+            }
+            other => panic!("expected JobStarted, got {:?}", other),
+        }
+    }
+
+    /// ADR-119 F4 — old payloads (without the new audit fields) must still
+    /// deserialize via `#[serde(default)]` for forward/backward compat.
+    #[test]
+    fn req_adr119_f4_job_started_serde_backward_compat() {
+        let legacy = r#"{
+            "type": "job_started",
+            "job_id": "j1",
+            "title": "t",
+            "browse_url": "/p/abc"
+        }"#;
+        let parsed: AppEvent = serde_json::from_str(legacy).unwrap();
+        match parsed {
+            AppEvent::JobStarted {
+                runtime_mode,
+                image,
+                endpoint,
+                credential_grants,
+                ..
+            } => {
+                assert_eq!(runtime_mode, "");
+                assert_eq!(image, None);
+                assert_eq!(endpoint, None);
+                assert!(credential_grants.is_empty());
+            }
+            other => panic!("expected JobStarted, got {:?}", other),
+        }
+    }
+
+    /// ADR-119 F4 — `credential_grants` must contain only the secret *names*
+    /// chosen for the job; the secret *values* must never appear in any
+    /// serialised audit payload (OWASP A02 / Cryptographic Failures).
+    #[test]
+    fn req_adr119_f4_credential_grants_no_secret_values() {
+        let event = AppEvent::JobStarted {
+            job_id: "j".to_string(),
+            title: "t".to_string(),
+            browse_url: "/p".to_string(),
+            runtime_mode: "local_container".to_string(),
+            image: Some("img".to_string()),
+            endpoint: None,
+            // Only NAMES, never values.
+            credential_grants: vec!["github_token".to_string(), "npm_token".to_string()],
+        };
+        let json = serde_json::to_string(&event).unwrap();
+        // Sentinel values that would indicate a leak if any code path ever
+        // pushed the actual secret value into the grants vector.
+        for forbidden in &[
+            "ghp_supersecretvalue",
+            "Bearer ",
+            "AKIA",
+            "sk-",
+            "PRIVATE KEY",
+        ] {
+            assert!(
+                !json.contains(forbidden),
+                "secret-shaped substring leaked into audit event: {}",
+                forbidden
+            );
+        }
+        // Names are present.
+        assert!(json.contains("github_token"));
+        assert!(json.contains("npm_token"));
     }
 }

--- a/desktop-client/ironclaw/src/channels/web/mod.rs
+++ b/desktop-client/ironclaw/src/channels/web/mod.rs
@@ -434,6 +434,16 @@ impl Channel for GatewayChannel {
                 job_id,
                 title,
                 browse_url,
+                // ADR-119 F4 — channel-side conversion path does not have
+                // access to the resolved JobRuntimeMode. The orchestrator
+                // emits the canonical audit-grade JobStarted event with
+                // populated metadata; this path is for forwarding chat
+                // status updates and intentionally leaves audit fields
+                // empty.
+                runtime_mode: String::new(),
+                image: None,
+                endpoint: None,
+                credential_grants: Vec::new(),
             },
             StatusUpdate::ApprovalNeeded {
                 request_id,

--- a/desktop-client/ironclaw/src/main.rs
+++ b/desktop-client/ironclaw/src/main.rs
@@ -608,6 +608,8 @@ async fn async_main() -> anyhow::Result<()> {
                         None
                     },
                     secrets_store: components.secrets_store.clone(),
+                    // ADR-119 F4 — stamp runtime mode for the JobStarted audit event.
+                    runtime_mode: config.job_runtime.mode.as_str().to_string(),
                 },
             ),
             ..Default::default()

--- a/desktop-client/ironclaw/src/orchestrator/job_manager.rs
+++ b/desktop-client/ironclaw/src/orchestrator/job_manager.rs
@@ -255,6 +255,11 @@ impl ContainerJobManager {
         }
     }
 
+    /// Container image used to launch worker jobs (ADR-119 F4 audit field).
+    pub fn image(&self) -> &str {
+        &self.config.image
+    }
+
     /// Get or create a Docker connection.
     async fn docker(&self) -> Result<bollard::Docker, OrchestratorError> {
         {

--- a/desktop-client/ironclaw/src/tools/bootstrap.rs
+++ b/desktop-client/ironclaw/src/tools/bootstrap.rs
@@ -122,6 +122,12 @@ pub struct JobToolsConfig {
     pub inject_tx: Option<tokio::sync::mpsc::Sender<IncomingMessage>>,
     pub prompt_queue: Option<PromptQueue>,
     pub secrets_store: Option<Arc<dyn SecretsStore + Send + Sync>>,
+    /// ADR-119 F4 — resolved [`crate::config::JobRuntimeMode`] as a stable
+    /// audit string (`disabled` / `local_container` / `cloud`). Stamped onto
+    /// the [`ironclaw_common::AppEvent::JobStarted`] event when a sandbox
+    /// job is created. Empty string when the caller did not supply a mode
+    /// (legacy callers / tests).
+    pub runtime_mode: String,
 }
 
 impl JobToolsConfig {
@@ -137,6 +143,7 @@ impl JobToolsConfig {
             inject_tx: None,
             prompt_queue: None,
             secrets_store: None,
+            runtime_mode: String::new(),
         }
     }
 }

--- a/desktop-client/ironclaw/src/tools/builtin/job.rs
+++ b/desktop-client/ironclaw/src/tools/builtin/job.rs
@@ -90,6 +90,10 @@ pub struct CreateJobTool {
     inject_tx: Option<tokio::sync::mpsc::Sender<IncomingMessage>>,
     /// Encrypted secrets store for validating credential grants.
     secrets_store: Option<Arc<dyn SecretsStore + Send + Sync>>,
+    /// ADR-119 F4 — resolved [`JobRuntimeMode`] as a stable string
+    /// (`disabled` / `local_container` / `cloud`). Stamped onto the
+    /// [`AppEvent::JobStarted`] audit event when a sandbox job is created.
+    runtime_mode: String,
 }
 
 impl CreateJobTool {
@@ -102,6 +106,7 @@ impl CreateJobTool {
             event_tx: None,
             inject_tx: None,
             secrets_store: None,
+            runtime_mode: String::new(),
         }
     }
 
@@ -137,6 +142,13 @@ impl CreateJobTool {
     /// Inject secrets store for credential validation.
     pub fn with_secrets(mut self, secrets: Arc<dyn SecretsStore + Send + Sync>) -> Self {
         self.secrets_store = Some(secrets);
+        self
+    }
+
+    /// ADR-119 F4 — set the resolved runtime mode string used in the
+    /// [`AppEvent::JobStarted`] audit event.
+    pub fn with_runtime_mode(mut self, mode: impl Into<String>) -> Self {
+        self.runtime_mode = mode.into();
         self
     }
 
@@ -443,6 +455,12 @@ impl CreateJobTool {
         }
 
         // Create the container job with the pre-determined job_id.
+        // Snapshot grant names for the audit event before the vector is
+        // moved into create_job (ADR-119 F4).
+        let credential_grant_names: Vec<String> = credential_grants
+            .iter()
+            .map(|g| g.secret_name.clone())
+            .collect();
         let _token = jm
             .create_job(job_id, task, Some(project_dir), mode, credential_grants)
             .await
@@ -462,6 +480,23 @@ impl CreateJobTool {
         // Container started successfully.
         let now = Utc::now();
         self.update_status(job_id, "running", None, None, Some(now), None);
+
+        // ADR-119 F4 — emit JobStarted audit event with runtime metadata.
+        // SECURITY: only credential *names* are included; the secret values
+        // never leave the orchestrator process (OWASP A02 / Cryptographic
+        // Failures).
+        if let Some(etx) = &self.event_tx {
+            let audit_event = AppEvent::JobStarted {
+                job_id: job_id.to_string(),
+                title: task.to_string(),
+                browse_url: format!("/projects/{}", browse_id),
+                runtime_mode: self.runtime_mode.clone(),
+                image: Some(jm.image().to_string()),
+                endpoint: None,
+                credential_grants: credential_grant_names,
+            };
+            let _ = etx.send((job_id, ctx.user_id.clone(), audit_event));
+        }
 
         if !wait {
             // Spawn a background monitor that forwards Claude Code output
@@ -2286,5 +2321,24 @@ mod tests {
         let cm = ContextManager::new(5);
         let result = resolve_job_id("not-hex-at-all!", &cm).await;
         assert!(result.is_err()); // safety: test
+    }
+
+    /// ADR-119 F4 — `with_runtime_mode` builder must store the resolved
+    /// runtime-mode string for later stamping onto `JobStarted` audit events.
+    #[test]
+    fn req_adr119_f4_with_runtime_mode_stores_value() {
+        let manager = Arc::new(ContextManager::new(5));
+        let tool = CreateJobTool::new(manager).with_runtime_mode("local_container");
+        assert_eq!(tool.runtime_mode, "local_container"); // safety: test
+    }
+
+    /// ADR-119 F4 — `CreateJobTool::new` defaults `runtime_mode` to an empty
+    /// string so legacy/test callers keep compiling without forcing the
+    /// builder to be invoked.
+    #[test]
+    fn req_adr119_f4_runtime_mode_defaults_empty() {
+        let manager = Arc::new(ContextManager::new(5));
+        let tool = CreateJobTool::new(manager);
+        assert_eq!(tool.runtime_mode, ""); // safety: test
     }
 }

--- a/desktop-client/ironclaw/src/tools/registry.rs
+++ b/desktop-client/ironclaw/src/tools/registry.rs
@@ -406,6 +406,7 @@ impl ToolRegistry {
                 jc.inject_tx.clone(),
                 jc.prompt_queue.clone(),
                 jc.secrets_store.clone(),
+                jc.runtime_mode.clone(),
             );
         }
 
@@ -564,8 +565,10 @@ impl ToolRegistry {
         inject_tx: Option<tokio::sync::mpsc::Sender<crate::channels::IncomingMessage>>,
         prompt_queue: Option<PromptQueue>,
         secrets_store: Option<Arc<dyn SecretsStore + Send + Sync>>,
+        runtime_mode: String,
     ) {
-        let mut create_tool = CreateJobTool::new(Arc::clone(&context_manager));
+        let mut create_tool =
+            CreateJobTool::new(Arc::clone(&context_manager)).with_runtime_mode(runtime_mode);
         if let Some(slot) = scheduler_slot {
             create_tool = create_tool.with_scheduler_slot(slot);
         }

--- a/desktop-client/src/engine.rs
+++ b/desktop-client/src/engine.rs
@@ -465,6 +465,8 @@ pub async fn start_ironclaw_engine(app_handle: AppHandle) -> anyhow::Result<()> 
         None, // inject_tx: 无需注入
         None, // prompt_queue: 无 sandbox prompt
         None, // secrets_store: 无 sandbox credentials
+        // ADR-119 F4 — 桌面客户端无 sandbox，runtime_mode 留空（不会触发 emit）。
+        String::new(),
     );
 
     // ── Phase 8: 构建 Agent ───────────────────────────────────────


### PR DESCRIPTION
**Source**: [ADR-119 §5 F4](docs/plans/architecture-refactor/adr-119-job-runtime-decision-for-desktop-client.md) · Closes #170

> **Stacked PR** — base 是 `w6-f1-job-runtime-mode-config`（PR #171），不是 `xClaw`。
> 合并顺序：先 #171 → 再本 PR。后续会 rebase 到 xClaw。

## 背景 / 目标

ADR-119 决策 D5 要求每次 `create_job` 成功执行后必须发出含 `runtime_mode` /
`credential_grants` / `image` / `endpoint` 的审计事件，便于政企合规追溯。本 PR
扩展 `AppEvent::JobStarted` 的 schema 并在 `CreateJobTool::execute_sandbox` 的成
功分支植入审计事件发射。

## 改动范围

- `desktop-client/ironclaw/crates/ironclaw_common/src/event.rs`
  - `AppEvent::JobStarted` 新增 4 个审计字段：
    - `runtime_mode: String`（`#[serde(default)]`）
    - `image: Option<String>`（`skip_serializing_if = Option::is_none`）
    - `endpoint: Option<String>`（`skip_serializing_if = Option::is_none`）
    - `credential_grants: Vec<String>`（`skip_serializing_if = Vec::is_empty`）
  - `samples()` 默认值更新（旧序列化输出保持兼容：新字段省略时用 serde 默认）
- `desktop-client/ironclaw/src/orchestrator/job_manager.rs`
  - `ContainerJobManager::image()` 公开访问器（用于审计事件填充 `image`）
- `desktop-client/ironclaw/src/tools/bootstrap.rs`
  - `JobToolsConfig` 新增 `runtime_mode: String` 字段
- `desktop-client/ironclaw/src/tools/builtin/job.rs`
  - `CreateJobTool` 新增 `runtime_mode` 字段 + `with_runtime_mode()` builder
  - `execute_sandbox` 在 `jm.create_job(...)` 成功后发出 `AppEvent::JobStarted`
    审计事件，`credential_grants` 仅写 secret 名（OWASP A02）
- `desktop-client/ironclaw/src/tools/registry.rs`
  - `register_job_tools()` 新增 `runtime_mode: String` 形参，转交给 `CreateJobTool`
- `desktop-client/ironclaw/src/main.rs`
  - bootstrap 处把 `config.job_runtime.mode.as_str().to_string()` 传入 `JobToolsConfig`
- `desktop-client/ironclaw/src/channels/web/mod.rs`
  - `StatusUpdate::JobStarted → AppEvent::JobStarted` 转换路径补齐 4 个新字段
    （此路径不持有 runtime 元数据，留空，以编排器 emit 为准）

### 测试

- `req_adr119_f4_job_started_round_trip_includes_audit_fields` — 7 字段端到端 JSON
- `req_adr119_f4_job_started_serde_backward_compat` — 旧 payload 仍可反序列化
- `req_adr119_f4_credential_grants_no_secret_values` — 哨兵值检测，确保
  secret value 不会泄露进审计载荷（OWASP A02）
- `req_adr119_f4_with_runtime_mode_stores_value` — builder 行为
- `req_adr119_f4_runtime_mode_defaults_empty` — 缺省构造器兼容性

## 非目标（What's NOT in this PR）

- 不实现 `Cloud` mode 的 `endpoint` 填充（D6 后续 issue）
- 不动 `JobCompleted` / `JobFailed` 事件
- 不改 `DataReporter` 的下游链路（schema 已开放，下游零改动即透传）
- 不实现 `parent_conversation_id` / `project_dir` 字段（issue 文中描述但当前
  事件路径无对应数据，留待与监控订阅器一同推进）
- 不改 F1/F2/F3 的任何代码

## 验证

```bash
$ cargo check -p ironclaw --tests
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 4m 12s

$ cargo nextest run -p ironclaw_common -p ironclaw \
      -E 'test(req_adr119_f4) | test(round_trip_deserialize) | test(event_type_matches_serde_type_field)'
    Starting 7 tests across 66 binaries (4558 tests skipped)
        PASS (1/7) round_trip_deserialize
        PASS (2/7) event_type_matches_serde_type_field
        PASS (3/7) req_adr119_f4_job_started_round_trip_includes_audit_fields
        PASS (4/7) req_adr119_f4_credential_grants_no_secret_values
        PASS (5/7) req_adr119_f4_job_started_serde_backward_compat
        PASS (6/7) req_adr119_f4_runtime_mode_defaults_empty
        PASS (7/7) req_adr119_f4_with_runtime_mode_stores_value
     Summary 7 tests run: 7 passed, 4558 skipped

$ cargo fmt --all   # clean
$ python3.12 scripts/check_no_panics.py --base origin/xClaw
OK: No panic-inducing calls in changed production code.
```

Closes #170
