### PR TITLE
docs(adr): ADR-117 v1.3 — close #131 W3/C implementation issue

### DIFF
--- a/docs/plans/architecture-refactor/adr-117-p0c-prompt-builder-unification.md
+++ b/docs/plans/architecture-refactor/adr-117-p0c-prompt-builder-unification.md
@@ -1,17 +1,18 @@
 # ADR-117: P0-C Prompt Builder 统一（吸收 claw-code 至 LayeredPromptBuilder）
 
-- **Status**: Accepted (v1.2 partial-supersede)
+- **Status**: Accepted (v1.3 partial-supersede)
 - **Date**: 2026-04-30
-- **Last revision**: 2026-05-02 (v1.2)
+- **Last revision**: 2026-05-05 (v1.3)
 - **Approver**: x-claw 架构组
-- **Issue**: [#130](https://github.com/Linnanli/xClaw/issues/130)（W3/B P0-C — Prompt Builder 统一） — closed by [#142](https://github.com/Linnanli/xClaw/pull/142)
-- **Closes**: #130
+- **Issue**: [#130](https://github.com/Linnanli/xClaw/issues/130)（W3/B P0-C — Prompt Builder 统一） — closed by [#142](https://github.com/Linnanli/xClaw/pull/142)；[#131](https://github.com/Linnanli/xClaw/issues/131)（W3/C 实施）— closed by [#141](https://github.com/Linnanli/xClaw/pull/141) + [#142](https://github.com/Linnanli/xClaw/pull/142)（D5/D7 撤回，详 v1.3 修订记）
+- **Closes**: #130, #131
 
 ## 修订记 (Revisions)
 
 - **v1.0 (2026-04-30)** — 初稿（Proposed）
 - **v1.1 (2026-05-02, 已撤回)** — 试图扩档 D7 删除半径至「档 1.5」（在 claw-code 子仓内删 5 项 crate），方向错误，PR #143 已 close
 - **v1.2 (2026-05-02)** — **D5 + D7 子仓内删除工作项已撤回**（claw-code 子仓恢复原代码 db8ff4d revert c36c0ef），由 [ADR-118](adr-118-claw-code-readonly-and-self-impl.md) 取代为「主仓自实现 LLM provider + 删除 desktop-client/ironclaw 对 claw-code-api 的 path-dep」。本 ADR 其余部分（D6 / D8.2 / D8.3 / D8.4 / 提示词单源核心目标）保持有效。
+- **v1.3 (2026-05-05)** — **W3/C 实施 issue [#131](https://github.com/Linnanli/xClaw/issues/131) 收尾**：三层验证（`semantic_search` + `grep_search`）确认 `SystemPromptBuilder` 在 x-claw 主仓代码层 0 调用方（仅在只读区 `claw-code/rust/crates/runtime/` 与本 ADR 注释中出现）；`DynamicLayerInput.environment` / `project_doc` 字段、`## Environment` Markdown render、reasoning.rs 喂数据、5 个不变量测试均已在 #141 + #142 落地；D5/D7 已由 v1.2 + ADR-118 接手。结论：**#131 的 7 个 scope checkbox 全部由 #141 + #142 + ADR-118 履约**，无新增代码改动需要落地。本 v1.3 修订仅为关闭 issue 的过程透明度记录。
 
 ### Done 状态（v1.2 截至 2026-05-02）
 
@@ -21,6 +22,7 @@
 | D8.2 + D8.3 cache refactor | [#141](https://github.com/Linnanli/xClaw/pull/141) | ✅ Merged b8049f4c |
 | D6 + D8.4 删 static_hash / legacy 字段 | [#142](https://github.com/Linnanli/xClaw/pull/142) | ✅ Merged 51e14910，closes #130 |
 | **核心目标「提示词单源 = LayeredPromptBuilder」** | — | ✅ **达成** |
+| **W3/C 实施 #131 收尾**（v1.3） | 本文 doc-only PR | ✅ closes #131（7 scope items 全部履约：见 v1.3 修订记） |
 | ~~v1.1 D7 扩档（在子仓内删）~~ | ~~[#143](https://github.com/Linnanli/xClaw/pull/143)~~ | ❌ Closed（方向错误，由 ADR-118 取代） |
 | ~~父仓 bump submodule~~ | ~~[#144](https://github.com/Linnanli/xClaw/pull/144)~~ | ❌ Closed（子仓 revert 后无需 bump） |
 | **D5 + D7 撤回** | [ADR-118](adr-118-claw-code-readonly-and-self-impl.md) | 🟡 Pending（W6 实施） |


### PR DESCRIPTION
## 背景 / 目标

[#131](https://github.com/Linnanli/xClaw/issues/131)（W3/C — Prompt builder unification implementation）自 2026-04-30 开 issue 起一直 OPEN，但实际 7 个 scope checkbox 早已在 ADR-117 §4 三段 PR 计划的 PR-2 + PR-3 中履约：

| #131 scope | 落地 PR / 状态 |
|---|---|
| Create owner module per #37-B | ✅ #141（`crates/x_claw_agent::PROMPT_CACHE_BOUNDARY` + `desktop-client/ironclaw/src/llm/prompt/`） |
| Implement unified builder absorbing `SystemPromptBuilder` | ✅ #141（`LayeredPromptBuilder` 单源装配） |
| Retain `Arc<String>` cache + cache_control | ✅ #141 + #142（保留 Arc 缓存；删 static_hash 死字段） |
| Make `SystemPromptBuilder` thin wrapper or migrate | ✅ ADR-117 v1.2 + ADR-118：claw-code 子仓变只读，主仓 `SystemPromptBuilder` 0 调用方（grep 仅命中只读区与 ADR 注释） |
| Update all callers (rusty-claude-cli, reasoning.rs) | ✅ reasoning.rs 已切到 `LayeredPromptBuilder::build`（#141 661a63df 起）；rusty-claude-cli 在只读区不动（ADR-118） |
| Implement invariant harness tests | ✅ #141 5 测试：`test_environment_section_renders` / `test_project_doc_field_default_empty` / `test_dynamic_section_order_invariant` / `test_openai_compat_prompt_serializes` / `test_anthropic_compat_prompt_serializes` |
| Migration script if required | ✅ 不需要（D8.4 字段为 0-caller 死字段，#137 已登记未来路径） |

## 改动范围

仅一份 ADR 文档：

- `docs/plans/architecture-refactor/adr-117-p0c-prompt-builder-unification.md`
  - Status banner v1.2 → v1.3（partial-supersede）
  - Last revision 2026-05-02 → 2026-05-05
  - Issue 行追加 #131 closed-by 链路
  - Closes 行追加 #131
  - 修订记新增 v1.3 条目（含三层验证结论）
  - Done 状态表新增 「W3/C 实施 #131 收尾」一行

净 +6 / -4 行，无任何代码改动。

## What's NOT in this PR

- ❌ 任何 `.rs` / `Cargo.toml` / migration 改动
- ❌ 重新打开 ADR-117 §2 的任何决策
- ❌ 接入 #55 ProjectDocLoader（仍为占位字段）
- ❌ 修复 R-1 boundary marker 无 provider 消费（单独 P1 issue 范围）
- ❌ 关闭 #37 父 issue（W3/C 是 #37 的一个 sub-issue）

## 验证

doc-only PR，按 [.github/copilot-instructions.md](https://github.com/Linnanli/xClaw/blob/xClaw/.github/copilot-instructions.md) 第 3 节本地管线相关内容跳过 `cargo check` / `cargo nextest` / `cargo clippy`（无 `.rs` 改动）。已跑：

```bash
$ python3 scripts/check_no_new_ironclaw_literal.py --base origin/xClaw
OK: No new .ironclaw / IRONCLAW_BASE_DIR literals introduced.

$ python3.12 scripts/check_no_panics.py --base origin/xClaw
OK: No panic-inducing calls in changed production code.
```

三层验证（已写入 v1.3 修订记）：

- **Tier 1** `semantic_search` "SystemPromptBuilder usage in x-claw main repo" → 仅命中 `crates/x_claw_agent/src/prompt.rs` 注释引用与 `claw-code/rust/crates/runtime/` 只读区
- **Tier 3** `grep_search 'SystemPromptBuilder|rusty_claude_cli|runtime::prompt'` → 12 命中全部在只读区或 ADR 注释；x-claw 主仓代码层 0 引用

## Cross-cuts

ADR-114（`.ironclaw` → `.dasclaw` 命名迁移）：**类A** — 无新增 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量（grep guard 通过）。

## 后续

- 此 PR 合并后 #131 自动 closed
- #37 父 issue 仍 OPEN，由 W3/C 后续 wave 决定是否关闭
- ADR-118 W6 实施工作（删 desktop-client/ironclaw 对 claw-code-api 的 path-dep）独立追踪

Closes #131
