### PR TITLE
feat(sandbox-windows): port codex_utils_pty cross-platform core (Phase 1.1.3a)

### DIFF
--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -25,8 +25,15 @@ on:
       - 'feat/win/**'
       - 'ci/win-**'
       - 'windows-**'
+    # 任何分支动到 Windows 沙箱代码或 vendor 快照都触发（PR-1.1.3a 起）
+    paths:
+      - 'crates/dasclaw_sandbox_windows/**'
+      - 'vendor/codex-windows-sandbox/**'
+      - '.github/workflows/windows-ci.yml'
   pull_request:
     types: [opened, synchronize, reopened, labeled]
+    # 注意：保留 label 全局触发（任何 PR 标 windows-ci 都跑），
+    # 同时 push 端的 paths 已覆盖 Windows 沙箱目录的回归保护。
 
 permissions:
   contents: read

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1258,7 +1258,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1da5ab77c1437701eeff7c88d968729e7766172279eab0676857b3d63af7a6f"
 dependencies = [
  "borsh-derive",
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
 ]
 
 [[package]]
@@ -1610,6 +1610,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "cfg_aliases"
@@ -2641,7 +2647,7 @@ dependencies = [
 name = "dasclaw_pty"
 version = "0.1.0-w2"
 dependencies = [
- "portable-pty",
+ "portable-pty 0.8.1",
  "thiserror 1.0.69",
 ]
 
@@ -2669,10 +2675,13 @@ dependencies = [
  "anyhow",
  "dirs 6.0.0",
  "dunce",
+ "libc",
+ "portable-pty 0.9.0",
  "pretty_assertions",
  "serde",
  "serde_json",
  "tempfile",
+ "tokio",
 ]
 
 [[package]]
@@ -5802,13 +5811,25 @@ dependencies = [
 
 [[package]]
 name = "nix"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "cfg_aliases 0.1.1",
+ "libc",
+]
+
+[[package]]
+name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
  "bitflags 2.11.0",
  "cfg-if",
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "libc",
  "memoffset 0.9.1",
 ]
@@ -5821,7 +5842,7 @@ checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
  "bitflags 2.11.0",
  "cfg-if",
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "libc",
 ]
 
