### PR TITLE
feat(sandbox-windows): port sandbox_utils.rs + logging.rs (Phase 1.1.4b)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2673,6 +2673,7 @@ name = "dasclaw_sandbox_windows"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "chrono",
  "dirs 6.0.0",
  "dunce",
  "filedescriptor",

--- a/crates/dasclaw_sandbox_windows/Cargo.toml
+++ b/crates/dasclaw_sandbox_windows/Cargo.toml
@@ -12,6 +12,7 @@ path = "src/lib.rs"
 
 [dependencies]
 anyhow = "1"
+chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
 dirs = "6"
 dunce = "1.0"
 portable-pty = "0.9.0"

--- a/crates/dasclaw_sandbox_windows/src/lib.rs
+++ b/crates/dasclaw_sandbox_windows/src/lib.rs
@@ -9,12 +9,12 @@
 //! See `vendor/codex-windows-sandbox/README.md` for the reference snapshot
 //! and the porting plan in tracker issue #250.
 //!
-//! ## Crate status (Phase 1.1.4a)
+//! ## Crate status (Phase 1.1.4b)
 //!
 //! V'-b "port-on-demand" subset. The cross-platform PTY/process plumbing
 //! (`pty::process`) and the `cfg(windows)`-only ConPTY backend
-//! (`pty::win::*`, `RawConPty`) are in tree, and the leaf path-key utilities
-//! consumed by the sandbox have started landing.
+//! (`pty::win::*`, `RawConPty`) are in tree, plus the leaf path-key,
+//! sandbox setup, and logging utilities consumed across the upstream crate.
 //!
 //! Currently exposed:
 //!
@@ -22,6 +22,10 @@
 //!   `types::WritableRoot`).
 //! - String / path utilities (`string_util`, `absolute_path`,
 //!   `path_normalization`).
+//! - Sandbox setup helpers (`sandbox_utils::ensure_codex_home_exists`,
+//!   `sandbox_utils::inject_git_safe_directory`).
+//! - Sandbox audit log (`logging::log_start` / `log_success` / `log_failure`
+//!   / `log_note` / `debug_log`).
 //! - Cross-platform PTY/process driver adapter (`pty::ProcessDriver`,
 //!   `pty::SpawnedProcess`, `pty::TerminalSize`, `pty::spawn_from_driver`).
 //! - On non-Windows targets, [`unsupported`] returns a typed error indicating
@@ -31,8 +35,10 @@
 //! lands in subsequent PRs under tracker issue #263 / #250.
 
 pub mod absolute_path;
+pub mod logging;
 pub mod path_normalization;
 pub mod pty;
+pub mod sandbox_utils;
 pub mod string_util;
 pub mod types;
 

