### PR TITLE
feat(governance): port stale_base + stale_branch detection (#69)

### DIFF
--- a/crates/dasclaw_governance/src/stale_base.rs
+++ b/crates/dasclaw_governance/src/stale_base.rs
@@ -1,5 +1,362 @@
-//! `stale_base` — W4 placeholder. Implementation lands in follow-up issue.
+//! Stale-base detection (#69).
 //!
-//! See the module table in `lib.rs` for issue mapping.
+//! Pure port from `claw-code/rust/crates/runtime/src/stale_base.rs`.
+//! Compares worktree HEAD against an expected base commit (from `--base-commit`
+//! flag or `.claw-base` file) so the orchestrator can warn / abort when the
+//! session would otherwise run on a stale codebase.
+//!
+//! Read-only: shells out to `git rev-parse` via `std::process::Command`,
+//! never mutates the repo.
 
-#![allow(dead_code)]
+#![allow(clippy::must_use_candidate)]
+use std::path::Path;
+use std::process::Command;
+
+/// Outcome of comparing the worktree HEAD against the expected base commit.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BaseCommitState {
+    /// HEAD matches the expected base commit.
+    Matches,
+    /// HEAD has diverged from the expected base.
+    Diverged { expected: String, actual: String },
+    /// No expected base was supplied (neither flag nor file).
+    NoExpectedBase,
+    /// The working directory is not inside a git repository.
+    NotAGitRepo,
+}
+
+/// Where the expected base commit originated from.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BaseCommitSource {
+    Flag(String),
+    File(String),
+}
+
+/// Read the `.claw-base` file from the given directory and return the trimmed
+/// commit hash, or `None` when the file is absent or empty.
+pub fn read_claw_base_file(cwd: &Path) -> Option<String> {
+    let path = cwd.join(".claw-base");
+    let content = std::fs::read_to_string(path).ok()?;
+    let trimmed = content.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+/// Resolve the expected base commit: prefer the `--base-commit` flag value,
+/// fall back to reading `.claw-base` from `cwd`.
+pub fn resolve_expected_base(flag_value: Option<&str>, cwd: &Path) -> Option<BaseCommitSource> {
+    if let Some(value) = flag_value {
+        let trimmed = value.trim();
+        if !trimmed.is_empty() {
+            return Some(BaseCommitSource::Flag(trimmed.to_string()));
+        }
+    }
+    read_claw_base_file(cwd).map(BaseCommitSource::File)
+}
+
+/// Verify that the worktree HEAD matches `expected_base`.
+///
+/// Returns [`BaseCommitState::NoExpectedBase`] when no expected commit is
+/// provided (the check is effectively a no-op in that case).
+pub fn check_base_commit(cwd: &Path, expected_base: Option<&BaseCommitSource>) -> BaseCommitState {
+    let Some(source) = expected_base else {
+        return BaseCommitState::NoExpectedBase;
+    };
+    let expected_raw = match source {
+        BaseCommitSource::Flag(value) | BaseCommitSource::File(value) => value.as_str(),
+    };
+
+    let Some(head_sha) = resolve_head_sha(cwd) else {
+        return BaseCommitState::NotAGitRepo;
+    };
+
+    let Some(expected_sha) = resolve_rev(cwd, expected_raw) else {
+        return if head_sha.starts_with(expected_raw) || expected_raw.starts_with(&head_sha) {
+            BaseCommitState::Matches
+        } else {
+            BaseCommitState::Diverged {
+                expected: expected_raw.to_string(),
+                actual: head_sha,
+            }
+        };
+    };
+
+    if head_sha == expected_sha {
+        BaseCommitState::Matches
+    } else {
+        BaseCommitState::Diverged {
+            expected: expected_sha,
+            actual: head_sha,
+        }
+    }
+}
+
+/// Format a human-readable warning when the base commit has diverged.
+///
+/// Returns `None` for non-warning states (`Matches`, `NoExpectedBase`).
+pub fn format_stale_base_warning(state: &BaseCommitState) -> Option<String> {
+    match state {
+        BaseCommitState::Diverged { expected, actual } => Some(format!(
+            "warning: worktree HEAD ({actual}) does not match expected base commit ({expected}). \
+             Session may run against a stale codebase."
+        )),
+        BaseCommitState::NotAGitRepo => {
+            Some("warning: stale-base check skipped — not inside a git repository.".to_string())
+        }
+        BaseCommitState::Matches | BaseCommitState::NoExpectedBase => None,
+    }
+}
+
+fn resolve_head_sha(cwd: &Path) -> Option<String> {
+    resolve_rev(cwd, "HEAD")
+}
+
+fn resolve_rev(cwd: &Path, rev: &str) -> Option<String> {
+    let output = Command::new("git")
+        .args(["rev-parse", rev])
+        .current_dir(cwd)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let sha = String::from_utf8(output.stdout).ok()?;
+    let trimmed = sha.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::process::Command;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_dir() -> std::path::PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("time should be after epoch")
+            .as_nanos();
+        std::env::temp_dir().join(format!("dasclaw-stale-base-{nanos}"))
+    }
+
+    fn init_repo(path: &std::path::Path) {
+        fs::create_dir_all(path).expect("create repo dir");
+        run(path, &["init", "--quiet", "-b", "main"]);
+        run(path, &["config", "user.email", "tests@example.com"]);
+        run(path, &["config", "user.name", "Stale Base Tests"]);
+        fs::write(path.join("init.txt"), "initial\n").expect("write init file");
+        run(path, &["add", "."]);
+        run(path, &["commit", "-m", "initial commit", "--quiet"]);
+    }
+
+    fn run(cwd: &std::path::Path, args: &[&str]) {
+        let status = Command::new("git")
+            .args(args)
+            .current_dir(cwd)
+            .status()
+            .unwrap_or_else(|e| panic!("git {} failed to execute: {e}", args.join(" ")));
+        assert!(
+            status.success(),
+            "git {} exited with {status}",
+            args.join(" ")
+        );
+    }
+
+    fn commit_file(repo: &std::path::Path, name: &str, msg: &str) {
+        fs::write(repo.join(name), format!("{msg}\n")).expect("write file");
+        run(repo, &["add", name]);
+        run(repo, &["commit", "-m", msg, "--quiet"]);
+    }
+
+    fn head_sha(repo: &std::path::Path) -> String {
+        let output = Command::new("git")
+            .args(["rev-parse", "HEAD"])
+            .current_dir(repo)
+            .output()
+            .expect("git rev-parse HEAD");
+        String::from_utf8(output.stdout)
+            .expect("valid utf8")
+            .trim()
+            .to_string()
+    }
+
+    #[test]
+    fn req_stale_base_69_matches_when_head_equals_expected_base() {
+        let root = temp_dir();
+        init_repo(&root);
+        let sha = head_sha(&root);
+        let source = BaseCommitSource::Flag(sha);
+        let state = check_base_commit(&root, Some(&source));
+        assert_eq!(state, BaseCommitState::Matches);
+        fs::remove_dir_all(&root).expect("cleanup");
+    }
+
+    #[test]
+    fn req_stale_base_69_diverged_when_head_moved_past_expected_base() {
+        let root = temp_dir();
+        init_repo(&root);
+        let old_sha = head_sha(&root);
+        commit_file(&root, "extra.txt", "move head forward");
+        let new_sha = head_sha(&root);
+        let source = BaseCommitSource::Flag(old_sha.clone());
+        let state = check_base_commit(&root, Some(&source));
+        assert_eq!(
+            state,
+            BaseCommitState::Diverged {
+                expected: old_sha,
+                actual: new_sha,
+            }
+        );
+        fs::remove_dir_all(&root).expect("cleanup");
+    }
+
+    #[test]
+    fn req_stale_base_69_no_expected_base_when_source_is_none() {
+        let root = temp_dir();
+        init_repo(&root);
+        let state = check_base_commit(&root, None);
+        assert_eq!(state, BaseCommitState::NoExpectedBase);
+        fs::remove_dir_all(&root).expect("cleanup");
+    }
+
+    #[test]
+    fn req_stale_base_69_not_a_git_repo_when_outside_repo() {
+        let root = temp_dir();
+        fs::create_dir_all(&root).expect("create dir");
+        let source = BaseCommitSource::Flag("abc1234".to_string());
+        let state = check_base_commit(&root, Some(&source));
+        assert_eq!(state, BaseCommitState::NotAGitRepo);
+        fs::remove_dir_all(&root).expect("cleanup");
+    }
+
+    #[test]
+    fn req_stale_base_69_reads_claw_base_file() {
+        let root = temp_dir();
+        fs::create_dir_all(&root).expect("create dir");
+        fs::write(root.join(".claw-base"), "abc1234def5678\n").expect("write .claw-base");
+        let value = read_claw_base_file(&root);
+        assert_eq!(value, Some("abc1234def5678".to_string()));
+        fs::remove_dir_all(&root).expect("cleanup");
+    }
+
+    #[test]
+    fn req_stale_base_69_returns_none_for_missing_claw_base_file() {
+        let root = temp_dir();
+        fs::create_dir_all(&root).expect("create dir");
+        let value = read_claw_base_file(&root);
+        assert!(value.is_none());
+        fs::remove_dir_all(&root).expect("cleanup");
+    }
+
+    #[test]
+    fn req_stale_base_69_returns_none_for_empty_claw_base_file() {
+        let root = temp_dir();
+        fs::create_dir_all(&root).expect("create dir");
+        fs::write(root.join(".claw-base"), "  \n").expect("write empty .claw-base");
+        let value = read_claw_base_file(&root);
+        assert!(value.is_none());
+        fs::remove_dir_all(&root).expect("cleanup");
+    }
+
+    #[test]
+    fn req_stale_base_69_resolve_expected_base_prefers_flag_over_file() {
+        let root = temp_dir();
+        fs::create_dir_all(&root).expect("create dir");
+        fs::write(root.join(".claw-base"), "from_file\n").expect("write .claw-base");
+        let source = resolve_expected_base(Some("from_flag"), &root);
+        assert_eq!(
+            source,
+            Some(BaseCommitSource::Flag("from_flag".to_string()))
+        );
+        fs::remove_dir_all(&root).expect("cleanup");
+    }
+
+    #[test]
+    fn req_stale_base_69_resolve_expected_base_falls_back_to_file() {
+        let root = temp_dir();
+        fs::create_dir_all(&root).expect("create dir");
+        fs::write(root.join(".claw-base"), "from_file\n").expect("write .claw-base");
+        let source = resolve_expected_base(None, &root);
+        assert_eq!(
+            source,
+            Some(BaseCommitSource::File("from_file".to_string()))
+        );
+        fs::remove_dir_all(&root).expect("cleanup");
+    }
+
+    #[test]
+    fn req_stale_base_69_resolve_expected_base_returns_none_when_nothing_available() {
+        let root = temp_dir();
+        fs::create_dir_all(&root).expect("create dir");
+        let source = resolve_expected_base(None, &root);
+        assert!(source.is_none());
+        fs::remove_dir_all(&root).expect("cleanup");
+    }
+
+    #[test]
+    fn req_stale_base_69_format_warning_returns_message_for_diverged() {
+        let state = BaseCommitState::Diverged {
+            expected: "abc1234".to_string(),
+            actual: "def5678".to_string(),
+        };
+        let warning = format_stale_base_warning(&state);
+        let message = warning.expect("should produce warning");
+        assert!(message.contains("abc1234"));
+        assert!(message.contains("def5678"));
+        assert!(message.contains("stale codebase"));
+    }
+
+    #[test]
+    fn req_stale_base_69_format_warning_returns_none_for_matches() {
+        let state = BaseCommitState::Matches;
+        let warning = format_stale_base_warning(&state);
+        assert!(warning.is_none());
+    }
+
+    #[test]
+    fn req_stale_base_69_format_warning_returns_none_for_no_expected_base() {
+        let state = BaseCommitState::NoExpectedBase;
+        let warning = format_stale_base_warning(&state);
+        assert!(warning.is_none());
+    }
+
+    #[test]
+    fn req_stale_base_69_matches_with_claw_base_file_in_real_repo() {
+        let root = temp_dir();
+        init_repo(&root);
+        let sha = head_sha(&root);
+        fs::write(root.join(".claw-base"), format!("{sha}\n")).expect("write .claw-base");
+        let source = resolve_expected_base(None, &root);
+        let state = check_base_commit(&root, source.as_ref());
+        assert_eq!(state, BaseCommitState::Matches);
+        fs::remove_dir_all(&root).expect("cleanup");
+    }
+
+    #[test]
+    fn req_stale_base_69_diverged_with_claw_base_file_after_new_commit() {
+        let root = temp_dir();
+        init_repo(&root);
+        let old_sha = head_sha(&root);
+        fs::write(root.join(".claw-base"), format!("{old_sha}\n")).expect("write .claw-base");
+        commit_file(&root, "new.txt", "advance head");
+        let new_sha = head_sha(&root);
+        let source = resolve_expected_base(None, &root);
+        let state = check_base_commit(&root, source.as_ref());
+        assert_eq!(
+            state,
+            BaseCommitState::Diverged {
+                expected: old_sha,
+                actual: new_sha,
+            }
+        );
+        fs::remove_dir_all(&root).expect("cleanup");
+    }
+}

