### PR TITLE
test(governance): port integration_tests from claw-code runtime (#75)

### DIFF
--- a/crates/dasclaw_governance/Cargo.toml
+++ b/crates/dasclaw_governance/Cargo.toml
@@ -44,3 +44,12 @@ full = [
 thiserror = "1"
 serde = { version = "1", features = ["derive"], optional = true }
 serde_json = { version = "1", optional = true }
+
+# Cross-module wiring tests for the full 6-pack — only compiled when
+# the convenience `full` feature is on. Keeps the default `cargo test`
+# (no features) lean, while `cargo nextest run -p dasclaw_governance
+# --features full` exercises the integration surface (#75).
+[[test]]
+name = "integration_tests"
+path = "tests/integration_tests.rs"
+required-features = ["full"]

--- a/crates/dasclaw_governance/tests/integration_tests.rs
+++ b/crates/dasclaw_governance/tests/integration_tests.rs
@@ -1,0 +1,341 @@
+#![allow(clippy::doc_markdown, clippy::uninlined_format_args)]
+//! Cross-module wiring integration tests for the governance 6-pack.
+//!
+//! Ported from `claw-code/rust/crates/runtime/tests/integration_tests.rs`
+//! per #75 (W4 acceptance: claw-code test suite full port).
+//!
+//! These tests verify that adjacent modules in `dasclaw_governance` connect
+//! correctly — catching wiring gaps that per-module unit tests miss.
+//!
+//! Invariants preserved from upstream:
+//! - PolicyEngine + LaneContext + StaleBranch flow
+//! - GreenContract level ordering across PolicyCondition::GreenAt
+//! - LaneContext::reconciled() reconcile-before-closeout precedence
+//! - WorkerFailureKind → FailureScenario → recovery → post-recovery policy
+//!
+//! Upstream variant `worker_provider_failure_flows_through_recovery_to_policy`
+//! sourced `WorkerFailureKind`/`WorkerRegistry`/`WorkerStatus` from the
+//! runtime-only `worker_boot` module. In dasclaw_governance the kind enum
+//! lives in `recovery_recipes`, and `WorkerRegistry` plumbing is out of
+//! crate scope. The ported test enters the recovery path directly with
+//! `WorkerFailureKind::Provider`, which preserves the failure→recovery→
+//! policy wiring contract under test.
+
+use std::time::Duration;
+
+use dasclaw_governance::green_contract::{GreenContract, GreenLevel};
+use dasclaw_governance::policy_engine::{
+    DiffScope, LaneBlocker, LaneContext, PolicyAction, PolicyCondition, PolicyEngine, PolicyRule,
+    ReconcileReason, ReviewStatus,
+};
+use dasclaw_governance::recovery_recipes::{
+    attempt_recovery, FailureScenario, RecoveryContext, RecoveryEvent, RecoveryResult,
+    WorkerFailureKind,
+};
+use dasclaw_governance::stale_branch::{
+    apply_policy, BranchFreshness, StaleBranchAction, StaleBranchPolicy,
+};
+
+/// stale_branch + policy_engine integration:
+/// When a branch is detected stale, does it correctly flow through
+/// PolicyCondition::StaleBranch to generate the expected action?
+#[test]
+fn stale_branch_detection_flows_into_policy_engine() {
+    let stale_context = LaneContext::new(
+        "stale-lane",
+        0,
+        Duration::from_secs(2 * 60 * 60),
+        LaneBlocker::None,
+        ReviewStatus::Pending,
+        DiffScope::Full,
+        false,
+    );
+
+    let engine = PolicyEngine::new(vec![PolicyRule::new(
+        "stale-merge-forward",
+        PolicyCondition::StaleBranch,
+        PolicyAction::MergeForward,
+        10,
+    )]);
+
+    let actions = engine.evaluate(&stale_context);
+    assert_eq!(actions, vec![PolicyAction::MergeForward]);
+}
+
+/// stale_branch + policy_engine: Fresh branch does NOT trigger stale rules.
+#[test]
+fn fresh_branch_does_not_trigger_stale_policy() {
+    let fresh_context = LaneContext::new(
+        "fresh-lane",
+        0,
+        Duration::from_secs(30 * 60),
+        LaneBlocker::None,
+        ReviewStatus::Pending,
+        DiffScope::Full,
+        false,
+    );
+
+    let engine = PolicyEngine::new(vec![PolicyRule::new(
+        "stale-merge-forward",
+        PolicyCondition::StaleBranch,
+        PolicyAction::MergeForward,
+        10,
+    )]);
+
+    let actions = engine.evaluate(&fresh_context);
+    assert!(actions.is_empty());
+}
+
+/// green_contract: lane that meets contract is satisfied; lane below is not.
+#[test]
+fn green_contract_satisfied_allows_merge() {
+    let contract = GreenContract::new(GreenLevel::Workspace);
+    assert!(contract.is_satisfied_by(GreenLevel::Workspace));
+    assert!(contract.is_satisfied_by(GreenLevel::MergeReady));
+    assert!(!contract.is_satisfied_by(GreenLevel::Package));
+}
+
+/// green_contract + policy_engine: lane below required green level is blocked.
+#[test]
+fn green_contract_unsatisfied_blocks_merge() {
+    let context = LaneContext::new(
+        "partial-green-lane",
+        1,
+        Duration::from_secs(0),
+        LaneBlocker::None,
+        ReviewStatus::Pending,
+        DiffScope::Full,
+        false,
+    );
+
+    let engine = PolicyEngine::new(vec![PolicyRule::new(
+        "workspace-green-required",
+        PolicyCondition::GreenAt { level: 3 },
+        PolicyAction::MergeToDev,
+        10,
+    )]);
+
+    let actions = engine.evaluate(&context);
+    assert!(actions.is_empty());
+}
+
+/// reconciliation + policy_engine: reconcile rule fires before generic closeout.
+#[test]
+fn reconciled_lane_matches_reconcile_condition() {
+    let context = LaneContext::reconciled("reconciled-lane");
+
+    let engine = PolicyEngine::new(vec![
+        PolicyRule::new(
+            "reconcile-first",
+            PolicyCondition::LaneReconciled,
+            PolicyAction::Reconcile {
+                reason: ReconcileReason::AlreadyMerged,
+            },
+            5,
+        ),
+        PolicyRule::new(
+            "generic-closeout",
+            PolicyCondition::LaneCompleted,
+            PolicyAction::CloseoutLane,
+            30,
+        ),
+    ]);
+
+    let actions = engine.evaluate(&context);
+    assert_eq!(
+        actions,
+        vec![
+            PolicyAction::Reconcile {
+                reason: ReconcileReason::AlreadyMerged,
+            },
+            PolicyAction::CloseoutLane,
+        ]
+    );
+}
+
+/// stale_branch::apply_policy: AutoRebase yields Rebase action.
+#[test]
+fn stale_branch_apply_policy_produces_rebase_action() {
+    let stale = BranchFreshness::Stale {
+        commits_behind: 5,
+        missing_fixes: vec!["fix-123".to_string()],
+    };
+
+    let action = apply_policy(&stale, StaleBranchPolicy::AutoRebase);
+    assert_eq!(action, StaleBranchAction::Rebase);
+}
+
+/// stale_branch::apply_policy: AutoMergeForward yields MergeForward action.
+#[test]
+fn stale_branch_apply_policy_produces_merge_forward_action() {
+    let stale = BranchFreshness::Stale {
+        commits_behind: 3,
+        missing_fixes: vec![],
+    };
+
+    let action = apply_policy(&stale, StaleBranchPolicy::AutoMergeForward);
+    assert_eq!(action, StaleBranchAction::MergeForward);
+}
+
+/// stale_branch::apply_policy: WarnOnly produces a Warn action with detail.
+#[test]
+fn stale_branch_apply_policy_warn_only() {
+    let stale = BranchFreshness::Stale {
+        commits_behind: 2,
+        missing_fixes: vec!["fix-456".to_string()],
+    };
+
+    let action = apply_policy(&stale, StaleBranchPolicy::WarnOnly);
+    match action {
+        StaleBranchAction::Warn { message } => {
+            assert!(message.contains("2 commit(s) behind main"));
+            assert!(message.contains("fix-456"));
+        }
+        other => panic!("expected Warn action, got {:?}", other),
+    }
+}
+
+/// stale_branch::apply_policy: Fresh branch produces Noop regardless of policy.
+#[test]
+fn stale_branch_fresh_produces_noop() {
+    let fresh = BranchFreshness::Fresh;
+    let action = apply_policy(&fresh, StaleBranchPolicy::AutoRebase);
+    assert_eq!(action, StaleBranchAction::Noop);
+}
+
+/// End-to-end: stale + approved lane gets MergeForward + Notify in priority order.
+#[test]
+fn end_to_end_stale_lane_gets_merge_forward_action() {
+    let context = LaneContext::new(
+        "lane-9411",
+        3,
+        Duration::from_secs(5 * 60 * 60),
+        LaneBlocker::None,
+        ReviewStatus::Approved,
+        DiffScope::Scoped,
+        false,
+    );
+
+    let engine = PolicyEngine::new(vec![
+        PolicyRule::new(
+            "auto-merge-forward-if-stale-and-approved",
+            PolicyCondition::And(vec![
+                PolicyCondition::StaleBranch,
+                PolicyCondition::ReviewPassed,
+            ]),
+            PolicyAction::MergeForward,
+            5,
+        ),
+        PolicyRule::new(
+            "stale-warning",
+            PolicyCondition::StaleBranch,
+            PolicyAction::Notify {
+                channel: "#build-status".to_string(),
+            },
+            10,
+        ),
+    ]);
+
+    let actions = engine.evaluate(&context);
+    assert_eq!(
+        actions,
+        vec![
+            PolicyAction::MergeForward,
+            PolicyAction::Notify {
+                channel: "#build-status".to_string(),
+            },
+        ]
+    );
+}
+
+/// Fresh + approved lane bypasses stale handling and merges directly.
+#[test]
+fn fresh_approved_lane_gets_merge_action() {
+    let context = LaneContext::new(
+        "fresh-approved-lane",
+        3,
+        Duration::from_secs(30 * 60),
+        LaneBlocker::None,
+        ReviewStatus::Approved,
+        DiffScope::Scoped,
+        false,
+    );
+
+    let engine = PolicyEngine::new(vec![PolicyRule::new(
+        "merge-if-green-approved-not-stale",
+        PolicyCondition::And(vec![
+            PolicyCondition::GreenAt { level: 3 },
+            PolicyCondition::ReviewPassed,
+        ]),
+        PolicyAction::MergeToDev,
+        5,
+    )]);
+
+    let actions = engine.evaluate(&context);
+    assert_eq!(actions, vec![PolicyAction::MergeToDev]);
+}
+
+/// recovery_recipes + policy_engine integration:
+/// A provider-failure WorkerFailureKind maps to a FailureScenario that
+/// recovers in one step, after which the lane satisfies a green+approved
+/// policy rule. Upstream test additionally drove a `WorkerRegistry` to
+/// produce the `WorkerFailureKind`; that plumbing is out of crate scope
+/// here, so the test enters the recovery path directly with the kind.
+#[test]
+fn worker_provider_failure_flows_through_recovery_to_policy() {
+    let kind = WorkerFailureKind::Provider;
+
+    let scenario = FailureScenario::from_worker_failure_kind(kind);
+    assert_eq!(scenario, FailureScenario::ProviderFailure);
+
+    let mut ctx = RecoveryContext::new();
+    let result = attempt_recovery(&scenario, &mut ctx);
+
+    assert!(
+        matches!(result, RecoveryResult::Recovered { steps_taken: 1 }),
+        "provider failure should recover via single RestartWorker step, got: {:?}",
+        result
+    );
+    assert!(
+        ctx.events().iter().any(|event| matches!(
+            event,
+            RecoveryEvent::RecoveryAttempted {
+                result: RecoveryResult::Recovered { steps_taken: 1 },
+                ..
+            }
+        )),
+        "recovery should emit structured attempt event"
+    );
+
+    let recovery_success = matches!(result, RecoveryResult::Recovered { .. });
+    let post_recovery_context = LaneContext::new(
+        "recovered-lane",
+        3,
+        Duration::from_secs(30 * 60),
+        LaneBlocker::None,
+        ReviewStatus::Approved,
+        DiffScope::Scoped,
+        false,
+    );
+
+    let policy_engine = PolicyEngine::new(vec![PolicyRule::new(
+        "merge-after-successful-recovery",
+        PolicyCondition::And(vec![
+            PolicyCondition::GreenAt { level: 3 },
+            PolicyCondition::ReviewPassed,
+        ]),
+        PolicyAction::MergeToDev,
+        10,
+    )]);
+
+    assert!(
+        recovery_success,
+        "recovery must succeed for lane to proceed"
+    );
+    let actions = policy_engine.evaluate(&post_recovery_context);
+    assert_eq!(
+        actions,
+        vec![PolicyAction::MergeToDev],
+        "post-recovery green+approved lane should be merge-ready"
+    );
+}


### PR DESCRIPTION
## 背景 / 目标

W4 验收任务 #75: claw-code `tests/integration_tests.rs` 12 个跨模块联接测试 port 到 `dasclaw_governance`,验证 6-pack 治理模块在 dasclaw_governance crate 内连接正确。

**Source**: `docs/plans/architecture-refactor/32-execution-plan.md` W4 验收
**依赖**: 6-pack 11 模块全部 port 完成 (#65-#71 + #198-#200,均已 merged)

## 改动范围

- `crates/dasclaw_governance/tests/integration_tests.rs` (NEW, +290): 12 个跨模块联接测试
- `crates/dasclaw_governance/Cargo.toml` (+10): 新增 `[[test]]` 段,通过 `required-features = ["full"]` 把测试 target gating 到现有的 `full` 便利 feature 上

## 非目标 (What's NOT in this PR)

- 不改任何 production 代码 (单元测试已随 #65-#71/#198-#200 一起 port)
- 不引入新依赖、不暴露新 public API
- 不动 ADR-118 readonly vendored 副本
- 不 port `worker_boot` / `WorkerRegistry` (超出 governance crate 边界,见下方)
- 不补 ironclaw / desktop-client / scanner 的下游 wire-up (后续 issue)

## 上游差异说明

`worker_provider_failure_flows_through_recovery_to_policy` 上游版本从 runtime 专属的 `worker_boot` 模块取 `WorkerFailureKind`/`WorkerRegistry`/`WorkerStatus`。在 dasclaw_governance 中:

- `WorkerFailureKind` 已位于 `recovery_recipes` 模块
- `WorkerRegistry` 与 `WorkerStatus` 不属于 governance crate 边界

ported 版直接以 `WorkerFailureKind::Provider` 进入 recovery 路径,保留 "failure -> scenario -> recovery -> policy" 的接线契约,移除越界 plumbing。这是契约同构而非补丁式裁剪。

## 验证

```bash
# 1. 完整测试 (含 unit + integration)
cargo nextest run -p dasclaw_governance --features full
# Summary [84.763s] 156 tests run: 156 passed, 0 skipped
#   包含: 144 unit + 12 integration

# 2. 仅 integration 子集
cargo nextest run -p dasclaw_governance --features full --test integration_tests
# Summary [8.254s] 12 tests run: 12 passed, 0 skipped

# 3. fmt
cargo fmt --all  # clean

# 4. clippy (crate 级,带 full feature 与 all-targets)
cargo clippy --no-deps -p dasclaw_governance --all-targets --features full -- -D warnings
# Finished `dev` profile [unoptimized + debuginfo] target(s) in 4.49s

# 5. no-panics
python3.12 scripts/check_no_panics.py --base origin/xClaw
# OK: No panic-inducing calls in changed production code.
```

## 验收对应

#75 acceptance 三条:

- [x] 18 unit test port 通过 -> 实际已 port 144 个 (跨 11 模块,远超上游 18)
- [x] 6 integration test port 通过 -> 实际 port 12 个 (上游真实是 12,ticket 文本里的 6 是早期估计)
- [x] `cargo nextest run -p dasclaw_governance` 全绿 -> 156/156

## Skill 自审

- code-quality-audit: 无 unwrap/expect/panic 在生产路径 (测试内仅 `assert!` 与 `panic!` 在 `match` arm,允许);Cargo.toml 段非补丁式新增 (用 `required-features` 标准机制,不靠 cfg 切换大块)
- code-simplifier: 测试沿用上游函数级隔离风格,无重复模板;import 全部 module-qualified 路径,无 wildcard
- code-review-expert: 上游差异说明在 PR body 与文件 doc-comment 双位置标注,合规可追溯

Closes #75
