### PR TITLE
chore(clippy): drop redundant tokio imports + unneeded return (batch 1)

### DIFF
--- a/desktop-client/src/engine.rs
+++ b/desktop-client/src/engine.rs
@@ -840,7 +840,7 @@ async fn resolve_managed_policy(
         }
         Err(error) => {
             tracing::warn!(error = %error, "Failed to load cached signed managed policy");
-            return None;
+            None
         }
     }
 }

--- a/desktop-client/tests/auth_integration_tests.rs
+++ b/desktop-client/tests/auth_integration_tests.rs
@@ -3,7 +3,6 @@ use desktop_client::commands::get_auth_token;
 use desktop_client::{clean_token, is_valid_token};
 use std::fs;
 use tempfile::TempDir;
-use tokio;
 
 // ========== 集成测试覆盖率 >80% ==========
 

--- a/desktop-client/tests/auth_regression_tests.rs
+++ b/desktop-client/tests/auth_regression_tests.rs
@@ -2,7 +2,6 @@ use desktop_client::auth_token_manager::AuthTokenManager;
 use desktop_client::{clean_token, is_valid_token};
 use std::fs;
 use tempfile::TempDir;
-use tokio;
 
 // ========== 变更覆盖率 >70% ==========
 // 确保重构不会破坏现有功能的回归测试

--- a/desktop-client/tests/auth_requirements_tests.rs
+++ b/desktop-client/tests/auth_requirements_tests.rs
@@ -3,7 +3,6 @@ use desktop_client::commands::get_auth_token;
 use desktop_client::{clean_token, is_valid_token};
 use std::fs;
 use tempfile::TempDir;
-use tokio;
 
 // ========== 需求级覆盖率 >85% ==========
 


### PR DESCRIPTION
## 背景 / 目标

ADR-114 收尾完成后，[`desktop-client`](desktop-client/) 上仍存在 ~46 条 clippy warning（CI `--cap-lints warn` 兜住）。本 PR 是 **batch 1**，挑出 4 处零语义风险机械化清理，作为后续批量清理的样板。

## 改动范围

| 文件 | 改动 | warning 类型 |
|---|---|---|
| [desktop-client/tests/auth_integration_tests.rs](desktop-client/tests/auth_integration_tests.rs#L6) | 删 `use tokio;` | redundant import |
| [desktop-client/tests/auth_requirements_tests.rs](desktop-client/tests/auth_requirements_tests.rs#L6) | 删 `use tokio;` | redundant import |
| [desktop-client/tests/auth_regression_tests.rs](desktop-client/tests/auth_regression_tests.rs#L5) | 删 `use tokio;` | redundant import |
| [desktop-client/src/engine.rs](desktop-client/src/engine.rs#L843) | `return None;` → `None` | unneeded return |

合计 +1 / -4 行。

`#[tokio::test]` 属性宏由 proc-macro 解析 crate path，`use tokio;` 是真正的 no-op。`engine.rs` 的 `return None;` 处于 `match` 表达式最后一支末尾，无 `#[cfg]` 兄弟节点，删除是 byte-for-byte 语义保留。

## 非目标 (What's NOT in this PR)

- **不**触碰 `enterprise_policy_sync.rs` 中两处 `#[cfg(test)] { ... return ...; }` / `#[cfg(not(test))] { ... }` 互斥块的 `unneeded return`（语义微妙，留独立 PR 评估）
- **不**重写 13 条 `field assignment outside of initializer`（量大，建议拆批）
- **不**修复 `desktop-client/src/dlp/data_coverage_tests.rs:214` 的 `assert!(x || !x)` 真重言式 error（独立测试缺陷）
- **不**触碰任何 `module has the same name as containing module` / `too many arguments`（结构性变动）
- **不**新增 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量（ADR-114 红线）

## 验证

```bash
cargo check -p desktop-client --tests
# Finished `dev` profile [unoptimized + debuginfo] target(s)

cargo nextest run -p desktop-client \
    --test auth_integration_tests \
    --test auth_requirements_tests \
    --test auth_regression_tests
# Summary [43.550s] 25 tests run: 25 passed, 1 skipped

cargo fmt --all
python3.12 scripts/check_no_panics.py --base origin/xClaw
# OK: No panic-inducing calls in changed production code.

python3 scripts/check_no_new_ironclaw_literal.py --base origin/xClaw
# OK: No new .ironclaw / IRONCLAW_BASE_DIR literals introduced.
```

## Cross-cuts

不涉及

Closes #224
