### PR TITLE
feat(governance): W4 dasclaw_governance crate scaffolding

### DIFF
--- a/crates/dasclaw_governance/Cargo.toml
+++ b/crates/dasclaw_governance/Cargo.toml
@@ -9,5 +9,30 @@ publish = false
 [lib]
 path = "src/lib.rs"
 
+[features]
+# All 6-pack governance modules are OFF by default (W4 scaffolding).
+# Each module is opt-in via its cargo feature; activating a module pulls in
+# its `pub mod` declaration. Implementations land in #65-#71.
+default = []
+policy_engine = []
+recovery_recipes = []
+trust_resolver = []
+branch_lock = []
+stale_base = []
+stale_branch = []
+green_contract = []
+lane_events = []
+# Convenience: enable the full 6-pack at once (used by integration tests).
+full = [
+    "policy_engine",
+    "recovery_recipes",
+    "trust_resolver",
+    "branch_lock",
+    "stale_base",
+    "stale_branch",
+    "green_contract",
+    "lane_events",
+]
+
 [dependencies]
 thiserror = "1"

--- a/crates/dasclaw_governance/README.md
+++ b/crates/dasclaw_governance/README.md
@@ -1,0 +1,50 @@
+# dasclaw_governance
+
+> Self-governance 6-pack: policy / recovery / trust / branch_lock / stale / green.
+
+W4 阶段 crate 骨架。每个治理模块通过 cargo feature 单独开启，**默认全部关闭**。
+
+## 模块表
+
+| 模块 | Issue | Cargo feature | 描述 |
+|---|---|---|---|
+| `policy_engine` | #65 | `policy_engine` | 策略引擎核心（claw-code 端口） |
+| `recovery_recipes` | #66 | `recovery_recipes` | 7 类 FailureScenario + RecoveryStep |
+| `trust_resolver` | #67 | `trust_resolver` | OAuth + worktree + allowlist |
+| `branch_lock` | #68 | `branch_lock` | 分支保护策略 |
+| `stale_base` | #69 | `stale_base` | base 落后检测 |
+| `stale_branch` | #69 | `stale_branch` | 分支陈旧检测 |
+| `green_contract` | #70 | `green_contract` | level 0-3 绿契约 |
+| `lane_events` | #71 | `lane_events` | governance hook 联动 |
+
+## 用法
+
+```toml
+[dependencies]
+# 默认（仅 trait surface，无任何模块体）
+dasclaw_governance = { path = "../crates/dasclaw_governance" }
+
+# 单独启用某模块（实现就绪后）
+dasclaw_governance = { path = "../crates/dasclaw_governance", features = ["policy_engine"] }
+
+# 集成测试一次启全
+dasclaw_governance = { path = "../crates/dasclaw_governance", features = ["full"] }
+```
+
+## 验证
+
+```bash
+cargo check -p dasclaw_governance                      # 默认 features
+cargo check -p dasclaw_governance --features full      # 全开
+cargo nextest run -p dasclaw_governance                # 包含 default-off 守卫测试
+```
+
+## 红线
+
+- `default = []` 由 `req_governance_64_default_features_off` 测试保护，禁止默认开启任何模块。
+- 实现 PR（#65-#71）必须只动自己 feature 对应的 `.rs` 文件 + 必要的 `[dependencies]`，不得触碰 `[features]` 默认值。
+
+## 设计参考
+
+- `docs/plans/architecture-refactor/31-target-architecture.md` §4
+- `docs/plans/architecture-refactor/32-execution-plan.md` W4

--- a/crates/dasclaw_governance/src/branch_lock.rs
+++ b/crates/dasclaw_governance/src/branch_lock.rs
@@ -1,0 +1,5 @@
+//! `branch_lock` — W4 placeholder. Implementation lands in follow-up issue.
+//!
+//! See the module table in `lib.rs` for issue mapping.
+
+#![allow(dead_code)]

--- a/crates/dasclaw_governance/src/green_contract.rs
+++ b/crates/dasclaw_governance/src/green_contract.rs
@@ -1,0 +1,5 @@
+//! `green_contract` — W4 placeholder. Implementation lands in follow-up issue.
+//!
+//! See the module table in `lib.rs` for issue mapping.
+
+#![allow(dead_code)]

--- a/crates/dasclaw_governance/src/lane_events.rs
+++ b/crates/dasclaw_governance/src/lane_events.rs
@@ -1,0 +1,5 @@
+//! `lane_events` — W4 placeholder. Implementation lands in follow-up issue.
+//!
+//! See the module table in `lib.rs` for issue mapping.
+
+#![allow(dead_code)]

