### PR TITLE
feat(sandbox-windows): port codex-windows-sandbox skeleton + types (Phase 1.1.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2663,6 +2663,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dasclaw_sandbox_windows"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "pretty_assertions",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,8 @@ members = [
 	"crates/dasclaw_exec",
 	# W6-C 主仓自实现 LLM provider —— 替代 claw-code-api path-dep（ADR-118 PR-A.0 骨架）
 	"crates/dasclaw_llm_provider",
+	# W4 ADR-121 D3-3 / Phase 1.1 — Windows sandbox port from openai/codex (commit 6e838a19fa)
+	"crates/dasclaw_sandbox_windows",
 	"desktop-client/ironclaw",
 	"desktop-client/ironclaw/crates/ironclaw_common",
 	"desktop-client/ironclaw/crates/ironclaw_safety",

--- a/crates/dasclaw_sandbox_windows/Cargo.toml
+++ b/crates/dasclaw_sandbox_windows/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "dasclaw_sandbox_windows"
+version = "0.1.0"
+edition = "2024"
+license = "Apache-2.0"
+description = "Windows-specific sandbox runtime for x-claw, ported from openai/codex windows-sandbox-rs."
+publish = false
+
+[lib]
+name = "dasclaw_sandbox_windows"
+path = "src/lib.rs"
+
+[dependencies]
+anyhow = "1"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+# Win32 deps land in PR-1.1.3+ when actual sandbox logic is ported.
+# Skeleton intentionally has no platform-specific deps yet.
+
+[dev-dependencies]
+pretty_assertions = "1"

--- a/crates/dasclaw_sandbox_windows/src/lib.rs
+++ b/crates/dasclaw_sandbox_windows/src/lib.rs
@@ -1,0 +1,49 @@
+// Derived from openai/codex commit 6e838a19fa
+//   path: codex-rs/windows-sandbox-rs/src/lib.rs
+// SPDX-License-Identifier: Apache-2.0
+
+//! Windows-specific sandbox runtime for x-claw.
+//!
+//! Ported (mechanically, with import rewrites) from
+//! `openai/codex` `codex-rs/windows-sandbox-rs/` at commit `6e838a19fa`.
+//! See `vendor/codex-windows-sandbox/README.md` for the reference snapshot
+//! and the porting plan in tracker issue #250.
+//!
+//! ## Crate status (Phase 1.1.0)
+//!
+//! This is the **skeleton-only** revision. It exposes:
+//!
+//! - The sandbox policy types (`types::SandboxPolicy`, `types::NetworkAccess`,
+//!   `types::WritableRoot`) so callers across the workspace can construct
+//!   policies on every platform.
+//! - On non-Windows targets, [`unsupported`] returns a typed error indicating
+//!   that the Windows sandbox is unavailable on the current platform.
+//!
+//! The actual Win32 sandbox logic (AppContainer, JobObject, network ACLs)
+//! lands in subsequent PRs under tracker issue #250.
+
+pub mod types;
+
+/// Returned by sandbox entry points on platforms where the Windows sandbox is
+/// unavailable.
+///
+/// Until the Win32 implementation lands (tracker #250), this is the only
+/// surface the rest of the workspace can call into.
+pub fn unsupported() -> anyhow::Error {
+    anyhow::anyhow!(
+        "dasclaw_sandbox_windows: Windows sandbox runtime is not yet implemented on this build (Phase 1.1.0 skeleton)"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unsupported_message_is_stable() {
+        let err = unsupported();
+        let msg = err.to_string();
+        assert!(msg.contains("dasclaw_sandbox_windows"));
+        assert!(msg.contains("Phase 1.1.0"));
+    }
+}

--- a/crates/dasclaw_sandbox_windows/src/types.rs
+++ b/crates/dasclaw_sandbox_windows/src/types.rs
@@ -1,0 +1,208 @@
+// Derived from openai/codex commit 6e838a19fa
+//   path: codex-rs/protocol/src/protocol.rs (SandboxPolicy / NetworkAccess / WritableRoot)
+// SPDX-License-Identifier: Apache-2.0
+
+//! Sandbox policy types, inlined from the upstream `codex-protocol` crate.
+//!
+//! The upstream definitions additionally derive `strum::Display`, `JsonSchema`,
+//! and `TS`. Those derives drag in `strum_macros`, `schemars`, and `ts-rs`,
+//! which we do not yet vendor. They are intentionally omitted here in
+//! Phase 1.1.0; downstream PRs may reintroduce them if x-claw needs the
+//! corresponding capabilities.
+//!
+//! `AbsolutePathBuf` is also part of the upstream sandbox-policy surface; it
+//! lives in `codex-utils-absolute-path`. Until that helper is ported in
+//! PR-1.1.1, this module uses `std::path::PathBuf` for `writable_roots`. The
+//! serde representation is unchanged (a JSON array of path strings), so the
+//! switch to `AbsolutePathBuf` is a non-breaking refinement.
+
+use std::path::Path;
+use std::path::PathBuf;
+
+use serde::Deserialize;
+use serde::Serialize;
+
+/// Represents whether outbound network access is available to the agent.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "kebab-case")]
+pub enum NetworkAccess {
+    #[default]
+    Restricted,
+    Enabled,
+}
+
+impl NetworkAccess {
+    pub fn is_enabled(self) -> bool {
+        matches!(self, NetworkAccess::Enabled)
+    }
+}
+
+/// Determines execution restrictions for model shell commands.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "kebab-case")]
+pub enum SandboxPolicy {
+    /// No restrictions whatsoever. Use with caution.
+    #[serde(rename = "danger-full-access")]
+    DangerFullAccess,
+
+    /// Read-only access configuration.
+    #[serde(rename = "read-only")]
+    ReadOnly {
+        /// When set to `true`, outbound network access is allowed. `false` by
+        /// default.
+        #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+        network_access: bool,
+    },
+
+    /// Indicates the process is already in an external sandbox. Allows full
+    /// disk access while honoring the provided network setting.
+    #[serde(rename = "external-sandbox")]
+    ExternalSandbox {
+        /// Whether the external sandbox permits outbound network traffic.
+        #[serde(default)]
+        network_access: NetworkAccess,
+    },
+
+    /// Same as `ReadOnly` but additionally grants write access to the current
+    /// working directory ("workspace").
+    #[serde(rename = "workspace-write")]
+    WorkspaceWrite {
+        /// Additional folders (beyond cwd and possibly TMPDIR) that should be
+        /// writable from within the sandbox.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        writable_roots: Vec<PathBuf>,
+
+        /// When set to `true`, outbound network access is allowed. `false` by
+        /// default.
+        #[serde(default)]
+        network_access: bool,
+
+        /// When set to `true`, will NOT include the per-user `TMPDIR`
+        /// environment variable among the default writable roots. Defaults to
+        /// `false`.
+        #[serde(default)]
+        exclude_tmpdir_env_var: bool,
+
+        /// When set to `true`, will NOT include the `/tmp` among the default
+        /// writable roots on UNIX. Defaults to `false`.
+        #[serde(default)]
+        exclude_slash_tmp: bool,
+    },
+}
+
+/// A writable root path accompanied by a list of subpaths that should remain
+/// read-only even when the root is writable.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WritableRoot {
+    pub root: PathBuf,
+
+    /// By construction, these subpaths are all under `root`.
+    pub read_only_subpaths: Vec<PathBuf>,
+}
+
+impl WritableRoot {
+    pub fn is_path_writable(&self, path: &Path) -> bool {
+        if !path.starts_with(&self.root) {
+            return false;
+        }
+        for subpath in &self.read_only_subpaths {
+            if path.starts_with(subpath) {
+                return false;
+            }
+        }
+        true
+    }
+}
+
+impl SandboxPolicy {
+    /// Returns a policy with read-only disk access and no network.
+    pub fn new_read_only_policy() -> Self {
+        SandboxPolicy::ReadOnly {
+            network_access: false,
+        }
+    }
+
+    /// Returns a policy that can read the entire disk, but can only write to
+    /// the current working directory and the per-user tmp dir on macOS. It
+    /// does not allow network access.
+    pub fn new_workspace_write_policy() -> Self {
+        SandboxPolicy::WorkspaceWrite {
+            writable_roots: vec![],
+            network_access: false,
+            exclude_tmpdir_env_var: false,
+            exclude_slash_tmp: false,
+        }
+    }
+
+    pub fn has_full_disk_read_access(&self) -> bool {
+        true
+    }
+
+    pub fn has_full_disk_write_access(&self) -> bool {
+        match self {
+            SandboxPolicy::DangerFullAccess => true,
+            SandboxPolicy::ExternalSandbox { .. } => true,
+            SandboxPolicy::ReadOnly { .. } => false,
+            SandboxPolicy::WorkspaceWrite { .. } => false,
+        }
+    }
+
+    pub fn has_full_network_access(&self) -> bool {
+        match self {
+            SandboxPolicy::DangerFullAccess => true,
+            SandboxPolicy::ExternalSandbox { network_access } => network_access.is_enabled(),
+            SandboxPolicy::ReadOnly { network_access, .. } => *network_access,
+            SandboxPolicy::WorkspaceWrite { network_access, .. } => *network_access,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn read_only_policy_round_trips_through_serde_json() {
+        let policy = SandboxPolicy::new_read_only_policy();
+        let json = serde_json::to_string(&policy).expect("serialize");
+        let parsed: SandboxPolicy = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(policy, parsed);
+    }
+
+    #[test]
+    fn workspace_write_policy_default_excludes_optional_fields() {
+        let policy = SandboxPolicy::new_workspace_write_policy();
+        let json = serde_json::to_string(&policy).expect("serialize");
+        // network_access serializes (because it is `false` by default but not
+        // skipped); writable_roots is empty so `skip_serializing_if` drops it.
+        assert!(json.contains("\"type\":\"workspace-write\""));
+        assert!(!json.contains("writable_roots"));
+        assert!(!policy.has_full_disk_write_access());
+        assert!(!policy.has_full_network_access());
+    }
+
+    #[test]
+    fn external_sandbox_with_network_enabled_round_trips() {
+        let policy = SandboxPolicy::ExternalSandbox {
+            network_access: NetworkAccess::Enabled,
+        };
+        assert!(policy.has_full_disk_write_access());
+        assert!(policy.has_full_network_access());
+
+        let json = serde_json::to_string(&policy).expect("serialize");
+        let parsed: SandboxPolicy = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(policy, parsed);
+    }
+
+    #[test]
+    fn writable_root_blocks_paths_under_read_only_subpath() {
+        let root = WritableRoot {
+            root: PathBuf::from("/repo"),
+            read_only_subpaths: vec![PathBuf::from("/repo/.git")],
+        };
+        assert!(root.is_path_writable(Path::new("/repo/src/main.rs")));
+        assert!(!root.is_path_writable(Path::new("/repo/.git/HEAD")));
+        assert!(!root.is_path_writable(Path::new("/other/path")));
+    }
+}

--- a/vendor/codex-windows-sandbox/README.md
+++ b/vendor/codex-windows-sandbox/README.md
@@ -1,56 +1,47 @@
 # vendor/codex-windows-sandbox
 
-Phase 1.0 vendor scaffolding for **[ADR-121](../../docs/plans/architecture-refactor/adr-121-p0a-sandbox-activation-decision.md) D3-3**
-(Windows OS sandbox via fork of `codex-windows-sandbox`).
+> **Status (Phase 1.1.0)**: Read-only **reference snapshot**. The actual workspace crate
+> being built is [`crates/dasclaw_sandbox_windows`](../../crates/dasclaw_sandbox_windows).
+> Files under this directory are **never compiled** — root `Cargo.toml` keeps
+> `vendor` in `[workspace] exclude` and that exclusion will not be lifted.
 
-Tracking: epic [#241](https://github.com/Linnanli/xClaw/issues/241)
+This snapshot exists to make the porting plan in [tracker #250](https://github.com/Linnanli/xClaw/issues/250) auditable:
+each module ported into `crates/dasclaw_sandbox_windows/` carries a header that
+points back to the corresponding file under `upstream/`.
 
-## What is in this directory
+## Background
 
-- `upstream/` — verbatim copy of selected crates from
-  [openai/codex](https://github.com/openai/codex) at commit
-  [`6e838a19fa52f2c30442c5bd2913acd1e6fe4c9d`](https://github.com/openai/codex/commit/6e838a19fa52f2c30442c5bd2913acd1e6fe4c9d).
-  No file under `upstream/` has been modified relative to that commit.
-- `LICENSE-APACHE-2.0` — full text of the upstream Apache License 2.0.
-- `NOTICE-upstream` — verbatim copy of the upstream `NOTICE` file.
-- `vendor-pin.json` — machine-readable manifest of what was vendored, from where,
-  and at which upstream commit.
+Per [ADR-121](../../docs/plans/architecture-refactor/adr-121-p0a-sandbox-activation-decision.md) D3-3
+(epic [#241](https://github.com/Linnanli/xClaw/issues/241)), x-claw forks
+`codex-windows-sandbox`. Phase 1.0 (PR #248) vendored selected upstream crates
+verbatim. Phase 1.1 then re-evaluated build wiring and concluded that a verbatim
+build would drag in 30+ transitive `codex-*` crates. The decision (**design
+path V'-b**) is to:
 
-## What is **not** in this PR (PR-1.0)
+1. Keep the verbatim snapshot under `upstream/` as a **reference only**, and
+2. Hand-port the parts we actually need into a brand-new main-workspace crate
+   `crates/dasclaw_sandbox_windows/`, mechanically rewriting imports to local
+   equivalents, with each ported file carrying an Apache-2.0 attribution header.
 
-- ❌ Workspace registration — root `Cargo.toml` adds `vendor` to `[workspace] exclude`,
-  so vendored `Cargo.toml` files are intentionally **not** picked up by `cargo build`.
-- ❌ Edits to vendored `Cargo.toml` (no `[workspace.dependencies]` rewrites yet).
-- ❌ Brand renaming (`CodexSandboxUsers` → `DasclawSandboxUsers`, etc.).
-- ❌ Adapter glue from `crates/dasclaw_sandbox` to the vendored crate.
-- ❌ Windows CI matrix.
+## Layout
 
-These are deliberately deferred to **PR-1.1** so this PR can be reviewed strictly
-on three axes:
+| Path | Purpose |
+| --- | --- |
+| `upstream/` | Verbatim copy of selected upstream crates at the pinned commit. **Never built.** |
+| `LICENSE-APACHE-2.0` | Full text of the upstream Apache License 2.0. |
+| `NOTICE-upstream` | Verbatim copy of the upstream `NOTICE` file. |
+| `vendor-pin.json` | Machine-readable manifest: upstream commit, vendored paths, current usage status. |
 
-1. License attribution correctness (Apache 2.0 + NOTICE preserved, upstream commit pinned).
-2. Vendor scope (which 5 crates were copied and why — see `vendor-pin.json`).
-3. No accidental coupling to the workspace build graph.
+The vendored crates and the upstream commit are documented in
+[`vendor-pin.json`](./vendor-pin.json).
 
-## Vendored crates (5 total, ~32.8k LOC)
+## Refreshing the snapshot
 
-| Upstream path | Role | Local path |
-| --- | --- | --- |
-| `codex-rs/windows-sandbox-rs` | primary (12 253 LOC) | `upstream/windows-sandbox-rs/` |
-| `codex-rs/protocol` | transitive (`SandboxPolicy`, `NetworkAccess`) | `upstream/protocol/` |
-| `codex-rs/utils/pty` | transitive (ConPTY wrapper) | `upstream/utils/pty/` |
-| `codex-rs/utils/string` | transitive (2 helpers) | `upstream/utils/string/` |
-| `codex-rs/utils/absolute-path` | transitive (`AbsolutePathBuf`) | `upstream/utils/absolute-path/` |
-
-The full motivation for vendoring (vs. submodule / cargo path-dep) and the exact
-upstream surface used by `windows-sandbox-rs` is recorded in `vendor-pin.json`.
-
-## Refresh procedure
-
-To re-vendor against a newer upstream commit:
+Refresh is optional and only needed when porting a new upstream feature. To
+re-snapshot against a newer upstream commit:
 
 1. `cd codex-cli-main && git fetch && git checkout <new-commit>`
-2. From repo root, re-run the rsync used in PR-1.0 (one line per crate):
+2. From repo root, re-run the rsync (one line per crate):
    ```bash
    for d in windows-sandbox-rs protocol utils/pty utils/string utils/absolute-path; do
      rsync -a --delete --exclude='target' --exclude='.git' \
@@ -60,18 +51,12 @@ To re-vendor against a newer upstream commit:
 3. Update `vendor-pin.json` (`upstream.commit`, `commit_subject`, `captured_at`).
 4. Re-copy `LICENSE` / `NOTICE` from `codex-cli-main/` if the upstream files changed.
 
-## Why a separate `vendor/` tree (rather than a fresh `crates/` member)
-
-ADR-121 D3-3 explicitly chose **fork** over rewrite. Keeping the vendored tree
-isolated under `vendor/` preserves a clean delta against upstream so future
-cherry-picks stay tractable. PR-1.1 will introduce a `crates/dasclaw_sandbox_windows/`
-shim that depends on (or wraps) the vendored crate; the vendored sources
-themselves will continue to live under `vendor/` and remain branded `codex-*`
-until Phase 2 (Brand & Naming).
+Because the build does not depend on this directory, refresh **never affects
+CI**. It only affects the diff readers see when inspecting future ports.
 
 ## License
 
 Code under `upstream/` is © OpenAI and licensed under the Apache License 2.0
-(see `LICENSE-APACHE-2.0` and `NOTICE-upstream`). Any modifications introduced
-by later phases of this fork will preserve the Apache 2.0 license and add a
-modification notice as required by the license.
+(see `LICENSE-APACHE-2.0` and `NOTICE-upstream`). Files ported into
+`crates/dasclaw_sandbox_windows/` carry per-file attribution headers crediting
+the upstream source path and commit, in compliance with Apache 2.0 §4.

--- a/vendor/codex-windows-sandbox/vendor-pin.json
+++ b/vendor/codex-windows-sandbox/vendor-pin.json
@@ -43,8 +43,9 @@
       "reason": "windows-sandbox-rs uses codex_utils_absolute_path::AbsolutePathBuf."
     }
   ],
-  "modifications_in_this_pr": "None. This is a verbatim vendor copy. No file in vendor/codex-windows-sandbox/upstream/ has been modified relative to the captured upstream commit. Phase 1.1 will introduce workspace integration (workspace.dependencies, target gating, brand-neutral naming).",
-  "workspace_integration_status": "DEFERRED to PR-1.1. Vendored Cargo.toml files are intentionally NOT registered in the root workspace (see root Cargo.toml `exclude = [\"vendor\"]`). Running cargo build/check from the workspace root does not currently compile vendored code.",
+  "modifications_in_this_pr": "None. Files under vendor/codex-windows-sandbox/upstream/ are unchanged relative to the captured upstream commit and remain a read-only reference snapshot.",
+  "workspace_integration_status": "REFERENCE_ONLY. Per Phase 1.1 design path V'-b (tracker #250), files under vendor/codex-windows-sandbox/upstream/ are NEVER compiled. Root Cargo.toml keeps `vendor` in [workspace] exclude permanently. The actual built crate is crates/dasclaw_sandbox_windows/, which mechanically ports needed code from this snapshot with per-file Apache-2.0 attribution headers.",
+  "phase_1_1_tracker": "https://github.com/Linnanli/xClaw/issues/250",
   "epic": "https://github.com/Linnanli/xClaw/issues/241",
   "adr": "docs/plans/architecture-refactor/adr-121-p0a-sandbox-activation-decision.md"
 }


### PR DESCRIPTION
## 背景 / 目标

Phase 1.1 tracker #250（设计路径 V'-b）的第一个港口 PR。引入 `crates/dasclaw_sandbox_windows` 作为主 workspace 新成员，承载从 openai/codex commit `6e838a19fa` 端口过来的 Windows 沙箱运行时。

本 PR **只是骨架** —— 真正的 Win32 沙箱逻辑（AppContainer / JobObject / 网络 ACL）随其消费者在 #250 后续 PR 一起进。

ADR 引用：[ADR-121](../docs/plans/architecture-refactor/adr-121-p0a-sandbox-activation-decision.md) D3-3 (Accepted v1.1)。

## 改动范围

### 新增 `crates/dasclaw_sandbox_windows/`

- `Cargo.toml`：主 workspace 风格，最小依赖（`anyhow`/`serde`/`serde_json`/`pretty_assertions`）。Win32 deps 在后续 PR 配合实际逻辑一起加。
- `src/lib.rs`：cfg-agnostic stub。单一入口 `unsupported() -> anyhow::Error`，文档记录 Phase 1.1.0 状态。
- `src/types.rs`：`SandboxPolicy` / `NetworkAccess` / `WritableRoot` 三个类型，从 upstream `codex-rs/protocol/src/protocol.rs` 端口。
  - 文件头按 Apache-2.0 §4 加 attribution（commit + 路径 + SPDX）。
  - **意图省略**的 upstream-only derive：`strum::Display`、`JsonSchema`、`TS`（避免拖入 strum_macros / schemars / ts-rs 三个 crate；后续如需可重新加回）。
  - **暂用** `PathBuf` 替代 `AbsolutePathBuf`，serde 表示不变（路径字符串数组）。tracker #250 PR-1.1.1 会引入端口的 `AbsolutePathBuf` 并切换。

### 测试（5 个，全 pass）

- `unsupported_message_is_stable`
- `read_only_policy_round_trips_through_serde_json`
- `workspace_write_policy_default_excludes_optional_fields`
- `external_sandbox_with_network_enabled_round_trips`
- `writable_root_blocks_paths_under_read_only_subpath`

### 主 workspace `Cargo.toml`

加 `crates/dasclaw_sandbox_windows` 进 `members`。`vendor` 仍在 `exclude`（永久）。

### `vendor/codex-windows-sandbox/`

- `README.md`：完全重写，定位改为 **reference snapshot, never built**。说明为什么转向 V'-b。
- `vendor-pin.json`：`workspace_integration_status` 改为 `REFERENCE_ONLY`，加 `phase_1_1_tracker` 字段。
- `upstream/` 内容**未改**（仍是 PR #248 的 verbatim 拷贝）。

## 非目标（What's NOT in this PR）

- ❌ 真正的 Win32 沙箱逻辑（AppContainer / JobObject / 网络 ACL）
- ❌ 端口 `windows-sandbox-rs/src/*` 任何业务模块（allow / policy / lib / unified_exec / ...）
- ❌ 端口 `utils/pty` / `utils/string` / `utils/absolute-path`
- ❌ 接入 `crates/dasclaw_sandbox` `SandboxRuntime` trait
- ❌ Windows CI 矩阵（还没有 Windows-specific 代码可测）
- ❌ 任何对 `vendor/codex-windows-sandbox/upstream/*` 内文件的修改

这些都在 #250 后续 PR 中分块进。

## 验证

```bash
cargo check -p dasclaw_sandbox_windows --tests        # pass (21.64s)
cargo nextest run -p dasclaw_sandbox_windows          # 5/5 pass (0.86s)
cargo fmt --all                                       # clean
python3.12 scripts/check_no_panics.py --base origin/xClaw      # OK
python3.12 scripts/check_no_new_ironclaw_literal.py --base origin/xClaw  # OK
cargo clippy --no-deps -p dasclaw_sandbox_windows --all-targets -- -D warnings  # pass
cargo metadata --no-deps                              # 27 → 28 packages
```

## Refs

- Closes #251
- Refs #250 (Phase 1.1 tracker), #241 (epic), ADR-121 D3-3
- Predecessors: #248 (Phase 1.0 vendor scaffolding, merged `79138402`)
