### PR TITLE
feat(governance): port green_contract level 0-3 + lane policy bridge (#70)

### DIFF
--- a/crates/dasclaw_governance/Cargo.toml
+++ b/crates/dasclaw_governance/Cargo.toml
@@ -20,7 +20,7 @@ trust_resolver = []
 branch_lock = ["dep:serde"]
 stale_base = []
 stale_branch = []
-green_contract = []
+green_contract = ["dep:serde"]
 lane_events = []
 # Convenience: enable the full 6-pack at once (used by integration tests).
 full = [

--- a/crates/dasclaw_governance/src/green_contract.rs
+++ b/crates/dasclaw_governance/src/green_contract.rs
@@ -1,5 +1,326 @@
-//! `green_contract` — W4 placeholder. Implementation lands in follow-up issue.
+//! Green contract — declarative test-greenness contracts (level 0–3).
 //!
-//! See the module table in `lib.rs` for issue mapping.
+//! Ported from `claw-code/rust/crates/runtime/src/green_contract.rs` (W4 #70).
+//!
+//! A `GreenContract` declares the minimum [`GreenLevel`] required for a lane
+//! to be considered "merge-green". Evaluation accepts an `Option<GreenLevel>`
+//! (None = no observation yet) and returns a [`GreenContractOutcome`].
+//!
+//! Level ordering (`PartialOrd`/`Ord`) is **stable, ascending**:
+//! `TargetedTests < Package < Workspace < MergeReady`.
+//!
+//! Lane-completion integration helper [`evaluate_completed_lane`] is gated
+//! behind both the `green_contract` and `policy_engine` features so the
+//! green contract's policy effect (CloseoutLane / CleanupSession) can be
+//! exercised by integration tests when both modules are active. The
+//! `AgentOutput`-shaped `detect_lane_completion` adapter from the source
+//! crate is **not** ported here (depends on a `tools::AgentOutput` type that
+//! doesn't exist in x-claw yet) — see Non-target in PR #70 for rationale.
 
-#![allow(dead_code)]
+use serde::{Deserialize, Serialize};
+
+/// Green level a lane has reached. Higher = more verified.
+///
+/// 4 levels mapped to issue requirement "level 0–3":
+/// - 0 = `TargetedTests`
+/// - 1 = `Package`
+/// - 2 = `Workspace`
+/// - 3 = `MergeReady`
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GreenLevel {
+    /// Level 0 — only the targeted tests for the change ran green.
+    TargetedTests,
+    /// Level 1 — the owning package's full test suite ran green.
+    Package,
+    /// Level 2 — the entire workspace ran green.
+    Workspace,
+    /// Level 3 — workspace + integration + reviewer sign-off; ready to merge.
+    MergeReady,
+}
+
+impl GreenLevel {
+    /// Stable string identifier used by config, audit logs, and serde.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::TargetedTests => "targeted_tests",
+            Self::Package => "package",
+            Self::Workspace => "workspace",
+            Self::MergeReady => "merge_ready",
+        }
+    }
+}
+
+impl std::fmt::Display for GreenLevel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+/// Contract declaring the minimum [`GreenLevel`] required to merge.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GreenContract {
+    /// Minimum green level the lane must reach.
+    pub required_level: GreenLevel,
+}
+
+impl GreenContract {
+    /// Create a contract requiring at least `required_level`.
+    #[must_use]
+    pub fn new(required_level: GreenLevel) -> Self {
+        Self { required_level }
+    }
+
+    /// Evaluate the contract against the current observation.
+    ///
+    /// `None` for `observed_level` means "no green report yet" — always
+    /// `Unsatisfied`. Any observed level >= `required_level` satisfies.
+    #[must_use]
+    pub fn evaluate(self, observed_level: Option<GreenLevel>) -> GreenContractOutcome {
+        match observed_level {
+            Some(level) if level >= self.required_level => GreenContractOutcome::Satisfied {
+                required_level: self.required_level,
+                observed_level: level,
+            },
+            _ => GreenContractOutcome::Unsatisfied {
+                required_level: self.required_level,
+                observed_level,
+            },
+        }
+    }
+
+    /// Convenience predicate when the caller already has a definite level.
+    #[must_use]
+    pub fn is_satisfied_by(self, observed_level: GreenLevel) -> bool {
+        observed_level >= self.required_level
+    }
+}
+
+/// Outcome of evaluating a [`GreenContract`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "outcome", rename_all = "snake_case")]
+pub enum GreenContractOutcome {
+    /// `observed_level >= required_level`.
+    Satisfied {
+        required_level: GreenLevel,
+        observed_level: GreenLevel,
+    },
+    /// `observed_level < required_level` (or `None`).
+    Unsatisfied {
+        required_level: GreenLevel,
+        observed_level: Option<GreenLevel>,
+    },
+}
+
+impl GreenContractOutcome {
+    /// `true` iff the contract was satisfied.
+    #[must_use]
+    pub fn is_satisfied(&self) -> bool {
+        matches!(self, Self::Satisfied { .. })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Lane completion ↔ green contract integration
+// ---------------------------------------------------------------------------
+
+/// Map a [`GreenLevel`] to the `u8` level used by
+/// [`crate::policy_engine::PolicyCondition::GreenAt`].
+///
+/// `TargetedTests = 0, Package = 1, Workspace = 2, MergeReady = 3` — matches
+/// the issue title's "level 0-3" requirement and the policy_engine contract.
+#[must_use]
+pub fn level_as_u8(level: GreenLevel) -> u8 {
+    match level {
+        GreenLevel::TargetedTests => 0,
+        GreenLevel::Package => 1,
+        GreenLevel::Workspace => 2,
+        GreenLevel::MergeReady => 3,
+    }
+}
+
+/// Lane-completion → policy_engine integration helper.
+///
+/// Given a completed [`crate::policy_engine::LaneContext`], returns the
+/// [`crate::policy_engine::PolicyAction`]s the green-contract policy fires
+/// (closeout + cleanup). Gated on `policy_engine` because it consumes the
+/// engine's types directly.
+#[cfg(feature = "policy_engine")]
+#[must_use]
+pub fn evaluate_completed_lane(
+    context: &crate::policy_engine::LaneContext,
+) -> Vec<crate::policy_engine::PolicyAction> {
+    use crate::policy_engine::{evaluate, PolicyAction, PolicyCondition, PolicyEngine, PolicyRule};
+
+    let engine = PolicyEngine::new(vec![
+        PolicyRule::new(
+            "closeout-completed-lane",
+            PolicyCondition::And(vec![
+                PolicyCondition::LaneCompleted,
+                PolicyCondition::GreenAt {
+                    level: level_as_u8(GreenLevel::MergeReady),
+                },
+            ]),
+            PolicyAction::CloseoutLane,
+            10,
+        ),
+        PolicyRule::new(
+            "cleanup-completed-session",
+            PolicyCondition::LaneCompleted,
+            PolicyAction::CleanupSession,
+            5,
+        ),
+    ]);
+
+    evaluate(&engine, context)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn req_green_contract_70_matching_level_satisfies_contract() {
+        let contract = GreenContract::new(GreenLevel::Package);
+
+        let outcome = contract.evaluate(Some(GreenLevel::Package));
+
+        assert_eq!(
+            outcome,
+            GreenContractOutcome::Satisfied {
+                required_level: GreenLevel::Package,
+                observed_level: GreenLevel::Package,
+            }
+        );
+        assert!(outcome.is_satisfied());
+    }
+
+    #[test]
+    fn req_green_contract_70_higher_level_still_satisfies() {
+        let contract = GreenContract::new(GreenLevel::TargetedTests);
+
+        assert!(contract.is_satisfied_by(GreenLevel::Workspace));
+        assert!(contract.is_satisfied_by(GreenLevel::MergeReady));
+    }
+
+    #[test]
+    fn req_green_contract_70_lower_level_unsatisfied() {
+        let contract = GreenContract::new(GreenLevel::Workspace);
+
+        let outcome = contract.evaluate(Some(GreenLevel::Package));
+
+        assert_eq!(
+            outcome,
+            GreenContractOutcome::Unsatisfied {
+                required_level: GreenLevel::Workspace,
+                observed_level: Some(GreenLevel::Package),
+            }
+        );
+        assert!(!outcome.is_satisfied());
+    }
+
+    #[test]
+    fn req_green_contract_70_no_observation_unsatisfied() {
+        let contract = GreenContract::new(GreenLevel::MergeReady);
+
+        let outcome = contract.evaluate(None);
+
+        assert_eq!(
+            outcome,
+            GreenContractOutcome::Unsatisfied {
+                required_level: GreenLevel::MergeReady,
+                observed_level: None,
+            }
+        );
+        assert!(!outcome.is_satisfied());
+    }
+
+    #[test]
+    fn req_green_contract_70_level_ordering_is_ascending() {
+        assert!(GreenLevel::TargetedTests < GreenLevel::Package);
+        assert!(GreenLevel::Package < GreenLevel::Workspace);
+        assert!(GreenLevel::Workspace < GreenLevel::MergeReady);
+    }
+
+    #[test]
+    fn req_green_contract_70_level_as_u8_maps_zero_through_three() {
+        assert_eq!(level_as_u8(GreenLevel::TargetedTests), 0);
+        assert_eq!(level_as_u8(GreenLevel::Package), 1);
+        assert_eq!(level_as_u8(GreenLevel::Workspace), 2);
+        assert_eq!(level_as_u8(GreenLevel::MergeReady), 3);
+    }
+
+    #[test]
+    fn req_green_contract_70_as_str_round_trip() {
+        for level in [
+            GreenLevel::TargetedTests,
+            GreenLevel::Package,
+            GreenLevel::Workspace,
+            GreenLevel::MergeReady,
+        ] {
+            assert_eq!(level.to_string(), level.as_str());
+        }
+    }
+
+    #[cfg(feature = "policy_engine")]
+    #[test]
+    fn req_green_contract_70_evaluate_completed_lane_fires_closeout_and_cleanup() {
+        use crate::policy_engine::{
+            DiffScope, LaneBlocker, LaneContext, PolicyAction, ReviewStatus,
+        };
+        use std::time::Duration;
+
+        let ctx = LaneContext {
+            lane_id: "completed-lane".to_string(),
+            green_level: level_as_u8(GreenLevel::MergeReady),
+            branch_freshness: Duration::from_secs(0),
+            blocker: LaneBlocker::None,
+            review_status: ReviewStatus::Approved,
+            diff_scope: DiffScope::Scoped,
+            completed: true,
+            reconciled: false,
+        };
+
+        let actions = evaluate_completed_lane(&ctx);
+
+        assert!(
+            actions.contains(&PolicyAction::CloseoutLane),
+            "expected CloseoutLane in {actions:?}"
+        );
+        assert!(
+            actions.contains(&PolicyAction::CleanupSession),
+            "expected CleanupSession in {actions:?}"
+        );
+    }
+
+    #[cfg(feature = "policy_engine")]
+    #[test]
+    fn req_green_contract_70_evaluate_incomplete_lane_no_closeout() {
+        use crate::policy_engine::{
+            DiffScope, LaneBlocker, LaneContext, PolicyAction, ReviewStatus,
+        };
+        use std::time::Duration;
+
+        // A lane that has NOT completed — closeout/cleanup must NOT fire.
+        let ctx = LaneContext {
+            lane_id: "active-lane".to_string(),
+            green_level: level_as_u8(GreenLevel::MergeReady),
+            branch_freshness: Duration::from_secs(0),
+            blocker: LaneBlocker::None,
+            review_status: ReviewStatus::Approved,
+            diff_scope: DiffScope::Scoped,
+            completed: false,
+            reconciled: false,
+        };
+
+        let actions = evaluate_completed_lane(&ctx);
+
+        assert!(!actions.contains(&PolicyAction::CloseoutLane));
+        assert!(!actions.contains(&PolicyAction::CleanupSession));
+    }
+}


### PR DESCRIPTION
## 背景 / 目标

W4 governance 6 件套第 5 件 — 把 `claw-code/rust/crates/runtime/src/green_contract.rs`（152 LOC）整体移植到 `dasclaw_governance::green_contract`，并加一条与 `policy_engine`（#65, 已合 #184）的"联动测试"桥接（issue 验收点）。

**Source**: [docs/plans/architecture-refactor/32-execution-plan.md](docs/plans/architecture-refactor/32-execution-plan.md) W4 任务 1。

**Depends on**: #65（policy_engine）— 已合（#184），可直接消费 `LaneContext` / `PolicyAction` / `evaluate`。

**与开 PR (#185 trust_resolver, #186 bash_validation) 完全独立**：不同文件 / 不同 crate。

## 改动范围

- `crates/dasclaw_governance/src/green_contract.rs`：**完整替换** W4 stub（5 行）→ 完整实现（327 行，含测试）
- `crates/dasclaw_governance/Cargo.toml`：1 行变更，`green_contract = []` → `green_contract = ["dep:serde"]`（**必需**——源文件用 `#[derive(Serialize, Deserialize)]`，非 drift）

## 公开 API

```rust
pub enum GreenLevel { TargetedTests, Package, Workspace, MergeReady }   // Ord 升序
pub fn level_as_u8(level: GreenLevel) -> u8                              // 0..=3

pub struct GreenContract { pub required_level: GreenLevel }
impl GreenContract {
    pub fn new(required_level: GreenLevel) -> Self
    pub fn evaluate(self, observed: Option<GreenLevel>) -> GreenContractOutcome
    pub fn is_satisfied_by(self, observed: GreenLevel) -> bool
}

pub enum GreenContractOutcome {
    Satisfied   { required_level, observed_level: GreenLevel },
    Unsatisfied { required_level, observed_level: Option<GreenLevel> },
}

#[cfg(feature = "policy_engine")]
pub fn evaluate_completed_lane(&LaneContext) -> Vec<PolicyAction>
```

## 决策语义

- `GreenLevel` 严格升序：`TargetedTests < Package < Workspace < MergeReady`（4 个 level，对应 issue 标题"level 0-3"）
- `evaluate(None)` → `Unsatisfied`（fail-closed：无观察就不放行）
- `observed >= required` → `Satisfied`，否则 `Unsatisfied`
- `evaluate_completed_lane`：`completed && green at level 3` → 触发 `CloseoutLane`（priority 10）+ `CleanupSession`（priority 5）；`completed=false` → 都不触发（守护红线）
- serde 序列化 tag = `outcome`，rename_all = snake_case（与源 1:1）

## 非目标 (What's NOT in this PR)

- **不**移植 `claw-code/rust/crates/tools/src/lane_completion.rs::detect_lane_completion(AgentOutput, ...)`：该函数依赖 `tools::AgentOutput` 类型，x-claw 的 `dasclaw_governance` 不应耦合 agent crate 的输出形状。`evaluate_completed_lane(LaneContext)` 已经覆盖 issue 的"green_contract 与 lane_completion 联动测试"要点（输入用 governance 自己的 `LaneContext`，输出用 governance 的 `PolicyAction`）。`AgentOutput` → `LaneContext` 的 adapter 属 `x_claw_agent` 范围，单独跟踪。
- **不**改 `default = []` 契约（运行时 test `req_governance_64_default_features_off` 仍绿）
- **不**引入 `serde_json` dev-dep：源文件没有 JSON round-trip 测试，强加属补丁式扩张
- **不**新增 `lane_events` / `recovery_recipes` 实现（各自独立 issue：#71 / #66）

## 验证

```bash
cargo check -p dasclaw_governance --tests --features green_contract
# PASS

cargo check -p dasclaw_governance --tests --features "green_contract policy_engine"
# PASS

cargo nextest run -p dasclaw_governance --features "green_contract policy_engine"
# 21 tests run: 21 passed (9 green_contract_70 + 10 policy_engine_65 + 2 skeleton)

cargo fmt --all
python3.12 scripts/check_no_panics.py --base origin/xClaw   # OK
cargo clippy --no-deps -p dasclaw_governance --all-targets \
  --features "green_contract policy_engine" -- -D warnings   # 0 warning
```

测试覆盖（全 `req_green_contract_70_*`）：

| 测试 | 验收点 |
|---|---|
| `matching_level_satisfies_contract` | observed == required → Satisfied |
| `higher_level_still_satisfies` | observed > required → Satisfied |
| `lower_level_unsatisfied` | observed < required → Unsatisfied(Some) |
| `no_observation_unsatisfied` | None → Unsatisfied(None) |
| `level_ordering_is_ascending` | enum Ord 不可被错误重排 |
| `level_as_u8_maps_zero_through_three` | 0/1/2/3 映射稳定 |
| `as_str_round_trip` | Display ≡ as_str() |
| `evaluate_completed_lane_fires_closeout_and_cleanup` ⭐ | green_contract × policy_engine 联动 |
| `evaluate_incomplete_lane_no_closeout` ⭐ | completed=false 时两个 action 都不触发（守护边界） |

⭐ = issue 验收点要求的"联动测试"。

## 设计取舍（no-patch 自检）

- **完整替换 stub**：源文件 152 行原样移植，仅做 doc-comment 增强 + test 改名为 `req_green_contract_70_*`（命名约定）
- **Cargo.toml 1 行变更**：feature 开 `dep:serde` 是源文件 `derive(Serialize)` 的硬需求，非 drift
- **bridge 单独 cfg gate**：`evaluate_completed_lane` 用 `#[cfg(feature = "policy_engine")]`，避免 green_contract feature 被开但 policy_engine 没开时编译失败
- **拒绝补丁式扩张**：源文件无 OAuth / 无 AgentOutput adapter / 无 JSON round-trip，本 PR 都**不**加（解释见 Non-target）
- **0 panic / 0 unwrap / 0 expect** 在生产代码
- 没有引入 `unsafe`，没有引入异步

## Skills 自审

- `code-quality-audit`：最长函数 `evaluate_completed_lane` ~25 行（一个 `PolicyEngine::new` builder），其余 ≤ 10 行；无嵌套 match；常量数组顺序与 source 1:1。
- `code-simplifier`：`level_as_u8` 是 4 路分支 match，未用 `as u8` 强转——因 `GreenLevel` 没有显式 `#[repr(u8)]`，`as u8` 不稳定；显式 match 是契约级映射，更安全。
- `code-review-expert`：`evaluate_completed_lane` 用 cfg gate 而非 hard dep，下游可只开 `green_contract` 不付出 policy_engine 的代价；`Unsatisfied` 同时携带 `Option<GreenLevel>`（保留"曾观察过但低于阈值"和"从未观察"两态），避免后续 debug 信息丢失。

## 后续

- #66 recovery_recipes（依赖 #65 已合，可立即开始）
- #71 lane_events（依赖多模块）
- 独立 issue：`detect_lane_completion(AgentOutput)` adapter 落地 `x_claw_agent`
- 当 `dasclaw_governance` 与 `claw-code` 完全断舍后，把 `policy_engine::GreenLevel`（u8 别名）也升级成本 PR 的强类型 enum（重构议题，不在本 PR）

Closes #70
