### PR TITLE
feat(sandbox-windows): port AbsolutePathBuf + adopt in types (Phase 1.1.2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2667,9 +2667,12 @@ name = "dasclaw_sandbox_windows"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "dirs 6.0.0",
+ "dunce",
  "pretty_assertions",
  "serde",
  "serde_json",
+ "tempfile",
 ]
 
 [[package]]

--- a/crates/dasclaw_sandbox_windows/Cargo.toml
+++ b/crates/dasclaw_sandbox_windows/Cargo.toml
@@ -12,6 +12,8 @@ path = "src/lib.rs"
 
 [dependencies]
 anyhow = "1"
+dirs = "6"
+dunce = "1.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 
@@ -20,3 +22,4 @@ serde_json = "1"
 
 [dev-dependencies]
 pretty_assertions = "1"
+tempfile = "3"

--- a/crates/dasclaw_sandbox_windows/src/absolute_path.rs
+++ b/crates/dasclaw_sandbox_windows/src/absolute_path.rs
@@ -1,0 +1,316 @@
+// Derived from openai/codex commit 6e838a19fa
+//   path: codex-rs/utils/absolute-path/src/lib.rs
+//   path: codex-rs/utils/absolute-path/src/absolutize.rs
+// SPDX-License-Identifier: Apache-2.0
+//
+// `absolutize` submodule is itself adapted from path-absolutize 3.1.1
+// (Copyright (c) 2018 magiclen.org / Ron Li, MIT-licensed) — see upstream
+// commentary preserved at the top of the inlined `absolutize` module.
+
+//! Slim port of `codex-utils-absolute-path::AbsolutePathBuf`.
+//!
+//! Per V'-b "port-on-demand" rule, this module **omits** the upstream surface
+//! that `windows-sandbox-rs` does not consume:
+//!
+//! - `JsonSchema` / `ts_rs::TS` derives (no schema generation in this crate).
+//! - `AbsolutePathBufGuard` thread-local + custom `Deserialize` impl (we use
+//!   the default derive, which only accepts already-absolute paths — sufficient
+//!   for the `WritableRoot` payload deserialized from sandbox configs).
+//! - `canonicalize_preserving_symlinks` /
+//!   `canonicalize_existing_preserving_symlinks` (used elsewhere in codex CLI,
+//!   not by the windows sandbox).
+//! - `test_support::{PathExt, PathBufExt}` extension traits (depend on
+//!   `expect()` and are unused on this path).
+//!
+//! The retained surface (`from_absolute_path`, `from_absolute_path_checked`,
+//! `try_from`, `resolve_path_against_base`, `join`, `parent`, `ancestors`,
+//! `as_path`, `into_path_buf`, `to_path_buf`, `to_string_lossy`, `display`,
+//! `current_dir`, `relative_to_current_dir`, `canonicalize`, plus `Deref` /
+//! `AsRef<Path>` / `From<AbsolutePathBuf> for PathBuf`) is a verbatim copy of
+//! the upstream definitions — only the noise above is dropped.
+
+use serde::Deserialize;
+use serde::Deserializer;
+use serde::Serialize;
+use serde::de::Error as SerdeError;
+use std::path::Display;
+use std::path::Path;
+use std::path::PathBuf;
+
+mod absolutize;
+
+/// A path that is guaranteed to be absolute and normalized (though it is not
+/// guaranteed to be canonicalized or exist on the filesystem).
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
+#[serde(into = "PathBuf")]
+pub struct AbsolutePathBuf(PathBuf);
+
+impl AbsolutePathBuf {
+    fn maybe_expand_home_directory(path: &Path) -> PathBuf {
+        if let Some(path_str) = path.to_str()
+            && let Some(home) = dirs::home_dir()
+            && let Some(rest) = path_str.strip_prefix('~')
+        {
+            if rest.is_empty() {
+                return home;
+            } else if let Some(rest) = rest.strip_prefix('/') {
+                return home.join(rest.trim_start_matches('/'));
+            } else if cfg!(windows)
+                && let Some(rest) = rest.strip_prefix('\\')
+            {
+                return home.join(rest.trim_start_matches('\\'));
+            }
+        }
+        path.to_path_buf()
+    }
+
+    pub fn resolve_path_against_base<P: AsRef<Path>, B: AsRef<Path>>(
+        path: P,
+        base_path: B,
+    ) -> Self {
+        let expanded = Self::maybe_expand_home_directory(path.as_ref());
+        Self(absolutize::absolutize_from(&expanded, base_path.as_ref()))
+    }
+
+    pub fn from_absolute_path<P: AsRef<Path>>(path: P) -> std::io::Result<Self> {
+        let expanded = Self::maybe_expand_home_directory(path.as_ref());
+        Ok(Self(absolutize::absolutize(&expanded)?))
+    }
+
+    pub fn from_absolute_path_checked<P: AsRef<Path>>(path: P) -> std::io::Result<Self> {
+        let expanded = Self::maybe_expand_home_directory(path.as_ref());
+        if !expanded.is_absolute() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!("path is not absolute: {}", path.as_ref().display()),
+            ));
+        }
+
+        Ok(Self(absolutize::absolutize_from(&expanded, Path::new("/"))))
+    }
+
+    pub fn current_dir() -> std::io::Result<Self> {
+        let current_dir = std::env::current_dir()?;
+        Ok(Self(absolutize::absolutize_from(
+            &current_dir,
+            &current_dir,
+        )))
+    }
+
+    /// Construct an absolute path from `path`, resolving relative paths against
+    /// the process current working directory.
+    pub fn relative_to_current_dir<P: AsRef<Path>>(path: P) -> std::io::Result<Self> {
+        Ok(Self::resolve_path_against_base(
+            path,
+            std::env::current_dir()?,
+        ))
+    }
+
+    pub fn join<P: AsRef<Path>>(&self, path: P) -> Self {
+        Self::resolve_path_against_base(path, &self.0)
+    }
+
+    pub fn canonicalize(&self) -> std::io::Result<Self> {
+        dunce::canonicalize(&self.0).map(Self)
+    }
+
+    pub fn parent(&self) -> Option<Self> {
+        self.0.parent().map(|p| {
+            debug_assert!(
+                p.is_absolute(),
+                "parent of AbsolutePathBuf must be absolute"
+            );
+            Self(p.to_path_buf())
+        })
+    }
+
+    pub fn ancestors(&self) -> impl Iterator<Item = Self> + '_ {
+        self.0.ancestors().map(|p| {
+            debug_assert!(
+                p.is_absolute(),
+                "ancestor of AbsolutePathBuf must be absolute"
+            );
+            Self(p.to_path_buf())
+        })
+    }
+
+    pub fn as_path(&self) -> &Path {
+        &self.0
+    }
+
+    pub fn into_path_buf(self) -> PathBuf {
+        self.0
+    }
+
+    pub fn to_path_buf(&self) -> PathBuf {
+        self.0.clone()
+    }
+
+    pub fn to_string_lossy(&self) -> std::borrow::Cow<'_, str> {
+        self.0.to_string_lossy()
+    }
+
+    pub fn display(&self) -> Display<'_> {
+        self.0.display()
+    }
+}
+
+impl AsRef<Path> for AbsolutePathBuf {
+    fn as_ref(&self) -> &Path {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for AbsolutePathBuf {
+    type Target = Path;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl From<AbsolutePathBuf> for PathBuf {
+    fn from(path: AbsolutePathBuf) -> Self {
+        path.into_path_buf()
+    }
+}
+
+impl TryFrom<&Path> for AbsolutePathBuf {
+    type Error = std::io::Error;
+
+    fn try_from(value: &Path) -> Result<Self, Self::Error> {
+        Self::from_absolute_path(value)
+    }
+}
+
+impl TryFrom<PathBuf> for AbsolutePathBuf {
+    type Error = std::io::Error;
+
+    fn try_from(value: PathBuf) -> Result<Self, Self::Error> {
+        Self::from_absolute_path(value)
+    }
+}
+
+impl TryFrom<&str> for AbsolutePathBuf {
+    type Error = std::io::Error;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        Self::from_absolute_path(value)
+    }
+}
+
+impl TryFrom<String> for AbsolutePathBuf {
+    type Error = std::io::Error;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::from_absolute_path(value)
+    }
+}
+
+/// Deserialize an absolute path. Mirrors upstream's "no guard installed"
+/// branch: only already-absolute paths are accepted; relative paths produce
+/// a deserialization error. The `AbsolutePathBufGuard` thread-local mechanism
+/// upstream uses to relative-resolve during config load is intentionally not
+/// ported (windows-sandbox configs are loaded through paths that are already
+/// absolute by construction).
+impl<'de> Deserialize<'de> for AbsolutePathBuf {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let path = PathBuf::deserialize(deserializer)?;
+        if path.is_absolute() {
+            Self::from_absolute_path(path).map_err(SerdeError::custom)
+        } else {
+            Err(SerdeError::custom("AbsolutePathBuf: path is not absolute"))
+        }
+    }
+}
+
+/// Helper to construct platform-absolute test paths.
+///
+/// On Windows, `/tmp/example` maps to `C:\tmp\example`. Lifted from the
+/// upstream `test_support` module; the `PathExt`/`PathBufExt` traits were
+/// dropped because they require `expect()` (forbidden by the workspace
+/// no-panic guard).
+#[cfg(test)]
+pub(crate) fn test_path_buf(unix_path: &str) -> PathBuf {
+    if cfg!(windows) {
+        let mut path = PathBuf::from(r"C:\");
+        path.extend(
+            unix_path
+                .trim_start_matches('/')
+                .split('/')
+                .filter(|segment| !segment.is_empty()),
+        );
+        path
+    } else {
+        PathBuf::from(unix_path)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn from_absolute_path_checked_rejects_relative_path() {
+        let err = AbsolutePathBuf::from_absolute_path_checked("relative/path")
+            .expect_err("relative path should fail");
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+    }
+
+    #[test]
+    fn resolve_relative_path_against_base() {
+        let base = test_path_buf("/base");
+        let abs = AbsolutePathBuf::resolve_path_against_base("file.txt", &base);
+        assert_eq!(abs.as_path(), base.join("file.txt").as_path());
+    }
+
+    #[test]
+    fn resolve_normalizes_dot_dot() {
+        let base = test_path_buf("/base");
+        let abs = AbsolutePathBuf::resolve_path_against_base("./nested/../file.txt", &base);
+        assert_eq!(abs.as_path(), base.join("file.txt").as_path());
+    }
+
+    #[test]
+    fn ancestors_returns_absolute_path_bufs() {
+        let abs = AbsolutePathBuf::from_absolute_path_checked(test_path_buf("/tmp/one/two"))
+            .expect("absolute path");
+        let got: Vec<PathBuf> = abs.ancestors().map(|p| p.to_path_buf()).collect();
+        let expected = vec![
+            test_path_buf("/tmp/one/two"),
+            test_path_buf("/tmp/one"),
+            test_path_buf("/tmp"),
+            test_path_buf("/"),
+        ];
+        assert_eq!(got, expected);
+    }
+
+    #[test]
+    fn try_from_absolute_str_succeeds() {
+        let s = test_path_buf("/abs/path");
+        let abs = AbsolutePathBuf::try_from(s.to_str().expect("utf8")).expect("absolute");
+        assert_eq!(abs.as_path(), s.as_path());
+    }
+
+    #[test]
+    fn serde_round_trips_absolute_path() {
+        let s = test_path_buf("/abs/path");
+        let abs =
+            AbsolutePathBuf::from_absolute_path_checked(&s).expect("absolute path constructable");
+        let json = serde_json::to_string(&abs).expect("serialize");
+        let back: AbsolutePathBuf = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back.as_path(), s.as_path());
+    }
+
+    #[test]
+    fn serde_rejects_relative_path() {
+        let json = serde_json::to_string("relative/path").expect("serialize string");
+        let err = serde_json::from_str::<AbsolutePathBuf>(&json)
+            .expect_err("relative path should fail");
+        assert!(err.to_string().contains("not absolute"));
+    }
+}

--- a/crates/dasclaw_sandbox_windows/src/absolute_path.rs
+++ b/crates/dasclaw_sandbox_windows/src/absolute_path.rs
@@ -309,8 +309,8 @@ mod tests {
     #[test]
     fn serde_rejects_relative_path() {
         let json = serde_json::to_string("relative/path").expect("serialize string");
-        let err = serde_json::from_str::<AbsolutePathBuf>(&json)
-            .expect_err("relative path should fail");
+        let err =
+            serde_json::from_str::<AbsolutePathBuf>(&json).expect_err("relative path should fail");
         assert!(err.to_string().contains("not absolute"));
     }
 }

--- a/crates/dasclaw_sandbox_windows/src/absolute_path/absolutize.rs
+++ b/crates/dasclaw_sandbox_windows/src/absolute_path/absolutize.rs
@@ -1,0 +1,157 @@
+// Derived from openai/codex commit 6e838a19fa
+//   path: codex-rs/utils/absolute-path/src/absolutize.rs
+// SPDX-License-Identifier: Apache-2.0
+//
+// Adapted from path-absolutize 3.1.1:
+// Copyright (c) 2018 magiclen.org (Ron Li)
+// Licensed under the MIT License.
+//
+// Keep this implementation local so explicit-base normalization can be
+// infallible for `AbsolutePathBuf::resolve_path_against_base` and
+// `AbsolutePathBuf::join`; only current-working-directory lookup remains
+// fallible.
+
+use std::path::Component;
+use std::path::Path;
+use std::path::PathBuf;
+
+pub(super) fn absolutize(path: &Path) -> std::io::Result<PathBuf> {
+    if path.is_absolute() {
+        return Ok(normalize_path(path));
+    }
+
+    Ok(absolutize_from(path, &std::env::current_dir()?))
+}
+
+pub(super) fn absolutize_from(path: &Path, base_path: &Path) -> PathBuf {
+    normalize_path(&path_with_base(path, base_path))
+}
+
+fn normalize_path(path: &Path) -> PathBuf {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                normalized.pop();
+            }
+            Component::Prefix(_) | Component::RootDir | Component::Normal(_) => {
+                normalized.push(component.as_os_str());
+            }
+        }
+    }
+
+    if normalized.as_os_str().is_empty() {
+        PathBuf::from(".")
+    } else {
+        normalized
+    }
+}
+
+#[cfg(not(windows))]
+fn path_with_base(path: &Path, base_path: &Path) -> PathBuf {
+    if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        base_path.join(path)
+    }
+}
+
+#[cfg(windows)]
+fn path_with_base(path: &Path, base_path: &Path) -> PathBuf {
+    if path.is_absolute() || path.has_root() {
+        return base_path.join(path);
+    }
+
+    let mut components = path.components();
+    let Some(Component::Prefix(prefix)) = components.next() else {
+        return base_path.join(path);
+    };
+
+    let mut path = PathBuf::new();
+    path.push(prefix.as_os_str());
+
+    if components.clone().next().is_none() {
+        path.push(std::path::MAIN_SEPARATOR_STR);
+        return path;
+    }
+
+    let skip_base_prefix = matches!(base_path.components().next(), Some(Component::Prefix(_)));
+    for component in base_path
+        .components()
+        .skip(usize::from(skip_base_prefix))
+        .chain(components)
+    {
+        path.push(component.as_os_str());
+    }
+    path
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[cfg(unix)]
+    #[test]
+    fn absolute_path_without_dots_is_unchanged() {
+        assert_eq!(
+            absolutize_from(Path::new("/path/to/123/456"), Path::new("/base")),
+            PathBuf::from("/path/to/123/456")
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn absolute_path_dots_are_removed() {
+        assert_eq!(
+            absolutize_from(Path::new("/path/to/./123/../456"), Path::new("/base")),
+            PathBuf::from("/path/to/456")
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn relative_path_without_dot_uses_base() {
+        assert_eq!(
+            absolutize_from(Path::new("path/to/123/456"), Path::new("/base")),
+            PathBuf::from("/base/path/to/123/456")
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn relative_path_with_parent_dir_uses_base_parent() {
+        assert_eq!(
+            absolutize_from(Path::new("../path/to/123/456"), Path::new("/base/cwd")),
+            PathBuf::from("/base/path/to/123/456")
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn parent_dir_above_root_stays_at_root() {
+        assert_eq!(
+            absolutize_from(Path::new("../../path/to/123/456"), Path::new("/")),
+            PathBuf::from("/path/to/123/456")
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_root_relative_path_uses_base_prefix() {
+        assert_eq!(
+            absolutize_from(Path::new(r"\path\to\file"), Path::new(r"C:\base\cwd")),
+            PathBuf::from(r"C:\path\to\file")
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_drive_relative_path_uses_path_prefix_and_base_tail() {
+        assert_eq!(
+            absolutize_from(Path::new(r"D:path\to\file"), Path::new(r"C:\base\cwd")),
+            PathBuf::from(r"D:\base\cwd\path\to\file")
+        );
+    }
+}

--- a/crates/dasclaw_sandbox_windows/src/lib.rs
+++ b/crates/dasclaw_sandbox_windows/src/lib.rs
@@ -22,6 +22,7 @@
 //! The actual Win32 sandbox logic (AppContainer, JobObject, network ACLs)
 //! lands in subsequent PRs under tracker issue #250.
 
+pub mod absolute_path;
 pub mod string_util;
 pub mod types;
 

--- a/crates/dasclaw_sandbox_windows/src/types.rs
+++ b/crates/dasclaw_sandbox_windows/src/types.rs
@@ -10,17 +10,17 @@
 //! Phase 1.1.0; downstream PRs may reintroduce them if x-claw needs the
 //! corresponding capabilities.
 //!
-//! `AbsolutePathBuf` is also part of the upstream sandbox-policy surface; it
-//! lives in `codex-utils-absolute-path`. Until that helper is ported in
-//! PR-1.1.1, this module uses `std::path::PathBuf` for `writable_roots`. The
-//! serde representation is unchanged (a JSON array of path strings), so the
-//! switch to `AbsolutePathBuf` is a non-breaking refinement.
+//! `writable_roots` and `WritableRoot::{root, read_only_subpaths}` use
+//! [`AbsolutePathBuf`](crate::absolute_path::AbsolutePathBuf), matching
+//! upstream `codex-protocol`. The serde representation is a JSON array of
+//! path strings; `AbsolutePathBuf::Deserialize` rejects relative paths.
 
 use std::path::Path;
-use std::path::PathBuf;
 
 use serde::Deserialize;
 use serde::Serialize;
+
+use crate::absolute_path::AbsolutePathBuf;
 
 /// Represents whether outbound network access is available to the agent.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
@@ -70,7 +70,7 @@ pub enum SandboxPolicy {
         /// Additional folders (beyond cwd and possibly TMPDIR) that should be
         /// writable from within the sandbox.
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
-        writable_roots: Vec<PathBuf>,
+        writable_roots: Vec<AbsolutePathBuf>,
 
         /// When set to `true`, outbound network access is allowed. `false` by
         /// default.
@@ -94,19 +94,19 @@ pub enum SandboxPolicy {
 /// read-only even when the root is writable.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct WritableRoot {
-    pub root: PathBuf,
+    pub root: AbsolutePathBuf,
 
     /// By construction, these subpaths are all under `root`.
-    pub read_only_subpaths: Vec<PathBuf>,
+    pub read_only_subpaths: Vec<AbsolutePathBuf>,
 }
 
 impl WritableRoot {
     pub fn is_path_writable(&self, path: &Path) -> bool {
-        if !path.starts_with(&self.root) {
+        if !path.starts_with(self.root.as_path()) {
             return false;
         }
         for subpath in &self.read_only_subpaths {
-            if path.starts_with(subpath) {
+            if path.starts_with(subpath.as_path()) {
                 return false;
             }
         }
@@ -197,12 +197,35 @@ mod tests {
 
     #[test]
     fn writable_root_blocks_paths_under_read_only_subpath() {
+        let repo = crate::absolute_path::test_path_buf("/repo");
+        let dotgit = crate::absolute_path::test_path_buf("/repo/.git");
+        let main_rs = crate::absolute_path::test_path_buf("/repo/src/main.rs");
+        let head = crate::absolute_path::test_path_buf("/repo/.git/HEAD");
+        let other = crate::absolute_path::test_path_buf("/other/path");
         let root = WritableRoot {
-            root: PathBuf::from("/repo"),
-            read_only_subpaths: vec![PathBuf::from("/repo/.git")],
+            root: AbsolutePathBuf::from_absolute_path_checked(&repo).expect("abs repo"),
+            read_only_subpaths: vec![
+                AbsolutePathBuf::from_absolute_path_checked(&dotgit).expect("abs .git"),
+            ],
         };
-        assert!(root.is_path_writable(Path::new("/repo/src/main.rs")));
-        assert!(!root.is_path_writable(Path::new("/repo/.git/HEAD")));
-        assert!(!root.is_path_writable(Path::new("/other/path")));
+        assert!(root.is_path_writable(&main_rs));
+        assert!(!root.is_path_writable(&head));
+        assert!(!root.is_path_writable(&other));
+    }
+
+    #[test]
+    fn workspace_write_with_writable_roots_round_trips() {
+        let root_path = crate::absolute_path::test_path_buf("/extra/root");
+        let abs = AbsolutePathBuf::from_absolute_path_checked(&root_path).expect("abs path");
+        let policy = SandboxPolicy::WorkspaceWrite {
+            writable_roots: vec![abs.clone()],
+            network_access: false,
+            exclude_tmpdir_env_var: false,
+            exclude_slash_tmp: false,
+        };
+        let json = serde_json::to_string(&policy).expect("serialize");
+        assert!(json.contains("writable_roots"));
+        let parsed: SandboxPolicy = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(policy, parsed);
     }
 }


### PR DESCRIPTION
## 背景 / 目标

Phase 1.1 tracker #250 第 3 步（V'-b path）。把 `codex-utils-absolute-path::AbsolutePathBuf` 按需移植进 `crate::absolute_path`，然后在 `crate::types` 把 `WritableRoot.{root, read_only_subpaths}` 和 `SandboxPolicy::WorkspaceWrite::writable_roots` 从 `PathBuf` 换成 `AbsolutePathBuf`，吃掉 #254 / #252 留下的 TODO，使 sandbox 类型与上游 `codex-protocol` 完全对齐。

## 改动范围

- 新建 [crates/dasclaw_sandbox_windows/src/absolute_path.rs](crates/dasclaw_sandbox_windows/src/absolute_path.rs)：来自上游 `codex-rs/utils/absolute-path/src/lib.rs` @ `6e838a19fa` 的瘦身移植。
- 新建 [crates/dasclaw_sandbox_windows/src/absolute_path/absolutize.rs](crates/dasclaw_sandbox_windows/src/absolute_path/absolutize.rs)：上游 `absolutize` 子模块原样移植（含其 path-absolutize 3.1.1 / MIT 的二级 attribution）。
- [crates/dasclaw_sandbox_windows/Cargo.toml](crates/dasclaw_sandbox_windows/Cargo.toml)：新增 runtime deps `dirs = "6"`（home-dir 展开）、`dunce = "1.0"`（`canonicalize`）；dev-dep `tempfile = "3"`。
- [crates/dasclaw_sandbox_windows/src/lib.rs](crates/dasclaw_sandbox_windows/src/lib.rs)：`pub mod absolute_path;`。
- [crates/dasclaw_sandbox_windows/src/types.rs](crates/dasclaw_sandbox_windows/src/types.rs)：`WritableRoot.{root, read_only_subpaths}` + `SandboxPolicy::WorkspaceWrite::writable_roots` `PathBuf → AbsolutePathBuf`，删掉 TODO 注释；`writable_root_blocks_paths_under_read_only_subpath` 改用 `AbsolutePathBuf`，新增 `workspace_write_with_writable_roots_round_trips`。

## 非目标 (What's NOT in this PR)

- ❌ 上游 `JsonSchema` / `ts_rs::TS` 派生（无 schema/TS 生成需求）。
- ❌ 上游 `AbsolutePathBufGuard` thread-local + relative-against-base 反序列化（windows-sandbox-rs 配置入口的路径在传入时已是绝对路径；用瘦身版本对应上游 "no guard installed" 分支：相对路径反序列化直接报错）。
- ❌ `canonicalize_preserving_symlinks` / `canonicalize_existing_preserving_symlinks`（codex CLI 其他模块用，windows-sandbox-rs 不用）。
- ❌ `test_support::PathExt` / `PathBufExt`（依赖 `expect()`，被 workspace no-panic guard 禁止）。
- ❌ Win32 / `cfg(windows)` 代码、`vendor/` 修改、`SandboxRuntime` 接线。

## 验证

```bash
cargo nextest run -p dasclaw_sandbox_windows
# Summary: 27 tests run: 27 passed, 0 skipped  (was 14/14 in #254)

cargo fmt --all                                                  # clean
python3.12 scripts/check_no_panics.py --base origin/xClaw
# OK: No panic-inducing calls in changed production code.
python3.12 scripts/check_no_new_ironclaw_literal.py --base origin/xClaw
# OK: No new .ironclaw / IRONCLAW_BASE_DIR literals introduced.
cargo clippy --no-deps -p dasclaw_sandbox_windows --all-targets -- -D warnings
# Finished `dev` profile ... (clean)
```

## Refs

- Closes #255
- Phase 1.1 tracker: #250
- Predecessor: #254 (squash `68d0f2f7`, PR-1.1.1)
- Epic: #241  ·  ADR-121 D3-3
