### PR TITLE
feat(llm): consume PROMPT_CACHE_BOUNDARY for Anthropic ephemeral cache_control

### DIFF
--- a/crates/dasclaw_llm_provider/src/lib.rs
+++ b/crates/dasclaw_llm_provider/src/lib.rs
@@ -59,8 +59,9 @@ pub use providers::{
 pub use retry::{parse_retry_after, RetryPolicy};
 pub use sse::{parse_frame, SseParser};
 pub use types::{
-    ContentBlockDelta, ContentBlockDeltaEvent, ContentBlockStartEvent, ContentBlockStopEvent,
-    InputContentBlock, InputMessage, MessageDelta, MessageDeltaEvent, MessageRequest,
-    MessageResponse, MessageStartEvent, MessageStopEvent, OutputContentBlock, StreamEvent,
-    ToolChoice, ToolDefinition, ToolResultContentBlock, Usage,
+    CacheControl, ContentBlockDelta, ContentBlockDeltaEvent, ContentBlockStartEvent,
+    ContentBlockStopEvent, InputContentBlock, InputMessage, MessageDelta, MessageDeltaEvent,
+    MessageRequest, MessageResponse, MessageStartEvent, MessageStopEvent, OutputContentBlock,
+    StreamEvent, SystemBlock, SystemPrompt, ToolChoice, ToolDefinition, ToolResultContentBlock,
+    Usage,
 };

--- a/crates/dasclaw_llm_provider/src/providers/openai_compat.rs
+++ b/crates/dasclaw_llm_provider/src/providers/openai_compat.rs
@@ -426,8 +426,15 @@ pub fn build_chat_completion_request(
     _config: OpenAiCompatConfig,
 ) -> Value {
     let mut messages = Vec::new();
-    if let Some(system) = request.system.as_ref().filter(|value| !value.is_empty()) {
-        messages.push(json!({ "role": "system", "content": system }));
+    // OpenAI-compat 不识别 Anthropic 的 SystemPrompt::Blocks（含 cache_control），通过
+    // SystemPrompt::as_text 投影为单段文本注入第一条 role=system message。
+    if let Some(text) = request
+        .system
+        .as_ref()
+        .map(|sp| sp.as_text())
+        .filter(|s| !s.is_empty())
+    {
+        messages.push(json!({ "role": "system", "content": text }));
     }
     for message in &request.messages {
         messages.extend(translate_message(message));
@@ -1221,7 +1228,7 @@ mod tests {
             model: "gpt-4o".to_string(),
             max_tokens: 16,
             messages: vec![InputMessage::user_text("hi")],
-            system: Some("you are a tester".to_string()),
+            system: Some("you are a tester".into()),
             ..MessageRequest::default()
         };
         let payload = build_chat_completion_request(&request, OpenAiCompatConfig::openai());

--- a/crates/dasclaw_llm_provider/src/types.rs
+++ b/crates/dasclaw_llm_provider/src/types.rs
@@ -26,8 +26,14 @@ pub struct MessageRequest {
     pub messages: Vec<InputMessage>,
     /// System prompt。Anthropic 协议是顶层字段，OpenAI-compat 走第一条 `role=system` message
     /// （由 client 实现负责适配，wire 层统一暴露此字段）。
+    ///
+    /// 支持两种形态（[`SystemPrompt`]）：
+    /// - `Text(String)`：单段文本，序列化为 `"system": "..."`（Anthropic / OpenAI-compat 通用）。
+    /// - `Blocks(Vec<SystemBlock>)`：分段文本，序列化为 `"system": [{"type":"text","text":"...","cache_control":...}]`，
+    ///   仅 Anthropic 识别（用于 prompt cache 边界标注）；OpenAI-compat 后端通过 [`SystemPrompt::as_text`]
+    ///   降级为单段文本。
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub system: Option<String>,
+    pub system: Option<SystemPrompt>,
     /// 工具定义。
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tools: Option<Vec<ToolDefinition>>,
@@ -64,6 +70,130 @@ impl MessageRequest {
     pub fn with_streaming(mut self) -> Self {
         self.stream = true;
         self
+    }
+}
+
+/// System prompt 字段值。
+///
+/// Anthropic Messages API 的 `system` 字段同时接受字符串与 content-block 数组：
+/// - 字符串形态：`"system": "You are..."`
+/// - 数组形态：`"system": [{"type":"text","text":"...","cache_control":{"type":"ephemeral"}}]`
+///
+/// 通过 `#[serde(untagged)]` 在序列化时自动选择形态。OpenAI-compat 等不支持数组形态的
+/// 后端可调用 [`SystemPrompt::as_text`] 降级为单段文本。
+///
+/// 数组形态用于 Anthropic prompt cache 边界标注（见 `__SYSTEM_PROMPT_DYNAMIC_BOUNDARY__`
+/// 在 ironclaw `LayeredPromptBuilder` 中的注入点）：把 system 切成 *静态前缀 + 动态后缀*，
+/// 在静态前缀块上挂 `cache_control: {"type":"ephemeral"}`，让 Anthropic 缓存命中静态部分。
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum SystemPrompt {
+    /// 单段纯文本（默认形态，所有后端通用）。
+    Text(String),
+    /// 多段 content blocks（仅 Anthropic 直连使用；OpenAI-compat 通过 [`Self::as_text`] 降级）。
+    Blocks(Vec<SystemBlock>),
+}
+
+impl SystemPrompt {
+    /// 构造单段文本 system prompt。
+    #[must_use]
+    pub fn text(s: impl Into<String>) -> Self {
+        Self::Text(s.into())
+    }
+
+    /// 把当前 system prompt 投影成单段文本：
+    /// - `Text(s)` → `s.clone()`
+    /// - `Blocks(blocks)` → 把每块的 `text` 字段顺序拼接（不插入分隔符，保留原始字面量）
+    #[must_use]
+    pub fn as_text(&self) -> String {
+        match self {
+            Self::Text(s) => s.clone(),
+            Self::Blocks(blocks) => blocks
+                .iter()
+                .map(|b| b.text.as_str())
+                .collect::<Vec<_>>()
+                .concat(),
+        }
+    }
+
+    /// 是否为空（Text 空串 或 Blocks 全为空文本）。
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        match self {
+            Self::Text(s) => s.is_empty(),
+            Self::Blocks(blocks) => blocks.iter().all(|b| b.text.is_empty()),
+        }
+    }
+}
+
+impl From<String> for SystemPrompt {
+    fn from(s: String) -> Self {
+        Self::Text(s)
+    }
+}
+
+impl From<&str> for SystemPrompt {
+    fn from(s: &str) -> Self {
+        Self::Text(s.to_string())
+    }
+}
+
+/// Anthropic system content block（仅在 [`SystemPrompt::Blocks`] 中使用）。
+///
+/// 字段对齐 [Anthropic prompt caching 文档](https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching)：
+/// `{ "type": "text", "text": "...", "cache_control": { "type": "ephemeral" } }`。
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SystemBlock {
+    /// Block 类型（当前仅 `"text"`）。
+    #[serde(rename = "type")]
+    pub block_type: String,
+    /// 块文本内容。
+    pub text: String,
+    /// 缓存控制；`Some(CacheControl::ephemeral())` 表示在此块结尾打 prompt cache 断点。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cache_control: Option<CacheControl>,
+}
+
+impl SystemBlock {
+    /// 构造一个不含 `cache_control` 的纯文本块。
+    #[must_use]
+    pub fn text(text: impl Into<String>) -> Self {
+        Self {
+            block_type: "text".to_string(),
+            text: text.into(),
+            cache_control: None,
+        }
+    }
+
+    /// 在当前块上附加 `cache_control: {"type":"ephemeral"}` 并返回自身。
+    #[must_use]
+    pub fn with_ephemeral_cache(mut self) -> Self {
+        self.cache_control = Some(CacheControl::ephemeral());
+        self
+    }
+}
+
+/// Anthropic `cache_control` 标记。
+///
+/// 当前仅支持 `{"type": "ephemeral"}`（5 分钟默认 TTL）。`ttl` 字段保留供未来扩展（如 1 小时 beta）。
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CacheControl {
+    /// `"ephemeral"`。
+    #[serde(rename = "type")]
+    pub cache_type: String,
+    /// 可选 TTL（如 `"5m"` / `"1h"`）；None 时 Anthropic 应用默认 5 分钟。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ttl: Option<String>,
+}
+
+impl CacheControl {
+    /// 构造 `{"type": "ephemeral"}`（默认 5 分钟 TTL）。
+    #[must_use]
+    pub fn ephemeral() -> Self {
+        Self {
+            cache_type: "ephemeral".to_string(),
+            ttl: None,
+        }
     }
 }
 

--- a/desktop-client/ironclaw/src/llm/claw_code_provider.rs
+++ b/desktop-client/ironclaw/src/llm/claw_code_provider.rs
@@ -17,7 +17,8 @@ use async_trait::async_trait;
 use dasclaw_llm_provider::{
     AnthropicClient, ApiError, AuthSource, InputContentBlock, InputMessage, MessageRequest,
     MessageResponse, OpenAiCompatClient, OpenAiCompatConfig, OutputContentBlock, ProviderClient,
-    ToolChoice as ApiToolChoice, ToolDefinition as ApiToolDefinition, ToolResultContentBlock,
+    SystemBlock, SystemPrompt, ToolChoice as ApiToolChoice, ToolDefinition as ApiToolDefinition,
+    ToolResultContentBlock,
 };
 use rust_decimal::Decimal;
 use secrecy::ExposeSecret;
@@ -108,12 +109,14 @@ pub(crate) fn build_chat_message_request(
     req: &CompletionRequest,
     default_model: &str,
 ) -> MessageRequest {
-    let (system, messages) = split_system_and_messages(&req.messages);
+    let (system_text, messages) = split_system_and_messages(&req.messages);
+    let model = req
+        .model
+        .clone()
+        .unwrap_or_else(|| default_model.to_string());
+    let system = build_system_prompt(system_text, &model);
     MessageRequest {
-        model: req
-            .model
-            .clone()
-            .unwrap_or_else(|| default_model.to_string()),
+        model,
         max_tokens: req.max_tokens.unwrap_or(DEFAULT_MAX_TOKENS),
         messages,
         system,
@@ -134,17 +137,19 @@ pub(crate) fn build_tool_message_request(
     req: &ToolCompletionRequest,
     default_model: &str,
 ) -> MessageRequest {
-    let (system, messages) = split_system_and_messages(&req.messages);
+    let (system_text, messages) = split_system_and_messages(&req.messages);
     let tools = if req.tools.is_empty() {
         None
     } else {
         Some(req.tools.iter().map(map_tool_definition).collect())
     };
+    let model = req
+        .model
+        .clone()
+        .unwrap_or_else(|| default_model.to_string());
+    let system = build_system_prompt(system_text, &model);
     MessageRequest {
-        model: req
-            .model
-            .clone()
-            .unwrap_or_else(|| default_model.to_string()),
+        model,
         max_tokens: req.max_tokens.unwrap_or(DEFAULT_MAX_TOKENS),
         messages,
         system,
@@ -186,6 +191,48 @@ fn split_system_and_messages(messages: &[ChatMessage]) -> (Option<String>, Vec<I
         Some(system_parts.join("\n\n"))
     };
     (system, out)
+}
+
+/// Anthropic prompt cache 边界标注（HTML comment 形态，由 [`crate::llm::prompt::LayeredPromptBuilder`] 注入）。
+///
+/// 与 [`x_claw_agent::PROMPT_CACHE_BOUNDARY`] 保持一致：包裹成 HTML 注释后，
+/// 系统提示词中的边界标记不会被任何下游 markdown / 模型行为意外渲染。
+const CACHE_BOUNDARY_COMMENT: &str = concat!("<!-- ", "__SYSTEM_PROMPT_DYNAMIC_BOUNDARY__", " -->");
+
+/// 把合并好的 system 文本根据 protocol 投影到合适的 [`SystemPrompt`] 形态。
+///
+/// - **Anthropic 模型 + 含 [`x_claw_agent::PROMPT_CACHE_BOUNDARY`] 标记**：
+///   切成 `[static_prefix(cache_control=ephemeral), dynamic_suffix]` 两个 [`SystemBlock`]，
+///   让 Anthropic prompt cache 命中静态前缀（identity + tools + safety）；动态后缀
+///   （skills + channel + runtime ctx）每轮变化不进缓存。
+/// - **其它情形**：单段 `SystemPrompt::Text`（OpenAI-compat / 无边界标记 / 空文本）。
+///
+/// 边界检测在请求构造期完成，[`crate::llm::prompt::LayeredPromptBuilder`] 不感知 provider；
+/// 这样 ADR-117 R-1 标记从 *惰性* 变 *实际生效*，并保持 builder 与 provider 解耦。
+fn build_system_prompt(system_text: Option<String>, model: &str) -> Option<SystemPrompt> {
+    let text = system_text?;
+    if text.is_empty() {
+        return None;
+    }
+
+    // 复用 reasoning.rs 中的 Anthropic 检测逻辑（model 名包含 "claude"）。
+    let is_anthropic = model.contains("claude");
+    if !is_anthropic {
+        return Some(SystemPrompt::Text(text));
+    }
+
+    // 找到 HTML 注释形态的边界，整体剔除（不保留注释字面量）。
+    match text.split_once(CACHE_BOUNDARY_COMMENT) {
+        Some((prefix, suffix)) if !prefix.is_empty() => {
+            let mut blocks = vec![SystemBlock::text(prefix).with_ephemeral_cache()];
+            if !suffix.is_empty() {
+                blocks.push(SystemBlock::text(suffix));
+            }
+            Some(SystemPrompt::Blocks(blocks))
+        }
+        // 边界不存在（非 layered 路径）或前缀为空（异常）：回退到单段文本。
+        _ => Some(SystemPrompt::Text(text)),
+    }
 }
 
 fn map_user_message(m: &ChatMessage) -> InputMessage {
@@ -979,7 +1026,10 @@ mod tests {
         let req = CompletionRequest::new(msgs);
         let built = build_chat_message_request(&req, "claude-sonnet-4-6");
 
-        assert_eq!(built.system.as_deref(), Some("be brief"));
+        assert_eq!(
+            built.system.as_ref().map(|s| s.as_text()).as_deref(),
+            Some("be brief")
+        );
         // user, assistant(tool_use), user(tool_result)
         assert_eq!(built.messages.len(), 3);
         assert_eq!(built.messages[0].role, "user");
@@ -1347,5 +1397,121 @@ mod tests {
             !observed.contains("Bearer "),
             "observed error must not echo Bearer tokens"
         );
+    }
+
+    // -------- Anthropic prompt cache 边界切分 (issue #139, ADR-117 R-1) --------
+
+    /// 边界常量必须与 x_claw_agent 源真理一致（HTML comment 包装版本）。
+    #[test]
+    fn cache_boundary_comment_matches_agent_constant() {
+        let expected = format!("<!-- {} -->", x_claw_agent::PROMPT_CACHE_BOUNDARY);
+        assert_eq!(CACHE_BOUNDARY_COMMENT, expected);
+    }
+
+    /// req_llm_anthropic_cache_001：Anthropic 模型 + system 含 prompt cache 边界标记
+    /// → 切成 2 个 SystemBlock，静态前缀挂 `cache_control: {"type":"ephemeral"}`，
+    ///   动态后缀不挂 cache_control。
+    #[test]
+    fn req_llm_anthropic_cache_001_boundary_splits_into_two_blocks() {
+        let static_prefix = "You are an AI assistant.\n\nTools:\n- shell\n- read";
+        let dynamic_suffix = "\n\nCurrent time: 2025-01-15T10:00:00Z";
+        let system_text = format!(
+            "{static_prefix}\n\n{boundary}\n\n{dynamic_suffix}",
+            static_prefix = static_prefix,
+            boundary = CACHE_BOUNDARY_COMMENT,
+            dynamic_suffix = dynamic_suffix.trim_start(),
+        );
+
+        let req = CompletionRequest::new(vec![ChatMessage::system(&system_text), mk_user("hi")]);
+        let built = build_chat_message_request(&req, "claude-sonnet-4-6");
+
+        let blocks = match built.system.expect("system must be present") {
+            SystemPrompt::Blocks(b) => b,
+            other => panic!("expected Blocks form for Anthropic+boundary, got {other:?}"),
+        };
+        assert_eq!(blocks.len(), 2, "must produce exactly 2 system blocks");
+        // 静态前缀块：必须挂 ephemeral cache_control
+        assert_eq!(blocks[0].block_type, "text");
+        assert!(
+            blocks[0].text.contains("You are an AI assistant."),
+            "static block must contain identity prefix; got: {:?}",
+            blocks[0].text
+        );
+        let cc = blocks[0]
+            .cache_control
+            .as_ref()
+            .expect("static block must carry cache_control");
+        assert_eq!(cc.cache_type, "ephemeral");
+        // 动态后缀块：不挂 cache_control
+        assert_eq!(blocks[1].block_type, "text");
+        assert!(
+            blocks[1].text.contains("Current time"),
+            "dynamic block must contain runtime context; got: {:?}",
+            blocks[1].text
+        );
+        assert!(
+            blocks[1].cache_control.is_none(),
+            "dynamic block must NOT carry cache_control"
+        );
+        // 边界 HTML 注释必须被剔除（不在任何块的 text 中残留）
+        for b in &blocks {
+            assert!(
+                !b.text.contains(CACHE_BOUNDARY_COMMENT),
+                "boundary HTML comment must be stripped; leaked in: {:?}",
+                b.text
+            );
+        }
+    }
+
+    /// req_llm_anthropic_cache_002：Anthropic 模型 + system 不含边界标记
+    /// → 单段 `SystemPrompt::Text`，不引入任何 cache_control。
+    ///   并验证：非 Anthropic 模型即便含边界标记也保持单段文本（cache_control 仅 Anthropic 适用）。
+    #[test]
+    fn req_llm_anthropic_cache_002_no_boundary_keeps_text_form() {
+        // case 1：Anthropic 模型 + 无边界标记 → Text 形态
+        let req_a = CompletionRequest::new(vec![
+            ChatMessage::system("plain system prompt without boundary marker"),
+            mk_user("hi"),
+        ]);
+        let built_a = build_chat_message_request(&req_a, "claude-sonnet-4-6");
+        match built_a.system.expect("system present") {
+            SystemPrompt::Text(s) => {
+                assert_eq!(s, "plain system prompt without boundary marker");
+            }
+            other => panic!("expected Text form when no boundary marker; got {other:?}"),
+        }
+
+        // case 2：非 Anthropic 模型 + 含边界标记 → 仍是 Text 形态（cache_control 仅 Anthropic 识别）
+        let with_marker = format!("static\n\n{CACHE_BOUNDARY_COMMENT}\n\ndynamic");
+        let req_b = CompletionRequest::new(vec![ChatMessage::system(&with_marker), mk_user("hi")]);
+        let built_b = build_chat_message_request(&req_b, "gpt-4o");
+        match built_b.system.expect("system present") {
+            SystemPrompt::Text(s) => {
+                assert_eq!(s, with_marker, "non-Anthropic 模型应保留原始 system 文本");
+            }
+            other => panic!("expected Text form for non-Anthropic; got {other:?}"),
+        }
+    }
+
+    /// req_llm_anthropic_cache_002b：边界切分后的 wire JSON 序列化形态匹配 Anthropic API
+    /// （`system` 字段为数组，第一个元素含 `cache_control.type == "ephemeral"`）。
+    #[test]
+    fn req_llm_anthropic_cache_002b_wire_serialization_matches_anthropic_schema() {
+        let system_text = format!("STATIC{boundary}DYNAMIC", boundary = CACHE_BOUNDARY_COMMENT,);
+        let req = CompletionRequest::new(vec![ChatMessage::system(&system_text), mk_user("hi")]);
+        let built = build_chat_message_request(&req, "claude-opus-4-6");
+        let wire = serde_json::to_value(&built).expect("MessageRequest must serialize");
+        let system = wire
+            .get("system")
+            .expect("system field present")
+            .as_array()
+            .expect("system must serialize as array under Blocks form");
+        assert_eq!(system.len(), 2);
+        assert_eq!(system[0]["type"], "text");
+        assert_eq!(system[0]["text"], "STATIC");
+        assert_eq!(system[0]["cache_control"]["type"], "ephemeral");
+        assert_eq!(system[1]["type"], "text");
+        assert_eq!(system[1]["text"], "DYNAMIC");
+        assert!(system[1].get("cache_control").is_none());
     }
 }


### PR DESCRIPTION
## 背景 / 目标

ADR-117 §3.3 R-1：`LayeredPromptBuilder.with_cache_boundary(true)` 注入的 `<!-- __SYSTEM_PROMPT_DYNAMIC_BOUNDARY__ -->` HTML 注释当前是 inert 的——三层验证（`rg cache_control` 在 desktop-client/ironclaw/、claw-code/、ironclaw-main/ 全部 0 命中）确认没有任何 provider 消费它，导致 Anthropic prompt cache 实际命中率为 0。

本 PR 让 ironclaw → `dasclaw_llm_provider` 的 Anthropic 请求路径**实际消费**该 marker：把 system prompt 切成 *static_prefix*（含 `cache_control: {"type":"ephemeral"}`） + *dynamic_suffix*（无 cache_control）两段 `SystemBlock`，让 Anthropic 服务端缓存命中静态前缀（identity + tools + safety），动态后缀（skills + channel + runtime ctx）不入缓存。

## 改动范围

**Wire 层（`dasclaw_llm_provider`）**
- `src/types.rs`：把 `MessageRequest.system` 从 `Option<String>` 升级为 `Option<SystemPrompt>`；新增 `SystemPrompt`（`#[serde(untagged)]` 枚举：`Text(String)` | `Blocks(Vec<SystemBlock>)`）、`SystemBlock`、`CacheControl` 三个公开类型。`SystemPrompt` 提供 `as_text()` 投影供 OpenAI-compat 等不识别 array form 的后端降级。
- `src/providers/openai_compat.rs`：通过 `SystemPrompt::as_text()` 投影为单段 `role=system` message，OpenAI-compat 路径行为不变。
- `src/lib.rs`：导出新类型。

**适配层（ironclaw）**
- `src/llm/claw_code_provider.rs`：新增 `build_system_prompt(text, model) -> Option<SystemPrompt>`；当 `model.contains("claude")` 且文本包含边界 HTML 注释时切成两段 `SystemBlock`，静态前缀挂 `cache_control: ephemeral`；其它情形（非 Anthropic / 无边界）保持单段 `Text`。边界 HTML 注释整体剔除（不残留在任何块的 text 中）。
- `build_chat_message_request` / `build_tool_message_request` 都走该函数；`split_system_and_messages` 不变。
- 新增 `cache_boundary_comment_matches_agent_constant` runtime 测试守卫常量与 `x_claw_agent::PROMPT_CACHE_BOUNDARY` 同步。

**ADR-117 R-1 标记由 inert 转为 effective**：`LayeredPromptBuilder` 不感知 provider，provider 在请求构造期消费 marker —— builder 与 provider 解耦、单向数据流。

## 非目标 (What's NOT in this PR)

- ❌ 不修改 `LayeredPromptBuilder`（issue #139 显式要求）
- ❌ 不实现 `req_llm_anthropic_cache_003`（mock anthropic SSE 端到端 + `PromptCacheMonitor` 联调）—— 需要 wiremock/SSE fixture 较重，留给后续 observability PR；本 PR 已通过 wire JSON 序列化测试 (`req_llm_anthropic_cache_002b_wire_serialization_matches_anthropic_schema`) 锁定上行字段形态
- ❌ 不改 OpenAI / OpenAI-compat / Ollama / Copilot 路径（OpenAI 走自动 prefix cache）
- ❌ 不引入 1-hour TTL beta（`CacheControl.ttl` 字段已预留，当前不写）

## 验证

```bash
cargo check -p dasclaw_llm_provider --tests   # OK
cargo check -p ironclaw --tests               # OK
cargo nextest run -p dasclaw_llm_provider \
  -E 'test(full_message_request_roundtrip) + test(build_request_emits_system)'
# Summary 2 tests run: 2 passed
cargo nextest run -p ironclaw \
  -E 'test(req_llm_anthropic_cache) | test(cache_boundary_comment) | test(test_split_system) | test(test_chat_request_with_tool_history)'
# Summary 7 tests run: 7 passed, 4554 skipped
cargo fmt --all                               # clean
python3.12 scripts/check_no_panics.py --base origin/xClaw
# OK: No panic-inducing calls in changed production code.
```

新增测试：
- `req_llm_anthropic_cache_001_boundary_splits_into_two_blocks`
- `req_llm_anthropic_cache_002_no_boundary_keeps_text_form`（覆盖 Anthropic+无 boundary 与 非Anthropic+有 boundary 两个 case）
- `req_llm_anthropic_cache_002b_wire_serialization_matches_anthropic_schema`（wire JSON 形态与 Anthropic 官方 schema 对齐）
- `cache_boundary_comment_matches_agent_constant`（防止本地常量与 `x_claw_agent::PROMPT_CACHE_BOUNDARY` 漂移）

## Closes

Closes #139
