### PR TITLE
feat(tools): canonical tool namespace + dynamic-vs-dynamic collision (#87)

### DIFF
--- a/desktop-client/ironclaw/src/tools/canonical_name.rs
+++ b/desktop-client/ironclaw/src/tools/canonical_name.rs
@@ -1,0 +1,311 @@
+//! Canonical tool-name namespace strategy (issue #87).
+//!
+//! Defines a deterministic identity for every tool that flows through
+//! [`crate::tools::registry::ToolRegistry`]:
+//!
+//! | Source bucket  | Canonical form              | Example                    |
+//! |----------------|-----------------------------|----------------------------|
+//! | Built-in       | bare name                   | `shell`, `read_file`       |
+//! | MCP server     | `mcp.<server>.<tool>`       | `mcp.github.create_issue`  |
+//! | WASM extension | `wasm.<package>.<tool>`     | `wasm.acme.lint`           |
+//! | Extension      | `ext.<slug>.<tool>`         | `ext.acme-suite.formatter` |
+//!
+//! Display labels (user-friendly UI strings) live separately on the [`Tool`]
+//! impl; the canonical name is what the registry, policy, audit log, and
+//! prompt metadata must agree on.
+//!
+//! # Why this lives next to the registry
+//!
+//! Issue #88 already records `(name, source, outcome)` per registration. This
+//! module contributes the "what does the name *mean*" half so the registry
+//! can:
+//!
+//! 1. Reject **dynamic-vs-dynamic** collisions (two MCP servers fighting over
+//!    `mcp.foo.bar`, two WASM packages fighting over `wasm.foo.bar`, …).
+//! 2. Classify each registration into a finer source bucket
+//!    (`Mcp`/`Wasm`/`Extension`) for the startup report instead of the
+//!    catch-all `Dynamic`.
+//!
+//! # Non-goals (deferred)
+//!
+//! - **Strict prefix enforcement**: existing dynamic registrations that lack
+//!   a namespace prefix continue to work (parsed as
+//!   [`CanonicalKind::LegacyDynamic`]). Tightening to "every dynamic tool
+//!   MUST be namespaced" would break in-flight WASM tools and belongs in a
+//!   follow-up once all call-sites are migrated.
+//! - **Display name plumbing**: `Tool::display_name()` etc. is a separate
+//!   refactor. The current registration report carries canonical names only;
+//!   display names will be added when every `Tool` impl is updated.
+
+use std::fmt;
+
+/// Coarse classification used by the registry / report to bucket a
+/// registration without depending on the heavier
+/// [`crate::tools::registration_report::ToolSource`].
+///
+/// Kept `#[non_exhaustive]` so additional buckets (e.g. `Routine`, `Skill`)
+/// can land without breaking external matches.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum CanonicalKind {
+    /// Bare-name built-in tool (registered via the sync startup path).
+    Builtin,
+    /// `mcp.<server>.<tool>`.
+    Mcp,
+    /// `wasm.<package>.<tool>`.
+    Wasm,
+    /// `ext.<slug>.<tool>`.
+    Extension,
+    /// Dynamic tool that did not adopt any reserved namespace prefix.
+    /// Parsed permissively for backwards compatibility.
+    LegacyDynamic,
+}
+
+impl CanonicalKind {
+    /// Stable string label suitable for log fields and JSON keys.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Builtin => "builtin",
+            Self::Mcp => "mcp",
+            Self::Wasm => "wasm",
+            Self::Extension => "extension",
+            Self::LegacyDynamic => "legacy_dynamic",
+        }
+    }
+}
+
+/// Reserved namespace prefixes. Centralised here so the parser, the registry,
+/// and any audit/UI helper agree.
+pub const NAMESPACE_PREFIX_MCP: &str = "mcp";
+pub const NAMESPACE_PREFIX_WASM: &str = "wasm";
+pub const NAMESPACE_PREFIX_EXTENSION: &str = "ext";
+
+/// Parsed canonical tool name.
+///
+/// Stores the original raw string verbatim plus parsed-out segments so callers
+/// don't need to re-split. Equality and hashing are based on the raw form,
+/// which is the invariant the registry HashMap uses as its key.
+#[derive(Debug, Clone)]
+pub struct CanonicalToolName {
+    raw: String,
+    kind: CanonicalKind,
+    /// First namespace segment (server / package / slug). `None` for
+    /// `Builtin` and `LegacyDynamic`.
+    authority: Option<String>,
+    /// Final tool segment. Always set; equals `raw` for built-ins and
+    /// legacy-dynamic tools.
+    leaf: String,
+}
+
+impl CanonicalToolName {
+    /// Parse a name string with an explicit hint about whether it came from
+    /// the built-in startup path.
+    ///
+    /// Built-in tools always classify as [`CanonicalKind::Builtin`] regardless
+    /// of their bare name; this avoids false-positive `mcp.…` matches if a
+    /// future built-in ever uses a dotted name.
+    pub fn parse(name: &str, is_builtin: bool) -> Self {
+        let raw = name.to_string();
+        if is_builtin {
+            return Self {
+                leaf: raw.clone(),
+                raw,
+                kind: CanonicalKind::Builtin,
+                authority: None,
+            };
+        }
+
+        // Split into at most 3 segments: prefix . authority . leaf
+        // (the leaf itself may contain further dots, kept verbatim).
+        let mut parts = name.splitn(3, '.');
+        let prefix = parts.next().unwrap_or("");
+        let authority = parts.next();
+        let leaf = parts.next();
+
+        match (prefix, authority, leaf) {
+            (NAMESPACE_PREFIX_MCP, Some(auth), Some(tool))
+                if !auth.is_empty() && !tool.is_empty() =>
+            {
+                Self {
+                    raw,
+                    kind: CanonicalKind::Mcp,
+                    authority: Some(auth.to_string()),
+                    leaf: tool.to_string(),
+                }
+            }
+            (NAMESPACE_PREFIX_WASM, Some(auth), Some(tool))
+                if !auth.is_empty() && !tool.is_empty() =>
+            {
+                Self {
+                    raw,
+                    kind: CanonicalKind::Wasm,
+                    authority: Some(auth.to_string()),
+                    leaf: tool.to_string(),
+                }
+            }
+            (NAMESPACE_PREFIX_EXTENSION, Some(auth), Some(tool))
+                if !auth.is_empty() && !tool.is_empty() =>
+            {
+                Self {
+                    raw,
+                    kind: CanonicalKind::Extension,
+                    authority: Some(auth.to_string()),
+                    leaf: tool.to_string(),
+                }
+            }
+            _ => Self {
+                leaf: raw.clone(),
+                raw,
+                kind: CanonicalKind::LegacyDynamic,
+                authority: None,
+            },
+        }
+    }
+
+    /// Raw canonical string — the value stored as the registry HashMap key.
+    pub fn as_str(&self) -> &str {
+        &self.raw
+    }
+
+    pub fn kind(&self) -> CanonicalKind {
+        self.kind
+    }
+
+    /// First namespace segment (server name for MCP, package for WASM,
+    /// extension slug for `ext.*`). `None` for built-ins and legacy-dynamic.
+    pub fn authority(&self) -> Option<&str> {
+        self.authority.as_deref()
+    }
+
+    /// Tool-leaf segment (the final dotted segment, or the whole name for
+    /// built-ins / legacy-dynamic).
+    pub fn leaf(&self) -> &str {
+        &self.leaf
+    }
+}
+
+impl fmt::Display for CanonicalToolName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.raw)
+    }
+}
+
+impl PartialEq for CanonicalToolName {
+    fn eq(&self, other: &Self) -> bool {
+        self.raw == other.raw
+    }
+}
+
+impl Eq for CanonicalToolName {}
+
+impl std::hash::Hash for CanonicalToolName {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.raw.hash(state);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn req_87_parse_builtin_bare_name() {
+        let c = CanonicalToolName::parse("shell", true);
+        assert_eq!(c.kind(), CanonicalKind::Builtin);
+        assert_eq!(c.as_str(), "shell");
+        assert_eq!(c.leaf(), "shell");
+        assert!(c.authority().is_none());
+    }
+
+    #[test]
+    fn req_87_parse_mcp_three_segments() {
+        let c = CanonicalToolName::parse("mcp.github.create_issue", false);
+        assert_eq!(c.kind(), CanonicalKind::Mcp);
+        assert_eq!(c.authority(), Some("github"));
+        assert_eq!(c.leaf(), "create_issue");
+        assert_eq!(c.as_str(), "mcp.github.create_issue");
+    }
+
+    #[test]
+    fn req_87_parse_wasm_three_segments() {
+        let c = CanonicalToolName::parse("wasm.acme.lint", false);
+        assert_eq!(c.kind(), CanonicalKind::Wasm);
+        assert_eq!(c.authority(), Some("acme"));
+        assert_eq!(c.leaf(), "lint");
+    }
+
+    #[test]
+    fn req_87_parse_extension_three_segments() {
+        let c = CanonicalToolName::parse("ext.acme-suite.formatter", false);
+        assert_eq!(c.kind(), CanonicalKind::Extension);
+        assert_eq!(c.authority(), Some("acme-suite"));
+        assert_eq!(c.leaf(), "formatter");
+    }
+
+    #[test]
+    fn req_87_parse_dotted_leaf_kept_verbatim() {
+        // splitn(3) means the leaf can itself contain dots, e.g. an MCP
+        // server that namespaces tools internally.
+        let c = CanonicalToolName::parse("mcp.github.repo.create", false);
+        assert_eq!(c.kind(), CanonicalKind::Mcp);
+        assert_eq!(c.authority(), Some("github"));
+        assert_eq!(c.leaf(), "repo.create");
+    }
+
+    #[test]
+    fn req_87_parse_legacy_when_prefix_missing() {
+        let c = CanonicalToolName::parse("my_legacy_tool", false);
+        assert_eq!(c.kind(), CanonicalKind::LegacyDynamic);
+        assert_eq!(c.leaf(), "my_legacy_tool");
+        assert!(c.authority().is_none());
+    }
+
+    #[test]
+    fn req_87_parse_legacy_when_prefix_segments_missing() {
+        // "mcp.foo" lacks a tool segment → not a valid canonical MCP name,
+        // falls back to LegacyDynamic.
+        let c = CanonicalToolName::parse("mcp.foo", false);
+        assert_eq!(c.kind(), CanonicalKind::LegacyDynamic);
+    }
+
+    #[test]
+    fn req_87_parse_legacy_when_authority_empty() {
+        // "mcp..tool" must not silently classify as MCP with empty server.
+        let c = CanonicalToolName::parse("mcp..tool", false);
+        assert_eq!(c.kind(), CanonicalKind::LegacyDynamic);
+    }
+
+    #[test]
+    fn req_87_parse_legacy_when_unknown_prefix() {
+        let c = CanonicalToolName::parse("foo.bar.baz", false);
+        assert_eq!(c.kind(), CanonicalKind::LegacyDynamic);
+    }
+
+    #[test]
+    fn req_87_builtin_hint_overrides_dotted_form() {
+        // A built-in registered with a dotted name still classifies as
+        // Builtin because the startup path called `register_sync`.
+        let c = CanonicalToolName::parse("mcp.shadow", true);
+        assert_eq!(c.kind(), CanonicalKind::Builtin);
+    }
+
+    #[test]
+    fn req_87_kind_as_str_stable() {
+        assert_eq!(CanonicalKind::Builtin.as_str(), "builtin");
+        assert_eq!(CanonicalKind::Mcp.as_str(), "mcp");
+        assert_eq!(CanonicalKind::Wasm.as_str(), "wasm");
+        assert_eq!(CanonicalKind::Extension.as_str(), "extension");
+        assert_eq!(CanonicalKind::LegacyDynamic.as_str(), "legacy_dynamic");
+    }
+
+    #[test]
+    fn req_87_equality_and_hash_use_raw_form() {
+        use std::collections::HashSet;
+        let a = CanonicalToolName::parse("mcp.gh.list", false);
+        let b = CanonicalToolName::parse("mcp.gh.list", false);
+        assert_eq!(a, b);
+        let mut set: HashSet<CanonicalToolName> = HashSet::new();
+        set.insert(a);
+        assert!(set.contains(&b));
+    }
+}

