### PR TITLE
feat(sandbox-windows): port codex_utils_pty win/* ConPTY backend (Phase 1.1.3b)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2675,13 +2675,18 @@ dependencies = [
  "anyhow",
  "dirs 6.0.0",
  "dunce",
+ "filedescriptor",
+ "lazy_static",
  "libc",
+ "log",
  "portable-pty 0.9.0",
  "pretty_assertions",
  "serde",
  "serde_json",
+ "shared_library",
  "tempfile",
  "tokio",
+ "winapi",
 ]
 
 [[package]]

--- a/crates/dasclaw_sandbox_windows/Cargo.toml
+++ b/crates/dasclaw_sandbox_windows/Cargo.toml
@@ -23,8 +23,25 @@ tokio = { version = "1", features = ["macros", "rt", "sync", "time"] }
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 
-# Win32 transport (RawConPty + win::*) lands in PR-1.1.3b.
-# Until then, no `cfg(windows)`-only deps are required.
+# Win32 transport (RawConPty + win::*).
+# These are required only when building for Windows targets.
+[target.'cfg(windows)'.dependencies]
+filedescriptor = "0.8"
+lazy_static = "1.4"
+log = "0.4"
+shared_library = "0.1"
+winapi = { version = "0.3", features = [
+  "handleapi",
+  "minwinbase",
+  "ntdef",
+  "ntstatus",
+  "processthreadsapi",
+  "synchapi",
+  "winbase",
+  "wincon",
+  "winerror",
+  "winnt",
+] }
 
 [dev-dependencies]
 pretty_assertions = "1"

--- a/crates/dasclaw_sandbox_windows/src/lib.rs
+++ b/crates/dasclaw_sandbox_windows/src/lib.rs
@@ -9,12 +9,12 @@
 //! See `vendor/codex-windows-sandbox/README.md` for the reference snapshot
 //! and the porting plan in tracker issue #250.
 //!
-//! ## Crate status (Phase 1.1.3a)
+//! ## Crate status (Phase 1.1.3b)
 //!
 //! V'-b "port-on-demand" subset. The cross-platform PTY/process plumbing
-//! (`pty::process`) required by `windows-sandbox-rs` is now in tree.
-//! The `cfg(windows)`-only ConPTY backend (`pty::win::*`, `RawConPty`) lands
-//! with PR-1.1.3b.
+//! (`pty::process`) and the `cfg(windows)`-only ConPTY backend
+//! (`pty::win::*`, `RawConPty`) required by `windows-sandbox-rs` are now in
+//! tree.
 //!
 //! Currently exposed:
 //!

--- a/crates/dasclaw_sandbox_windows/src/pty.rs
+++ b/crates/dasclaw_sandbox_windows/src/pty.rs
@@ -11,12 +11,15 @@
 //! - [`SpawnedProcess`] — return value of spawn helpers.
 //! - [`ProcessDriver`] — adapter for backends that own their own transport.
 //! - [`spawn_from_driver`] — turns a [`ProcessDriver`] into a [`SpawnedProcess`].
-//! - `RawConPty` — `cfg(windows)` only, lands with PR-1.1.3b.
+//! - [`RawConPty`] — `cfg(windows)` only ConPTY backend (PR-1.1.3b).
 //!
 //! Upstream's `pipe`, `pty`, `process_group`, and bundled `tests` modules
 //! are intentionally omitted: nothing in `windows-sandbox-rs` imports them.
 
 mod process;
+
+#[cfg(windows)]
+mod win;
 
 pub use process::ProcessDriver;
 pub use process::ProcessHandle;
@@ -24,3 +27,6 @@ pub use process::SpawnedProcess;
 pub use process::TerminalSize;
 pub use process::combine_output_receivers;
 pub use process::spawn_from_driver;
+
+#[cfg(windows)]
+pub use win::RawConPty;

--- a/crates/dasclaw_sandbox_windows/src/pty/win/conpty.rs
+++ b/crates/dasclaw_sandbox_windows/src/pty/win/conpty.rs
@@ -1,0 +1,196 @@
+// Derived from openai/codex commit 6e838a19fa
+//   path: codex-rs/utils/pty/src/win/conpty.rs
+// SPDX-License-Identifier: MIT
+//
+// Original WezTerm copyright preserved below.
+
+#![allow(clippy::unwrap_used)]
+
+// This file is copied from https://github.com/wezterm/wezterm (MIT license).
+// Copyright (c) 2018-Present Wez Furlong
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+use super::psuedocon::PsuedoCon;
+use anyhow::Error;
+use filedescriptor::FileDescriptor;
+use filedescriptor::Pipe;
+use portable_pty::Child;
+use portable_pty::MasterPty;
+use portable_pty::PtyPair;
+use portable_pty::PtySize;
+use portable_pty::PtySystem;
+use portable_pty::SlavePty;
+use portable_pty::cmdbuilder::CommandBuilder;
+use std::mem::ManuallyDrop;
+use std::os::windows::io::AsRawHandle;
+use std::os::windows::io::RawHandle;
+use std::sync::Arc;
+use std::sync::Mutex;
+use winapi::um::wincon::COORD;
+
+#[derive(Default)]
+pub struct ConPtySystem {}
+
+fn create_conpty_handles(
+    size: PtySize,
+) -> anyhow::Result<(PsuedoCon, FileDescriptor, FileDescriptor)> {
+    let stdin = Pipe::new()?;
+    let stdout = Pipe::new()?;
+
+    let con = PsuedoCon::new(
+        COORD {
+            X: size.cols as i16,
+            Y: size.rows as i16,
+        },
+        stdin.read,
+        stdout.write,
+    )?;
+
+    Ok((con, stdin.write, stdout.read))
+}
+
+pub struct RawConPty {
+    con: PsuedoCon,
+    input_write: FileDescriptor,
+    output_read: FileDescriptor,
+}
+
+impl RawConPty {
+    pub fn new(cols: i16, rows: i16) -> anyhow::Result<Self> {
+        let (con, input_write, output_read) = create_conpty_handles(PtySize {
+            rows: rows as u16,
+            cols: cols as u16,
+            pixel_width: 0,
+            pixel_height: 0,
+        })?;
+        Ok(Self {
+            con,
+            input_write,
+            output_read,
+        })
+    }
+
+    pub fn pseudoconsole_handle(&self) -> RawHandle {
+        self.con.raw_handle()
+    }
+
+    pub fn into_raw_handles(self) -> (RawHandle, RawHandle, RawHandle) {
+        let me = ManuallyDrop::new(self);
+        (
+            me.con.raw_handle(),
+            me.input_write.as_raw_handle(),
+            me.output_read.as_raw_handle(),
+        )
+    }
+}
+
+impl PtySystem for ConPtySystem {
+    fn openpty(&self, size: PtySize) -> anyhow::Result<PtyPair> {
+        let (con, writable, readable) = create_conpty_handles(size)?;
+
+        let master = ConPtyMasterPty {
+            inner: Arc::new(Mutex::new(Inner {
+                con,
+                readable,
+                writable: Some(writable),
+                size,
+            })),
+        };
+
+        let slave = ConPtySlavePty {
+            inner: master.inner.clone(),
+        };
+
+        Ok(PtyPair {
+            master: Box::new(master),
+            slave: Box::new(slave),
+        })
+    }
+}
+
+struct Inner {
+    con: PsuedoCon,
+    readable: FileDescriptor,
+    writable: Option<FileDescriptor>,
+    size: PtySize,
+}
+
+impl Inner {
+    pub fn resize(
+        &mut self,
+        num_rows: u16,
+        num_cols: u16,
+        pixel_width: u16,
+        pixel_height: u16,
+    ) -> Result<(), Error> {
+        self.con.resize(COORD {
+            X: num_cols as i16,
+            Y: num_rows as i16,
+        })?;
+        self.size = PtySize {
+            rows: num_rows,
+            cols: num_cols,
+            pixel_width,
+            pixel_height,
+        };
+        Ok(())
+    }
+}
+
+#[derive(Clone)]
+pub struct ConPtyMasterPty {
+    inner: Arc<Mutex<Inner>>,
+}
+
+pub struct ConPtySlavePty {
+    inner: Arc<Mutex<Inner>>,
+}
+
+impl MasterPty for ConPtyMasterPty {
+    fn resize(&self, size: PtySize) -> anyhow::Result<()> {
+        let mut inner = self.inner.lock().unwrap(); // safety: poisoned mutex implies prior panic; propagating is acceptable for sandbox driver
+        inner.resize(size.rows, size.cols, size.pixel_width, size.pixel_height)
+    }
+
+    fn get_size(&self) -> Result<PtySize, Error> {
+        let inner = self.inner.lock().unwrap(); // safety: poisoned mutex implies prior panic; propagating is acceptable for sandbox driver
+        Ok(inner.size)
+    }
+
+    fn try_clone_reader(&self) -> anyhow::Result<Box<dyn std::io::Read + Send>> {
+        Ok(Box::new(self.inner.lock().unwrap().readable.try_clone()?)) // safety: poisoned mutex implies prior panic; propagating is acceptable for sandbox driver
+    }
+
+    fn take_writer(&self) -> anyhow::Result<Box<dyn std::io::Write + Send>> {
+        Ok(Box::new(
+            self.inner
+                .lock()
+                .unwrap() // safety: poisoned mutex implies prior panic; propagating is acceptable for sandbox driver
+                .writable
+                .take()
+                .ok_or_else(|| anyhow::anyhow!("writer already taken"))?,
+        ))
+    }
+}
+
+impl SlavePty for ConPtySlavePty {
+    fn spawn_command(&self, cmd: CommandBuilder) -> anyhow::Result<Box<dyn Child + Send + Sync>> {
+        let inner = self.inner.lock().unwrap(); // safety: poisoned mutex implies prior panic; propagating is acceptable for sandbox driver
+        let child = inner.con.spawn_command(cmd)?;
+        Ok(Box::new(child))
+    }
+}

--- a/crates/dasclaw_sandbox_windows/src/pty/win/mod.rs
+++ b/crates/dasclaw_sandbox_windows/src/pty/win/mod.rs
@@ -1,0 +1,181 @@
+// Derived from openai/codex commit 6e838a19fa
+//   path: codex-rs/utils/pty/src/win/mod.rs
+// SPDX-License-Identifier: MIT
+//
+// Original WezTerm copyright preserved below.
+
+#![allow(clippy::unwrap_used)]
+
+// This file is copied from https://github.com/wezterm/wezterm (MIT license).
+// Copyright (c) 2018-Present Wez Furlong
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// Local modifications:
+// - Fix Codex bug #13945 in the Windows PTY kill path. The vendored code treated
+//   `TerminateProcess`'s nonzero success return as failure and `0` as success,
+//   which inverts kill outcomes for both `WinChild::do_kill` and
+//   `WinChildKiller::kill`.
+// - This bug still exists in the original WezTerm source as of 2026-03-08, so
+//   this is an intentional divergence from upstream.
+
+use anyhow::Context as _;
+use filedescriptor::OwnedHandle;
+use portable_pty::Child;
+use portable_pty::ChildKiller;
+use portable_pty::ExitStatus;
+use std::io::Error as IoError;
+use std::io::Result as IoResult;
+use std::os::windows::io::AsRawHandle;
+use std::pin::Pin;
+use std::sync::Mutex;
+use std::task::Context;
+use std::task::Poll;
+use winapi::shared::minwindef::DWORD;
+use winapi::um::minwinbase::STILL_ACTIVE;
+use winapi::um::processthreadsapi::*;
+use winapi::um::synchapi::WaitForSingleObject;
+use winapi::um::winbase::INFINITE;
+
+pub(crate) mod conpty;
+mod procthreadattr;
+mod psuedocon;
+
+pub use conpty::ConPtySystem;
+pub use conpty::RawConPty;
+pub use psuedocon::conpty_supported;
+
+#[derive(Debug)]
+pub struct WinChild {
+    proc: Mutex<OwnedHandle>,
+}
+
+impl WinChild {
+    fn is_complete(&mut self) -> IoResult<Option<ExitStatus>> {
+        let mut status: DWORD = 0;
+        let proc = self.proc.lock().unwrap().try_clone().unwrap(); // safety: poisoned mutex / clone failure imply prior panic; propagating is acceptable for sandbox driver
+        let res = unsafe { GetExitCodeProcess(proc.as_raw_handle() as _, &mut status) };
+        if res != 0 {
+            if status == STILL_ACTIVE {
+                Ok(None)
+            } else {
+                Ok(Some(ExitStatus::with_exit_code(status)))
+            }
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn do_kill(&mut self) -> IoResult<()> {
+        let proc = self.proc.lock().unwrap().try_clone().unwrap(); // safety: poisoned mutex / clone failure imply prior panic; propagating is acceptable for sandbox driver
+        let res = unsafe { TerminateProcess(proc.as_raw_handle() as _, 1) };
+        // Codex bug #13945: Win32 returns nonzero on success, so only `0` is an error.
+        if res == 0 {
+            Err(IoError::last_os_error())
+        } else {
+            Ok(())
+        }
+    }
+}
+
+impl ChildKiller for WinChild {
+    fn kill(&mut self) -> IoResult<()> {
+        self.do_kill().ok();
+        Ok(())
+    }
+
+    fn clone_killer(&self) -> Box<dyn ChildKiller + Send + Sync> {
+        let proc = self.proc.lock().unwrap().try_clone().unwrap(); // safety: poisoned mutex / clone failure imply prior panic; propagating is acceptable for sandbox driver
+        Box::new(WinChildKiller { proc })
+    }
+}
+
+#[derive(Debug)]
+pub struct WinChildKiller {
+    proc: OwnedHandle,
+}
+
+impl ChildKiller for WinChildKiller {
+    fn kill(&mut self) -> IoResult<()> {
+        let res = unsafe { TerminateProcess(self.proc.as_raw_handle() as _, 1) };
+        // Codex bug #13945: Win32 returns nonzero on success, so only `0` is an error.
+        if res == 0 {
+            Err(IoError::last_os_error())
+        } else {
+            Ok(())
+        }
+    }
+
+    fn clone_killer(&self) -> Box<dyn ChildKiller + Send + Sync> {
+        let proc = self.proc.try_clone().unwrap(); // safety: clone failure implies handle exhaustion; propagating is acceptable for sandbox driver
+        Box::new(WinChildKiller { proc })
+    }
+}
+
+impl Child for WinChild {
+    fn try_wait(&mut self) -> IoResult<Option<ExitStatus>> {
+        self.is_complete()
+    }
+
+    fn wait(&mut self) -> IoResult<ExitStatus> {
+        if let Ok(Some(status)) = self.try_wait() {
+            return Ok(status);
+        }
+        let proc = self.proc.lock().unwrap().try_clone().unwrap(); // safety: poisoned mutex / clone failure imply prior panic; propagating is acceptable for sandbox driver
+        unsafe {
+            WaitForSingleObject(proc.as_raw_handle() as _, INFINITE);
+        }
+        let mut status: DWORD = 0;
+        let res = unsafe { GetExitCodeProcess(proc.as_raw_handle() as _, &mut status) };
+        if res != 0 {
+            Ok(ExitStatus::with_exit_code(status))
+        } else {
+            Err(IoError::last_os_error())
+        }
+    }
+
+    fn process_id(&self) -> Option<u32> {
+        let res = unsafe { GetProcessId(self.proc.lock().unwrap().as_raw_handle() as _) }; // safety: poisoned mutex implies prior panic; propagating is acceptable for sandbox driver
+        if res == 0 { None } else { Some(res) }
+    }
+
+    fn as_raw_handle(&self) -> Option<std::os::windows::io::RawHandle> {
+        let proc = self.proc.lock().unwrap(); // safety: poisoned mutex implies prior panic; propagating is acceptable for sandbox driver
+        Some(proc.as_raw_handle())
+    }
+}
+
+impl std::future::Future for WinChild {
+    type Output = anyhow::Result<ExitStatus>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<anyhow::Result<ExitStatus>> {
+        match self.is_complete() {
+            Ok(Some(status)) => Poll::Ready(Ok(status)),
+            Err(err) => Poll::Ready(Err(err).context("Failed to retrieve process exit status")),
+            Ok(None) => {
+                let proc = self.proc.lock().unwrap().try_clone()?; // safety: poisoned mutex implies prior panic; propagating is acceptable for sandbox driver
+                let waker = cx.waker().clone();
+                std::thread::spawn(move || {
+                    unsafe {
+                        WaitForSingleObject(proc.as_raw_handle() as _, INFINITE);
+                    }
+                    waker.wake();
+                });
+                Poll::Pending
+            }
+        }
+    }
+}

--- a/crates/dasclaw_sandbox_windows/src/pty/win/procthreadattr.rs
+++ b/crates/dasclaw_sandbox_windows/src/pty/win/procthreadattr.rs
@@ -1,0 +1,97 @@
+// Derived from openai/codex commit 6e838a19fa
+//   path: codex-rs/utils/pty/src/win/procthreadattr.rs
+// SPDX-License-Identifier: MIT
+//
+// Original WezTerm copyright preserved below.
+
+#![allow(clippy::uninit_vec)]
+
+// This file is copied from https://github.com/wezterm/wezterm (MIT license).
+// Copyright (c) 2018-Present Wez Furlong
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+use super::psuedocon::HPCON;
+use anyhow::Error;
+use anyhow::ensure;
+use std::io::Error as IoError;
+use std::mem;
+use std::ptr;
+use winapi::shared::minwindef::DWORD;
+use winapi::um::processthreadsapi::*;
+
+const PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE: usize = 0x00020016;
+
+pub struct ProcThreadAttributeList {
+    data: Vec<u8>,
+}
+
+impl ProcThreadAttributeList {
+    pub fn with_capacity(num_attributes: DWORD) -> Result<Self, Error> {
+        let mut bytes_required: usize = 0;
+        unsafe {
+            InitializeProcThreadAttributeList(
+                ptr::null_mut(),
+                num_attributes,
+                0,
+                &mut bytes_required,
+            )
+        };
+        let mut data = Vec::with_capacity(bytes_required);
+        unsafe { data.set_len(bytes_required) };
+
+        let attr_ptr = data.as_mut_slice().as_mut_ptr() as *mut _;
+        let res = unsafe {
+            InitializeProcThreadAttributeList(attr_ptr, num_attributes, 0, &mut bytes_required)
+        };
+        ensure!(
+            res != 0,
+            "InitializeProcThreadAttributeList failed: {}",
+            IoError::last_os_error()
+        );
+        Ok(Self { data })
+    }
+
+    pub fn as_mut_ptr(&mut self) -> LPPROC_THREAD_ATTRIBUTE_LIST {
+        self.data.as_mut_slice().as_mut_ptr() as *mut _
+    }
+
+    pub fn set_pty(&mut self, con: HPCON) -> Result<(), Error> {
+        let res = unsafe {
+            UpdateProcThreadAttribute(
+                self.as_mut_ptr(),
+                0,
+                PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE,
+                con,
+                mem::size_of::<HPCON>(),
+                ptr::null_mut(),
+                ptr::null_mut(),
+            )
+        };
+        ensure!(
+            res != 0,
+            "UpdateProcThreadAttribute failed: {}",
+            IoError::last_os_error()
+        );
+        Ok(())
+    }
+}
+
+impl Drop for ProcThreadAttributeList {
+    fn drop(&mut self) {
+        unsafe { DeleteProcThreadAttributeList(self.as_mut_ptr()) };
+    }
+}

--- a/crates/dasclaw_sandbox_windows/src/pty/win/psuedocon.rs
+++ b/crates/dasclaw_sandbox_windows/src/pty/win/psuedocon.rs
@@ -1,0 +1,384 @@
+// Derived from openai/codex commit 6e838a19fa
+//   path: codex-rs/utils/pty/src/win/psuedocon.rs
+// SPDX-License-Identifier: MIT
+//
+// Original WezTerm copyright preserved below.
+
+#![allow(clippy::expect_used)]
+#![allow(clippy::upper_case_acronyms)]
+
+// This file is copied from https://github.com/wezterm/wezterm (MIT license).
+// Copyright (c) 2018-Present Wez Furlong
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+use super::WinChild;
+use super::procthreadattr::ProcThreadAttributeList;
+use anyhow::Error;
+use anyhow::bail;
+use anyhow::ensure;
+use filedescriptor::FileDescriptor;
+use filedescriptor::OwnedHandle;
+use lazy_static::lazy_static;
+use portable_pty::cmdbuilder::CommandBuilder;
+use shared_library::shared_library;
+use std::env;
+use std::ffi::OsStr;
+use std::ffi::OsString;
+use std::io::Error as IoError;
+use std::mem;
+use std::os::windows::ffi::OsStrExt;
+use std::os::windows::ffi::OsStringExt;
+use std::os::windows::io::AsRawHandle;
+use std::os::windows::io::FromRawHandle;
+use std::path::Path;
+use std::ptr;
+use std::sync::Mutex;
+use winapi::shared::minwindef::DWORD;
+use winapi::shared::ntdef::NTSTATUS;
+use winapi::shared::ntstatus::STATUS_SUCCESS;
+use winapi::shared::winerror::HRESULT;
+use winapi::shared::winerror::S_OK;
+use winapi::um::handleapi::*;
+use winapi::um::processthreadsapi::*;
+use winapi::um::winbase::CREATE_UNICODE_ENVIRONMENT;
+use winapi::um::winbase::EXTENDED_STARTUPINFO_PRESENT;
+use winapi::um::winbase::STARTF_USESTDHANDLES;
+use winapi::um::winbase::STARTUPINFOEXW;
+use winapi::um::wincon::COORD;
+use winapi::um::winnt::HANDLE;
+use winapi::um::winnt::OSVERSIONINFOW;
+
+pub type HPCON = HANDLE;
+
+pub const PSEUDOCONSOLE_RESIZE_QUIRK: DWORD = 0x2;
+#[allow(dead_code)]
+pub const PSEUDOCONSOLE_PASSTHROUGH_MODE: DWORD = 0x8;
+
+// https://learn.microsoft.com/en-gb/windows/console/createpseudoconsole
+// https://learn.microsoft.com/en-gb/windows/release-health/release-information
+const MIN_CONPTY_BUILD: u32 = 17_763;
+
+shared_library!(ConPtyFuncs,
+    pub fn CreatePseudoConsole(
+        size: COORD,
+        hInput: HANDLE,
+        hOutput: HANDLE,
+        flags: DWORD,
+        hpc: *mut HPCON
+    ) -> HRESULT,
+    pub fn ResizePseudoConsole(hpc: HPCON, size: COORD) -> HRESULT,
+    pub fn ClosePseudoConsole(hpc: HPCON),
+);
+
+shared_library!(Ntdll,
+    pub fn RtlGetVersion(
+        version_info: *mut OSVERSIONINFOW
+    ) -> NTSTATUS,
+);
+
+fn load_conpty() -> ConPtyFuncs {
+    let kernel = ConPtyFuncs::open(Path::new("kernel32.dll")).expect(
+        // safety: ConPTY APIs are required for the Windows sandbox; absence indicates an unsupported OS and is not recoverable
+        "this system does not support conpty.  Windows 10 October 2018 or newer is required",
+    );
+
+    if let Ok(sideloaded) = ConPtyFuncs::open(Path::new("conpty.dll")) {
+        sideloaded
+    } else {
+        kernel
+    }
+}
+
+lazy_static! {
+    static ref CONPTY: ConPtyFuncs = load_conpty();
+}
+
+pub fn conpty_supported() -> bool {
+    windows_build_number().is_some_and(|build| build >= MIN_CONPTY_BUILD)
+}
+
+fn windows_build_number() -> Option<u32> {
+    let ntdll = Ntdll::open(Path::new("ntdll.dll")).ok()?;
+    let mut info: OSVERSIONINFOW = unsafe { mem::zeroed() };
+    info.dwOSVersionInfoSize = mem::size_of::<OSVERSIONINFOW>() as u32;
+    let status = unsafe { (ntdll.RtlGetVersion)(&mut info) };
+    if status == STATUS_SUCCESS {
+        Some(info.dwBuildNumber)
+    } else {
+        None
+    }
+}
+
+pub struct PsuedoCon {
+    con: HPCON,
+    // CreatePseudoConsole borrows these pipe handles for the lifetime of the
+    // pseudoconsole, so we must keep owning them until ClosePseudoConsole.
+    _input: FileDescriptor,
+    _output: FileDescriptor,
+}
+
+unsafe impl Send for PsuedoCon {}
+unsafe impl Sync for PsuedoCon {}
+
+impl Drop for PsuedoCon {
+    fn drop(&mut self) {
+        unsafe { (CONPTY.ClosePseudoConsole)(self.con) };
+    }
+}
+
+impl PsuedoCon {
+    pub fn raw_handle(&self) -> HPCON {
+        self.con
+    }
+
+    pub fn new(size: COORD, input: FileDescriptor, output: FileDescriptor) -> Result<Self, Error> {
+        let mut con: HPCON = INVALID_HANDLE_VALUE;
+        let result = unsafe {
+            (CONPTY.CreatePseudoConsole)(
+                size,
+                input.as_raw_handle() as _,
+                output.as_raw_handle() as _,
+                PSEUDOCONSOLE_RESIZE_QUIRK,
+                &mut con,
+            )
+        };
+        ensure!(
+            result == S_OK,
+            "failed to create psuedo console: HRESULT {result}"
+        );
+        Ok(Self {
+            con,
+            _input: input,
+            _output: output,
+        })
+    }
+
+    pub fn resize(&self, size: COORD) -> Result<(), Error> {
+        let result = unsafe { (CONPTY.ResizePseudoConsole)(self.con, size) };
+        ensure!(
+            result == S_OK,
+            "failed to resize console to {}x{}: HRESULT: {}",
+            size.X,
+            size.Y,
+            result
+        );
+        Ok(())
+    }
+
+    pub fn spawn_command(&self, cmd: CommandBuilder) -> anyhow::Result<WinChild> {
+        let mut si: STARTUPINFOEXW = unsafe { mem::zeroed() };
+        si.StartupInfo.cb = mem::size_of::<STARTUPINFOEXW>() as u32;
+        si.StartupInfo.dwFlags = STARTF_USESTDHANDLES;
+        si.StartupInfo.hStdInput = INVALID_HANDLE_VALUE;
+        si.StartupInfo.hStdOutput = INVALID_HANDLE_VALUE;
+        si.StartupInfo.hStdError = INVALID_HANDLE_VALUE;
+
+        let mut attrs = ProcThreadAttributeList::with_capacity(/*num_attributes*/ 1)?;
+        attrs.set_pty(self.con)?;
+        si.lpAttributeList = attrs.as_mut_ptr();
+
+        let mut pi: PROCESS_INFORMATION = unsafe { mem::zeroed() };
+
+        let (mut exe, mut cmdline) = build_cmdline(&cmd)?;
+        let cmd_os = OsString::from_wide(&cmdline);
+
+        let cwd = resolve_current_directory(&cmd);
+        let mut env_block = build_environment_block(&cmd);
+
+        let res = unsafe {
+            CreateProcessW(
+                exe.as_mut_ptr(),
+                cmdline.as_mut_ptr(),
+                ptr::null_mut(),
+                ptr::null_mut(),
+                0,
+                EXTENDED_STARTUPINFO_PRESENT | CREATE_UNICODE_ENVIRONMENT,
+                env_block.as_mut_ptr() as *mut _,
+                cwd.as_ref().map_or(ptr::null(), std::vec::Vec::as_ptr),
+                &mut si.StartupInfo,
+                &mut pi,
+            )
+        };
+        if res == 0 {
+            let err = IoError::last_os_error();
+            let msg = format!(
+                "CreateProcessW `{:?}` in cwd `{:?}` failed: {}",
+                cmd_os,
+                cwd.as_ref().map(|c| OsString::from_wide(c)),
+                err
+            );
+            log::error!("{msg}");
+            bail!("{msg}");
+        }
+
+        let _main_thread = unsafe { OwnedHandle::from_raw_handle(pi.hThread as _) };
+        let proc = unsafe { OwnedHandle::from_raw_handle(pi.hProcess as _) };
+
+        Ok(WinChild {
+            proc: Mutex::new(proc),
+        })
+    }
+}
+
+fn resolve_current_directory(cmd: &CommandBuilder) -> Option<Vec<u16>> {
+    let home = cmd
+        .get_env("USERPROFILE")
+        .and_then(|path| Path::new(path).is_dir().then(|| path.to_owned()));
+    let cwd = cmd
+        .get_cwd()
+        .and_then(|path| Path::new(path).is_dir().then(|| path.to_owned()));
+    let dir = cwd.or(home)?;
+
+    let mut wide = Vec::new();
+    if Path::new(&dir).is_relative() {
+        if let Ok(current_dir) = env::current_dir() {
+            wide.extend(current_dir.join(&dir).as_os_str().encode_wide());
+        } else {
+            wide.extend(dir.encode_wide());
+        }
+    } else {
+        wide.extend(dir.encode_wide());
+    }
+    wide.push(0);
+    Some(wide)
+}
+
+fn build_environment_block(cmd: &CommandBuilder) -> Vec<u16> {
+    let mut block = Vec::new();
+    for (key, value) in cmd.iter_full_env_as_str() {
+        block.extend(OsStr::new(key).encode_wide());
+        block.push(b'=' as u16);
+        block.extend(OsStr::new(value).encode_wide());
+        block.push(0);
+    }
+    block.push(0);
+    block
+}
+
+fn build_cmdline(cmd: &CommandBuilder) -> anyhow::Result<(Vec<u16>, Vec<u16>)> {
+    let exe_os: OsString = if cmd.is_default_prog() {
+        cmd.get_env("ComSpec")
+            .unwrap_or(OsStr::new("cmd.exe"))
+            .to_os_string()
+    } else {
+        let argv = cmd.get_argv();
+        let Some(first) = argv.first() else {
+            anyhow::bail!("missing program name");
+        };
+        search_path(cmd, first)
+    };
+
+    let mut cmdline = Vec::new();
+    append_quoted(&exe_os, &mut cmdline);
+    for arg in cmd.get_argv().iter().skip(1) {
+        cmdline.push(' ' as u16);
+        ensure!(
+            !arg.encode_wide().any(|c| c == 0),
+            "invalid encoding for command line argument {arg:?}"
+        );
+        append_quoted(arg, &mut cmdline);
+    }
+    cmdline.push(0);
+
+    let mut exe: Vec<u16> = exe_os.encode_wide().collect();
+    exe.push(0);
+
+    Ok((exe, cmdline))
+}
+
+fn search_path(cmd: &CommandBuilder, exe: &OsStr) -> OsString {
+    if let Some(path) = cmd.get_env("PATH") {
+        let extensions = cmd.get_env("PATHEXT").unwrap_or(OsStr::new(".EXE"));
+        for path in env::split_paths(path) {
+            let candidate = path.join(exe);
+            if candidate.exists() {
+                return candidate.into_os_string();
+            }
+
+            for ext in env::split_paths(extensions) {
+                let ext = ext.to_str().unwrap_or("");
+                let path = path
+                    .join(exe)
+                    .with_extension(ext.strip_prefix('.').unwrap_or(ext));
+                if path.exists() {
+                    return path.into_os_string();
+                }
+            }
+        }
+    }
+
+    exe.to_os_string()
+}
+
+fn append_quoted(arg: &OsStr, cmdline: &mut Vec<u16>) {
+    if !arg.is_empty()
+        && !arg.encode_wide().any(|c| {
+            c == ' ' as u16
+                || c == '\t' as u16
+                || c == '\n' as u16
+                || c == '\x0b' as u16
+                || c == '\"' as u16
+        })
+    {
+        cmdline.extend(arg.encode_wide());
+        return;
+    }
+    cmdline.push('"' as u16);
+
+    let arg: Vec<_> = arg.encode_wide().collect();
+    let mut i = 0;
+    while i < arg.len() {
+        let mut num_backslashes = 0;
+        while i < arg.len() && arg[i] == '\\' as u16 {
+            i += 1;
+            num_backslashes += 1;
+        }
+
+        if i == arg.len() {
+            for _ in 0..num_backslashes * 2 {
+                cmdline.push('\\' as u16);
+            }
+            break;
+        } else if arg[i] == b'"' as u16 {
+            for _ in 0..num_backslashes * 2 + 1 {
+                cmdline.push('\\' as u16);
+            }
+            cmdline.push(arg[i]);
+        } else {
+            for _ in 0..num_backslashes {
+                cmdline.push('\\' as u16);
+            }
+            cmdline.push(arg[i]);
+        }
+        i += 1;
+    }
+    cmdline.push('"' as u16);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::MIN_CONPTY_BUILD;
+    use super::windows_build_number;
+
+    #[test]
+    fn windows_build_number_returns_value() {
+        // We can't stably check the version of the GH workers, but we can
+        // at least check that this.
+        let version = windows_build_number().unwrap();
+        assert!(version > MIN_CONPTY_BUILD);
+    }
+}

