### PR TITLE
chore(clippy): drop unneeded return in cfg(test) blocks of enterprise_policy_sync

### DIFF
--- a/desktop-client/src/enterprise_policy_sync.rs
+++ b/desktop-client/src/enterprise_policy_sync.rs
@@ -390,7 +390,7 @@ impl EnterprisePolicySyncManager {
                 last_sync: current_timestamp(),
             };
 
-            return Ok((dlp_policies, sensitive_ops_policies, version));
+            Ok((dlp_policies, sensitive_ops_policies, version))
         }
 
         #[cfg(not(test))]
@@ -592,11 +592,11 @@ impl EnterprisePolicySyncManager {
             // 测试环境：返回模拟版本
             use crate::policy_sync::PolicyVersion;
 
-            return Ok(PolicyVersion {
+            Ok(PolicyVersion {
                 dlp_rules_version: 1,
                 sensitive_ops_version: 1,
                 last_sync: current_timestamp(),
-            });
+            })
         }
 
         #[cfg(not(test))]


### PR DESCRIPTION
## 背景 / 目标

[PR #225](https://github.com/Linnanli/xClaw/pull/225) 处理 `unneeded return` 时**故意延后**了 `enterprise_policy_sync.rs` 内 2 处 `#[cfg(test)] { ...; return Ok(...); }` 块（语义微妙需精读）。本 PR 完成该尾巴：clippy 的等价性分析是正确的，可以安全清掉。

## 改动范围

[desktop-client/src/enterprise_policy_sync.rs](desktop-client/src/enterprise_policy_sync.rs) 单文件 +3/-3：

```diff
@@ async fn fetch_remote_policies @@
-            return Ok((dlp_policies, sensitive_ops_policies, version));
+            Ok((dlp_policies, sensitive_ops_policies, version))
         }

         #[cfg(not(test))]

@@ async fn fetch_remote_version @@
-            return Ok(PolicyVersion {
+            Ok(PolicyVersion {
                 dlp_rules_version: 1,
                 sensitive_ops_version: 1,
                 last_sync: current_timestamp(),
-            });
+            })
         }
```

### 等价性

两个 cfg 块互斥且紧邻：

```rust
async fn fetch_remote_policies(...) {
    #[cfg(test)] { ...; return Ok(..); }
    #[cfg(not(test))] { ...; }
}
```

- 当 `cfg(test)` 启用：`#[cfg(not(test))]` 块被剥光 → 第一个块成为 fn 体唯一/尾位块表达式 → 块尾表达式即 fn 返回值
- 当 `cfg(test)` 禁用：第一个块被剥光 → 第二个块同理

删除 `return` + 末尾 `;` 在两条 cfg 路径下都保持 byte-equivalent 语义。clippy `needless_return` 在此处给出的建议是正确的。

## 非目标 (What's NOT in this PR)

- **不**触碰 13 × `field_reassign_with_default`（独立 batch-2 PR 处理）
- **不**触碰 `module same name` / `manual is_multiple_of` 等其他 clippy warning
- **不**改变测试/生产路径的实际行为，仅 keyword 级清理

## 验证

```bash
cargo check -p desktop-client --tests
# Finished `dev` profile

cargo nextest run -p desktop-client --lib enterprise_policy_sync
# Summary: 13 tests run: 13 passed, 704 skipped

cargo clippy --no-deps -p desktop-client --all-targets 2>&1 | grep enterprise_policy_sync
# (no output — 两条 needless_return 已消)

cargo fmt --all
python3.12 scripts/check_no_panics.py --base origin/xClaw
# OK: No panic-inducing calls in changed production code.
python3 scripts/check_no_new_ironclaw_literal.py --base origin/xClaw
# OK: No new .ironclaw / IRONCLAW_BASE_DIR literals introduced.
```

## Cross-cuts

不涉及

Closes #228
