### PR TITLE
chore(adr-114): scrub legacy .ironclaw from V8 migration comment (OQ-3)

### DIFF
--- a/desktop-client/ironclaw/migrations/V8__settings.sql
+++ b/desktop-client/ironclaw/migrations/V8__settings.sql
@@ -1,6 +1,7 @@
 -- Settings table: key-value store for all user configuration.
 --
--- Replaces ~/.ironclaw/settings.json, session.json, and mcp-servers.json.
+-- Replaces ~/.dasclaw/settings.json, session.json, and mcp-servers.json
+-- (see ADR-114 for the namespace migration history).
 -- Keys use dotted paths matching the existing Settings.get()/set() convention
 -- (e.g., "agent.name", "sandbox.enabled", "mcp_servers").
 -- One row per setting so individual values can be updated atomically.


### PR DESCRIPTION
## 背景 / 目标

ADR-114 §6 列出 3 个 Open Question：
- OQ-1：`desktop-client/ironclaw/` 目录改名（git history 影响，独立子 issue）
- OQ-2：keychain entry `com.ironclaw.*` 迁移（涉及 secrets，迁移器范畴）
- **OQ-3：`migrations/V8__settings.sql` 注释字面量是否走类 A？建议是**

本 PR 落地 OQ-3，扫掉 `desktop-client/ironclaw/migrations/` 下唯一一处遗留的 `~/.ironclaw/` 字面量（位于 V8 表头注释）。

Closes #218

## 改动范围

`desktop-client/ironclaw/migrations/V8__settings.sql` — header 注释 1 行改为：

```diff
- -- Replaces ~/.ironclaw/settings.json, session.json, and mcp-servers.json.
+ -- Replaces ~/.dasclaw/settings.json, session.json, and mcp-servers.json
+ -- (see ADR-114 for the namespace migration history).
```

## 安全性论证（为什么改已应用 migration 的注释是安全的）

`desktop-client/ironclaw/src/db/libsql/mod.rs::run_migrations` 的 incremental 部分由 `libsql_migrations::run_incremental` 处理，跟踪表是 `_migrations(version, name)`——按版本号去重，**不**对 SQL 文本做 checksum。已应用 V8 的旧库、新部署的全新库都不会因为注释变动重新执行或报错。

grep 验证主仓代码不依赖 V8 SQL 文本：

```
grep -rn 'V8__settings\|include_str.*V8' --include='*.rs' \
  desktop-client/ironclaw/src/ admin-backend/src/
# 无命中
```

## 非目标

- 不动 OQ-1（目录改名）/ OQ-2（keychain 迁移）：那是各自独立子 issue
- 不动 ADR-114 文档自身：避免与 PR #216（grep guard + Status flip）发生冲突
- 不动 `bootstrap.rs` / 数据迁移器逻辑

## 验证

```bash
# 1. 主仓再无 .ironclaw 字面量遗留在 migrations/
grep -rn '\.ironclaw\b' --include='*.sql' desktop-client/ironclaw/migrations/
# 无命中（exit 1）

# 2. 必跑三件套
cargo fmt --all -- --check                                  # clean
python3.12 scripts/check_no_panics.py --base origin/xClaw   # OK
git diff origin/xClaw --stat                                # 1 file +2/-1
```

无 Rust 代码改动，未触发 `cargo check` / `cargo nextest` / `cargo clippy`。

## Cross-cuts

ADR-114: 类A 无新增 .ironclaw / IRONCLAW_BASE_DIR 字面量。

## 与 PR #216 的关系

PR #216 是 ADR-114 的最终收尾（grep guard + PR 模板 + Status: Accepted），动 4 个 meta 文件。本 PR 动 1 个业务文件，两者无文件交集，**可独立合并、独立顺序**。本 PR 即使先合也不会影响 #216；#216 先合后本 PR 重新跑 CI 时会通过新增的 `no-new-ironclaw-literal` job（diff 中无新增 `.ironclaw` 字面量，删除行不被计算）。

