### PR TITLE
feat(sandbox-windows): port path_normalization.rs (Phase 1.1.4a)

### DIFF
--- a/crates/dasclaw_sandbox_windows/src/lib.rs
+++ b/crates/dasclaw_sandbox_windows/src/lib.rs
@@ -9,27 +9,29 @@
 //! See `vendor/codex-windows-sandbox/README.md` for the reference snapshot
 //! and the porting plan in tracker issue #250.
 //!
-//! ## Crate status (Phase 1.1.3b)
+//! ## Crate status (Phase 1.1.4a)
 //!
 //! V'-b "port-on-demand" subset. The cross-platform PTY/process plumbing
 //! (`pty::process`) and the `cfg(windows)`-only ConPTY backend
-//! (`pty::win::*`, `RawConPty`) required by `windows-sandbox-rs` are now in
-//! tree.
+//! (`pty::win::*`, `RawConPty`) are in tree, and the leaf path-key utilities
+//! consumed by the sandbox have started landing.
 //!
 //! Currently exposed:
 //!
 //! - Sandbox policy types (`types::SandboxPolicy`, `types::NetworkAccess`,
 //!   `types::WritableRoot`).
-//! - String / path utilities (`string_util`, `absolute_path`).
+//! - String / path utilities (`string_util`, `absolute_path`,
+//!   `path_normalization`).
 //! - Cross-platform PTY/process driver adapter (`pty::ProcessDriver`,
 //!   `pty::SpawnedProcess`, `pty::TerminalSize`, `pty::spawn_from_driver`).
 //! - On non-Windows targets, [`unsupported`] returns a typed error indicating
 //!   that the Windows sandbox runtime is unavailable.
 //!
 //! The actual Win32 sandbox logic (AppContainer, JobObject, network ACLs)
-//! lands in subsequent PRs under tracker issue #250.
+//! lands in subsequent PRs under tracker issue #263 / #250.
 
 pub mod absolute_path;
+pub mod path_normalization;
 pub mod pty;
 pub mod string_util;
 pub mod types;

--- a/crates/dasclaw_sandbox_windows/src/path_normalization.rs
+++ b/crates/dasclaw_sandbox_windows/src/path_normalization.rs
@@ -1,0 +1,35 @@
+// Derived from openai/codex commit 6e838a19fa
+//   path: codex-rs/windows-sandbox-rs/src/path_normalization.rs
+// SPDX-License-Identifier: Apache-2.0
+
+use std::path::Path;
+use std::path::PathBuf;
+
+pub fn canonicalize_path(path: &Path) -> PathBuf {
+    dunce::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+}
+
+pub fn canonical_path_key(path: &Path) -> String {
+    canonicalize_path(path)
+        .to_string_lossy()
+        .replace('\\', "/")
+        .to_ascii_lowercase()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::canonical_path_key;
+    use pretty_assertions::assert_eq;
+    use std::path::Path;
+
+    #[test]
+    fn canonical_path_key_normalizes_case_and_separators() {
+        let windows_style = Path::new(r"C:\Users\Dev\Repo");
+        let slash_style = Path::new("c:/users/dev/repo");
+
+        assert_eq!(
+            canonical_path_key(windows_style),
+            canonical_path_key(slash_style)
+        );
+    }
+}


### PR DESCRIPTION
## 背景 / 目标

W4 ADR-121 D3-3 Phase 1.1.4 第一刀（V'-b 最叶子）：移植 `codex-rs/windows-sandbox-rs/src/path_normalization.rs`（28 LOC）。

文件是纯 path 字符串规整 — 2 函数 `canonicalize_path` + `canonical_path_key`，仅依赖 `dunce`（已在 Cargo.toml）。无 winapi、无 cfg、跨平台直接编。

## 改动范围

- **新增** `crates/dasclaw_sandbox_windows/src/path_normalization.rs`（35 LOC，含 attribution header + 1 测试）
- **修改** `crates/dasclaw_sandbox_windows/src/lib.rs`：phase doc 1.1.3b → 1.1.4a，新增 `pub mod path_normalization;`，`unsupported()` 仍是 1.1.0 wording（不在本刀范围）

净增 42 行，`git diff --stat`：
```
crates/dasclaw_sandbox_windows/src/lib.rs          | 12 ++++----
crates/dasclaw_sandbox_windows/src/path_normalization.rs | 35 ++++++++++++++++++++++
2 files changed, 42 insertions(+), 5 deletions(-)
```

## 非目标（What's NOT in this PR）

- 不引入其它 windows-sandbox-rs 模块（workspace_acl / read_acl_mutex / sandbox_utils 等下一刀）
- 不动 `pty/*` 已有结构
- 不动 `windows-ci.yml`（已含 `crates/dasclaw_sandbox_windows/**` 路径）
- 不修 `unsupported()` 文案（属另一独立任务）
- 不在 stack 上叠 PR

## 验证

5 项流水线本机全绿：

```
$ cargo check -p dasclaw_sandbox_windows --tests
    Finished `dev` profile [unoptimized + debuginfo]

$ cargo nextest run -p dasclaw_sandbox_windows
Summary [3.775s] 32 tests run: 32 passed, 0 skipped

$ cargo fmt --all  # 无 diff

$ python3.12 scripts/check_no_panics.py --base origin/xClaw
OK: No panic-inducing calls in changed production code.

$ python3.12 scripts/check_no_new_ironclaw_literal.py --base origin/xClaw
OK: No new .ironclaw / IRONCLAW_BASE_DIR literals introduced.

$ cargo clippy --no-deps -p dasclaw_sandbox_windows --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo]
```

## 关联

Closes #264
Refs #263（1.1.4 parent）#246（W4 epic）#250（windows-sandbox-rs port plan）

## Skills 自查

V'-b "port-on-demand"：本 PR 仅含上游 28 LOC 的 verbatim 移植 + 一个 `pub mod` 注册，attribution header 钉到 `openai/codex 6e838a19fa`，license SPDX-License-Identifier: Apache-2.0 与上游一致。无新 unwrap/expect / panic / unsafe，无 .ironclaw / IRONCLAW_BASE_DIR 字面量，无补丁式 if-flag 切换。