--- a/crates/dasclaw_governance/src/lib.rs
+++ b/crates/dasclaw_governance/src/lib.rs
@@ -1,31 +1,96 @@
 //! Self-governance 6-pack: policy / recovery / trust / branch_lock / stale / green.
 //!
-//! W1 skeleton — trait surface only, no impl.
-//! See `docs/plans/architecture-refactor/31-target-architecture.md` §4 for design.
+//! W4 scaffolding — module placeholders behind cargo features. Implementations
+//! land in follow-up issues:
+//!
+//! | Module             | Issue | Cargo feature       |
+//! |--------------------|-------|---------------------|
+//! | `policy_engine`    | #65   | `policy_engine`     |
+//! | `recovery_recipes` | #66   | `recovery_recipes`  |
+//! | `trust_resolver`   | #67   | `trust_resolver`    |
+//! | `branch_lock`      | #68   | `branch_lock`       |
+//! | `stale_base`       | #69   | `stale_base`        |
+//! | `stale_branch`     | #69   | `stale_branch`      |
+//! | `green_contract`   | #70   | `green_contract`    |
+//! | `lane_events`      | #71   | `lane_events`       |
+//!
+//! All features default to **off**. See `docs/plans/architecture-refactor/
+//! 31-target-architecture.md` §4 and `32-execution-plan.md` W4 for design.
 
 #![allow(dead_code)]
 
-/// Placeholder error type. Replaced with module-specific errors in W2+.
+/// Placeholder error type. Replaced with module-specific errors as each
+/// 6-pack module lands its real implementation.
 #[derive(Debug, thiserror::Error)]
 #[error("dasclaw_governance skeleton error: {0}")]
 pub struct SkeletonError(pub String);
 
 pub struct GovernanceContext;
+
 pub enum GovernanceDecision {
     Allow,
     Deny,
     Escalate,
 }
 
-/// Primary entry trait (placeholder). Replaced with full surface in W2+.
+/// Primary entry trait (placeholder). Replaced with the full surface once
+/// `policy_engine` (#65) lands.
 pub trait GovernanceEngine {
     /// Self-governance 6-pack: policy / recovery / trust / branch_lock / stale / green.
     fn evaluate(&self, ctx: &GovernanceContext) -> GovernanceDecision;
 }
 
