### PR TITLE
chore(clippy): rewrite field-reassign-with-default in dlp tests batch (batch 2b)

### DIFF
--- a/desktop-client/src/dlp/data_coverage_tests.rs
+++ b/desktop-client/src/dlp/data_coverage_tests.rs
@@ -202,9 +202,11 @@ mod data_coverage_tests {
         // 布尔值测试
         let bool_values = [true, false];
         for enabled in &bool_values {
-            let mut config = SanitizationConfig::default();
-            config.enabled = *enabled;
-            config.preserve_format = !*enabled;
+            let config = SanitizationConfig {
+                enabled: *enabled,
+                preserve_format: !*enabled,
+                ..Default::default()
+            };
 
             let detector = DlpDetector::new();
             let sanitizer = DlpSanitizer::new(detector, config);
@@ -408,8 +410,10 @@ mod data_coverage_tests {
         replacement_map.insert("chinese_mobile".to_string(), "[手机号]".to_string());
         replacement_map.insert("custom_pattern".to_string(), "[自定义]".to_string());
 
-        let mut config = SanitizationConfig::default();
-        config.replacement_map = replacement_map;
+        let config = SanitizationConfig {
+            replacement_map,
+            ..Default::default()
+        };
 
         let detector2 = DlpDetector::new();
         let sanitizer = DlpSanitizer::new(detector2, config);

--- a/desktop-client/src/dlp/security_tests.rs
+++ b/desktop-client/src/dlp/security_tests.rs
@@ -265,10 +265,12 @@ mod access_control_tests {
     fn test_security_configuration_tampering() {
         let patterns = get_all_builtin_patterns().unwrap();
         let detector = DlpDetector::with_custom_patterns(patterns);
-        let mut config = SanitizationConfig::default();
 
         // 测试配置篡改保护
-        config.enabled = false;
+        let config = SanitizationConfig {
+            enabled: false,
+            ..Default::default()
+        };
         let sanitizer = DlpSanitizer::new(detector, config);
 
         // 即使禁用，也应该安全处理

--- a/desktop-client/src/safety_bridge_tests.rs
+++ b/desktop-client/src/safety_bridge_tests.rs
@@ -335,8 +335,10 @@ mod failure_tests {
 
     #[test]
     fn test_failure_disabled_sanitization() {
-        let mut config = SanitizationConfig::default();
-        config.enabled = false;
+        let config = SanitizationConfig {
+            enabled: false,
+            ..Default::default()
+        };
 
         let bridge = create_bridge_with_config(config);
         let result = bridge.scan_user_input("身份证：110101199003071234");


### PR DESCRIPTION
## 背景 / 目标

`desktop-client` 上 `field_reassign_with_default` clippy warning 的测试代码批次清理。延续 [#231](https://github.com/Linnanli/xClaw/pull/231) 同款机械化改写。

## 改动范围

3 文件 / 4 处 / +17 / -9：

### 1. `desktop-client/src/dlp/data_coverage_tests.rs` (2 处)

**Line 205-208** — 同时改写两个字段：
```diff
-        let mut config = SanitizationConfig::default();
-        config.enabled = *enabled;
-        config.preserve_format = !*enabled;
+        let config = SanitizationConfig {
+            enabled: *enabled,
+            preserve_format: !*enabled,
+            ..Default::default()
+        };
```

**Line 411-412** — `replacement_map`：
```diff
-        let mut config = SanitizationConfig::default();
-        config.replacement_map = replacement_map;
+        let config = SanitizationConfig {
+            replacement_map,
+            ..Default::default()
+        };
```
（前置 `replacement_map.insert(...)` 调用顺序保持不变。）

### 2. `desktop-client/src/dlp/security_tests.rs` (1 处)

**Line 268-271** — `enabled = false`，注释 `// 测试配置篡改保护` 上移以贴近新初始化器：
```diff
-        let mut config = SanitizationConfig::default();
-
-        // 测试配置篡改保护
-        config.enabled = false;
+        // 测试配置篡改保护
+        let config = SanitizationConfig {
+            enabled: false,
+            ..Default::default()
+        };
```

### 3. `desktop-client/src/safety_bridge_tests.rs` (1 处)

**Line 338-339** — `enabled = false`：
```diff
-        let mut config = SanitizationConfig::default();
-        config.enabled = false;
+        let config = SanitizationConfig {
+            enabled: false,
+            ..Default::default()
+        };
```

## 非目标 (What's NOT in this PR)

- **不**触碰生产代码 5 处 `field_reassign`（`dlp/integration.rs` 2 + `dlp/sanitizer.rs` 3）— 独立 PR 后续推进，DLP 安全敏感模块需独立 review 关注
- **不**碰其他 clippy lint：`module same name`（结构性，可能与 ADR-114 类 B crate rename 交织）/ `unwrap-on-result-after-is_ok` (security_tests:292) / `manual is_multiple_of` 等
- **不**修改任何测试断言或测试逻辑

## 验证

```bash
cargo check -p desktop-client --tests        # ✅ Finished
cargo nextest run -p desktop-client \
  -E 'test(/data_coverage/) + test(test_security_configuration_tampering) + test(test_failure_disabled_sanitization)'
# Summary: 16 tests run: 16 passed, 779 skipped

cargo clippy --no-deps -p desktop-client --all-targets 2>&1 \
  | grep -E "data_coverage_tests|security_tests|safety_bridge_tests" \
  | grep -E "field_reassign|--> "
#   --> desktop-client/src/dlp/data_coverage_tests.rs:7:1   (module-same-name, 无关)
#   --> desktop-client/src/dlp/security_tests.rs:10:1       (module-same-name, 无关)
#   --> desktop-client/src/dlp/security_tests.rs:294:29     (unwrap-on-result-after-is_ok, 无关)
# 4 条 field_reassign_with_default 全消

cargo fmt --all
python3.12 scripts/check_no_panics.py --base origin/xClaw    # OK
python3 scripts/check_no_new_ironclaw_literal.py --base origin/xClaw  # OK
```

## 与并行 PR 的关系

| 并行 PR | 文件 | 冲突 |
|---|---|---|
| [#229](https://github.com/Linnanli/xClaw/pull/229) | `enterprise_policy_sync.rs` | ❌ 零重叠 |
| [#231](https://github.com/Linnanli/xClaw/pull/231) | `dlp/code_coverage_tests.rs` | ❌ 零重叠 |

可独立 review/merge，无依赖、无 stacked-PR 风险。

## Cross-cuts

不涉及

Closes #232
