### PR TITLE
chore(clippy): rewrite field-reassign-with-default in code_coverage_tests (batch 2a)

### DIFF
--- a/desktop-client/src/dlp/code_coverage_tests.rs
+++ b/desktop-client/src/dlp/code_coverage_tests.rs
@@ -59,8 +59,10 @@ mod code_coverage_tests {
         // 测试脱敏器的所有分支
 
         // 分支1: 脱敏功能禁用
-        let mut config_disabled = SanitizationConfig::default();
-        config_disabled.enabled = false;
+        let config_disabled = SanitizationConfig {
+            enabled: false,
+            ..Default::default()
+        };
         let detector_disabled = DlpDetector::new();
         let sanitizer_disabled = DlpSanitizer::new(detector_disabled, config_disabled);
 
@@ -82,8 +84,10 @@ mod code_coverage_tests {
         assert!(result_block.was_blocked);
 
         // 分支5: 格式保留开启
-        let mut config_preserve = SanitizationConfig::default();
-        config_preserve.preserve_format = true;
+        let config_preserve = SanitizationConfig {
+            preserve_format: true,
+            ..Default::default()
+        };
         let detector_preserve = DlpDetector::new();
         let sanitizer_preserve = DlpSanitizer::new(detector_preserve, config_preserve);
 
@@ -91,8 +95,10 @@ mod code_coverage_tests {
         assert!(result_preserve.sanitized_content.contains("*"));
 
         // 分支6: 格式保留关闭
-        let mut config_no_preserve = SanitizationConfig::default();
-        config_no_preserve.preserve_format = false;
+        let config_no_preserve = SanitizationConfig {
+            preserve_format: false,
+            ..Default::default()
+        };
         let detector_no_preserve = DlpDetector::new();
         let sanitizer_no_preserve = DlpSanitizer::new(detector_no_preserve, config_no_preserve);
 


### PR DESCRIPTION
## 背景 / 目标

`desktop-client` 上 12 处 `field_reassign_with_default` clippy warning 的首批清理。本 PR 仅触一文件 3 处，避免一次性改 12 处带来的 review 复杂度。

## 改动范围

[desktop-client/src/dlp/code_coverage_tests.rs](desktop-client/src/dlp/code_coverage_tests.rs) 单文件 +12 / -6：

```diff
-        let mut config_disabled = SanitizationConfig::default();
-        config_disabled.enabled = false;
+        let config_disabled = SanitizationConfig {
+            enabled: false,
+            ..Default::default()
+        };

-        let mut config_preserve = SanitizationConfig::default();
-        config_preserve.preserve_format = true;
+        let config_preserve = SanitizationConfig {
+            preserve_format: true,
+            ..Default::default()
+        };

-        let mut config_no_preserve = SanitizationConfig::default();
-        config_no_preserve.preserve_format = false;
+        let config_no_preserve = SanitizationConfig {
+            preserve_format: false,
+            ..Default::default()
+        };
```

机械化、语义保留改动。每处都是 clippy `note: consider initializing the variable with ... and removing relevant reassignments` 直接给出的建议。

## 非目标 (What's NOT in this PR)

- **不**触碰剩余 9 处 `field_reassign_with_default`（独立 follow-up PR 处理；其中 5 处在生产代码 `dlp/sanitizer.rs` + `dlp/integration.rs`，需要独立 review 关注）
- **不**触碰其他 clippy lint（`module same name` / `manual is_multiple_of` / `consecutive str::replace` 等）
- **不**修改测试逻辑或扩充用例
- 同函数内未被 clippy 标记的 `config_custom`（line 103-105 — 因前置 `replacement_map.insert(...)` 方法调用 clippy 主动跳过）保持原状

## 验证

```bash
cargo check -p desktop-client --tests        # ✅ Finished
cargo nextest run -p desktop-client --lib code_coverage
# Summary: 8 tests run: 8 passed (1 leaky), 709 skipped
# (1 leaky 是 base 已有行为，与本改动无关)

cargo clippy --no-deps -p desktop-client --all-targets 2>&1 | grep code_coverage_tests
# 仅剩 module-level 与无关的其他 lint；3 条 field_reassign_with_default 已消

cargo fmt --all
python3.12 scripts/check_no_panics.py --base origin/xClaw
# OK: No panic-inducing calls in changed production code.
python3 scripts/check_no_new_ironclaw_literal.py --base origin/xClaw
# OK: No new .ironclaw / IRONCLAW_BASE_DIR literals introduced.
```

## Cross-cuts

不涉及

Closes #230
