### PR TITLE
chore(service): ADR-114 Ⅳ rename launchd/systemd units + migrate (#109)

### DIFF
--- a/desktop-client/ironclaw/src/cli/doctor.rs
+++ b/desktop-client/ironclaw/src/cli/doctor.rs
@@ -566,23 +566,40 @@ fn check_secrets(settings: &Settings) -> CheckResult {
 
 fn check_service_installed() -> CheckResult {
     if cfg!(target_os = "macos") {
-        let plist =
-            dirs::home_dir().map(|h| h.join("Library/LaunchAgents/com.ironclaw.daemon.plist"));
-        match plist {
-            Some(path) if path.exists() => {
-                CheckResult::Pass(format!("launchd plist installed ({})", path.display()))
-            }
-            Some(_) => CheckResult::Skip("not installed (run `ironclaw service install`)".into()),
-            None => CheckResult::Skip("cannot determine home directory".into()),
+        let home = match dirs::home_dir() {
+            Some(h) => h,
+            None => return CheckResult::Skip("cannot determine home directory".into()),
+        };
+        let new_plist = home.join("Library/LaunchAgents/com.dasclaw.daemon.plist");
+        let legacy_plist = home.join("Library/LaunchAgents/com.ironclaw.daemon.plist");
+        if new_plist.exists() {
+            CheckResult::Pass(format!("launchd plist installed ({})", new_plist.display()))
+        } else if legacy_plist.exists() {
+            // Legacy plist still installed — surface a hint so the user runs
+            // `ironclaw service migrate` instead of leaving an orphan unit.
+            CheckResult::Pass(format!(
+                "legacy launchd plist installed at {}; run `ironclaw service migrate` to upgrade to com.dasclaw.daemon",
+                legacy_plist.display()
+            ))
+        } else {
+            CheckResult::Skip("not installed (run `ironclaw service install`)".into())
         }
     } else if cfg!(target_os = "linux") {
-        let unit = dirs::home_dir().map(|h| h.join(".config/systemd/user/ironclaw.service"));
-        match unit {
-            Some(path) if path.exists() => {
-                CheckResult::Pass(format!("systemd unit installed ({})", path.display()))
-            }
-            Some(_) => CheckResult::Skip("not installed (run `ironclaw service install`)".into()),
-            None => CheckResult::Skip("cannot determine home directory".into()),
+        let home = match dirs::home_dir() {
+            Some(h) => h,
+            None => return CheckResult::Skip("cannot determine home directory".into()),
+        };
+        let new_unit = home.join(".config/systemd/user/dasclaw.service");
+        let legacy_unit = home.join(".config/systemd/user/ironclaw.service");
+        if new_unit.exists() {
+            CheckResult::Pass(format!("systemd unit installed ({})", new_unit.display()))
+        } else if legacy_unit.exists() {
+            CheckResult::Pass(format!(
+                "legacy systemd unit installed at {}; run `ironclaw service migrate` to upgrade to dasclaw.service",
+                legacy_unit.display()
+            ))
+        } else {
+            CheckResult::Skip("not installed (run `ironclaw service install`)".into())
         }
     } else {
         CheckResult::Skip("service management not supported on this platform".into())

--- a/desktop-client/ironclaw/src/cli/service.rs
+++ b/desktop-client/ironclaw/src/cli/service.rs
@@ -14,8 +14,12 @@ pub enum ServiceCommand {
     Stop,
     /// Show service status.
     Status,
-    /// Uninstall the OS service and remove the unit file.
+    /// Uninstall the OS service and remove the unit file (also clears any
+    /// legacy `ironclaw.*` unit left over from before ADR-114 Ⅳ).
     Uninstall,
+    /// Migrate a pre-ADR-114 `ironclaw.*` service install to the renamed
+    /// `dasclaw.*` family: stop legacy → uninstall legacy → install new → start.
+    Migrate,
 }
 
 impl ServiceCommand {
@@ -27,6 +31,7 @@ impl ServiceCommand {
             ServiceCommand::Stop => ServiceAction::Stop,
             ServiceCommand::Status => ServiceAction::Status,
             ServiceCommand::Uninstall => ServiceAction::Uninstall,
+            ServiceCommand::Migrate => ServiceAction::Migrate,
         }
     }
 }

--- a/desktop-client/ironclaw/src/service.rs
+++ b/desktop-client/ironclaw/src/service.rs
@@ -1,11 +1,19 @@
-//! OS service management for running IronClaw as a daemon.
+//! OS service management for running the daemon.
 //!
 //! Generates and manages platform-native service definitions:
-//! - **macOS**: launchd plist at `~/Library/LaunchAgents/com.ironclaw.daemon.plist`
-//! - **Linux**: systemd user unit at `~/.config/systemd/user/ironclaw.service`
+//! - **macOS**: launchd plist at `~/Library/LaunchAgents/com.dasclaw.daemon.plist`
+//! - **Linux**: systemd user unit at `~/.config/systemd/user/dasclaw.service`
 //!
 //! The installed service runs `ironclaw run` (the default agent mode) and is
 //! configured to restart automatically on failure.
+//!
+//! ## ADR-114 Ⅳ rename + migration
+//!
+//! The current names are the rebranded `dasclaw` family. The previous
+//! `com.ironclaw.daemon` / `ironclaw.service` names are still recognised so
+//! that `service uninstall` and `service migrate` can clean up legacy
+//! installations without leaving orphan units behind. See
+//! `docs/SERVICE_MIGRATION.md` for the user-facing flow.
 
 use std::path::PathBuf;
 use std::process::Command;
@@ -14,8 +22,13 @@ use anyhow::{Context, Result, bail};
 
 use crate::bootstrap::dasclaw_base_dir;
 
-const SERVICE_LABEL: &str = "com.ironclaw.daemon";
-const SYSTEMD_UNIT: &str = "ironclaw.service";
+const SERVICE_LABEL: &str = "com.dasclaw.daemon";
+const SYSTEMD_UNIT: &str = "dasclaw.service";
+
+/// Pre-rename launchd label, kept for `service uninstall` / `service migrate`.
+const LEGACY_SERVICE_LABEL: &str = "com.ironclaw.daemon";
+/// Pre-rename systemd unit, kept for `service uninstall` / `service migrate`.
+const LEGACY_SYSTEMD_UNIT: &str = "ironclaw.service";
 
 // ── Public dispatch ─────────────────────────────────────────────
 
@@ -27,10 +40,11 @@ pub fn handle_command(command: &ServiceAction) -> Result<()> {
         ServiceAction::Stop => stop(),
         ServiceAction::Status => status(),
         ServiceAction::Uninstall => uninstall(),
+        ServiceAction::Migrate => migrate(),
     }
 }
 
-/// The five service lifecycle actions.
+/// Service lifecycle actions.
 #[derive(Debug, Clone)]
 pub enum ServiceAction {
     Install,
@@ -38,6 +52,9 @@ pub enum ServiceAction {
     Stop,
     Status,
     Uninstall,
+    /// ADR-114 Ⅳ — detect legacy `ironclaw.*` service, stop+uninstall it,
+    /// then install+start the new `dasclaw.*` service.
+    Migrate,
 }
 
 // ── Install ─────────────────────────────────────────────────────
@@ -224,28 +241,147 @@ fn status() -> Result<()> {
 // ── Uninstall ───────────────────────────────────────────────────
 
 fn uninstall() -> Result<()> {
-    // Stop first (ignore errors, service might not be running)
+    // Stop first (ignore errors, service might not be running). We attempt
+    // to stop both current and legacy units so that a stale ironclaw.* unit
+    // does not survive an `uninstall` issued after a partial migration.
     stop().ok();
+    stop_legacy().ok();
 
     if cfg!(target_os = "macos") {
         let file = macos_plist_path()?;
-        if file.exists() {
-            std::fs::remove_file(&file)
-                .with_context(|| format!("failed to remove {}", file.display()))?;
+        let legacy = macos_legacy_plist_path()?;
+        let mut removed = Vec::new();
+        for p in [&file, &legacy] {
+            if p.exists() {
+                std::fs::remove_file(p)
+                    .with_context(|| format!("failed to remove {}", p.display()))?;
+                removed.push(p.display().to_string());
+            }
         }
-        println!("Service uninstalled ({})", file.display());
+        if removed.is_empty() {
+            println!(
+                "Service uninstalled (nothing to remove at {})",
+                file.display()
+            );
+        } else {
+            println!("Service uninstalled ({})", removed.join(", "));
+        }
         Ok(())
     } else if cfg!(target_os = "linux") {
         let file = linux_unit_path()?;
-        if file.exists() {
-            std::fs::remove_file(&file)
-                .with_context(|| format!("failed to remove {}", file.display()))?;
+        let legacy = linux_legacy_unit_path()?;
+        let mut removed = Vec::new();
+        for p in [&file, &legacy] {
+            if p.exists() {
+                std::fs::remove_file(p)
+                    .with_context(|| format!("failed to remove {}", p.display()))?;
+                removed.push(p.display().to_string());
+            }
         }
         run_checked(Command::new("systemctl").args(["--user", "daemon-reload"])).ok();
-        println!("Service uninstalled ({})", file.display());
+        if removed.is_empty() {
+            println!(
+                "Service uninstalled (nothing to remove at {})",
+                file.display()
+            );
+        } else {
+            println!("Service uninstalled ({})", removed.join(", "));
+        }
         Ok(())
     } else {
         bail!("Service management is only supported on macOS and Linux");
+    }
+}
+
+// ── Migrate (ADR-114 Ⅳ) ────────────────────────────────────────
+
+/// Detect a legacy `ironclaw.*` service installation and migrate it to the
+/// new `dasclaw.*` names: stop legacy → remove legacy unit file → install
+/// new unit → start it. Idempotent: if no legacy install is found, this is
+/// equivalent to `install` followed by `start` (skipping start if a current
+/// install already exists).
+fn migrate() -> Result<()> {
+    if !cfg!(target_os = "macos") && !cfg!(target_os = "linux") {
+        bail!("Service management is only supported on macOS and Linux");
+    }
+
+    let legacy_present = legacy_unit_path_if_present()?;
+    match &legacy_present {
+        Some(p) => println!("Detected legacy service at {}", p.display()),
+        None => println!("No legacy ironclaw service detected"),
+    }
+
+    // Step 1: stop the legacy service (best-effort, ignore errors when not
+    // loaded). Skipped when no legacy unit exists.
+    if legacy_present.is_some() {
+        stop_legacy().ok();
+    }
+
+    // Step 2: remove the legacy unit file so the new install does not
+    // collide with stale auto-load metadata.
+    if let Some(path) = legacy_present.as_ref()
+        && path.exists()
+    {
+        std::fs::remove_file(path)
+            .with_context(|| format!("failed to remove legacy {}", path.display()))?;
+        println!("Removed legacy unit {}", path.display());
+        if cfg!(target_os = "linux") {
+            run_checked(Command::new("systemctl").args(["--user", "daemon-reload"])).ok();
+        }
+    }
+
+    // Step 3: install the new unit (idempotent — overwrites if present).
+    install()?;
+
+    // Step 4: start the new service. Best-effort stop first so re-running
+    // `migrate` against an already-loaded current install does not trip
+    // launchctl's "service already loaded" error.
+    stop().ok();
+    start()?;
+    println!("Migration to {SERVICE_LABEL} / {SYSTEMD_UNIT} complete");
+    Ok(())
+}
+
+/// Stop the legacy service if any. Best-effort; never bails.
+fn stop_legacy() -> Result<()> {
+    if cfg!(target_os = "macos") {
+        let plist = macos_legacy_plist_path()?;
+        run_checked(
+            Command::new("launchctl")
+                .arg("stop")
+                .arg(LEGACY_SERVICE_LABEL),
+        )
+        .ok();
+        if plist.exists() {
+            run_checked(
+                Command::new("launchctl")
+                    .arg("unload")
+                    .arg("-w")
+                    .arg(&plist),
+            )
+            .ok();
+        }
+        Ok(())
+    } else if cfg!(target_os = "linux") {
+        run_checked(Command::new("systemctl").args(["--user", "stop", LEGACY_SYSTEMD_UNIT])).ok();
+        run_checked(Command::new("systemctl").args(["--user", "disable", LEGACY_SYSTEMD_UNIT]))
+            .ok();
+        Ok(())
+    } else {
+        Ok(())
+    }
+}
+
+/// Return the path to the legacy unit file if it exists on disk, else `None`.
+fn legacy_unit_path_if_present() -> Result<Option<PathBuf>> {
+    if cfg!(target_os = "macos") {
+        let p = macos_legacy_plist_path()?;
+        Ok(if p.exists() { Some(p) } else { None })
+    } else if cfg!(target_os = "linux") {
+        let p = linux_legacy_unit_path()?;
+        Ok(if p.exists() { Some(p) } else { None })
+    } else {
+        Ok(None)
     }
 }
 
@@ -259,6 +395,14 @@ fn macos_plist_path() -> Result<PathBuf> {
         .join(format!("{SERVICE_LABEL}.plist")))
 }
 
+fn macos_legacy_plist_path() -> Result<PathBuf> {
+    let home = dirs::home_dir().context("could not find home directory")?;
+    Ok(home
+        .join("Library")
+        .join("LaunchAgents")
+        .join(format!("{LEGACY_SERVICE_LABEL}.plist")))
+}
+
 fn linux_unit_path() -> Result<PathBuf> {
     let home = dirs::home_dir().context("could not find home directory")?;
     Ok(home
@@ -266,6 +410,15 @@ fn linux_unit_path() -> Result<PathBuf> {
         .join("systemd")
         .join("user")
         .join(SYSTEMD_UNIT))
+}
+
+fn linux_legacy_unit_path() -> Result<PathBuf> {
+    let home = dirs::home_dir().context("could not find home directory")?;
+    Ok(home
+        .join(".config")
+        .join("systemd")
+        .join("user")
+        .join(LEGACY_SYSTEMD_UNIT))
 }
 
 fn ironclaw_logs_dir() -> PathBuf {
@@ -345,24 +498,61 @@ mod tests {
 
     #[cfg(target_os = "macos")]
     #[test]
-    fn macos_plist_path_has_expected_suffix() {
+    fn req_109_macos_plist_path_uses_dasclaw_label() {
         let path = macos_plist_path().unwrap();
         let s = path.to_string_lossy();
         assert!(
+            s.ends_with("Library/LaunchAgents/com.dasclaw.daemon.plist"),
+            "unexpected path: {s}"
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn req_109_macos_legacy_plist_path_points_at_ironclaw() {
+        let path = macos_legacy_plist_path().unwrap();
+        let s = path.to_string_lossy();
+        assert!(
             s.ends_with("Library/LaunchAgents/com.ironclaw.daemon.plist"),
+            "legacy path must still resolve to the pre-rename plist: {s}"
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn req_109_linux_unit_path_uses_dasclaw_unit() {
+        let path = linux_unit_path().unwrap();
+        let s = path.to_string_lossy();
+        assert!(
+            s.ends_with(".config/systemd/user/dasclaw.service"),
             "unexpected path: {s}"
         );
     }
 
     #[cfg(target_os = "linux")]
     #[test]
-    fn linux_unit_path_has_expected_suffix() {
-        let path = linux_unit_path().unwrap();
+    fn req_109_linux_legacy_unit_path_points_at_ironclaw() {
+        let path = linux_legacy_unit_path().unwrap();
         let s = path.to_string_lossy();
         assert!(
             s.ends_with(".config/systemd/user/ironclaw.service"),
-            "unexpected path: {s}"
+            "legacy path must still resolve to the pre-rename unit: {s}"
         );
+    }
+
+    #[test]
+    fn req_109_legacy_constants_remain_pinned_to_ironclaw_names() {
+        // Hard guard: if anyone refactors the constants away the rebrand
+        // window leaves users with no migration path. These two lines must
+        // stay literal.
+        assert_eq!(LEGACY_SERVICE_LABEL, "com.ironclaw.daemon");
+        assert_eq!(LEGACY_SYSTEMD_UNIT, "ironclaw.service");
+    }
+
+    #[test]
+    fn req_109_current_constants_use_dasclaw_namespace() {
+        assert_eq!(SERVICE_LABEL, "com.dasclaw.daemon");
+        assert_eq!(SYSTEMD_UNIT, "dasclaw.service");
     }
 
     #[test]

--- a/docs/SERVICE_MIGRATION.md
+++ b/docs/SERVICE_MIGRATION.md
@@ -1,0 +1,82 @@
+# Service Migration — `ironclaw.*` → `dasclaw.*` (ADR-114 Ⅳ)
+
+> Status: shipped via #109 (PR-link to be filled on merge). Source ADR:
+> [adr-114 §2.2 类 B-Ⅳ](plans/architecture-refactor/adr-114-dasclaw-rebrand.md).
+
+This document explains how the OS service unit names migrate from the
+pre-rebrand `ironclaw.*` family to the new `dasclaw.*` family without
+leaving orphan launchd plists or systemd units on user machines.
+
+## Name table
+
+| Platform | Old | New |
+|---|---|---|
+| macOS launchd label | `com.ironclaw.daemon` | `com.dasclaw.daemon` |
+| macOS launchd plist | `~/Library/LaunchAgents/com.ironclaw.daemon.plist` | `~/Library/LaunchAgents/com.dasclaw.daemon.plist` |
+| Linux systemd unit name | `ironclaw.service` | `dasclaw.service` |
+| Linux systemd unit path | `~/.config/systemd/user/ironclaw.service` | `~/.config/systemd/user/dasclaw.service` |
+
+## What `service install` does now
+
+```sh
+ironclaw service install
+```
+
+Always installs the **new** `dasclaw.*` family. It does not touch any
+legacy `ironclaw.*` file that may still be on disk.
+
+## Migrating an existing install
+
+```sh
+ironclaw service migrate
+```
+
+The migrate subcommand performs a single-shot upgrade in this order:
+
+1. **Detect** any legacy `com.ironclaw.daemon.plist` (macOS) or
+   `ironclaw.service` (Linux). If absent, the rest is equivalent to
+   `service install` followed by `service start`.
+2. **Stop legacy** (best-effort, ignores "not loaded"):
+   - macOS: `launchctl stop com.ironclaw.daemon` then `launchctl unload -w …`.
+   - Linux: `systemctl --user stop ironclaw.service` then
+     `systemctl --user disable ironclaw.service`.
+3. **Remove the legacy unit file** so its auto-load metadata cannot
+   resurrect it on the next login.
+4. **Install** the new `dasclaw.*` unit (idempotent — safe to re-run).
+5. **Stop-then-start** the new unit so a re-run from a clean state
+   does not collide with an already-loaded current install.
+
+The command is idempotent: running it twice on a fully-migrated
+machine is a no-op aside from a stop/start cycle of the current unit.
+
+## Uninstalling
+
+```sh
+ironclaw service uninstall
+```
+
+Stops and removes **both** the new and any leftover legacy unit, so a
+single `uninstall` invocation guarantees no stray daemon survives.
+
+## Doctor
+
+```sh
+ironclaw doctor
+```
+
+The service-installed check now prefers the new unit and falls back to
+the legacy unit if the new one is missing. When the legacy file is
+detected, the doctor message includes a hint to run
+`ironclaw service migrate`.
+
+## Non-goals (deferred)
+
+- Binary / crate rename (`ironclaw` → `dasclaw`) — tracked separately
+  by ADR-114 Ⅴ / issue #110.
+- Production-deployment systemd unit at
+  `desktop-client/ironclaw/deploy/ironclaw.service` is a Docker host
+  unit on cloud VMs and is **not** in scope for the user-side migrate
+  flow. Operators of that unit must rename it manually together with
+  their deploy automation.
+- `IRONCLAW_BASE_DIR` / data directory rename — handled by the
+  ADR-114 Ⅱ / Ⅲ work that already shipped.


### PR DESCRIPTION
## Background / Goal

ADR-114 Ⅳ rebrand of the OS service layer. Issue #109.

| Platform | Old | New |
|---|---|---|
| macOS launchd | `com.ironclaw.daemon.plist` | `com.dasclaw.daemon.plist` |
| Linux systemd | `ironclaw.service` | `dasclaw.service` |

The previous PR (#210, ADR-114 Ⅲ) renamed the internal `dasclaw_base_dir`
API. This PR renames the OS-side unit names that the rebranded daemon
registers, and ships a single-shot `service migrate` flow so existing
users on the old install do not end up with orphan units.

## Changes

- `desktop-client/ironclaw/src/service.rs`
  - `SERVICE_LABEL = "com.dasclaw.daemon"`, `SYSTEMD_UNIT = "dasclaw.service"`
  - `LEGACY_SERVICE_LABEL = "com.ironclaw.daemon"`, `LEGACY_SYSTEMD_UNIT = "ironclaw.service"` retained for migrate / uninstall
  - `ServiceAction::Migrate` variant + `migrate()` flow:
    detect legacy → stop legacy (best-effort, ignore "not loaded") →
    remove legacy unit file → install new → stop+start new (idempotent)
  - `uninstall()` now stops and removes both new and legacy units in
    one shot — no orphan after a single `service uninstall`
  - `stop_legacy()` + `legacy_unit_path_if_present()` helpers
  - 6 new tests `req_109_*` covering both label families and constants
- `desktop-client/ironclaw/src/cli/service.rs`
  - `ServiceCommand::Migrate` variant wired through `to_action()`
- `desktop-client/ironclaw/src/cli/doctor.rs::check_service_installed`
  - Prefer new unit; fall back to legacy and emit a Pass message that
    explicitly tells the user to run `ironclaw service migrate`
- `docs/SERVICE_MIGRATION.md` (NEW) — user-facing migration guide

## Non-goals (What's NOT in this PR)

- Binary / crate rename `ironclaw → dasclaw` (issue #110, ADR-114 Ⅴ)
- `desktop-client/ironclaw/deploy/ironclaw.service` (Docker-host
  systemd unit on cloud VMs) — explicitly noted as out of scope in
  `docs/SERVICE_MIGRATION.md`; operators must rename it together with
  their deploy automation
- Data dir / `IRONCLAW_BASE_DIR` rename (already shipped via #210
  ADR-114 Ⅲ + earlier ADR-114 Ⅰ/Ⅱ work)
- Adding a `Warn` variant to `CheckResult`: the legacy-detected case
  reuses `Pass` with a hint string to keep doctor output schema stable

## Verification

- `cargo check -p ironclaw --tests` : pass (2m24s)
- `cargo nextest run -p ironclaw -E 'test(req_109_) | test(xml_escape) | test(run_capture) | test(run_checked) | test(logs_dir) | test(macos_plist_sets)'` : **12/12 PASS** (3 leaky — pre-existing pattern shared with #88 / #87)
- `cargo fmt --all` : clean
- `python3.12 scripts/check_no_panics.py --base origin/xClaw` : OK
- `cargo clippy --no-deps -p ironclaw --all-targets` : zero warnings on
  `service.rs` / `cli/service.rs` / `cli/doctor.rs`; pre-existing
  toolchain-drift warnings on unrelated files (job.rs, web_search.rs,
  …) are CI-known and gated by the same workflow that #88 / #211 / #213 cleared.

Closes #109
