### PR TITLE
fix(dlp): replace tautology assert with let-discard in data_coverage_tests

### DIFF
--- a/desktop-client/src/dlp/data_coverage_tests.rs
+++ b/desktop-client/src/dlp/data_coverage_tests.rs
@@ -211,8 +211,9 @@ mod data_coverage_tests {
 
             let result = sanitizer.sanitize("身份证： 110101199003071234 ");
             if *enabled {
-                assert!(result.had_sensitive_data || !result.had_sensitive_data);
-            // 任一结果都可接受
+                // 启用时仅验证调用不 panic；命中与否取决于检测器内部规则，
+                // 此处不强制断言（与本文件其它边界/无效用例的 `let _ =` 模式一致）。
+                let _ = result.had_sensitive_data;
             } else {
                 assert!(!result.had_sensitive_data); // 禁用时不应检测
             }


### PR DESCRIPTION
## 背景 / 目标

`desktop-client/src/dlp/data_coverage_tests.rs:214` 中存在 `assert!(x || !x)` 重言式断言，clippy `logic_bug` 报 **error**。
CI 当前用 `--cap-lints warn` 兜住未挂掉，但这是真实测试缺陷：assert 永真 = 没断。

## 改动范围

[desktop-client/src/dlp/data_coverage_tests.rs](desktop-client/src/dlp/data_coverage_tests.rs#L213-L222) 单点改动：

```diff
-            if *enabled {
-                assert!(result.had_sensitive_data || !result.had_sensitive_data);
-            // 任一结果都可接受
-            } else {
+            if *enabled {
+                // 启用时仅验证调用不 panic；命中与否取决于检测器内部规则，
+                // 此处不强制断言（与本文件其它边界/无效用例的 `let _ =` 模式一致）。
+                let _ = result.had_sensitive_data;
+            } else {
                 assert!(!result.had_sensitive_data); // 禁用时不应检测
             }
```

恢复作者**真实意图**（注释原文「任一结果都可接受」），与同文件 `test_data_coverage_numeric_boundary_values` / `test_data_coverage_invalid_data_handling` 的 `let _ = result.has_sensitive_data;` 写法对齐。

## 非目标 (What's NOT in this PR)

- **不**重写测试逻辑或扩充用例（仅消除 fake-assert，保留 enabled / disabled 两条分支结构）
- **不**清理本文件其他 clippy warning
- **不**修 `enterprise_policy_sync.rs` 的 cfg-block return（独立 PR）
- **不**升级 CI 的 `--cap-lints warn` 策略

## 验证

```bash
cargo check -p desktop-client --tests        # ✅
cargo nextest run -p desktop-client --lib data_coverage_tests
# Summary: 14 tests run: 14 passed, 703 skipped

cargo clippy --no-deps -p desktop-client --all-targets 2>&1 | grep 'logic bug'
# (no output — error 已消)

cargo fmt --all                              # ✅
python3.12 scripts/check_no_panics.py --base origin/xClaw
# OK: No panic-inducing calls in changed production code.
python3 scripts/check_no_new_ironclaw_literal.py --base origin/xClaw
# OK: No new .ironclaw / IRONCLAW_BASE_DIR literals introduced.
```

## Cross-cuts

不涉及

Closes #226
