### PR TITLE
feat(governance): port trust_resolver allowlist/denylist + prompt detection (#67)

### DIFF
--- a/crates/dasclaw_governance/src/trust_resolver.rs
+++ b/crates/dasclaw_governance/src/trust_resolver.rs
@@ -1,5 +1,368 @@
-//! `trust_resolver` — W4 placeholder. Implementation lands in follow-up issue.
+//! `trust_resolver` — worktree / cwd trust evaluation.
 //!
-//! See the module table in `lib.rs` for issue mapping.
+//! Ported from `claw-code/rust/crates/runtime/src/trust_resolver.rs`.
+//!
+//! # Surface
+//!
+//! - [`detect_trust_prompt`] — substring scan for known TUI trust prompts.
+//! - [`TrustConfig`] — builder over allowlist + denylist of `PathBuf` roots.
+//! - [`TrustResolver::resolve`] — fold a screen capture + cwd into a
+//!   [`TrustDecision`] with an event trail.
+//! - [`TrustResolver::trusts`] — `bool` shortcut: `cwd ∈ allowlist ∧ cwd ∉ denylist`.
+//! - [`path_matches_trusted_root`] — pure-string matcher reused by callers
+//!   that already have a normalised root string.
+//!
+//! Decision precedence: **denylist > allowlist > require-approval**. The
+//! denylist is checked first so an explicit deny always wins, even when an
+//! ancestor allowlist root would otherwise match.
+//!
+//! `normalize_path` falls back to the original path when `canonicalize` fails
+//! (path not yet on disk, permission errors, …) — mandatory for tests that
+//! work with synthetic paths under `/tmp/worktrees/...`.
 
-#![allow(dead_code)]
+use std::path::{Path, PathBuf};
+
+const TRUST_PROMPT_CUES: &[&str] = &[
+    "do you trust the files in this folder",
+    "trust the files in this folder",
+    "trust this folder",
+    "allow and continue",
+    "yes, proceed",
+];
+
+/// Outcome handed back to the caller after a trust evaluation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TrustPolicy {
+    /// Cwd matched the allowlist — auto-trust the worktree.
+    AutoTrust,
+    /// Cwd did not match any list — caller must surface to the operator.
+    RequireApproval,
+    /// Cwd matched the denylist — refuse to trust.
+    Deny,
+}
+
+/// Audit event emitted during resolution. Order in the returned slice
+/// matches emission order; downstream pipelines forward them verbatim.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TrustEvent {
+    TrustRequired { cwd: String },
+    TrustResolved { cwd: String, policy: TrustPolicy },
+    TrustDenied { cwd: String, reason: String },
+}
+
+/// Allowlist / denylist of trust roots. Empty by default — every cwd then
+/// resolves to `RequireApproval` whenever a prompt is detected.
+#[derive(Debug, Clone, Default)]
+pub struct TrustConfig {
+    allowlisted: Vec<PathBuf>,
+    denied: Vec<PathBuf>,
+}
+
+impl TrustConfig {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Add a directory to the allowlist (cwd or any descendant matches).
+    #[must_use]
+    pub fn with_allowlisted(mut self, path: impl Into<PathBuf>) -> Self {
+        self.allowlisted.push(path.into());
+        self
+    }
+
+    /// Add a directory to the denylist (cwd or any descendant matches).
+    /// Denylist beats allowlist.
+    #[must_use]
+    pub fn with_denied(mut self, path: impl Into<PathBuf>) -> Self {
+        self.denied.push(path.into());
+        self
+    }
+}
+
+/// Top-level decision surfaced by [`TrustResolver::resolve`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TrustDecision {
+    /// No trust prompt was detected — caller can keep streaming.
+    NotRequired,
+    /// A trust prompt was detected; act according to `policy` and emit
+    /// `events`.
+    Required {
+        policy: TrustPolicy,
+        events: Vec<TrustEvent>,
+    },
+}
+
+impl TrustDecision {
+    #[must_use]
+    pub fn policy(&self) -> Option<TrustPolicy> {
+        match self {
+            Self::NotRequired => None,
+            Self::Required { policy, .. } => Some(*policy),
+        }
+    }
+
+    #[must_use]
+    pub fn events(&self) -> &[TrustEvent] {
+        match self {
+            Self::NotRequired => &[],
+            Self::Required { events, .. } => events,
+        }
+    }
+}
+
+/// Stateless evaluator. Cheap to clone — holds only the config.
+#[derive(Debug, Clone)]
+pub struct TrustResolver {
+    config: TrustConfig,
+}
+
+impl TrustResolver {
+    #[must_use]
+    pub fn new(config: TrustConfig) -> Self {
+        Self { config }
+    }
+
+    /// Inspect `screen_text`; if it contains a known trust prompt, classify
+    /// `cwd` against the configured lists and emit the audit trail.
+    #[must_use]
+    pub fn resolve(&self, cwd: &str, screen_text: &str) -> TrustDecision {
+        if !detect_trust_prompt(screen_text) {
+            return TrustDecision::NotRequired;
+        }
+
+        let mut events = vec![TrustEvent::TrustRequired {
+            cwd: cwd.to_owned(),
+        }];
+
+        if let Some(matched_root) = self
+            .config
+            .denied
+            .iter()
+            .find(|root| path_matches(cwd, root))
+        {
+            let reason = format!("cwd matches denied trust root: {}", matched_root.display());
+            events.push(TrustEvent::TrustDenied {
+                cwd: cwd.to_owned(),
+                reason,
+            });
+            return TrustDecision::Required {
+                policy: TrustPolicy::Deny,
+                events,
+            };
+        }
+
+        if self
+            .config
+            .allowlisted
+            .iter()
+            .any(|root| path_matches(cwd, root))
+        {
+            events.push(TrustEvent::TrustResolved {
+                cwd: cwd.to_owned(),
+                policy: TrustPolicy::AutoTrust,
+            });
+            return TrustDecision::Required {
+                policy: TrustPolicy::AutoTrust,
+                events,
+            };
+        }
+
+        TrustDecision::Required {
+            policy: TrustPolicy::RequireApproval,
+            events,
+        }
+    }
+
+    /// Bool shortcut without the audit trail: cwd is on the allowlist and
+    /// not on the denylist.
+    #[must_use]
+    pub fn trusts(&self, cwd: &str) -> bool {
+        !self
+            .config
+            .denied
+            .iter()
+            .any(|root| path_matches(cwd, root))
+            && self
+                .config
+                .allowlisted
+                .iter()
+                .any(|root| path_matches(cwd, root))
+    }
+}
+
+/// Returns `true` iff `screen_text` matches one of the known TUI trust
+/// prompts (case-insensitive substring match).
+#[must_use]
+pub fn detect_trust_prompt(screen_text: &str) -> bool {
+    let lowered = screen_text.to_ascii_lowercase();
+    TRUST_PROMPT_CUES
+        .iter()
+        .any(|needle| lowered.contains(needle))
+}
+
+/// Pure-string equivalent of the in-resolver path comparison. Intended for
+/// callers that already have a canonicalised trusted root string.
+#[must_use]
+pub fn path_matches_trusted_root(cwd: &str, trusted_root: &str) -> bool {
+    path_matches(cwd, &normalize_path(Path::new(trusted_root)))
+}
+
+fn path_matches(candidate: &str, root: &Path) -> bool {
+    let candidate = normalize_path(Path::new(candidate));
+    let root = normalize_path(root);
+    candidate == root || candidate.starts_with(&root)
+}
+
+fn normalize_path(path: &Path) -> PathBuf {
+    // Tests work with synthetic /tmp/worktrees/... paths that don't exist on
+    // disk; canonicalize() will fail with ENOENT — fall back to the literal
+    // path so allowlist matching stays meaningful.
+    std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        detect_trust_prompt, path_matches_trusted_root, TrustConfig, TrustDecision, TrustEvent,
+        TrustPolicy, TrustResolver,
+    };
+
+    #[test]
+    fn req_trust_resolver_67_detects_known_trust_prompt_copy() {
+        let screen_text = "Do you trust the files in this folder?\n1. Yes, proceed\n2. No";
+        assert!(detect_trust_prompt(screen_text));
+    }
+
+    #[test]
+    fn req_trust_resolver_67_detects_alternate_cues_case_insensitive() {
+        // "Allow and continue" cue + uppercase variants should still match.
+        assert!(detect_trust_prompt("ALLOW AND CONTINUE"));
+        assert!(detect_trust_prompt("Trust this folder?"));
+        assert!(detect_trust_prompt("Trust the files in this folder"));
+        // Negative: no cue → not detected.
+        assert!(!detect_trust_prompt("Ready for your input\n>"));
+    }
+
+    #[test]
+    fn req_trust_resolver_67_does_not_emit_events_when_prompt_is_absent() {
+        let resolver = TrustResolver::new(TrustConfig::new().with_allowlisted("/tmp/worktrees"));
+
+        let decision = resolver.resolve("/tmp/worktrees/repo-a", "Ready for your input\n>");
+
+        assert_eq!(decision, TrustDecision::NotRequired);
+        assert_eq!(decision.events(), &[]);
+        assert_eq!(decision.policy(), None);
+    }
+
+    #[test]
+    fn req_trust_resolver_67_auto_trusts_allowlisted_cwd_after_prompt_detection() {
+        let resolver = TrustResolver::new(TrustConfig::new().with_allowlisted("/tmp/worktrees"));
+
+        let decision = resolver.resolve(
+            "/tmp/worktrees/repo-a",
+            "Do you trust the files in this folder?\n1. Yes, proceed\n2. No",
+        );
+
+        assert_eq!(decision.policy(), Some(TrustPolicy::AutoTrust));
+        assert_eq!(
+            decision.events(),
+            &[
+                TrustEvent::TrustRequired {
+                    cwd: "/tmp/worktrees/repo-a".to_string(),
+                },
+                TrustEvent::TrustResolved {
+                    cwd: "/tmp/worktrees/repo-a".to_string(),
+                    policy: TrustPolicy::AutoTrust,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn req_trust_resolver_67_requires_approval_for_unknown_cwd_after_prompt() {
+        let resolver = TrustResolver::new(TrustConfig::new().with_allowlisted("/tmp/worktrees"));
+
+        let decision = resolver.resolve(
+            "/tmp/other/repo-b",
+            "Do you trust the files in this folder?\n1. Yes, proceed\n2. No",
+        );
+
+        assert_eq!(decision.policy(), Some(TrustPolicy::RequireApproval));
+        assert_eq!(
+            decision.events(),
+            &[TrustEvent::TrustRequired {
+                cwd: "/tmp/other/repo-b".to_string(),
+            }]
+        );
+    }
+
+    #[test]
+    fn req_trust_resolver_67_denied_root_takes_precedence_over_allowlist() {
+        let resolver = TrustResolver::new(
+            TrustConfig::new()
+                .with_allowlisted("/tmp/worktrees")
+                .with_denied("/tmp/worktrees/repo-c"),
+        );
+
+        let decision = resolver.resolve(
+            "/tmp/worktrees/repo-c",
+            "Do you trust the files in this folder?\n1. Yes, proceed\n2. No",
+        );
+
+        assert_eq!(decision.policy(), Some(TrustPolicy::Deny));
+        assert_eq!(
+            decision.events(),
+            &[
+                TrustEvent::TrustRequired {
+                    cwd: "/tmp/worktrees/repo-c".to_string(),
+                },
+                TrustEvent::TrustDenied {
+                    cwd: "/tmp/worktrees/repo-c".to_string(),
+                    reason: "cwd matches denied trust root: /tmp/worktrees/repo-c".to_string(),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn req_trust_resolver_67_sibling_prefix_does_not_match_trusted_root() {
+        // "/tmp/worktrees-other/..." must NOT match "/tmp/worktrees".
+        assert!(!path_matches_trusted_root(
+            "/tmp/worktrees-other/repo-d",
+            "/tmp/worktrees"
+        ));
+    }
+
+    #[test]
+    fn req_trust_resolver_67_trusts_helper_matches_resolve_outcome() {
+        let resolver = TrustResolver::new(
+            TrustConfig::new()
+                .with_allowlisted("/tmp/worktrees")
+                .with_denied("/tmp/worktrees/repo-c"),
+        );
+
+        // allowlisted → trusted
+        assert!(resolver.trusts("/tmp/worktrees/repo-a"));
+        // denied wins → not trusted
+        assert!(!resolver.trusts("/tmp/worktrees/repo-c"));
+        // unknown → not trusted
+        assert!(!resolver.trusts("/tmp/other/repo-b"));
+    }
+
+    #[test]
+    fn req_trust_resolver_67_empty_config_requires_approval() {
+        // No allowlist, no denylist, prompt detected → RequireApproval (fail safe).
+        let resolver = TrustResolver::new(TrustConfig::new());
+
+        let decision = resolver.resolve(
+            "/tmp/anywhere",
+            "Do you trust the files in this folder?\n1. Yes, proceed\n2. No",
+        );
+
+        assert_eq!(decision.policy(), Some(TrustPolicy::RequireApproval));
+        // No prompt → NotRequired (fail-closed when no signal).
+        let no_prompt = resolver.resolve("/tmp/anywhere", "ready");
+        assert_eq!(no_prompt, TrustDecision::NotRequired);
+    }
+}


### PR DESCRIPTION
## 背景 / 目标

W4 自治 6 件套移植第四件 — 把 `claw-code/rust/crates/runtime/src/trust_resolver.rs`（299 LOC）整体移植到 `dasclaw_governance::trust_resolver`，gated 在 #64 已声明的 `trust_resolver` cargo feature 后。

**与已开/已合 PR 完全独立**：
- #182（`stale_base.rs` + `stale_branch.rs`）— 不同文件
- #184（`policy_engine.rs`）— 不同文件
- #183（`dasclaw_features` 整 crate）— 不同 crate

来源：`docs/plans/architecture-refactor/32-execution-plan.md` W4 任务 1 + Closes #67。

## 改动范围

- `crates/dasclaw_governance/src/trust_resolver.rs`：**完整替换** W4 stub（5 行）→ 完整实现（368 行）
  - `TrustPolicy` { AutoTrust, RequireApproval, Deny }
  - `TrustEvent` { TrustRequired, TrustResolved, TrustDenied }（审计 trail）
  - `TrustConfig`（builder：`with_allowlisted` / `with_denied`）
  - `TrustDecision` { NotRequired, Required { policy, events } } + accessors
  - `TrustResolver::new` / `::resolve(cwd, screen_text)` / `::trusts(cwd)`
  - `detect_trust_prompt(text)` — 5 个 TUI cue 的 case-insensitive 子串匹配
  - `path_matches_trusted_root(cwd, root)` — 纯字符串 matcher
- `Cargo.toml`：**无变更**（std-only：`PathBuf` + `std::fs::canonicalize`）

## 决策语义

- 优先级：**denylist > allowlist > require-approval**
- 空配置 + 检测到 prompt → `RequireApproval`（fail safe，不无脑放行）
- 无 prompt → `NotRequired`（无事件、无 policy；不打扰）
- `normalize_path` 在 canonicalize 失败时回落到字面路径（合成 `/tmp/...` 测试路径必需），用 `Result::unwrap_or_else` —— **非** panic 类的 `Option::unwrap`，无 panic 风险

## 非目标 (What's NOT in this PR)

- 不实现 OAuth / token 解析：issue 标题提到 OAuth，但 claw-code 源文件本身**不含** OAuth 代码（grep 三层确认：源文件 299 行无 oauth/token 字样）。OAuth 属 `dasclaw_identity` crate 范围，强行加进来会偏离 trust_resolver 的核心契约（worktree trust + allowlist），属补丁式扩张。OAuth token 解析单独跟踪（建议另开 issue）。
- 不接 `dasclaw_governance::GovernanceEngine` trait（同 #184，避免补丁式适配）
- 不动 `default = []` 契约
- 不动其他模块（policy_engine 由 #184，stale_base/branch 由 #182，branch_lock 已合）

## 验证

```bash
cargo check -p dasclaw_governance --tests --features trust_resolver
# PASS

cargo nextest run -p dasclaw_governance --features trust_resolver
# 11 tests run: 11 passed (9 trust_resolver_67 + 2 skeleton)

cargo fmt --all
python3.12 scripts/check_no_panics.py --base origin/xClaw   # clean
cargo clippy --no-deps -p dasclaw_governance --all-targets \
  --features trust_resolver -- -D warnings                  # 0 warning
```

测试覆盖（在 source 6 个的基础上 +3 个）：

| Test | 验收点 |
|---|---|
| `detects_known_trust_prompt_copy` | "Yes, proceed" cue 命中 |
| `detects_alternate_cues_case_insensitive` ⭐ | "ALLOW AND CONTINUE" / "Trust this folder" / 否定路径 |
| `does_not_emit_events_when_prompt_is_absent` | NotRequired + 无事件 |
| `auto_trusts_allowlisted_cwd_after_prompt_detection` | allowlist 命中 → AutoTrust + 2 个事件 |
| `requires_approval_for_unknown_cwd_after_prompt` | 未知 cwd → RequireApproval |
| `denied_root_takes_precedence_over_allowlist` | 优先级红线 |
| `sibling_prefix_does_not_match_trusted_root` | `worktrees-other` ≠ `worktrees` |
| `trusts_helper_matches_resolve_outcome` ⭐ | bool 快捷与 resolve 一致 |
| `empty_config_requires_approval` ⭐ | 空配置 fail-safe |

⭐ = 在 source 之外补充的覆盖。

## 设计取舍（no-patch 自检）

- **完整替换 stub**（5 行 placeholder + `#![allow(dead_code)]`，无 reverse-dep）
- **不重复 cfg gate**：`lib.rs` 已声明 `#[cfg(feature = "trust_resolver")] pub mod trust_resolver;`（#180 落地），本 PR 不重复也不修改
- **不强加 OAuth**：issue 标题提到但源文件无该实现，强加会破坏单一职责。建议作为独立 issue 补齐。
- **denylist-first** 顺序与 source 完全一致，未引入"优化型"重排
- 生产代码 0 panic / 0 unwrap / 0 expect（`unwrap_or_else` 为 fallback，不 panic）
- 没有引入 `unsafe`，没有引入异步

## Skills 自审

- `code-quality-audit`：最长函数 `TrustResolver::resolve` ~30 行（线性 if/let-Some 链，无嵌套 match），其他 ≤ 10 行。无 panic。无未使用 import。
- `code-simplifier`：`trusts()` 与 `resolve()` 的 deny+allow 检查重复，但抽提共享 helper 会迫使 `resolve` 路径再走一次 mut events 流，反而复杂。保留双轨更清晰。
- `code-review-expert`：审计事件数组顺序与决策路径绑定（TrustRequired 总是首条），方便下游做事件流断言；`TrustDecision::events()` 在 `NotRequired` 分支返回 `&[]` 而非 `Option<&[]>`，调用侧无需解包。

## 后续

- OAuth token / signed policy 解析（独立 issue 补 #67 标题里的 OAuth 部分）
- `TrustEvent` 接入 `lane_events`（#71）
- worktree trust 与 `dasclaw_identity` 的统一身份解析（独立设计）

Closes #67
