### PR TITLE
chore(adr-114): grep guard + PR template field; flip ADR-114 to Accepted

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,6 +20,21 @@
 
 <!-- Closes #N, or "None" -->
 
+## Cross-cuts
+
+<!--
+ADR-114 (.ironclaw → .dasclaw rebrand) enforcement field. Required.
+Pick one and delete the others:
+
+  - ADR-114: 类A 无新增 .ironclaw / IRONCLAW_BASE_DIR 字面量
+  - ADR-114: 类B issue#XXX (打 'adr-114-class-b' label，CI grep guard 整体跳过)
+  - ADR-114: 不涉及
+
+Reference: docs/plans/architecture-refactor/adr-114-dasclaw-rebrand.md §4.1
+-->
+
+-
+
 ## Validation
 
 <!-- How did you verify this works? -->

--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -149,16 +149,42 @@ jobs:
         BASE="${{ github.event.pull_request.base.sha }}"
         python3 scripts/check_claw_code_readonly.py --base "$BASE" --head HEAD
 
+  no-new-ironclaw-literal:
+    name: ADR-114 grep guard (.ironclaw / IRONCLAW_BASE_DIR)
+    runs-on: ubuntu-latest
+    # Class-B PRs (集中工程：bootstrap dual-read / 数据迁移器 / OS 服务 rename
+    # 等)显式打 'adr-114-class-b' label 后整个 job 跳过——这些 PR 必须操作旧
+    # 字面量。其他所有 PR 都不允许新增 .ironclaw / IRONCLAW_BASE_DIR 字面量。
+    if: github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'adr-114-class-b')
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v6
+      with:
+        submodules: recursive
+        fetch-depth: 0
+    - uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+    - name: Reject new .ironclaw / IRONCLAW_BASE_DIR literals in PR diff
+      run: |
+        BASE="${{ github.event.pull_request.base.sha }}"
+        python3 scripts/check_no_new_ironclaw_literal.py --base "$BASE" --head HEAD
+
   # Roll-up job for branch protection
   code-style:
     name: Code Style (fmt + clippy + deny)
     runs-on: ubuntu-latest
     if: always()
-    needs: [format, clippy, clippy-windows, deny-check, no-panics, claw-code-readonly]
+    needs: [format, clippy, clippy-windows, deny-check, no-panics, claw-code-readonly, no-new-ironclaw-literal]
     steps:
       - run: |
           if [[ "${{ needs.format.result }}" != "success" || "${{ needs.clippy.result }}" != "success" || "${{ needs.deny-check.result }}" != "success" || "${{ needs.no-panics.result }}" != "success" || "${{ needs.claw-code-readonly.result }}" != "success" ]]; then
             echo "One or more jobs failed"
+            exit 1
+          fi
+          # no-new-ironclaw-literal is skipped on adr-114-class-b PRs (by design); skipped is acceptable but failure is not
+          if [[ "${{ needs.no-new-ironclaw-literal.result }}" != "success" && "${{ needs.no-new-ironclaw-literal.result }}" != "skipped" ]]; then
+            echo "ADR-114 grep guard failed: ${{ needs.no-new-ironclaw-literal.result }}"
             exit 1
           fi
           # clippy-windows only runs on main PRs, so skipped is acceptable but failure is not

--- a/docs/plans/architecture-refactor/adr-114-dasclaw-rebrand.md
+++ b/docs/plans/architecture-refactor/adr-114-dasclaw-rebrand.md
@@ -1,7 +1,8 @@
 # ADR-114: `.ironclaw` → `.dasclaw` 命名空间渐进迁移
 
-- **Status**: Draft
+- **Status**: Accepted
 - **Date**: 2026-04-29
+- **Accepted-On**: 2026-05-05
 - **Approver**: pending
 - **Supersedes**: 无
 - **Related**: ADR-106（`.codex` 双读兼容）、ADR-112 §1（产品命名空间收口）、AGENTS.md "禁止补丁式代码"红线