--- a/crates/dasclaw_sandbox_windows/src/pty/win/psuedocon.rs
+++ b/crates/dasclaw_sandbox_windows/src/pty/win/psuedocon.rs
@@ -90,11 +90,11 @@ shared_library!(Ntdll,
     ) -> NTSTATUS,
 );
 
+const CONPTY_UNSUPPORTED: &str =
+    "this system does not support conpty.  Windows 10 October 2018 or newer is required";
+
 fn load_conpty() -> ConPtyFuncs {
-    let kernel = ConPtyFuncs::open(Path::new("kernel32.dll")).expect(
-        // safety: ConPTY APIs are required for the Windows sandbox; absence indicates an unsupported OS and is not recoverable
-        "this system does not support conpty.  Windows 10 October 2018 or newer is required",
-    );
+    let kernel = ConPtyFuncs::open(Path::new("kernel32.dll")).expect(CONPTY_UNSUPPORTED); // safety: ConPTY APIs are required for the Windows sandbox; absence indicates an unsupported OS and is not recoverable
 
     if let Ok(sideloaded) = ConPtyFuncs::open(Path::new("conpty.dll")) {
         sideloaded


### PR DESCRIPTION
## 背景 / 目标

Phase 1.1.3b — 把 `codex-utils-pty` 的 `cfg(windows)` ConPTY 后端按 V'-b "port-on-demand" 移植 进 `dasclaw_sandbox_windows`。结合 #258 (1.1.3a, squash `63ab35df`) 的跨平台核心，`pty::*` 在 unix/windows 双平台编译就绪，`RawConPty` 在 Windows target 下导出，为 `windows-sandbox-rs` 主体落地铺最后一段路。

WezTerm 上游 15 处 `unwrap()/expect()` 通过 `scripts/check_no_panics.py:243` 原生支持的 `// safety: <reason>` 逐行豁免协议标注（非放宽脚本、非新增全局 allow），并保留 Codex bug #13945 的 TerminateProcess 反转修复（与上游 WezTerm 的故意分歧已记入文件头注释）。

## 改动范围

- `crates/dasclaw_sandbox_windows/src/pty/win/mod.rs` (174 LOC) — `WinChild` / `WinChildKiller` + `Child`/`ChildKiller`/`Future` impls，含 #13945 修复
- `crates/dasclaw_sandbox_windows/src/pty/win/conpty.rs` (190 LOC) — `ConPtySystem` / `RawConPty` / `ConPtyMasterPty` / `ConPtySlavePty`
- `crates/dasclaw_sandbox_windows/src/pty/win/procthreadattr.rs` (91 LOC) — `ProcThreadAttributeList`
- `crates/dasclaw_sandbox_windows/src/pty/win/psuedocon.rs` (377 LOC) — `PsuedoCon` + `load_conpty()` + cmdline/env builder
- `crates/dasclaw_sandbox_windows/src/pty.rs` — 加 `#[cfg(windows)] mod win` + `pub use win::RawConPty`
- `crates/dasclaw_sandbox_windows/Cargo.toml` — 加 `[target.'cfg(windows)'.dependencies]` filedescriptor / lazy_static / log / shared_library / winapi 0.3
- `crates/dasclaw_sandbox_windows/src/lib.rs` — Phase doc 1.1.3a → 1.1.3b
- 每个移植文件带 `// Derived from openai/codex commit 6e838a19fa // path: codex-rs/utils/pty/src/win/<file>.rs // SPDX-License-Identifier: MIT` 头，保留 WezTerm 原始版权块

## 非目标（What's NOT in this PR）

- 不实现 Win32 sandbox 主体（AppContainer / JobObject / 网络 ACL）
- 不动 1.1.3a 已落库的 process.rs
- 不放宽 `scripts/check_no_panics.py`、不加全局 `#![allow(clippy::unwrap_used)]`（仅文件级，与上游一致）
- 不动 codex-cli-main 上游只读快照
- 不动 claw-code/（ADR-118）；不引入 .ironclaw / IRONCLAW_BASE_DIR 字面量（ADR-114）

## 验证（在本地 macOS 上）

```
cargo check -p dasclaw_sandbox_windows --tests
  → Finished `dev` profile, 0 warnings
cargo nextest run -p dasclaw_sandbox_windows
  → 31 tests run: 31 passed, 0 skipped (cfg(windows) tests 由 Windows CI 跑)
cargo fmt --all
  → no changes
python3.12 scripts/check_no_panics.py --base origin/xClaw
  → OK: No panic-inducing calls in changed production code.
python3.12 scripts/check_no_new_ironclaw_literal.py --base origin/xClaw
  → OK: No new .ironclaw / IRONCLAW_BASE_DIR literals introduced.
cargo clippy --no-deps -p dasclaw_sandbox_windows --all-targets -- -D warnings
  → Finished `dev` profile, 0 warnings.
```

Windows-target 编译验证依赖 GitHub Actions 的 `windows-ci.yml`（已在 #258 把 `crates/dasclaw_sandbox_windows/**` 加入 `on.push.paths`）。

## 关联

- Closes #260
- 父：#250 (windows-sandbox-rs port plan), #246 (W4 epic)
- 前置：#258 (1.1.3a, squash `63ab35df`)
- Cross-cuts ADR-114 / ADR-118
