### PR TITLE
feat(sandbox-windows): port dpapi.rs (Phase 1.1.4c)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2688,6 +2688,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "winapi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/crates/dasclaw_sandbox_windows/Cargo.toml
+++ b/crates/dasclaw_sandbox_windows/Cargo.toml
@@ -44,6 +44,13 @@ winapi = { version = "0.3", features = [
   "winnt",
 ] }
 
+[target.'cfg(windows)'.dependencies.windows-sys]
+version = "0.52"
+features = [
+  "Win32_Foundation",
+  "Win32_Security_Cryptography",
+]
+
 [dev-dependencies]
 pretty_assertions = "1"
 tempfile = "3"

--- a/crates/dasclaw_sandbox_windows/src/dpapi.rs
+++ b/crates/dasclaw_sandbox_windows/src/dpapi.rs
@@ -1,0 +1,89 @@
+// Derived from openai/codex commit 6e838a19fa
+//   path: codex-rs/windows-sandbox-rs/src/dpapi.rs
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use anyhow::anyhow;
+use windows_sys::Win32::Foundation::GetLastError;
+use windows_sys::Win32::Foundation::HLOCAL;
+use windows_sys::Win32::Foundation::LocalFree;
+use windows_sys::Win32::Security::Cryptography::CRYPT_INTEGER_BLOB;
+use windows_sys::Win32::Security::Cryptography::CRYPTPROTECT_LOCAL_MACHINE;
+use windows_sys::Win32::Security::Cryptography::CRYPTPROTECT_UI_FORBIDDEN;
+use windows_sys::Win32::Security::Cryptography::CryptProtectData;
+use windows_sys::Win32::Security::Cryptography::CryptUnprotectData;
+
+fn make_blob(data: &[u8]) -> CRYPT_INTEGER_BLOB {
+    CRYPT_INTEGER_BLOB {
+        cbData: data.len() as u32,
+        pbData: data.as_ptr() as *mut u8,
+    }
+}
+
+#[allow(clippy::unnecessary_mut_passed)]
+pub fn protect(data: &[u8]) -> Result<Vec<u8>> {
+    let mut in_blob = make_blob(data);
+    let mut out_blob = CRYPT_INTEGER_BLOB {
+        cbData: 0,
+        pbData: std::ptr::null_mut(),
+    };
+    let ok = unsafe {
+        CryptProtectData(
+            &mut in_blob,
+            std::ptr::null(),
+            std::ptr::null(),
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            // Use machine scope so elevated and non-elevated processes can decrypt.
+            CRYPTPROTECT_UI_FORBIDDEN | CRYPTPROTECT_LOCAL_MACHINE,
+            &mut out_blob,
+        )
+    };
+    if ok == 0 {
+        return Err(anyhow!("CryptProtectData failed: {}", unsafe {
+            GetLastError()
+        }));
+    }
+    let slice =
+        unsafe { std::slice::from_raw_parts(out_blob.pbData, out_blob.cbData as usize) }.to_vec();
+    unsafe {
+        if !out_blob.pbData.is_null() {
+            LocalFree(out_blob.pbData as HLOCAL);
+        }
+    }
+    Ok(slice)
+}
+
+#[allow(clippy::unnecessary_mut_passed)]
+pub fn unprotect(blob: &[u8]) -> Result<Vec<u8>> {
+    let mut in_blob = make_blob(blob);
+    let mut out_blob = CRYPT_INTEGER_BLOB {
+        cbData: 0,
+        pbData: std::ptr::null_mut(),
+    };
+    let ok = unsafe {
+        CryptUnprotectData(
+            &mut in_blob,
+            std::ptr::null_mut(),
+            std::ptr::null(),
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            // Use machine scope so elevated and non-elevated processes can decrypt.
+            CRYPTPROTECT_UI_FORBIDDEN | CRYPTPROTECT_LOCAL_MACHINE,
+            &mut out_blob,
+        )
+    };
+    if ok == 0 {
+        return Err(anyhow!("CryptUnprotectData failed: {}", unsafe {
+            GetLastError()
+        }));
+    }
+    let slice =
+        unsafe { std::slice::from_raw_parts(out_blob.pbData, out_blob.cbData as usize) }.to_vec();
+    unsafe {
+        if !out_blob.pbData.is_null() {
+            LocalFree(out_blob.pbData as HLOCAL);
+        }
+    }
+    Ok(slice)
+}

