### PR TITLE
chore(clippy): rewrite manual strip_prefix patterns (batch 5)

### DIFF
--- a/desktop-client/src/dlp/sanitizer.rs
+++ b/desktop-client/src/dlp/sanitizer.rs
@@ -373,8 +373,8 @@ impl DlpSanitizer {
     /// 手机号格式保留（处理国际区号）
     fn preserve_format_mobile(&self, text: &str, preserve_chars: usize, mask_char: char) -> String {
         // 如果包含+86等国际区号，保留区号部分
-        if text.starts_with("+86") {
-            let mobile_part = &text[3..].trim_start_matches(&['-', ' '][..]);
+        if let Some(rest) = text.strip_prefix("+86") {
+            let mobile_part = rest.trim_start_matches(&['-', ' '][..]);
             let preserved_mobile =
                 self.preserve_format_generic(mobile_part, preserve_chars, mask_char);
             // 保持原有的分隔符

--- a/desktop-client/src/platform_utils.rs
+++ b/desktop-client/src/platform_utils.rs
@@ -126,10 +126,10 @@ pub fn get_log_file_path() -> PathBuf {
 pub fn normalize_path(path: &str) -> PathBuf {
     let path = path.replace("\\", "/");
 
-    if path.starts_with("~/") {
+    if let Some(rest) = path.strip_prefix("~/") {
         dirs::home_dir()
             .unwrap_or_else(|| PathBuf::from("."))
-            .join(&path[2..])
+            .join(rest)
     } else {
         PathBuf::from(path)
     }


### PR DESCRIPTION
## 背景/目标

`cargo clippy --no-deps -p desktop-client --all-targets` 在两处生产代码报告 `clippy::manual_strip`（`stripping a prefix manually`）。clippy 推荐改用 `str::strip_prefix`，避免硬编码的 `&s[N..]` 切片造成 prefix 长度漂移风险。承接 desktop-client clippy 清理节奏（batch 1–4：#224/#228/#230/#232/#234/#236 → #225/#229/#231/#233/#235/#237）。

## 改动范围

- `desktop-client/src/platform_utils.rs:129` (`normalize_path`)
  - `if path.starts_with("~/") { ...join(&path[2..]) }`
  - → `if let Some(rest) = path.strip_prefix("~/") { ...join(rest) }`
- `desktop-client/src/dlp/sanitizer.rs:376` (`preserve_format_mobile`)
  - `if text.starts_with("+86") { let mobile_part = &text[3..].trim_start_matches(...); ... }`
  - → `if let Some(rest) = text.strip_prefix("+86") { let mobile_part = rest.trim_start_matches(...); ... }`

+4 -4 / 2 文件。语义完全等价（被剥离前缀长度一致）。

## 非目标（What's NOT in this PR）

- 不动 ADR-114 / ADR-117 / ADR-118 红线
- 不处理其他 clippy 类别（consecutive `str::replace`、`map_or`、`length comparison to zero/one`、`let...else`→`?`、`impl can be derived` 等留作后续 batch）
- 不重构 `normalize_path` 或 `preserve_format_mobile` 其它行为

## 验证

```
cargo check -p desktop-client --tests                                   # OK (13.83s)
cargo nextest run -p desktop-client \
  -E 'test(/normalize_path/) | test(/preserve_format_mobile/) \
      | test(/sanitiz/) | test(/dlp/)'                                  # 196/196 PASS, 599 skipped
cargo clippy --no-deps -p desktop-client --all-targets 2>&1 \
  | grep -E 'manual_strip|stripping a prefix'                           # 空输出（warning 清零）
cargo fmt --all                                                         # OK
python3.12 scripts/check_no_panics.py --base origin/xClaw               # OK
python3 scripts/check_no_new_ironclaw_literal.py --base origin/xClaw    # OK
```

## Cross-cuts

类A（仅纯 Rust 代码 clippy 重写，不涉及 `.ironclaw`/`.dasclaw` 字面量、ADR 红线、跨 crate 接口）。

Closes #239
