### PR TITLE
feat(governance): port branch_lock collision detection (#68)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2421,6 +2421,7 @@ dependencies = [
 name = "dasclaw_governance"
 version = "0.0.0-w1"
 dependencies = [
+ "serde",
  "thiserror 1.0.69",
 ]
 

--- a/crates/dasclaw_governance/Cargo.toml
+++ b/crates/dasclaw_governance/Cargo.toml
@@ -17,7 +17,7 @@ default = []
 policy_engine = []
 recovery_recipes = []
 trust_resolver = []
-branch_lock = []
+branch_lock = ["dep:serde"]
 stale_base = []
 stale_branch = []
 green_contract = []
@@ -36,3 +36,4 @@ full = [
 
 [dependencies]
 thiserror = "1"
+serde = { version = "1", features = ["derive"], optional = true }

--- a/crates/dasclaw_governance/src/branch_lock.rs
+++ b/crates/dasclaw_governance/src/branch_lock.rs
@@ -1,5 +1,164 @@
-//! `branch_lock` — W4 placeholder. Implementation lands in follow-up issue.
+//! Branch-lock collision detection.
 //!
-//! See the module table in `lib.rs` for issue mapping.
+//! Pure-function port from `claw-code/rust/crates/runtime/src/branch_lock.rs`
+//! (#68). Detects when multiple lanes intend to lock the same branch on
+//! overlapping module scopes, so the orchestrator can serialize or escalate
+//! before the worktrees collide on the filesystem.
+//!
+//! No actual lock acquisition / release lives here — this module only
+//! computes intent collisions on plain data. Locking semantics are owned by
+//! the lane scheduler (#71 `lane_events`) once it lands.
 
-#![allow(dead_code)]
+use serde::{Deserialize, Serialize};
+
+/// Declared intent of a single lane to take a branch lock on a set of
+/// module paths. `worktree` is informational; collisions are computed from
+/// `branch` + `modules` only.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BranchLockIntent {
+    #[serde(rename = "laneId")]
+    pub lane_id: String,
+    pub branch: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub worktree: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub modules: Vec<String>,
+}
+
+/// One detected collision: a `branch` + `module` scope that two or more
+/// lanes both intend to lock. `lane_ids` lists the conflicting lanes in
+/// pairwise order (left lane first).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BranchLockCollision {
+    pub branch: String,
+    pub module: String,
+    #[serde(rename = "laneIds")]
+    pub lane_ids: Vec<String>,
+}
+
+/// Pairwise scan over `intents`. Two intents collide when they share a
+/// branch and at least one module path overlaps (equality, parent/child
+/// scope, or nested scope). Result is sorted + deduped for stable output.
+#[must_use]
+pub fn detect_branch_lock_collisions(intents: &[BranchLockIntent]) -> Vec<BranchLockCollision> {
+    let mut collisions = Vec::new();
+
+    for (index, left) in intents.iter().enumerate() {
+        for right in &intents[index + 1..] {
+            if left.branch != right.branch {
+                continue;
+            }
+            for module in overlapping_modules(&left.modules, &right.modules) {
+                collisions.push(BranchLockCollision {
+                    branch: left.branch.clone(),
+                    module,
+                    lane_ids: vec![left.lane_id.clone(), right.lane_id.clone()],
+                });
+            }
+        }
+    }
+
+    collisions.sort_by(|a, b| {
+        a.branch
+            .cmp(&b.branch)
+            .then(a.module.cmp(&b.module))
+            .then(a.lane_ids.cmp(&b.lane_ids))
+    });
+    collisions.dedup();
+    collisions
+}
+
+fn overlapping_modules(left: &[String], right: &[String]) -> Vec<String> {
+    let mut overlaps = Vec::new();
+    for left_module in left {
+        for right_module in right {
+            if modules_overlap(left_module, right_module) {
+                overlaps.push(shared_scope(left_module, right_module));
+            }
+        }
+    }
+    overlaps.sort();
+    overlaps.dedup();
+    overlaps
+}
+
+fn modules_overlap(left: &str, right: &str) -> bool {
+    left == right
+        || left.starts_with(&format!("{right}/"))
+        || right.starts_with(&format!("{left}/"))
+}
+
+fn shared_scope(left: &str, right: &str) -> String {
+    if left.starts_with(&format!("{right}/")) || left == right {
+        right.to_string()
+    } else {
+        left.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{detect_branch_lock_collisions, BranchLockIntent};
+
+    #[test]
+    fn req_branch_lock_68_detects_same_branch_same_module_collisions() {
+        let collisions = detect_branch_lock_collisions(&[
+            BranchLockIntent {
+                lane_id: "lane-a".to_string(),
+                branch: "feature/lock".to_string(),
+                worktree: Some("wt-a".to_string()),
+                modules: vec!["runtime/mcp".to_string()],
+            },
+            BranchLockIntent {
+                lane_id: "lane-b".to_string(),
+                branch: "feature/lock".to_string(),
+                worktree: Some("wt-b".to_string()),
+                modules: vec!["runtime/mcp".to_string()],
+            },
+        ]);
+
+        assert_eq!(collisions.len(), 1);
+        assert_eq!(collisions[0].branch, "feature/lock");
+        assert_eq!(collisions[0].module, "runtime/mcp");
+    }
+
+    #[test]
+    fn req_branch_lock_68_detects_nested_module_scope_collisions() {
+        let collisions = detect_branch_lock_collisions(&[
+            BranchLockIntent {
+                lane_id: "lane-a".to_string(),
+                branch: "feature/lock".to_string(),
+                worktree: None,
+                modules: vec!["runtime".to_string()],
+            },
+            BranchLockIntent {
+                lane_id: "lane-b".to_string(),
+                branch: "feature/lock".to_string(),
+                worktree: None,
+                modules: vec!["runtime/mcp".to_string()],
+            },
+        ]);
+
+        assert_eq!(collisions[0].module, "runtime");
+    }
+
+    #[test]
+    fn req_branch_lock_68_ignores_different_branches() {
+        let collisions = detect_branch_lock_collisions(&[
+            BranchLockIntent {
+                lane_id: "lane-a".to_string(),
+                branch: "feature/a".to_string(),
+                worktree: None,
+                modules: vec!["runtime/mcp".to_string()],
+            },
+            BranchLockIntent {
+                lane_id: "lane-b".to_string(),
+                branch: "feature/b".to_string(),
+                worktree: None,
+                modules: vec!["runtime/mcp".to_string()],
+            },
+        ]);
+
+        assert!(collisions.is_empty());
+    }
+}


### PR DESCRIPTION
## 背景 / 目标

W4 自治 6 件套移植第一弹。把 claw-code 已经验证的纯函数 `detect_branch_lock_collisions` 移植进 `dasclaw_governance::branch_lock`，让 orchestrator 在多 lane 抢同一分支同一模块时能预先检测意图冲突，再决定串行化或上抛。

源：`claw-code/rust/crates/runtime/src/branch_lock.rs`（144 行，纯函数 + 3 个内联测试）。

依赖：#180（W4 scaffolding）已合，本 PR 直接基于 `xClaw`。

## 改动范围

- `crates/dasclaw_governance/Cargo.toml`
  - 新增 `serde = { version = "1", features = ["derive"], optional = true }` 作 scoped 依赖
  - `branch_lock = []` → `branch_lock = ["dep:serde"]`，仅在该模块启用时拉入 serde
  - `default = []` 保持不变（#64 契约由 `req_governance_64_default_features_off` 守护）
- `crates/dasclaw_governance/src/branch_lock.rs`
  - 替换 W4 stub 为完整移植
  - 公开 `BranchLockIntent` / `BranchLockCollision` / `detect_branch_lock_collisions()`
  - 私有辅助 `overlapping_modules` / `modules_overlap` / `shared_scope`
  - 3 个内置测试加 `req_branch_lock_68_` 前缀（AGENTS.md 命名）

## 非目标 (What's NOT in this PR)

- 不实现实际的锁获取/释放语义（属 #71 `lane_events`）
- 不引入异步 / 持久化 / IO（纯函数）
- 不动 `default = []` 契约
- 不引入第二个 6 件套模块（#69 `stale_*` 是下一 PR）
- 不增加 always-on 依赖（serde 仍是 optional，default build 不引入）

## 验证

```bash
# 三档 cargo check 都过
cargo check -p dasclaw_governance --tests                  # default
cargo check -p dasclaw_governance --tests --features branch_lock
cargo check -p dasclaw_governance --tests --features full

# 测试
cargo nextest run -p dasclaw_governance --features branch_lock
#   → 5 tests run: 5 passed (3 新 + 2 已有 skeleton)
cargo nextest run -p dasclaw_governance
#   → 2 tests run: 2 passed (默认仍只跑 skeleton)

# 红线
cargo fmt --all
python3.12 scripts/check_no_panics.py --base origin/xClaw   # OK
cargo clippy --no-deps -p dasclaw_governance --all-targets --features branch_lock -- -D warnings  # 0 warning
```

## 设计取舍（no-patch 自检）

- 没有在共享方法尾部追加 `if` 分支：本 PR 是替换 stub，不是改动既有函数。
- 没有靠 flag 切换大块代码：唯一开关是 cargo feature `branch_lock`，已在 #180 lib.rs 用 `#[cfg(feature = "branch_lock")] pub mod branch_lock;` 一处声明，本 PR 不动它。
- 没有复制粘贴：`overlapping_modules` / `modules_overlap` / `shared_scope` 各有单一职责，移植自 claw-code 已验证实现。
- serde 作 scoped optional dep，default build 体积不变。

## Skills 自审

- `code-quality-audit`：函数最长 26 行（detect_*），嵌套最深 3 层，无 unwrap/expect/panic（生产），无重复造轮子（移植已有实现）。
- `code-simplifier`：移植代码已紧凑，`format!("{right}/")` 在 `modules_overlap` 调用 2 次属于热路径，提取局部变量收益不明显。
- `code-review-expert`：SOLID 单一职责（仅冲突检测，无副作用）；camelCase serde 字段名与 claw-code TS 端兼容；O(n²·m²) 适合 lane 规模小的场景，#71 lane_events 若需扩大可改 BTreeMap 索引（设计意图）。

## 后续

- #69 `stale_base` + `stale_branch`（依赖本 PR）
- #74 `dasclaw_features` 6-flag 默认 OFF（依赖任一 6 件套实现，本 PR 满足）

Closes #68