--- a/crates/dasclaw_sandbox_windows/src/lib.rs
+++ b/crates/dasclaw_sandbox_windows/src/lib.rs
@@ -9,7 +9,7 @@
 //! See `vendor/codex-windows-sandbox/README.md` for the reference snapshot
 //! and the porting plan in tracker issue #250.
 //!
-//! ## Crate status (Phase 1.1.4b)
+//! ## Crate status (Phase 1.1.4c)
 //!
 //! V'-b "port-on-demand" subset. The cross-platform PTY/process plumbing
 //! (`pty::process`) and the `cfg(windows)`-only ConPTY backend
@@ -26,6 +26,7 @@
 //!   `sandbox_utils::inject_git_safe_directory`).
 //! - Sandbox audit log (`logging::log_start` / `log_success` / `log_failure`
 //!   / `log_note` / `debug_log`).
+//! - DPAPI wrappers (`dpapi::protect` / `dpapi::unprotect`, `cfg(windows)`).
 //! - Cross-platform PTY/process driver adapter (`pty::ProcessDriver`,
 //!   `pty::SpawnedProcess`, `pty::TerminalSize`, `pty::spawn_from_driver`).
 //! - On non-Windows targets, [`unsupported`] returns a typed error indicating
@@ -35,6 +36,8 @@
 //! lands in subsequent PRs under tracker issue #263 / #250.
 
 pub mod absolute_path;
+#[cfg(windows)]
+pub mod dpapi;
 pub mod logging;
 pub mod path_normalization;
 pub mod pty;


### PR DESCRIPTION
## 背景 / 目标

W4 ADR-121 D3-3 Phase **1.1.4c**：把 `codex-rs/windows-sandbox-rs/src/dpapi.rs` 按 V'-b verbatim 落到 `crates/dasclaw_sandbox_windows/`。

这是本 crate 首次引入 `windows-sys` 依赖，按"最小特性集"原则只开 `Win32_Foundation` + `Win32_Security_Cryptography`，后续 PR 用到再追加。

## Cross-cuts

- ADR-114：**类A**（无新增 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量）

## 改动范围

- 新增 `crates/dasclaw_sandbox_windows/src/dpapi.rs`（85 LOC，verbatim + attribution header）
- `Cargo.toml`：新增 `[target.'cfg(windows)'.dependencies.windows-sys]` 表，version 0.52，feature 集 = `Win32_Foundation`、`Win32_Security_Cryptography`
- `lib.rs`：`#[cfg(windows)] pub mod dpapi;`，phase doc 1.1.4b → 1.1.4c，doc 列出 `dpapi::protect` / `dpapi::unprotect`

## 非目标（What's NOT in this PR）

- 不引入 read_acl_mutex / workspace_acl / acl / token / proc_thread_attr 等其它模块
- 不动 pty/* / windows-ci.yml
- 不增加 windows-sys 之外的新 dep；不扩 windows-sys feature 集到 dpapi 之外的需求

## 验证

```
$ cargo check -p dasclaw_sandbox_windows --tests
    Finished `dev` profile

$ cargo nextest run -p dasclaw_sandbox_windows
     Summary [   3.911s] 33 tests run: 33 passed, 0 skipped

$ cargo fmt --all
$ python3.12 scripts/check_no_panics.py --base origin/xClaw
OK: No panic-inducing calls in changed production code.

$ python3.12 scripts/check_no_new_ironclaw_literal.py --base origin/xClaw
OK: No new .ironclaw / IRONCLAW_BASE_DIR literals introduced.

$ cargo clippy --no-deps -p dasclaw_sandbox_windows --all-targets -- -D warnings
    Finished `dev` profile
```

注：dpapi.rs 在 macOS 本地不被 `cfg(windows)` 编译；Windows 实际编译验证由仓库 `windows-ci.yml` workflow 兜底（`crates/dasclaw_sandbox_windows/**` 已在 1.1.3a 加入 `on.push.paths` 触发）。

## 关联

Closes #268
Refs #263（1.1.4 parent）#246（W4 epic）#250（windows-sandbox-rs port plan）

## Skills 自查

- V'-b verbatim：100% 与上游一致，仅加 attribution header
- attribution header 钉到 `openai/codex 6e838a19fa`，SPDX-License-Identifier: Apache-2.0
- 无新 `unwrap` / `expect` / `panic`
- 上游本就有 `unsafe` 块（DPAPI Win32 调用），保持不变
- 无 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量
- windows-sys 用 cfg(windows) gate + 最小特性集（仅 dpapi 需要的两个）
- 不是补丁式：单一语义模块，一次完整移植