@@ -6853,6 +6874,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-pty"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4a596a2b3d2752d94f51fac2d4a96737b8705dddd311a32b9af47211f08671e"
+dependencies = [
+ "anyhow",
+ "bitflags 1.3.2",
+ "downcast-rs",
+ "filedescriptor",
+ "lazy_static",
+ "libc",
+ "log",
+ "nix 0.28.0",
+ "serial2",
+ "shared_library",
+ "shell-words",
+ "winapi",
+ "winreg 0.10.1",
+]
+
+[[package]]
 name = "postcard"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7144,7 +7186,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
 dependencies = [
  "bytes",
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
@@ -7184,7 +7226,7 @@ version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
 dependencies = [
- "cfg_aliases",
+ "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
  "socket2 0.6.3",
@@ -8558,6 +8600,17 @@ checksum = "15c6d3b776267a75d31bbdfd5d36c0ca051251caafc285827052bc53bcdc8162"
 dependencies = [
  "libc",
  "serial-core",
+]
+
+[[package]]
+name = "serial2"
+version = "0.2.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcdbc46aa3882ec3d48ec2b5abcb4f0d863a13d7599265f3faa6d851f23c12f3"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "winapi",
 ]
 
 [[package]]

--- a/crates/dasclaw_sandbox_windows/Cargo.toml
+++ b/crates/dasclaw_sandbox_windows/Cargo.toml
@@ -14,12 +14,19 @@ path = "src/lib.rs"
 anyhow = "1"
 dirs = "6"
 dunce = "1.0"
+portable-pty = "0.9.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+tokio = { version = "1", features = ["macros", "rt", "sync", "time"] }
 
-# Win32 deps land in PR-1.1.3+ when actual sandbox logic is ported.
-# Skeleton intentionally has no platform-specific deps yet.
+# libc is unix-only; required by `pty::process` for the unix resize path.
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
+# Win32 transport (RawConPty + win::*) lands in PR-1.1.3b.
+# Until then, no `cfg(windows)`-only deps are required.
 
 [dev-dependencies]
 pretty_assertions = "1"
 tempfile = "3"
+tokio = { version = "1", features = ["macros", "rt", "sync", "time", "test-util"] }

--- a/crates/dasclaw_sandbox_windows/src/lib.rs
+++ b/crates/dasclaw_sandbox_windows/src/lib.rs
@@ -9,20 +9,28 @@
 //! See `vendor/codex-windows-sandbox/README.md` for the reference snapshot
 //! and the porting plan in tracker issue #250.
 //!
-//! ## Crate status (Phase 1.1.0)
+//! ## Crate status (Phase 1.1.3a)
 //!
-//! This is the **skeleton-only** revision. It exposes:
+//! V'-b "port-on-demand" subset. The cross-platform PTY/process plumbing
+//! (`pty::process`) required by `windows-sandbox-rs` is now in tree.
+//! The `cfg(windows)`-only ConPTY backend (`pty::win::*`, `RawConPty`) lands
+//! with PR-1.1.3b.
 //!
-//! - The sandbox policy types (`types::SandboxPolicy`, `types::NetworkAccess`,
-//!   `types::WritableRoot`) so callers across the workspace can construct
-//!   policies on every platform.
+//! Currently exposed:
+//!
+//! - Sandbox policy types (`types::SandboxPolicy`, `types::NetworkAccess`,
+//!   `types::WritableRoot`).
+//! - String / path utilities (`string_util`, `absolute_path`).
+//! - Cross-platform PTY/process driver adapter (`pty::ProcessDriver`,
+//!   `pty::SpawnedProcess`, `pty::TerminalSize`, `pty::spawn_from_driver`).
 //! - On non-Windows targets, [`unsupported`] returns a typed error indicating
-//!   that the Windows sandbox is unavailable on the current platform.
+//!   that the Windows sandbox runtime is unavailable.
 //!
 //! The actual Win32 sandbox logic (AppContainer, JobObject, network ACLs)
 //! lands in subsequent PRs under tracker issue #250.
 
 pub mod absolute_path;
+pub mod pty;
 pub mod string_util;
 pub mod types;
 

--- a/crates/dasclaw_sandbox_windows/src/pty.rs
+++ b/crates/dasclaw_sandbox_windows/src/pty.rs
@@ -1,0 +1,26 @@
+// Derived from openai/codex commit 6e838a19fa
+//   path: codex-rs/utils/pty/src/lib.rs
+// SPDX-License-Identifier: Apache-2.0
+
+//! PTY/process plumbing required by the Windows sandbox.
+//!
+//! V'-b "port-on-demand" subset of `codex-utils-pty`. Only the symbols
+//! actually consumed by `windows-sandbox-rs` are exposed:
+//!
+//! - [`TerminalSize`] — terminal cell dimensions for spawn / resize.
+//! - [`SpawnedProcess`] — return value of spawn helpers.
+//! - [`ProcessDriver`] — adapter for backends that own their own transport.
+//! - [`spawn_from_driver`] — turns a [`ProcessDriver`] into a [`SpawnedProcess`].
+//! - `RawConPty` — `cfg(windows)` only, lands with PR-1.1.3b.
+//!
+//! Upstream's `pipe`, `pty`, `process_group`, and bundled `tests` modules
+//! are intentionally omitted: nothing in `windows-sandbox-rs` imports them.
+
+mod process;
+
+pub use process::ProcessDriver;
+pub use process::ProcessHandle;
+pub use process::SpawnedProcess;
+pub use process::TerminalSize;
+pub use process::combine_output_receivers;
+pub use process::spawn_from_driver;

--- a/crates/dasclaw_sandbox_windows/src/pty/process.rs
+++ b/crates/dasclaw_sandbox_windows/src/pty/process.rs
@@ -1,0 +1,507 @@
+// Derived from openai/codex commit 6e838a19fa
+//   path: codex-rs/utils/pty/src/process.rs
+// SPDX-License-Identifier: Apache-2.0
+
+use core::fmt;
+use std::io;
+#[cfg(unix)]
+use std::os::fd::RawFd;
+use std::sync::Arc;
+use std::sync::Mutex as StdMutex;
+use std::sync::atomic::AtomicBool;
+
+use anyhow::anyhow;
+use portable_pty::MasterPty;
+use portable_pty::PtySize;
+use portable_pty::SlavePty;
+use tokio::sync::broadcast;
+use tokio::sync::mpsc;
+use tokio::sync::oneshot;
+use tokio::sync::watch;
+use tokio::task::AbortHandle;
+use tokio::task::JoinHandle;
+
+pub(crate) trait ChildTerminator: Send + Sync {
+    fn kill(&mut self) -> io::Result<()>;
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct TerminalSize {
+    pub rows: u16,
+    pub cols: u16,
+}
+
+impl Default for TerminalSize {
+    fn default() -> Self {
+        Self { rows: 24, cols: 80 }
+    }
+}
+
+impl From<TerminalSize> for PtySize {
+    fn from(value: TerminalSize) -> Self {
+        Self {
+            rows: value.rows,
+            cols: value.cols,
+            pixel_width: 0,
+            pixel_height: 0,
+        }
+    }
+}
+
+#[cfg(unix)]
+pub(crate) trait PtyHandleKeepAlive: Send {}
+
+#[cfg(unix)]
+impl<T: Send + ?Sized> PtyHandleKeepAlive for T {}
+
+// `Resizable` is constructed by the upstream PTY spawn helper and `Opaque` by
+// the unix raw-fd path; both land with PR-1.1.3b. In the 1.1.3a slice, only
+// driver-backed sessions exist, which leave `_pty_handles` as `None`.
+#[allow(dead_code)]
+pub(crate) enum PtyMasterHandle {
+    Resizable(Box<dyn MasterPty + Send>),
+    #[cfg(unix)]
+    Opaque {
+        raw_fd: RawFd,
+        _handle: Box<dyn PtyHandleKeepAlive>,
+    },
+}
+
+pub struct PtyHandles {
+    pub _slave: Option<Box<dyn SlavePty + Send>>,
+    pub(crate) _master: PtyMasterHandle,
+}
+
+impl fmt::Debug for PtyHandles {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PtyHandles").finish()
+    }
+}
+
+/// Callback used by driver-backed sessions to resize a PTY-like backend when
+/// there is no local `PtyHandles` instance to resize directly.
+type ResizeFn = Box<dyn FnMut(TerminalSize) -> anyhow::Result<()> + Send>;
+
+/// Handle for driving an interactive process (PTY or pipe).
+pub struct ProcessHandle {
+    writer_tx: StdMutex<Option<mpsc::Sender<Vec<u8>>>>,
+    killer: StdMutex<Option<Box<dyn ChildTerminator>>>,
+    reader_handle: StdMutex<Option<JoinHandle<()>>>,
+    reader_abort_handles: StdMutex<Vec<AbortHandle>>,
+    writer_handle: StdMutex<Option<JoinHandle<()>>>,
+    wait_handle: StdMutex<Option<JoinHandle<()>>>,
+    exit_status: Arc<AtomicBool>,
+    exit_code: Arc<StdMutex<Option<i32>>>,
+    // PtyHandles must be preserved because the process will receive Control+C if the
+    // slave is closed
+    _pty_handles: StdMutex<Option<PtyHandles>>,
+    // Optional resize hook for driver-backed sessions that proxy PTY control to
+    // another backend instead of owning local PTY handles.
+    resizer: StdMutex<Option<ResizeFn>>,
+}
+
+impl fmt::Debug for ProcessHandle {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ProcessHandle").finish()
+    }
+}
+
+impl ProcessHandle {
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn new(
+        writer_tx: mpsc::Sender<Vec<u8>>,
+        killer: Box<dyn ChildTerminator>,
+        reader_handle: JoinHandle<()>,
+        reader_abort_handles: Vec<AbortHandle>,
+        writer_handle: JoinHandle<()>,
+        wait_handle: JoinHandle<()>,
+        exit_status: Arc<AtomicBool>,
+        exit_code: Arc<StdMutex<Option<i32>>>,
+        pty_handles: Option<PtyHandles>,
+        resizer: Option<ResizeFn>,
+    ) -> Self {
+        Self {
+            writer_tx: StdMutex::new(Some(writer_tx)),
+            killer: StdMutex::new(Some(killer)),
+            reader_handle: StdMutex::new(Some(reader_handle)),
+            reader_abort_handles: StdMutex::new(reader_abort_handles),
+            writer_handle: StdMutex::new(Some(writer_handle)),
+            wait_handle: StdMutex::new(Some(wait_handle)),
+            exit_status,
+            exit_code,
+            _pty_handles: StdMutex::new(pty_handles),
+            resizer: StdMutex::new(resizer),
+        }
+    }
+
+    /// Returns a channel sender for writing raw bytes to the child stdin.
+    pub fn writer_sender(&self) -> mpsc::Sender<Vec<u8>> {
+        if let Ok(writer_tx) = self.writer_tx.lock()
+            && let Some(writer_tx) = writer_tx.as_ref()
+        {
+            return writer_tx.clone();
+        }
+
+        let (writer_tx, writer_rx) = mpsc::channel(1);
+        drop(writer_rx);
+        writer_tx
+    }
+
+    /// True if the child process has exited.
+    pub fn has_exited(&self) -> bool {
+        self.exit_status.load(std::sync::atomic::Ordering::SeqCst)
+    }
+
+    /// Returns the exit code if known.
+    pub fn exit_code(&self) -> Option<i32> {
+        self.exit_code.lock().ok().and_then(|guard| *guard)
+    }
+
+    /// Resize the PTY in character cells.
+    pub fn resize(&self, size: TerminalSize) -> anyhow::Result<()> {
+        {
+            let handles = self
+                ._pty_handles
+                .lock()
+                .map_err(|_| anyhow!("failed to lock PTY handles"))?;
+            if let Some(handles) = handles.as_ref() {
+                return match &handles._master {
+                    PtyMasterHandle::Resizable(master) => master.resize(size.into()),
+                    #[cfg(unix)]
+                    PtyMasterHandle::Opaque { raw_fd, .. } => resize_raw_pty(*raw_fd, size),
+                };
+            }
+        }
+
+        let mut resizer = self
+            .resizer
+            .lock()
+            .map_err(|_| anyhow!("failed to lock PTY resizer"))?;
+        if let Some(resizer) = resizer.as_mut() {
+            resizer(size)
+        } else {
+            Err(anyhow!("process is not attached to a PTY"))
+        }
+    }
+
+    /// Close the child's stdin channel.
+    pub fn close_stdin(&self) {
+        if let Ok(mut writer_tx) = self.writer_tx.lock() {
+            writer_tx.take();
+        }
+    }
+
+    /// Attempts to kill the child while leaving the reader/writer tasks alive
+    /// so callers can still drain output until EOF.
+    pub fn request_terminate(&self) {
+        if let Ok(mut killer_opt) = self.killer.lock()
+            && let Some(mut killer) = killer_opt.take()
+        {
+            let _ = killer.kill();
+        }
+    }
+
+    /// Attempts to kill the child and abort helper tasks.
+    pub fn terminate(&self) {
+        self.request_terminate();
+
+        if let Ok(mut h) = self.reader_handle.lock()
+            && let Some(handle) = h.take()
+        {
+            handle.abort();
+        }
+        if let Ok(mut handles) = self.reader_abort_handles.lock() {
+            for handle in handles.drain(..) {
+                handle.abort();
+            }
+        }
+        if let Ok(mut h) = self.writer_handle.lock()
+            && let Some(handle) = h.take()
+        {
+            handle.abort();
+        }
+        if let Ok(mut h) = self.wait_handle.lock()
+            && let Some(handle) = h.take()
+        {
+            handle.abort();
+        }
+    }
+}
+
+impl Drop for ProcessHandle {
+    fn drop(&mut self) {
+        self.terminate();
+    }
+}
+
+/// Adapts a closure into a `ChildTerminator` implementation.
+struct ClosureTerminator {
+    inner: Option<Box<dyn FnMut() + Send + Sync>>,
+}
+
+impl ChildTerminator for ClosureTerminator {
+    fn kill(&mut self) -> io::Result<()> {
+        if let Some(inner) = self.inner.as_mut() {
+            (inner)();
+        }
+        Ok(())
+    }
+}
+
+#[cfg(unix)]
+fn resize_raw_pty(raw_fd: RawFd, size: TerminalSize) -> anyhow::Result<()> {
+    let mut winsize = libc::winsize {
+        ws_row: size.rows,
+        ws_col: size.cols,
+        ws_xpixel: 0,
+        ws_ypixel: 0,
+    };
+    let result = unsafe { libc::ioctl(raw_fd, libc::TIOCSWINSZ, &mut winsize) };
+    if result == -1 {
+        return Err(std::io::Error::last_os_error().into());
+    }
+    Ok(())
+}
+
+/// Combine split stdout/stderr receivers into a single broadcast receiver.
+pub fn combine_output_receivers(
+    mut stdout_rx: mpsc::Receiver<Vec<u8>>,
+    mut stderr_rx: mpsc::Receiver<Vec<u8>>,
+) -> broadcast::Receiver<Vec<u8>> {
+    let (combined_tx, combined_rx) = broadcast::channel(256);
+    tokio::spawn(async move {
+        let mut stdout_open = true;
+        let mut stderr_open = true;
+
+        loop {
+            tokio::select! {
+                stdout = stdout_rx.recv(), if stdout_open => match stdout {
+                    Some(chunk) => {
+                        let _ = combined_tx.send(chunk);
+                    }
+                    None => {
+                        stdout_open = false;
+                    }
+                },
+                stderr = stderr_rx.recv(), if stderr_open => match stderr {
+                    Some(chunk) => {
+                        let _ = combined_tx.send(chunk);
+                    }
+                    None => {
+                        stderr_open = false;
+                    }
+                },
+                else => break,
+            }
+        }
+    });
+    combined_rx
+}
+
+/// Return value from PTY or pipe spawn helpers.
+#[derive(Debug)]
+pub struct SpawnedProcess {
+    pub session: ProcessHandle,
+    pub stdout_rx: mpsc::Receiver<Vec<u8>>,
+    pub stderr_rx: mpsc::Receiver<Vec<u8>>,
+    pub exit_rx: oneshot::Receiver<i32>,
+}
+
+/// Driver-backed process handles for non-standard spawn backends.
+pub struct ProcessDriver {
+    pub writer_tx: mpsc::Sender<Vec<u8>>,
+    pub stdout_rx: broadcast::Receiver<Vec<u8>>,
+    pub stderr_rx: Option<broadcast::Receiver<Vec<u8>>>,
+    pub exit_rx: oneshot::Receiver<i32>,
+    pub terminator: Option<Box<dyn FnMut() + Send + Sync>>,
+    pub writer_handle: Option<JoinHandle<()>>,
+    pub resizer: Option<ResizeFn>,
+}
+
+/// Build a `SpawnedProcess` from a driver that supplies stdin/output/exit channels.
+pub fn spawn_from_driver(driver: ProcessDriver) -> SpawnedProcess {
+    let ProcessDriver {
+        writer_tx,
+        stdout_rx: stdout_driver_rx,
+        stderr_rx: mut stderr_driver_rx,
+        exit_rx,
+        terminator,
+        writer_handle,
+        resizer,
+    } = driver;
+
+    let (stdout_tx, stdout_rx) = mpsc::channel::<Vec<u8>>(256);
+    let (stderr_tx, stderr_rx) = mpsc::channel::<Vec<u8>>(256);
+    let (exit_seen_tx, exit_seen_rx) = watch::channel(false);
+    let spawn_stream_reader =
+        |mut output_rx: broadcast::Receiver<Vec<u8>>,
+         output_tx: mpsc::Sender<Vec<u8>>,
+         mut exit_seen_rx: watch::Receiver<bool>| {
+            tokio::spawn(async move {
+                let mut process_exited = false;
+                loop {
+                    let recv_result = if process_exited {
+                        match tokio::time::timeout(
+                            std::time::Duration::from_millis(200),
+                            output_rx.recv(),
+                        )
+                        .await
+                        {
+                            Ok(result) => result,
+                            Err(_) => break,
+                        }
+                    } else {
+                        tokio::select! {
+                            _ = exit_seen_rx.changed() => {
+                                process_exited = *exit_seen_rx.borrow();
+                                continue;
+                            }
+                            result = output_rx.recv() => result,
+                        }
+                    };
+                    match recv_result {
+                        Ok(chunk) => {
+                            if output_tx.send(chunk).await.is_err() {
+                                break;
+                            }
+                        }
+                        Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
+                        Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+                    }
+                }
+            })
+        };
+    let reader_handle = spawn_stream_reader(stdout_driver_rx, stdout_tx, exit_seen_rx.clone());
+    let stderr_reader_handle = stderr_driver_rx
+        .take()
+        .map(|rx| spawn_stream_reader(rx, stderr_tx, exit_seen_rx));
+
+    let writer_handle = writer_handle.unwrap_or_else(|| tokio::spawn(async {}));
+
+    let (exit_tx, exit_rx_out) = oneshot::channel::<i32>();
+    let exit_status = Arc::new(AtomicBool::new(false));
+    let wait_exit_status = Arc::clone(&exit_status);
+    let exit_code = Arc::new(StdMutex::new(None));
+    let wait_exit_code = Arc::clone(&exit_code);
+    let wait_handle = tokio::spawn(async move {
+        let code = exit_rx.await.unwrap_or(-1);
+        wait_exit_status.store(true, std::sync::atomic::Ordering::SeqCst);
+        if let Ok(mut guard) = wait_exit_code.lock() {
+            *guard = Some(code);
+        }
+        let _ = exit_seen_tx.send(true);
+        let _ = exit_tx.send(code);
+    });
+
+    let handle = ProcessHandle::new(
+        writer_tx,
+        Box::new(ClosureTerminator { inner: terminator }),
+        reader_handle,
+        stderr_reader_handle
+            .map(|handle| handle.abort_handle())
+            .into_iter()
+            .collect(),
+        writer_handle,
+        wait_handle,
+        exit_status,
+        exit_code,
+        /*pty_handles*/ None,
+        resizer,
+    );
+
+    SpawnedProcess {
+        session: handle,
+        stdout_rx,
+        stderr_rx,
+        exit_rx: exit_rx_out,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! Driver-only unit tests. We deliberately do **not** spawn real child
+    //! processes here — that path is exercised by `windows-sandbox-rs` on
+    //! Windows CI once PR-1.1.3b lands the ConPTY backend.
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn terminal_size_default_is_24_by_80() {
+        assert_eq!(TerminalSize::default(), TerminalSize { rows: 24, cols: 80 });
+    }
+
+    #[test]
+    fn terminal_size_into_pty_size_zero_pixel_dims() {
+        let pty: PtySize = TerminalSize {
+            rows: 30,
+            cols: 100,
+        }
+        .into();
+        assert_eq!(pty.rows, 30);
+        assert_eq!(pty.cols, 100);
+        assert_eq!(pty.pixel_width, 0);
+        assert_eq!(pty.pixel_height, 0);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn spawn_from_driver_forwards_stdout_and_exit_code() {
+        let (writer_tx, _writer_rx) = mpsc::channel::<Vec<u8>>(8);
+        let (stdout_tx, stdout_rx) = broadcast::channel::<Vec<u8>>(8);
+        let (exit_tx, exit_rx) = oneshot::channel::<i32>();
+
+        let driver = ProcessDriver {
+            writer_tx,
+            stdout_rx,
+            stderr_rx: None,
+            exit_rx,
+            terminator: None,
+            writer_handle: None,
+            resizer: None,
+        };
+
+        let mut spawned = spawn_from_driver(driver);
+
+        // Push one chunk, then signal exit with code 7.
+        stdout_tx.send(b"hello".to_vec()).expect("send");
+        exit_tx.send(7).expect("exit");
+
+        // Drain stdout — first the explicit chunk, then channel closes.
+        let chunk = spawned.stdout_rx.recv().await.expect("chunk");
+        assert_eq!(chunk, b"hello");
+
+        let code = spawned.exit_rx.await.expect("exit code");
+        assert_eq!(code, 7);
+
+        // Allow background tasks to observe exit.
+        tokio::task::yield_now().await;
+        assert!(spawned.session.has_exited());
+        assert_eq!(spawned.session.exit_code(), Some(7));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn process_handle_resize_without_pty_or_resizer_errors() {
+        let (writer_tx, _writer_rx) = mpsc::channel::<Vec<u8>>(8);
+        let (_stdout_tx, stdout_rx) = broadcast::channel::<Vec<u8>>(8);
+        let (_exit_tx, exit_rx) = oneshot::channel::<i32>();
+
+        let driver = ProcessDriver {
+            writer_tx,
+            stdout_rx,
+            stderr_rx: None,
+            exit_rx,
+            terminator: None,
+            writer_handle: None,
+            resizer: None,
+        };
+
+        let spawned = spawn_from_driver(driver);
+        let err = spawned
+            .session
+            .resize(TerminalSize {
+                rows: 50,
+                cols: 120,
+            })
+            .expect_err("driver-only handle without resizer should refuse resize");
+        assert!(err.to_string().contains("not attached to a PTY"));
+    }
+}


### PR DESCRIPTION
## 背景 / 目标

Phase 1.1.3a — 按 V'-b "port-on-demand" 规则把 `codex-utils-pty` 跨平台核心移植进 `dasclaw_sandbox_windows`，为 PR-1.1.3b 的 ConPTY 后端铺路。

扫描结果：windows-sandbox-rs 仅 import 5 个 `codex_utils_pty` 符号 — `TerminalSize` / `SpawnedProcess` / `ProcessDriver` / `spawn_from_driver`（4 个跨平台，全在 `process.rs`）+ `RawConPty`（cfg(windows)，留给 1.1.3b）。`pipe.rs` / `pty.rs` / `process_group.rs` / 上游 `tests.rs` 零依赖，全部跳过。

## 改动范围

- **新增** `crates/dasclaw_sandbox_windows/src/pty.rs` — mod 入口，仅 `pub use` windows-sandbox-rs 实际需要的符号；注释指向 1.1.3b。
- **新增** `crates/dasclaw_sandbox_windows/src/pty/process.rs` — verbatim 移植自 `codex-rs/utils/pty/src/process.rs`，含归属头 `// Derived from openai/codex commit 6e838a19fa`、SPDX Apache-2.0。`PtyMasterHandle` 加 `#[allow(dead_code)]` 因为构造方在 1.1.3b 才入。新增 driver-only 单测：`terminal_size_default_is_24_by_80` / `terminal_size_into_pty_size_zero_pixel_dims` / `spawn_from_driver_forwards_stdout_and_exit_code` / `process_handle_resize_without_pty_or_resizer_errors`。
- **改** `crates/dasclaw_sandbox_windows/Cargo.toml` — 加 `portable-pty = "0.9.0"`（与上游 6e838a19fa 同 pin）、`tokio = { version = "1", features = ["macros","rt","sync","time"] }`、`libc`（unix-only）；dev-dep 加 tokio test-util。
- **改** `crates/dasclaw_sandbox_windows/src/lib.rs` — 挂 `pub mod pty;`；Phase 文档 1.1.0 → 1.1.3a。
- **改** `.github/workflows/windows-ci.yml` — `on.push.paths` 加 `crates/dasclaw_sandbox_windows/**` + `vendor/codex-windows-sandbox/**` + 自身路径，履行 #256 mcp-feedback 截止承诺。`pull_request.paths` 故意保持不动以保留 `windows-ci` label 的全局触发语义。

## 非目标（What's NOT in this PR）

- ❌ 不引入任何 `cfg(windows)` 代码 / Win32 deps — 那是 PR-1.1.3b 的范围。
- ❌ 不移植 `codex-utils-pty` 的 `pipe.rs` / `pty.rs`(spawn 助手) / `process_group.rs` — windows-sandbox-rs 不用。
- ❌ 不移植上游 `tests.rs`（1055 LOC 的 e2e harness）— 我们写各自闭环的 driver-only 单测。
- ❌ 不改任何下游 caller（只是把符号摆好；windows-sandbox-rs 真正接入在更后续 PR）。
- ❌ 不动 `windows-ci.yml` 的 `pull_request` paths（保持 `windows-ci` label 全局可用）。

## 验证

```
cargo check -p dasclaw_sandbox_windows --tests
  → Finished `dev` profile, 1 dead_code warning (已加 #[allow])
cargo nextest run -p dasclaw_sandbox_windows
  → 31 tests run: 31 passed, 0 skipped
cargo fmt --all
  → no changes
python3.12 scripts/check_no_panics.py --base origin/xClaw
  → OK: No panic-inducing calls in changed production code.
python3.12 scripts/check_no_new_ironclaw_literal.py --base origin/xClaw
  → OK: No new .ironclaw / IRONCLAW_BASE_DIR literals introduced.
cargo clippy --no-deps -p dasclaw_sandbox_windows --all-targets -- -D warnings
  → Finished `dev` profile, 0 warnings.
```

## 关联

- Issue: Closes #257
- 父：#250 (windows-sandbox-rs port plan), #246 (W4 epic)
- 前置：#256 (1.1.2 AbsolutePathBuf, squash 79502e0e)
- 后继：1.1.3b — 移植 `pty/win/{mod,conpty,procthreadattr,psuedocon}.rs` (~832 LOC, cfg(windows))，加 `filedescriptor` / `winapi` / `lazy_static` / `shared_library` deps
