### PR TITLE
chore(gitignore): add codex-cli-main to local reference source ignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,5 +52,8 @@ claude-code-main
 !.codex/prompts/**
 /decode-claude-code-main/
 /claw-decode-main/
+
+# Local reference source copies (not tracked, kept for reading only)
 /ironclaw-main/
+/codex-cli-main/
 /docs/repomix-out/


### PR DESCRIPTION
## 背景 / 目标

本地保留 `codex-cli-main/` 作为参考源副本（与 `ironclaw-main/`、`docs/repomix-out/` 同类），但 xClaw 当前 `.gitignore` 仅忽略后两者，未覆盖 `codex-cli-main`。本 PR 补齐该条目，并加入分组注释让用途自描述。

来源：本地 DasClaw 分支 commit `1f5b2d23`（仅取 .gitignore 部分；submodule 指针在 xClaw 已是目标值，无需变更）。

## 改动范围

- `.gitignore`: +3 行
  - 新增分组注释 `# Local reference source copies (not tracked, kept for reading only)`
  - 新增 `/codex-cli-main/` 条目

## 非目标 (What's NOT in this PR)

- ❌ 不修改 `claw-code` 子模块指针（ADR-118 readonly）
- ❌ 不删除既有忽略条目
- ❌ 不引入新的本地参考目录

## 验证

```bash
git diff --stat xClaw..HEAD
# 1 file changed, 3 insertions(+)

# 验证忽略生效
mkdir -p codex-cli-main && touch codex-cli-main/foo
git status --short codex-cli-main/  # 无输出 → 已被忽略
```

## 后续

- 合并后删除本地 `DasClaw` 分支与 `origin/DasClaw`，统一以 `xClaw` 为唯一主线

Refs: AGENTS.md "Repomix 核心模块打包" / ADR-118