### PR TITLE
chore(clippy): rewrite manual % 0 to is_multiple_of in safety_bridge::is_leap_year (batch 4)

### DIFF
--- a/desktop-client/src/safety_bridge.rs
+++ b/desktop-client/src/safety_bridge.rs
@@ -439,7 +439,7 @@ fn days_to_ymd(days: u64) -> (u64, u64, u64) {
 }
 
 fn is_leap_year(y: u64) -> bool {
-    (y % 4 == 0 && y % 100 != 0) || y % 400 == 0
+    (y.is_multiple_of(4) && !y.is_multiple_of(100)) || y.is_multiple_of(400)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## 背景/目标

`cargo clippy --no-deps -p desktop-client --all-targets` 在 `desktop-client/src/safety_bridge.rs:442` 报告 3 处 `manual implementation of .is_multiple_of()`（`is_leap_year` 函数同行）。clippy 推荐改用 `u64::is_multiple_of`（Rust 1.87 stable）。

## 改动范围

- `desktop-client/src/safety_bridge.rs::is_leap_year`: 1 行（3 处替换）
  - `(y % 4 == 0 && y % 100 != 0) || y % 400 == 0`
  - → `(y.is_multiple_of(4) && !y.is_multiple_of(100)) || y.is_multiple_of(400)`

+1 -1, 单文件单函数。

## 非目标（What's NOT in this PR）

- 不改 `is_leap_year` 调用方逻辑
- 不动 ADR-114 红线、不动其他 clippy 类别（manual strip_prefix、consecutive str::replace、length comparison to zero/one、impl can be derived 等留作后续 batch）
- 不重构 `safety_bridge.rs` 其它部分

## 验证

```
cargo check -p desktop-client --tests              # OK
cargo nextest run -p desktop-client \
  -E 'test(safety_bridge) | test(is_leap)'         # 59/59 PASS, 736 skipped
cargo clippy --no-deps -p desktop-client --all-targets 2>&1 \
  | grep is_multiple_of                            # 空输出（warning 全消）
cargo fmt --all                                    # OK
python3.12 scripts/check_no_panics.py --base origin/xClaw       # OK
python3 scripts/check_no_new_ironclaw_literal.py --base origin/xClaw  # OK
```

## Cross-cuts

不涉及（纯 clippy 重写）。

Closes #236