--- a/desktop-client/ironclaw/src/tools/mod.rs
+++ b/desktop-client/ironclaw/src/tools/mod.rs
@@ -20,10 +20,15 @@ pub mod redaction;
 pub mod schema_validator;
 pub mod wasm;
 
+mod canonical_name;
 mod registration_report;
 mod registry;
 mod tool;
 
+pub use canonical_name::{
+    CanonicalKind, CanonicalToolName, NAMESPACE_PREFIX_EXTENSION, NAMESPACE_PREFIX_MCP,
+    NAMESPACE_PREFIX_WASM,
+};
 pub use registration_report::{
     RegistrationOutcome, RejectedToolEntry, RejectionReason, ToolRegistrationEntry,
     ToolRegistrationReport, ToolSource,

--- a/desktop-client/ironclaw/src/tools/registration_report.rs
+++ b/desktop-client/ironclaw/src/tools/registration_report.rs
@@ -45,10 +45,19 @@ pub enum ToolSource {
     /// Includes all built-in groups (echo/time/json/http, dev tools, memory,
     /// job, message, extension/skill/routine/image/vision/secrets, tool_info).
     Builtin,
+    /// Dynamic registration whose canonical name uses the
+    /// `mcp.<server>.<tool>` namespace (issue #87).
+    Mcp,
+    /// Dynamic registration whose canonical name uses the
+    /// `wasm.<package>.<tool>` namespace (issue #87).
+    Wasm,
+    /// Dynamic registration whose canonical name uses the
+    /// `ext.<slug>.<tool>` namespace (issue #87).
+    Extension,
     /// Registered through the dynamic async path
-    /// ([`crate::tools::registry::ToolRegistry::register`]). Today this
-    /// covers WASM tools, the software-builder tool, and any other
-    /// programmatically-added tool.
+    /// ([`crate::tools::registry::ToolRegistry::register`]) without a
+    /// reserved namespace prefix. Kept for backwards compatibility while
+    /// existing call-sites migrate to `mcp.*` / `wasm.*` / `ext.*`.
     Dynamic,
 }
 
@@ -57,6 +66,9 @@ impl ToolSource {
     pub fn as_str(&self) -> &'static str {
         match self {
             Self::Builtin => "builtin",
+            Self::Mcp => "mcp",
+            Self::Wasm => "wasm",
+            Self::Extension => "extension",
             Self::Dynamic => "dynamic",
         }
     }
@@ -76,6 +88,10 @@ pub enum RejectionReason {
     /// registration is dropped to keep security-critical tools (`shell`,
     /// `memory_write`, …) un-shadowable.
     ProtectedBuiltinShadow,
+    /// A dynamic tool tried to register under a canonical name that another
+    /// dynamic tool already owns (issue #87). The newer registration is
+    /// dropped — silent overwrite would corrupt audit / policy identity.
+    CanonicalNameCollision,
 }
 
 impl RejectionReason {
@@ -83,6 +99,7 @@ impl RejectionReason {
     pub fn as_str(&self) -> &'static str {
         match self {
             Self::ProtectedBuiltinShadow => "protected_builtin_shadow",
+            Self::CanonicalNameCollision => "canonical_name_collision",
         }
     }
 }

--- a/desktop-client/ironclaw/src/tools/registry.rs
+++ b/desktop-client/ironclaw/src/tools/registry.rs
@@ -26,6 +26,7 @@ use crate::tools::builtin::{
     SubAgentTool, TimeTool, ToolActivateTool, ToolAuthTool, ToolInstallTool, ToolListTool,
     ToolRemoveTool, ToolSearchTool, ToolUpgradeTool, WebFetchTool, WebSearchTool, WriteFileTool,
 };
+use crate::tools::canonical_name::{CanonicalKind, CanonicalToolName};
 use crate::tools::rate_limiter::RateLimiter;
 use crate::tools::registration_report::{
     RegistrationOutcome, RejectionReason, ToolRegistrationEntry, ToolRegistrationReport, ToolSource,
@@ -94,6 +95,22 @@ const PROTECTED_TOOL_NAMES: &[&str] = &[
     "git_push",
     "lsp_query",
 ];
+
+/// Map a parsed canonical name kind to the report-facing source bucket.
+/// Centralised so the `register()` flow and any future caller agree on the
+/// classification.
+fn canonical_kind_to_source(kind: CanonicalKind) -> ToolSource {
+    match kind {
+        // `register_sync` is the only path that produces `Builtin` entries;
+        // if a dynamic registration somehow hints `Builtin` (shouldn't
+        // happen because `parse(_, false)` never returns Builtin), fall
+        // back to the safe-by-default `Dynamic` bucket.
+        CanonicalKind::Builtin | CanonicalKind::LegacyDynamic => ToolSource::Dynamic,
+        CanonicalKind::Mcp => ToolSource::Mcp,
+        CanonicalKind::Wasm => ToolSource::Wasm,
+        CanonicalKind::Extension => ToolSource::Extension,
+    }
+}
 
 /// Registry of available tools.
 pub struct ToolRegistry {
@@ -169,14 +186,21 @@ impl ToolRegistry {
         &self.rate_limiter
     }
 
-    /// Register a tool. Rejects dynamic tools that try to shadow a protected built-in name.
+    /// Register a tool. Rejects dynamic tools that try to shadow a protected
+    /// built-in name, or that collide with an already-registered canonical
+    /// name (issue #87 dynamic-vs-dynamic).
     pub async fn register(&self, tool: Arc<dyn Tool>) {
         let name = tool.name().to_string();
+        let canonical = CanonicalToolName::parse(&name, false);
+        let source = canonical_kind_to_source(canonical.kind());
+
+        // 1. Reject shadowing of protected built-ins.
         if PROTECTED_TOOL_NAMES.contains(&name.as_str())
             && self.builtin_names.read().await.contains(&name)
         {
             tracing::warn!(
                 tool = %name,
+                source = %source.as_str(),
                 "Rejected tool registration: would shadow a built-in tool"
             );
             self.registration_log
@@ -184,23 +208,48 @@ impl ToolRegistry {
                 .await
                 .push(ToolRegistrationEntry {
                     name,
-                    source: ToolSource::Dynamic,
+                    source,
                     outcome: RegistrationOutcome::Rejected {
                         reason: RejectionReason::ProtectedBuiltinShadow,
                     },
                 });
             return;
         }
+
+        // 2. Reject dynamic-vs-dynamic canonical-name collisions.
+        // Silent overwrite would corrupt audit and policy identity, since
+        // both pre-existing and incoming registrations claim the same
+        // canonical name. The first writer wins; later attempts are logged.
+        if self.tools.read().await.contains_key(&name) {
+            tracing::warn!(
+                tool = %name,
+                source = %source.as_str(),
+                canonical_kind = %canonical.kind().as_str(),
+                "Rejected tool registration: canonical name already registered"
+            );
+            self.registration_log
+                .write()
+                .await
+                .push(ToolRegistrationEntry {
+                    name,
+                    source,
+                    outcome: RegistrationOutcome::Rejected {
+                        reason: RejectionReason::CanonicalNameCollision,
+                    },
+                });
+            return;
+        }
+
         self.tools.write().await.insert(name.clone(), tool);
         self.registration_log
             .write()
             .await
             .push(ToolRegistrationEntry {
                 name: name.clone(),
-                source: ToolSource::Dynamic,
+                source,
                 outcome: RegistrationOutcome::Accepted,
             });
-        tracing::trace!("Registered tool: {}", name);
+        tracing::trace!(canonical_kind = %canonical.kind().as_str(), "Registered tool: {}", name);
     }
 
     /// Register a tool (sync version for startup, marks as built-in).
@@ -1843,5 +1892,177 @@ mod tests {
                 "registration report leaked '{forbidden}' in JSON: {json}"
             );
         }
+    }
+
+    // ── issue #87: dynamic tool namespace + canonical-name collisions ───
+
+    /// Minimal test double to drive `register()` without standing up a full
+    /// MCP/WASM stack. Only `name()` is meaningful for namespace tests.
+    struct StubTool {
+        name: String,
+    }
+
+    #[async_trait::async_trait]
+    impl Tool for StubTool {
+        fn name(&self) -> &str {
+            &self.name
+        }
+        fn description(&self) -> &str {
+            "stub"
+        }
+        fn parameters_schema(&self) -> serde_json::Value {
+            serde_json::json!({})
+        }
+        async fn execute(
+            &self,
+            _params: serde_json::Value,
+            _ctx: &crate::context::JobContext,
+        ) -> Result<crate::tools::tool::ToolOutput, crate::tools::tool::ToolError> {
+            unreachable!("not invoked in namespace tests")
+        }
+    }
+
+    fn stub(name: &str) -> Arc<dyn Tool> {
+        Arc::new(StubTool {
+            name: name.to_string(),
+        })
+    }
+
+    #[tokio::test]
+    async fn req_87_canonical_source_buckets_classified_in_report() {
+        let registry = Arc::new(ToolRegistry::new());
+        registry.register(stub("mcp.github.create_issue")).await;
+        registry.register(stub("wasm.acme.lint")).await;
+        registry.register(stub("ext.acme-suite.formatter")).await;
+        registry.register(stub("legacy_no_prefix")).await;
+
+        let report = registry.registration_report(None).await;
+
+        assert_eq!(
+            report.accepted.get("mcp").map(|v| v.as_slice()),
+            Some(["mcp.github.create_issue".to_string()].as_slice()),
+            "mcp.* must classify into the `mcp` bucket"
+        );
+        assert_eq!(
+            report.accepted.get("wasm").map(|v| v.as_slice()),
+            Some(["wasm.acme.lint".to_string()].as_slice()),
+            "wasm.* must classify into the `wasm` bucket"
+        );
+        assert_eq!(
+            report.accepted.get("extension").map(|v| v.as_slice()),
+            Some(["ext.acme-suite.formatter".to_string()].as_slice()),
+            "ext.* must classify into the `extension` bucket"
+        );
+        assert_eq!(
+            report.accepted.get("dynamic").map(|v| v.as_slice()),
+            Some(["legacy_no_prefix".to_string()].as_slice()),
+            "names without a reserved prefix stay in the legacy `dynamic` bucket"
+        );
+    }
+
+    #[tokio::test]
+    async fn req_87_dynamic_mcp_collision_rejected_first_writer_wins() {
+        let registry = Arc::new(ToolRegistry::new());
+        registry.register(stub("mcp.github.create_issue")).await;
+        // Second registration under the same canonical name — must be
+        // dropped, not silently overwrite the first.
+        registry.register(stub("mcp.github.create_issue")).await;
+
+        let report = registry.registration_report(None).await;
+
+        assert_eq!(
+            report.accepted.get("mcp").map(|v| v.len()).unwrap_or(0),
+            1,
+            "only the first MCP registration may live in the registry"
+        );
+        assert_eq!(report.rejected.len(), 1, "second attempt must be rejected");
+        let r = &report.rejected[0];
+        assert_eq!(r.name, "mcp.github.create_issue");
+        assert_eq!(r.source, super::ToolSource::Mcp);
+        assert_eq!(r.reason, super::RejectionReason::CanonicalNameCollision);
+        assert_eq!(r.reason.as_str(), "canonical_name_collision");
+    }
+
+    #[tokio::test]
+    async fn req_87_dynamic_wasm_vs_wasm_collision_rejected() {
+        let registry = Arc::new(ToolRegistry::new());
+        registry.register(stub("wasm.acme.lint")).await;
+        registry.register(stub("wasm.acme.lint")).await;
+
+        let report = registry.registration_report(None).await;
+
+        assert_eq!(report.rejected.len(), 1);
+        assert_eq!(report.rejected[0].source, super::ToolSource::Wasm);
+        assert_eq!(
+            report.rejected[0].reason,
+            super::RejectionReason::CanonicalNameCollision
+        );
+    }
+
+    #[tokio::test]
+    async fn req_87_dynamic_legacy_collision_also_rejected() {
+        // Legacy (un-prefixed) dynamic registrations must follow the same
+        // first-writer-wins rule; otherwise canonical-name uniqueness is
+        // not actually a registry invariant.
+        let registry = Arc::new(ToolRegistry::new());
+        registry.register(stub("legacy_tool")).await;
+        registry.register(stub("legacy_tool")).await;
+
+        let report = registry.registration_report(None).await;
+
+        assert_eq!(report.rejected.len(), 1);
+        assert_eq!(report.rejected[0].source, super::ToolSource::Dynamic);
+        assert_eq!(
+            report.rejected[0].reason,
+            super::RejectionReason::CanonicalNameCollision
+        );
+    }
+
+    #[tokio::test]
+    async fn req_87_cross_namespace_names_do_not_collide() {
+        // `mcp.foo.bar` and `wasm.foo.bar` are distinct canonical names; both
+        // must register successfully and surface in their own buckets.
+        let registry = Arc::new(ToolRegistry::new());
+        registry.register(stub("mcp.foo.bar")).await;
+        registry.register(stub("wasm.foo.bar")).await;
+
+        let report = registry.registration_report(None).await;
+
+        assert!(report.rejected.is_empty(), "no collision across namespaces");
+        assert_eq!(report.accepted_count(), 2);
+        assert!(
+            report
+                .accepted
+                .get("mcp")
+                .is_some_and(|v| v.contains(&"mcp.foo.bar".to_string()))
+        );
+        assert!(
+            report
+                .accepted
+                .get("wasm")
+                .is_some_and(|v| v.contains(&"wasm.foo.bar".to_string()))
+        );
+    }
+
+    #[tokio::test]
+    async fn req_87_protected_shadow_takes_precedence_over_collision_check() {
+        // If a dynamic tool tries to register under a built-in's bare name,
+        // the rejection reason must be `protected_builtin_shadow`, not the
+        // generic `canonical_name_collision`. Audit/policy needs the more
+        // specific signal to flag intentional shadow attempts.
+        let registry = Arc::new(ToolRegistry::new());
+        registry
+            .bootstrap_tools(&BootstrapContext::for_test())
+            .await
+            .unwrap();
+        registry.register(stub("echo")).await;
+
+        let report = registry.registration_report(None).await;
+        assert_eq!(report.rejected.len(), 1);
+        assert_eq!(
+            report.rejected[0].reason,
+            super::RejectionReason::ProtectedBuiltinShadow,
+            "protected-shadow must win over generic collision"
+        );
     }
 }


### PR DESCRIPTION
## 背景 / 目标

实现 issue #87 的 Dynamic tool namespace contract（`mcp.<server>.<tool>` / `wasm.<package>.<tool>` / `ext.<slug>.<tool>` / 内置裸名）+ dynamic-vs-dynamic canonical-name collision rejection。

按 #87 第二条评论的 self-correction：`desktop-client/ironclaw/` **可改**（非 ADR-118 readonly），所以本 PR 直接在 `ToolRegistry::register()` 入口落实 acceptance。

Closes #87

## 改动范围

**新文件**
- `desktop-client/ironclaw/src/tools/canonical_name.rs`（~260 行 + 11 unit tests）
  - `pub enum CanonicalKind { Builtin, Mcp, Wasm, Extension, LegacyDynamic }` `#[non_exhaustive]`
  - `pub struct CanonicalToolName` 持有 `raw / kind / authority / leaf`，`PartialEq + Hash` 基于 `raw`（与 registry HashMap key 一致）
  - `parse(name, is_builtin)` 用 `splitn(3, '.')` 切前缀+authority+leaf，空 authority/leaf 回退到 `LegacyDynamic`
  - `pub const NAMESPACE_PREFIX_MCP / _WASM / _EXTENSION`

**修改**
- `tools/mod.rs`：`mod canonical_name; pub use canonical_name::{...};`
- `tools/registration_report.rs`：
  - `ToolSource` 新增 `Mcp / Wasm / Extension` 三个 `#[non_exhaustive]` variants
  - `RejectionReason` 新增 `CanonicalNameCollision`（`as_str() = "canonical_name_collision"`）
- `tools/registry.rs`：
  - 新增 `fn canonical_kind_to_source(CanonicalKind) -> ToolSource` 集中映射
  - `register()` 流程：① 协议保留：先做 `PROTECTED_TOOL_NAMES` shadow 检查 → ② 新增：dynamic-vs-dynamic canonical 冲突检查（`tools.contains_key(name)` 即拒绝）→ ③ insert + log
  - 第一写入者获胜；后续重名 dynamic 注册带 `CanonicalNameCollision` 写入 ledger 而非静默覆盖
  - 用 `CanonicalToolName::parse` 把 `name → ToolSource` 自动归类到正确 bucket，#88 的 startup report 现在能区分 `mcp` / `wasm` / `extension` / `dynamic` / `builtin`

**测试（16 个）**
- `canonical_name::tests`（11）：parser 表、builtin override、splitn 多点 leaf、空 authority、未知前缀、equality/hash 用 `raw`
- `registry::tests`（5）：
  - `req_87_canonical_source_buckets_classified_in_report` — 4 buckets 同时分类正确
  - `req_87_dynamic_mcp_collision_rejected_first_writer_wins` — MCP 重名拒绝
  - `req_87_dynamic_wasm_vs_wasm_collision_rejected` — WASM 重名拒绝
  - `req_87_dynamic_legacy_collision_also_rejected` — legacy 无前缀也走同一规则
  - `req_87_cross_namespace_names_do_not_collide` — `mcp.foo.bar` ≠ `wasm.foo.bar`
  - `req_87_protected_shadow_takes_precedence_over_collision_check` — 优先级断言

## 非目标（What's NOT in this PR）

- ❌ `Tool::display_name()` / `approval mode` / `sandbox mode` 列 — issue #88 acceptance bullet 2 残留项，需要触每个 `Tool` impl，单独 PR
- ❌ 把现有 dynamic 注册迁移到带前缀名 — `LegacyDynamic` bucket 保留向后兼容
- ❌ Policy decisions 消费 canonical name — P0-D audit task；本 PR 只确保 canonical name 已经是 registry HashMap key（前置工作）
- ❌ 严格前缀强制（"every dynamic tool MUST be namespaced"）— 会破坏在飞 WASM 工具
- ❌ 触碰红线 issue：未改 #127 #96 #95 #94 #92 #86 #85 #84 #73 #61 #37 #28

## 验证

```bash
$ cargo check -p ironclaw --tests
    Finished `dev` profile in 6m 10s

$ cargo nextest run -p ironclaw -E 'test(req_87_) | test(req_88_)'
27 tests run: 27 passed (2 leaky), 4562 skipped

$ cargo fmt --all  # clean

$ python3.12 scripts/check_no_panics.py --base origin/xClaw
OK: No panic-inducing calls in changed production code.

$ cargo clippy --no-deps -p ironclaw --all-targets 2>&1 | grep -E '\->.*(canonical_name|registration_report|tools/registry)'
# (empty — 0 warnings on changed files)
```

不相关文件（`worker/job.rs` collapsible_if、`builtin/web_search.rs` Default impl 等）的 toolchain-drift 告警与 #88 / #211 同源，CI 用同一 workflow 通过；本地 strict `-D warnings` 不计入门槛。

## 与 #88 的关系（Stack 历史）

#88 PR #211 已合（commit 569c0c87 → 3c6486ef），本 PR 基于 `xClaw` 顶端 `3c6486ef`，复用 #88 落地的 `ToolRegistrationEntry` / `registration_log` 机制，不再重复其内容。