+// ---- 6-pack module placeholders (feature-gated, default OFF) ----------------
+
+#[cfg(feature = "policy_engine")]
+pub mod policy_engine;
+
+#[cfg(feature = "recovery_recipes")]
+pub mod recovery_recipes;
+
+#[cfg(feature = "trust_resolver")]
+pub mod trust_resolver;
+
+#[cfg(feature = "branch_lock")]
+pub mod branch_lock;
+
+#[cfg(feature = "stale_base")]
+pub mod stale_base;
+
+#[cfg(feature = "stale_branch")]
+pub mod stale_branch;
+
+#[cfg(feature = "green_contract")]
+pub mod green_contract;
+
+#[cfg(feature = "lane_events")]
+pub mod lane_events;
+
 #[cfg(test)]
 mod tests {
     #[test]
-    fn skeleton_compiles() { /* W1 placeholder */
+    fn skeleton_compiles() { /* W4 placeholder */
+    }
+
+    /// `req_governance_64_default_features_off` — runtime check that the
+    /// crate's default `Cargo.toml` features list is empty. Reads the
+    /// manifest at test time; fails if someone adds anything to
+    /// `[features] default = [...]`. Guards W4 contract: scaffolding only.
+    #[test]
+    fn req_governance_64_default_features_off() {
+        let manifest = include_str!("../Cargo.toml");
+        // Look for the `default = ...` line inside the [features] block.
+        let features_block = manifest
+            .split("[features]")
+            .nth(1)
+            .expect("Cargo.toml must contain [features] block");
+        let default_line = features_block
+            .lines()
+            .find(|l| l.trim_start().starts_with("default"))
+            .expect("[features] must declare default = []");
+        assert!(
+            default_line.contains("[]"),
+            "default features must be empty (W4 contract); got: {default_line}"
+        );
     }
 }

--- a/crates/dasclaw_governance/src/policy_engine.rs
+++ b/crates/dasclaw_governance/src/policy_engine.rs
@@ -1,0 +1,5 @@
+//! `policy_engine` — W4 placeholder. Implementation lands in follow-up issue.
+//!
+//! See the module table in `lib.rs` for issue mapping.
+
+#![allow(dead_code)]

--- a/crates/dasclaw_governance/src/recovery_recipes.rs
+++ b/crates/dasclaw_governance/src/recovery_recipes.rs
@@ -1,0 +1,5 @@
+//! `recovery_recipes` — W4 placeholder. Implementation lands in follow-up issue.
+//!
+//! See the module table in `lib.rs` for issue mapping.
+
+#![allow(dead_code)]

--- a/crates/dasclaw_governance/src/stale_base.rs
+++ b/crates/dasclaw_governance/src/stale_base.rs
@@ -1,0 +1,5 @@
+//! `stale_base` — W4 placeholder. Implementation lands in follow-up issue.
+//!
+//! See the module table in `lib.rs` for issue mapping.
+
+#![allow(dead_code)]

--- a/crates/dasclaw_governance/src/stale_branch.rs
+++ b/crates/dasclaw_governance/src/stale_branch.rs
@@ -1,0 +1,5 @@
+//! `stale_branch` — W4 placeholder. Implementation lands in follow-up issue.
+//!
+//! See the module table in `lib.rs` for issue mapping.
+
+#![allow(dead_code)]

--- a/crates/dasclaw_governance/src/trust_resolver.rs
+++ b/crates/dasclaw_governance/src/trust_resolver.rs
@@ -1,0 +1,5 @@
+//! `trust_resolver` — W4 placeholder. Implementation lands in follow-up issue.
+//!
+//! See the module table in `lib.rs` for issue mapping.
+
+#![allow(dead_code)]


### PR DESCRIPTION
## 背景 / 目标

W4 governance 6-pack 链路的入口 PR — 把 `crates/dasclaw_governance/` 从 W1 placeholder 升级为 W4 可用骨架，让后续 #65-#71 各自落地实现时不必再重做 feature-flag 配电。

**Source**: `docs/plans/architecture-refactor/32-execution-plan.md` W4 任务节。

## 改动范围（What's IN）

| 文件 | 变更 |
|---|---|
| `crates/dasclaw_governance/Cargo.toml` | 新增 `[features]`：8 个 module feature + `full` 便捷集合，`default = []` |
| `crates/dasclaw_governance/src/lib.rs` | 新增模块表 + `#[cfg(feature = ...)] pub mod ...` ×8；新增 `req_governance_64_default_features_off` 守卫测试 |
| `crates/dasclaw_governance/src/{policy_engine,recovery_recipes,trust_resolver,branch_lock,stale_base,stale_branch,green_contract,lane_events}.rs` | 8 个 5 行 placeholder（doc header + `#![allow(dead_code)]`） |
| `crates/dasclaw_governance/README.md` | 模块表 / 用法 / 红线说明 |

## 非目标（What's NOT in this PR）

- ❌ 不实现任何模块业务逻辑（留给 #65-#71）
- ❌ 不引入对其他 `dasclaw_*` crate 的依赖
- ❌ 不动 `dasclaw_features`（与本 crate cargo features 是两个独立概念）
- ❌ 不动 workspace `Cargo.toml`（crate 已在 members 列表）

## 验证（命令 + 结果）

```bash
$ cargo check -p dasclaw_governance --tests
    Finished `dev` profile

$ cargo check -p dasclaw_governance --features full --tests
    Finished `dev` profile           # 8 个 mod 文件都被收到

$ cargo nextest run -p dasclaw_governance
    Starting 2 tests across 1 binary
        PASS skeleton_compiles
        PASS req_governance_64_default_features_off
     Summary 2 tests run: 2 passed, 0 skipped

$ cargo fmt --all                    # clean
$ python3.12 scripts/check_no_panics.py --base origin/xClaw
OK: No panic-inducing calls in changed production code.

$ cargo clippy --no-deps -p dasclaw_governance --all-targets --all-features -- -D warnings
    Finished `dev` profile           # zero warnings
```

## 红线 / 设计说明

- **`default = []` 由测试保护**：`req_governance_64_default_features_off` 在测试时直接 `include_str!("../Cargo.toml")` 解析 `[features]` 区，断言 `default` 行包含 `[]`。任何改成 `default = ["..."]` 都会立刻红测，避免后续 PR "顺手"开默认。
- **By construction，不打补丁**：每个未来模块（#65-#71）只动自己 `feature` 对应的 `.rs` 文件，无需触碰 `[features]` 默认值，零冲突起点。
- **零跨 crate 耦合**：本 PR 不新增任何 `dasclaw_*` 依赖，保持 governance 起点最小面。

## 验收对照（issue #64）

- [x] mod 声明 6 件套占位（policy_engine / recovery_recipes / trust_resolver / branch_lock / stale_base / stale_branch / green_contract / lane_events，共 8 个）
- [x] features 默认全 disabled（cargo features `default = []`，由测试守卫）
- [x] `cargo check -p dasclaw_governance` 通过

Closes #64
