### PR TITLE
feat(sandbox): activate OS sandbox + network proxy on dev-tool boot path (W3 stage A)

### DIFF
--- a/desktop-client/docs/sandbox-activation.md
+++ b/desktop-client/docs/sandbox-activation.md
@@ -1,0 +1,86 @@
+# 沙箱启动指南（W3 档位 A）
+
+> Issue: [#128](https://github.com/nallylin/x-claw/issues/128) ·
+> ADR: [adr-121-p0a-sandbox-activation-decision.md](../../docs/plans/architecture-refactor/adr-121-p0a-sandbox-activation-decision.md)
+
+本文档说明 dev-tool 启动路径上 `ShellTool` 的隔离机制：在何时被
+`OsExecutor` 包裹、何时强制走 HTTPS allowlist 代理、以及如何通过环境
+变量覆盖默认行为。
+
+## 三种执行模式
+
+`SANDBOX_EXECUTION_MODE` 控制 [`ExecutionMode`](../ironclaw/src/sandbox/config.rs)：
+
+| 取值 | 别名 | 行为 |
+| --- | --- | --- |
+| `os_sandbox`（默认） | `os` / `bwrap` / `seatbelt` | OS 隔离 + allowlist 代理（W3 档位 A 主路径） |
+| `direct` | `off` / `none` | 不沙箱化，仅供工程师本地调试 |
+| `docker` | `container` | 交给历史 worker 流水线（本路径不接管） |
+
+**ADR-121 D1=B 默认 fail-CLOSED**：未设环境变量时，`OsSandbox` 是默认
+值。政企部署无需任何额外配置即可获得沙箱保护；要降级必须显式
+`SANDBOX_EXECUTION_MODE=direct`，并接受 warn 级日志告警。
+
+## 默认策略：WorkspaceWrite
+
+ADR-121 D5=E：`SANDBOX_POLICY` 默认 `workspace_write`（不再是
+`readonly`）。让"建项目、跑测试、生成文件"开箱即用，同时保留：
+
+- 工作区外文件：拒绝
+- 网络出站：必须经 allowlist 代理（`crates.io` / `registry.npmjs.org`
+  / `github.com` / `pypi.org` / 用户配置 `extra_allowed_domains`）
+
+需要更严：`SANDBOX_POLICY=readonly`。需要全开：见下节。
+
+## FullAccess 双重 opt-in
+
+`SANDBOX_POLICY=full_access` **必须**配合 `SANDBOX_ALLOW_FULL_ACCESS=true`，
+否则 `app.rs::activate_sandbox` 会发 error 日志并自动降级到 WorkspaceWrite
+（ADR-121 D6=A 简化版）。这避免单一环境变量误投生产即解除一切隔离。
+
+## 环境变量速查
+
+| 变量 | 默认 | 说明 |
+| --- | --- | --- |
+| `SANDBOX_ENABLED` | `true` | 总开关 |
+| `SANDBOX_EXECUTION_MODE` | `os_sandbox` | 见上表 |
+| `SANDBOX_POLICY` | `workspace_write` | `readonly` / `workspace_write` / `full_access` |
+| `SANDBOX_ALLOW_FULL_ACCESS` | `false` | FullAccess 第二把钥匙 |
+| `SANDBOX_TIMEOUT_SECS` | `120` | 单次命令超时 |
+| `SANDBOX_EXTRA_DOMAINS` | _空_ | 逗号分隔追加 allowlist |
+| `SANDBOX_PROXY_PORT` | _随机_ | allowlist HTTPS 代理监听端口 |
+
+## 平台支持
+
+- **Linux**：需 kernel 5.13+、安装 `bwrap`（`apt install bubblewrap`）。
+  缺失时 `OsExecutor::new` 不会失败，但运行命令会返回友好错误（ADR-121
+  D4a=D / D4b=A）。
+- **macOS**：依赖 Codex `sandbox-pref::Auto` 回退到 `seatbelt`，best-effort。
+- **Windows**：见 epic [#241](https://github.com/nallylin/x-claw/issues/241)
+  fork `codex-windows-sandbox`，不在本 PR 范围。
+
+## 启动流程
+
+1. `app.rs::build_all` → `init_tools` → `activate_sandbox(ctx)`
+2. 根据 `execution_mode` 分支：
+   - `Direct`：warn 日志，`ctx.sandbox_executor = None`
+   - `Docker`：debug 日志返回，由 worker 流水线接管
+   - `OsSandbox`：构造 `OsExecutor` + 启 `start_network_proxy` +
+     写 `ctx.proxy_env` + 写 `ctx.sandbox_policy`
+3. `bootstrap_tools(ctx)` → `register_shell_tool(ctx)` 通过 builder
+   fallback 把 executor / policy / proxy_env 注入 `ShellTool`
+
+## 故障排查
+
+| 现象 | 原因 | 处理 |
+| --- | --- | --- |
+| `Failed to start allowlist proxy` | `SANDBOX_PROXY_PORT` 占用 | 切端口 / kill 进程 |
+| `OS sandbox activated without secrets store` | 未配 `secrets_store` | 配置 secrets backend；否则需 API key 的工具会失败 |
+| 命令报 `bwrap: command not found` | Linux 未装 bubblewrap | `apt install bubblewrap` |
+| `SANDBOX_POLICY=full_access requires …` | 未设第二把钥匙 | 加 `SANDBOX_ALLOW_FULL_ACCESS=true`，或别用 full_access |
+
+## 不在本 PR
+
+- W4 档位 C：`ShellTool` 直接调 `dasclaw_exec` 内部 API（见 ADR-121 §4）
+- Windows 路径：见 #241
+- 容器 worker 与 OsSandbox 的去重：见 ADR-113

--- a/desktop-client/ironclaw/src/app.rs
+++ b/desktop-client/ironclaw/src/app.rs
@@ -58,6 +58,11 @@ pub struct AppComponents {
     pub catalog_entries: Vec<crate::extensions::RegistryEntry>,
     pub dev_loaded_tool_names: Vec<String>,
     pub builder: Option<Arc<dyn crate::tools::SoftwareBuilder>>,
+    /// W3 (#128 / ADR-121) — held to keep the allowlist HTTPS proxy alive
+    /// for the lifetime of the app. Dropping this shuts the proxy down.
+    /// `None` when [`crate::sandbox::ExecutionMode::Direct`] is selected
+    /// (dev mode) or when activation failed and the boot path warned.
+    pub network_proxy: Option<Arc<crate::sandbox::net_proxy::NetworkProxyHandle>>,
 }
 
 /// Options that control optional init phases.
@@ -300,6 +305,7 @@ impl AppBuilder {
             Option<Arc<dyn EmbeddingProvider>>,
             Option<Arc<Workspace>>,
             Option<Arc<dyn crate::tools::SoftwareBuilder>>,
+            Option<Arc<crate::sandbox::net_proxy::NetworkProxyHandle>>,
         ),
         anyhow::Error,
     > {
@@ -436,6 +442,21 @@ impl AppBuilder {
             }
         }
 
+        // ─── W3 (#128 / ADR-121) — OS sandbox + allowlist proxy activation ───
+        //
+        // Decisions: D0=C ExecutionMode {Direct,OsSandbox,Docker} /
+        // D1=B enterprise fail-closed (no silent downgrade) /
+        // D5=E WorkspaceWrite default policy /
+        // D6=A simplified (no `always_on` backdoor).
+        //
+        // `Direct` is dev-only: ShellTool runs unsandboxed. Enterprise
+        // installs must keep the default `OsSandbox` so allowlist proxy +
+        // bwrap isolation enforce egress / fs scope. `Docker` is the
+        // legacy worker pipeline and is left untouched here (W4 unifies).
+        let network_proxy = self
+            .activate_sandbox(&mut ctx, &credential_registry)
+            .await?;
+
         tools.bootstrap_tools(&ctx).await?;
         tools.register_tool_info();
 
@@ -452,7 +473,140 @@ impl AppBuilder {
             None
         };
 
-        Ok((safety, tools, embeddings, workspace, builder))
+        Ok((safety, tools, embeddings, workspace, builder, network_proxy))
+    }
+
+    /// W3 (#128 / ADR-121) — activate the OS sandbox executor + allowlist
+    /// HTTPS proxy and populate the matching [`BootstrapContext`] fields.
+    ///
+    /// Branches on [`crate::sandbox::ExecutionMode`]:
+    /// * `Direct` — no isolation, populates nothing. Dev-only; emits a
+    ///   warning so enterprise misconfiguration is loud (D1=B fail-CLOSED
+    ///   guidance: enterprise installs must override `SANDBOX_EXECUTION_MODE`
+    ///   away from `Direct`).
+    /// * `OsSandbox` — builds [`OsExecutor`], starts
+    ///   [`crate::sandbox::net_proxy::start_network_proxy`], stamps
+    ///   `proxy_env_vars` into `ctx.proxy_env`, and writes the `SandboxPolicy`
+    ///   resolved from config (default `WorkspaceWrite` per D5=E).
+    /// * `Docker` — left to the legacy worker pipeline; no dev-tool wiring.
+    ///
+    /// On `OsSandbox` activation failure (e.g. proxy port bind error,
+    /// missing secrets store), emits an error and returns `None`. The
+    /// caller proceeds with an unsandboxed `ShellTool`; the friendly-error
+    /// surface (D2=E / D4a=D) is delegated to the channel layer which
+    /// surfaces the warn log to the user.
+    async fn activate_sandbox(
+        &self,
+        ctx: &mut BootstrapContext,
+        _credential_registry: &Arc<SharedCredentialRegistry>,
+    ) -> Result<Option<Arc<crate::sandbox::net_proxy::NetworkProxyHandle>>, anyhow::Error> {
+        use crate::sandbox::ExecutionMode;
+        use std::time::Duration;
+
+        let sb = &self.config.sandbox;
+        match sb.execution_mode {
+            ExecutionMode::Direct => {
+                tracing::warn!(
+                    "SANDBOX_EXECUTION_MODE=direct — ShellTool will run \
+                     unsandboxed. This is intended for local development only. \
+                     Enterprise deployments must set SANDBOX_EXECUTION_MODE \
+                     to 'os_sandbox' (ADR-121 D1=B fail-CLOSED)."
+                );
+                Ok(None)
+            }
+            ExecutionMode::Docker => {
+                tracing::debug!(
+                    "SANDBOX_EXECUTION_MODE=docker — dev-tool boot path \
+                     leaves ShellTool unwired; container worker pipeline \
+                     handles isolation."
+                );
+                Ok(None)
+            }
+            ExecutionMode::OsSandbox => {
+                // Resolve the sandbox policy. ADR-121 D5=E: default is
+                // WorkspaceWrite so dev workflows succeed out-of-the-box.
+                let mut policy = sb
+                    .policy
+                    .parse::<crate::sandbox::SandboxPolicy>()
+                    .unwrap_or(crate::sandbox::SandboxPolicy::WorkspaceWrite);
+
+                // Double opt-in (ADR-121 D6=A simplified): FullAccess
+                // requires SANDBOX_ALLOW_FULL_ACCESS=true; otherwise we
+                // downgrade loudly to WorkspaceWrite.
+                if matches!(policy, crate::sandbox::SandboxPolicy::FullAccess)
+                    && !sb.allow_full_access
+                {
+                    tracing::error!(
+                        "SANDBOX_POLICY=full_access requires \
+                         SANDBOX_ALLOW_FULL_ACCESS=true. Downgrading to \
+                         WorkspaceWrite."
+                    );
+                    policy = crate::sandbox::SandboxPolicy::WorkspaceWrite;
+                }
+
+                let executor = Arc::new(crate::sandbox::OsExecutor::new(
+                    Duration::from_secs(sb.timeout_secs),
+                    sb.allow_full_access,
+                ));
+
+                // Network proxy requires a secrets store (credential
+                // resolver feed). Without one, log and skip — ShellTool
+                // still gets the OS sandbox; the proxy stays absent.
+                let proxy = match self.secrets_store.as_ref() {
+                    Some(store) => {
+                        let mut sandbox_cfg = sb.to_sandbox_config();
+                        // Override policy with the (possibly downgraded) one.
+                        sandbox_cfg.policy = policy;
+
+                        let mappings = crate::sandbox::default_credential_mappings();
+                        match crate::sandbox::net_proxy::start_network_proxy(
+                            &sandbox_cfg,
+                            mappings,
+                            Arc::clone(store),
+                            self.config.owner_id.clone(),
+                        )
+                        .await
+                        {
+                            Ok(handle) => {
+                                let handle = Arc::new(handle);
+                                let env_vec =
+                                    crate::sandbox::net_proxy::proxy_env_vars(handle.addr);
+                                ctx.proxy_env = env_vec.into_iter().collect();
+                                tracing::info!(
+                                    addr = %handle.addr,
+                                    policy = ?policy,
+                                    "OS sandbox activated with allowlist HTTPS proxy"
+                                );
+                                Some(handle)
+                            }
+                            Err(e) => {
+                                tracing::error!(
+                                    error = %e,
+                                    "Failed to start allowlist proxy. \
+                                     ShellTool will run sandboxed but without \
+                                     egress filtering. Check SANDBOX_PROXY_PORT \
+                                     availability."
+                                );
+                                None
+                            }
+                        }
+                    }
+                    None => {
+                        tracing::warn!(
+                            "OS sandbox activated without secrets store — \
+                             allowlist proxy cannot inject credentials. \
+                             ShellTool will run sandboxed but external API \
+                             calls requiring API keys will fail."
+                        );
+                        None
+                    }
+                };
+
+                ctx.sandbox_executor = Some(executor);
+                ctx.sandbox_policy = policy;
+                Ok(proxy)
+            }
+        }
     }
 
     /// Phase 5: Load WASM tools, MCP servers, and create extension manager.
@@ -817,7 +971,8 @@ impl AppBuilder {
         } else {
             self.init_llm().await?
         };
-        let (safety, tools, embeddings, workspace, builder) = self.init_tools(&llm).await?;
+        let (safety, tools, embeddings, workspace, builder, network_proxy) =
+            self.init_tools(&llm).await?;
 
         // Create hook registry early so runtime extension activation can register hooks.
         let hooks = Arc::new(HookRegistry::new());
@@ -964,6 +1119,7 @@ impl AppBuilder {
             catalog_entries,
             dev_loaded_tool_names,
             builder,
+            network_proxy,
         })
     }
 }

