### PR TITLE
feat(sandbox-windows): port utils/string helpers (Phase 1.1.1)

### DIFF
--- a/crates/dasclaw_sandbox_windows/src/lib.rs
+++ b/crates/dasclaw_sandbox_windows/src/lib.rs
@@ -22,6 +22,7 @@
 //! The actual Win32 sandbox logic (AppContainer, JobObject, network ACLs)
 //! lands in subsequent PRs under tracker issue #250.
 
+pub mod string_util;
 pub mod types;
 
 /// Returned by sandbox entry points on platforms where the Windows sandbox is

--- a/crates/dasclaw_sandbox_windows/src/string_util.rs
+++ b/crates/dasclaw_sandbox_windows/src/string_util.rs
@@ -1,0 +1,130 @@
+// Derived from openai/codex commit 6e838a19fa
+//   path: codex-rs/utils/string/src/lib.rs
+//     - `take_bytes_at_char_boundary`
+//     - `sanitize_metric_tag_value`
+// SPDX-License-Identifier: Apache-2.0
+
+//! String helpers ported from `codex-utils-string`.
+//!
+//! Only the two helpers actually consumed by `windows-sandbox-rs` are ported:
+//! `sanitize_metric_tag_value` (used by `setup_error.rs`) and
+//! `take_bytes_at_char_boundary` (used by `logging.rs`). The remaining
+//! upstream surface (UUID extraction, markdown-hash-location normalization,
+//! token-budget truncation) is intentionally **not** ported because it is
+//! unused on the Windows sandbox path; reintroduce only when a porting PR
+//! actually needs it.
+
+/// Truncate a `&str` to a byte budget at a UTF-8 character boundary, returning
+/// the longest prefix that fits within `maxb` bytes without splitting a
+/// multi-byte codepoint.
+#[inline]
+pub fn take_bytes_at_char_boundary(s: &str, maxb: usize) -> &str {
+    if s.len() <= maxb {
+        return s;
+    }
+    let mut last_ok = 0;
+    for (i, ch) in s.char_indices() {
+        let nb = i + ch.len_utf8();
+        if nb > maxb {
+            break;
+        }
+        last_ok = nb;
+    }
+    &s[..last_ok]
+}
+
+/// Sanitize a tag value to comply with metric tag validation rules: only
+/// ASCII alphanumeric, '.', '_', '-', and '/' are allowed.
+///
+/// Invalid characters become '_'. The result is trimmed of leading and
+/// trailing underscores. If the trimmed result is empty or contains no
+/// alphanumeric characters, returns `"unspecified"`. Results longer than 256
+/// bytes are truncated.
+pub fn sanitize_metric_tag_value(value: &str) -> String {
+    const MAX_LEN: usize = 256;
+    let sanitized: String = value
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || matches!(ch, '.' | '_' | '-' | '/') {
+                ch
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    let trimmed = sanitized.trim_matches('_');
+    if trimmed.is_empty() || trimmed.chars().all(|ch| !ch.is_ascii_alphanumeric()) {
+        return "unspecified".to_string();
+    }
+    if trimmed.len() <= MAX_LEN {
+        trimmed.to_string()
+    } else {
+        trimmed[..MAX_LEN].to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn take_bytes_at_char_boundary_returns_input_when_within_budget() {
+        assert_eq!(take_bytes_at_char_boundary("hello", 10), "hello");
+        assert_eq!(take_bytes_at_char_boundary("hello", 5), "hello");
+    }
+
+    #[test]
+    fn take_bytes_at_char_boundary_truncates_ascii() {
+        assert_eq!(take_bytes_at_char_boundary("hello", 3), "hel");
+    }
+
+    #[test]
+    fn take_bytes_at_char_boundary_does_not_split_multibyte_codepoint() {
+        // "🙂" is 4 bytes (U+1F642, F0 9F 99 82).
+        let s = "ab🙂c";
+        assert_eq!(s.len(), 7);
+        // Budget 3 → "ab" (next char would push to 6 > 3).
+        assert_eq!(take_bytes_at_char_boundary(s, 3), "ab");
+        // Budget 5 → still "ab", because the smiley is 4 bytes and 2+4=6>5.
+        assert_eq!(take_bytes_at_char_boundary(s, 5), "ab");
+        // Budget 6 → "ab🙂".
+        assert_eq!(take_bytes_at_char_boundary(s, 6), "ab🙂");
+    }
+
+    #[test]
+    fn take_bytes_at_char_boundary_zero_budget_returns_empty() {
+        assert_eq!(take_bytes_at_char_boundary("hello", 0), "");
+    }
+
+    #[test]
+    fn sanitize_metric_tag_value_replaces_invalid_chars() {
+        assert_eq!(sanitize_metric_tag_value("bad value!"), "bad_value");
+    }
+
+    #[test]
+    fn sanitize_metric_tag_value_returns_unspecified_for_empty_after_trim() {
+        assert_eq!(sanitize_metric_tag_value("///"), "unspecified");
+    }
+
+    #[test]
+    fn sanitize_metric_tag_value_returns_unspecified_when_only_underscores_remain() {
+        assert_eq!(sanitize_metric_tag_value("???"), "unspecified");
+    }
+
+    #[test]
+    fn sanitize_metric_tag_value_keeps_allowed_punctuation() {
+        assert_eq!(
+            sanitize_metric_tag_value("foo.bar-baz_qux/quux"),
+            "foo.bar-baz_qux/quux"
+        );
+    }
+
+    #[test]
+    fn sanitize_metric_tag_value_truncates_at_max_len() {
+        let input: String = "a".repeat(300);
+        let out = sanitize_metric_tag_value(&input);
+        assert_eq!(out.len(), 256);
+        assert!(out.chars().all(|c| c == 'a'));
+    }
+}


### PR DESCRIPTION
## 背景 / 目标

Phase 1.1 tracker #250 第 2 步（V'-b path）。把 `windows-sandbox-rs` 实际依赖的两个 `codex-utils-string` 助手搬进 `dasclaw_sandbox_windows::string_util`，去掉对 `codex-utils-string` workspace crate 的传递依赖前置条件。

`grep` 已确认 `vendor/codex-windows-sandbox/upstream/windows-sandbox-rs/src/` 仅有两处：
- `setup_error.rs:3` → `sanitize_metric_tag_value`
- `logging.rs:7` → `take_bytes_at_char_boundary`

## 改动范围

- 新建 [crates/dasclaw_sandbox_windows/src/string_util.rs](crates/dasclaw_sandbox_windows/src/string_util.rs) — 上游 `codex-rs/utils/string/src/lib.rs`（commit `6e838a19fa`）的逐行移植，附 Apache-2.0 attribution header；`MAX_LEN = 256`，"unspecified" sentinel 行为完全保留。
- [crates/dasclaw_sandbox_windows/src/lib.rs](crates/dasclaw_sandbox_windows/src/lib.rs) — `pub mod string_util;`。
- 8 个单元测试：ASCII / 多字节字符（🙂）边界 / 0 预算 / 非法字符替换 / 全下划线 trim 后空 / `MAX_LEN` 截断 / 允许标点直通。

## 非目标 (What's NOT in this PR)

- ❌ 上游 `codex-utils-string` 的其余功能（`find_uuids`、`normalize_markdown_hash_location_suffix`、token-budget `truncate` 模块）。`windows-sandbox-rs` 不用，按 V'-b "按需移植" 原则不带入。
- ❌ 任何 Win32 / `cfg(windows)` 代码（`logging.rs`、`setup_error.rs` 本身延后到 PR-1.1.4+）。
- ❌ 修改 `vendor/codex-windows-sandbox/`（仍是 read-only reference snapshot）。
- ❌ 接线到 `dasclaw_sandbox::SandboxRuntime`（最后一步，PR-1.1.N）。

## 验证

```bash
cargo nextest run -p dasclaw_sandbox_windows
# Summary: 14 tests run: 14 passed, 0 skipped  (was 5/5 in #252)

cargo fmt --all                                    # clean
python3.12 scripts/check_no_panics.py --base origin/xClaw
# OK: No panic-inducing calls in changed production code.
python3.12 scripts/check_no_new_ironclaw_literal.py --base origin/xClaw
# OK: No new .ironclaw / IRONCLAW_BASE_DIR literals introduced.
cargo clippy --no-deps -p dasclaw_sandbox_windows --all-targets -- -D warnings
# Finished `dev` profile ... (clean)
```

## Refs

- Closes #253
- Phase 1.1 tracker: #250
- Predecessor: #252 (squash `715ea642`)
- Epic: #241  ·  ADR-121 D3-3
