### PR TITLE
feat(governance): port task_registry from claw-code runtime (#199)

### DIFF
--- a/crates/dasclaw_governance/Cargo.toml
+++ b/crates/dasclaw_governance/Cargo.toml
@@ -24,6 +24,7 @@ green_contract = ["dep:serde"]
 lane_events = ["dep:serde", "dep:serde_json"]
 team_cron_registry = ["dep:serde", "dep:serde_json"]
 task_packet = ["dep:serde", "dep:serde_json"]
+task_registry = ["dep:serde", "dep:serde_json", "task_packet"]
 # Convenience: enable the full 6-pack + task lifecycle at once (used by integration tests).
 full = [
     "policy_engine",
@@ -36,6 +37,7 @@ full = [
     "lane_events",
     "team_cron_registry",
     "task_packet",
+    "task_registry",
 ]
 
 [dependencies]

--- a/crates/dasclaw_governance/src/lib.rs
+++ b/crates/dasclaw_governance/src/lib.rs
@@ -72,6 +72,9 @@ pub mod team_cron_registry;
 #[cfg(feature = "task_packet")]
 pub mod task_packet;
 
+#[cfg(feature = "task_registry")]
+pub mod task_registry;
+
 #[cfg(test)]
 mod tests {
     #[test]

--- a/crates/dasclaw_governance/src/task_registry.rs
+++ b/crates/dasclaw_governance/src/task_registry.rs
@@ -1,0 +1,555 @@
+//! In-memory task registry for sub-agent task lifecycle management.
+//!
+//! Ported from `claw-code/rust/crates/runtime/src/task_registry.rs` (W5 #199).
+//!
+//! ## Hardening vs upstream
+//!
+//! Upstream uses `mutex.lock().expect("registry lock poisoned")` at every
+//! lock site. That violates the dasclaw red-line `scripts/check_no_panics.py`
+//! (no `.expect()` in production code). We instead route every lock through
+//! [`lock_registry`], which calls `unwrap_or_else(|p| p.into_inner())` —
+//! a Fail-Safe recovery that lets a healthy task continue serving requests
+//! after another thread panicked while holding the lock.
+//!
+//! See `req_task_registry_199_lock_recovers_from_poison` for the explicit
+//! poison-recovery contract.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, MutexGuard};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize};
+
+use super::task_packet::{validate_packet, TaskPacket, TaskPacketValidationError};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TaskStatus {
+    Created,
+    Running,
+    Completed,
+    Failed,
+    Stopped,
+}
+
+impl std::fmt::Display for TaskStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Created => write!(f, "created"),
+            Self::Running => write!(f, "running"),
+            Self::Completed => write!(f, "completed"),
+            Self::Failed => write!(f, "failed"),
+            Self::Stopped => write!(f, "stopped"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Task {
+    pub task_id: String,
+    pub prompt: String,
+    pub description: Option<String>,
+    pub task_packet: Option<TaskPacket>,
+    pub status: TaskStatus,
+    pub created_at: u64,
+    pub updated_at: u64,
+    pub messages: Vec<TaskMessage>,
+    pub output: String,
+    pub team_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct TaskMessage {
+    pub role: String,
+    pub content: String,
+    pub timestamp: u64,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct TaskRegistry {
+    inner: Arc<Mutex<RegistryInner>>,
+}
+
+#[derive(Debug, Default)]
+struct RegistryInner {
+    tasks: HashMap<String, Task>,
+    counter: u64,
+}
+
+fn now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+/// Acquire the registry mutex with Fail-Safe poison recovery.
+///
+/// Replaces upstream's `.expect("registry lock poisoned")` red-line violation.
+/// If a previous holder panicked, we recover the inner state and continue —
+/// see `req_task_registry_199_lock_recovers_from_poison` for the contract.
+fn lock_registry(m: &Mutex<RegistryInner>) -> MutexGuard<'_, RegistryInner> {
+    m.lock().unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+impl TaskRegistry {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn create(&self, prompt: &str, description: Option<&str>) -> Task {
+        self.create_task(prompt.to_owned(), description.map(str::to_owned), None)
+    }
+
+    pub fn create_from_packet(
+        &self,
+        packet: TaskPacket,
+    ) -> Result<Task, TaskPacketValidationError> {
+        let packet = validate_packet(packet)?.into_inner();
+        let description = packet
+            .scope_path
+            .clone()
+            .or_else(|| Some(packet.scope.to_string()));
+        Ok(self.create_task(packet.objective.clone(), description, Some(packet)))
+    }
+
+    fn create_task(
+        &self,
+        prompt: String,
+        description: Option<String>,
+        task_packet: Option<TaskPacket>,
+    ) -> Task {
+        let mut inner = lock_registry(&self.inner);
+        inner.counter += 1;
+        let ts = now_secs();
+        let task_id = format!("task_{:08x}_{}", ts, inner.counter);
+        let task = Task {
+            task_id: task_id.clone(),
+            prompt,
+            description,
+            task_packet,
+            status: TaskStatus::Created,
+            created_at: ts,
+            updated_at: ts,
+            messages: Vec::new(),
+            output: String::new(),
+            team_id: None,
+        };
+        inner.tasks.insert(task_id, task.clone());
+        task
+    }
+
+    #[must_use]
+    pub fn get(&self, task_id: &str) -> Option<Task> {
+        let inner = lock_registry(&self.inner);
+        inner.tasks.get(task_id).cloned()
+    }
+
+    #[must_use]
+    pub fn list(&self, status_filter: Option<TaskStatus>) -> Vec<Task> {
+        let inner = lock_registry(&self.inner);
+        inner
+            .tasks
+            .values()
+            .filter(|t| status_filter.is_none_or(|s| t.status == s))
+            .cloned()
+            .collect()
+    }
+
+    pub fn stop(&self, task_id: &str) -> Result<Task, String> {
+        let mut inner = lock_registry(&self.inner);
+        let task = inner
+            .tasks
+            .get_mut(task_id)
+            .ok_or_else(|| format!("task not found: {task_id}"))?;
+
+        match task.status {
+            TaskStatus::Completed | TaskStatus::Failed | TaskStatus::Stopped => {
+                return Err(format!(
+                    "task {task_id} is already in terminal state: {}",
+                    task.status
+                ));
+            }
+            _ => {}
+        }
+
+        task.status = TaskStatus::Stopped;
+        task.updated_at = now_secs();
+        Ok(task.clone())
+    }
+
+    pub fn update(&self, task_id: &str, message: &str) -> Result<Task, String> {
+        let mut inner = lock_registry(&self.inner);
+        let task = inner
+            .tasks
+            .get_mut(task_id)
+            .ok_or_else(|| format!("task not found: {task_id}"))?;
+
+        task.messages.push(TaskMessage {
+            role: String::from("user"),
+            content: message.to_owned(),
+            timestamp: now_secs(),
+        });
+        task.updated_at = now_secs();
+        Ok(task.clone())
+    }
+
+    pub fn output(&self, task_id: &str) -> Result<String, String> {
+        let inner = lock_registry(&self.inner);
+        let task = inner
+            .tasks
+            .get(task_id)
+            .ok_or_else(|| format!("task not found: {task_id}"))?;
+        Ok(task.output.clone())
+    }
+
+    pub fn append_output(&self, task_id: &str, output: &str) -> Result<(), String> {
+        let mut inner = lock_registry(&self.inner);
+        let task = inner
+            .tasks
+            .get_mut(task_id)
+            .ok_or_else(|| format!("task not found: {task_id}"))?;
+        task.output.push_str(output);
+        task.updated_at = now_secs();
+        Ok(())
+    }
+
+    pub fn set_status(&self, task_id: &str, status: TaskStatus) -> Result<(), String> {
+        let mut inner = lock_registry(&self.inner);
+        let task = inner
+            .tasks
+            .get_mut(task_id)
+            .ok_or_else(|| format!("task not found: {task_id}"))?;
+        task.status = status;
+        task.updated_at = now_secs();
+        Ok(())
+    }
+
+    pub fn assign_team(&self, task_id: &str, team_id: &str) -> Result<(), String> {
+        let mut inner = lock_registry(&self.inner);
+        let task = inner
+            .tasks
+            .get_mut(task_id)
+            .ok_or_else(|| format!("task not found: {task_id}"))?;
+        task.team_id = Some(team_id.to_owned());
+        task.updated_at = now_secs();
+        Ok(())
+    }
+
+    pub fn remove(&self, task_id: &str) -> Option<Task> {
+        let mut inner = lock_registry(&self.inner);
+        inner.tasks.remove(task_id)
+    }
+
+    #[must_use]
+    pub fn len(&self) -> usize {
+        let inner = lock_registry(&self.inner);
+        inner.tasks.len()
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::task_packet::TaskScope;
+    use super::*;
+
+    fn sample_packet() -> TaskPacket {
+        TaskPacket {
+            objective: "Ship task packet support".to_string(),
+            scope: TaskScope::Module,
+            scope_path: Some("runtime/task system".to_string()),
+            worktree: Some("/tmp/wt-task".to_string()),
+            repo: "claw-code-parity".to_string(),
+            branch_policy: "origin/main only".to_string(),
+            acceptance_tests: vec!["cargo test --workspace".to_string()],
+            commit_policy: "single commit".to_string(),
+            reporting_contract: "print commit sha".to_string(),
+            escalation_policy: "manual escalation".to_string(),
+        }
+    }
+
+    #[test]
+    fn req_task_registry_199_creates_and_retrieves_tasks() {
+        let registry = TaskRegistry::new();
+        let task = registry.create("Do something", Some("A test task"));
+        assert_eq!(task.status, TaskStatus::Created);
+        assert_eq!(task.prompt, "Do something");
+        assert_eq!(task.description.as_deref(), Some("A test task"));
+        assert_eq!(task.task_packet, None);
+
+        let fetched = registry.get(&task.task_id).expect("task should exist");
+        assert_eq!(fetched.task_id, task.task_id);
+    }
+
+    #[test]
+    fn req_task_registry_199_creates_task_from_packet() {
+        let registry = TaskRegistry::new();
+        let packet = sample_packet();
+
+        let task = registry
+            .create_from_packet(packet.clone())
+            .expect("packet-backed task should be created");
+
+        assert_eq!(task.prompt, packet.objective);
+        assert_eq!(task.description.as_deref(), Some("runtime/task system"));
+        assert_eq!(task.task_packet, Some(packet.clone()));
+
+        let fetched = registry.get(&task.task_id).expect("task should exist");
+        assert_eq!(fetched.task_packet, Some(packet));
+    }
+
+    #[test]
+    fn req_task_registry_199_create_from_packet_propagates_validation_error() {
+        let registry = TaskRegistry::new();
+        let mut packet = sample_packet();
+        packet.objective = String::new(); // missing required field
+
+        let err = registry
+            .create_from_packet(packet)
+            .expect_err("validation error should propagate");
+
+        assert!(!err.errors().is_empty());
+        assert!(registry.is_empty());
+    }
+
+    #[test]
+    fn req_task_registry_199_create_from_packet_falls_back_to_scope_string() {
+        let registry = TaskRegistry::new();
+        let mut packet = sample_packet();
+        packet.scope = TaskScope::Workspace;
+        packet.scope_path = None;
+
+        let task = registry
+            .create_from_packet(packet)
+            .expect("workspace-scoped packet should be valid");
+
+        assert_eq!(task.description.as_deref(), Some("workspace"));
+    }
+
+    #[test]
+    fn req_task_registry_199_lists_tasks_with_optional_filter() {
+        let registry = TaskRegistry::new();
+        registry.create("Task A", None);
+        let task_b = registry.create("Task B", None);
+        registry
+            .set_status(&task_b.task_id, TaskStatus::Running)
+            .expect("set status should succeed");
+
+        let all = registry.list(None);
+        assert_eq!(all.len(), 2);
+
+        let running = registry.list(Some(TaskStatus::Running));
+        assert_eq!(running.len(), 1);
+        assert_eq!(running[0].task_id, task_b.task_id);
+
+        let created = registry.list(Some(TaskStatus::Created));
+        assert_eq!(created.len(), 1);
+    }
+
+    #[test]
+    fn req_task_registry_199_stops_running_task() {
+        let registry = TaskRegistry::new();
+        let task = registry.create("Stoppable", None);
+        registry
+            .set_status(&task.task_id, TaskStatus::Running)
+            .expect("set status should succeed");
+
+        let stopped = registry.stop(&task.task_id).expect("stop should succeed");
+        assert_eq!(stopped.status, TaskStatus::Stopped);
+
+        let result = registry.stop(&task.task_id);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn req_task_registry_199_updates_task_with_messages() {
+        let registry = TaskRegistry::new();
+        let task = registry.create("Messageable", None);
+        let updated = registry
+            .update(&task.task_id, "Here's more context")
+            .expect("update should succeed");
+        assert_eq!(updated.messages.len(), 1);
+        assert_eq!(updated.messages[0].content, "Here's more context");
+        assert_eq!(updated.messages[0].role, "user");
+    }
+
+    #[test]
+    fn req_task_registry_199_appends_and_retrieves_output() {
+        let registry = TaskRegistry::new();
+        let task = registry.create("Output task", None);
+        registry
+            .append_output(&task.task_id, "line 1\n")
+            .expect("append should succeed");
+        registry
+            .append_output(&task.task_id, "line 2\n")
+            .expect("append should succeed");
+
+        let output = registry.output(&task.task_id).expect("output should exist");
+        assert_eq!(output, "line 1\nline 2\n");
+    }
+
+    #[test]
+    fn req_task_registry_199_assigns_team_and_removes_task() {
+        let registry = TaskRegistry::new();
+        let task = registry.create("Team task", None);
+        registry
+            .assign_team(&task.task_id, "team_abc")
+            .expect("assign should succeed");
+
+        let fetched = registry.get(&task.task_id).expect("task should exist");
+        assert_eq!(fetched.team_id.as_deref(), Some("team_abc"));
+
+        let removed = registry.remove(&task.task_id);
+        assert!(removed.is_some());
+        assert!(registry.get(&task.task_id).is_none());
+        assert!(registry.is_empty());
+    }
+
+    #[test]
+    fn req_task_registry_199_rejects_operations_on_missing_task() {
+        let registry = TaskRegistry::new();
+        assert!(registry.stop("nonexistent").is_err());
+        assert!(registry.update("nonexistent", "msg").is_err());
+        assert!(registry.output("nonexistent").is_err());
+        assert!(registry.append_output("nonexistent", "data").is_err());
+        assert!(registry
+            .set_status("nonexistent", TaskStatus::Running)
+            .is_err());
+        assert!(registry.assign_team("nonexistent", "team").is_err());
+    }
+
+    #[test]
+    fn req_task_registry_199_task_status_display_all_variants() {
+        let cases = [
+            (TaskStatus::Created, "created"),
+            (TaskStatus::Running, "running"),
+            (TaskStatus::Completed, "completed"),
+            (TaskStatus::Failed, "failed"),
+            (TaskStatus::Stopped, "stopped"),
+        ];
+        for (status, expected) in cases {
+            assert_eq!(status.to_string(), expected);
+        }
+    }
+
+    #[test]
+    fn req_task_registry_199_stop_rejects_completed_task() {
+        let registry = TaskRegistry::new();
+        let task = registry.create("done", None);
+        registry
+            .set_status(&task.task_id, TaskStatus::Completed)
+            .expect("set status should succeed");
+
+        let error = registry
+            .stop(&task.task_id)
+            .expect_err("completed task should be rejected");
+        assert!(error.contains("already in terminal state"));
+        assert!(error.contains("completed"));
+    }
+
+    #[test]
+    fn req_task_registry_199_stop_rejects_failed_task() {
+        let registry = TaskRegistry::new();
+        let task = registry.create("failed", None);
+        registry
+            .set_status(&task.task_id, TaskStatus::Failed)
+            .expect("set status should succeed");
+
+        let error = registry
+            .stop(&task.task_id)
+            .expect_err("failed task should be rejected");
+        assert!(error.contains("already in terminal state"));
+        assert!(error.contains("failed"));
+    }
+
+    #[test]
+    fn req_task_registry_199_stop_succeeds_from_created_state() {
+        let registry = TaskRegistry::new();
+        let task = registry.create("created task", None);
+
+        let stopped = registry.stop(&task.task_id).expect("stop should succeed");
+
+        assert_eq!(stopped.status, TaskStatus::Stopped);
+        assert!(stopped.updated_at >= task.updated_at);
+    }
+
+    #[test]
+    fn req_task_registry_199_new_registry_is_empty() {
+        let registry = TaskRegistry::new();
+        let all_tasks = registry.list(None);
+
+        assert!(registry.is_empty());
+        assert_eq!(registry.len(), 0);
+        assert!(all_tasks.is_empty());
+    }
+
+    #[test]
+    fn req_task_registry_199_create_without_description() {
+        let registry = TaskRegistry::new();
+
+        let task = registry.create("Do the thing", None);
+
+        assert!(task.task_id.starts_with("task_"));
+        assert_eq!(task.description, None);
+        assert_eq!(task.task_packet, None);
+        assert!(task.messages.is_empty());
+        assert!(task.output.is_empty());
+        assert_eq!(task.team_id, None);
+    }
+
+    #[test]
+    fn req_task_registry_199_remove_nonexistent_returns_none() {
+        let registry = TaskRegistry::new();
+        let removed = registry.remove("missing");
+        assert!(removed.is_none());
+    }
+
+    #[test]
+    fn req_task_registry_199_assign_team_rejects_missing_task() {
+        let registry = TaskRegistry::new();
+        let result = registry.assign_team("missing", "team_123");
+        let error = result.expect_err("missing task should be rejected");
+        assert_eq!(error, "task not found: missing");
+    }
+
+    #[test]
+    fn req_task_registry_199_serde_roundtrip_preserves_task() {
+        let registry = TaskRegistry::new();
+        let task = registry.create("Serializable", Some("desc"));
+        let json = serde_json::to_string(&task).expect("serialize");
+        let parsed: Task = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(parsed, task);
+        // wire format must use snake_case for the status enum
+        assert!(json.contains("\"status\":\"created\""));
+    }
+
+    /// Fail-Safe contract: if a thread panics while holding the registry
+    /// mutex, subsequent lock acquisitions must recover (not propagate
+    /// the panic). This guards against the upstream `.expect()` red-line
+    /// violation and ensures availability under partial failure.
+    #[test]
+    fn req_task_registry_199_lock_recovers_from_poison() {
+        let registry = TaskRegistry::new();
+        registry.create("seed", None);
+
+        // Spawn a thread that panics while holding the lock — poisons the mutex.
+        let registry_clone = registry.clone();
+        let handle = std::thread::spawn(move || {
+            let _guard = lock_registry(&registry_clone.inner);
+            panic!("intentional poison");
+        });
+        let _ = handle.join();
+
+        // Subsequent calls must still succeed — registry must be Fail-Safe.
+        assert_eq!(registry.len(), 1);
+        let task = registry.create("after poison", None);
+        assert_eq!(registry.len(), 2);
+        assert_eq!(task.status, TaskStatus::Created);
+    }
+}


### PR DESCRIPTION
## Summary

Port `task_registry.rs` from `claw-code/rust/crates/runtime/` to `dasclaw_governance` behind the new `task_registry` feature flag — final piece of the W5 task-lifecycle 3-pack (after #198 task_packet via #201 and #200 team_cron_registry via #202).

## Background / Goal

`task_registry` provides in-memory CRUD + lifecycle for sub-agent tasks: create-from-prompt or create-from-validated-`TaskPacket`, status transitions (Created → Running → Completed/Failed/Stopped), message log, output buffer, optional team assignment. It depends on `task_packet` for packet validation, hence the feature dependency `task_registry = ["task_packet", ...]`.

## What's IN this PR

- New module `crates/dasclaw_governance/src/task_registry.rs` (~525 LOC including tests)
- New feature `task_registry = ["dep:serde", "dep:serde_json", "task_packet"]`
- Public surface: `TaskStatus` (snake_case serde + Display), `Task`, `TaskMessage`, `TaskRegistry::{new, create, create_from_packet, get, list, stop, update, output, append_output, set_status, assign_team, remove, len, is_empty}`
- 19 `req_task_registry_199_*` tests covering CRUD, lifecycle transitions, validation propagation, scope-fallback description, missing-task rejection, serde snake_case roundtrip, Display all-variants, and **lock-poison recovery**
- Added `task_registry` to `[features] full = [...]` so workspace test suite picks it up

## Hardening vs upstream (red-line compliance)

Upstream uses `mutex.lock().expect("registry lock poisoned")` at **11 lock sites** in production code — that violates `scripts/check_no_panics.py` (no `.expect()` in production). Replaced with a single `lock_registry()` helper using `unwrap_or_else(|p| p.into_inner())` for Fail-Safe poison recovery, mirroring the pattern established in #202 (#200).

`req_task_registry_199_lock_recovers_from_poison` explicitly poisons the mutex via a panicking thread and asserts subsequent `len()` + `create()` calls still succeed. **No Fail-Open**: the test confirms the registry remains consistent (count preserved) before/after poison.

## What's NOT in this PR

- No callers wired up — module is opt-in via feature flag, dead code in default build (consistent with W4/W5 module-by-module contract)
- No bridge to upstream `tools/` crate stubs (separate W5 work)
- No async / spawn / executor integration — kept pure CRUD per upstream API
- No persistence — registry is in-memory only

## Verification

```bash
cargo check -p dasclaw_governance --tests --features task_registry   # OK
cargo nextest run -p dasclaw_governance --features task_registry     # 34/34 passed
cargo nextest run -p dasclaw_governance --features full              # 144/144 passed
cargo fmt --all                                                       # OK
python3.12 scripts/check_no_panics.py --base origin/xClaw             # OK: No panic-inducing calls
cargo clippy --no-deps -p dasclaw_governance --all-targets \
    --features task_registry -- -D warnings                           # OK
```

Closes #199