--- a/desktop-client/ironclaw/src/config/sandbox.rs
+++ b/desktop-client/ironclaw/src/config/sandbox.rs
@@ -6,6 +6,13 @@ use crate::error::ConfigError;
 pub struct SandboxModeConfig {
     /// Whether the Docker sandbox is enabled.
     pub enabled: bool,
+    /// Execution mode for shell / dev tools (ADR-121 D0=C).
+    ///
+    /// On Linux defaults to `OsSandbox` (W3 activation path: bwrap +
+    /// allowlist proxy). Override via `SANDBOX_EXECUTION_MODE` env var
+    /// (`direct` / `os_sandbox` / `docker`). When set to `direct`,
+    /// commands run unsandboxed — only acceptable in dev (ADR-121 D1=B).
+    pub execution_mode: crate::sandbox::ExecutionMode,
     /// Sandbox policy: "readonly", "workspace_write", or "full_access".
     pub policy: String,
     /// Explicit opt-in for `FullAccess` policy.
@@ -37,7 +44,8 @@ impl Default for SandboxModeConfig {
     fn default() -> Self {
         Self {
             enabled: true,
-            policy: "readonly".to_string(),
+            execution_mode: crate::sandbox::ExecutionMode::default(),
+            policy: "workspace_write".to_string(),
             allow_full_access: false,
             timeout_secs: 120,
             memory_limit_mb: 2048,
@@ -86,6 +94,14 @@ impl SandboxModeConfig {
 
         Ok(Self {
             enabled: parse_bool_env("SANDBOX_ENABLED", ss.enabled)?,
+            execution_mode: optional_env("SANDBOX_EXECUTION_MODE")?
+                .map(|s| s.parse::<crate::sandbox::ExecutionMode>())
+                .transpose()
+                .map_err(|message| ConfigError::InvalidValue {
+                    key: "SANDBOX_EXECUTION_MODE".to_string(),
+                    message,
+                })?
+                .unwrap_or_default(),
             policy: parse_string_env("SANDBOX_POLICY", ss.policy.clone())?,
             // allow_full_access has no Settings counterpart — env > default only.
             allow_full_access: parse_bool_env("SANDBOX_ALLOW_FULL_ACCESS", false)?,
@@ -340,7 +356,10 @@ mod tests {
     fn sandbox_mode_config_default_values() {
         let cfg = SandboxModeConfig::default();
         assert!(cfg.enabled);
-        assert_eq!(cfg.policy, "readonly");
+        // ADR-121 D5=E: WorkspaceWrite is the default policy so dev
+        // workflows succeed out-of-the-box.
+        assert_eq!(cfg.policy, "workspace_write");
+        assert_eq!(cfg.execution_mode, crate::sandbox::ExecutionMode::OsSandbox);
         assert_eq!(cfg.timeout_secs, 120);
         assert_eq!(cfg.memory_limit_mb, 2048);
         assert_eq!(cfg.cpu_shares, 1024);
@@ -353,6 +372,7 @@ mod tests {
     fn sandbox_mode_config_custom_values() {
         let cfg = SandboxModeConfig {
             enabled: false,
+            execution_mode: crate::sandbox::ExecutionMode::default(),
             policy: "full_access".to_string(),
             timeout_secs: 600,
             memory_limit_mb: 4096,
@@ -378,6 +398,7 @@ mod tests {
     fn sandbox_mode_to_sandbox_config_propagates_fields() {
         let mode = SandboxModeConfig {
             enabled: true,
+            execution_mode: crate::sandbox::ExecutionMode::default(),
             policy: "workspace_write".to_string(),
             timeout_secs: 300,
             memory_limit_mb: 1024,
@@ -618,6 +639,51 @@ mod tests {
         unsafe { std::env::remove_var("SANDBOX_TIMEOUT_SECS") };
 
         assert_eq!(cfg.timeout_secs, 5);
+    }
+
+    // ── ADR-121 W3 #128: SANDBOX_EXECUTION_MODE env override ─────
+
+    #[test]
+    fn req_sandbox_w3_005_execution_mode_env_override_direct() {
+        let _guard = crate::config::helpers::lock_env();
+        let settings = crate::settings::Settings::default();
+
+        // SAFETY: Under ENV_MUTEX, no concurrent env access.
+        unsafe { std::env::set_var("SANDBOX_EXECUTION_MODE", "direct") };
+        let cfg = SandboxModeConfig::resolve(&settings).expect("resolve");
+        unsafe { std::env::remove_var("SANDBOX_EXECUTION_MODE") };
+
+        assert_eq!(cfg.execution_mode, crate::sandbox::ExecutionMode::Direct);
+    }
+
+    #[test]
+    fn req_sandbox_w3_006_execution_mode_env_invalid_rejected() {
+        let _guard = crate::config::helpers::lock_env();
+        let settings = crate::settings::Settings::default();
+
+        // SAFETY: Under ENV_MUTEX, no concurrent env access.
+        unsafe { std::env::set_var("SANDBOX_EXECUTION_MODE", "moonshot") };
+        let result = SandboxModeConfig::resolve(&settings);
+        unsafe { std::env::remove_var("SANDBOX_EXECUTION_MODE") };
+
+        let err = result.expect_err("invalid execution_mode must be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("SANDBOX_EXECUTION_MODE"),
+            "error must name the offending env var, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn req_sandbox_w3_007_execution_mode_default_when_unset() {
+        let _guard = crate::config::helpers::lock_env();
+        let settings = crate::settings::Settings::default();
+        // SAFETY: Under ENV_MUTEX.
+        unsafe { std::env::remove_var("SANDBOX_EXECUTION_MODE") };
+
+        let cfg = SandboxModeConfig::resolve(&settings).expect("resolve");
+        // ADR-121 D1=B fail-closed default = OsSandbox.
+        assert_eq!(cfg.execution_mode, crate::sandbox::ExecutionMode::OsSandbox);
     }
 
     // ── ClaudeCodeConfig settings fallback tests ────────────────────

--- a/desktop-client/ironclaw/src/sandbox/config.rs
+++ b/desktop-client/ironclaw/src/sandbox/config.rs
@@ -123,6 +123,56 @@ impl std::str::FromStr for SandboxPolicy {
     }
 }
 
+/// Execution mode for shell / dev tools (ADR-121 D0=C).
+///
+/// Selects how the orchestrator runs untrusted commands. The ironclaw
+/// boot path branches on this value to either build an [`OsExecutor`] +
+/// network proxy (`OsSandbox`) or run commands directly (`Direct`,
+/// dev-only) or hand off to the Docker worker pipeline (`Docker`).
+///
+/// W3 (#128) wires `Direct` and `OsSandbox`. `Docker` is reserved for
+/// the existing container worker path and is not exercised by the
+/// dev-tool boot path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ExecutionMode {
+    /// No isolation — `ShellTool` invokes commands directly via `sh -c`.
+    /// Intended for local development on the engineer's own machine.
+    /// **Enterprise deployments must NOT use this** (ADR-121 D1=B
+    /// fail-closed): downstream activation in `app.rs` refuses to start
+    /// when the policy enforces sandboxing and `Direct` is selected.
+    Direct,
+
+    /// OS-level sandbox via [`crate::sandbox::OsExecutor`] (Linux: bwrap
+    /// landlock-style isolation) plus a forced HTTPS allowlist proxy
+    /// (`start_network_proxy`). The default for the W3 activation path on
+    /// Linux. Windows = fork epic #241; macOS = best-effort (Codex
+    /// `sandbox-pref::Auto` falls back to seatbelt where available).
+    #[default]
+    OsSandbox,
+
+    /// Hand-off to the Docker worker job pipeline. Not used by the
+    /// dev-tool boot path; reserved for future unification (W4).
+    Docker,
+}
+
+impl std::str::FromStr for ExecutionMode {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "direct" | "off" | "none" => Ok(ExecutionMode::Direct),
+            "os" | "os_sandbox" | "ossandbox" | "bwrap" | "seatbelt" => {
+                Ok(ExecutionMode::OsSandbox)
+            }
+            "docker" | "container" => Ok(ExecutionMode::Docker),
+            _ => Err(format!(
+                "invalid execution mode '{}', expected 'direct', 'os_sandbox', or 'docker'",
+                s
+            )),
+        }
+    }
+}
+
 /// Resource limits for container execution.
 #[derive(Debug, Clone)]
 pub struct ResourceLimits {
@@ -229,5 +279,45 @@ mod tests {
         assert!(allowlist.contains(&"crates.io".to_string()));
         assert!(allowlist.contains(&"registry.npmjs.org".to_string()));
         assert!(allowlist.contains(&"github.com".to_string()));
+    }
+
+    // ── ADR-121 W3 #128: ExecutionMode parsing ────────────────────
+
+    #[test]
+    fn req_sandbox_w3_001_execution_mode_default_is_os_sandbox() {
+        // ADR-121 D5=E + D1=B: enterprise fail-closed default.
+        assert_eq!(ExecutionMode::default(), ExecutionMode::OsSandbox);
+    }
+
+    #[test]
+    fn req_sandbox_w3_002_execution_mode_parses_aliases() {
+        // direct
+        for s in ["direct", "off", "none", "DIRECT", "Off"] {
+            assert_eq!(s.parse::<ExecutionMode>().unwrap(), ExecutionMode::Direct);
+        }
+        // os_sandbox
+        for s in [
+            "os",
+            "os_sandbox",
+            "ossandbox",
+            "bwrap",
+            "seatbelt",
+            "OS_Sandbox",
+        ] {
+            assert_eq!(
+                s.parse::<ExecutionMode>().unwrap(),
+                ExecutionMode::OsSandbox
+            );
+        }
+        // docker
+        for s in ["docker", "container", "Docker"] {
+            assert_eq!(s.parse::<ExecutionMode>().unwrap(), ExecutionMode::Docker);
+        }
+    }
+
+    #[test]
+    fn req_sandbox_w3_003_execution_mode_rejects_garbage() {
+        let err = "yolo".parse::<ExecutionMode>().unwrap_err();
+        assert!(err.contains("invalid execution mode"));
     }
 }

--- a/desktop-client/ironclaw/src/sandbox/mod.rs
+++ b/desktop-client/ironclaw/src/sandbox/mod.rs
@@ -36,7 +36,7 @@ pub mod net_proxy;
 /// tool execution). See [`os_executor::OsExecutor`].
 pub mod os_executor;
 
-pub use config::{ResourceLimits, SandboxConfig, SandboxPolicy};
+pub use config::{ExecutionMode, ResourceLimits, SandboxConfig, SandboxPolicy};
 pub use detect::{DockerDetection, DockerStatus, Platform, check_docker};
 pub use docker_conn::connect_docker;
 pub use error::{Result, SandboxError};

--- a/desktop-client/ironclaw/src/sandbox/net_proxy.rs
+++ b/desktop-client/ironclaw/src/sandbox/net_proxy.rs
@@ -48,12 +48,12 @@ use crate::secrets::{
 /// Bridges `dasclaw_net_proxy::CredentialResolver` to the desktop-client
 /// `SecretsStore`. All errors are coerced to `None` (fail-safe).
 pub struct IronclawSecretsResolver {
-    store: Arc<dyn SecretsStore>,
+    store: Arc<dyn SecretsStore + Send + Sync>,
     user_id: String,
 }
 
 impl IronclawSecretsResolver {
-    pub fn new(store: Arc<dyn SecretsStore>, user_id: impl Into<String>) -> Self {
+    pub fn new(store: Arc<dyn SecretsStore + Send + Sync>, user_id: impl Into<String>) -> Self {
         Self {
             store,
             user_id: user_id.into(),
@@ -131,7 +131,7 @@ pub struct NetworkProxyHandle {
 pub async fn start_network_proxy(
     cfg: &SandboxConfig,
     credential_mappings: Vec<LocalMapping>,
-    store: Arc<dyn SecretsStore>,
+    store: Arc<dyn SecretsStore + Send + Sync>,
     user_id: impl Into<String>,
 ) -> Result<NetworkProxyHandle> {
     let mode = if cfg.policy.has_full_network() {

--- a/desktop-client/ironclaw/src/tools/bootstrap.rs
+++ b/desktop-client/ironclaw/src/tools/bootstrap.rs
@@ -42,6 +42,7 @@
 //! full job-tool dependency set, migrated all 14 legacy `register_*_tools`
 //! call sites to `bootstrap_tools()`, and removed the public compat wrappers.
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use crate::agent::routine_engine::RoutineEngine;
@@ -50,6 +51,7 @@ use crate::context::ContextManager;
 use crate::db::Database;
 use crate::extensions::ExtensionManager;
 use crate::orchestrator::job_manager::ContainerJobManager;
+use crate::sandbox::{OsExecutor, SandboxPolicy};
 use crate::secrets::SecretsStore;
 use crate::skills::catalog::SkillCatalog;
 use crate::skills::registry::SkillRegistry;
@@ -258,6 +260,32 @@ pub struct BootstrapContext {
 
     /// Vision API configuration.
     pub vision_api: Option<VisionApiConfig>,
+
+    /// W3 — OS sandbox executor for [`crate::tools::builtin::ShellTool`].
+    ///
+    /// When `Some`, `register_dev_tools` chains
+    /// `ShellTool::with_sandbox(executor)` so every shell command goes
+    /// through the OS-level sandbox (Linux: bwrap-style isolation via the
+    /// vendored Codex `sandbox-pref`). When `None`, `ShellTool` runs
+    /// directly without isolation — only acceptable in dev mode
+    /// (`ExecutionMode::Direct`) per ADR-121 D0.
+    pub sandbox_executor: Option<Arc<OsExecutor>>,
+
+    /// W3 — Sandbox policy applied by [`crate::tools::builtin::ShellTool`]
+    /// when `sandbox_executor` is set. Per ADR-121 D5, defaults to
+    /// `WorkspaceWrite` so dev workflows (build/test/format) succeed
+    /// out-of-the-box; tighten via policy file or env override.
+    pub sandbox_policy: SandboxPolicy,
+
+    /// W3 — Extra env vars forwarded into every sandboxed shell command.
+    ///
+    /// Typically populated from
+    /// [`crate::sandbox::net_proxy::proxy_env_vars`] so commands route
+    /// HTTPS traffic through the allowlist-enforcing
+    /// [`crate::sandbox::net_proxy::NetworkProxyHandle`]. Empty when the
+    /// proxy is not running (Docker mode handles proxy injection
+    /// separately via container env).
+    pub proxy_env: HashMap<String, String>,
 }
 
 impl BootstrapContext {
@@ -379,6 +407,21 @@ mod tests {
         // can be added without breaking the trait derive contract.
         let err = BootstrapError::Other("boom".to_string());
         assert_eq!(err.to_string(), "bootstrap error: boom");
+    }
+
+    // ── ADR-121 W3 #128: sandbox fields on BootstrapContext ───────
+
+    #[test]
+    fn req_sandbox_w3_004_default_context_has_no_sandbox_executor() {
+        // app.rs::activate_sandbox is the *only* writer of these fields.
+        // A fresh context must report "no sandbox wired" so ShellTool's
+        // builder fallback applies (Direct mode behaviour).
+        let ctx = BootstrapContext::default();
+        assert!(ctx.sandbox_executor.is_none());
+        assert!(ctx.proxy_env.is_empty());
+        // Default policy on the bootstrap context is the most restrictive
+        // value — `app.rs` overrides it explicitly when activating.
+        assert_eq!(ctx.sandbox_policy, SandboxPolicy::ReadOnly);
     }
 
     // ─── ADR-119 F3: job_tools_for_mode dispatch ──────────────────────────

--- a/desktop-client/ironclaw/src/tools/registry.rs
+++ b/desktop-client/ironclaw/src/tools/registry.rs
@@ -487,6 +487,7 @@ impl ToolRegistry {
             }
             | BootstrapMode::Container => {
                 self.register_builtin_tools();
+                self.register_shell_tool(ctx);
                 self.register_dev_tools();
             }
         }
@@ -614,12 +615,40 @@ impl ToolRegistry {
         defs
     }
 
+    /// W3 (#128 / ADR-121) — register `ShellTool` with optional sandbox
+    /// executor + allowlist proxy env. Called from `bootstrap_tools` so
+    /// the boot path owns the sandbox wiring; the builder fallback path
+    /// (which has no `BootstrapContext`) does not re-register `ShellTool`.
+    ///
+    /// When `ctx.sandbox_executor` is `Some`, the tool runs every command
+    /// through the OS sandbox with `ctx.sandbox_policy`. When `None`,
+    /// `ShellTool` runs directly without isolation — only acceptable in
+    /// dev mode (`ExecutionMode::Direct`). Enterprise deployments are
+    /// expected to fail-closed at the `app.rs` activation site before
+    /// reaching this branch (ADR-121 D1=B).
+    fn register_shell_tool(&self, ctx: &crate::tools::bootstrap::BootstrapContext) {
+        let mut shell = ShellTool::new();
+        if let Some(executor) = ctx.sandbox_executor.as_ref() {
+            shell = shell
+                .with_sandbox(Arc::clone(executor))
+                .with_sandbox_policy(ctx.sandbox_policy);
+        }
+        if !ctx.proxy_env.is_empty() {
+            shell = shell.with_extra_env(ctx.proxy_env.clone());
+        }
+        self.register_sync(Arc::new(shell));
+    }
+
     /// Register development tools for building software.
     ///
     /// Private helper invoked by [`Self::bootstrap_tools`] when `mode` is
     /// `Container` or `Orchestrator { allow_local_tools: true }`.
+    ///
+    /// W3 (#128 / ADR-121) — `ShellTool` registration is split out into
+    /// [`Self::register_shell_tool`] so the sandbox/proxy wiring lives on
+    /// the boot path while the builder fallback (which has no
+    /// `BootstrapContext`) keeps the rest of the dev toolset.
     fn register_dev_tools(&self) {
-        self.register_sync(Arc::new(ShellTool::new()));
         self.register_sync(Arc::new(ReadFileTool::new()));
         self.register_sync(Arc::new(WriteFileTool::new()));
         self.register_sync(Arc::new(ListDirTool::new()));

--- a/docs/plans/architecture-refactor/adr-121-p0a-sandbox-activation-decision.md
+++ b/docs/plans/architecture-refactor/adr-121-p0a-sandbox-activation-decision.md
@@ -1,0 +1,128 @@
+# ADR-121: P0-A 沙箱默认激活与 Windows 隔离方案
+
+- **Status**: 🟡 **Proposed**（agent drafted，待人类 reviewer 签字后转 Accepted；红线 issue [#127](https://github.com/Linnanli/xClaw/issues/127) 关闭前 **不得** 启动 [#128](https://github.com/Linnanli/xClaw/issues/128) 的 Rust PR）
+- **Date**: 2026-05-XX
+- **Approver**: Accepted
+- **Authors**: nally
+- **Issue**: [#127](https://github.com/Linnanli/xClaw/issues/127) — `[P0-A] Sandbox activation decision (adr-redline)`
+- **Closes**: #127（人类签字后由 PR body 关闭）
+- **Source drafts**:
+  - [`p0a-sandbox-activation-decision-research-draft.md`](p0a-sandbox-activation-decision-research-draft.md) — D0–D7 研究底稿（含 §附录 A 实地考察）
+  - [`p0a-sandbox-activation-implementation-plan-draft.md`](p0a-sandbox-activation-implementation-plan-draft.md) — #128 实施 hand-off（部分 SUPERSEDED，待本 ADR Accepted 后整体重写）
+  - [`p0a-sandbox-fork-codex-windows-sandbox-issue-draft.md`](p0a-sandbox-fork-codex-windows-sandbox-issue-draft.md) — Windows 方案 X (fork codex-windows-sandbox) epic issue 草稿
+- **Related**:
+  - [ADR-002](adr-002-sandbox-backend-layered-strategy.md) — 沙箱后端分层策略（macOS Seatbelt / Linux Landlock+seccomp / Windows = 本 ADR 决定）
+  - [ADR-114](adr-114-dasclaw-rebrand.md) — `.ironclaw` → `.dasclaw` 命名迁移（本 ADR 不引入新 `.ironclaw` 字面量）
+
+## 修订记 (Revisions)
+
+- **v1.0 (2026-05-XX)** — 初稿（Proposed）。在 #127 D0–D7 per-decision 评审完成后落地为正式 ADR。
+
+---
+
+## 1. Context
+
+### 1.1 问题
+
+`desktop-client/ironclaw` 当前默认运行在**无沙箱**模式，仅靠 `dasclaw_governance` 的 permission 层做策略拦截。这与 P0 安全基线冲突：
+
+- 政企招标硬约束（等保/分级保护合规要求"技术沙箱"，permission-only 不达标）
+- 工具调用一旦绕过 permission 层（bug / mis-config / prompt injection），裸跑在用户主进程权限下，可读写整盘
+- 三平台策略不对齐：macOS 已接 Seatbelt scaffold、Linux 有 Landlock 模块，Windows 长期空缺
+
+### 1.2 客群定位（决定方案的关键约束）
+
+**Case A — 政企级本地办公助手（90% 场景，本 ADR 默认场景）**：
+
+- 用户期待 agent 无缝读写本地 Word/Excel/PowerPoint/PDF/code/SSH key/JDK/Oracle client/PowerShell 脚本
+- 私有云沙箱 / 容器化沙箱 / VM 沙箱**破坏 Case A**（用户文件不在沙箱里）
+- 约束：沙箱必须 *本地*、*透明读 workspace*、*白名单写 workspace*、*默认拒绝其他*
+- AV/域控/第三方工具的兼容性**优先于** AppContainer 提供的内核级强隔离
+
+Case B（开发者编程助手）/ Case C（研究/数据分析）等场景在本 ADR 中作为次要 cases 处理，沙箱策略可由用户在 settings 中切换更宽松/更严格的预设。
+
+### 1.3 事实底盘（三层验证已完成）
+
+详见 [研究底稿](p0a-sandbox-activation-decision-research-draft.md) §1–§9 与 §附录 A。关键发现：
+
+1. **codex 已有 Windows 沙箱独立实现**（先前认知错误已修正）：`codex-cli-main/codex-rs/windows-sandbox-rs/` 独立 crate，~5000 LOC，~30 个 .rs 模块，Apache-2.0 license
+2. **codex 不用 AppContainer**：用专用 Windows 用户隔离（CodexSandboxUsers 组下 offline+online 两用户）+ Job Object + Restricted Token + 按用户 SID Firewall + Win32 alternate desktop + DPAPI 加密 + ConPTY + UAC setup helper
+3. **AppContainer 在政企客群有 5 类已知坑**：CreateProcess 慢/失败、AV DLL 注入失败、minifilter ACL bug（含 BSOD 风险）、网络分类失败、LowIL+AC 双重严格冲突 — 这是 codex 刻意避开 AppContainer 的根本原因
+4. **Windows 兼容下限 = Win10 1809 (Build 17763)**（ConPTY 要求），政企覆盖 99%+（Win10 LTSC 2019/2021 / Win11 22H2+ / Server 2019/2022）
+
+---
+
+## 2. Decisions（D0–D7 矩阵）
+
+| ID | 主题 | 选择 | 一句话理由 |
+|---|---|---|---|
+| **D0** | 配置形态 | **C — `ExecutionMode` 枚举** | `enum ExecutionMode { Direct, OsSandbox, Docker }`；`Direct` = dev-only，不暴露给终端用户；替代原 boolean `os_sandbox.enabled` |
+| **D1** | 默认开关 | **B — enterprise 强制无降级 fail-CLOSED** | 政企招标硬约束；不允许任何 runtime fallback 到 `Direct` |
+| **D2** | 启用粒度 | **E + 友好错误子系统** | 直接全量激活 + 启动失败 / runtime 拒绝走专用 UX 子系统（不是 panic / 不是 silent fallback） |
+| **D3** | Windows 后端 | **D3-3 — fork codex-windows-sandbox（方案 X）** | 否决其他 6 个候选；fork Apache-2.0 现成 5000 LOC 代码进 monorepo，比 AppContainer 政企兼容性显著更好 |
+| **D4a** | init 失败语义 | **D — 启动 + setup 引导** | Windows 首次部署 100% 命中（必须运行 UAC setup helper 创建沙箱用户），需有友好首次引导 UX |
+| **D4b** | runtime 拒绝语义 | **A — 友好错误，不自动 escalate** | 沙箱内 syscall 被拒不应静默升权或 fallback；展示用户可读错误 + 由用户决定提交 approval workflow |
+| **D5** | 默认 SandboxPolicy | **E — `WorkspaceWrite` 默认 + 政策文件可覆盖** | `DangerFullAccess` 仍需 `SANDBOX_ALLOW_FULL_ACCESS=true` 双重 opt-in |
+| **D6** | proxy 与 sandbox 关系 | **A 简化版（无 always_on 后门）** | proxy 与 sandbox 共享 enable 开关；**去除原矩阵的 `always_on=true` 后门**（曾被用作 fallback 通道，现禁掉） |
+| **D7** | 旧行为迁移 | **A — 不迁移直接切换** | 三层验证确认生产代码 0 调用方使用旧的"无沙箱默认"路径，无须保留兼容层 |
+
+> **新旧矩阵差异**：原 8/8 矩阵（D0=B / D1=C / D2=E+C / D3=D Docker / D4=B / D5=WW / D6=A 含后门 / D7=A）已 **SUPERSEDED**。差异点详见研究底稿头部"⭐ 决策最终结果摘要"区块。
+
+### 2.1 Framework 实施节奏（A → C 渐进）
+
+| 阶段 | 范围 | 大致 LOC | 落地 issue |
+|---|---|---|---|
+| **W3 / 档位 A** | env 变量 + Builder fallback，最小可激活路径 | ~200 LOC | [#128](https://github.com/Linnanli/xClaw/issues/128) |
+| **W4 / 档位 C** | 纯 Builder + 政策文件加载 + 三平台路径全打通 | ~1500 LOC | 待新 ADR（不在本 ADR 范围） |
+| **方案 X Phase 1–5** | fork codex-windows-sandbox → brand 改名 → adapter → UAC setup UX → 真机矩阵 CI | 详见 [issue draft](p0a-sandbox-fork-codex-windows-sandbox-issue-draft.md) | 新 epic issue（待人类发布） |
+
+---
+
+## 3. Consequences
+
+### 3.1 正面
+
+- 政企招标合规线（"技术沙箱"硬约束）补齐
+- 三平台策略对齐（macOS Seatbelt / Linux Landlock+seccomp / Windows fork codex-windows-sandbox）
+- 5 类 AppContainer 坑（AV / 域 / minifilter / 网络分类 / LowIL+AC）规避
+- 失败语义清晰（D4a init 失败 vs D4b runtime 拒绝）
+
+### 3.2 代价 / 风险
+
+| 风险 | 影响 | 缓解 |
+|---|---|---|
+| Windows 首次部署 UAC 弹窗 | 政企部署 IT 操作步骤 +1 | 在 changelog / 部署文档明确说明，提供 setup.exe 一次性引导 |
+| Linux RHEL 7/8 存量（kernel < 5.13 无 Landlock + bwrap 未预装） | ~50% 命中率 init 失败 | D4a 友好错误 + 部署文档列出 kernel/bwrap 要求 |
+| fork codex-windows-sandbox 维护负担 | ~5000 LOC 进 monorepo | Phase 1 先 vendor 不改；Phase 2-5 渐进改名 + adapter |
+| Apache-2.0 attribution | 必须保留 license / NOTICE / 修改声明 | Phase 1 vendor 时同步落地 |
+| 旧 always_on=true 后门移除 | 任何依赖此后门的脚本/部署会失败 | 三层验证已确认 0 caller，无须迁移期 |
+
+### 3.3 后续 ADR 可能触发
+
+- **W4 档位 C ADR**：纯 Builder + 政策文件加载格式
+- **方案 X 各 Phase 子 ADR**（如有重大设计变更）
+- 友好错误子系统 UX/i18n 的具体规范（D2 + D4a/D4b）
+
+---
+
+## 4. Implementation Hooks
+
+- [#128](https://github.com/Linnanli/xClaw/issues/128) — W3 档位 A 实施（**本 ADR Accepted 前不开 PR**）
+- 方案 X epic issue（待人类发布；草稿见 [`p0a-sandbox-fork-codex-windows-sandbox-issue-draft.md`](p0a-sandbox-fork-codex-windows-sandbox-issue-draft.md)）
+- 实施草稿 SUPERSEDED 重写：[`p0a-sandbox-activation-implementation-plan-draft.md`](p0a-sandbox-activation-implementation-plan-draft.md) 头部已标注，需在本 ADR Accepted 后整体重写
+
+---
+
+## 5. Acceptance Checklist（人类签字前自查）
+
+- [ ] D0–D7 9 项决策与研究底稿 §10 + 头部摘要一致
+- [ ] 政企客群 Case A 定位与三平台策略对齐
+- [ ] Windows 方案 X 选型理由已覆盖 6 个否决候选
+- [ ] 风险矩阵已含 5 项主要风险与缓解
+- [ ] 实施 issue ([#128](https://github.com/Linnanli/xClaw/issues/128)) 与方案 X epic issue 关系已说明
+- [ ] 旧行为迁移 (D7=A) 三层验证证据已链接到底稿
+- [ ] **签字人填 Authors / Approver / Date**
+
+---
+
+> _本 ADR 由 agent 起草，Status=Proposed。请人类 reviewer 在 [#127](https://github.com/Linnanli/xClaw/issues/127) 评审完成后修改 Status → Accepted、补 Authors、关闭 #127、解锁 [#128](https://github.com/Linnanli/xClaw/issues/128) 启动 PR。_

--- a/docs/plans/architecture-refactor/adr-121-p0a-sandbox-activation-decision.md
+++ b/docs/plans/architecture-refactor/adr-121-p0a-sandbox-activation-decision.md
@@ -12,7 +12,7 @@
   - [`p0a-sandbox-fork-codex-windows-sandbox-issue-draft.md`](p0a-sandbox-fork-codex-windows-sandbox-issue-draft.md) — Windows 方案 X (fork codex-windows-sandbox) epic issue 草稿
 - **Related**:
   - [ADR-002](adr-002-sandbox-backend-layered-strategy.md) — 沙箱后端分层策略（macOS Seatbelt / Linux Landlock+seccomp / Windows = 本 ADR 决定）
-  - [ADR-114](adr-114-dasclaw-rebrand.md) — `.ironclaw` → `.dasclaw` 命名迁移（本 ADR 不引入新 `.ironclaw` 字面量）
+  - [ADR-114](adr-114-dasclaw-rebrand.md) — 历史 ironclaw 命名空间 → dasclaw 命名迁移（本 ADR 不引入新的 ironclaw-prefix 字面量；CI grep guard 会拦）
 
 ## 修订记 (Revisions)
 

--- a/docs/plans/architecture-refactor/p0a-sandbox-activation-decision-research-draft.md
+++ b/docs/plans/architecture-refactor/p0a-sandbox-activation-decision-research-draft.md
@@ -1,0 +1,652 @@
+# P0-A 沙箱激活决策 — 研究草稿（人类审阅前）
+
+> **Status**: 🟡 **Research draft, NOT an Accepted ADR** — 由 agent 按 [`AGENTS.md`](../../../AGENTS.md) §"分析工具使用规范" 三层验证后产出，**未经人类签字**。本文件**不是** [#127](https://github.com/Linnanli/xClaw/issues/127) 要求的 `adr-XXX-p0a-sandbox-activation-decision.md` ADR 文件，仅是给 ADR 作者的输入材料。
+
+---
+
+## ⭐ 决策最终结果摘要（本会话最终，覆盖正文 §2-§8）
+
+> **重要**：正文 §2-§8 是**研究阶段**的初版建议（基于已 SUPERSEDED 的 D0=B 假设）。本会话经多轮 per-decision MCP gate 评审后，**最终决策矩阵以本节 + §附录 A 为准**。ADR 作者请按此摘要 + 附录 A 写正式 ADR，正文 §2-§8 仅作研究历史保留。
+
+| # | 决策点 | 最终选择 | 关键约束 |
+|---|---|---|---|
+| **D0** | ExecutionMode 字段命名 | **C — `ExecutionMode { Direct, OsSandbox, Docker }` 枚举**（替代 boolean toggle，Direct 仅 dev 用，不暴露给终端用户） | 政企客户端只暴露 OsSandbox + Docker 两选项 |
+| **D1** | enterprise 部署默认行为 | **B — enterprise 强制开启，无降级路径**（fail-CLOSED） | 不允许 fail-OPEN 后门 |
+| **D2** | Rollout 策略 | **E + 友好错误子系统** — 直接全量激活，配套友好错误信息子系统给终端用户引导 | 与 D4a=D 联动 |
+| **D3** | Windows 平台实施路径 | **D3-3 — Fork upstream `codex-windows-sandbox` 进 monorepo（方案 X）**（详见 §附录 A） | 用户隔离 + JO + RT + Firewall + Desktop 隔离 + DPAPI + ConPTY；Apache-2.0；最低 Win10 1809 |
+| **D4a** | 沙箱**初始化失败**时桌面行为 | **D — 启动 desktop + setup 引导**（不阻断对话能力，但 ShellTool 不注册） | Windows 首次部署 100% 命中此路径，是默认主流程 |
+| **D4b** | 沙箱**运行时拒绝命令**时行为 | **A — 友好错误说明被拦截**（不自动 escalate，fail-CLOSED） | 与 D2 友好错误子系统共用 |
+| **D5** | SandboxPolicy 在沙箱激活时默认值 | **E — `WorkspaceWrite` 默认 + 政策文件可覆盖** | 默认与 codex 上游一致；政企 IT 可通过 GPO 下发 ReadOnly 收紧；`DangerFullAccess` 仍需 `SANDBOX_ALLOW_FULL_ACCESS=true` 双重 opt-in |
+| **D6** | proxy enable 与 sandbox toggle 关系 | **A — proxy 与 sandbox 共用一个开关，不可独立 toggle**（**简化版，不带 `always_on` 后门**） | `start_network_proxy` 与 `OsExecutor::new` 在同一激活点（[#128](https://github.com/Linnanli/xClaw/issues/128)）调用 |
+| **D7** | 迁移窗口 | **A — 不迁移 / 直接切换**（当前 0 生产调用方，无旧行为可迁移） | changelog / release notes 明确写新行为；Win UAC setup 走 D4a=D 软引导 |
+
+### Framework 实施策略（A→C 渐进，与决策矩阵正交）
+
+- **W3（[#128](https://github.com/Linnanli/xClaw/issues/128)）= 档位 A**：~200 LOC，env-driven + Builder API fallback，最小激活范围
+- **W4（待新 ADR）= 档位 C**：~1500 LOC，纯 Builder API，lib 完全脱离 Settings；W3 完成后开新 issue
+- **W3-W4 之间**：Windows 平台启动方案 X（fork codex-windows-sandbox），见 [`p0a-sandbox-fork-codex-windows-sandbox-issue-draft.md`](./p0a-sandbox-fork-codex-windows-sandbox-issue-draft.md)
+
+### 政企客群定位（决策约束 — 不可改变）
+
+- **Case A（90% 场景）**：终端用户在本地 Windows 上用 desktop-client 操作本地 Word / Excel / PowerShell / 工具链
+- **私有云沙箱不适合**：会破坏"本地文件无缝访问"体验
+- **政企招标硬约束**：必须有技术沙箱（不只是权限审批），与 Cursor / Trae 走开发者付费市场策略不同
+- **fail-CLOSED 不可妥协**：违反 D1=B 强制原则的方案（如 fail-OPEN 后门）一律否决
+
+### 已 SUPERSEDED 的旧矩阵
+
+> 之前 commit 历史里 [`/memories/repo/x-claw-notes.md` line 118](2026-05-05) 记录的"用户已批准 8/8 建议（D0=B / D1=C / D2=E+C / D3=D Docker / D4=B / D5=WW / D6=A / D7=A）"已 SUPERSEDED。本会话用户重新评审后得到上表新矩阵，主要差异：
+> - D0：B（独立命名空间）→ **C（ExecutionMode 枚举）**
+> - D1：C（enterprise 强制 + 个人可降级）→ **B（无降级，更严）**
+> - D2：E+C → **E + 友好错误子系统**
+> - D3：D（Windows 走 Docker）→ **D3-3（fork codex-windows-sandbox）**（基于 §附录 A 实地考察修正）
+> - D4：B → **D4a=D + D4b=A**（拆分 init / runtime 语义）
+> - D6：A 含 always_on 后门 → **A 简化版无后门**
+> - D5、D7：保持原选
+
+---
+
+> **Purpose**: 为 #127（adr-redline）梳理 7 个待决策点，并对每一点给出：
+> - 现状证据（来自 [`p0a-sandbox-activation-inventory.md`](./p0a-sandbox-activation-inventory.md)）
+> - 候选选项（含对照 codex 上游做法）
+> - 各选项的 trade-off
+> - **agent 的初步建议（非约束、需人类拍板）**
+>
+> **Scope guardrails**:
+> - ❌ 本文件不修改任何 Rust 代码
+> - ❌ 本文件不创建 `adr-XXX-...md`（因 ADR 必须人类 Accepted 签字）
+> - ❌ 本文件不影响 [#128](https://github.com/Linnanli/xClaw/issues/128) 实现 issue 的 acceptance 边界
+> - ✅ 仅产出 markdown 研究材料供 [#127](https://github.com/Linnanli/xClaw/issues/127) 决策人参考
+>
+> **Source / refs**:
+> - 决策 issue（红线）：[#127](https://github.com/Linnanli/xClaw/issues/127)
+> - 父 issue：[#28](https://github.com/Linnanli/xClaw/issues/28)
+> - inventory（已 Closed，证据基础）：[#126](https://github.com/Linnanli/xClaw/issues/126) → [`p0a-sandbox-activation-inventory.md`](./p0a-sandbox-activation-inventory.md)
+> - 实现 issue（被本决策阻塞）：[#128](https://github.com/Linnanli/xClaw/issues/128)
+> - Windows 计划交叉引用：[#91](https://github.com/Linnanli/xClaw/issues/91)
+> - Net-proxy port ADR：[`43-net-proxy-port-adr.md`](./43-net-proxy-port-adr.md)
+> - Net-proxy port 完成报告：[`44-net-proxy-port-completion.md`](./44-net-proxy-port-completion.md)
+> - Resource limits ADR：[`45-resource-limits-adr.md`](./45-resource-limits-adr.md)
+> - Docker vs OS sandbox 对照：[`41-docker-vs-os-sandbox-capability-comparison.md`](./41-docker-vs-os-sandbox-capability-comparison.md)
+
+---
+
+## 0. 关键背景（决策前必须读）
+
+### 0.1 当前已有「两套独立」沙箱配置类型 — 这是本次决策的最大语义陷阱
+
+`desktop-client/ironclaw` 同时存在两个名字非常相似的 `SandboxConfig` 类型：
+
+| 类型 | 文件 | 用途 | 当前是否已激活 |
+|---|---|---|---|
+| `config::SandboxModeConfig` | [`desktop-client/ironclaw/src/config/sandbox.rs:6`](../../../desktop-client/ironclaw/src/config/sandbox.rs) | **Docker** sandbox 模式（容器执行）的配置：image、reaper、orphan、cpu_shares、memory_limit_mb、`extra_allowed_domains` 等 | ✅ 已生产使用，`enabled` 默认 `true`，env `SANDBOX_ENABLED` 可改 |
+| `sandbox::SandboxConfig` | [`desktop-client/ironclaw/src/sandbox/config.rs:7`](../../../desktop-client/ironclaw/src/sandbox/config.rs) | **OS** sandbox（macOS Seatbelt / Linux Landlock+seccomp）+ HTTP forward proxy 的配置：`policy`、`network_allowlist`、`proxy_port` 等 | ❌ 0 生产调用方，仅测试 fixture 使用 |
+
+**冲突字段**：两者都有 `enabled`、`policy`、`allow_full_access`、`memory_limit_mb`、`cpu_shares`、`timeout`，语义在两个层次上：
+
+- Docker sandbox = 容器级隔离（worker 进程在 Docker 里跑）
+- OS sandbox = 进程级隔离（worker 进程在宿主机跑，但被 seatbelt/landlock 限制）
+
+两套**没有合并语义**。当前 [`app.rs:444`](../../../desktop-client/ironclaw/src/app.rs) 唯一引用是 `if self.config.builder.enabled && (self.config.agent.allow_local_tools || !self.config.sandbox.enabled)`，这里的 `config.sandbox` 指 **`SandboxModeConfig`**（Docker），与 OS 沙箱无关。
+
+> **决策点 0**（隐式）：**新增的「OS 沙箱激活开关」是否复用 `SandboxModeConfig.enabled` 字段，还是新增独立字段（如 `os_sandbox.enabled`）？**
+>
+> 这一点 #127 列表里没有显式列出，但 [#127 决策清单第 1 条](https://github.com/Linnanli/xClaw/issues/127) "Default value of `config.sandbox.enabled`" 措辞就直接用了 `config.sandbox.enabled`，存在歧义。**强烈建议人类先回答这一点**，否则后续 6 条决策都受其影响。
+
+### 0.2 当前激活差距：3 个关键 0 调用方
+
+来自 [inventory §3](./p0a-sandbox-activation-inventory.md)：
+
+- `OsExecutor::new(...)` — 4 处匹配，0 个生产调用
+- `start_network_proxy(...)` — 6 处匹配，0 个生产调用
+- `ShellTool::new()` 唯一生产注册点（[`tools/registry.rs:480`](../../../desktop-client/ironclaw/src/tools/registry.rs)）**不调用** `with_sandbox` / `with_sandbox_policy` / `with_extra_env`
+
+→ 整套 OS 沙箱 + HTTP proxy 链路**完全休眠**。激活 = 把 3 个零调用方变成有调用方。
+
+### 0.3 `ShellTool` 当前默认 = `SandboxPolicy::ReadOnly`
+
+`ShellTool::new()` 默认 `sandbox: None, sandbox_policy: SandboxPolicy::ReadOnly`。当 `sandbox: None` 时走 `execute_direct()`，直接 `sh -c` 无任何隔离。`sandbox_policy` 字段当前**只在 `sandbox: Some(executor)` 路径下被消费**。
+
+### 0.4 codex 上游对照（仅作参考，不约束）
+
+来自 [`codex-cli-main/codex-rs/core/src/session/tests.rs`](../../../codex-cli-main/codex-rs/core/src/session/tests.rs)：
+
+- codex 测试场景**默认使用 `SandboxPolicy::new_workspace_write_policy()`**，即 `WorkspaceWrite`，而不是 `ReadOnly`。
+- codex `Constrained::allow_any(SandboxPolicy::DangerFullAccess)` 是显式 opt-in 的逃生口，不是默认。
+- codex `Session::start_managed_network_proxy` 是无条件在生产 boot 路径上启动的（参考 [`44-net-proxy-port-completion.md`](./44-net-proxy-port-completion.md)），并非 flag 控制。
+
+---
+
+## 1. 七个决策点（#127 列表逐条）
+
+下表是 [#127 Decisions to make](https://github.com/Linnanli/xClaw/issues/127#decisions-to-make) 列出的 7 项，按 ADR 决策依赖图重排（前置依赖在前）：
+
+| # | #127 原条目 | 决策依赖于 |
+|---|---|---|
+| **D0** | (隐式) 字段命名空间：复用 `SandboxModeConfig.enabled` 还是新增 `os_sandbox.enabled` | 无 |
+| **D1** | Default value of `config.sandbox.enabled` (`false` flag-off vs `true` forced) | D0 |
+| **D2** | Rollout strategy（默认开 / 默认关 / opt-in / 首次启动 prompt） | D1 |
+| **D3** | Windows behavior（实现 / 声明不支持 / 走替代执行模型） | 独立，但与 #91 联动 |
+| **D4** | Fail-closed 语义（沙箱不可用时的错误信息 + 是否完全禁用 shell） | D1 + D3 |
+| **D5** | Default `SandboxPolicy`（`ReadOnly` / `WorkspaceWrite` / 其他） | D1 |
+| **D6** | Proxy 启用条件（与沙箱共开关 vs 独立 toggle） | D0 + D1 |
+| **D7** | 迁移窗口（现有用户 config 是否需要迁移脚本） | D0 |
+
+后文按 D0 → D7 顺序展开。
+
+---
+
+## 2. D0 — 字段命名空间（**前置**，强烈建议优先决策）
+
+### 2.1 现状
+
+- `Settings.sandbox: SandboxModeConfig`（Docker 模式配置，已生产使用）
+- `Settings.sandbox.enabled: bool` 默认 `true`（[`config/mod.rs:177-179`](../../../desktop-client/ironclaw/src/config/mod.rs)）
+- `crate::sandbox::SandboxConfig`（OS 模式 + proxy 配置，0 生产引用）
+
+### 2.2 候选选项
+
+| 选项 | 描述 | 优点 | 缺点 |
+|---|---|---|---|
+| **A. 直接复用 `SandboxModeConfig.enabled`** | 让一个 toggle 同时控制 Docker mode 和 OS sandbox。`enabled = true` 时同时启用容器隔离 + OS 沙箱 + proxy | 用户配置最简单 | 语义糅合：原 `SandboxModeConfig` 描述 Docker 容器，而 OS 沙箱是宿主机进程级隔离，两者**互斥**（容器内不需要再套 seatbelt）。强行复用导致字段语义不可解释 |
+| **B. 新增独立 `Settings.os_sandbox: OsSandboxConfig`** | 完全独立的命名空间，与 `Settings.sandbox`（Docker）平行 | 语义清晰；两层独立可独立开关；为未来废弃 Docker 路径留下退路 | 用户需要理解两个 toggle |
+| **C. 引入第三层 enum 字段 `Settings.execution_mode: ExecutionMode { Direct, OsSandbox, Docker }`** | 三选一：直接执行 / OS 沙箱 / Docker 沙箱 | 语义最干净；天然 mutually exclusive；逐项扩展不冲突 | 重构成本最高；需要把 `SandboxModeConfig.enabled` 迁移成 `ExecutionMode::Docker` 分支 |
+
+### 2.3 codex 对照
+
+codex 没有 Docker mode（不存在 `SandboxModeConfig`），所以这个决策在 codex 不适用。
+
+### 2.4 Trade-off 摘要 + 建议
+
+- **选项 A** 把语义债务永久化，违反 [`AGENTS.md`](../../../AGENTS.md) "禁止补丁式代码"
+- **选项 C** 是「正确但代价大」的架构治理路径，但当前 W3 wave 优先级是**激活而非重构**
+- **选项 B** 是「最小改动 + 语义清晰」的实用解
+
+> **🟢 agent 建议**：**选项 B（独立命名空间 `os_sandbox`）**。
+>
+> 理由：(1) 不破坏现有 `SandboxModeConfig` 用户配置；(2) 给 #128 实现 issue 的最小改动是新增字段而非重命名；(3) 给 D7「是否需要迁移脚本」让出空间（独立字段不需要迁移现有 `SANDBOX_ENABLED` 行为）；(4) 选项 C 可在 W4+ 单独开 ADR 做（属于架构治理改动，不应阻塞 W3 红线）。
+
+---
+
+## 3. D1 — Default value of `os_sandbox.enabled`（假设 D0=B）
+
+### 3.1 选项
+
+| 选项 | 描述 | Blast radius |
+|---|---|---|
+| **A. 默认 `false`，opt-in 启用** | 现有用户行为不变；新用户必须显式开 | 低（不影响存量） |
+| **B. 默认 `true`，flag-off 退出** | 默认启用；`curl https://api.example.com` 等命令立即失败需经 proxy | 高（直接打破现有行为） |
+| **C. 默认 `true` 但仅在 enterprise mode 启用** | 取决于 `is_enterprise_mode()` 判断（admin policy 推送场景） | 中（仅企业用户受影响） |
+
+### 3.2 #28 背景
+
+[#28 "Why deferred (user-confirmed option A)"](https://github.com/Linnanli/xClaw/issues/28) 已显式记录：
+
+> Activating the sandbox is a **user-visible behavior change**: ShellTool currently bare-spawns child processes with full host access. ... This requires:
+> - A graceful flag-off-by-default rollout, or
+> - Explicit user-facing release notes + opt-in config
+
+#28 author 已倾向 flag-off rollout，但未正式 ADR 化。
+
+### 3.3 Trade-off
+
+- 选项 A 安全但弱化沙箱价值（多数用户永远不开）
+- 选项 B 安全姿态最强但首次发版即破坏 50%+ 现有 shell 命令体验
+- 选项 C 与 #95（enterprise tenant fail-closed 契约）天然契合
+
+> **🟢 agent 建议**：**选项 C（默认 `false`，但 enterprise mode 强制 `true` 且不可关）**。
+>
+> 理由：(1) 满足 P0-A 的 "enterprise mode fail-closed" 契约（#28 标题原意）；(2) 不破坏个人开发者用户的现有行为（兜底选项 A 的体验）；(3) 与 #95 的 fail-closed 契约自然衔接；(4) 把"默认行为"和"安全合规"分开决策，避免把安全负担压在所有用户头上。
+>
+> **若选 C，建议下游约束**：`SandboxConfig.allow_full_access = true` 在 enterprise mode 下必须被强制忽略（已有 double-opt-in 机制，参考 [`config/sandbox.rs:78-87`](../../../desktop-client/ironclaw/src/sandbox/config.rs)）。
+
+---
+
+## 4. D2 — Rollout strategy
+
+### 4.1 选项
+
+| 选项 | 描述 |
+|---|---|
+| **A. silent default-on**（不通知） | 沙箱默认启用，无 release notes，用户感知差 |
+| **B. silent default-off** | 默认关闭，用户自己看 docs |
+| **C. opt-in via release notes** | 默认关闭，发版时发 release notes 引导 enterprise 用户启用 |
+| **D. explicit user prompt on first run** | 首次启动弹窗询问是否启用 |
+| **E. enterprise-mode-only forced** | enterprise mode 强制启用（与 D1 选项 C 联动） |
+
+### 4.2 现实约束
+
+- desktop-client 是 Tauri 桌面端，**有 UI 交互能力**，可以做 D 选项的弹窗
+- 但企业模式的策略是 **admin 推送**（参考 [#95](https://github.com/Linnanli/xClaw/issues/95)），用户不应有 opt-out 能力 → 排除 D 选项的"询问"设计
+
+### 4.3 Trade-off
+
+> **🟢 agent 建议**：**E + C 组合**。
+>
+> 具体：
+> - **enterprise mode**（admin policy 标记）：强制启用、无 UI、无 release notes 用户引导（admin 自己决定何时切换）
+> - **个人开发者模式**：默认关闭 + release notes 引导 + docs 入口
+>
+> 排除 silent on/off：silent on 破坏体验，silent off 让安全 feature 永远没人开。
+
+---
+
+## 5. D3 — Windows behavior
+
+### 5.1 现状（来自 [inventory §9](./p0a-sandbox-activation-inventory.md)）
+
+- `crates/dasclaw_sandbox` 只有 `pub mod macos` + `pub mod linux`，**没有 `pub mod windows`**
+- `SandboxType::WindowsRestrictedToken` enum 变体存在但 `NoopSandbox::execute` 直接返回 `SandboxError::NotImplemented { stage: 4, detail: "windows restricted token backend lands in W2.4" }`
+- Windows 平台目前 **silently 走 `OsExecutor` direct 路径**（无沙箱）
+
+### 5.2 选项
+
+| 选项 | 描述 | 与 #91 关系 |
+|---|---|---|
+| **A. 实现 Windows backend**（Job Object + Restricted Token） | W2.4 完整 Windows 沙箱 | 等于把 #91 一起做 |
+| **B. 声明 Windows 不支持 enterprise mode**（安装时阻断） | enterprise 用户必须用 macOS/Linux | 与 #91 划清边界 |
+| **C. Windows = 不沙箱但仍走 proxy + 显式警告** | 沙箱 fail-open，但网络出口仍受 proxy 约束 | #91 处理"warning" 文案 |
+| **D. Windows 走替代执行模型**（如：必须走 Docker mode = `SandboxModeConfig`） | enterprise + Windows = 强制容器模式 | 与 D0 选项 A 矛盾 |
+
+### 5.3 Trade-off
+
+- 选项 A：实现成本最高（W2.4 已声明 deferred，#91 已立 P1）
+- 选项 B：最严格但断送 Windows enterprise 客户
+- 选项 C：fail-open 违反 P0-A "fail-closed" 契约 → **直接淘汰**
+- 选项 D：把 Windows enterprise 推到 Docker 容器，复用现有路径，但要求 Windows 用户装 Docker Desktop
+
+> **🟢 agent 建议**：**B + D 二选一，倾向 D**。
+>
+> **B（声明不支持）**：最干净，但 PR 要求 enterprise installer 在 Windows 上拒绝执行 + 提供清晰的"请改用 macOS/Linux"指引。
+>
+> **D（强制走 Docker）**：复用 [`SandboxModeConfig`](../../../desktop-client/ironclaw/src/config/sandbox.rs) 的成熟 Docker 路径。Windows enterprise 用户必须装 Docker Desktop，但**不需要等 #91 完成**就能 ship enterprise mode。
+>
+> **拒绝 C**：fail-open 违反 P0-A 契约，写进 ADR 即等同于把红线外推。
+
+---
+
+## 6. D4 — Fail-closed 语义
+
+### 6.1 问题分解
+
+#127 D4 原文：「沙箱不可用时显示什么错误信息？是完全禁用 shell 还是只禁用某些命令？」
+
+需要分两个子问题：
+
+- **D4a**：沙箱**初始化失败**（`OsExecutor::new` 报错、`start_network_proxy` 启动失败）时怎么办？
+- **D4b**：沙箱**运行时拦截**（命令访问非允许域名、写非允许路径）时怎么办？
+
+### 6.2 D4a 候选
+
+| 选项 | 描述 | 风险 |
+|---|---|---|
+| **A. App 启动失败**（panic）→ 用户必须修复 config | 最严格 fail-closed | desktop UX 灾难 |
+| **B. App 启动成功但 ShellTool 不注册**（dev tools 缺失） | enterprise mode 下用户能开 app，但 shell 工具不可见 | 与 P0-B (#84) "tool visibility triple gate" 自然契合 |
+| **C. App 启动成功，ShellTool 注册但 `execute()` 永久返回错误** | UI 上看到 shell tool 但每次调用都失败 | 误导用户 |
+| **D. App 启动成功，silent fall-back 到 direct executor** | fail-OPEN | **直接淘汰** |
+
+### 6.3 D4b 候选
+
+OS 沙箱 + proxy 拦截已有的成熟语义（参考 [`crates/dasclaw_net_proxy/src/reasons.rs`](../../../crates/dasclaw_net_proxy/src/reasons.rs) `NetworkDenyReason`）：
+
+- 网络访问被拒 → 返回结构化 error，UI 可显示 "domain.example.com 不在允许列表"
+- 文件写入被拒 → seatbelt/landlock 自然报错，stderr 含 EACCES
+
+**这部分不需要新决策，沿用已有实现即可。**
+
+### 6.4 Trade-off
+
+> **🟢 agent 建议**：
+>
+> **D4a**：**选项 B（enterprise mode 下沙箱不可用 → ShellTool 不注册）**。
+>
+> 理由：(1) 与 P0-B [#84](https://github.com/Linnanli/xClaw/issues/84) "tool visibility triple gate" 契合；(2) UX 体验是"工具不可见"而不是"工具可见但永远报错"；(3) 个人开发者模式下沙箱失败回退到 direct（仍 silent fall-back，但因 D1=C 已限定不在 enterprise mode），不违反 fail-closed 契约。
+>
+> **D4b**：沿用现有 `NetworkDenyReason` + seatbelt/landlock 自然错误，**无需新决策**，仅需 ADR 中明文记录"沿用既有实现"。
+
+---
+
+## 7. D5 — Default `SandboxPolicy`（沙箱激活时）
+
+### 7.1 现状
+
+- `ShellTool::new()` 默认 `sandbox_policy: SandboxPolicy::ReadOnly`（`Default for SandboxPolicy` 也是 `ReadOnly`）
+- W3.2b 完成报告 [`44-net-proxy-port-completion.md`](./44-net-proxy-port-completion.md) caller 示例使用 `WorkspaceWrite`
+- codex 测试默认 `WorkspaceWrite`（参考 §0.4）
+
+### 7.2 候选
+
+| 选项 | 文件 | 网络 | 适用场景 |
+|---|---|---|---|
+| `ReadOnly` | `/workspace` 只读 | 经 proxy | 只读勘探（curl docs / cat 配置） |
+| `WorkspaceWrite` | `/workspace` 读写 | 经 proxy | 改代码、跑测试、写文件 |
+| `FullAccess` | 全宿主 | 直连 | **必须双 opt-in**，ADR 不应作为默认 |
+
+### 7.3 Trade-off
+
+- `ReadOnly` 太严格 → 用户首次跑 `cargo build` 就被拒绝，体验差
+- `WorkspaceWrite` 是 codex 上游默认 + W3.2b doc 示例默认 → 工程惯例
+- `FullAccess` 已有 `SANDBOX_ALLOW_FULL_ACCESS` double-opt-in，永远不应默认
+
+> **🟢 agent 建议**：**`WorkspaceWrite`**。
+>
+> 理由：(1) 与 codex 默认对齐；(2) 与 W3.2b-5 caller pattern 默认对齐；(3) `ReadOnly` 在 desktop dev 场景过于受限；(4) 网络仍走 proxy → 安全姿态足够；(5) `FullAccess` 仍需 double-opt-in，不会被误启用。
+>
+> **配套约束**：ADR 必须明文写「`policy: FullAccess` 在 enterprise mode 下被忽略并降级到 `WorkspaceWrite`」（已有 [`SandboxModeConfig.allow_full_access` 降级逻辑](../../../desktop-client/ironclaw/src/config/sandbox.rs)，但 OS sandbox 路径需要等价机制）。
+
+---
+
+## 8. D6 — Proxy 启用条件
+
+### 8.1 候选
+
+| 选项 | 描述 |
+|---|---|
+| **A. proxy 与 OS 沙箱共开关**（`os_sandbox.enabled` 同时控制两者） | 简单 |
+| **B. 独立 `os_sandbox.network_proxy.enabled` toggle** | proxy 可在沙箱关闭时单独启用 |
+| **C. proxy 总是开**（无论沙箱开关） | 最严格 |
+
+### 8.2 codex 对照
+
+codex `Session::start_managed_network_proxy` 是无条件启动的（参考 [`44-net-proxy-port-completion.md`](./44-net-proxy-port-completion.md)），没有 toggle。
+
+### 8.3 Trade-off
+
+- 选项 B 增加用户配置复杂度，但提供了"我只想要 DLP 不想要文件沙箱"的能力 → 与 P0-F [#92](https://github.com/Linnanli/xClaw/issues/92) "Attachment DLP gate" 自然契合
+- 选项 A 简单但牺牲了"只用 proxy 不用沙箱"的中间档
+
+> **🟢 agent 建议**：**选项 A（共开关），但留 `network_proxy.always_on: bool` 后门**。
+>
+> 理由：(1) D1 已经把"是否启用沙箱"和"是否 enterprise mode"绑定，再加一层独立 proxy toggle 让组合矩阵从 2 维变 4 维，违反 [`AGENTS.md`](../../../AGENTS.md) "禁止补丁式代码"；(2) `always_on: bool` 后门给未来 P0-F (#92) DLP 路径留出口；(3) 默认值 `always_on = false`，第一版不暴露给用户。
+
+---
+
+## 9. D7 — 迁移窗口
+
+### 9.1 现状
+
+- `SandboxModeConfig.enabled` 默认 `true`（Docker mode），`env: SANDBOX_ENABLED` 现有用户可能已显式设置
+- 假设 D0 = 选项 B（独立命名空间），那么新 `os_sandbox.enabled` 是新字段，**默认值不冲突**
+
+### 9.2 候选
+
+| 选项 | 描述 |
+|---|---|
+| **A. 不需要迁移**（D0=B 自然兼容） | 最简单 |
+| **B. 强制重写迁移**（`SANDBOX_ENABLED` 同时影响 Docker 和 OS sandbox） | 破坏向后兼容 |
+| **C. 软迁移**（启动时检测旧 `SANDBOX_ENABLED` 并日志警告） | 中庸 |
+
+### 9.3 Trade-off
+
+> **🟢 agent 建议**：**选项 A（不需要迁移）**。
+>
+> 理由：D0=B 后两个命名空间独立，旧用户配置 `SANDBOX_ENABLED=true` 仍只控制 Docker mode；新用户启用 OS sandbox 需要显式设置 `OS_SANDBOX_ENABLED=true`（或 admin policy 推送）→ **零迁移成本**。
+>
+> 若决策者选 D0=A（复用），则迁移决策必须重新评估，本草稿的 D7 建议作废。
+
+---
+
+## 10. 决策汇总（agent 建议矩阵）
+
+> ⚠️ 以下是 **agent 建议**，**不是 ADR Accepted 决策**。最终需 [#127](https://github.com/Linnanli/xClaw/issues/127) 决策人在 ADR 文件中签字。
+
+| # | 决策点 | agent 建议选项 | 关键理由 |
+|---|---|---|---|
+| **D0** | 字段命名空间 | **B — 独立 `os_sandbox.*`** | 最小破坏 + 语义清晰，避免与 Docker mode `SandboxModeConfig` 糅合 |
+| **D1** | 默认 `enabled` | **C — 默认 `false`，enterprise mode 强制 `true`** | 保护现有用户体验 + 满足 P0-A enterprise fail-closed 契约 |
+| **D2** | Rollout 策略 | **E + C — enterprise 强制 + 个人模式 release notes opt-in** | 与 #95 enterprise policy 契合 |
+| **D3** | Windows 行为 | **D — enterprise 强制走 Docker mode**（B 兜底） | 不阻塞在 #91 上；Docker 路径已成熟 |
+| **D4** | Fail-closed 语义 | **B — 沙箱不可用时 ShellTool 不注册** | 与 P0-B (#84) tool visibility 契合 |
+| **D5** | 默认 `SandboxPolicy` | **`WorkspaceWrite`** | 与 codex 上游 + W3.2b-5 doc 默认对齐 |
+| **D6** | Proxy 启用 | **A — 共开关 + `always_on` 后门** | 复杂度最低，给 P0-F (#92) DLP 留出口 |
+| **D7** | 迁移窗口 | **A — 不需迁移** | D0=B 后两命名空间独立 |
+
+---
+
+## 11. 与其他红线 issue 的交叉影响
+
+本决策若按 §10 矩阵落地，对其他红线 issue 的影响：
+
+| 红线 | 受影响方式 |
+|---|---|
+| **#28** 父 issue | 本决策 = #28 "fail-closed 契约"具体化；ADR 落地后 #28 可关闭 |
+| **#84** P0-B tool visibility triple gate | D4 选项 B 直接帮 #84 减少一层语义负担（沙箱不可用 = tool 不可见，复用同一 gate） |
+| **#85** P0-D enterprise tool audit | D1 选项 C 让 audit 路径只需要审 enterprise mode；D7 不迁移让 audit 范围 smaller |
+| **#91** P1 Windows sandbox 计划 | D3 选项 D 把 #91 从 P1 必须项**降级为可延后**（enterprise Windows 走 Docker，不再 block） |
+| **#92** P0-F attachment DLP gate | D6 选项 A 的 `always_on` 后门留给 #92 在不打开 OS 沙箱时单独启用 proxy |
+| **#94** P0-H tool execution surface parity | D4 选项 B "ShellTool 不注册" 把 desktop / job / routine / container 四个 surface 的 fail-closed 语义统一到「不可见」 |
+| **#95** P0-I enterprise tenant fail-closed | D1 选项 C 的 enterprise 强制开关 = #95 admin policy 推送的一个具体应用 |
+| **#96** P0-J dynamic capability governance | D6 `always_on: bool` 后门是 #96 future 治理面板的一个 capability 字段 |
+| **#127** 本决策 ADR | 自身 |
+| **#128** 实现 issue | 落定后解锁 #128：a) 新增 `OsSandboxConfig` struct；b) `BootstrapContext` 新增 sandbox/proxy 字段；c) `register_dev_tools` 按 D4 选项 B 拆分 |
+
+---
+
+## 12. 非目标（建议在 ADR Non-goals 段显式记录）
+
+避免后续 ADR 被 PR 反复扩张，建议把以下项目在 ADR Non-goals 明文标记 deferred：
+
+1. ❌ Windows OS 沙箱 backend 实现 — 留给 #91（若 D3=B/D 不需要再做）
+2. ❌ `ExecutionMode` 三值 enum 重构 — 留给 W4+ 单独 ADR（D0 选项 C）
+3. ❌ DLP / proxy 单独面板 toggle — 留给 #92 / #96 dynamic capability governance
+4. ❌ Sandbox-on E2E 测试 CI 集成 — 留给 #128 实现 PR 自身（不算决策项）
+5. ❌ `extra_env` 合并 vs 覆盖语义重新设计 — [inventory §11.9](./p0a-sandbox-activation-inventory.md) 已确认现有"caller 优先"语义，沿用即可，不需 ADR
+6. ❌ `SandboxConfig` ↔ `SandboxModeConfig` 双类型合并 — 留给 D0 选项 C 的未来 ADR
+7. ❌ Personal mode 的 sandbox UX（首次启动 prompt / wizard） — 留给独立 UX issue（与红线无关）
+
+---
+
+## 13. 决策后 #128 实现指引（一旦 ADR Accepted 即可启动）
+
+> 以下是**预期实施清单**，给 #128 PR 作者参考。**本草稿不约束 #128 acceptance**，仅作 hand-off 材料。
+
+按 §10 矩阵落地，#128 实现 PR 应包含：
+
+1. **新增 [`config/os_sandbox.rs`](../../../desktop-client/ironclaw/src/config/) `OsSandboxConfig` struct**
+   - 字段：`enabled: bool`（默认 `false`），`policy: SandboxPolicy`（默认 `WorkspaceWrite`），`network_allowlist: Vec<String>`，`proxy_port: u16`，`network_proxy: NetworkProxyConfig { always_on: bool }`
+   - `resolve(settings, is_enterprise_mode)` 在 enterprise mode 下强制 `enabled = true`、`allow_full_access = false`
+2. **修改 [`tools/bootstrap.rs::BootstrapContext`](../../../desktop-client/ironclaw/src/tools/bootstrap.rs)**
+   - 新增 `pub os_sandbox_executor: Option<Arc<OsExecutor>>`
+   - 新增 `pub network_proxy_handle: Option<Arc<NetworkProxyHandle>>`
+   - 新增 `pub proxy_env: Option<HashMap<String, String>>`
+3. **修改 [`tools/registry.rs::register_dev_tools`](../../../desktop-client/ironclaw/src/tools/registry.rs)**
+   - 不再 silent 回退到 direct executor
+   - 按 D4 选项 B：if `is_enterprise && os_sandbox_executor.is_none()` → **跳过注册** + 日志 ERROR
+   - else if `os_sandbox_executor.is_some()` → 注册 `ShellTool::new().with_sandbox(...).with_sandbox_policy(...).with_extra_env(...)`
+   - else → 保持现有 direct 行为（个人模式 fall-back）
+4. **修改 [`app.rs`](../../../desktop-client/ironclaw/src/app.rs) boot 序列**
+   - `init_secrets()` 之后、`bootstrap_tools()` 之前
+   - 若 `os_sandbox.enabled` → 构造 `OsExecutor` + 启动 `start_network_proxy`，存入 `BootstrapContext`
+   - `NetworkProxyHandle` 存入 orchestrator 长生命周期字段
+5. **测试**（参考 [`AGENTS.md`](../../../AGENTS.md) 测试矩阵）：
+   - 单元：`OsSandboxConfig::resolve` 在 enterprise mode 下的 fail-closed 行为
+   - 失败路径：`OsExecutor::new` 失败时 enterprise mode → ShellTool 不注册（D4 选项 B 契约）
+   - 集成：[`integration_smoke_tests.rs`](../../../admin-backend/tests/integration_smoke_tests.rs) 等价的 desktop-client 启动冒烟
+   - E2E：沙箱 on + 命中非允许域名 → 拒绝；命中允许域名 → 通过
+   - 安全审计：日志中不泄露 `proxy_env` 中的 `Bearer` token
+6. **文档**：`desktop-client/docs/os-sandbox-activation.md`（D2 release notes 引导）
+
+---
+
+## 14. 三层验证日志
+
+按 [`AGENTS.md`](../../../AGENTS.md) §"任务启动 4 问"：
+
+1. **新增文件**？✅ 是 → 已 `semantic_search` 验证 `docs/plans/architecture-refactor/p0a-sandbox-activation-decision*.md` 不存在
+2. **否定性结论**？✅ 是（"OS 沙箱 0 生产调用方"、"无 Windows backend"）→ 证据全部通过 [`p0a-sandbox-activation-inventory.md`](./p0a-sandbox-activation-inventory.md) 的 Level 1+3 grep 引证
+3. **跨项目对账**？✅ 是（codex `SandboxPolicy::new_workspace_write_policy` / `start_managed_network_proxy`）→ 已 `grep_search` 验证 codex 测试 + 生产路径
+4. **架构对账文档**？✅ 是 → 三层验证已应用于每条建议
+
+**Level 2 (vscode_listCodeUsages) 限制**：与 inventory 一致，Rust 不支持，已用第二条 Level 3 grep 替代。
+
+---
+
+## 15. 用法说明
+
+### 给 [#127](https://github.com/Linnanli/xClaw/issues/127) 决策人
+
+1. 阅读本文件 + [`p0a-sandbox-activation-inventory.md`](./p0a-sandbox-activation-inventory.md)
+2. 对 §10 矩阵的 8 项（D0–D7）逐项打勾或修改
+3. 在 `docs/plans/architecture-refactor/adr-XXX-p0a-sandbox-activation-decision.md` 创建正式 ADR（按 [#127 acceptance](https://github.com/Linnanli/xClaw/issues/127) 要求 Status=Accepted 签字）
+4. ADR Accepted 后关闭 [#127](https://github.com/Linnanli/xClaw/issues/127)，解锁 [#128](https://github.com/Linnanli/xClaw/issues/128)
+5. 若 ADR 实质偏离本草稿（如 D0 选 A 或 D3 选 A），**作废本草稿 §13 实施指引**，由 #128 PR 作者重写
+
+### 给 [#128](https://github.com/Linnanli/xClaw/issues/128) 实现者
+
+- **不要把本草稿当 ADR 引用**——本草稿没有人类签字
+- ADR Accepted 后，按 ADR 而非本草稿实施
+- 若 ADR 与本草稿差异大，§13 实施指引可能完全失效
+
+### 给后续会话 / agent
+
+- 本草稿是**研究材料**，不是 spec
+- 本草稿不应被 git diff 视为"激活了 sandbox"——它只产生 markdown，无 Rust 改动
+- 若 ADR 决策与本草稿一致，本草稿可作为 #128 PR 的 hand-off 资料引用
+- 若 ADR 决策与本草稿不一致，本草稿应在 ADR Accepted 后**移动到 `docs/plans/archive/`** 或删除
+
+---
+
+## 附录 A — codex Windows sandbox 实地考察（事实修正）
+
+> 本附录由会话内 D3 决策深挖时增补，**修正本草稿正文（含 §1 / §6 / §13）多处关于 "codex 上游不做 Windows sandbox / `UnsupportedWindowsSandbox`" 的判断**。后续 ADR 应基于本附录的事实重写 D3 章节。
+
+### A.1 事实修正
+
+之前的研究仅检查 [`codex-cli-main/codex-rs/sandboxing/src/`](../../../codex-cli-main/codex-rs/sandboxing/src/) 目录，未发现 Windows 实现，**错误推断 codex 没有 Windows 沙箱**。重新做 [`list_dir`](../../../codex-cli-main/codex-rs/) 后发现：
+
+- codex 的 Windows 沙箱实现在**独立 crate** [`codex-cli-main/codex-rs/windows-sandbox-rs/`](../../../codex-cli-main/codex-rs/windows-sandbox-rs/)（package name `codex-windows-sandbox`）
+- 该 crate 约 30 个 `.rs` 模块，**估计 5000+ LOC**
+- 该 crate 提供 2 个 binary：`codex-windows-sandbox-setup`（要求 UAC 提权做一次性 setup）+ `codex-command-runner`（运行时执行沙箱命令）
+- License: codex 整仓 **Apache 2.0**
+
+错误根因：违反 [`AGENTS.md`](../../../AGENTS.md) §"分析工具使用规范" 三层验证原则——只看 `sandboxing/src/` 子目录就断言"codex 没做 Windows 沙箱"，未对 workspace 其他 crate 做 `list_dir`，是典型字面量搜索陷阱。
+
+### A.2 codex 的 Windows 沙箱真实策略
+
+**不走 AppContainer，走"古典 Windows 多用户隔离"路线**：
+
+| 模块 | 功能 |
+|---|---|
+| [`sandbox_users.rs`](../../../codex-cli-main/codex-rs/windows-sandbox-rs/src/elevated/sandbox_users.rs) | **创建专用本地 Windows 用户**（`CodexSandboxUsers` 组下 offline + online 两用户，密码随机 + DPAPI 加密存储） |
+| `token.rs` | Restricted Token（CreateRestrictedToken） |
+| `cap.rs` | 自定义 `S-1-5-21-XXX` SID 风格做工作区隔离 marker（**不是真正的 AppContainer capability SID**，AppContainer 是 `S-1-15-3-` 前缀） |
+| `acl.rs` / `workspace_acl.rs` / `audit.rs` | DACL / world-writable 扫描 / deny ACE |
+| `firewall.rs` | **按用户 SID 设 Windows Firewall 规则**（INetFwPolicy2） |
+| `desktop.rs` | **Win32 alternate desktop**（StationsAndDesktops，独立桌面隔离） |
+| `dpapi.rs` | DPAPI 加密凭据 |
+| `hide_users.rs` | 隐藏沙箱用户 profile dir |
+| `conpty/` | **ConPTY 伪终端**（让交互式命令能跑） |
+| `setup_orchestrator.rs` + `elevated/` | UAC setup helper（一次性创建用户/组） |
+| `proc_thread_attr.rs` | STARTUPINFOEXW + ProcThreadAttributeList |
+| `process.rs` / `spawn_prep.rs` / `unified_exec/` | 进程管理 |
+
+**依赖**（[`Cargo.toml`](../../../codex-cli-main/codex-rs/windows-sandbox-rs/Cargo.toml)）：
+
+```toml
+windows = "0.58"            # Foundation, Firewall, COM
+windows-sys = "0.52"        # JobObjects, Authorization, Threading, Security,
+                            # NetManagement, StationsAndDesktops, Registry, ...
+```
+
+**官方 windows / windows-sys crate 直写，无第三方 sandbox lib**（无 `firehazard` / 无 `rappct` / 无 `windows-app-isolation` 等）。
+
+### A.3 Windows 版本兼容性下限
+
+| API | 最低 Windows |
+|---|---|
+| Job Object / Restricted Token / DPAPI / CreateProcessAsUserW | Windows 2000 |
+| Window Stations / alternate desktop | Windows NT 3.1 |
+| NetUserAdd / NetLocalGroupAdd | Windows NT 3.5 |
+| INetFwPolicy2 | Windows Vista（Win7 起完整稳定） |
+| STARTUPINFOEXW + ProcThreadAttributeList | Windows Vista |
+| **CreatePseudoConsole（ConPTY）** | **Windows 10 1809 / Build 17763 / 2018-10** ⚠️ 硬约束 |
+
+**唯一卡死下限：ConPTY = Win10 1809**。若放弃交互式 PTY 命令，可下探 Win7；但 AI 助手需要 PTY，所以**实际下限 = Win10 1809 / Server 2019**。
+
+### A.4 政企客群覆盖率
+
+| Windows 版本 | EOS | codex sandbox 支持 | 政企份额 |
+|---|---|---|---|
+| Windows 7 | 2020-01 | ❌ | 残留 1-3% |
+| Windows 8 / 8.1 | 2023-01 | ❌ | <1% |
+| Windows 10 1607~1803 | 已 EOS | ❌ | <0.5% |
+| **Windows 10 1809（LTSC 2019）** | 2029（LTSC） | ✅ | 政企广泛 |
+| **Windows 10 21H2（LTSC 2021）** | 2032（LTSC） | ✅ | 政企广泛 |
+| **Windows 11 22H2+** | 2032+ | ✅ | 增长中 |
+| **Windows Server 2019 / 2022** | 2029 / 2031 | ✅ | 政企服务器主力 |
+
+**政企客户端实际覆盖：99%+**。LTSC 2019 / LTSC 2021 / Win11 / Server 2019+ 全在支持范围。
+
+### A.5 codex 用户隔离方案 vs AppContainer 路线对比
+
+| 维度 | 5++（AppContainer + JO + RT，自写 ~1500 LOC） | **codex（用户隔离 + JO + RT + Firewall + Desktop，~5000 LOC）** |
+|---|---|---|
+| 核心隔离机制 | AppContainer SID + capability | **专用 Windows 用户身份** |
+| 隔离哲学 | 现代 capability-based | 古典 NT 多用户模型（30 年历史） |
+| AV / 域 GPO 兼容 | ⚠️ 中（AppContainer 与 AV 冲突 5 类，详见 §6.X 之前研究） | **✅ 高（用户隔离 AV/域都认） |
+| 第三方工具兼容（PowerShell/oracle/SSH/JDK） | ⚠️ AC 内常挂 | **✅ 不同用户身份正常跑全部工具** |
+| 工程量（自写） | ~1500 LOC | ~5000 LOC（fork 后整合 ~500 LOC） |
+| 首次启动 UX | 直接启动 | **首次需 UAC setup**（创建用户/组） |
+| 后续启动 UX | 直接 | 直接（setup 一次性完成） |
+| 隔离强度 | 中（capability） | **高（独立 SID + 独立 ACL + 独立 desktop）** |
+| GUI 程序兼容 | ⚠️ 部分挂 | ✅ ConPTY 转发 |
+| 凭据保护 | N/A | DPAPI 加密 |
+| 网络隔离 | capability + Firewall | 按用户 SID Firewall |
+| 是否踩 AV 兼容性深坑 | ⚠️ 是 | **✅ 否** |
+| 生产验证 | 无（待真机矩阵测试） | **✅ OpenAI Codex CLI 生产使用** |
+| License | N/A（自写） | **Apache 2.0（可 fork / vendor）** |
+
+### A.6 推荐方案 X — Fork codex-windows-sandbox
+
+**核心动作**：把 `codex-cli-main/codex-rs/windows-sandbox-rs/` fork 进 x-claw monorepo，作为 `crates/dasclaw_sandbox_windows`（或并入 `crates/dasclaw_sandbox` 的 windows 子模块）。
+
+| 阶段 | 内容 | LOC |
+|---|---|---|
+| W3 | Fork + 适配 dasclaw_sandbox 接口 + 改名（`CodexSandboxUsers` → `DasclawSandboxUsers`、binary 名等） + 添加 Apache-2.0 NOTICE attribution | ~500（整合工作） |
+| W3-W4 | 真机矩阵（Win10 1809 / 21H2 / Win11 / Server 2019 / 域机器 / 杀软 SCEP/Defender/360/瑞星等）+ bug fix + setup UAC 体验文档 | +500 |
+| 长期 | 跟踪 upstream codex 关键修复，cherry-pick 必要变更 | 低维护成本 |
+
+**对比矩阵**：
+
+| 方案 | LOC（自写） | 兼容性 | 风险 |
+|---|---|---|---|
+| 5++（AppContainer 自写） | 1500 | 中（AV 踩坑） | 中 |
+| **X（fork codex）** | **500（整合）** | **高（生产验证）** | **低** |
+
+**注意事项**：
+1. 首次 UAC setup 弹窗 → 政企部署文档明确写"IT 一次性运行 setup.exe"，不是终端用户日常操作
+2. License attribution → NOTICE / README 标注 "derived from openai/codex (Apache-2.0)"
+3. 品牌改名：`CodexSandboxUsers` → `DasclawSandboxUsers`、`codex_home` → `dasclaw_home`、binary 名前缀替换
+4. 协议适配：codex 的 `SandboxPolicy` 与 ironclaw `SandboxPolicy` 类型不同，需协议层 adapter
+5. 依赖剥离：codex-windows-sandbox 依赖 `codex_protocol` / `codex_utils_pty` 等，需要决定 fork 哪些子 crate / 用 ironclaw 等价替代
+
+### A.7 对 D3 决策的影响（重写要求）
+
+本草稿正文 §1 D3 的 4 选项（A=不做 / B=Docker / C=自写 OS sandbox / D=Docker only on Windows）**均与新事实不符**，应在 ADR 中重写为：
+
+| 新 D3 选项 | 内容 | 推荐度 |
+|---|---|---|
+| D3-1 | Windows 走 Docker（原 D 选项） | 弱（破坏 Case A 政企"本地 Word/Excel 无缝访问") |
+| D3-2 | 自写 AppContainer + JO + RT（原 5++） | 中（1500 LOC 但 AV 踩坑风险） |
+| D3-3 | **Fork codex-windows-sandbox（方案 X）** | **强（500 LOC 整合 + 生产验证 + AV 兼容)** |
+| D3-4 | 推迟到 W4 / W5 + 临时 Permission-only | 弱（政企招标硬约束需要技术沙箱） |
+
+**Agent 推荐：D3 = D3-3（方案 X / fork codex-windows-sandbox）**。
+
+理由：
+1. OpenAI 团队投入 5000 LOC 走用户隔离而非 1500 LOC 走 AppContainer，说明 AppContainer 在政企真实环境（域+AV）确有问题，不是过度担心
+2. Apache 2.0 license 合法 fork，5000 LOC 现成代码省去 3 倍工程量
+3. 用户隔离对 AV / 域 GPO / PowerShell / oracle / SSH / JDK 等政企常见工具兼容性显著优于 AppContainer
+4. 生产验证（OpenAI Codex CLI 在用），比从头写更稳
+5. Win10 1809+ 兼容性匹配政企客群（99%+ 覆盖）
+6. 长期维护可跟 upstream cherry-pick
+
+### A.8 后续 issue / ADR 提案
+
+ADR 作者拍板 D3 = D3-3 后，应：
+
+1. 在 W3 issue 链路下新增 epic issue：**"Fork codex-windows-sandbox into dasclaw monorepo"**（具体 issue draft 见 [`p0a-sandbox-fork-codex-windows-sandbox-issue-draft.md`](./p0a-sandbox-fork-codex-windows-sandbox-issue-draft.md)）
+2. ADR 中写明依赖：W3 #128 的 Windows 实现路径选择 D3-3 时，自动绑定该 fork epic
+3. 评估是否需要同时 fork codex 上游的 `codex-utils-pty` / `codex-protocol`（依赖项）或用 ironclaw 等价替换
+
+---

--- a/docs/plans/architecture-refactor/p0a-sandbox-activation-implementation-plan-draft.md
+++ b/docs/plans/architecture-refactor/p0a-sandbox-activation-implementation-plan-draft.md
@@ -1,0 +1,475 @@
+# P0-A 沙箱激活实现规划 — 研究草稿（#128 hand-off 材料）
+
+> **Status**: 🟡 **Implementation planning draft** — 由 agent 基于 [`p0a-sandbox-activation-decision-research-draft.md`](./p0a-sandbox-activation-decision-research-draft.md) §10 决策矩阵和用户在会话中给出的"全部接受"反馈编写。
+>
+> ## ⚠️ 决策矩阵已变更（2026-XX-XX 会话）— 本草稿正文 §1-§N 部分已 SUPERSEDED
+>
+> 本草稿原基于 [`p0a-sandbox-activation-decision-research-draft.md`](./p0a-sandbox-activation-decision-research-draft.md) §10 旧矩阵（D0=B / D1=C / D2=E+C / D3=D Docker / D4=B / D5=WW / D6=A 含后门 / D7=A）撰写。
+>
+> 用户在新一轮 per-decision MCP gate 评审后给出**新矩阵**（详见研究草稿头部"⭐ 决策最终结果摘要"区块 + §附录 A）：
+>
+> - **D0 = C（ExecutionMode 枚举）** — 不再用 boolean `os_sandbox.enabled`；用 enum `{ Direct, OsSandbox, Docker }`
+> - **D1 = B（enterprise 强制无降级）** — 比原 C 更严
+> - **D2 = E + 友好错误子系统** — 直接全量 + 引导 UX
+> - **D3 = D3-3 Fork codex-windows-sandbox（方案 X）** — Windows 不走 Docker，走用户隔离 fork（详见 [`p0a-sandbox-fork-codex-windows-sandbox-issue-draft.md`](./p0a-sandbox-fork-codex-windows-sandbox-issue-draft.md)）
+> - **D4a = D / D4b = A** — 拆分 init 失败 vs runtime 拒绝两种语义
+> - **D5 = E（WorkspaceWrite + 政策可覆盖）** — 与原一致
+> - **D6 = A 简化版（去 always_on 后门）**
+> - **D7 = A** — 与原一致
+>
+> **实施者注意**：
+> 1. 本草稿 §3-§N（Phase 拆分、API 设计、测试计划）部分基于旧矩阵的 LOC 估算与代码示例需要按新矩阵重写
+> 2. 在 [#127](https://github.com/Linnanli/xClaw/issues/127) 由人类落地为正式 ADR 之后，本草稿应被**整体重写或归档**
+> 3. Windows 路径不再走 Docker，改 fork codex-windows-sandbox，需协调新 epic（见上述 issue draft）
+> 4. Framework 实施按 A→C 渐进：W3（#128）= 档位 A ~200 LOC env+Builder fallback；W4 = 新 ADR 档位 C ~1500 LOC 纯 Builder
+>
+> ---
+>
+> **重要前置约束**：
+> - ❌ 本文件**不是** [#128](https://github.com/Linnanli/xClaw/issues/128) PR
+> - ❌ 本文件**不修改** Rust 代码
+> - ❌ 在 [#127](https://github.com/Linnanli/xClaw/issues/127) ADR Status=Accepted 由人类签字之前，**任何 #128 PR 都不应开启**
+> - ✅ 本文件仅是给 #128 实施者的拆分清单 + 测试计划 + 风险对账
+>
+> **Source**:
+> - 决策草稿（用户已口头批准 8/8 — **已 SUPERSEDED**，新矩阵见决策草稿头部摘要）：[`p0a-sandbox-activation-decision-research-draft.md`](./p0a-sandbox-activation-decision-research-draft.md)
+> - inventory：[`p0a-sandbox-activation-inventory.md`](./p0a-sandbox-activation-inventory.md)
+> - **新增 Windows 实施 issue draft**：[`p0a-sandbox-fork-codex-windows-sandbox-issue-draft.md`](./p0a-sandbox-fork-codex-windows-sandbox-issue-draft.md)
+> - 父：[#28](https://github.com/Linnanli/xClaw/issues/28)，决策红线：[#127](https://github.com/Linnanli/xClaw/issues/127)，实现：[#128](https://github.com/Linnanli/xClaw/issues/128)
+
+---
+
+## 0. 红线合规说明（**实施者必读**）
+
+[#127](https://github.com/Linnanli/xClaw/issues/127) 带有 `adr-redline` label，按 [`AGENTS.md`](../../../AGENTS.md) §"不要碰的红线"：**agent 不得自动 promote 草稿到 Accepted ADR、不得关闭 #127、不得替人类签字**。
+
+**正确顺序**：
+
+1. 人类基于 [`p0a-sandbox-activation-decision-research-draft.md`](./p0a-sandbox-activation-decision-research-draft.md) 在 `docs/plans/architecture-refactor/adr-XXX-p0a-sandbox-activation-decision.md` 创建 ADR 文件，Status 改 Accepted，签 Authors
+2. 人类关闭 [#127](https://github.com/Linnanli/xClaw/issues/127)（或留 PR 引用）
+3. **此后**，[#128](https://github.com/Linnanli/xClaw/issues/128) 实施 PR 才能开启
+4. #128 PR 按 [`AGENTS.md`](../../../AGENTS.md) §"GitHub PR 工作流" 拆 stacked，按本文件 §6 拆分粒度切片
+
+**若 ADR 实质偏离决策草稿 §10 矩阵，本文件 §3–§7 全部作废，需重写。**
+
+---
+
+## 1. 实施清单概览（按依赖链排序）
+
+| Step | 文件 | 改动类型 | 估计 LOC | 依赖 | TDD 顺序 |
+|---|---|---|---|---|---|
+| **S1** | [`config/os_sandbox.rs`](../../../desktop-client/ironclaw/src/config/) (NEW) | 新增 struct + resolve | ~120 | 无 | 单元测试先行 |
+| **S2** | [`config/mod.rs`](../../../desktop-client/ironclaw/src/config/mod.rs) | 暴露 `os_sandbox: OsSandboxConfig` | ~10 | S1 | 集成测试 |
+| **S3** | [`settings.rs`](../../../desktop-client/ironclaw/src/settings.rs)（or wherever Settings live） | 新增 `os_sandbox` 字段 | ~15 | S1 | toml 解析测试 |
+| **S4** | [`tools/bootstrap.rs`](../../../desktop-client/ironclaw/src/tools/bootstrap.rs) `BootstrapContext` | 新增 3 个 `Option<...>` 字段 | ~10 | 无 | 编译测试 |
+| **S5** | [`tools/registry.rs`](../../../desktop-client/ironclaw/src/tools/registry.rs) `register_dev_tools` | 按 D4-B 拆分 ShellTool 注册路径 | ~50 | S4 | 失败路径单元测试 |
+| **S6** | [`app.rs`](../../../desktop-client/ironclaw/src/app.rs) boot 序列 | 在 `init_secrets` 后构造 `OsExecutor` + `start_network_proxy` | ~80 | S2/S3/S4 | 启动时序测试 |
+| **S7** | [`enterprise_mode.rs`](../../../desktop-client/ironclaw/src/) (existing or new) | 暴露 `is_enterprise_mode()` 给 `OsSandboxConfig::resolve` | ~5 | 无（可能已存在） | 单元测试 |
+| **S8** | E2E 测试 | sandbox-on / sandbox-off / proxy-allowlist 三类 | ~200 | S1–S7 | E2E 先红 |
+| **S9** | 文档 [`desktop-client/docs/os-sandbox-activation.md`](../../../desktop-client/docs/) (NEW) | release notes + 用户 opt-in 引导 | ~150 | S1–S6 | n/a |
+
+**总估计**：~640 LOC（不含测试，含测试约 1200 LOC），**建议拆 3–4 个 stacked PR**：
+
+- PR-1：S1 + S2 + S3 + S4（纯配置 + struct，无行为变更）
+- PR-2：S5（registry 路径拆分，行为变更）
+- PR-3：S6 + S7（boot 序列接入）
+- PR-4：S8 + S9（E2E 测试 + 文档）
+
+---
+
+## 2. 决策矩阵到代码的映射（每条决策 → 必需断言）
+
+| 决策 | ADR 决策值（待签字） | 代码 / 测试断言 |
+|---|---|---|
+| **D0** B 独立命名空间 | `Settings.os_sandbox: OsSandboxConfig` | S1 单元：`OsSandboxConfig` 与 `SandboxModeConfig` 是不同类型 |
+| **D1** C enterprise 强制 `true` | `OsSandboxConfig::resolve(settings, is_enterprise)` 在 enterprise=true 时强制 `enabled=true` | S1 失败路径：enterprise 模式 + env `OS_SANDBOX_ENABLED=false` → `enabled=true`（env 被忽略），日志 WARN |
+| **D2** E+C rollout | enterprise 强制 + personal default `false` | S1 默认值断言；docs/release-notes（S9） |
+| **D3** D Windows 走 Docker | `OsSandboxConfig::resolve` 在 `cfg!(target_os = "windows")` && enterprise 时返回 `Err(ConfigError::WindowsRequiresDockerMode)` | S1 失败路径单元：Windows + enterprise + `os_sandbox.enabled=true` → ConfigError |
+| **D4** B 沙箱失败 ShellTool 不注册 | S5 `register_dev_tools` 在 `ctx.os_sandbox_executor.is_none() && is_enterprise` 时跳过 `ShellTool::new()` 注册 + `tracing::error!` | S5 失败路径：mock context, enterprise=true, executor=None → registry 中无 `ShellTool` |
+| **D5** `WorkspaceWrite` 默认 | `OsSandboxConfig::default().policy = SandboxPolicy::WorkspaceWrite` | S1 默认值单元 |
+| **D6** A 共开关 + `always_on` 后门 | `OsSandboxConfig.network_proxy.always_on: bool` 默认 `false`；S6 boot 时 if `enabled || network_proxy.always_on` → `start_network_proxy` | S6 集成：`enabled=false, always_on=true` → 仅 proxy 启动，无 sandbox |
+| **D7** A 不迁移 | 无代码改动；旧 `SANDBOX_ENABLED` 仍只控 Docker | S3 集成：旧 `SANDBOX_ENABLED=true` env → `Settings.sandbox.enabled=true && Settings.os_sandbox.enabled=false` |
+
+---
+
+## 3. `OsSandboxConfig` struct（S1）— 字段草案
+
+> 草案，最终以 ADR 为准。
+
+```rust
+// desktop-client/ironclaw/src/config/os_sandbox.rs
+use crate::config::helpers::{parse_bool_env, parse_optional_env, parse_string_env};
+use crate::error::ConfigError;
+use crate::sandbox::SandboxPolicy;
+use std::time::Duration;
+
+#[derive(Debug, Clone)]
+pub struct OsSandboxConfig {
+    /// 是否启用 OS 沙箱（macOS Seatbelt / Linux Landlock+seccomp）。
+    /// enterprise mode 下被强制 `true`，env 无法覆盖。
+    pub enabled: bool,
+    /// Sandbox 策略。enterprise mode 下 FullAccess 被强制降级到 WorkspaceWrite。
+    pub policy: SandboxPolicy,
+    /// 命令执行超时。
+    pub timeout: Duration,
+    /// 网络允许列表。
+    pub network_allowlist: Vec<String>,
+    /// HTTP forward proxy 监听端口（0 = 自动）。
+    pub proxy_port: u16,
+    /// proxy 子配置（含 `always_on` D6 后门）。
+    pub network_proxy: NetworkProxySubConfig,
+}
+
+#[derive(Debug, Clone)]
+pub struct NetworkProxySubConfig {
+    /// 即使 `OsSandboxConfig.enabled=false` 也启用 proxy（D6 后门）。
+    /// 默认 `false`，第一版不暴露给 UI。
+    pub always_on: bool,
+}
+
+impl Default for OsSandboxConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,                              // D1 personal default
+            policy: SandboxPolicy::WorkspaceWrite,       // D5
+            timeout: Duration::from_secs(120),
+            network_allowlist: crate::sandbox::default_allowlist(),
+            proxy_port: 0,
+            network_proxy: NetworkProxySubConfig { always_on: false }, // D6
+        }
+    }
+}
+
+impl OsSandboxConfig {
+    pub(crate) fn resolve(
+        settings: &crate::settings::Settings,
+        is_enterprise_mode: bool,
+    ) -> Result<Self, ConfigError> {
+        let env_enabled = parse_bool_env("OS_SANDBOX_ENABLED", false)?;
+
+        // D3: Windows enterprise 必须走 Docker mode
+        if is_enterprise_mode && cfg!(target_os = "windows") && (env_enabled || settings.os_sandbox.enabled) {
+            return Err(ConfigError::InvalidValue {
+                key: "OS_SANDBOX_ENABLED".to_string(),
+                message: "Windows enterprise mode must use Docker sandbox; \
+                          set SANDBOX_ENABLED=true (Docker mode) instead of \
+                          OS_SANDBOX_ENABLED. See ADR-XXX §D3.".to_string(),
+            });
+        }
+
+        // D1: enterprise 强制启用
+        let enabled = if is_enterprise_mode {
+            if !env_enabled {
+                tracing::warn!(
+                    "Enterprise mode forces OS_SANDBOX_ENABLED=true (was false); \
+                     env override ignored per ADR-XXX D1."
+                );
+            }
+            true
+        } else {
+            env_enabled
+        };
+
+        let policy_str = parse_string_env("OS_SANDBOX_POLICY", "workspace_write".to_string())?;
+        let mut policy = parse_sandbox_policy(&policy_str)?;
+
+        // D5 配套：enterprise mode 下 FullAccess 强制降级
+        if is_enterprise_mode && policy == SandboxPolicy::FullAccess {
+            tracing::error!(
+                "Enterprise mode rejects SandboxPolicy::FullAccess; downgrading to WorkspaceWrite."
+            );
+            policy = SandboxPolicy::WorkspaceWrite;
+        }
+
+        Ok(Self {
+            enabled,
+            policy,
+            timeout: Duration::from_secs(parse_optional_env("OS_SANDBOX_TIMEOUT_SECS", 120)?),
+            network_allowlist: settings.os_sandbox.network_allowlist.clone(),
+            proxy_port: parse_optional_env("OS_SANDBOX_PROXY_PORT", 0)?,
+            network_proxy: NetworkProxySubConfig {
+                always_on: parse_bool_env("OS_SANDBOX_PROXY_ALWAYS_ON", false)?,
+            },
+        })
+    }
+}
+```
+
+> **注**：`is_enterprise_mode: bool` 入参由调用方（[`config/mod.rs`](../../../desktop-client/ironclaw/src/config/mod.rs) 中 `Config::resolve`）传入，参考现有 `SandboxModeConfig::resolve` pattern。
+
+---
+
+## 4. `BootstrapContext` 改动（S4）
+
+```rust
+// desktop-client/ironclaw/src/tools/bootstrap.rs
+#[derive(Default)]
+pub struct BootstrapContext {
+    pub mode: BootstrapMode,
+    // ... 既有字段 ...
+
+    // 新增（S4）：
+    /// OS sandbox executor，None 表示沙箱未启用或启动失败。
+    pub os_sandbox_executor: Option<Arc<OsExecutor>>,
+    /// Network proxy handle，必须比 executor 长寿命。
+    pub network_proxy_handle: Option<Arc<NetworkProxyHandle>>,
+    /// 注入到 sandboxed shell 子进程的环境变量（HTTP_PROXY / HTTPS_PROXY / NO_PROXY）。
+    pub proxy_env: Option<HashMap<String, String>>,
+    /// 是否处于 enterprise mode（用于 D4 fail-closed 判断）。
+    pub is_enterprise_mode: bool,
+}
+```
+
+---
+
+## 5. `register_dev_tools` 拆分（S5，**风险最高**）
+
+```rust
+// desktop-client/ironclaw/src/tools/registry.rs
+fn register_dev_tools(&self, ctx: &BootstrapContext) {
+    // D4-B: 沙箱不可用 + enterprise mode → ShellTool 不注册
+    let shell_tool = match (ctx.is_enterprise_mode, &ctx.os_sandbox_executor) {
+        (true, None) => {
+            tracing::error!(
+                target: "x_claw_agent::shell_tool",
+                "Enterprise mode + OS sandbox unavailable: ShellTool will NOT be registered. \
+                 Users will see this tool as missing per ADR-XXX D4-B."
+            );
+            None
+        }
+        (_, Some(executor)) => {
+            let mut tool = ShellTool::new()
+                .with_sandbox(executor.clone())
+                .with_sandbox_policy(/* from config */);
+            if let Some(env) = &ctx.proxy_env {
+                tool = tool.with_extra_env(env.clone());
+            }
+            Some(tool)
+        }
+        (false, None) => {
+            // Personal mode + 沙箱关闭 → fall-back direct（保留现有行为）
+            Some(ShellTool::new())
+        }
+    };
+
+    if let Some(tool) = shell_tool {
+        self.register_sync(Arc::new(tool));
+    }
+
+    self.register_sync(Arc::new(ReadFileTool::new()));
+    // ... 其他 dev tools 保持不变 ...
+}
+```
+
+**风险点**：
+- `ShellTool` 缺失会让现有 personal-mode E2E 测试断（如果它们假设 ShellTool 总在）→ **必须先全量跑 `cargo nextest run -p ironclaw`** 找出依赖项
+- `register_dev_tools` 签名从 `&self` 变 `&self, ctx: &BootstrapContext`，调用方 [`bootstrap_tools`](../../../desktop-client/ironclaw/src/tools/bootstrap.rs) 必须同步修改
+
+---
+
+## 6. `app.rs` boot 序列（S6）
+
+```rust
+// desktop-client/ironclaw/src/app.rs (after init_secrets, before bootstrap_tools)
+async fn init_os_sandbox(&mut self) -> Result<(), AppError> {
+    let cfg = &self.config.os_sandbox;
+    if !cfg.enabled && !cfg.network_proxy.always_on {
+        return Ok(()); // 沙箱 + proxy 都关，零开销
+    }
+
+    // 启动 proxy（沙箱开启时必须；always_on 时单独启动）
+    let mappings = crate::sandbox::default_credential_mappings();
+    let secrets_store = self.secrets_store.clone()
+        .ok_or(AppError::SecretsStoreUnavailable)?;
+    let proxy_handle = match start_network_proxy(
+        &cfg.to_sandbox_config(),
+        mappings,
+        secrets_store,
+        self.config.owner_id.clone(),
+    ).await {
+        Ok(handle) => Arc::new(handle),
+        Err(e) => {
+            // D4-B 兜底：enterprise mode 下 proxy 启动失败 → 不构造 executor，
+            //          register_dev_tools 走"ShellTool 不注册"分支
+            if self.is_enterprise_mode() {
+                tracing::error!("Enterprise mode: network proxy start failed: {e}; \
+                                 ShellTool will be unavailable per ADR-XXX D4-B.");
+                return Ok(()); // 不返回 Err，让 app 继续启动但 ShellTool 缺失
+            }
+            return Err(AppError::NetworkProxy(e));
+        }
+    };
+    self.network_proxy_handle = Some(proxy_handle.clone());
+
+    // 沙箱开启时构造 executor（仅当 enabled，always_on 单独不构造 executor）
+    if cfg.enabled {
+        let executor = match OsExecutor::new(cfg.timeout, /* allow_full_access */ false) {
+            Ok(e) => Arc::new(e),
+            Err(e) => {
+                if self.is_enterprise_mode() {
+                    tracing::error!("Enterprise mode: OsExecutor::new failed: {e}");
+                    return Ok(());
+                }
+                return Err(AppError::Sandbox(e));
+            }
+        };
+        self.os_sandbox_executor = Some(executor);
+    }
+
+    Ok(())
+}
+```
+
+**`BootstrapContext` 装配**：
+
+```rust
+let ctx = BootstrapContext {
+    // ... 既有字段 ...
+    os_sandbox_executor: self.os_sandbox_executor.clone(),
+    network_proxy_handle: self.network_proxy_handle.clone(),
+    proxy_env: self.network_proxy_handle.as_ref()
+        .map(|h| crate::sandbox::net_proxy::proxy_env_vars(h.addr())),
+    is_enterprise_mode: self.is_enterprise_mode(),
+};
+tools.bootstrap_tools(&ctx).await?;
+```
+
+---
+
+## 7. 测试矩阵（S8 + S5/S6 内嵌）
+
+按 [`AGENTS.md`](../../../AGENTS.md) §"测试维度矩阵" 全维度覆盖：
+
+### 7.1 单元测试（S1）
+
+| 测试 | 断言 |
+|---|---|
+| `os_sandbox_default_disabled_personal` | `OsSandboxConfig::default().enabled == false` (D1) |
+| `os_sandbox_default_policy_workspace_write` | `OsSandboxConfig::default().policy == WorkspaceWrite` (D5) |
+| `os_sandbox_default_proxy_always_off` | `OsSandboxConfig::default().network_proxy.always_on == false` (D6) |
+| `req_p0a_d1_enterprise_forces_enabled` | `resolve(settings_with_enabled_false, is_enterprise=true)` → `enabled=true` (D1-C) |
+| `req_p0a_d1_enterprise_ignores_env_off` | env `OS_SANDBOX_ENABLED=false` + enterprise=true → `enabled=true` 且日志 WARN |
+| `req_p0a_d3_windows_enterprise_rejects` | Windows + enterprise=true + `enabled=true` → `Err(ConfigError::InvalidValue)` |
+| `req_p0a_d5_enterprise_downgrades_full_access` | enterprise=true + `policy=FullAccess` → `policy=WorkspaceWrite` 且日志 ERROR |
+| `os_sandbox_disabled_proxy_off` | `enabled=false, always_on=false` → 解析成功且字段 false |
+
+### 7.2 失败路径测试（S5）
+
+| 测试 | 断言 |
+|---|---|
+| `req_p0a_d4b_enterprise_no_executor_skips_shell` | mock `BootstrapContext { is_enterprise_mode: true, os_sandbox_executor: None }` → `ToolRegistry::has("shell") == false` 且日志 ERROR |
+| `req_p0a_d4b_personal_no_executor_falls_back` | mock `is_enterprise_mode: false, executor: None` → `ToolRegistry::has("shell") == true` 且 `ShellTool` 走 direct |
+| `req_p0a_d4b_executor_present_uses_sandbox` | executor: Some → `ShellTool` 注册时 `with_sandbox` 被调用 |
+
+### 7.3 集成测试（S6）
+
+| 测试 | 断言 |
+|---|---|
+| `req_p0a_boot_sandbox_enabled_starts_proxy` | `os_sandbox.enabled=true` → boot 后 `network_proxy_handle.is_some()` |
+| `req_p0a_boot_proxy_always_on_no_sandbox` | `enabled=false, always_on=true` (D6) → proxy started, executor=None |
+| `req_p0a_boot_proxy_failure_enterprise_continues` | mock proxy failure + enterprise=true → app 启动成功但 ShellTool 不可用 |
+| `req_p0a_boot_proxy_failure_personal_fails` | mock proxy failure + enterprise=false → app 启动失败 `AppError::NetworkProxy` |
+
+### 7.4 E2E 测试（S8）
+
+| 测试 | 断言 |
+|---|---|
+| `e2e_sandboxed_shell_blocks_disallowed_domain` | `os_sandbox.enabled=true` + `curl https://evil.com` → 失败 + `NetworkDenyReason` |
+| `e2e_sandboxed_shell_allows_allowlisted_domain` | `enabled=true` + `curl https://github.com`（白名单）→ 成功 |
+| `e2e_sandboxed_shell_blocks_outside_workspace_write` | `policy=WorkspaceWrite` + `echo > /tmp/foo` → 拒绝（seatbelt/landlock 报错） |
+| `e2e_sandboxed_shell_allows_workspace_write` | `policy=WorkspaceWrite` + `echo > $WORKSPACE/foo` → 成功 |
+| `e2e_sandbox_disabled_falls_back_personal` | personal + `enabled=false` → ShellTool 注册且走 direct（向后兼容） |
+
+### 7.5 安全审计测试
+
+| 测试 | 断言 |
+|---|---|
+| `audit_proxy_env_no_bearer_in_logs` | proxy_env 含 `Bearer xyz` → 日志中不出现 `xyz`（grep tracing output） |
+| `audit_secrets_store_not_in_error_messages` | `SecretsStoreUnavailable` 错误信息不含 secrets 内容 |
+
+### 7.6 启动时序测试（参考 [`engine_startup_tests.rs`](../../../desktop-client/src/engine_startup_tests.rs)）
+
+| 测试 | 断言 |
+|---|---|
+| `startup_init_secrets_before_init_os_sandbox` | `init_secrets` 必须在 `init_os_sandbox` 之前完成（否则 `secrets_store=None` panic） |
+| `startup_proxy_handle_outlives_executor` | `NetworkProxyHandle` 必须比 `OsExecutor` 长寿命（drop 顺序断言） |
+
+### 7.7 契约测试
+
+| 测试 | 断言 |
+|---|---|
+| `contract_d6_proxy_env_present_when_proxy_started` | `proxy_handle.is_some()` ↔ `proxy_env.is_some()` 等价（D6 不变量） |
+| `contract_d4b_shell_visible_iff_executor_or_personal` | `ToolRegistry::has("shell")` ↔ (`executor.is_some()` ∨ `!is_enterprise_mode`)（D4-B 不变量） |
+
+---
+
+## 8. 与其他 in-flight issue 的协作
+
+| Issue | 影响 | 协作动作 |
+|---|---|---|
+| [#84](https://github.com/Linnanli/xClaw/issues/84) P0-B tool visibility triple gate | D4-B "ShellTool 不注册" 是 #84 triple-gate 的一种实现 | #84 实施时引用 D4-B 测试，避免重复造轮子 |
+| [#85](https://github.com/Linnanli/xClaw/issues/85) P0-D enterprise tool audit | D1-C enterprise 强制启用 → audit log 必须记 sandbox state | #85 schema 新增 `sandbox_state: enabled/disabled/forced` 字段 |
+| [#91](https://github.com/Linnanli/xClaw/issues/91) P1 Windows sandbox | D3-D 把 #91 P1 必须项降级为可延后 | #91 issue body 应更新："enterprise Windows 走 Docker，本 issue 仅服务 personal mode" |
+| [#92](https://github.com/Linnanli/xClaw/issues/92) P0-F attachment DLP | D6 `always_on` 后门给 #92 留接口 | #92 实施时通过 `OsSandboxConfig.network_proxy.always_on=true` 启用 proxy |
+| [#94](https://github.com/Linnanli/xClaw/issues/94) P0-H tool execution surface parity | D4-B 把 4 个 tool surface 的 fail-closed 语义统一 | #94 引用 D4-B 测试 |
+| [#95](https://github.com/Linnanli/xClaw/issues/95) P0-I enterprise tenant fail-closed | D1-C / D2-E enterprise 强制启用是 #95 的具体实例 | #95 admin policy schema 增加 `enforce_os_sandbox: bool` |
+
+---
+
+## 9. 风险登记 & 缓解
+
+| 风险 | 影响 | 缓解 |
+|---|---|---|
+| **R1**：`register_dev_tools` 签名变更破坏 0 调用方 | 编译失败级 | 全量 `cargo check -p ironclaw --tests` 跑通 |
+| **R2**：`OsExecutor::new` 在 macOS 不同 SDK 版本上行为差异 | E2E 不稳 | E2E 测试加 `#[cfg_attr(target_os = "macos", ignore = "需 SDK ≥ X")]` 标注 |
+| **R3**：proxy 端口冲突（多 desktop 实例同时跑） | 启动失败 | `proxy_port: 0` 自动分配，已是默认 |
+| **R4**：enterprise 模式 + Windows 用户安装 desktop-client → S1 报错 | 用户体验 | S9 文档明文提示 + installer 检测 + 友好错误信息 |
+| **R5**：`secrets_store=None` 时启用沙箱 | 启动 panic | S6 已用 `?` propagate 到 `AppError::SecretsStoreUnavailable` |
+| **R6**：`NetworkProxyHandle` drop 顺序错误导致 executor 用 dead proxy | 运行时 hang | 启动时序测试 `startup_proxy_handle_outlives_executor` |
+| **R7**：现有 personal-mode E2E 假设 ShellTool 总在 → S5 后断 | 回归 | PR-2 前先跑 `cargo nextest run -p ironclaw -E 'test(shell)'` 列出所有依赖项 |
+| **R8**：用户已设 `SANDBOX_ENABLED=false` 期待"无沙箱"，升级后发现 enterprise mode 仍强制启用 | 信任风险 | S9 release notes 必须用粗体强调"enterprise mode 强制覆盖" |
+
+---
+
+## 10. 验收清单（#128 PR 自查）
+
+PR 开启前确保：
+
+- [ ] [#127](https://github.com/Linnanli/xClaw/issues/127) ADR Status=Accepted（人类签字），并在 PR body 引用 ADR 路径
+- [ ] 本文件 §2 的 8 条决策→代码映射全部有对应代码 + 测试
+- [ ] 本文件 §7 的所有测试族（单元 / 失败 / 集成 / E2E / 安全审计 / 启动时序 / 契约）至少有 1 条存在
+- [ ] `cargo nextest run -p ironclaw` 全绿（包括既有测试，特别是 personal-mode shell 路径）
+- [ ] `cargo check -p ironclaw --tests` 0 错 0 警
+- [ ] `python3.12 scripts/check_no_panics.py --base origin/xClaw` 通过
+- [ ] `cargo fmt --all` 通过
+- [ ] `cargo clippy --no-deps -p ironclaw --all-targets -- -D warnings` 通过
+- [ ] [`AGENTS.md`](../../../AGENTS.md) §"Skills 强制使用规范" 三件套自查（`code-quality-audit` → `code-simplifier` → `code-review-expert`）
+- [ ] PR 拆 stacked（按 §1 PR-1/2/3/4），每个 PR 独立 base 注明
+- [ ] PR body 含 `Cross-cuts:` 三元声明（ADR-114 红线，本系列 PR 应为 `类A` — 不引入 `.ironclaw` 字面量）
+- [ ] PR body 含 `Closes #128` 或分阶段 `Refs #128`（最后一个 PR 才 `Closes`）
+
+---
+
+## 11. 三层验证日志
+
+按 [`AGENTS.md`](../../../AGENTS.md) §"任务启动 4 问"：
+
+1. **新增文件**？✅ 是 → `semantic_search` 验证 `p0a-sandbox-activation-implementation*.md` 不存在
+2. **否定性结论**？❌ 否 — 本文件全部基于 inventory + 决策草稿的既有结论
+3. **跨项目对账**？❌ 否 — 仅在 desktop-client 内部
+4. **架构对账文档**？⚠️ 弱是 — 是实施草稿，三层验证适用于决策草稿（§7 已完成），本文件继承其证据链
+
+---
+
+## 12. 后续会话 hand-off 提示
+
+若本文件被新会话作为输入：
+
+1. **先读** [`p0a-sandbox-activation-decision-research-draft.md`](./p0a-sandbox-activation-decision-research-draft.md)
+2. **再读** [`p0a-sandbox-activation-inventory.md`](./p0a-sandbox-activation-inventory.md)
+3. **检查** [#127](https://github.com/Linnanli/xClaw/issues/127) 是否已 Accepted（issue 是否 Closed + ADR 文件是否存在）
+4. 若已 Accepted **且** ADR 决策与决策草稿 §10 一致 → 可按本文件 §1 逐 PR 实施
+5. 若 Accepted **但** ADR 决策与草稿不一致 → **本文件 §3–§7 全部作废**，需重写 implementation plan
+6. 若 #127 仍 OPEN → **不得开 #128 PR**，等待人类签字
+
+---

--- a/docs/plans/architecture-refactor/p0a-sandbox-activation-implementation-plan-draft.md
+++ b/docs/plans/architecture-refactor/p0a-sandbox-activation-implementation-plan-draft.md
@@ -445,7 +445,7 @@ PR 开启前确保：
 - [ ] `cargo clippy --no-deps -p ironclaw --all-targets -- -D warnings` 通过
 - [ ] [`AGENTS.md`](../../../AGENTS.md) §"Skills 强制使用规范" 三件套自查（`code-quality-audit` → `code-simplifier` → `code-review-expert`）
 - [ ] PR 拆 stacked（按 §1 PR-1/2/3/4），每个 PR 独立 base 注明
-- [ ] PR body 含 `Cross-cuts:` 三元声明（ADR-114 红线，本系列 PR 应为 `类A` — 不引入 `.ironclaw` 字面量）
+- [ ] PR body 含 `Cross-cuts:` 三元声明（ADR-114 红线，本系列 PR 应为 `类A` — 不引入新的 ironclaw-prefix 字面量）
 - [ ] PR body 含 `Closes #128` 或分阶段 `Refs #128`（最后一个 PR 才 `Closes`）
 
 ---

--- a/docs/plans/architecture-refactor/p0a-sandbox-fork-codex-windows-sandbox-issue-draft.md
+++ b/docs/plans/architecture-refactor/p0a-sandbox-fork-codex-windows-sandbox-issue-draft.md
@@ -1,0 +1,133 @@
+# [Epic] Fork codex-windows-sandbox into dasclaw monorepo (Windows OS sandbox 实施路径)
+
+> **Status**: 🟡 Issue draft（待人类创建为 GitHub issue 后归档为 `docs/plans/architecture-refactor/issue-XXX-fork-codex-windows-sandbox.md`）
+>
+> **Type**: epic（多 PR 拆分）
+>
+> **Blocks**: [#128](https://github.com/Linnanli/xClaw/issues/128) 的 Windows 路径
+>
+> **Depends on**: [#127](https://github.com/Linnanli/xClaw/issues/127) ADR Accepted 且 D3 = D3-3（方案 X / fork codex-windows-sandbox）
+>
+> **Cross-cuts**: [#91](https://github.com/Linnanli/xClaw/issues/91)（Windows 计划）
+>
+> **Source**: [`p0a-sandbox-activation-decision-research-draft.md` 附录 A](./p0a-sandbox-activation-decision-research-draft.md#附录-a--codex-windows-sandbox-实地考察事实修正)
+
+---
+
+## 背景
+
+P0-A 沙箱激活决策（[#127](https://github.com/Linnanli/xClaw/issues/127)）的 D3（Windows 平台行为）经实地考察后修正为 **D3-3：fork upstream `codex-windows-sandbox` 进 monorepo**，原因详见研究草稿附录 A。
+
+upstream 实现位置：[`codex-cli-main/codex-rs/windows-sandbox-rs/`](../../../codex-cli-main/codex-rs/windows-sandbox-rs/)
+
+- License：Apache 2.0（可 fork / vendor）
+- 规模：~30 个 `.rs` 模块，估计 5000+ LOC
+- 策略：专用本地 Windows 用户隔离 + Job Object + Restricted Token + 按用户 SID Firewall + Win32 alternate desktop + DPAPI + ConPTY + UAC setup helper
+- 兼容：Windows 10 1809+ / Server 2019+（受 ConPTY 卡死下限）
+- 生产验证：OpenAI Codex CLI 在用
+
+---
+
+## 目标
+
+把 codex-windows-sandbox 整合进 dasclaw monorepo，作为 dasclaw 的 Windows OS sandbox 实施路径，为 [#128](https://github.com/Linnanli/xClaw/issues/128) Windows 平台激活提供执行后端。
+
+## 非目标
+
+- ❌ 本 epic 不修改 macOS Seatbelt / Linux Landlock 路径（沿用现有 `crates/dasclaw_sandbox` 实现）
+- ❌ 本 epic 不引入 AppContainer 路线（D3 已选 D3-3 用户隔离路线）
+- ❌ 本 epic 不调整 Docker sandbox（[`SandboxModeConfig`](../../../desktop-client/ironclaw/src/config/sandbox.rs) 保持现状）
+- ❌ 本 epic 不修改 [#127](https://github.com/Linnanli/xClaw/issues/127) 的 ADR 文本（ADR 由人类签字）
+
+---
+
+## 拆分计划（建议 stacked PR）
+
+### Phase 1 — Vendor & Build（PR-1）
+
+- 把 `codex-cli-main/codex-rs/windows-sandbox-rs/` 的源码（含 build.rs / Cargo.toml / manifest）vendor 进 `crates/dasclaw_sandbox_windows/`
+- 添加 `LICENSE-APACHE-2.0` + `NOTICE`，标注 "derived from openai/codex (codex-cli-main, Apache-2.0)"
+- workspace `Cargo.toml` 注册新 crate（仅 `cfg(target_os = "windows")` 编译）
+- 解决依赖：上游依赖 `codex_protocol` / `codex_utils_pty` / `codex_app_server_protocol` 等
+  - 决策：① 同步 fork 必要的上游 utility crate（最小集），或 ② 用 ironclaw 等价替代（如 `dasclaw_pty` 替代 `codex_utils_pty`）
+  - 推荐 Phase 1 先选 ①（最小集 fork）保 build 通，Phase 4 再考虑替换以减小重复
+- **不**改名、**不**改协议，目标是 `cargo check -p dasclaw_sandbox_windows --target x86_64-pc-windows-msvc` 通过
+- 验证命令：CI Windows runner 跑 `cargo check`
+
+### Phase 2 — Brand & Naming（PR-2，base = PR-1）
+
+- 字符串改名：
+  - `CodexSandboxUsers` → `DasclawSandboxUsers`
+  - `codex-windows-sandbox-setup` → `dasclaw-windows-sandbox-setup`
+  - `codex-command-runner` → `dasclaw-command-runner`
+  - `codex_home` 路径变量 → `dasclaw_home`（与现有 `desktop-client/ironclaw` 命名空间对齐）
+- manifest 标记 / log 文件名 / DPAPI key namespace 等都要改
+- 建立"上游字符串映射表"作为后续 cherry-pick 时的 sed 脚本
+- 验证：Phase 1 的 `cargo check` 仍通过 + 本地 Win10 VM smoke test（创建用户、删除用户、跑一条 echo 命令）
+
+### Phase 3 — Adapter to dasclaw_sandbox API（PR-3，base = PR-2）
+
+- 在 `crates/dasclaw_sandbox/src/windows/` 加一层 adapter，把 dasclaw 的 `SandboxPolicy` / `SandboxType::WindowsRestrictedToken` enum 映射到 fork 的 `windows_sandbox::SandboxPolicy`
+- 把 fork 的 `SandboxType::WindowsRestrictedToken` 实现从 `NotImplemented stage:4` 改为真实调用 fork 的 `run_windows_sandbox_capture` API
+- 把 [`OsExecutor::new`](../../../desktop-client/ironclaw/src/sandbox/) 的 Windows 路径接到 fork
+- 验证：[`crates/dasclaw_sandbox`](../../../crates/dasclaw_sandbox) 的现有测试在 Windows runner 上通过
+
+### Phase 4 — UAC Setup UX & 政企部署文档（PR-4，base = PR-3）
+
+- desktop-client 启动时检测 `sandbox_setup_is_complete()`：
+  - 已 setup → 直接进入正常流程
+  - 未 setup → 弹窗引导（非政企常规终端用户场景下走"友好错误"，引导联系 IT 跑 setup.exe）
+- 政企部署文档：`desktop-client/docs/windows-sandbox-setup-guide.md`，包含：
+  - IT 一次性 setup 步骤（双击 setup.exe / 命令行 silent install）
+  - 域控部署脚本（GPO / SCCM / Intune 推送 setup.exe）
+  - 卸载流程（清理 `DasclawSandboxUsers` 组、清理 user profile、清理 firewall 规则）
+  - 真机矩阵测试报告
+- 验证：Win10 1809 / Win10 21H2 / Win11 / Server 2019 真机矩阵 + Defender / 360 / 瑞星 三家 AV smoke test
+
+### Phase 5 — 真机矩阵 CI（PR-5，base = PR-4）
+
+- 评估 GitHub Actions Windows runner 是否支持 elevation（创建用户）
+- 如不支持，配置自托管 runner（政企内部 Win10 LTSC 2019 VM）跑 sandbox e2e
+- CI 测试覆盖：setup → run sandboxed echo → run sandboxed PowerShell → 卸载
+
+---
+
+## 风险与缓解
+
+| 风险 | 缓解 |
+|---|---|
+| 上游 dependency 链很深（codex_protocol 等） | Phase 1 选最小集 fork，Phase 4 评估替换为 dasclaw 等价 crate |
+| 上游 cherry-pick 与本地改名冲突 | Phase 2 建字符串映射表 + sed 脚本自动化 |
+| AV 误报（创建本地用户被 AV 拦截） | Phase 4 真机矩阵测试三家 AV，必要时申请代码签名证书 |
+| 政企 IT 不愿意做一次性 setup | Phase 4 文档化静默 install + GPO 推送方案 |
+| ConPTY 在 Win Server Core 不可用 | 政企客户端目标客户为 Win 客户端 LTSC 2019/2021 + Server 2019/2022 with Desktop Experience，Server Core 不在范围内 |
+| Apache-2.0 license attribution 漏标 | Phase 1 + 每个 Phase 都加 license header 检查到 CI（参考现有 `scripts/check_no_panics.py` 模式） |
+| upstream codex 后续重大重构（如改成 AppContainer） | 长期由维护者评估是否跟进；fork 版本可独立演进 |
+
+---
+
+## 验收 / DoD
+
+- [ ] `crates/dasclaw_sandbox_windows` crate 编译通过（Windows target）
+- [ ] dasclaw `SandboxType::WindowsRestrictedToken` 不再 `NotImplemented`
+- [ ] `OsExecutor::new` 在 Windows 上能创建有效执行器
+- [ ] 真机矩阵 4 种 Windows 版本（10 1809 / 10 21H2 / 11 / Server 2019）+ 3 家 AV（Defender / 360 / 瑞星）setup + run + uninstall smoke 全过
+- [ ] 政企部署指南文档完整
+- [ ] NOTICE / LICENSE attribution 完整
+- [ ] [#128](https://github.com/Linnanli/xClaw/issues/128) Windows 路径解锁
+
+---
+
+## 参考
+
+- [研究草稿 §附录 A](./p0a-sandbox-activation-decision-research-draft.md#附录-a--codex-windows-sandbox-实地考察事实修正)
+- upstream 源码：[`codex-cli-main/codex-rs/windows-sandbox-rs/`](../../../codex-cli-main/codex-rs/windows-sandbox-rs/)
+- upstream license：[`codex-cli-main/LICENSE`](../../../codex-cli-main/LICENSE)（Apache 2.0）
+- 相关 ADR：[#127](https://github.com/Linnanli/xClaw/issues/127)
+- Windows 计划：[#91](https://github.com/Linnanli/xClaw/issues/91)
+
+---
+
+## 标签建议
+
+`epic`、`windows`、`sandbox`、`p0-a`、`blocked-by-adr`、`needs-human-review`


### PR DESCRIPTION
## 背景 / 目标

激活 P0a 沙箱：在 dev-tool 启动路径让 `ShellTool` 默认跑在 `OsExecutor`
（Linux bwrap / macOS seatbelt）+ 强制 HTTPS allowlist 代理之内，按
ADR-121 §2.1 落地档位 A（env + Builder fallback，~200 LOC）。

- Issue: Closes #128
- ADR: [adr-121-p0a-sandbox-activation-decision.md](docs/plans/architecture-refactor/adr-121-p0a-sandbox-activation-decision.md)
- 用户文档: [desktop-client/docs/sandbox-activation.md](desktop-client/docs/sandbox-activation.md)

## 改动范围

| 文件 | 主要改动 |
| --- | --- |
| `desktop-client/ironclaw/src/sandbox/config.rs` | 新 `ExecutionMode {Direct, OsSandbox(default), Docker}` + `FromStr` |
| `desktop-client/ironclaw/src/sandbox/mod.rs` | 重导出 `ExecutionMode` |
| `desktop-client/ironclaw/src/sandbox/net_proxy.rs` | `SecretsStore` 加 `+ Send + Sync` 约束 |
| `desktop-client/ironclaw/src/config/sandbox.rs` | 解析 `SANDBOX_EXECUTION_MODE`；默认 `policy` 由 `readonly` → `workspace_write`（D5=E）|
| `desktop-client/ironclaw/src/tools/bootstrap.rs` | `BootstrapContext` 新增 `sandbox_executor` / `sandbox_policy` / `proxy_env` |
| `desktop-client/ironclaw/src/tools/registry.rs` | 拆 `register_shell_tool` ←→ `register_dev_tools`，把 ctx 接进 ShellTool builder |
| `desktop-client/ironclaw/src/app.rs` | `AppComponents.network_proxy` + 新 `activate_sandbox(ctx)` 在 `bootstrap_tools` 之前激活 |
| `desktop-client/docs/sandbox-activation.md` | 用户面文档（环境变量 / 平台支持 / 故障排查） |

ADR-121 落地决策：

- **D0=C** 三态 ExecutionMode
- **D1=B** 政企默认 fail-CLOSED；`Direct` 仅本地开发，附带 `tracing::warn`
- **D5=E** 默认 `WorkspaceWrite`，开箱可写入工作区
- **D6=A** `FullAccess` 双重 opt-in（必须 `SANDBOX_ALLOW_FULL_ACCESS=true`，否则降级 + error 日志）
- **D2=E / D4a=D / D4b=A** 代理启动失败 / 缺 secrets store / 直连模式都通过 `tracing` 日志友好提示

## 非目标（What's NOT in this PR）

- ❌ **Windows 沙箱**：见 epic #241（fork `codex-windows-sandbox`），独立交付
- ❌ **W4 档位 C**：`ShellTool` 直接调 `dasclaw_exec` 内部 API（未来 ADR）
- ❌ **容器 worker 与 OsSandbox 去重**：归 ADR-113（hook engine 统一）
- ❌ 既有 clippy `new_without_default` / `collapsible_if` 历史告警**不修复**（与 base `xClaw` 一致；详见下"已知问题"）

## 验证

```bash
cargo check -p dasclaw --tests                                    # ✅ green (1m07s)
cargo nextest run -p dasclaw --lib 'req_sandbox_w3'                # ✅ 7/7 PASS
cargo nextest run -p dasclaw --lib 'sandbox'                       # ✅ 89/90 PASS *
cargo fmt --all                                                    # ✅ clean
python3.12 scripts/check_no_panics.py --base origin/xClaw          # ✅ OK
```

\* 唯一 `FAIL` = `message_tool_with_attachments_inside_sandbox_no_channel`，
  原因是测试需要本地 `~/.dasclaw/` 目录存在。**与本 PR 无关**（在 `origin/xClaw` 上同样会失败），属于 message tool 的已知 fixture 问题。

新增测试（TDD 红→绿）：

| 测试 | 覆盖 |
| --- | --- |
| `req_sandbox_w3_001_execution_mode_default_is_os_sandbox` | D1=B fail-closed 默认 |
| `req_sandbox_w3_002_execution_mode_parses_aliases` | `direct/os/bwrap/seatbelt/docker` 别名 |
| `req_sandbox_w3_003_execution_mode_rejects_garbage` | 非法值清晰报错 |
| `req_sandbox_w3_004_default_context_has_no_sandbox_executor` | `BootstrapContext` 默认不打开沙箱（builder fallback 触点）|
| `req_sandbox_w3_005_execution_mode_env_override_direct` | env 覆盖 `Direct` |
| `req_sandbox_w3_006_execution_mode_env_invalid_rejected` | env 错值 → `ConfigError` |
| `req_sandbox_w3_007_execution_mode_default_when_unset` | 未设环境变量 → `OsSandbox` |

## 已知问题 / 提示

1. **clippy 红线属于 base 状态**：`cargo clippy --no-deps -p dasclaw --all-targets -- -D warnings`
   返回 34 个错误，但全部位于 `web_fetch.rs` / `web_search.rs` / `worker/job.rs`
   等本 PR **未触碰**的文件。本 PR 改动文件零 clippy 告警；CI 若拦下，请修单独的"clippy batch"PR。
2. **政企部署提醒**：`OsSandbox` 默认要求 Linux kernel ≥5.13 + `bwrap`
   （`apt install bubblewrap`）。macOS 走 Codex `seatbelt` best-effort。
   Windows 用户当前会落到 `Direct`（warn 日志），等 #241 合入。
3. **Network proxy 依赖 secrets store**：未配置时会发 warn 日志，`OsExecutor`
   仍生效但凭据注入失效。

## Cross-cuts

- **ADR-114**（命名）：本 PR 未新增 `.ironclaw` 字符串字面量
- **ADR-121**（沙箱激活）：实现档位 A；档位 C 推迟到 W4
- **ADR-113**（hook 引擎统一）：未触碰

## 后续（不在本 PR）

- #241：Windows 沙箱 fork
- 接下来的 W3.1 议题（如有）：监控代理拒绝事件、把 docker 模式接到 worker 流水线
