### PR TITLE
test(auth-token): drop misnamed timing-attack test on format validator

### DIFF
--- a/desktop-client/src/auth_token_manager.rs
+++ b/desktop-client/src/auth_token_manager.rs
@@ -191,7 +191,13 @@ fn generate_random_token() -> String {
 
 /// 验证令牌格式
 ///
-/// 令牌应该是 64 字符的十六进制字符串，不包含控制字符、引号、空格等
+/// 令牌应该是 64 字符的十六进制字符串，不包含控制字符、引号、空格等。
+///
+/// 注意：本函数是"格式校验器"，**不是**密文比对函数。它会因不同的非法
+/// 输入在不同字符位置短路返回（例如长度不符 vs 含非 hex 字符），这是
+/// 设计预期的 fail-fast 行为。如需把外部输入的 token 与已存储的密钥做
+/// 等值比较以判定身份，请在调用方使用恒定时间比较（如 `subtle::
+/// ConstantTimeEq`），而不是依赖本函数提供旁路抗性。
 pub fn is_valid_token(token: &str) -> bool {
     token.len() == 64
         && token.chars().all(|c| c.is_ascii_hexdigit())
@@ -487,57 +493,17 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_security_timing_attack_resistance() {
-        let valid_token = "a".repeat(64);
-        let invalid_tokens = vec![
-            "b".repeat(64),
-            "c".repeat(64),
-            "d".repeat(64),
-            "e".repeat(64),
-            "f".repeat(64),
-        ];
-
-        // 测试多次以获得更稳定的时间测量
-        let iterations = 100;
-        let mut valid_times = Vec::new();
-        let mut invalid_times = Vec::new();
-
-        for _ in 0..iterations {
-            let start = std::time::Instant::now();
-            let _ = is_valid_token(&valid_token);
-            valid_times.push(start.elapsed());
-
-            for invalid_token in &invalid_tokens {
-                let start = std::time::Instant::now();
-                let _ = is_valid_token(invalid_token);
-                invalid_times.push(start.elapsed());
-            }
-        }
-
-        let avg_valid_time: u128 =
-            valid_times.iter().map(|d| d.as_nanos()).sum::<u128>() / valid_times.len() as u128;
-        let avg_invalid_time: u128 =
-            invalid_times.iter().map(|d| d.as_nanos()).sum::<u128>() / invalid_times.len() as u128;
-
-        // 时间差不应该太大（允许一定的变化，但不应该有明显的时序泄露）
-        let time_diff = avg_valid_time.abs_diff(avg_invalid_time);
-        let max_allowed_diff = std::cmp::max(avg_valid_time, avg_invalid_time) / 2; // 允许50%的差异
-
-        println!("Average valid time: {}ns", avg_valid_time);
-        println!("Average invalid time: {}ns", avg_invalid_time);
-        println!(
-            "Time difference: {}ns (max allowed: {}ns)",
-            time_diff, max_allowed_diff
-        );
-
-        assert!(
-            time_diff < max_allowed_diff,
-            "Timing difference too large: {}ns > {}ns (may indicate timing attack vulnerability)",
-            time_diff,
-            max_allowed_diff
-        );
-    }
+    // NOTE: 历史上此处有一个 `test_security_timing_attack_resistance`，断言
+    // `is_valid_token(valid)` 与 `is_valid_token(invalid)` 平均耗时差 < 50%。
+    // 该测试的前提是错的：`is_valid_token` 是"格式校验器"，按设计就会在不同
+    // 位置短路（长度不符立即返回 / 非 hex 字符短路 / 含控制字符短路），并非
+    // 密文比对函数；本模块也没有任何 secret-equality 比较路径需要恒定时间。
+    // 真正需要旁路抗性的是调用方在做 `received_token == stored_secret` 时使
+    // 用 `subtle::ConstantTimeEq`（已在 `is_valid_token` 的 doc 注释里说明）。
+    // 因此原测试既测错了对象（拿 `b/c/d/e/f` * 64 这类全合法 hex + 长度合规
+    // 的输入跑 valid 路径，看似在比对，实际两侧都走完整 happy path），又对
+    // 一个有意 fail-fast 的格式校验器强加恒定时间约束，长期作为 base 上的
+    // 不稳定测试。已删除；格式覆盖由 `test_is_valid_token_all_cases` 保证。
 
     #[test]
     fn test_security_memory_safety() {


### PR DESCRIPTION
## 背景 / 目标

`desktop-client/src/auth_token_manager.rs` 的 `tests::test_security_timing_attack_resistance` 长期作为 base 上的不稳定测试出现：在 PR #216 (`498ebbac`) Tests / Run Tests 红中**它是唯一红的项**；本身命名是"timing attack resistance"，但被测对象 `is_valid_token` 根本不是密文比较器。

本 PR 删除该 misnamed 测试，并把 `is_valid_token` 的语义在 doc 注释里写清楚。

Refs `desktop-client/src/auth_token_manager.rs:195-218`

## 改动范围（1 文件 / +18 -52）

| 文件 | 变化 |
|------|------|
| `desktop-client/src/auth_token_manager.rs` | (a) 给 `is_valid_token` 加 doc 注释：声明它是\"格式校验器\"，按设计 fail-fast 短路；调用方做 `received_token == stored_secret` 时应使用 `subtle::ConstantTimeEq`，不要依赖本函数提供旁路抗性。(b) 删除 `tests::test_security_timing_attack_resistance` 整个块；保留 8 行 NOTE 说明删除原因，避免被人按"补回 missing security test"的方式重新加回。 |

## 根因（为什么这是删除而非修复）

1. **被测对象错配**：`is_valid_token` 是格式校验器，会因不同非法输入在不同字符位置短路（长度不符立即返回 / 非 hex 字符短路 / 控制字符短路）。把它当 secret-equality 比较器去测恒定时间，**前提就是错的**；本模块也没有任何 secret-equality 路径需要恒定时间。
2. **fixture 测错了路径**：原测试的 invalid 用例 `b/c/d/e/f` * 64 全部是合法 hex + 长度合规，`is_valid_token` 对 valid/invalid 都走完整 happy path（`chars().all(|c| c.is_ascii_hexdigit())` 短路特性下），名义上"两侧耗时差 < 50%"实则在比相同代码路径的微观抖动。
3. **断言阈值在系统抖动下天然不稳定**：CI 噪声下 50% 阈值会偶发翻车，长期被视作 flake。
4. **正确做法**：调用方做 token 等值比较时使用 `subtle::ConstantTimeEq`（已在 `is_valid_token` doc 注释里点明）。这是设计层面的修复，不是测试层面的修补。

不补丁（不改 fixture 例如改成 `"!".repeat(64)`），因为那只是把测试改成测同一个 fail-fast 短路位置的固定差异——既掩盖了\"被测对象错配\"这个真问题，也无法验证任何有意义的安全属性。

## 非目标（What's NOT in this PR）

- ❌ **不**新增 `subtle` 依赖或在生产路径引入恒定时间比较 — 当前模块没有任何 secret-equality 比较路径；如果未来上游模块需要做 token 等值校验，那个 PR 自己加 `subtle` 即可。本 PR 只把语义写进 doc，不替未来需求超前布署
- ❌ **不**触动其他 11 个 `auth_token_manager::tests::*`
- ❌ **不**改 ADR-114 / ADR-115 等任何架构文档
- ❌ **不**清理 base 上其他与本 issue 无关的 clippy warning（`field_reassign_with_default` 等），那些是独立工程任务

## 验证

```bash
# 1. 仅跑 auth_token_manager 测试
cargo nextest run -p desktop-client auth_token_manager
# Summary [18.061s] 11 tests run: 11 passed, 784 skipped

# 2. fmt
cargo fmt -p desktop-client -- --check    # rc=0

# 3. no-panics 红线
python3.12 scripts/check_no_panics.py --base origin/xClaw
# OK: No panic-inducing calls in changed production code.

# 4. 改动统计
git diff origin/xClaw --stat
# desktop-client/src/auth_token_manager.rs | 70 ++++++++------------------------
# 1 file changed, 18 insertions(+), 52 deletions(-)
```

未跑 workspace clippy / cargo build：本 PR 仅改 `desktop-client/src/auth_token_manager.rs`（删测试 + 加 doc），无生产逻辑改动；workspace clippy 由 CI（`code_style.yml::clippy`，使用 `--cap-lints warn`）兜底。

## Cross-cuts

ADR-114: **不涉及**（本 PR 不引入 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量；scripts/check_no_new_ironclaw_literal.py 自检通过）。

Closes #222