--- a/crates/dasclaw_sandbox_windows/src/logging.rs
+++ b/crates/dasclaw_sandbox_windows/src/logging.rs
@@ -1,0 +1,99 @@
+// Derived from openai/codex commit 6e838a19fa
+//   path: codex-rs/windows-sandbox-rs/src/logging.rs
+// SPDX-License-Identifier: Apache-2.0
+//
+// Mechanical import rewrite: `codex_utils_string::take_bytes_at_char_boundary`
+// → `crate::string_util::take_bytes_at_char_boundary` (already ported in
+// dasclaw_sandbox_windows Phase 1.1.1, PR #254). Logic is otherwise verbatim.
+
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::path::Path;
+use std::path::PathBuf;
+use std::sync::OnceLock;
+
+use crate::string_util::take_bytes_at_char_boundary;
+
+const LOG_COMMAND_PREVIEW_LIMIT: usize = 200;
+pub const LOG_FILE_NAME: &str = "sandbox.log";
+
+fn exe_label() -> &'static str {
+    static LABEL: OnceLock<String> = OnceLock::new();
+    LABEL.get_or_init(|| {
+        std::env::current_exe()
+            .ok()
+            .and_then(|p| p.file_name().map(|n| n.to_string_lossy().to_string()))
+            .unwrap_or_else(|| "proc".to_string())
+    })
+}
+
+fn preview(command: &[String]) -> String {
+    let joined = command.join(" ");
+    if joined.len() <= LOG_COMMAND_PREVIEW_LIMIT {
+        joined
+    } else {
+        take_bytes_at_char_boundary(&joined, LOG_COMMAND_PREVIEW_LIMIT).to_string()
+    }
+}
+
+fn log_file_path(base_dir: &Path) -> Option<PathBuf> {
+    if base_dir.is_dir() {
+        Some(base_dir.join(LOG_FILE_NAME))
+    } else {
+        None
+    }
+}
+
+fn append_line(line: &str, base_dir: Option<&Path>) {
+    if let Some(dir) = base_dir
+        && let Some(path) = log_file_path(dir)
+        && let Ok(mut f) = OpenOptions::new().create(true).append(true).open(path)
+    {
+        let _ = writeln!(f, "{line}");
+    }
+}
+
+pub fn log_start(command: &[String], base_dir: Option<&Path>) {
+    let p = preview(command);
+    log_note(&format!("START: {p}"), base_dir);
+}
+
+pub fn log_success(command: &[String], base_dir: Option<&Path>) {
+    let p = preview(command);
+    log_note(&format!("SUCCESS: {p}"), base_dir);
+}
+
+pub fn log_failure(command: &[String], detail: &str, base_dir: Option<&Path>) {
+    let p = preview(command);
+    log_note(&format!("FAILURE: {p} ({detail})"), base_dir);
+}
+
+// Debug logging helper. Emits only when SBX_DEBUG=1 to avoid noisy logs.
+pub fn debug_log(msg: &str, base_dir: Option<&Path>) {
+    if std::env::var("SBX_DEBUG").ok().as_deref() == Some("1") {
+        append_line(&format!("DEBUG: {msg}"), base_dir);
+        eprintln!("{msg}");
+    }
+}
+
+// Unconditional note logging to sandbox.log
+pub fn log_note(msg: &str, base_dir: Option<&Path>) {
+    let ts = chrono::Local::now().format("%Y-%m-%d %H:%M:%S%.3f");
+    append_line(&format!("[{ts} {}] {}", exe_label(), msg), base_dir);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn preview_does_not_panic_on_utf8_boundary() {
+        // Place a 4-byte emoji such that naive (byte-based) truncation would split it.
+        let prefix = "x".repeat(LOG_COMMAND_PREVIEW_LIMIT - 1);
+        let command = vec![format!("{prefix}😀")];
+        let result = std::panic::catch_unwind(|| preview(&command));
+        assert!(result.is_ok());
+        let previewed = result.unwrap();
+        assert!(previewed.len() <= LOG_COMMAND_PREVIEW_LIMIT);
+    }
+}

--- a/crates/dasclaw_sandbox_windows/src/sandbox_utils.rs
+++ b/crates/dasclaw_sandbox_windows/src/sandbox_utils.rs
@@ -1,0 +1,71 @@
+// Derived from openai/codex commit 6e838a19fa
+//   path: codex-rs/windows-sandbox-rs/src/sandbox_utils.rs
+// SPDX-License-Identifier: Apache-2.0
+
+//! Shared helper utilities for Windows sandbox setup.
+//!
+//! These helpers centralize small pieces of setup logic used across both legacy and
+//! elevated paths, including unified_exec sessions and capture flows. They cover
+//! codex home directory creation and git safe.directory injection so sandboxed
+//! users can run git inside a repo owned by the primary user.
+
+use anyhow::Result;
+use std::collections::HashMap;
+use std::path::Path;
+use std::path::PathBuf;
+
+/// Walk upward from `start` to locate the git worktree root (supports gitfile redirects).
+fn find_git_root(start: &Path) -> Option<PathBuf> {
+    let mut cur = dunce::canonicalize(start).ok()?;
+    loop {
+        let marker = cur.join(".git");
+        if marker.is_dir() {
+            return Some(cur);
+        }
+        if marker.is_file() {
+            if let Ok(txt) = std::fs::read_to_string(&marker)
+                && let Some(rest) = txt.trim().strip_prefix("gitdir:")
+            {
+                let gitdir = rest.trim();
+                let resolved = if Path::new(gitdir).is_absolute() {
+                    PathBuf::from(gitdir)
+                } else {
+                    cur.join(gitdir)
+                };
+                return resolved.parent().map(Path::to_path_buf).or(Some(cur));
+            }
+            return Some(cur);
+        }
+        let parent = cur.parent()?;
+        if parent == cur {
+            return None;
+        }
+        cur = parent.to_path_buf();
+    }
+}
+
+/// Ensure the sandbox codex home directory exists.
+pub fn ensure_codex_home_exists(p: &Path) -> Result<()> {
+    std::fs::create_dir_all(p)?;
+    Ok(())
+}
+
+/// Adds a git safe.directory entry to the environment when running inside a repository.
+/// git will not otherwise allow the Sandbox user to run git commands on the repo directory
+/// which is owned by the primary user.
+pub fn inject_git_safe_directory(env_map: &mut HashMap<String, String>, cwd: &Path) {
+    if let Some(git_root) = find_git_root(cwd) {
+        let mut cfg_count: usize = env_map
+            .get("GIT_CONFIG_COUNT")
+            .and_then(|v| v.parse::<usize>().ok())
+            .unwrap_or(0);
+        let git_path = git_root.to_string_lossy().replace("\\\\", "/");
+        env_map.insert(
+            format!("GIT_CONFIG_KEY_{cfg_count}"),
+            "safe.directory".to_string(),
+        );
+        env_map.insert(format!("GIT_CONFIG_VALUE_{cfg_count}"), git_path);
+        cfg_count += 1;
+        env_map.insert("GIT_CONFIG_COUNT".to_string(), cfg_count.to_string());
+    }
+}


