### PR TITLE
fix(tools/message): create sandbox base_dir before tempdir_in

### DIFF
--- a/desktop-client/ironclaw/src/tools/builtin/message.rs
+++ b/desktop-client/ironclaw/src/tools/builtin/message.rs
@@ -613,6 +613,7 @@ mod tests {
 
         // Create temp files inside the sandbox
         let sandbox_dir = &tool.base_dir;
+        fs::create_dir_all(sandbox_dir).unwrap();
         let temp_dir = tempfile::tempdir_in(sandbox_dir).unwrap();
         let file1 = temp_dir.path().join("file1.txt");
         let file2 = temp_dir.path().join("file2.png");
@@ -746,6 +747,7 @@ mod tests {
 
         // Create a temp file within the sandbox directory
         let sandbox_dir = &tool.base_dir;
+        fs::create_dir_all(sandbox_dir).unwrap();
         let temp_dir = tempfile::tempdir_in(sandbox_dir).unwrap();
         let temp_path = temp_dir.path().join("test.txt");
         fs::write(&temp_path, "test content").unwrap();
@@ -783,6 +785,7 @@ mod tests {
 
         // Create temp files within the sandbox directory
         let sandbox_dir = &tool.base_dir;
+        fs::create_dir_all(sandbox_dir).unwrap();
         let temp_dir = tempfile::tempdir_in(sandbox_dir).unwrap();
         let temp_path1 = temp_dir.path().join("test1.txt");
         let temp_path2 = temp_dir.path().join("test2.txt");


### PR DESCRIPTION
## 背景 / 目标

`message.rs` 的三个测试（`message_tool_with_attachments_inside_sandbox_no_channel` 等）使用 `tempfile::tempdir_in(&tool.base_dir)` 在 `~/.dasclaw` 下创建临时目录。在干净的 CI runner（或没有跑过 dasclaw 的开发机）上，这个目录尚未被创建，`tempdir_in` 直接 panic：`Os { code: 2, kind: NotFound }`。

## 改动范围

`desktop-client/ironclaw/src/tools/builtin/message.rs`：在三个受影响测试的 `tempdir_in` 之前补一行 `fs::create_dir_all(sandbox_dir).unwrap();`，让 fixture 自包含、与执行顺序无关。生产代码零改动。

## 非目标 (What's NOT in this PR)

- 不修改 `MessageTool` 生产路径或 `base_dir` 解析逻辑
- 不重构其他测试的 fixture 风格
- 不改 `base_dir` 创建策略（生产路径仍由 `dasclaw_base_dir()` 调用方负责）

## 验证

```
cargo nextest run -p dasclaw --lib message_tool
  -> Summary: 25 tests run: 25 passed, 4040 skipped

cargo fmt --all                                          # OK
python3.12 scripts/check_no_panics.py --base origin/xClaw # OK
```

Cross-cuts:
- ADR-114: 不引入新的 ironclaw-prefix 字面量
- ADR-113: 与 hook engine 无关
- 无 `unwrap/expect/panic!` 在生产代码（仅修改 `#[cfg(test)]` 块内）


Closes #244