--- a/crates/dasclaw_governance/src/stale_branch.rs
+++ b/crates/dasclaw_governance/src/stale_branch.rs
@@ -1,5 +1,371 @@
-//! `stale_branch` — W4 placeholder. Implementation lands in follow-up issue.
+//! Stale-branch detection (#69).
 //!
-//! See the module table in `lib.rs` for issue mapping.
+//! Pure port from `claw-code/rust/crates/runtime/src/stale_branch.rs`.
+//! Compares a feature branch against `main` (or any reference branch),
+//! classifies the freshness state, and resolves a configured policy
+//! (warn / block / auto-rebase / auto-merge-forward) into a single action.
+//!
+//! Read-only at the freshness-check layer: shells out to `git rev-list` and
+//! `git log`. The action returned by `apply_policy` is a *recommendation* —
+//! the orchestrator (lane scheduler) is responsible for executing rebase /
+//! merge / block.
 
-#![allow(dead_code)]
+#![allow(clippy::must_use_candidate)]
+use std::path::Path;
+use std::process::Command;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BranchFreshness {
+    Fresh,
+    Stale {
+        commits_behind: usize,
+        missing_fixes: Vec<String>,
+    },
+    Diverged {
+        ahead: usize,
+        behind: usize,
+        missing_fixes: Vec<String>,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StaleBranchPolicy {
+    AutoRebase,
+    AutoMergeForward,
+    WarnOnly,
+    Block,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StaleBranchEvent {
+    BranchStaleAgainstMain {
+        branch: String,
+        commits_behind: usize,
+        missing_fixes: Vec<String>,
+    },
+    RebaseAttempted {
+        branch: String,
+        result: String,
+    },
+    MergeForwardAttempted {
+        branch: String,
+        result: String,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StaleBranchAction {
+    Noop,
+    Warn { message: String },
+    Block { message: String },
+    Rebase,
+    MergeForward,
+}
+
+pub fn check_freshness(branch: &str, main_ref: &str) -> BranchFreshness {
+    check_freshness_in(branch, main_ref, Path::new("."))
+}
+
+pub fn apply_policy(freshness: &BranchFreshness, policy: StaleBranchPolicy) -> StaleBranchAction {
+    match freshness {
+        BranchFreshness::Fresh => StaleBranchAction::Noop,
+        BranchFreshness::Stale {
+            commits_behind,
+            missing_fixes,
+        } => match policy {
+            StaleBranchPolicy::WarnOnly => StaleBranchAction::Warn {
+                message: format!(
+                    "Branch is {commits_behind} commit(s) behind main. Missing fixes: {}",
+                    if missing_fixes.is_empty() {
+                        "(none)".to_string()
+                    } else {
+                        missing_fixes.join("; ")
+                    }
+                ),
+            },
+            StaleBranchPolicy::Block => StaleBranchAction::Block {
+                message: format!(
+                    "Branch is {commits_behind} commit(s) behind main and must be updated before proceeding."
+                ),
+            },
+            StaleBranchPolicy::AutoRebase => StaleBranchAction::Rebase,
+            StaleBranchPolicy::AutoMergeForward => StaleBranchAction::MergeForward,
+        },
+        BranchFreshness::Diverged {
+            ahead,
+            behind,
+            missing_fixes,
+        } => match policy {
+            StaleBranchPolicy::WarnOnly => StaleBranchAction::Warn {
+                message: format!(
+                    "Branch has diverged: {ahead} commit(s) ahead, {behind} commit(s) behind main. Missing fixes: {}",
+                    format_missing_fixes(missing_fixes)
+                ),
+            },
+            StaleBranchPolicy::Block => StaleBranchAction::Block {
+                message: format!(
+                    "Branch has diverged ({ahead} ahead, {behind} behind) and must be reconciled before proceeding. Missing fixes: {}",
+                    format_missing_fixes(missing_fixes)
+                ),
+            },
+            StaleBranchPolicy::AutoRebase => StaleBranchAction::Rebase,
+            StaleBranchPolicy::AutoMergeForward => StaleBranchAction::MergeForward,
+        },
+    }
+}
+
+pub(crate) fn check_freshness_in(
+    branch: &str,
+    main_ref: &str,
+    repo_path: &Path,
+) -> BranchFreshness {
+    let behind = rev_list_count(main_ref, branch, repo_path);
+    let ahead = rev_list_count(branch, main_ref, repo_path);
+
+    if behind == 0 {
+        return BranchFreshness::Fresh;
+    }
+
+    if ahead > 0 {
+        return BranchFreshness::Diverged {
+            ahead,
+            behind,
+            missing_fixes: missing_fix_subjects(main_ref, branch, repo_path),
+        };
+    }
+
+    let missing_fixes = missing_fix_subjects(main_ref, branch, repo_path);
+    BranchFreshness::Stale {
+        commits_behind: behind,
+        missing_fixes,
+    }
+}
+
+fn format_missing_fixes(missing_fixes: &[String]) -> String {
+    if missing_fixes.is_empty() {
+        "(none)".to_string()
+    } else {
+        missing_fixes.join("; ")
+    }
+}
+
+fn rev_list_count(a: &str, b: &str, repo_path: &Path) -> usize {
+    let output = Command::new("git")
+        .args(["rev-list", "--count", &format!("{b}..{a}")])
+        .current_dir(repo_path)
+        .output();
+    match output {
+        Ok(o) if o.status.success() => String::from_utf8_lossy(&o.stdout)
+            .trim()
+            .parse::<usize>()
+            .unwrap_or(0),
+        _ => 0,
+    }
+}
+
+fn missing_fix_subjects(a: &str, b: &str, repo_path: &Path) -> Vec<String> {
+    let output = Command::new("git")
+        .args(["log", "--format=%s", &format!("{b}..{a}")])
+        .current_dir(repo_path)
+        .output();
+    match output {
+        Ok(o) if o.status.success() => String::from_utf8_lossy(&o.stdout)
+            .lines()
+            .filter(|l| !l.is_empty())
+            .map(String::from)
+            .collect(),
+        _ => Vec::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_dir() -> std::path::PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("time should be after epoch")
+            .as_nanos();
+        std::env::temp_dir().join(format!("dasclaw-stale-branch-{nanos}"))
+    }
+
+    fn init_repo(path: &Path) {
+        fs::create_dir_all(path).expect("create repo dir");
+        run(path, &["init", "--quiet", "-b", "main"]);
+        run(path, &["config", "user.email", "tests@example.com"]);
+        run(path, &["config", "user.name", "Stale Branch Tests"]);
+        fs::write(path.join("init.txt"), "initial\n").expect("write init file");
+        run(path, &["add", "."]);
+        run(path, &["commit", "-m", "initial commit", "--quiet"]);
+    }
+
+    fn run(cwd: &Path, args: &[&str]) {
+        let status = Command::new("git")
+            .args(args)
+            .current_dir(cwd)
+            .status()
+            .unwrap_or_else(|e| panic!("git {} failed to execute: {e}", args.join(" ")));
+        assert!(
+            status.success(),
+            "git {} exited with {status}",
+            args.join(" ")
+        );
+    }
+
+    fn commit_file(repo: &Path, name: &str, msg: &str) {
+        fs::write(repo.join(name), format!("{msg}\n")).expect("write file");
+        run(repo, &["add", name]);
+        run(repo, &["commit", "-m", msg, "--quiet"]);
+    }
+
+    #[test]
+    fn req_stale_branch_69_fresh_branch_passes() {
+        let root = temp_dir();
+        init_repo(&root);
+        run(&root, &["checkout", "-b", "topic"]);
+        let freshness = check_freshness_in("topic", "main", &root);
+        assert_eq!(freshness, BranchFreshness::Fresh);
+        fs::remove_dir_all(&root).expect("cleanup");
+    }
+
+    #[test]
+    fn req_stale_branch_69_fresh_branch_ahead_of_main_still_fresh() {
+        let root = temp_dir();
+        init_repo(&root);
+        run(&root, &["checkout", "-b", "topic"]);
+        commit_file(&root, "feature.txt", "add feature");
+        let freshness = check_freshness_in("topic", "main", &root);
+        assert_eq!(freshness, BranchFreshness::Fresh);
+        fs::remove_dir_all(&root).expect("cleanup");
+    }
+
+    #[test]
+    fn req_stale_branch_69_stale_branch_detected_with_correct_behind_count_and_missing_fixes() {
+        let root = temp_dir();
+        init_repo(&root);
+        run(&root, &["checkout", "-b", "topic"]);
+        run(&root, &["checkout", "main"]);
+        commit_file(&root, "fix1.txt", "fix: resolve timeout");
+        commit_file(&root, "fix2.txt", "fix: handle null pointer");
+        let freshness = check_freshness_in("topic", "main", &root);
+        match freshness {
+            BranchFreshness::Stale {
+                commits_behind,
+                missing_fixes,
+            } => {
+                assert_eq!(commits_behind, 2);
+                assert_eq!(missing_fixes.len(), 2);
+                assert_eq!(missing_fixes[0], "fix: handle null pointer");
+                assert_eq!(missing_fixes[1], "fix: resolve timeout");
+            }
+            other => panic!("expected Stale, got {other:?}"),
+        }
+        fs::remove_dir_all(&root).expect("cleanup");
+    }
+
+    #[test]
+    fn req_stale_branch_69_diverged_branch_detection() {
+        let root = temp_dir();
+        init_repo(&root);
+        run(&root, &["checkout", "-b", "topic"]);
+        commit_file(&root, "topic_work.txt", "topic work");
+        run(&root, &["checkout", "main"]);
+        commit_file(&root, "main_fix.txt", "main fix");
+        let freshness = check_freshness_in("topic", "main", &root);
+        match freshness {
+            BranchFreshness::Diverged {
+                ahead,
+                behind,
+                missing_fixes,
+            } => {
+                assert_eq!(ahead, 1);
+                assert_eq!(behind, 1);
+                assert_eq!(missing_fixes, vec!["main fix".to_string()]);
+            }
+            other => panic!("expected Diverged, got {other:?}"),
+        }
+        fs::remove_dir_all(&root).expect("cleanup");
+    }
+
+    #[test]
+    fn req_stale_branch_69_policy_noop_for_fresh_branch() {
+        let freshness = BranchFreshness::Fresh;
+        let action = apply_policy(&freshness, StaleBranchPolicy::WarnOnly);
+        assert_eq!(action, StaleBranchAction::Noop);
+    }
+
+    #[test]
+    fn req_stale_branch_69_policy_warn_for_stale_branch() {
+        let freshness = BranchFreshness::Stale {
+            commits_behind: 3,
+            missing_fixes: vec!["fix: timeout".into(), "fix: null ptr".into()],
+        };
+        let action = apply_policy(&freshness, StaleBranchPolicy::WarnOnly);
+        match action {
+            StaleBranchAction::Warn { message } => {
+                assert!(message.contains("3 commit(s) behind"));
+                assert!(message.contains("fix: timeout"));
+                assert!(message.contains("fix: null ptr"));
+            }
+            other => panic!("expected Warn, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn req_stale_branch_69_policy_block_for_stale_branch() {
+        let freshness = BranchFreshness::Stale {
+            commits_behind: 1,
+            missing_fixes: vec!["hotfix".into()],
+        };
+        let action = apply_policy(&freshness, StaleBranchPolicy::Block);
+        match action {
+            StaleBranchAction::Block { message } => {
+                assert!(message.contains("1 commit(s) behind"));
+            }
+            other => panic!("expected Block, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn req_stale_branch_69_policy_auto_rebase_for_stale_branch() {
+        let freshness = BranchFreshness::Stale {
+            commits_behind: 2,
+            missing_fixes: vec![],
+        };
+        let action = apply_policy(&freshness, StaleBranchPolicy::AutoRebase);
+        assert_eq!(action, StaleBranchAction::Rebase);
+    }
+
+    #[test]
+    fn req_stale_branch_69_policy_auto_merge_forward_for_diverged_branch() {
+        let freshness = BranchFreshness::Diverged {
+            ahead: 5,
+            behind: 2,
+            missing_fixes: vec!["fix: merge main".into()],
+        };
+        let action = apply_policy(&freshness, StaleBranchPolicy::AutoMergeForward);
+        assert_eq!(action, StaleBranchAction::MergeForward);
+    }
+
+    #[test]
+    fn req_stale_branch_69_policy_warn_for_diverged_branch() {
+        let freshness = BranchFreshness::Diverged {
+            ahead: 3,
+            behind: 1,
+            missing_fixes: vec!["main hotfix".into()],
+        };
+        let action = apply_policy(&freshness, StaleBranchPolicy::WarnOnly);
+        match action {
+            StaleBranchAction::Warn { message } => {
+                assert!(message.contains("diverged"));
+                assert!(message.contains("3 commit(s) ahead"));
+                assert!(message.contains("1 commit(s) behind"));
+                assert!(message.contains("main hotfix"));
+            }
+            other => panic!("expected Warn, got {other:?}"),
+        }
+    }
+}


### PR DESCRIPTION
## 背景 / 目标

W4 自治 6 件套移植第二弹。把 claw-code 已经验证的 stale-base + stale-branch 检测器移植到 `dasclaw_governance`，让 orchestrator 在启动 session / 调度 lane 之前能识别：

1. **stale_base** — worktree HEAD 是否已偏离 `--base-commit` flag 或 `.claw-base` 文件指定的基准提交（4 状态 × 2 来源）
2. **stale_branch** — 特性分支相对 `main` 是否落后 / 已分叉，以及给定策略下应采取的动作（3 状态 × 4 策略 = 至多 12 路推荐 action）

源：`claw-code/rust/crates/runtime/src/{stale_base,stale_branch}.rs`（429 + 417 行）。

依赖：#181（branch_lock）已合，本 PR 直接基于 `xClaw`。

## 改动范围

- `crates/dasclaw_governance/src/stale_base.rs`：替换 W4 stub 为完整移植
  - 公开 `BaseCommitState` / `BaseCommitSource`
  - 公开 `read_claw_base_file()` / `resolve_expected_base()` / `check_base_commit()` / `format_stale_base_warning()`
  - 私有 `resolve_head_sha()` / `resolve_rev()`
  - 15 个内联测试加 `req_stale_base_69_` 前缀
- `crates/dasclaw_governance/src/stale_branch.rs`：替换 W4 stub 为完整移植
  - 公开 `BranchFreshness` / `StaleBranchPolicy` / `StaleBranchEvent` / `StaleBranchAction`
  - 公开 `check_freshness()` / `check_freshness_in()` / `apply_policy()`
  - 私有 `format_missing_fixes()` / `rev_list_count()` / `missing_fix_subjects()`
  - 10 个内联测试加 `req_stale_branch_69_` 前缀
- `Cargo.toml`：**无变更**（两个模块都只用 std，无新依赖）

## 非目标 (What's NOT in this PR)

- 不实际执行 rebase / merge-forward / block — `apply_policy()` 仅返回推荐 `StaleBranchAction`，执行属 #71 `lane_events`
- 不引入 serde / 异步 / 持久化（与本模块语义无关）
- 不动 `default = []` 契约（仍由 `req_governance_64_default_features_off` 守护）
- 不引入 #65 `policy_engine`（独立 issue）
- 不动 `branch_lock` / `lib.rs`（这两个模块的 `cfg(feature)` gate 由 #180 已声明）

## 验证

```bash
# 三档 cargo check
cargo check -p dasclaw_governance --tests --features stale_base
cargo check -p dasclaw_governance --tests --features stale_branch
cargo check -p dasclaw_governance --tests --features full

# 测试
cargo nextest run -p dasclaw_governance --features "stale_base stale_branch"
#   → 27 tests run: 27 passed (15 stale_base + 10 stale_branch + 2 skeleton)

# 红线
cargo fmt --all
python3.12 scripts/check_no_panics.py --base origin/xClaw   # OK (production code clean)
cargo clippy --no-deps -p dasclaw_governance --all-targets \
  --features "stale_base stale_branch" -- -D warnings        # 0 warning
```

## 设计取舍（no-patch 自检）

- 本 PR 是**替换 stub**，不是改既有方法尾部追加 `if`。
- 模块 `cfg(feature)` 在 lib.rs 已由 #180 一处声明，本 PR 不动 lib.rs。
- 没有复制粘贴：`format_missing_fixes` 在 `apply_policy` 的 Diverged 分支复用一次，提取为助手函数避免重复。
- 没有引入 always-on 依赖：std-only。
- 生产代码无 unwrap/expect/panic：`rev_list_count` 用 `unwrap_or(0)` 作"找不到时 0 行"的安全默认，`missing_fix_subjects` 用 `match output { ... _ => Vec::new() }`。测试代码（`#[cfg(test)]`）允许 `expect/panic` 用于 setup 断言。

## Skills 自审

- `code-quality-audit`：函数最长 `apply_policy` ~50 行（match 嵌套，无法进一步拆，可读性最佳形式）；其余生产函数 ≤ 25 行。无生产 panic。生产 IO 全部 best-effort：`Command::output().ok()?` / `unwrap_or(0)` / `_ => Vec::new()`。
- `code-simplifier`：`apply_policy` 的 `Stale` / `Diverged` 分支结构对称但消息文案差异显著，提取共享生成器收益不明显，保持原样最清晰。
- `code-review-expert`：SOLID 单一职责（freshness 检测 / policy 解析）；`StaleBranchEvent` 现未在本模块使用，留给 #71 lane_events 作事件 payload，避免到时再回改 API；测试用 `temp_dir()` + nanos 命名隔离，确保 nextest 并行无碰撞；`init_repo` 强制 `-b main` 适配新版 git 默认分支差异。

## 后续

- #74 `dasclaw_features` 6-flag 默认 OFF（已满足前置条件：6 件套 ≥1 件套实现）
- #65 `policy_engine`（独立）
- #71 `lane_events`（消费本 PR 的 `StaleBranchEvent` + #181 的 `BranchLockCollision`）

Closes #69