### PR DESCRIPTION
## 背景 / 目标

W4 ADR-121 D3-3 Phase 1.1.4 第二刀（V'-b 批量叶子）：把 windows-sandbox-rs 中两个跨平台纯叶子工具模块一次性纳入，单 PR 打包以减少 CI/issue 开销。

5 候选叶子（read_acl_mutex / sandbox_utils / workspace_acl / dpapi / logging）做依赖筛查后：

| 文件 | 依赖 | 决定 |
|---|---|---|
| sandbox_utils.rs | std + anyhow + dunce（跨平台） | ✅ 纳入 |
| logging.rs | std + chrono + `take_bytes_at_char_boundary`（已 1.1.1 移植） | ✅ 纳入 |
| read_acl_mutex.rs | windows-sys + `super::to_wide`（未移植） | ❌ 推迟 |
| workspace_acl.rs | `crate::acl::add_deny_write_ace`（未移植） | ❌ 推迟 |
| dpapi.rs | windows-sys 加密 API（需新增依赖） | ❌ 单独 1.1.4c |

## 改动范围

```
Cargo.lock                                         |  1 +
crates/dasclaw_sandbox_windows/Cargo.toml          |  1 +
crates/dasclaw_sandbox_windows/src/lib.rs          | 12 ++-
crates/dasclaw_sandbox_windows/src/logging.rs      | 99 ++++++++++++++++++++++
crates/dasclaw_sandbox_windows/src/sandbox_utils.rs | 71 ++++++++++++++++
5 files changed, 181 insertions(+), 3 deletions(-)
```

- 新增 `src/sandbox_utils.rs`（67 LOC verbatim + attribution header）
- 新增 `src/logging.rs`（91 LOC + 一处 mechanical import rewrite：`codex_utils_string::take_bytes_at_char_boundary` → `crate::string_util::take_bytes_at_char_boundary`，与 `lib.rs` 头部"Ported (mechanically, with import rewrites)"声明一致）
- `Cargo.toml`：新增 `chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }`（与 `dasclaw_hooks` 同最小特性集）
- `src/lib.rs`：phase doc 1.1.4a → 1.1.4b，注册 `pub mod sandbox_utils; pub mod logging;`

## 非目标（What's NOT in this PR）

- 不引入 read_acl_mutex / workspace_acl / dpapi（依赖链或新依赖未就绪）
- 不改 pty/* 已有结构
- 不动 windows-ci.yml
- 不改 `unsupported()` wording
- 不在 stack 上叠 PR

## 验证

5 项流水线本机全绿：

```
$ cargo check -p dasclaw_sandbox_windows --tests
    Finished `dev` profile [unoptimized + debuginfo]

$ cargo nextest run -p dasclaw_sandbox_windows
Summary [3.621s] 33 tests run: 33 passed, 0 skipped
  (新增 logging::tests::preview_does_not_panic_on_utf8_boundary)

$ cargo fmt --all  # 无 diff

$ python3.12 scripts/check_no_panics.py --base origin/xClaw
OK: No panic-inducing calls in changed production code.

$ python3.12 scripts/check_no_new_ironclaw_literal.py --base origin/xClaw
OK: No new .ironclaw / IRONCLAW_BASE_DIR literals introduced.

$ cargo clippy --no-deps -p dasclaw_sandbox_windows --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo]
```

## 关联

Closes #266
Refs #263（1.1.4 parent）#246（W4 epic）#250（windows-sandbox-rs port plan）

## Skills 自查

- V'-b verbatim：sandbox_utils 100% 上游一致；logging 仅 1 处 import rewrite（机械重命名，无逻辑变更）
- attribution header 钉到 `openai/codex 6e838a19fa`，SPDX-License-Identifier: Apache-2.0
- 无新 `unwrap` / `expect` / `panic` / `unsafe`
- 无 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量
- chrono 用 default-features=false + clock+std 最小特性，与 `dasclaw_hooks` 对齐
- 不是补丁式：两个文件各自一个完整语义模块，不是切片或 flag-toggle
