### PR TITLE
chore(bootstrap): ADR-114 Ⅲ rename internal base_dir API

### DIFF
--- a/desktop-client/ironclaw/src/agent/commands.rs
+++ b/desktop-client/ironclaw/src/agent/commands.rs
@@ -990,7 +990,7 @@ impl Agent {
             let model_env = registry.model_env_var(&backend);
             let env_var_prefix = format!("{}=", model_env);
 
-            let env_path = crate::bootstrap::ironclaw_env_path();
+            let env_path = crate::bootstrap::dasclaw_env_path();
             let env_has_var = std::fs::read_to_string(&env_path)
                 .ok()
                 .is_some_and(|content| {

--- a/desktop-client/ironclaw/src/bootstrap.rs
+++ b/desktop-client/ironclaw/src/bootstrap.rs
@@ -7,7 +7,7 @@
 //! File: `~/.dasclaw/.env` (standard dotenvy format).
 //!
 //! Legacy `~/.ironclaw/.env` is **not** read implicitly; if a user still has
-//! data in `~/.ironclaw/`, [`compute_ironclaw_base_dir`] emits a one-time
+//! data in `~/.ironclaw/`, [`compute_base_dir`] emits a one-time
 //! migration notice instructing them to run the `dasclaw migrate` subcommand
 //! (delivered by ADR-114 B-Ⅱ, see issue #107).
 
@@ -21,12 +21,12 @@ const DASCLAW_BASE_DIR_ENV: &str = "DASCLAW_BASE_DIR";
 const IRONCLAW_BASE_DIR_ENV: &str = "IRONCLAW_BASE_DIR";
 
 /// Lazily computed IronClaw base directory, cached for the lifetime of the process.
-static IRONCLAW_BASE_DIR: LazyLock<PathBuf> = LazyLock::new(compute_ironclaw_base_dir);
+static DASCLAW_BASE_DIR: LazyLock<PathBuf> = LazyLock::new(compute_base_dir);
 
 /// Compute the IronClaw base directory from environment.
 ///
 /// This is the underlying implementation used by both the public
-/// `ironclaw_base_dir()` function (which caches the result) and tests
+/// `dasclaw_base_dir()` function (which caches the result) and tests
 /// (which need to verify different configurations).
 ///
 /// Resolution order (per ADR-114 §2.2 类 B-Ⅰ):
@@ -37,7 +37,7 @@ static IRONCLAW_BASE_DIR: LazyLock<PathBuf> = LazyLock::new(compute_ironclaw_bas
 ///
 /// When the legacy directory `~/.ironclaw/` exists but `~/.dasclaw/` does not,
 /// a migration notice is logged pointing users at `dasclaw migrate` (B-Ⅱ).
-pub fn compute_ironclaw_base_dir() -> PathBuf {
+pub fn compute_base_dir() -> PathBuf {
     if let Some(path) = base_dir_from_env() {
         return path;
     }
@@ -132,18 +132,54 @@ fn emit_migration_notice_if_needed(dasclaw: &Path, legacy: &Path) {
 /// # Returns
 /// A `PathBuf` pointing to the base directory. The path is not validated
 /// for existence.
-pub fn ironclaw_base_dir() -> PathBuf {
-    IRONCLAW_BASE_DIR.clone()
+pub fn dasclaw_base_dir() -> PathBuf {
+    DASCLAW_BASE_DIR.clone()
 }
 
 /// Path to the IronClaw-specific `.env` file: `<base>/.env` where `<base>`
-/// resolves via [`ironclaw_base_dir`] (defaults to `~/.dasclaw/.env`).
+/// resolves via [`dasclaw_base_dir`] (defaults to `~/.dasclaw/.env`).
+pub fn dasclaw_env_path() -> PathBuf {
+    dasclaw_base_dir().join(".env")
+}
+
+// ---------------------------------------------------------------------------
+// ADR-114 Ⅲ: deprecated thin wrappers kept for one release cycle.
+// Old call-sites should migrate to `dasclaw_base_dir` / `dasclaw_env_path` /
+// `compute_base_dir`. Tracking removal: issue #108.
+// ---------------------------------------------------------------------------
+
+/// Deprecated alias for [`dasclaw_base_dir`]. Will be removed in a future release.
+#[deprecated(
+    since = "0.2.0",
+    note = "use `dasclaw_base_dir` instead (ADR-114 Ⅲ, issue #108)"
+)]
+#[inline]
+pub fn ironclaw_base_dir() -> PathBuf {
+    dasclaw_base_dir()
+}
+
+/// Deprecated alias for [`dasclaw_env_path`]. Will be removed in a future release.
+#[deprecated(
+    since = "0.2.0",
+    note = "use `dasclaw_env_path` instead (ADR-114 Ⅲ, issue #108)"
+)]
+#[inline]
 pub fn ironclaw_env_path() -> PathBuf {
-    ironclaw_base_dir().join(".env")
+    dasclaw_env_path()
+}
+
+/// Deprecated alias for [`compute_base_dir`]. Will be removed in a future release.
+#[deprecated(
+    since = "0.2.0",
+    note = "use `compute_base_dir` instead (ADR-114 Ⅲ, issue #108)"
+)]
+#[inline]
+pub fn compute_ironclaw_base_dir() -> PathBuf {
+    compute_base_dir()
 }
 
 /// Load env vars from `<base>/.env` (in addition to the standard `.env`),
-/// where `<base>` is [`ironclaw_base_dir`] (defaults to `~/.dasclaw`).
+/// where `<base>` is [`dasclaw_base_dir`] (defaults to `~/.dasclaw`).
 ///
 /// Call this **after** `dotenvy::dotenv()` so that the standard `./.env`
 /// takes priority over `<base>/.env`. dotenvy never overwrites
@@ -160,7 +196,7 @@ pub fn ironclaw_env_path() -> PathBuf {
 /// defaults to `libsql` so cloud instances work out of the box without any
 /// manual configuration.
 pub fn load_ironclaw_env() {
-    let path = ironclaw_env_path();
+    let path = dasclaw_env_path();
 
     if !path.exists() {
         // One-time upgrade: extract DATABASE_URL from legacy bootstrap.json
@@ -176,11 +212,11 @@ pub fn load_ironclaw_env() {
     // This avoids the chicken-and-egg problem on cloud instances where no
     // DATABASE_URL is configured but the local DB is already present.
     //
-    // Path follows `ironclaw_base_dir()` (defaults to `~/.dasclaw`); legacy
+    // Path follows `dasclaw_base_dir()` (defaults to `~/.dasclaw`); legacy
     // `~/.ironclaw/ironclaw.db` is reachable via `IRONCLAW_BASE_DIR=...`
     // until users run the B-Ⅱ migration helper (issue #107).
     if std::env::var("DATABASE_BACKEND").is_err() {
-        let default_db = ironclaw_base_dir().join("ironclaw.db");
+        let default_db = dasclaw_base_dir().join("ironclaw.db");
         if default_db.exists() {
             if tokio::runtime::Handle::try_current().is_ok() {
                 // Tokio runtime is active (multi-threaded); std::env::set_var is UB here.
@@ -250,7 +286,7 @@ fn migrate_bootstrap_json_to_env(env_path: &std::path::Path) {
 /// Values are double-quoted so that `#` (common in URL-encoded passwords)
 /// and other shell-special characters are preserved by dotenvy.
 pub fn save_bootstrap_env(vars: &[(&str, &str)]) -> std::io::Result<()> {
-    save_bootstrap_env_to(&ironclaw_env_path(), vars)
+    save_bootstrap_env_to(&dasclaw_env_path(), vars)
 }
 
 /// Write bootstrap vars to an arbitrary path (testable variant).
@@ -279,7 +315,7 @@ pub fn save_bootstrap_env_to(path: &std::path::Path, vars: &[(&str, &str)]) -> s
 /// and preserves all other existing lines. Use this instead of `save_bootstrap_env`
 /// when you want to update specific keys without destroying user-added variables.
 pub fn upsert_bootstrap_vars(vars: &[(&str, &str)]) -> std::io::Result<()> {
-    upsert_bootstrap_vars_to(&ironclaw_env_path(), vars)
+    upsert_bootstrap_vars_to(&dasclaw_env_path(), vars)
 }
 
 /// Update or add multiple variables at an arbitrary path (testable variant).
@@ -332,7 +368,7 @@ pub fn upsert_bootstrap_vars_to(
 /// or appends it otherwise. Use this when writing a single bootstrap var
 /// outside the wizard (which manages the full set via `save_bootstrap_env`).
 pub fn upsert_bootstrap_var(key: &str, value: &str) -> std::io::Result<()> {
-    upsert_bootstrap_var_to(&ironclaw_env_path(), key, value)
+    upsert_bootstrap_var_to(&dasclaw_env_path(), key, value)
 }
 
 /// Update or add a single variable at an arbitrary path (testable variant).
@@ -410,7 +446,7 @@ pub async fn migrate_disk_to_db(
     store: &dyn crate::db::Database,
     user_id: &str,
 ) -> Result<(), MigrationError> {
-    let ironclaw_dir = ironclaw_base_dir();
+    let ironclaw_dir = dasclaw_base_dir();
     let legacy_settings_path = ironclaw_dir.join("settings.json");
 
     if !legacy_settings_path.exists() {
@@ -448,7 +484,7 @@ pub async fn migrate_disk_to_db(
     if let Some(ref url) = settings.database_url {
         save_database_url(url)
             .map_err(|e| MigrationError::Io(format!("Failed to write .env: {}", e)))?;
-        tracing::info!("Wrote DATABASE_URL to {}", ironclaw_env_path().display());
+        tracing::info!("Wrote DATABASE_URL to {}", dasclaw_env_path().display());
     }
 
     // 3. Migrate mcp-servers.json if it exists
@@ -545,7 +581,7 @@ pub enum MigrationError {
 
 /// Path to the PID lock file: `~/.ironclaw/ironclaw.pid`.
 pub fn pid_lock_path() -> PathBuf {
-    ironclaw_base_dir().join("ironclaw.pid")
+    dasclaw_base_dir().join("ironclaw.pid")
 }
 
 /// A PID-based lock that prevents multiple IronClaw instances from running
@@ -732,8 +768,8 @@ INJECTED="pwned"#;
     }
 
     #[test]
-    fn test_ironclaw_env_path() {
-        // Use compute_ironclaw_base_dir() directly to avoid LazyLock caching,
+    fn test_dasclaw_env_path() {
+        // Use compute_base_dir() directly to avoid LazyLock caching,
         // which can be poisoned by whichever test initializes it first.
         let _guard = lock_env();
         let old_dasclaw = std::env::var(DASCLAW_BASE_DIR_ENV).ok();
@@ -744,7 +780,7 @@ INJECTED="pwned"#;
             std::env::remove_var(IRONCLAW_BASE_DIR_ENV);
         }
 
-        let path = compute_ironclaw_base_dir().join(".env");
+        let path = compute_base_dir().join(".env");
         assert!(
             path.ends_with(".dasclaw/.env"),
             "expected path ending with .dasclaw/.env, got: {}",
@@ -1119,7 +1155,7 @@ INJECTED="pwned"#;
     }
 
     #[test]
-    fn test_ironclaw_base_dir_default() {
+    fn test_dasclaw_base_dir_default() {
         // When neither DASCLAW_BASE_DIR nor IRONCLAW_BASE_DIR is set, the
         // default base dir is `~/.dasclaw` (ADR-114 B-Ⅰ).
         let _guard = lock_env();
@@ -1130,7 +1166,7 @@ INJECTED="pwned"#;
             std::env::remove_var(IRONCLAW_BASE_DIR_ENV);
         }
 
-        let path = compute_ironclaw_base_dir();
+        let path = compute_base_dir();
         let home = dirs::home_dir().unwrap_or_else(|| std::path::PathBuf::from("."));
         assert_eq!(path, home.join(".dasclaw"));
 
@@ -1138,7 +1174,7 @@ INJECTED="pwned"#;
     }
 
     #[test]
-    fn test_ironclaw_base_dir_env_override() {
+    fn test_dasclaw_base_dir_env_override() {
         // This test verifies that when IRONCLAW_BASE_DIR is set,
         // the custom path is used. Must run before LazyLock is initialized.
         let _guard = lock_env();
@@ -1147,7 +1183,7 @@ INJECTED="pwned"#;
         unsafe { std::env::set_var("IRONCLAW_BASE_DIR", "/custom/ironclaw/path") };
 
         // Force re-evaluation by calling the computation function directly
-        let path = compute_ironclaw_base_dir();
+        let path = compute_base_dir();
         assert_eq!(path, std::path::PathBuf::from("/custom/ironclaw/path"));
 
         if let Some(val) = old_val {
@@ -1161,15 +1197,15 @@ INJECTED="pwned"#;
 
     #[test]
     fn test_compute_base_dir_env_path_join() {
-        // Verifies that ironclaw_env_path correctly joins .env to the base dir.
-        // Uses compute_ironclaw_base_dir directly to avoid LazyLock caching.
+        // Verifies that dasclaw_env_path correctly joins .env to the base dir.
+        // Uses compute_base_dir directly to avoid LazyLock caching.
         let _guard = lock_env();
         let old_val = std::env::var("IRONCLAW_BASE_DIR").ok();
         // SAFETY: ENV_MUTEX ensures single-threaded access to env vars in tests
         unsafe { std::env::set_var("IRONCLAW_BASE_DIR", "/my/custom/dir") };
 
         // Test the path construction logic directly
-        let base_path = compute_ironclaw_base_dir();
+        let base_path = compute_base_dir();
         let env_path = base_path.join(".env");
         assert_eq!(env_path, std::path::PathBuf::from("/my/custom/dir/.env"));
 
@@ -1183,7 +1219,7 @@ INJECTED="pwned"#;
     }
 
     #[test]
-    fn test_ironclaw_base_dir_empty_env() {
+    fn test_dasclaw_base_dir_empty_env() {
         // Empty values for both DASCLAW_BASE_DIR and IRONCLAW_BASE_DIR fall
         // back to the default `~/.dasclaw`.
         let _guard = lock_env();
@@ -1194,7 +1230,7 @@ INJECTED="pwned"#;
             std::env::set_var(IRONCLAW_BASE_DIR_ENV, "");
         }
 
-        let path = compute_ironclaw_base_dir();
+        let path = compute_base_dir();
         let home = dirs::home_dir().unwrap_or_else(|| std::path::PathBuf::from("."));
         assert_eq!(path, home.join(".dasclaw"));
 
@@ -1202,7 +1238,7 @@ INJECTED="pwned"#;
     }
 
     #[test]
-    fn test_ironclaw_base_dir_special_chars() {
+    fn test_dasclaw_base_dir_special_chars() {
         // Verifies that paths with special characters are handled correctly.
         let _guard = lock_env();
         let old_val = std::env::var("IRONCLAW_BASE_DIR").ok();
@@ -1210,7 +1246,7 @@ INJECTED="pwned"#;
         unsafe { std::env::set_var("IRONCLAW_BASE_DIR", "/tmp/test_with-special.chars") };
 
         // Force re-evaluation by calling the computation function directly
-        let path = compute_ironclaw_base_dir();
+        let path = compute_base_dir();
         assert_eq!(
             path,
             std::path::PathBuf::from("/tmp/test_with-special.chars")
@@ -1527,7 +1563,7 @@ INJECTED="pwned"#;
             std::env::set_var(IRONCLAW_BASE_DIR_ENV, "/tmp/ironclaw-legacy");
         }
 
-        let resolved = compute_ironclaw_base_dir();
+        let resolved = compute_base_dir();
         assert_eq!(
             resolved,
             PathBuf::from("/tmp/dasclaw-priority"),
@@ -1539,7 +1575,7 @@ INJECTED="pwned"#;
 
     #[test]
     #[tracing_test::traced_test]
-    fn req_adr_114_bi_ironclaw_base_dir_fallback_with_warning() {
+    fn req_adr_114_bi_dasclaw_base_dir_fallback_with_warning() {
         let _guard = lock_env();
         let snap = snapshot_base_dir_envs();
         unsafe {
@@ -1547,7 +1583,7 @@ INJECTED="pwned"#;
             std::env::set_var(IRONCLAW_BASE_DIR_ENV, "/tmp/ironclaw-fallback");
         }
 
-        let resolved = compute_ironclaw_base_dir();
+        let resolved = compute_base_dir();
         assert_eq!(resolved, PathBuf::from("/tmp/ironclaw-fallback"));
         assert!(
             logs_contain("deprecated"),
@@ -1566,7 +1602,7 @@ INJECTED="pwned"#;
             std::env::remove_var(IRONCLAW_BASE_DIR_ENV);
         }
 
-        let resolved = compute_ironclaw_base_dir();
+        let resolved = compute_base_dir();
         assert!(
             resolved.ends_with(".dasclaw"),
             "default base dir must end with .dasclaw, got: {}",

--- a/desktop-client/ironclaw/src/channels/repl.rs
+++ b/desktop-client/ironclaw/src/channels/repl.rs
@@ -39,7 +39,7 @@ use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
 
 use crate::agent::truncate_for_preview;
-use crate::bootstrap::ironclaw_base_dir;
+use crate::bootstrap::dasclaw_base_dir;
 use crate::channels::{Channel, IncomingMessage, MessageStream, OutgoingResponse, StatusUpdate};
 use crate::cli::fmt;
 use crate::error::ChannelError;
@@ -481,7 +481,7 @@ fn print_help() {
 
 /// Get the history file path (~/.ironclaw/history).
 fn history_path() -> std::path::PathBuf {
-    ironclaw_base_dir().join("history")
+    dasclaw_base_dir().join("history")
 }
 
 #[async_trait]

--- a/desktop-client/ironclaw/src/channels/signal.rs
+++ b/desktop-client/ironclaw/src/channels/signal.rs
@@ -17,7 +17,7 @@ use serde::Deserialize;
 use tokio::sync::RwLock;
 use uuid::Uuid;
 
-use crate::bootstrap::ironclaw_base_dir;
+use crate::bootstrap::dasclaw_base_dir;
 use crate::channels::{Channel, IncomingMessage, MessageStream, OutgoingResponse, StatusUpdate};
 use crate::config::SignalConfig;
 use crate::error::ChannelError;
@@ -558,7 +558,7 @@ impl SignalChannel {
     /// - All paths are within ~/.ironclaw/ sandbox
     fn validate_attachment_paths(paths: &[String]) -> Result<(), ChannelError> {
         // Get the sandbox base directory (same as MessageTool uses)
-        let base_dir = ironclaw_base_dir();
+        let base_dir = dasclaw_base_dir();
 
         for path in paths {
             crate::tools::builtin::path_utils::validate_path(path, Some(&base_dir)).map_err(
@@ -2678,7 +2678,7 @@ mod tests {
         use std::fs;
 
         // Create test files in sandbox
-        let base_dir = crate::bootstrap::ironclaw_base_dir();
+        let base_dir = crate::bootstrap::dasclaw_base_dir();
 
         // Create sandbox directory if it doesn't exist (needed for CI)
         let _ = fs::create_dir_all(&base_dir);

--- a/desktop-client/ironclaw/src/channels/wasm/loader.rs
+++ b/desktop-client/ironclaw/src/channels/wasm/loader.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 
 use tokio::fs;
 
-use crate::bootstrap::ironclaw_base_dir;
+use crate::bootstrap::dasclaw_base_dir;
 use crate::channels::wasm::capabilities::ChannelCapabilities;
 use crate::channels::wasm::error::WasmChannelError;
 use crate::channels::wasm::runtime::WasmChannelRuntime;
@@ -419,7 +419,7 @@ pub struct DiscoveredChannel {
 /// Returns ~/.ironclaw/channels/
 #[allow(dead_code)]
 pub fn default_channels_dir() -> PathBuf {
-    ironclaw_base_dir().join("channels")
+    dasclaw_base_dir().join("channels")
 }
 
 #[cfg(test)]

--- a/desktop-client/ironclaw/src/channels/web/handlers/static_files.rs
+++ b/desktop-client/ironclaw/src/channels/web/handlers/static_files.rs
@@ -6,7 +6,7 @@ use axum::{
     response::{Html, IntoResponse},
 };
 
-use crate::bootstrap::ironclaw_base_dir;
+use crate::bootstrap::dasclaw_base_dir;
 use crate::channels::web::auth::AuthenticatedUser;
 use crate::channels::web::types::*;
 
@@ -73,7 +73,7 @@ async fn serve_project_file(project_id: &str, path: &str) -> axum::response::Res
         return (StatusCode::BAD_REQUEST, "Invalid project ID").into_response();
     }
 
-    let base = ironclaw_base_dir().join("projects").join(project_id);
+    let base = dasclaw_base_dir().join("projects").join(project_id);
 
     let file_path = base.join(path);
 

--- a/desktop-client/ironclaw/src/channels/web/server.rs
+++ b/desktop-client/ironclaw/src/channels/web/server.rs
@@ -27,7 +27,7 @@ use tower_http::set_header::SetResponseHeaderLayer;
 use uuid::Uuid;
 
 use crate::agent::SessionManager;
-use crate::bootstrap::ironclaw_base_dir;
+use crate::bootstrap::dasclaw_base_dir;
 use crate::channels::IncomingMessage;
 use crate::channels::relay::DEFAULT_RELAY_NAME;
 use crate::channels::web::auth::{
@@ -2488,7 +2488,7 @@ async fn serve_project_file(project_id: &str, path: &str) -> axum::response::Res
         return (StatusCode::BAD_REQUEST, "Invalid project ID").into_response();
     }
 
-    let base = ironclaw_base_dir().join("projects").join(project_id);
+    let base = dasclaw_base_dir().join("projects").join(project_id);
 
     let file_path = base.join(path);
 

--- a/desktop-client/ironclaw/src/cli/config.rs
+++ b/desktop-client/ironclaw/src/cli/config.rs
@@ -240,7 +240,7 @@ fn show_path(has_db: bool) -> anyhow::Result<()> {
     }
     println!(
         "Env config:         {}",
-        crate::bootstrap::ironclaw_env_path().display()
+        crate::bootstrap::dasclaw_env_path().display()
     );
 
     let toml_path = Settings::default_toml_path();

--- a/desktop-client/ironclaw/src/cli/doctor.rs
+++ b/desktop-client/ironclaw/src/cli/doctor.rs
@@ -6,7 +6,7 @@
 
 use std::path::PathBuf;
 
-use crate::bootstrap::ironclaw_base_dir;
+use crate::bootstrap::dasclaw_base_dir;
 use crate::cli::fmt;
 use crate::settings::Settings;
 
@@ -376,7 +376,7 @@ async fn try_pg_connect() -> Result<(), String> {
 // ── Workspace directory ─────────────────────────────────────
 
 fn check_workspace_dir() -> CheckResult {
-    let dir = ironclaw_base_dir();
+    let dir = dasclaw_base_dir();
 
     if dir.exists() {
         if dir.is_dir() {
@@ -523,8 +523,8 @@ async fn check_mcp_config() -> CheckResult {
 // ── Skills ──────────────────────────────────────────────────
 
 async fn check_skills() -> CheckResult {
-    let user_dir = ironclaw_base_dir().join("skills");
-    let installed_dir = ironclaw_base_dir().join("installed_skills");
+    let user_dir = dasclaw_base_dir().join("skills");
+    let installed_dir = dasclaw_base_dir().join("installed_skills");
 
     let mut registry = crate::skills::SkillRegistry::new(user_dir.clone());
     registry = registry.with_installed_dir(installed_dir);

--- a/desktop-client/ironclaw/src/cli/logs.rs
+++ b/desktop-client/ironclaw/src/cli/logs.rs
@@ -90,7 +90,7 @@ pub async fn run_logs_command(cmd: LogsCommand, config_path: Option<&Path>) -> a
 /// backwards in chunks to find the last `limit` newlines, so memory usage
 /// is proportional to the output size, not the file size.
 fn cmd_show(cmd: &LogsCommand) -> anyhow::Result<()> {
-    let log_path = crate::bootstrap::ironclaw_base_dir().join("gateway.log");
+    let log_path = crate::bootstrap::dasclaw_base_dir().join("gateway.log");
     if !log_path.exists() {
         anyhow::bail!(
             "No gateway log file found at {}.\n\

--- a/desktop-client/ironclaw/src/cli/models.rs
+++ b/desktop-client/ironclaw/src/cli/models.rs
@@ -147,7 +147,7 @@ fn save_settings(settings: &Settings, config_path: Option<&Path>) -> anyhow::Res
 }
 
 fn config_toml_path() -> std::path::PathBuf {
-    crate::bootstrap::ironclaw_base_dir().join("config.toml")
+    crate::bootstrap::dasclaw_base_dir().join("config.toml")
 }
 
 /// Try to fetch the live model list from a provider.

--- a/desktop-client/ironclaw/src/cli/status.rs
+++ b/desktop-client/ironclaw/src/cli/status.rs
@@ -5,7 +5,7 @@
 
 use std::path::PathBuf;
 
-use crate::bootstrap::ironclaw_base_dir;
+use crate::bootstrap::dasclaw_base_dir;
 use crate::cli::fmt;
 use crate::settings::Settings;
 
@@ -188,7 +188,7 @@ pub async fn run_status_command() -> anyhow::Result<()> {
         "{}",
         fmt::kv_line(
             "Config",
-            &crate::bootstrap::ironclaw_env_path().display().to_string(),
+            &crate::bootstrap::dasclaw_env_path().display().to_string(),
             12,
         )
     );
@@ -238,11 +238,11 @@ fn count_wasm_files(dir: &std::path::Path) -> usize {
 }
 
 fn default_tools_dir() -> PathBuf {
-    ironclaw_base_dir().join("tools")
+    dasclaw_base_dir().join("tools")
 }
 
 fn default_channels_dir() -> PathBuf {
-    ironclaw_base_dir().join("channels")
+    dasclaw_base_dir().join("channels")
 }
 
 #[cfg(test)]

--- a/desktop-client/ironclaw/src/cli/tool.rs
+++ b/desktop-client/ironclaw/src/cli/tool.rs
@@ -10,13 +10,13 @@ use std::sync::Arc;
 use clap::Subcommand;
 use tokio::fs;
 
-use crate::bootstrap::ironclaw_base_dir;
+use crate::bootstrap::dasclaw_base_dir;
 use crate::secrets::{CreateSecretParams, SecretsStore};
 use crate::tools::wasm::{CapabilitiesFile, compute_binary_hash};
 
 /// Default tools directory.
 fn default_tools_dir() -> PathBuf {
-    ironclaw_base_dir().join("tools")
+    dasclaw_base_dir().join("tools")
 }
 
 #[derive(Subcommand, Debug, Clone)]

--- a/desktop-client/ironclaw/src/config/channels.rs
+++ b/desktop-client/ironclaw/src/config/channels.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 
-use crate::bootstrap::ironclaw_base_dir;
+use crate::bootstrap::dasclaw_base_dir;
 use crate::config::helpers::{optional_env, parse_bool_env, parse_optional_env};
 use crate::error::ConfigError;
 use crate::settings::Settings;
@@ -350,7 +350,7 @@ pub const DEFAULT_GATEWAY_PORT: u16 = 3000;
 
 /// Get the default channels directory (~/.ironclaw/channels/).
 fn default_channels_dir() -> PathBuf {
-    ironclaw_base_dir().join("channels")
+    dasclaw_base_dir().join("channels")
 }
 
 #[cfg(test)]

--- a/desktop-client/ironclaw/src/config/database.rs
+++ b/desktop-client/ironclaw/src/config/database.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use secrecy::{ExposeSecret, SecretString};
 
-use crate::bootstrap::ironclaw_base_dir;
+use crate::bootstrap::dasclaw_base_dir;
 use crate::config::helpers::{optional_env, parse_optional_env};
 use crate::error::ConfigError;
 
@@ -226,7 +226,7 @@ impl SslMode {
 
 /// Default libSQL database path (~/.ironclaw/ironclaw.db).
 pub fn default_libsql_path() -> PathBuf {
-    ironclaw_base_dir().join("ironclaw.db")
+    dasclaw_base_dir().join("ironclaw.db")
 }
 
 #[cfg(test)]

--- a/desktop-client/ironclaw/src/config/hygiene.rs
+++ b/desktop-client/ironclaw/src/config/hygiene.rs
@@ -1,4 +1,4 @@
-use crate::bootstrap::ironclaw_base_dir;
+use crate::bootstrap::dasclaw_base_dir;
 use crate::config::helpers::{parse_bool_env, parse_optional_env};
 use crate::error::ConfigError;
 
@@ -50,7 +50,7 @@ impl HygieneConfig {
             daily_retention_days: self.daily_retention_days,
             conversation_retention_days: self.conversation_retention_days,
             cadence_hours: self.cadence_hours,
-            state_dir: ironclaw_base_dir(),
+            state_dir: dasclaw_base_dir(),
         }
     }
 }

--- a/desktop-client/ironclaw/src/config/llm.rs
+++ b/desktop-client/ironclaw/src/config/llm.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use secrecy::SecretString;
 
-use crate::bootstrap::ironclaw_base_dir;
+use crate::bootstrap::dasclaw_base_dir;
 use crate::config::helpers::{optional_env, parse_optional_env, validate_base_url};
 use crate::error::ConfigError;
 use crate::llm::config::*;
@@ -263,7 +263,7 @@ impl LlmConfig {
                 .unwrap_or_else(|| "app_EMoamEEZ73f0CkXaXp7hrann".to_string());
             let session_path = optional_env("OPENAI_CODEX_SESSION_PATH")?
                 .map(PathBuf::from)
-                .unwrap_or_else(|| ironclaw_base_dir().join("openai_codex_session.json"));
+                .unwrap_or_else(|| dasclaw_base_dir().join("openai_codex_session.json"));
             let token_refresh_margin_secs =
                 parse_optional_env("OPENAI_CODEX_REFRESH_MARGIN_SECS", 300)?;
             Some(OpenAiCodexConfig {
@@ -677,7 +677,7 @@ fn merge_extra_headers(
 
 /// Get the default session file path (~/.ironclaw/session.json).
 pub fn default_session_path() -> PathBuf {
-    ironclaw_base_dir().join("session.json")
+    dasclaw_base_dir().join("session.json")
 }
 
 #[cfg(test)]

--- a/desktop-client/ironclaw/src/config/skills.rs
+++ b/desktop-client/ironclaw/src/config/skills.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use crate::bootstrap::ironclaw_base_dir;
+use crate::bootstrap::dasclaw_base_dir;
 use crate::config::helpers::{optional_env, parse_bool_env, parse_optional_env};
 use crate::error::ConfigError;
 
@@ -39,12 +39,12 @@ impl Default for SkillsConfig {
 
 /// Get the default user skills directory (~/.ironclaw/skills/).
 fn default_skills_dir() -> PathBuf {
-    ironclaw_base_dir().join("skills")
+    dasclaw_base_dir().join("skills")
 }
 
 /// Get the default installed skills directory (~/.ironclaw/installed_skills/).
 fn default_installed_skills_dir() -> PathBuf {
-    ironclaw_base_dir().join("installed_skills")
+    dasclaw_base_dir().join("installed_skills")
 }
 
 impl SkillsConfig {

--- a/desktop-client/ironclaw/src/config/wasm.rs
+++ b/desktop-client/ironclaw/src/config/wasm.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 use std::time::Duration;
 
-use crate::bootstrap::ironclaw_base_dir;
+use crate::bootstrap::dasclaw_base_dir;
 use crate::config::helpers::{optional_env, parse_bool_env, parse_optional_env};
 use crate::error::ConfigError;
 
@@ -40,7 +40,7 @@ impl Default for WasmConfig {
 
 /// Get the default tools directory (~/.ironclaw/tools/).
 fn default_tools_dir() -> PathBuf {
-    ironclaw_base_dir().join("tools")
+    dasclaw_base_dir().join("tools")
 }
 
 impl WasmConfig {

--- a/desktop-client/ironclaw/src/llm/config.rs
+++ b/desktop-client/ironclaw/src/llm/config.rs
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 
 use secrecy::SecretString;
 
-use crate::bootstrap::ironclaw_base_dir;
+use crate::bootstrap::dasclaw_base_dir;
 use crate::llm::registry::ProviderProtocol;
 use crate::llm::session::SessionConfig;
 
@@ -131,7 +131,7 @@ impl Default for OpenAiCodexConfig {
             auth_endpoint: "https://auth.openai.com".to_string(),
             api_base_url: "https://chatgpt.com/backend-api/codex".to_string(),
             client_id: "app_EMoamEEZ73f0CkXaXp7hrann".to_string(),
-            session_path: ironclaw_base_dir().join("openai_codex_session.json"),
+            session_path: dasclaw_base_dir().join("openai_codex_session.json"),
             token_refresh_margin_secs: 300,
         }
     }

--- a/desktop-client/ironclaw/src/llm/registry.rs
+++ b/desktop-client/ironclaw/src/llm/registry.rs
@@ -337,7 +337,7 @@ impl ProviderRegistry {
 }
 
 fn user_providers_path() -> Option<std::path::PathBuf> {
-    Some(crate::bootstrap::ironclaw_base_dir().join("providers.json"))
+    Some(crate::bootstrap::dasclaw_base_dir().join("providers.json"))
 }
 
 #[cfg(test)]

--- a/desktop-client/ironclaw/src/orchestrator/job_manager.rs
+++ b/desktop-client/ironclaw/src/orchestrator/job_manager.rs
@@ -11,7 +11,7 @@ use chrono::{DateTime, Utc};
 use tokio::sync::RwLock;
 use uuid::Uuid;
 
-use crate::bootstrap::ironclaw_base_dir;
+use crate::bootstrap::dasclaw_base_dir;
 use crate::error::OrchestratorError;
 use crate::orchestrator::auth::{CredentialGrant, TokenStore};
 use crate::sandbox::connect_docker;
@@ -188,7 +188,7 @@ fn validate_bind_mount_path(
             ),
         })?;
 
-    let projects_base = ironclaw_base_dir().join("projects");
+    let projects_base = dasclaw_base_dir().join("projects");
 
     if !projects_base.is_absolute() {
         return Err(OrchestratorError::ContainerCreationFailed {
@@ -667,7 +667,7 @@ mod tests {
 
     #[test]
     fn test_validate_bind_mount_valid_path() {
-        let base = crate::bootstrap::compute_ironclaw_base_dir().join("projects");
+        let base = crate::bootstrap::compute_base_dir().join("projects");
         std::fs::create_dir_all(&base).unwrap();
 
         let test_dir = base.join("test_validate_bind");

--- a/desktop-client/ironclaw/src/pairing/store.rs
+++ b/desktop-client/ironclaw/src/pairing/store.rs
@@ -13,7 +13,7 @@ use rand::Rng;
 use rand::rngs::OsRng;
 use serde::{Deserialize, Serialize};
 
-use crate::bootstrap::ironclaw_base_dir;
+use crate::bootstrap::dasclaw_base_dir;
 
 const PAIRING_CODE_LENGTH: usize = 8;
 const PAIRING_ALPHABET: &[u8] = b"ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
@@ -76,7 +76,7 @@ struct AllowFromStoreFile {
 }
 
 fn default_pairing_dir() -> PathBuf {
-    ironclaw_base_dir()
+    dasclaw_base_dir()
 }
 
 fn safe_channel_key(channel: &str) -> Result<String, PairingStoreError> {

--- a/desktop-client/ironclaw/src/registry/installer.rs
+++ b/desktop-client/ironclaw/src/registry/installer.rs
@@ -5,7 +5,7 @@ use std::path::{Component, Path, PathBuf};
 
 use tokio::fs;
 
-use crate::bootstrap::ironclaw_base_dir;
+use crate::bootstrap::dasclaw_base_dir;
 use crate::registry::catalog::RegistryError;
 use crate::registry::manifest::{BundleDefinition, ExtensionManifest, ManifestKind, SourceSpec};
 
@@ -219,7 +219,7 @@ impl RegistryInstaller {
 
     /// Default installer using standard paths.
     pub fn with_defaults(repo_root: PathBuf) -> Self {
-        let base_dir = ironclaw_base_dir();
+        let base_dir = dasclaw_base_dir();
         Self {
             repo_root,
             tools_dir: base_dir.join("tools"),

--- a/desktop-client/ironclaw/src/service.rs
+++ b/desktop-client/ironclaw/src/service.rs
@@ -12,7 +12,7 @@ use std::process::Command;
 
 use anyhow::{Context, Result, bail};
 
-use crate::bootstrap::ironclaw_base_dir;
+use crate::bootstrap::dasclaw_base_dir;
 
 const SERVICE_LABEL: &str = "com.ironclaw.daemon";
 const SYSTEMD_UNIT: &str = "ironclaw.service";
@@ -269,7 +269,7 @@ fn linux_unit_path() -> Result<PathBuf> {
 }
 
 fn ironclaw_logs_dir() -> PathBuf {
-    ironclaw_base_dir().join("logs")
+    dasclaw_base_dir().join("logs")
 }
 
 // ── Shell helpers ───────────────────────────────────────────────

--- a/desktop-client/ironclaw/src/settings.rs
+++ b/desktop-client/ironclaw/src/settings.rs
@@ -12,7 +12,7 @@ use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
 
-use crate::bootstrap::ironclaw_base_dir;
+use crate::bootstrap::dasclaw_base_dir;
 
 /// A custom LLM provider defined by the user through the web UI.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -868,7 +868,7 @@ impl Settings {
 
     /// Get the default settings file path (~/.ironclaw/settings.json).
     pub fn default_path() -> std::path::PathBuf {
-        ironclaw_base_dir().join("settings.json")
+        dasclaw_base_dir().join("settings.json")
     }
 
     /// Load settings from disk, returning default if not found.
@@ -886,7 +886,7 @@ impl Settings {
 
     /// Default TOML config file path (~/.ironclaw/config.toml).
     pub fn default_toml_path() -> PathBuf {
-        ironclaw_base_dir().join("config.toml")
+        dasclaw_base_dir().join("config.toml")
     }
 
     /// Load settings from a TOML file.

--- a/desktop-client/ironclaw/src/setup/wizard.rs
+++ b/desktop-client/ironclaw/src/setup/wizard.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 use deadpool_postgres::Config as PoolConfig;
 use secrecy::{ExposeSecret, SecretString};
 
-use crate::bootstrap::ironclaw_base_dir;
+use crate::bootstrap::dasclaw_base_dir;
 use crate::channels::wasm::{
     ChannelCapabilitiesFile, available_channel_names, install_bundled_channel,
 };
@@ -2516,7 +2516,7 @@ impl SetupWizard {
         println!();
 
         // Discover available WASM channels
-        let channels_dir = ironclaw_base_dir().join("channels");
+        let channels_dir = dasclaw_base_dir().join("channels");
 
         let mut discovered_channels = discover_wasm_channels(&channels_dir).await;
         let installed_names: HashSet<String> = discovered_channels
@@ -2737,7 +2737,7 @@ impl SetupWizard {
         println!();
 
         // Check which tools are already installed
-        let tools_dir = ironclaw_base_dir().join("tools");
+        let tools_dir = dasclaw_base_dir().join("tools");
 
         let installed_tools = discover_installed_tools(&tools_dir).await;
 
@@ -2777,7 +2777,7 @@ impl SetupWizard {
         let installer = crate::registry::installer::RegistryInstaller::new(
             repo_root.to_path_buf(),
             tools_dir.clone(),
-            ironclaw_base_dir().join("channels"),
+            dasclaw_base_dir().join("channels"),
         );
 
         let mut installed_count = 0;
@@ -3641,7 +3641,7 @@ async fn install_selected_registry_channels(
 
         let installer = crate::registry::installer::RegistryInstaller::new(
             repo_root.clone(),
-            ironclaw_base_dir().join("tools"),
+            dasclaw_base_dir().join("tools"),
             channels_dir.to_path_buf(),
         );
 

--- a/desktop-client/ironclaw/src/tools/builtin/job.rs
+++ b/desktop-client/ironclaw/src/tools/builtin/job.rs
@@ -15,7 +15,7 @@ use chrono::Utc;
 use tokio::sync::RwLock;
 use uuid::Uuid;
 
-use crate::bootstrap::ironclaw_base_dir;
+use crate::bootstrap::dasclaw_base_dir;
 use crate::channels::IncomingMessage;
 use crate::context::{ContextManager, JobContext, JobState};
 use crate::db::Database;
@@ -740,7 +740,7 @@ fn validate_env_var_name(name: &str) -> Result<(), ToolError> {
 }
 
 fn projects_base() -> PathBuf {
-    ironclaw_base_dir().join("projects")
+    dasclaw_base_dir().join("projects")
 }
 
 /// Resolve the project directory, creating it if it doesn't exist.

--- a/desktop-client/ironclaw/src/tools/builtin/message.rs
+++ b/desktop-client/ironclaw/src/tools/builtin/message.rs
@@ -7,7 +7,7 @@ use std::sync::{Arc, RwLock};
 
 use async_trait::async_trait;
 
-use crate::bootstrap::ironclaw_base_dir;
+use crate::bootstrap::dasclaw_base_dir;
 use crate::channels::{ChannelManager, OutgoingResponse};
 use crate::context::JobContext;
 use crate::extensions::ExtensionManager;
@@ -30,7 +30,7 @@ pub struct MessageTool {
 
 impl MessageTool {
     pub fn new(channel_manager: Arc<ChannelManager>) -> Self {
-        let base_dir = ironclaw_base_dir();
+        let base_dir = dasclaw_base_dir();
 
         Self {
             channel_manager,

--- a/desktop-client/ironclaw/src/tools/mcp/config.rs
+++ b/desktop-client/ironclaw/src/tools/mcp/config.rs
@@ -9,7 +9,7 @@ use std::path::{Path, PathBuf};
 use serde::{Deserialize, Serialize};
 use tokio::fs;
 
-use crate::bootstrap::ironclaw_base_dir;
+use crate::bootstrap::dasclaw_base_dir;
 use crate::tools::tool::ToolError;
 
 /// Transport configuration for an MCP server.
@@ -410,7 +410,7 @@ impl From<ConfigError> for ToolError {
 
 /// Get the default MCP servers configuration path.
 pub fn default_config_path() -> PathBuf {
-    ironclaw_base_dir().join("mcp-servers.json")
+    dasclaw_base_dir().join("mcp-servers.json")
 }
 
 /// Load MCP server configurations from the default location.

--- a/desktop-client/ironclaw/src/workspace/hygiene.rs
+++ b/desktop-client/ironclaw/src/workspace/hygiene.rs
@@ -30,7 +30,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
-use crate::bootstrap::ironclaw_base_dir;
+use crate::bootstrap::dasclaw_base_dir;
 use crate::workspace::Workspace;
 
 /// Global guard preventing concurrent hygiene passes.
@@ -84,7 +84,7 @@ impl Default for HygieneConfig {
             daily_retention_days: 30,
             conversation_retention_days: 7,
             cadence_hours: 12,
-            state_dir: ironclaw_base_dir(),
+            state_dir: dasclaw_base_dir(),
         }
     }
 }

--- a/desktop-client/ironclaw/src/workspace_dir.rs
+++ b/desktop-client/ironclaw/src/workspace_dir.rs
@@ -11,11 +11,11 @@
 use std::path::{Path, PathBuf};
 use uuid::Uuid;
 
-use crate::bootstrap::ironclaw_base_dir;
+use crate::bootstrap::dasclaw_base_dir;
 
 /// Return the base directory for auto-created workspaces: `~/.ironclaw/projects/`.
 pub fn projects_base() -> PathBuf {
-    ironclaw_base_dir().join("projects")
+    dasclaw_base_dir().join("projects")
 }
 
 /// Create a sandboxed workspace directory for a conversation thread.


### PR DESCRIPTION
## 背景 / 目标

ADR-114 Ⅲ：将 `desktop-client/ironclaw/src/bootstrap.rs` 内部 base_dir API 从 `ironclaw_*` 重命名为 `dasclaw_*`，作为 Class B 重命名工作流的 Ⅲ 段（B-Ⅲ）。

## 改动范围

**重命名的内部 API**（共 4 个符号）：
- `ironclaw_base_dir()` → `dasclaw_base_dir()`
- `ironclaw_env_path()` → `dasclaw_env_path()`
- `compute_ironclaw_base_dir()` → `compute_base_dir()`
- `static IRONCLAW_BASE_DIR: LazyLock<PathBuf>` → `DASCLAW_BASE_DIR`

**旧名保留为 `#[deprecated]` `#[inline]` thin wrapper**（src/bootstrap.rs 末尾）：

```rust
#[deprecated(since = "0.2.0", note = "use `dasclaw_base_dir` instead (ADR-114 Ⅲ, issue #108)")]
#[inline]
pub fn ironclaw_base_dir() -> PathBuf { dasclaw_base_dir() }
// 同样的 wrapper 用于 ironclaw_env_path / compute_ironclaw_base_dir
```

**caller 同步更新到新名**（30+ 个 src/ 文件，覆盖 cli/, channels/, config/, llm/, orchestrator/, pairing/, registry/, setup/, tools/ 等）。

## 非目标 (What's NOT in this PR)

- ❌ **不动** `IRONCLAW_BASE_DIR_ENV` 常量名 — 这是 ADR-114 B-Ⅰ `DASCLAW_BASE_DIR` / `IRONCLAW_BASE_DIR` 双读契约的一部分，必须保留。
- ❌ **不动** 字符串字面量 `"IRONCLAW_BASE_DIR"`（env var 名值），同上原因。
- ❌ **不动** test 内部断言中包含 "IRONCLAW_BASE_DIR" 的字符串字面量。
- ❌ 不删除旧 wrapper（按 ADR-114 留一个 release cycle 的弃用窗口；删除窗口跟踪 issue 待开）。
- ❌ 不动 `crates/` 下任何 crate（本 PR 仅触及 `desktop-client/ironclaw/src/`）。
- ❌ 不动 `IRONCLAW_PID_LOCK_*` env vars（属于 PID 锁子流程契约，不在 ADR-114 重命名范围）。

## 验证 (命令 + 结果)

```bash
# 1. 编译（含 tests）
cargo check -p ironclaw --tests
# → Finished `dev` profile target(s) in 6m 15s ✅

# 2. 相关测试套件
cargo nextest run -p ironclaw \
  -E 'test(/bootstrap/) | test(/base_dir/) | test(/env_path/) | test(/adr_114_bi/)' \
  --no-fail-fast
# → 82 tests run: 82 passed (2 leaky), 4480 skipped ✅

# 3. fmt + 红线
cargo fmt --all
python3.12 scripts/check_no_panics.py --base origin/xClaw
# → OK: No panic-inducing calls in changed production code. ✅

# 4. clippy（本 PR 改动范围内）
cargo clippy --no-deps -p ironclaw --all-targets -- -D warnings
# → 报错文件全部为 toolchain 漂移假阳
#   （agent/dispatcher.rs, observability/prompt_cache.rs, tools/builtin/git/*,
#    tools/builtin/lsp/* 等），与本 PR 改动文件零交集。
```

**改动文件列表**（32 个 .rs 文件）：详见 `git diff --stat`，集中在 `desktop-client/ironclaw/src/`。

Closes #108
