### PR TITLE
chore(clippy): rewrite field-reassign-with-default in DLP integration/sanitizer (batch 3)

### DIFF
--- a/desktop-client/src/dlp/integration.rs
+++ b/desktop-client/src/dlp/integration.rs
@@ -584,8 +584,10 @@ mod tests {
     async fn test_update_config() {
         let integration = DlpIntegration::with_default_config().await.unwrap();
 
-        let mut new_config = DlpIntegrationConfig::default();
-        new_config.enabled = false;
+        let new_config = DlpIntegrationConfig {
+            enabled: false,
+            ..Default::default()
+        };
 
         integration.update_config(new_config).await.unwrap();
 
@@ -618,8 +620,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_disabled_dlp() {
-        let mut config = DlpIntegrationConfig::default();
-        config.enabled = false;
+        let config = DlpIntegrationConfig {
+            enabled: false,
+            ..Default::default()
+        };
 
         let integration = DlpIntegration::new(config).await.unwrap();
         let content = "身份证：110101199003071234";

--- a/desktop-client/src/dlp/sanitizer.rs
+++ b/desktop-client/src/dlp/sanitizer.rs
@@ -392,8 +392,10 @@ impl DlpSanitizer {
 
     /// 计算脱敏统计
     fn calculate_stats(&self, detection_result: &DlpDetectionResult) -> SanitizationStats {
-        let mut stats = SanitizationStats::default();
-        stats.total_matches = detection_result.matches.len();
+        let mut stats = SanitizationStats {
+            total_matches: detection_result.matches.len(),
+            ..Default::default()
+        };
 
         for dlp_match in &detection_result.matches {
             match dlp_match.action {
@@ -531,8 +533,10 @@ mod tests {
     fn test_sanitize_disabled() {
         let patterns = get_all_builtin_patterns().unwrap();
         let detector = DlpDetector::with_custom_patterns(patterns);
-        let mut config = SanitizationConfig::default();
-        config.enabled = false;
+        let config = SanitizationConfig {
+            enabled: false,
+            ..Default::default()
+        };
         let sanitizer = DlpSanitizer::new(detector, config);
 
         let content = "身份证：110101199003071234";
@@ -639,8 +643,10 @@ mod tests {
     fn test_update_config() {
         let mut sanitizer = create_test_sanitizer();
 
-        let mut new_config = SanitizationConfig::default();
-        new_config.enabled = false;
+        let new_config = SanitizationConfig {
+            enabled: false,
+            ..Default::default()
+        };
 
         sanitizer.update_config(new_config);
 


### PR DESCRIPTION
## 背景 / 目标

清理 DLP 模块（`dlp/integration.rs` + `dlp/sanitizer.rs`）剩余的 `field_reassign_with_default` clippy warning。延续 #225/#229/#231/#233 的机械化改写策略，全部改写为 struct literal + `..Default::default()`。

## 改动范围

2 文件 / 5 处 / +20 -10：

### 1. `desktop-client/src/dlp/sanitizer.rs` (3 处)

**Line 396 — 生产代码 `calculate_stats`**（保留 `mut` 供后续循环累加）：
```diff
 fn calculate_stats(&self, detection_result: &DlpDetectionResult) -> SanitizationStats {
-    let mut stats = SanitizationStats::default();
-    stats.total_matches = detection_result.matches.len();
+    let mut stats = SanitizationStats {
+        total_matches: detection_result.matches.len(),
+        ..Default::default()
+    };

     for dlp_match in &detection_result.matches {
         match dlp_match.action {
             DlpAction::Warn => stats.warned_count += 1,
             ...
```

**Line 535 — `test_sanitize_disabled`** + **Line 643 — `test_update_config`**：纯机械改写 `enabled: false`。

### 2. `desktop-client/src/dlp/integration.rs` (2 处)

**Line 588 — `test_update_config`** + **Line 622 — `test_disabled_dlp`**：纯机械改写 `enabled: false`。

## 非目标 (What's NOT in this PR)

- 其他 lint 类型保持不动：`module same name` (7) / `unwrap-on-result-after-is_ok` (security_tests:294) / `manual is_multiple_of` (3) / `consecutive str::replace` (2) / `manual strip_prefix` (2) 等
- 不修改任何业务逻辑、断言、测试覆盖
- 不引入新依赖

## 验证

```bash
cargo check -p desktop-client --tests        # ✅ Finished
cargo nextest run -p desktop-client -E 'test(/test_disabled_dlp/) | test(/test_update_config/) | test(/test_sanitize_disabled/)'
# Summary: 4 tests run: 4 passed, 791 skipped
#  PASS dlp::integration::tests::test_update_config
#  PASS dlp::integration::tests::test_disabled_dlp
#  PASS dlp::sanitizer::tests::test_sanitize_disabled
#  PASS dlp::sanitizer::tests::test_update_config

cargo clippy --no-deps -p desktop-client --all-targets 2>&1 | grep field_reassign_with_default
# (空 — 5 条全消)

cargo fmt --all
python3.12 scripts/check_no_panics.py --base origin/xClaw
# OK: No panic-inducing calls in changed production code.
python3 scripts/check_no_new_ironclaw_literal.py --base origin/xClaw
# OK: No new .ironclaw / IRONCLAW_BASE_DIR literals introduced.
```

注：`calculate_stats` 是私有方法，无直接单测，但被 `sanitize()` 流程覆盖（`test_sanitize_disabled` 等同链路验证）。

## Cross-cuts

DLP 安全敏感模块——本 PR 仅触 statistics 计数初始化，不涉及检测/脱敏/阻断逻辑。生产代码改动等价：先初始化 `total_matches` 字段后续累加 `warned_count` / `redacted_count` / `blocked_count` / `severity_stats`，与原版完全等价（`Default::default()` 初始化均为 0/空）。

Closes #234
