### PR TITLE
feat(tools): #88 builtin-only tool collision and visibility startup report

### DIFF
--- a/desktop-client/ironclaw/src/tools/mod.rs
+++ b/desktop-client/ironclaw/src/tools/mod.rs
@@ -20,8 +20,14 @@ pub mod redaction;
 pub mod schema_validator;
 pub mod wasm;
 
+mod registration_report;
 mod registry;
 mod tool;
+
+pub use registration_report::{
+    RegistrationOutcome, RejectedToolEntry, RejectionReason, ToolRegistrationEntry,
+    ToolRegistrationReport, ToolSource,
+};
 
 pub use autonomy::{
     AUTONOMOUS_TOOL_DENYLIST, autonomous_allowed_tool_names, autonomous_unavailable_error,

--- a/desktop-client/ironclaw/src/tools/registration_report.rs
+++ b/desktop-client/ironclaw/src/tools/registration_report.rs
@@ -1,0 +1,369 @@
+//! Tool registration report — startup-time visibility into which tools were
+//! accepted, rejected, or shadowed by the registry.
+//!
+//! Issue #88 (P1/W5): "Tool collision and visibility startup report".
+//!
+//! # Scope (this PR — builtin-only first cut)
+//!
+//! Records every call to [`crate::tools::registry::ToolRegistry::register`]
+//! and [`crate::tools::registry::ToolRegistry::register_sync`] with:
+//! - canonical tool name
+//! - source bucket ([`ToolSource`])
+//! - outcome ([`RegistrationOutcome`]) including rejection reason
+//!
+//! The combined report ([`ToolRegistrationReport`]) is rendered at startup as
+//! a structured `tracing::info!` event so operators can see registry shape and
+//! shadow-rejections at a glance, and can be consumed by tests / CI checks
+//! without leaking secrets (no tool params or secret values are recorded).
+//!
+//! # Out of scope (follow-up issues)
+//!
+//! - Per-source breakdowns for MCP / WASM / extension tools beyond the
+//!   `Builtin` / `Dynamic` split (those flow through `register` today and are
+//!   labelled `Dynamic`; finer attribution will land alongside per-source
+//!   call-site changes).
+//! - Display name / approval mode / sandbox mode / risk classification
+//!   columns — those require touching every `Tool` impl and belong in a
+//!   separate PR (issue #88 acceptance allows starting with builtin-only
+//!   reporting).
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+/// Where a tool registration originated from.
+///
+/// Only the two values produced by the current registry entry points are
+/// modelled. New variants are non-breaking additions thanks to
+/// `#[non_exhaustive]`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum ToolSource {
+    /// Registered through the synchronous startup path
+    /// ([`crate::tools::registry::ToolRegistry::register_sync`]).
+    /// Includes all built-in groups (echo/time/json/http, dev tools, memory,
+    /// job, message, extension/skill/routine/image/vision/secrets, tool_info).
+    Builtin,
+    /// Registered through the dynamic async path
+    /// ([`crate::tools::registry::ToolRegistry::register`]). Today this
+    /// covers WASM tools, the software-builder tool, and any other
+    /// programmatically-added tool.
+    Dynamic,
+}
+
+impl ToolSource {
+    /// Stable string label suitable for log fields and JSON keys.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Builtin => "builtin",
+            Self::Dynamic => "dynamic",
+        }
+    }
+}
+
+/// Why a registration attempt was rejected.
+///
+/// Only one variant exists today (shadowing a protected built-in). Marked
+/// `#[non_exhaustive]` so additional reasons (policy / capability / signature
+/// failure) can land without breaking external matches.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum RejectionReason {
+    /// A dynamic tool tried to register under a name owned by a protected
+    /// built-in (see `PROTECTED_TOOL_NAMES` in registry.rs). The dynamic
+    /// registration is dropped to keep security-critical tools (`shell`,
+    /// `memory_write`, …) un-shadowable.
+    ProtectedBuiltinShadow,
+}
+
+impl RejectionReason {
+    /// Stable string suitable for log fields and test fixtures.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::ProtectedBuiltinShadow => "protected_builtin_shadow",
+        }
+    }
+}
+
+/// Outcome of one registration attempt.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum RegistrationOutcome {
+    /// The tool was inserted into the registry.
+    Accepted,
+    /// The tool was dropped before insertion.
+    Rejected { reason: RejectionReason },
+}
+
+impl RegistrationOutcome {
+    /// `true` when the tool ended up in the registry.
+    pub fn is_accepted(&self) -> bool {
+        matches!(self, Self::Accepted)
+    }
+}
+
+/// One entry in the registration ledger.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ToolRegistrationEntry {
+    /// Canonical tool name (the value returned by `Tool::name()` at
+    /// registration time).
+    pub name: String,
+    /// Source bucket the registration came from.
+    pub source: ToolSource,
+    /// Whether the registration was accepted or rejected (with reason).
+    pub outcome: RegistrationOutcome,
+}
+
+/// Aggregated report consumed by tests, CI checks, and the startup
+/// `tracing::info!` event.
+///
+/// The struct is intentionally small and `Serialize`-able so callers can
+/// snapshot it as JSON for golden-file tests without depending on internal
+/// registry types.
+///
+/// Sort order is canonical: `accepted` lists are sorted by name and then by
+/// source label, and `rejected` is sorted by name. Tests can assert on the
+/// report without observing insertion order, satisfying the issue #88
+/// "deterministic, brittle-order-free" acceptance bullet.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ToolRegistrationReport {
+    /// Names accepted into the registry, grouped by [`ToolSource`].
+    /// Maps source label (`"builtin"`, `"dynamic"`) to a sorted, deduped
+    /// list of tool names.
+    pub accepted: BTreeMap<String, Vec<String>>,
+    /// Tools whose registration attempt was rejected, sorted by name.
+    pub rejected: Vec<RejectedToolEntry>,
+    /// Tools that are registered but disabled by feature-flag policy.
+    /// Populated only when [`ToolRegistry::registration_report`] is called
+    /// with a [`crate::tools::feature_flags::ToolFeatureFlags`] argument;
+    /// otherwise empty.
+    pub policy_disabled: Vec<String>,
+}
+
+/// Compact rejection record exposed in [`ToolRegistrationReport`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RejectedToolEntry {
+    pub name: String,
+    pub source: ToolSource,
+    pub reason: RejectionReason,
+}
+
+impl ToolRegistrationReport {
+    /// Build a report from a flat ledger plus the optional feature-flag view.
+    ///
+    /// `entries` is consumed; sort order of the input is irrelevant.
+    pub fn from_entries(entries: &[ToolRegistrationEntry], policy_disabled: Vec<String>) -> Self {
+        let mut accepted: BTreeMap<String, Vec<String>> = BTreeMap::new();
+        let mut rejected: Vec<RejectedToolEntry> = Vec::new();
+
+        for entry in entries {
+            match &entry.outcome {
+                RegistrationOutcome::Accepted => {
+                    accepted
+                        .entry(entry.source.as_str().to_string())
+                        .or_default()
+                        .push(entry.name.clone());
+                }
+                RegistrationOutcome::Rejected { reason } => {
+                    rejected.push(RejectedToolEntry {
+                        name: entry.name.clone(),
+                        source: entry.source,
+                        reason: reason.clone(),
+                    });
+                }
+            }
+        }
+
+        for names in accepted.values_mut() {
+            names.sort_unstable();
+            names.dedup();
+        }
+
+        rejected.sort_by(|a, b| a.name.cmp(&b.name));
+        rejected.dedup();
+
+        let mut policy_disabled = policy_disabled;
+        policy_disabled.sort_unstable();
+        policy_disabled.dedup();
+
+        Self {
+            accepted,
+            rejected,
+            policy_disabled,
+        }
+    }
+
+    /// Total accepted tool count across all sources.
+    pub fn accepted_count(&self) -> usize {
+        self.accepted.values().map(|v| v.len()).sum()
+    }
+
+    /// Render a single human-readable summary line, e.g.
+    /// `"tools: 42 accepted (builtin=40 dynamic=2), 1 rejected, 3 policy-disabled"`.
+    pub fn summary_line(&self) -> String {
+        let mut parts: Vec<String> = self
+            .accepted
+            .iter()
+            .map(|(src, names)| format!("{}={}", src, names.len()))
+            .collect();
+        parts.sort();
+        let breakdown = if parts.is_empty() {
+            String::new()
+        } else {
+            format!(" ({})", parts.join(" "))
+        };
+        format!(
+            "tools: {} accepted{}, {} rejected, {} policy-disabled",
+            self.accepted_count(),
+            breakdown,
+            self.rejected.len(),
+            self.policy_disabled.len(),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(
+        name: &str,
+        source: ToolSource,
+        outcome: RegistrationOutcome,
+    ) -> ToolRegistrationEntry {
+        ToolRegistrationEntry {
+            name: name.to_string(),
+            source,
+            outcome,
+        }
+    }
+
+    fn accepted(name: &str, source: ToolSource) -> ToolRegistrationEntry {
+        entry(name, source, RegistrationOutcome::Accepted)
+    }
+
+    fn rejected(name: &str, source: ToolSource, reason: RejectionReason) -> ToolRegistrationEntry {
+        entry(name, source, RegistrationOutcome::Rejected { reason })
+    }
+
+    #[test]
+    fn req_88_accepted_grouped_by_source_and_sorted() {
+        let entries = vec![
+            accepted("zeta", ToolSource::Builtin),
+            accepted("alpha", ToolSource::Builtin),
+            accepted("dyn_b", ToolSource::Dynamic),
+            accepted("dyn_a", ToolSource::Dynamic),
+        ];
+
+        let report = ToolRegistrationReport::from_entries(&entries, vec![]);
+
+        assert_eq!(
+            report.accepted.get("builtin").map(|v| v.as_slice()),
+            Some(["alpha".to_string(), "zeta".to_string()].as_slice())
+        );
+        assert_eq!(
+            report.accepted.get("dynamic").map(|v| v.as_slice()),
+            Some(["dyn_a".to_string(), "dyn_b".to_string()].as_slice())
+        );
+        assert_eq!(report.accepted_count(), 4);
+    }
+
+    #[test]
+    fn req_88_rejection_records_deterministic_reason() {
+        let entries = vec![
+            rejected(
+                "shell",
+                ToolSource::Dynamic,
+                RejectionReason::ProtectedBuiltinShadow,
+            ),
+            accepted("shell", ToolSource::Builtin),
+        ];
+
+        let report = ToolRegistrationReport::from_entries(&entries, vec![]);
+
+        assert_eq!(report.rejected.len(), 1);
+        let r = &report.rejected[0];
+        assert_eq!(r.name, "shell");
+        assert_eq!(r.source, ToolSource::Dynamic);
+        assert_eq!(r.reason, RejectionReason::ProtectedBuiltinShadow);
+        assert_eq!(r.reason.as_str(), "protected_builtin_shadow");
+
+        // Accepted entry for the same name still tracked separately —
+        // protected built-in is in the registry, dynamic was dropped.
+        assert!(
+            report
+                .accepted
+                .get("builtin")
+                .is_some_and(|v| v.contains(&"shell".to_string()))
+        );
+    }
+
+    #[test]
+    fn req_88_policy_disabled_sorted_and_deduped() {
+        let entries = vec![
+            accepted("shell", ToolSource::Builtin),
+            accepted("http", ToolSource::Builtin),
+        ];
+        let report = ToolRegistrationReport::from_entries(
+            &entries,
+            vec!["shell".into(), "http".into(), "shell".into()],
+        );
+
+        assert_eq!(
+            report.policy_disabled,
+            vec!["http".to_string(), "shell".to_string()]
+        );
+    }
+
+    #[test]
+    fn req_88_summary_line_shape_does_not_leak_internals() {
+        let entries = vec![
+            accepted("a", ToolSource::Builtin),
+            accepted("b", ToolSource::Builtin),
+            rejected(
+                "shell",
+                ToolSource::Dynamic,
+                RejectionReason::ProtectedBuiltinShadow,
+            ),
+        ];
+        let report = ToolRegistrationReport::from_entries(&entries, vec!["b".into()]);
+
+        let line = report.summary_line();
+        // Counts only — no tool names, parameters, or secrets.
+        assert_eq!(
+            line,
+            "tools: 2 accepted (builtin=2), 1 rejected, 1 policy-disabled"
+        );
+    }
+
+    #[test]
+    fn req_88_test_fixture_is_order_independent() {
+        // Two ledger orderings that should produce identical reports.
+        let a = vec![
+            accepted("alpha", ToolSource::Builtin),
+            accepted("beta", ToolSource::Builtin),
+            rejected(
+                "alpha",
+                ToolSource::Dynamic,
+                RejectionReason::ProtectedBuiltinShadow,
+            ),
+        ];
+        let b = vec![
+            rejected(
+                "alpha",
+                ToolSource::Dynamic,
+                RejectionReason::ProtectedBuiltinShadow,
+            ),
+            accepted("beta", ToolSource::Builtin),
+            accepted("alpha", ToolSource::Builtin),
+        ];
+
+        let ra = ToolRegistrationReport::from_entries(&a, vec![]);
+        let rb = ToolRegistrationReport::from_entries(&b, vec![]);
+
+        assert_eq!(ra.accepted, rb.accepted);
+        assert_eq!(ra.rejected, rb.rejected);
+    }
+}

--- a/desktop-client/ironclaw/src/tools/registry.rs
+++ b/desktop-client/ironclaw/src/tools/registry.rs
@@ -27,6 +27,9 @@ use crate::tools::builtin::{
     ToolRemoveTool, ToolSearchTool, ToolUpgradeTool, WebFetchTool, WebSearchTool, WriteFileTool,
 };
 use crate::tools::rate_limiter::RateLimiter;
+use crate::tools::registration_report::{
+    RegistrationOutcome, RejectionReason, ToolRegistrationEntry, ToolRegistrationReport, ToolSource,
+};
 use crate::tools::tool::{ApprovalRequirement, Tool, ToolDomain};
 use crate::tools::wasm::{
     Capabilities, OAuthRefreshConfig, ResourceLimits, SharedCredentialRegistry, WasmError,
@@ -105,6 +108,12 @@ pub struct ToolRegistry {
     rate_limiter: RateLimiter,
     /// Reference to the message tool for setting context per-turn.
     message_tool: RwLock<Option<Arc<crate::tools::builtin::MessageTool>>>,
+    /// Append-only ledger of registration attempts (issue #88).
+    /// Records both accepted and rejected attempts, classified by
+    /// [`ToolSource`]. Used by [`Self::registration_report`] to render the
+    /// startup tool collision/visibility view without observing insertion
+    /// order.
+    registration_log: RwLock<Vec<ToolRegistrationEntry>>,
 }
 
 impl ToolRegistry {
@@ -126,6 +135,7 @@ impl ToolRegistry {
             secrets_store: None,
             rate_limiter: RateLimiter::new(),
             message_tool: RwLock::new(None),
+            registration_log: RwLock::new(Vec::new()),
         }
     }
 
@@ -169,9 +179,27 @@ impl ToolRegistry {
                 tool = %name,
                 "Rejected tool registration: would shadow a built-in tool"
             );
+            self.registration_log
+                .write()
+                .await
+                .push(ToolRegistrationEntry {
+                    name,
+                    source: ToolSource::Dynamic,
+                    outcome: RegistrationOutcome::Rejected {
+                        reason: RejectionReason::ProtectedBuiltinShadow,
+                    },
+                });
             return;
         }
         self.tools.write().await.insert(name.clone(), tool);
+        self.registration_log
+            .write()
+            .await
+            .push(ToolRegistrationEntry {
+                name: name.clone(),
+                source: ToolSource::Dynamic,
+                outcome: RegistrationOutcome::Accepted,
+            });
         tracing::trace!("Registered tool: {}", name);
     }
 
@@ -182,6 +210,13 @@ impl ToolRegistry {
             tools.insert(name.clone(), tool);
             if let Ok(mut builtins) = self.builtin_names.try_write() {
                 builtins.insert(name.clone());
+            }
+            if let Ok(mut log) = self.registration_log.try_write() {
+                log.push(ToolRegistrationEntry {
+                    name: name.clone(),
+                    source: ToolSource::Builtin,
+                    outcome: RegistrationOutcome::Accepted,
+                });
             }
             tracing::debug!("Registered tool: {}", name);
         }
@@ -233,6 +268,58 @@ impl ToolRegistry {
     /// Get the set of built-in tool names currently registered.
     pub async fn builtin_tool_names(&self) -> std::collections::HashSet<String> {
         self.builtin_names.read().await.clone()
+    }
+
+    /// Render the tool registration report (issue #88).
+    ///
+    /// Captures every accepted and rejected registration attempt up to this
+    /// point, grouped by [`ToolSource`]. When `flags` is provided the
+    /// `policy_disabled` field lists tools that are registered but disabled
+    /// by feature-flag policy (so the LLM never sees them).
+    ///
+    /// Sort order is canonical and dedup-applied — tests can snapshot the
+    /// returned report without observing insertion order.
+    pub async fn registration_report(
+        &self,
+        flags: Option<&crate::tools::feature_flags::ToolFeatureFlags>,
+    ) -> ToolRegistrationReport {
+        let log = self.registration_log.read().await.clone();
+        let policy_disabled = match flags {
+            Some(flags) => {
+                let tools = self.tools.read().await;
+                tools
+                    .keys()
+                    .filter(|name| !flags.is_tool_enabled(name))
+                    .cloned()
+                    .collect()
+            }
+            None => Vec::new(),
+        };
+        ToolRegistrationReport::from_entries(&log, policy_disabled)
+    }
+
+    /// Emit the registration report as a single `tracing::info!` event.
+    ///
+    /// Intended for one-shot startup logging right after `bootstrap_tools`
+    /// completes. The summary line carries only counts (no tool params or
+    /// secret values), and per-source name lists are emitted as structured
+    /// fields so log shippers can index them without parsing.
+    pub async fn log_registration_report(
+        &self,
+        flags: Option<&crate::tools::feature_flags::ToolFeatureFlags>,
+    ) {
+        let report = self.registration_report(flags).await;
+        let rejected_names: Vec<&str> = report.rejected.iter().map(|r| r.name.as_str()).collect();
+        tracing::info!(
+            target: "ironclaw::tools::startup",
+            accepted = report.accepted_count(),
+            rejected = report.rejected.len(),
+            policy_disabled = report.policy_disabled.len(),
+            rejected_tools = ?rejected_names,
+            policy_disabled_tools = ?report.policy_disabled,
+            "{}",
+            report.summary_line()
+        );
     }
 
     /// Get tool definitions for LLM function calling.
@@ -415,6 +502,11 @@ impl ToolRegistry {
             self.register_message_tools(Arc::clone(channels), ctx.extension_manager.clone())
                 .await;
         }
+
+        // Issue #88: emit the startup tool collision/visibility report.
+        // Builtin-only first cut — feature-flag view requires an explicit
+        // call site that owns `ToolFeatureFlags`.
+        self.log_registration_report(None).await;
 
         Ok(())
     }
@@ -729,6 +821,14 @@ impl ToolRegistry {
             .write()
             .await
             .insert("message".to_string());
+        self.registration_log
+            .write()
+            .await
+            .push(ToolRegistrationEntry {
+                name: "message".to_string(),
+                source: ToolSource::Builtin,
+                outcome: RegistrationOutcome::Accepted,
+            });
         tracing::debug!("Registered message tool");
     }
 
@@ -1611,5 +1711,137 @@ mod tests {
         assert!(cfg.inject_tx.is_none());
         assert!(cfg.prompt_queue.is_none());
         assert!(cfg.secrets_store.is_none());
+    }
+
+    // ── issue #88: tool collision and visibility startup report ─────────
+
+    #[tokio::test]
+    async fn req_88_registration_report_captures_builtin_via_register_sync() {
+        let registry = Arc::new(ToolRegistry::new());
+        registry
+            .bootstrap_tools(&BootstrapContext::for_test())
+            .await
+            .unwrap();
+
+        let report = registry.registration_report(None).await;
+
+        // Test mode registers exactly the four base built-ins.
+        let builtins = report.accepted.get("builtin").expect("builtin bucket");
+        for name in ["echo", "time", "json", "http"] {
+            assert!(
+                builtins.contains(&name.to_string()),
+                "missing built-in {name} in {builtins:?}"
+            );
+        }
+        assert!(
+            report.rejected.is_empty(),
+            "no rejections expected in test mode"
+        );
+        assert!(report.policy_disabled.is_empty());
+
+        // Builtin bucket is sorted (deterministic ordering for fixtures).
+        let mut sorted = builtins.clone();
+        sorted.sort();
+        assert_eq!(builtins, &sorted);
+    }
+
+    #[tokio::test]
+    async fn req_88_registration_report_records_protected_shadow_rejection() {
+        // A dynamic tool that tries to register under a protected built-in
+        // name must be rejected and recorded with the deterministic reason
+        // `protected_builtin_shadow` — never silently dropped.
+        struct FakeShell;
+        #[async_trait::async_trait]
+        impl Tool for FakeShell {
+            fn name(&self) -> &str {
+                "shell"
+            }
+            fn description(&self) -> &str {
+                "fake"
+            }
+            fn parameters_schema(&self) -> serde_json::Value {
+                serde_json::json!({})
+            }
+            async fn execute(
+                &self,
+                _params: serde_json::Value,
+                _ctx: &crate::context::JobContext,
+            ) -> Result<crate::tools::tool::ToolOutput, crate::tools::tool::ToolError> {
+                unreachable!("rejected before registration")
+            }
+        }
+
+        let registry = Arc::new(ToolRegistry::new());
+        registry
+            .bootstrap_tools(&BootstrapContext {
+                mode: BootstrapMode::Container,
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+
+        registry.register(Arc::new(FakeShell)).await;
+
+        let report = registry.registration_report(None).await;
+        assert_eq!(report.rejected.len(), 1, "one rejection expected");
+        let r = &report.rejected[0];
+        assert_eq!(r.name, "shell");
+        assert_eq!(r.source, super::ToolSource::Dynamic);
+        assert_eq!(r.reason.as_str(), "protected_builtin_shadow");
+
+        // The legitimate built-in `shell` is still registered under the
+        // builtin bucket — the dynamic shadow attempt did not displace it.
+        let builtin_shell_present = report
+            .accepted
+            .get("builtin")
+            .is_some_and(|v| v.contains(&"shell".to_string()));
+        assert!(builtin_shell_present, "built-in shell must remain accepted");
+    }
+
+    #[tokio::test]
+    async fn req_88_registration_report_policy_disabled_view() {
+        use crate::tools::feature_flags::ToolFeatureFlags;
+
+        let registry = Arc::new(ToolRegistry::new());
+        registry
+            .bootstrap_tools(&BootstrapContext::for_test())
+            .await
+            .unwrap();
+
+        let flags = ToolFeatureFlags::with_disabled(vec!["http".into(), "echo".into()]);
+        let report = registry.registration_report(Some(&flags)).await;
+
+        assert_eq!(
+            report.policy_disabled,
+            vec!["echo".to_string(), "http".to_string()],
+            "policy_disabled must be sorted and dedup'd"
+        );
+    }
+
+    #[tokio::test]
+    async fn req_88_registration_report_does_not_leak_tool_state() {
+        // Defence-in-depth: the report only carries names + source labels +
+        // rejection reason kinds. Snapshot it as JSON and assert the JSON
+        // body never contains parameter/schema/secret terminology.
+        let registry = Arc::new(ToolRegistry::new());
+        registry
+            .bootstrap_tools(&BootstrapContext::for_test())
+            .await
+            .unwrap();
+        let report = registry.registration_report(None).await;
+        let json = serde_json::to_string(&report).unwrap();
+
+        for forbidden in [
+            "parameters_schema",
+            "api_key",
+            "secret",
+            "password",
+            "token",
+        ] {
+            assert!(
+                !json.contains(forbidden),
+                "registration report leaked '{forbidden}' in JSON: {json}"
+            );
+        }
     }
 }


### PR DESCRIPTION
## 背景 / 目标

实现 #88 [P1/W5] **Tool collision and visibility startup report**（启动期工具冲突 / 可见性诊断报告）。

`ToolRegistry` 在启动时已经会通过 `register_sync()` 阻止新工具影子覆盖受保护的内置工具（`ProtectedBuiltinShadow`），但这些「拒绝」事件以前没有被结构化记录，运维 / 排障无法快速看到「哪些工具被注册、哪些被拒绝、哪些被 policy 禁用」。本 PR 把整条注册链路升级为可审计的账本。

按 #88 验收条件「builtin-only first phase 即可」，本 PR 只覆盖 builtin 入口；MCP / WASM / extension / job-message 在后续 PR 接入同一份账本。

## 改动范围

### 新增 `desktop-client/ironclaw/src/tools/registration_report.rs`

- `ToolSource { Builtin, Dynamic }` 和 `RejectionReason { ProtectedBuiltinShadow }`，两者都标 `#[non_exhaustive]` 以便后续无破坏性扩展
- `ToolRegistrationEntry` / `RejectedToolEntry` / `ToolRegistrationReport` 三个数据结构
- `RegistrationOutcome` 用 `#[serde(tag = "status", rename_all = "snake_case")]` 序列化
- `from_entries(...)` 内部 `BTreeMap` + sort + dedup 保证报告顺序稳定、去重幂等
- `summary_line()` 输出 `tools: N accepted (builtin=N), R rejected, P policy-disabled`

### 修改 `desktop-client/ironclaw/src/tools/mod.rs`

新增 `mod registration_report;` 与对应 `pub use`。

### 修改 `desktop-client/ironclaw/src/tools/registry.rs`

- 新增字段 `registration_log: RwLock<Vec<ToolRegistrationEntry>>`
- 三处入口埋点：
  - `register()` — `Dynamic + Accepted` / `Dynamic + Rejected(ProtectedBuiltinShadow)`
  - `register_sync()` — `Builtin + Accepted`
  - `register_message_tools()` — `"message"` 工具 `Builtin + Accepted`（绕过 `register_sync` 必须显式补登）
- 公开 API：
  - `pub async fn registration_report(&self, flags: Option<&ToolFeatureFlags>) -> ToolRegistrationReport`
  - `pub async fn log_registration_report(&self, flags: Option<&ToolFeatureFlags>)` — 通过 `tracing::info!` (target = `ironclaw::tools::startup`) 输出结构化字段：`accepted` / `rejected` / `policy_disabled` / `rejected_tools` / `policy_disabled_tools`，以 `summary_line()` 作为消息体
- `bootstrap_tools()` 末尾自动调用一次 `log_registration_report(None).await`

### 测试

新增 9 个 `req_88_*` 测试（命名规范 `req_<module>_<id>_<desc>`）：

- `registration_report.rs` 内 5 个单元测试
  - 接受项按 source 分组排序
  - 拒绝原因字符串确定性 (`protected_builtin_shadow`)
  - `policy_disabled` 列表排序 + 去重
  - `summary_line` 不泄漏内部字段名
  - fixture 顺序无关
- `registry.rs` 内 4 个集成测试
  - `register_sync` 真实链路捕获 `echo / time / json / http` 进入 `accepted["builtin"]`
  - 注册同名 `shell` 影子工具被拒绝、记录为 `Dynamic + protected_builtin_shadow`，且合法内置 `shell` 仍在 `accepted["builtin"]`
  - 通过 `ToolFeatureFlags` 禁用 `["http", "echo"]` 后 `policy_disabled` 字段正确
  - 报告 JSON 序列化结果不包含 `parameters_schema` / `api_key` / `secret` / `password` / `token` 等敏感字段名

## 非目标 (What's NOT in this PR)

- ❌ MCP / WASM / extension / job-message 工具源接入（留给后续 PR，#88 验收允许 builtin-only 首阶段）
- ❌ HTTP / IPC 端点暴露报告（本 PR 仅 `tracing::info!` 结构化日志 + 公开 Rust API）
- ❌ UI / 前端可视化
- ❌ 修改任何已有工具的注册行为（仅新增可见性，不改动决策逻辑）
- ❌ 新增 / 修改任何 `unwrap` / `expect` / `panic!`（已通过 `check_no_panics.py`）

## 验证

```bash
# 编译
cargo check -p ironclaw --tests
# Finished `dev` profile [unoptimized + debuginfo] target(s) in 6m 59s

# 测试 (9/9 PASS)
cargo nextest run -p ironclaw -E 'test(/req_88/)' --no-fail-fast
# Summary [   7.265s] 9 tests run: 9 passed (1 leaky), 4562 skipped

# 格式 + 无 panic
cargo fmt --all
python3.12 scripts/check_no_panics.py --base origin/xClaw
# OK: No panic-inducing calls in changed production code.

# 改动文件零 clippy 警告
cargo clippy --no-deps -p ironclaw --all-targets
# 改动的 3 个文件 (registration_report.rs / mod.rs / registry.rs) 零警告
# 其他 untouched 文件预存的 toolchain-drift 假阳由 CI clippy job 兜底
```

## 后续 / 下一步

后续 PR 把 MCP / WASM / extension / job-message 注册链路也接入同一份账本（在对应入口处复用 `ToolSource` 与 `RegistrationOutcome` 即可，无需修改 report 结构）。

Closes #88