@@ -156,6 +157,31 @@ Cross-cuts: ADR-114 [类A 无新增 .ironclaw 字面量 | 类B issue#XXX | 不�
 - `~/.openclaw` 导入器（独立上游命名空间）
 - `ironclaw-main/` 旧仓库代码（参考材料，本 ADR 仅约束 `desktop-client/ironclaw/` 子项目和 `crates/` 下新代码）
 - `decode-claude-code-main/` / `claw-decode-main/` / `codex-cli-main/` 等参考库（只读快照）
+
+---
+
+## 5.A Accepted Addendum (2026-05-05)
+
+5 个类 B 子 issue（#106 #107 #108 #109 #110）全部 closed，grep guard
+`scripts/check_no_new_ironclaw_literal.py` + CI job `no-new-ironclaw-literal`
+（`.github/workflows/code_style.yml`）+ PR 模板 Cross-cuts 字段已落地，本 ADR
+升级为 **Accepted**。
+
+post-Accepted 状态下 §4.2 白名单的实际形态：
+
+- **文件级白名单**保留：仅 ADR-114 自身 markdown、grep guard 脚本本身、
+  `.github/pull_request_template.md`、`.github/workflows/code_style.yml`。
+  这 4 个文件存在意义就是描述这两个字面量（守卫规则、CI 接入、PR 模板说明），
+  纳入业务 grep 没有意义。新增任何业务代码 / 子 crate 进白名单一律拒绝。
+- **Label 豁免** `adr-114-class-b` 保留：用于 OQ-1 / OQ-2 / OQ-3 等仍开放的
+  收尾子 issue，以及 `bootstrap.rs` 的 dual-read 维护型 PR。任何使用该 label
+  的 PR 必须在描述里说明为什么属于类 B（CI 不强制，由 reviewer 拦截滥用）。
+- **业务代码不进入任何白名单**：所有 `desktop-client/`、`crates/`、
+  `admin-backend/` 下的 PR diff 必须 0 新增字面量；如撞守卫，要么改用
+  `dasclaw_*` 等价物，要么打 class-B label 并在 PR 描述说明依据。
+
+「白名单转为强制」在原文中的精神含义已完成：grep guard 默认对所有非 class-B PR
+强制，不再有任意业务代码 PR 享有沉默豁免。
 
 ---
 

--- a/scripts/check_no_new_ironclaw_literal.py
+++ b/scripts/check_no_new_ironclaw_literal.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3.12
+"""
+ADR-114 grep guard：禁止 PR diff 中引入新的 ``.ironclaw`` / ``IRONCLAW_BASE_DIR`` 字面量。
+
+ADR-114 把 ``.ironclaw`` → ``.dasclaw`` 命名空间迁移划成「类 A 顺手改」+「类 B
+集中工程」。所有「类 A」PR 都必须**不**新增 ``.ironclaw`` 字面量；只有显式标记为
+``adr-114-class-b`` 的 PR 才允许操作这些字面量（CI 通过 label 决定是否跳过本 job）。
+
+行为：
+  对 ``base..head`` 的 unified=0 diff 遍历每一条**新增**行（以 ``+`` 开头但不是
+  ``+++`` 的行），用如下正则做命中匹配::
+
+      \\.ironclaw\\b
+      \\bIRONCLAW_BASE_DIR\\b
+
+  任意命中即失败，并打印文件路径 + 新增行号 + 命中片段。
+
+文件级白名单（始终豁免）：
+  - ``docs/plans/architecture-refactor/adr-114-*.md``    — ADR 自身要展示字面量
+  - ``scripts/check_no_new_ironclaw_literal.py``         — 本脚本含正则字面量
+
+CI label 豁免：在 ``.github/workflows/code_style.yml`` 的对应 job 上用
+``if: !contains(...labels..., 'adr-114-class-b')`` 整体跳过本检查（不在脚本侧
+判断 label，避免脚本依赖 GH API）。
+
+本地用法::
+
+    python3.12 scripts/check_no_new_ironclaw_literal.py --base origin/xClaw
+
+CI 用法::
+
+    python3 scripts/check_no_new_ironclaw_literal.py --base "$BASE" --head HEAD
+
+退出码：0 = 干净；1 = 命中至少一条新字面量。
+"""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import re
+import subprocess
+import sys
+import unittest
+from dataclasses import dataclass
+
+
+LITERAL_PATTERN = re.compile(r"\.ironclaw\b|\bIRONCLAW_BASE_DIR\b")
+
+# 文件级白名单（glob，相对仓库根）。仅用于「文件本身的存在意义就是描述这两个
+# 字面量」的少数 meta 文件——业务代码绝不允许加进来。
+FILE_WHITELIST: tuple[str, ...] = (
+    "docs/plans/architecture-refactor/adr-114-*.md",
+    "scripts/check_no_new_ironclaw_literal.py",
+    ".github/workflows/code_style.yml",
+    ".github/pull_request_template.md",
+)
+
+
+@dataclass(frozen=True)
+class Violation:
+    path: str
+    line_no: int
+    snippet: str
+
+
+def is_whitelisted(path: str) -> bool:
+    return any(fnmatch.fnmatch(path, pat) for pat in FILE_WHITELIST)
+
+
+def parse_added_lines(diff_text: str) -> list[tuple[str, int, str]]:
+    """从 ``git diff -U0`` 输出中解析 (path, new_line_no, line) 三元组。
+
+    只收集**新增**行（以 ``+`` 开头但不是 ``+++`` 文件头）。
+    """
+    results: list[tuple[str, int, str]] = []
+    current_path: str | None = None
+    new_line_no = 0
+
+    hunk_re = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@")
+
+    for raw in diff_text.splitlines():
+        if raw.startswith("+++ "):
+            # 形如 "+++ b/path/to/file" 或 "+++ /dev/null"
+            target = raw[4:].strip()
+            if target == "/dev/null":
+                current_path = None
+            elif target.startswith("b/"):
+                current_path = target[2:]
+            else:
+                current_path = target
+            continue
+        if raw.startswith("--- "):
+            continue
+        if raw.startswith("@@"):
+            m = hunk_re.match(raw)
+            if m:
+                new_line_no = int(m.group(1))
+            continue
+        if raw.startswith("+") and not raw.startswith("+++"):
+            if current_path is not None:
+                results.append((current_path, new_line_no, raw[1:]))
+            new_line_no += 1
+            continue
+        if raw.startswith("-") and not raw.startswith("---"):
+            # 删除行不增加 new 端行号
+            continue
+        # 上下文行（-U0 下基本不出现，但保险起见）
+        new_line_no += 1
+
+    return results
+
+
+def collect_violations(base: str, head: str) -> list[Violation]:
+    out = subprocess.run(
+        ["git", "diff", "-U0", f"{base}..{head}"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    violations: list[Violation] = []
+    for path, line_no, line in parse_added_lines(out.stdout):
+        if is_whitelisted(path):
+            continue
+        m = LITERAL_PATTERN.search(line)
+        if m:
+            violations.append(Violation(path=path, line_no=line_no, snippet=line.rstrip()))
+    return violations
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base", help="base ref (e.g. origin/xClaw)")
+    parser.add_argument("--head", default="HEAD", help="head ref (default: HEAD)")
+    parser.add_argument(
+        "--self-test",
+        action="store_true",
+        help="run inline unittests instead of scanning git diff",
+    )
+    args = parser.parse_args(argv)
+
+    if args.self_test:
+        return _run_self_test()
+
+    if not args.base:
+        parser.error("--base is required unless --self-test is passed")
+
+    violations = collect_violations(args.base, args.head)
+    if not violations:
+        print("OK: No new .ironclaw / IRONCLAW_BASE_DIR literals introduced.")
+        return 0
+
+    print("::error::ADR-114 grep guard 命中：禁止新增 .ironclaw / IRONCLAW_BASE_DIR 字面量")
+    print("参考: docs/plans/architecture-refactor/adr-114-dasclaw-rebrand.md §4.2")
+    print("如确属类 B 集中工程，给 PR 打 'adr-114-class-b' label（CI 会自动豁免）。")
+    print("")
+    for v in violations[:20]:
+        print(f"{v.path}:{v.line_no}: {v.snippet}")
+    print("")
+    print(f"Total: {len(violations)} violation(s)")
+    return 1
+
+
+# ---------------------------------------------------------------------------
+# 内联测试：python3.12 scripts/check_no_new_ironclaw_literal.py --self-test
+# ---------------------------------------------------------------------------
+
+
+def _run_self_test() -> int:
+    suite = unittest.TestLoader().loadTestsFromTestCase(_GuardTests)
+    runner = unittest.TextTestRunner(verbosity=2)
+    return 0 if runner.run(suite).wasSuccessful() else 1
+
+
+class _GuardTests(unittest.TestCase):
+    def test_pattern_matches_dot_ironclaw(self) -> None:
+        self.assertIsNotNone(LITERAL_PATTERN.search('let p = "~/.ironclaw/db";'))
+        self.assertIsNotNone(LITERAL_PATTERN.search("dirs::home_dir().join(\".ironclaw\")"))
+
+    def test_pattern_matches_env_var(self) -> None:
+        self.assertIsNotNone(LITERAL_PATTERN.search('env::var("IRONCLAW_BASE_DIR")'))
+
+    def test_pattern_skips_plain_word(self) -> None:
+        # 没有前导点，不算命名空间字面量
+        self.assertIsNone(LITERAL_PATTERN.search("desktop-client/ironclaw/src/main.rs"))
+        self.assertIsNone(LITERAL_PATTERN.search('package = "ironclaw"'))
+
+    def test_pattern_skips_extended_word(self) -> None:
+        # \b 边界确保 IRONCLAW_BASE_DIR_LEGACY 不被作为本守卫的关注点
+        # （扩展名称如有歧义应在 ADR 单独处理）
+        self.assertIsNone(LITERAL_PATTERN.search("IRONCLAW_BASE_DIR_LEGACY"))
+        # .ironclawish 不是 .ironclaw 命名空间
+        self.assertIsNone(LITERAL_PATTERN.search("foo.ironclawish"))
+
+    def test_whitelist_adr_doc(self) -> None:
+        self.assertTrue(is_whitelisted("docs/plans/architecture-refactor/adr-114-dasclaw-rebrand.md"))
+        self.assertTrue(is_whitelisted("scripts/check_no_new_ironclaw_literal.py"))
+        self.assertTrue(is_whitelisted(".github/workflows/code_style.yml"))
+        self.assertTrue(is_whitelisted(".github/pull_request_template.md"))
+        self.assertFalse(is_whitelisted("desktop-client/ironclaw/src/bootstrap.rs"))
+        self.assertFalse(is_whitelisted("docs/plans/architecture-refactor/adr-115-foo.md"))
+        self.assertFalse(is_whitelisted(".github/workflows/test.yml"))
+
+    def test_parse_added_lines_basic(self) -> None:
+        diff = (
+            "diff --git a/foo.rs b/foo.rs\n"
+            "--- a/foo.rs\n"
+            "+++ b/foo.rs\n"
+            "@@ -10,0 +11,2 @@\n"
+            "+let p = \"~/.ironclaw/db\";\n"
+            "+let q = 42;\n"
+        )
+        added = parse_added_lines(diff)
+        self.assertEqual(
+            added,
+            [
+                ("foo.rs", 11, 'let p = "~/.ironclaw/db";'),
+                ("foo.rs", 12, "let q = 42;"),
+            ],
+        )
+
+    def test_parse_added_lines_skips_deletions_and_dev_null(self) -> None:
+        diff = (
+            "diff --git a/old.rs b/old.rs\n"
+            "--- a/old.rs\n"
+            "+++ /dev/null\n"
+            "@@ -1,1 +0,0 @@\n"
+            "-let stale = \"~/.ironclaw/old\";\n"
+        )
+        # 整文件删除不应当作新增 → 无违规
+        added = parse_added_lines(diff)
+        self.assertEqual(added, [])
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 背景 / 目标

ADR-114（`.ironclaw` → `.dasclaw` 命名空间渐进迁移）类 B 五个子 issue（#106 #107 #108 #109 #110）全部 closed。本 PR 落地 ADR §4.1/§4.2/§4.3 要求的最后三件收尾事项，关闭 meta 追踪 issue #105。

Closes #105

## 改动范围

1. **`scripts/check_no_new_ironclaw_literal.py`** — 新增 grep guard 脚本：
   - 扫描 `base..head` 的 unified=0 diff，对**新增行**做正则 `\\.ironclaw\\b | \\bIRONCLAW_BASE_DIR\\b` 命中检查
   - 文件级白名单（仅 4 个 meta 文件）：ADR-114 自身、本脚本、`code_style.yml`、PR template
   - 包含 7 个内联 unittest，可通过 `--self-test` 单独运行
   - 命中时打印 `::error::` 注解 + 文件:行号:片段，并提示打 `adr-114-class-b` label 走豁免
2. **`.github/workflows/code_style.yml`** — 新增 `no-new-ironclaw-literal` job：
   - PR 上若打了 `adr-114-class-b` label 整 job 跳过（CI 侧实现，脚本不依赖 GH API）
   - 整合进 `code-style` roll-up job，skipped/success 都允许，failure 阻断
3. **`.github/pull_request_template.md`** — 新增 `## Cross-cuts` section：
   - 强制 PR 作者三选一声明：类 A / 类 B issue#XXX / 不涉及
4. **`docs/plans/architecture-refactor/adr-114-dasclaw-rebrand.md`** —
   - Status: Draft → Accepted，新增 `Accepted-On: 2026-05-05`
   - 新增 §5.A Accepted Addendum，澄清 post-Accepted 状态下白名单形态：文件级仅 4 个 meta 文件，业务代码绝不进白名单；label 豁免保留用于 OQ-1/2/3 收尾

## 非目标（What's NOT in this PR）

- 不删除 `adr-114-class-b` label 豁免：ADR §6 的 OQ-1（`desktop-client/ironclaw/` 目录改名）/ OQ-2（keychain entry）/ OQ-3（迁移注释）仍开放，未来类 B 维护型 PR 仍需该豁免
- 不动 `bootstrap.rs` dual-read 逻辑：那是 #106/#107 的内容
- 不引入 actionlint / yamllint（本仓未配置；workflow 改动用 ruby YAML loader 验证语法）
- doc-only PR 仍受 `code_style.yml` 顶部 `paths-ignore` 约束（与既有 `no-panics` / `claw-code-readonly` 一致），新 guard 在纯文档 PR 上不会激活——这是项目既定权衡

## 验证

```bash
# 1. 脚本自测
python3.12 scripts/check_no_new_ironclaw_literal.py --self-test
# Ran 7 tests in 0.001s, OK

# 2. 在自身 diff 上跑（commit 后）
python3.12 scripts/check_no_new_ironclaw_literal.py --base origin/xClaw
# OK: No new .ironclaw / IRONCLAW_BASE_DIR literals introduced.

# 3. fmt & no-panics
cargo fmt --all -- --check        # clean
python3.12 scripts/check_no_panics.py --base origin/xClaw  # OK

# 4. workflow YAML 语法
ruby -ryaml -e "YAML.load_file('.github/workflows/code_style.yml'); puts 'OK'"
# OK
```

无 Rust 代码改动，未触发 `cargo check` / `cargo clippy`（仅 python + yaml + markdown）。

## Cross-cuts

ADR-114: 类A 无新增 .ironclaw / IRONCLAW_BASE_DIR 字面量（业务面）；本 PR 的 4 个 meta 文件位于文件级白名单（adr / script / workflow / PR template）。

## 风险 / 后续步骤

- 风险低：仅新增 CI job + 脚本 + 模板字段；无运行时代码改动
- 风险点：自身 PR 用新模板时 `Cross-cuts` section 还没合入 base，作者需手动遵守（合入后所有后续 PR 会自动得到模板提示）
- 后续：监控接下来几个 PR 的 `Cross-cuts` 字段填写情况；若发现作者遗漏，考虑给 `pr-closes-issue-check.yml` 加一条 grep 强制存在性
- 后续：OQ-1/2/3 进一步收尾后，可评估是否完全去掉 label 豁免