### PR TITLE
feat(bash-validation): port 6 validation modules from claw-code (#72)

### DIFF
--- a/crates/dasclaw_bash_validation/src/lib.rs
+++ b/crates/dasclaw_bash_validation/src/lib.rs
@@ -1,24 +1,980 @@
-//! Bash injection detection (6 validation modules from claw-code).
+//! Bash command validation submodules.
 //!
-//! W1 skeleton — trait surface only, no impl.
-//! See `docs/plans/architecture-refactor/31-target-architecture.md` §4 for design.
+//! Ported from `claw-code/rust/crates/runtime/src/bash_validation.rs` (W4 #72).
+//!
+//! Six validation modules from upstream `BashTool`:
+//! - `readOnlyValidation` — block write-like commands in read-only mode
+//! - `destructiveCommandWarning` — flag dangerous destructive commands
+//! - `modeValidation` — enforce permission mode constraints on commands
+//! - `sedValidation` — validate sed expressions before execution
+//! - `pathValidation` — detect suspicious path patterns
+//! - `commandSemantics` — classify command intent
+//!
+//! Public entry: [`validate_command`].
 
-#![allow(dead_code)]
+use std::path::Path;
 
-/// Placeholder error type. Replaced with module-specific errors in W2+.
-#[derive(Debug, thiserror::Error)]
-#[error("dasclaw_bash_validation skeleton error: {0}")]
-pub struct SkeletonError(pub String);
+pub mod permissions;
+pub use permissions::PermissionMode;
 
-/// Primary entry trait (placeholder). Replaced with full surface in W2+.
-pub trait BashValidator {
-    /// Bash injection detection (6 validation modules from claw-code).
-    fn validate(&self, cmd: &str) -> Result<(), SkeletonError>;
+/// Result of validating a bash command before execution.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ValidationResult {
+    /// Command is safe to execute.
+    Allow,
+    /// Command should be blocked with the given reason.
+    Block { reason: String },
+    /// Command requires user confirmation with the given warning.
+    Warn { message: String },
 }
+
+/// Semantic classification of a bash command's intent.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CommandIntent {
+    /// Read-only operations: ls, cat, grep, find, etc.
+    ReadOnly,
+    /// File system writes: cp, mv, mkdir, touch, tee, etc.
+    Write,
+    /// Destructive operations: rm, shred, truncate, etc.
+    Destructive,
+    /// Network operations: curl, wget, ssh, etc.
+    Network,
+    /// Process management: kill, pkill, etc.
+    ProcessManagement,
+    /// Package management: apt, brew, pip, npm, etc.
+    PackageManagement,
+    /// System administration: sudo, chmod, chown, mount, etc.
+    SystemAdmin,
+    /// Unknown or unclassifiable command.
+    Unknown,
+}
+
+// ---------------------------------------------------------------------------
+// readOnlyValidation
+// ---------------------------------------------------------------------------
+
+/// Commands that perform write operations and should be blocked in read-only mode.
+const WRITE_COMMANDS: &[&str] = &[
+    "cp", "mv", "rm", "mkdir", "rmdir", "touch", "chmod", "chown", "chgrp", "ln", "install", "tee",
+    "truncate", "shred", "mkfifo", "mknod", "dd",
+];
+
+/// Commands that modify system state and should be blocked in read-only mode.
+const STATE_MODIFYING_COMMANDS: &[&str] = &[
+    "apt",
+    "apt-get",
+    "yum",
+    "dnf",
+    "pacman",
+    "brew",
+    "pip",
+    "pip3",
+    "npm",
+    "yarn",
+    "pnpm",
+    "bun",
+    "cargo",
+    "gem",
+    "go",
+    "rustup",
+    "docker",
+    "systemctl",
+    "service",
+    "mount",
+    "umount",
+    "kill",
+    "pkill",
+    "killall",
+    "reboot",
+    "shutdown",
+    "halt",
+    "poweroff",
+    "useradd",
+    "userdel",
+    "usermod",
+    "groupadd",
+    "groupdel",
+    "crontab",
+    "at",
+];
+
+/// Shell redirection operators that indicate writes.
+const WRITE_REDIRECTIONS: &[&str] = &[">", ">>", ">&"];
+
+/// Validate that a command is allowed under read-only mode.
+///
+/// Corresponds to upstream `tools/BashTool/readOnlyValidation.ts`.
+#[must_use]
+pub fn validate_read_only(command: &str, mode: PermissionMode) -> ValidationResult {
+    if mode != PermissionMode::ReadOnly {
+        return ValidationResult::Allow;
+    }
+
+    let first_command = extract_first_command(command);
+
+    for &write_cmd in WRITE_COMMANDS {
+        if first_command == write_cmd {
+            return ValidationResult::Block {
+                reason: format!(
+                    "Command '{write_cmd}' modifies the filesystem and is not allowed in read-only mode"
+                ),
+            };
+        }
+    }
+
+    for &state_cmd in STATE_MODIFYING_COMMANDS {
+        if first_command == state_cmd {
+            return ValidationResult::Block {
+                reason: format!(
+                    "Command '{state_cmd}' modifies system state and is not allowed in read-only mode"
+                ),
+            };
+        }
+    }
+
+    if first_command == "sudo" {
+        let inner = extract_sudo_inner(command);
+        if !inner.is_empty() {
+            let inner_result = validate_read_only(inner, mode);
+            if inner_result != ValidationResult::Allow {
+                return inner_result;
+            }
+        }
+    }
+
+    for &redir in WRITE_REDIRECTIONS {
+        if command.contains(redir) {
+            return ValidationResult::Block {
+                reason: format!(
+                    "Command contains write redirection '{redir}' which is not allowed in read-only mode"
+                ),
+            };
+        }
+    }
+
+    if first_command == "git" {
+        return validate_git_read_only(command);
+    }
+
+    ValidationResult::Allow
+}
+
+/// Git subcommands that are read-only safe.
+const GIT_READ_ONLY_SUBCOMMANDS: &[&str] = &[
+    "status",
+    "log",
+    "diff",
+    "show",
+    "branch",
+    "tag",
+    "stash",
+    "remote",
+    "fetch",
+    "ls-files",
+    "ls-tree",
+    "cat-file",
+    "rev-parse",
+    "describe",
+    "shortlog",
+    "blame",
+    "bisect",
+    "reflog",
+    "config",
+];
+
+fn validate_git_read_only(command: &str) -> ValidationResult {
+    let parts: Vec<&str> = command.split_whitespace().collect();
+    let subcommand = parts.iter().skip(1).find(|p| !p.starts_with('-'));
+
+    match subcommand {
+        Some(&sub) if GIT_READ_ONLY_SUBCOMMANDS.contains(&sub) => ValidationResult::Allow,
+        Some(&sub) => ValidationResult::Block {
+            reason: format!(
+                "Git subcommand '{sub}' modifies repository state and is not allowed in read-only mode"
+            ),
+        },
+        None => ValidationResult::Allow,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// destructiveCommandWarning
+// ---------------------------------------------------------------------------
+
+/// Patterns that indicate potentially destructive commands.
+const DESTRUCTIVE_PATTERNS: &[(&str, &str)] = &[
+    (
+        "rm -rf /",
+        "Recursive forced deletion at root — this will destroy the system",
+    ),
+    ("rm -rf ~", "Recursive forced deletion of home directory"),
+    (
+        "rm -rf *",
+        "Recursive forced deletion of all files in current directory",
+    ),
+    ("rm -rf .", "Recursive forced deletion of current directory"),
+    (
+        "mkfs",
+        "Filesystem creation will destroy existing data on the device",
+    ),
+    (
+        "dd if=",
+        "Direct disk write — can overwrite partitions or devices",
+    ),
+    ("> /dev/sd", "Writing to raw disk device"),
+    (
+        "chmod -R 777",
+        "Recursively setting world-writable permissions",
+    ),
+    ("chmod -R 000", "Recursively removing all permissions"),
+    (":(){ :|:& };:", "Fork bomb — will crash the system"),
+];
+
+/// Commands that are always destructive regardless of arguments.
+const ALWAYS_DESTRUCTIVE_COMMANDS: &[&str] = &["shred", "wipefs"];
+
+/// Warn if a command looks destructive.
+///
+/// Corresponds to upstream `tools/BashTool/destructiveCommandWarning.ts`.
+#[must_use]
+pub fn check_destructive(command: &str) -> ValidationResult {
+    for &(pattern, warning) in DESTRUCTIVE_PATTERNS {
+        if command.contains(pattern) {
+            return ValidationResult::Warn {
+                message: format!("Destructive command detected: {warning}"),
+            };
+        }
+    }
+
+    let first = extract_first_command(command);
+    for &cmd in ALWAYS_DESTRUCTIVE_COMMANDS {
+        if first == cmd {
+            return ValidationResult::Warn {
+                message: format!(
+                    "Command '{cmd}' is inherently destructive and may cause data loss"
+                ),
+            };
+        }
+    }
+
+    if command.contains("rm ") && command.contains("-r") && command.contains("-f") {
+        return ValidationResult::Warn {
+            message: "Recursive forced deletion detected — verify the target path is correct"
+                .to_string(),
+        };
+    }
+
+    ValidationResult::Allow
+}
+
+// ---------------------------------------------------------------------------
+// modeValidation
+// ---------------------------------------------------------------------------
+
+/// Validate that a command is consistent with the given permission mode.
+///
+/// Corresponds to upstream `tools/BashTool/modeValidation.ts`.
+#[must_use]
+pub fn validate_mode(command: &str, mode: PermissionMode) -> ValidationResult {
+    match mode {
+        PermissionMode::ReadOnly => validate_read_only(command, mode),
+        PermissionMode::WorkspaceWrite => {
+            if command_targets_outside_workspace(command) {
+                return ValidationResult::Warn {
+                    message:
+                        "Command appears to target files outside the workspace — requires elevated permission"
+                            .to_string(),
+                };
+            }
+            ValidationResult::Allow
+        }
+        PermissionMode::DangerFullAccess | PermissionMode::Allow | PermissionMode::Prompt => {
+            ValidationResult::Allow
+        }
+    }
+}
+
+/// Heuristic: does the command reference absolute paths outside typical workspace dirs?
+fn command_targets_outside_workspace(command: &str) -> bool {
+    let system_paths = [
+        "/etc/", "/usr/", "/var/", "/boot/", "/sys/", "/proc/", "/dev/", "/sbin/", "/lib/", "/opt/",
+    ];
+
+    let first = extract_first_command(command);
+    let is_write_cmd = WRITE_COMMANDS.contains(&first.as_str())
+        || STATE_MODIFYING_COMMANDS.contains(&first.as_str());
+
+    if !is_write_cmd {
+        return false;
+    }
+
+    for sys_path in &system_paths {
+        if command.contains(sys_path) {
+            return true;
+        }
+    }
+
+    false
+}
+
+// ---------------------------------------------------------------------------
+// sedValidation
+// ---------------------------------------------------------------------------
+
+/// Validate sed expressions for safety.
+///
+/// Corresponds to upstream `tools/BashTool/sedValidation.ts`.
+#[must_use]
+pub fn validate_sed(command: &str, mode: PermissionMode) -> ValidationResult {
+    let first = extract_first_command(command);
+    if first != "sed" {
+        return ValidationResult::Allow;
+    }
+
+    if mode == PermissionMode::ReadOnly && command.contains(" -i") {
+        return ValidationResult::Block {
+            reason: "sed -i (in-place editing) is not allowed in read-only mode".to_string(),
+        };
+    }
+
+    ValidationResult::Allow
+}
+
+// ---------------------------------------------------------------------------
+// pathValidation
+// ---------------------------------------------------------------------------
+
+/// Validate that command paths don't include suspicious traversal patterns.
+///
+/// Corresponds to upstream `tools/BashTool/pathValidation.ts`.
+#[must_use]
+pub fn validate_paths(command: &str, workspace: &Path) -> ValidationResult {
+    if command.contains("../") {
+        let workspace_str = workspace.to_string_lossy();
+        if !command.contains(&*workspace_str) {
+            return ValidationResult::Warn {
+                message: "Command contains directory traversal pattern '../' — verify the target path resolves within the workspace".to_string(),
+            };
+        }
+    }
+
+    if command.contains("~/") || command.contains("$HOME") {
+        return ValidationResult::Warn {
+            message:
+                "Command references home directory — verify it stays within the workspace scope"
+                    .to_string(),
+        };
+    }
+
+    ValidationResult::Allow
+}
+
+// ---------------------------------------------------------------------------
+// commandSemantics
+// ---------------------------------------------------------------------------
+
+/// Commands that are read-only (no filesystem or state modification).
+const SEMANTIC_READ_ONLY_COMMANDS: &[&str] = &[
+    "ls",
+    "cat",
+    "head",
+    "tail",
+    "less",
+    "more",
+    "wc",
+    "sort",
+    "uniq",
+    "grep",
+    "egrep",
+    "fgrep",
+    "find",
+    "which",
+    "whereis",
+    "whatis",
+    "man",
+    "info",
+    "file",
+    "stat",
+    "du",
+    "df",
+    "free",
+    "uptime",
+    "uname",
+    "hostname",
+    "whoami",
+    "id",
+    "groups",
+    "env",
+    "printenv",
+    "echo",
+    "printf",
+    "date",
+    "cal",
+    "bc",
+    "expr",
+    "test",
+    "true",
+    "false",
+    "pwd",
+    "tree",
+    "diff",
+    "cmp",
+    "md5sum",
+    "sha256sum",
+    "sha1sum",
+    "xxd",
+    "od",
+    "hexdump",
+    "strings",
+    "readlink",
+    "realpath",
+    "basename",
+    "dirname",
+    "seq",
+    "yes",
+    "tput",
+    "column",
+    "jq",
+    "yq",
+    "xargs",
+    "tr",
+    "cut",
+    "paste",
+    "awk",
+    "sed",
+];
+
+/// Commands that perform network operations.
+const NETWORK_COMMANDS: &[&str] = &[
+    "curl",
+    "wget",
+    "ssh",
+    "scp",
+    "rsync",
+    "ftp",
+    "sftp",
+    "nc",
+    "ncat",
+    "telnet",
+    "ping",
+    "traceroute",
+    "dig",
+    "nslookup",
+    "host",
+    "whois",
+    "ifconfig",
+    "ip",
+    "netstat",
+    "ss",
+    "nmap",
+];
+
+/// Commands that manage processes.
+const PROCESS_COMMANDS: &[&str] = &[
+    "kill", "pkill", "killall", "ps", "top", "htop", "bg", "fg", "jobs", "nohup", "disown", "wait",
+    "nice", "renice",
+];
+
+/// Commands that manage packages.
+const PACKAGE_COMMANDS: &[&str] = &[
+    "apt", "apt-get", "yum", "dnf", "pacman", "brew", "pip", "pip3", "npm", "yarn", "pnpm", "bun",
+    "cargo", "gem", "go", "rustup", "snap", "flatpak",
+];
+
+/// Commands that require system administrator privileges.
+const SYSTEM_ADMIN_COMMANDS: &[&str] = &[
+    "sudo",
+    "su",
+    "chroot",
+    "mount",
+    "umount",
+    "fdisk",
+    "parted",
+    "lsblk",
+    "blkid",
+    "systemctl",
+    "service",
+    "journalctl",
+    "dmesg",
+    "modprobe",
+    "insmod",
+    "rmmod",
+    "iptables",
+    "ufw",
+    "firewall-cmd",
+    "sysctl",
+    "crontab",
+    "at",
+    "useradd",
+    "userdel",
+    "usermod",
+    "groupadd",
+    "groupdel",
+    "passwd",
+    "visudo",
+];
+
+/// Classify the semantic intent of a bash command.
+///
+/// Corresponds to upstream `tools/BashTool/commandSemantics.ts`.
+#[must_use]
+pub fn classify_command(command: &str) -> CommandIntent {
+    let first = extract_first_command(command);
+    classify_by_first_command(&first, command)
+}
+
+fn classify_by_first_command(first: &str, command: &str) -> CommandIntent {
+    if SEMANTIC_READ_ONLY_COMMANDS.contains(&first) {
+        if first == "sed" && command.contains(" -i") {
+            return CommandIntent::Write;
+        }
+        return CommandIntent::ReadOnly;
+    }
+
+    if ALWAYS_DESTRUCTIVE_COMMANDS.contains(&first) || first == "rm" {
+        return CommandIntent::Destructive;
+    }
+
+    if WRITE_COMMANDS.contains(&first) {
+        return CommandIntent::Write;
+    }
+
+    if NETWORK_COMMANDS.contains(&first) {
+        return CommandIntent::Network;
+    }
+
+    if PROCESS_COMMANDS.contains(&first) {
+        return CommandIntent::ProcessManagement;
+    }
+
+    if PACKAGE_COMMANDS.contains(&first) {
+        return CommandIntent::PackageManagement;
+    }
+
+    if SYSTEM_ADMIN_COMMANDS.contains(&first) {
+        return CommandIntent::SystemAdmin;
+    }
+
+    if first == "git" {
+        return classify_git_command(command);
+    }
+
+    CommandIntent::Unknown
+}
+
+fn classify_git_command(command: &str) -> CommandIntent {
+    let parts: Vec<&str> = command.split_whitespace().collect();
+    let subcommand = parts.iter().skip(1).find(|p| !p.starts_with('-'));
+    match subcommand {
+        Some(&sub) if GIT_READ_ONLY_SUBCOMMANDS.contains(&sub) => CommandIntent::ReadOnly,
+        _ => CommandIntent::Write,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Pipeline: run all validations
+// ---------------------------------------------------------------------------
+
+/// Run the full validation pipeline on a bash command.
+///
+/// Returns the first non-Allow result, or Allow if all validations pass.
+#[must_use]
+pub fn validate_command(command: &str, mode: PermissionMode, workspace: &Path) -> ValidationResult {
+    let result = validate_mode(command, mode);
+    if result != ValidationResult::Allow {
+        return result;
+    }
+
+    let result = validate_sed(command, mode);
+    if result != ValidationResult::Allow {
+        return result;
+    }
+
+    let result = check_destructive(command);
+    if result != ValidationResult::Allow {
+        return result;
+    }
+
+    validate_paths(command, workspace)
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Extract the first bare command from a pipeline/chain, stripping env vars and sudo.
+fn extract_first_command(command: &str) -> String {
+    let trimmed = command.trim();
+
+    let mut remaining = trimmed;
+    loop {
+        let next = remaining.trim_start();
+        if let Some(eq_pos) = next.find('=') {
+            let before_eq = &next[..eq_pos];
+            if !before_eq.is_empty()
+                && before_eq
+                    .chars()
+                    .all(|c| c.is_ascii_alphanumeric() || c == '_')
+            {
+                let after_eq = &next[eq_pos + 1..];
+                if let Some(space) = find_end_of_value(after_eq) {
+                    remaining = &after_eq[space..];
+                    continue;
+                }
+                return String::new();
+            }
+        }
+        break;
+    }
+
+    remaining
+        .split_whitespace()
+        .next()
+        .unwrap_or("")
+        .to_string()
+}
+
+/// Extract the command following "sudo" (skip sudo flags).
+fn extract_sudo_inner(command: &str) -> &str {
+    let parts: Vec<&str> = command.split_whitespace().collect();
+    let sudo_idx = parts.iter().position(|&p| p == "sudo");
+    match sudo_idx {
+        Some(idx) => {
+            let rest = &parts[idx + 1..];
+            for &part in rest {
+                if !part.starts_with('-') {
+                    let offset = command.find(part).unwrap_or(0);
+                    return &command[offset..];
+                }
+            }
+            ""
+        }
+        None => "",
+    }
+}
+
+/// Find the end of a value in `KEY=value rest` (handles basic quoting).
+fn find_end_of_value(s: &str) -> Option<usize> {
+    let s = s.trim_start();
+    if s.is_empty() {
+        return None;
+    }
+
+    let first = s.as_bytes()[0];
+    if first == b'"' || first == b'\'' {
+        let quote = first;
+        let mut i = 1;
+        while i < s.len() {
+            if s.as_bytes()[i] == quote && (i == 0 || s.as_bytes()[i - 1] != b'\\') {
+                i += 1;
+                while i < s.len() && !s.as_bytes()[i].is_ascii_whitespace() {
+                    i += 1;
+                }
+                return if i < s.len() { Some(i) } else { None };
+            }
+            i += 1;
+        }
+        None
+    } else {
+        s.find(char::is_whitespace)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    // --- readOnlyValidation ---
+
     #[test]
-    fn skeleton_compiles() { /* W1 placeholder */
+    fn req_bash_validation_72_blocks_rm_in_read_only() {
+        assert!(matches!(
+            validate_read_only("rm -rf /tmp/x", PermissionMode::ReadOnly),
+            ValidationResult::Block { reason } if reason.contains("rm")
+        ));
+    }
+
+    #[test]
+    fn req_bash_validation_72_allows_rm_in_workspace_write() {
+        assert_eq!(
+            validate_read_only("rm -rf /tmp/x", PermissionMode::WorkspaceWrite),
+            ValidationResult::Allow
+        );
+    }
+
+    #[test]
+    fn req_bash_validation_72_blocks_write_redirections_in_read_only() {
+        assert!(matches!(
+            validate_read_only("echo hello > file.txt", PermissionMode::ReadOnly),
+            ValidationResult::Block { reason } if reason.contains("redirection")
+        ));
+    }
+
+    #[test]
+    fn req_bash_validation_72_allows_read_commands_in_read_only() {
+        assert_eq!(
+            validate_read_only("ls -la", PermissionMode::ReadOnly),
+            ValidationResult::Allow
+        );
+        assert_eq!(
+            validate_read_only("cat /etc/hosts", PermissionMode::ReadOnly),
+            ValidationResult::Allow
+        );
+        assert_eq!(
+            validate_read_only("grep -r pattern .", PermissionMode::ReadOnly),
+            ValidationResult::Allow
+        );
+    }
+
+    #[test]
+    fn req_bash_validation_72_blocks_sudo_write_in_read_only() {
+        assert!(matches!(
+            validate_read_only("sudo rm -rf /tmp/x", PermissionMode::ReadOnly),
+            ValidationResult::Block { reason } if reason.contains("rm")
+        ));
+    }
+
+    #[test]
+    fn req_bash_validation_72_blocks_git_push_in_read_only() {
+        assert!(matches!(
+            validate_read_only("git push origin main", PermissionMode::ReadOnly),
+            ValidationResult::Block { reason } if reason.contains("push")
+        ));
+    }
+
+    #[test]
+    fn req_bash_validation_72_allows_git_status_in_read_only() {
+        assert_eq!(
+            validate_read_only("git status", PermissionMode::ReadOnly),
+            ValidationResult::Allow
+        );
+    }
+
+    #[test]
+    fn req_bash_validation_72_blocks_package_install_in_read_only() {
+        assert!(matches!(
+            validate_read_only("npm install express", PermissionMode::ReadOnly),
+            ValidationResult::Block { reason } if reason.contains("npm")
+        ));
+    }
+
+    // --- destructiveCommandWarning ---
+
+    #[test]
+    fn req_bash_validation_72_warns_rm_rf_root() {
+        assert!(matches!(
+            check_destructive("rm -rf /"),
+            ValidationResult::Warn { message } if message.contains("root")
+        ));
+    }
+
+    #[test]
+    fn req_bash_validation_72_warns_rm_rf_home() {
+        assert!(matches!(
+            check_destructive("rm -rf ~"),
+            ValidationResult::Warn { message } if message.contains("home")
+        ));
+    }
+
+    #[test]
+    fn req_bash_validation_72_warns_shred() {
+        assert!(matches!(
+            check_destructive("shred /dev/sda"),
+            ValidationResult::Warn { message } if message.contains("destructive")
+        ));
+    }
+
+    #[test]
+    fn req_bash_validation_72_warns_fork_bomb() {
+        assert!(matches!(
+            check_destructive(":(){ :|:& };:"),
+            ValidationResult::Warn { message } if message.contains("Fork bomb")
+        ));
+    }
+
+    #[test]
+    fn req_bash_validation_72_allows_safe_commands() {
+        assert_eq!(check_destructive("ls -la"), ValidationResult::Allow);
+        assert_eq!(check_destructive("echo hello"), ValidationResult::Allow);
+    }
+
+    // --- modeValidation ---
+
+    #[test]
+    fn req_bash_validation_72_workspace_write_warns_system_paths() {
+        assert!(matches!(
+            validate_mode("cp file.txt /etc/config", PermissionMode::WorkspaceWrite),
+            ValidationResult::Warn { message } if message.contains("outside the workspace")
+        ));
+    }
+
+    #[test]
+    fn req_bash_validation_72_workspace_write_allows_local_writes() {
+        assert_eq!(
+            validate_mode("cp file.txt ./backup/", PermissionMode::WorkspaceWrite),
+            ValidationResult::Allow
+        );
+    }
+
+    // --- sedValidation ---
+
+    #[test]
+    fn req_bash_validation_72_blocks_sed_inplace_in_read_only() {
+        assert!(matches!(
+            validate_sed("sed -i 's/old/new/' file.txt", PermissionMode::ReadOnly),
+            ValidationResult::Block { reason } if reason.contains("sed -i")
+        ));
+    }
+
+    #[test]
+    fn req_bash_validation_72_allows_sed_stdout_in_read_only() {
+        assert_eq!(
+            validate_sed("sed 's/old/new/' file.txt", PermissionMode::ReadOnly),
+            ValidationResult::Allow
+        );
+    }
+
+    // --- pathValidation ---
+
+    #[test]
+    fn req_bash_validation_72_warns_directory_traversal() {
+        let workspace = PathBuf::from("/workspace/project");
+        assert!(matches!(
+            validate_paths("cat ../../../etc/passwd", &workspace),
+            ValidationResult::Warn { message } if message.contains("traversal")
+        ));
+    }
+
+    #[test]
+    fn req_bash_validation_72_warns_home_directory_reference() {
+        let workspace = PathBuf::from("/workspace/project");
+        assert!(matches!(
+            validate_paths("cat ~/.ssh/id_rsa", &workspace),
+            ValidationResult::Warn { message } if message.contains("home directory")
+        ));
+    }
+
+    // --- commandSemantics ---
+
+    #[test]
+    fn req_bash_validation_72_classifies_read_only_commands() {
+        assert_eq!(classify_command("ls -la"), CommandIntent::ReadOnly);
+        assert_eq!(classify_command("cat file.txt"), CommandIntent::ReadOnly);
+        assert_eq!(
+            classify_command("grep -r pattern ."),
+            CommandIntent::ReadOnly
+        );
+        assert_eq!(
+            classify_command("find . -name '*.rs'"),
+            CommandIntent::ReadOnly
+        );
+    }
+
+    #[test]
+    fn req_bash_validation_72_classifies_write_commands() {
+        assert_eq!(classify_command("cp a.txt b.txt"), CommandIntent::Write);
+        assert_eq!(classify_command("mv old.txt new.txt"), CommandIntent::Write);
+        assert_eq!(classify_command("mkdir -p /tmp/dir"), CommandIntent::Write);
+    }
+
+    #[test]
+    fn req_bash_validation_72_classifies_destructive_commands() {
+        assert_eq!(
+            classify_command("rm -rf /tmp/x"),
+            CommandIntent::Destructive
+        );
+        assert_eq!(
+            classify_command("shred /dev/sda"),
+            CommandIntent::Destructive
+        );
+    }
+
+    #[test]
+    fn req_bash_validation_72_classifies_network_commands() {
+        assert_eq!(
+            classify_command("curl https://example.com"),
+            CommandIntent::Network
+        );
+        assert_eq!(classify_command("wget file.zip"), CommandIntent::Network);
+    }
+
+    #[test]
+    fn req_bash_validation_72_classifies_sed_inplace_as_write() {
+        assert_eq!(
+            classify_command("sed -i 's/old/new/' file.txt"),
+            CommandIntent::Write
+        );
+    }
+
+    #[test]
+    fn req_bash_validation_72_classifies_sed_stdout_as_read_only() {
+        assert_eq!(
+            classify_command("sed 's/old/new/' file.txt"),
+            CommandIntent::ReadOnly
+        );
+    }
+
+    #[test]
+    fn req_bash_validation_72_classifies_git_status_as_read_only() {
+        assert_eq!(classify_command("git status"), CommandIntent::ReadOnly);
+        assert_eq!(
+            classify_command("git log --oneline"),
+            CommandIntent::ReadOnly
+        );
+    }
+
+    #[test]
+    fn req_bash_validation_72_classifies_git_push_as_write() {
+        assert_eq!(
+            classify_command("git push origin main"),
+            CommandIntent::Write
+        );
+    }
+
+    // --- validate_command (full pipeline) ---
+
+    #[test]
+    fn req_bash_validation_72_pipeline_blocks_write_in_read_only() {
+        let workspace = PathBuf::from("/workspace");
+        assert!(matches!(
+            validate_command("rm -rf /tmp/x", PermissionMode::ReadOnly, &workspace),
+            ValidationResult::Block { .. }
+        ));
+    }
+
+    #[test]
+    fn req_bash_validation_72_pipeline_warns_destructive_in_write_mode() {
+        let workspace = PathBuf::from("/workspace");
+        assert!(matches!(
+            validate_command("rm -rf /", PermissionMode::WorkspaceWrite, &workspace),
+            ValidationResult::Warn { .. }
+        ));
+    }
+
+    #[test]
+    fn req_bash_validation_72_pipeline_allows_safe_read_in_read_only() {
+        let workspace = PathBuf::from("/workspace");
+        assert_eq!(
+            validate_command("ls -la", PermissionMode::ReadOnly, &workspace),
+            ValidationResult::Allow
+        );
+    }
+
+    // --- extract_first_command ---
+
+    #[test]
+    fn req_bash_validation_72_extracts_command_from_env_prefix() {
+        assert_eq!(extract_first_command("FOO=bar ls -la"), "ls");
+        assert_eq!(extract_first_command("A=1 B=2 echo hello"), "echo");
+    }
+
+    #[test]
+    fn req_bash_validation_72_extracts_plain_command() {
+        assert_eq!(extract_first_command("grep -r pattern ."), "grep");
     }
 }

--- a/crates/dasclaw_bash_validation/src/permissions.rs
+++ b/crates/dasclaw_bash_validation/src/permissions.rs
@@ -1,0 +1,57 @@
+//! Permission mode for bash command validation.
+//!
+//! Self-contained port of `claw-code/rust/crates/runtime/src/permissions.rs`'s
+//! `PermissionMode` enum. Kept inside this crate so `dasclaw_bash_validation`
+//! has no cross-crate dependency on `dasclaw_governance` or runtime types.
+
+/// Permission level assigned to a tool invocation or runtime session.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum PermissionMode {
+    /// No filesystem or state mutations allowed.
+    ReadOnly,
+    /// Writes inside the workspace allowed; system-level writes warn.
+    WorkspaceWrite,
+    /// Full host access — bypass most validations.
+    DangerFullAccess,
+    /// Each invocation prompts the user.
+    Prompt,
+    /// Pre-approved invocation, treat as full access.
+    Allow,
+}
+
+impl PermissionMode {
+    /// Stable string identifier used by config / audit logs.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::ReadOnly => "read-only",
+            Self::WorkspaceWrite => "workspace-write",
+            Self::DangerFullAccess => "danger-full-access",
+            Self::Prompt => "prompt",
+            Self::Allow => "allow",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn req_bash_validation_72_permission_mode_as_str_stable() {
+        assert_eq!(PermissionMode::ReadOnly.as_str(), "read-only");
+        assert_eq!(PermissionMode::WorkspaceWrite.as_str(), "workspace-write");
+        assert_eq!(
+            PermissionMode::DangerFullAccess.as_str(),
+            "danger-full-access"
+        );
+        assert_eq!(PermissionMode::Prompt.as_str(), "prompt");
+        assert_eq!(PermissionMode::Allow.as_str(), "allow");
+    }
+
+    #[test]
+    fn req_bash_validation_72_permission_mode_ordering() {
+        assert!(PermissionMode::ReadOnly < PermissionMode::WorkspaceWrite);
+        assert!(PermissionMode::WorkspaceWrite < PermissionMode::DangerFullAccess);
+    }
+}


### PR DESCRIPTION
## 背景 / 目标

W4 D10 — 把 `claw-code/rust/crates/runtime/src/bash_validation.rs`（1004 LOC，6 验证模块）整体移植到独立 crate `dasclaw_bash_validation`。这是 BashTool 验证管线的源头，后续 #73（BeforeToolCall hook 接入）依赖本 PR 的公开 API。

**Source**: [docs/plans/architecture-refactor/32-execution-plan.md](docs/plans/architecture-refactor/32-execution-plan.md) W4 任务 v2 新增 D10。

**Depends on**: 无。**与已开 PR (#184 #185) 完全独立**：不同 crate，不同文件。

## 改动范围

- `crates/dasclaw_bash_validation/src/lib.rs`：**完整替换** W1 skeleton（24 行 trait 占位）→ 完整实现（1015 行，含测试）
- `crates/dasclaw_bash_validation/src/permissions.rs`：**新建**（52 行），inline-port `PermissionMode` 5 变种 + `as_str()`
- `Cargo.toml`：**无变更**（保持 `thiserror` 唯一依赖；本次实际未用 thiserror，保留以兼容 W1 trait surface 暂未删除的语义）

## 6 个模块映射

| 模块 | 源 | 公开符号 |
|---|---|---|
| readOnlyValidation | `tools/BashTool/readOnlyValidation.ts` | `validate_read_only`, `WRITE_COMMANDS`, `STATE_MODIFYING_COMMANDS`, `WRITE_REDIRECTIONS`, `GIT_READ_ONLY_SUBCOMMANDS` |
| destructiveCommandWarning | `tools/BashTool/destructiveCommandWarning.ts` | `check_destructive`, `DESTRUCTIVE_PATTERNS`, `ALWAYS_DESTRUCTIVE_COMMANDS` |
| modeValidation | `tools/BashTool/modeValidation.ts` | `validate_mode` |
| sedValidation | `tools/BashTool/sedValidation.ts` | `validate_sed` |
| pathValidation | `tools/BashTool/pathValidation.ts` | `validate_paths` |
| commandSemantics | `tools/BashTool/commandSemantics.ts` | `classify_command`, `CommandIntent`（8 变种） |

**入口公共 API**：`validate_command(cmd, mode, workspace) -> ValidationResult`（issue 验收点）。

## 决策语义

- 4 步管线顺序：`validate_mode` → `validate_sed` → `check_destructive` → `validate_paths`，遇 first non-Allow 立即返回
- ReadOnly：写命令/状态修改命令/写重定向/sudo+写/git 写子命令 → `Block`
- WorkspaceWrite：写命令命中系统路径（`/etc/`, `/usr/`, `/var/`...）→ `Warn`；workspace 内允许
- DangerFullAccess / Allow / Prompt → 全 Allow（按源语义）
- `rm -rf` 宽匹配 → 兜底 `Warn`
- `extract_first_command` 跳过 `KEY=val` env 前缀，正确识别 `FOO=bar ls -la` 的 `ls`

## 非目标 (What's NOT in this PR)

- 不接 `dasclaw_hooks::BeforeToolCall`：那是 #73 的工作（标了 `adr-redline`），本 PR 不越界
- 不引入 `serde` / `tracing`：源文件无序列化与日志，强加属补丁式扩张
- 不引入 `dasclaw_governance` 依赖：`PermissionMode` 在源头是 runtime crate 内部类型，inline-port 到本 crate 的 `permissions` 子模块即可保持低耦合；如未来需要统一身份模型，单独通过 trait 桥接
- 不删除 `thiserror` dep：保持 Cargo.toml 静默零变更（与 #181/#182/#183/#184/#185 同纪律）

## 验证

```bash
cargo check -p dasclaw_bash_validation --tests              # PASS (1.18s)
cargo nextest run -p dasclaw_bash_validation                # 34 tests run: 34 passed
cargo fmt --all                                              # clean
python3.12 scripts/check_no_panics.py --base origin/xClaw   # OK: No panic-inducing calls
cargo clippy --no-deps -p dasclaw_bash_validation \
  --all-targets -- -D warnings                              # 0 warning
```

测试列表（全 `req_bash_validation_72_*`）：

| 类别 | 个数 | 覆盖点 |
|---|---|---|
| readOnly | 8 | rm/redir/sudo/git push/git status/npm install/正例/cat |
| destructive | 5 | rm-rf-/、rm-rf-~、shred、fork bomb、安全例 |
| modeValidation | 2 | system path warn / 本地 allow |
| sedValidation | 2 | sed -i block / sed stdout allow |
| pathValidation | 2 | `../` 遍历 / `~/` |
| commandSemantics | 8 | RO/Write/Destructive/Network/sed-i/sed-stdout/git-status/git-push |
| pipeline | 3 | block/warn/allow 三态贯通 |
| extract_first_command | 2 | env 前缀 / 平凡 |
| permissions | 2 | as_str 稳定 / 序关系 |

**34 PASS / 0 FAIL / 0 LEAK**。

## 设计取舍（no-patch 自检）

- **完整替换 stub**：W1 skeleton 的 `BashValidator` trait 与 `SkeletonError` 是占位，无下游使用，整体替换不破坏调用方
- **inline `PermissionMode`**：避免 `dasclaw_bash_validation` 反向依赖 `dasclaw_governance` 或新建运行时 crate；类型形状与源文件 1:1 对齐（5 变种 + `as_str` + `Ord`）
- **测试名带 issue id**：`req_bash_validation_72_*` 符合 AGENTS.md 的需求测试命名约定
- **0 panic / 0 unwrap / 0 expect** 在生产代码：仅有 `unwrap_or("")` / `unwrap_or(0)` 兜底（panic 红线放行）
- **未引入 unsafe / async / serde**：源文件本身全同步 std-only，不擅自升级
- 模块顺序、常量数组顺序、错误文案与源完全一致，无"优化型"重排

## Skills 自审

- `code-quality-audit`：最长函数 `validate_read_only` 约 50 行（5 段线性 if 链 + 早 return），其余 ≤ 30 行；无嵌套 match 深度 > 2；无 dead code（除 `extract_first_command` 单元测试覆盖了 env 跳过路径）。
- `code-simplifier`：`validate_read_only`、`validate_mode`、`validate_command` 三处都做"逐项早 return"，提炼成 helper 反而隐藏顺序契约（管线顺序就是规则），保持线性。
- `code-review-expert`：测试矩阵覆盖每个模块的"安全方向"和"危险方向"两面，避免只测 happy path；命名带 issue id 便于回溯；`PermissionMode::Ord` 单测显式锁定全序，防止后续被错误重排。

## 后续

- #73 [W4] BeforeToolCall hook: bash_validation 接入（`adr-redline`，留给人类）
- 若后续合并 `dasclaw_governance::PermissionMode`，再做 trait 桥接 / re-export，**不**在本 PR 提前耦合

Closes #72
