### PR TITLE
feat(sandbox-windows): port proc_thread_attr.rs (Phase 1.1.4d)

### DIFF
--- a/crates/dasclaw_sandbox_windows/Cargo.toml
+++ b/crates/dasclaw_sandbox_windows/Cargo.toml
@@ -49,6 +49,7 @@ version = "0.52"
 features = [
   "Win32_Foundation",
   "Win32_Security_Cryptography",
+  "Win32_System_Threading",
 ]
 
 [dev-dependencies]

--- a/crates/dasclaw_sandbox_windows/src/lib.rs
+++ b/crates/dasclaw_sandbox_windows/src/lib.rs
@@ -9,7 +9,7 @@
 //! See `vendor/codex-windows-sandbox/README.md` for the reference snapshot
 //! and the porting plan in tracker issue #250.
 //!
-//! ## Crate status (Phase 1.1.4c)
+//! ## Crate status (Phase 1.1.4d)
 //!
 //! V'-b "port-on-demand" subset. The cross-platform PTY/process plumbing
 //! (`pty::process`) and the `cfg(windows)`-only ConPTY backend
@@ -27,6 +27,8 @@
 //! - Sandbox audit log (`logging::log_start` / `log_success` / `log_failure`
 //!   / `log_note` / `debug_log`).
 //! - DPAPI wrappers (`dpapi::protect` / `dpapi::unprotect`, `cfg(windows)`).
+//! - Process/thread attribute list builder
+//!   (`proc_thread_attr::ProcThreadAttributeList`, `cfg(windows)`).
 //! - Cross-platform PTY/process driver adapter (`pty::ProcessDriver`,
 //!   `pty::SpawnedProcess`, `pty::TerminalSize`, `pty::spawn_from_driver`).
 //! - On non-Windows targets, [`unsupported`] returns a typed error indicating
@@ -40,6 +42,8 @@ pub mod absolute_path;
 pub mod dpapi;
 pub mod logging;
 pub mod path_normalization;
+#[cfg(windows)]
+pub mod proc_thread_attr;
 pub mod pty;
 pub mod sandbox_utils;
 pub mod string_util;

--- a/crates/dasclaw_sandbox_windows/src/proc_thread_attr.rs
+++ b/crates/dasclaw_sandbox_windows/src/proc_thread_attr.rs
@@ -1,0 +1,104 @@
+// Derived from openai/codex commit 6e838a19fa
+//   path: codex-rs/windows-sandbox-rs/src/proc_thread_attr.rs
+// SPDX-License-Identifier: Apache-2.0
+
+use std::io;
+use windows_sys::Win32::Foundation::GetLastError;
+use windows_sys::Win32::Foundation::HANDLE;
+use windows_sys::Win32::System::Threading::DeleteProcThreadAttributeList;
+use windows_sys::Win32::System::Threading::InitializeProcThreadAttributeList;
+use windows_sys::Win32::System::Threading::LPPROC_THREAD_ATTRIBUTE_LIST;
+use windows_sys::Win32::System::Threading::UpdateProcThreadAttribute;
+
+const PROC_THREAD_ATTRIBUTE_HANDLE_LIST: usize = 0x0002_0002;
+const PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE: usize = 0x0002_0016;
+
+pub struct ProcThreadAttributeList {
+    buffer: Vec<u8>,
+    handle_list: Option<Vec<HANDLE>>,
+}
+
+impl ProcThreadAttributeList {
+    pub fn new(attr_count: u32) -> io::Result<Self> {
+        let mut size: usize = 0;
+        unsafe {
+            InitializeProcThreadAttributeList(std::ptr::null_mut(), attr_count, 0, &mut size);
+        }
+        if size == 0 {
+            return Err(io::Error::from_raw_os_error(unsafe {
+                GetLastError() as i32
+            }));
+        }
+        let mut buffer = vec![0u8; size];
+        let list = buffer.as_mut_ptr() as LPPROC_THREAD_ATTRIBUTE_LIST;
+        let ok = unsafe { InitializeProcThreadAttributeList(list, attr_count, 0, &mut size) };
+        if ok == 0 {
+            return Err(io::Error::from_raw_os_error(unsafe {
+                GetLastError() as i32
+            }));
+        }
+        Ok(Self {
+            buffer,
+            handle_list: None,
+        })
+    }
+
+    pub fn as_mut_ptr(&mut self) -> LPPROC_THREAD_ATTRIBUTE_LIST {
+        self.buffer.as_mut_ptr() as LPPROC_THREAD_ATTRIBUTE_LIST
+    }
+
+    pub fn set_pseudoconsole(&mut self, hpc: isize) -> io::Result<()> {
+        let list = self.as_mut_ptr();
+        let mut hpc_value = hpc;
+        let ok = unsafe {
+            UpdateProcThreadAttribute(
+                list,
+                0,
+                PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE,
+                (&mut hpc_value as *mut isize).cast(),
+                std::mem::size_of::<isize>(),
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+            )
+        };
+        if ok == 0 {
+            return Err(io::Error::from_raw_os_error(unsafe {
+                GetLastError() as i32
+            }));
+        }
+        Ok(())
+    }
+
+    pub fn set_handle_list(&mut self, handles: Vec<HANDLE>) -> io::Result<()> {
+        self.handle_list = Some(handles);
+        let list = self.as_mut_ptr();
+        let Some(handle_list) = self.handle_list.as_mut() else {
+            return Err(io::Error::other("handle list missing after initialization"));
+        };
+        let ok = unsafe {
+            UpdateProcThreadAttribute(
+                list,
+                0,
+                PROC_THREAD_ATTRIBUTE_HANDLE_LIST,
+                handle_list.as_mut_ptr().cast(),
+                std::mem::size_of_val(handle_list.as_slice()),
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+            )
+        };
+        if ok == 0 {
+            return Err(io::Error::from_raw_os_error(unsafe {
+                GetLastError() as i32
+            }));
+        }
+        Ok(())
+    }
+}
+
+impl Drop for ProcThreadAttributeList {
+    fn drop(&mut self) {
+        unsafe {
+            DeleteProcThreadAttributeList(self.as_mut_ptr());
+        }
+    }
+}


### PR DESCRIPTION
## 背景 / 目标

W4 ADR-121 D3-3 Phase **1.1.4d**：把 `codex-rs/windows-sandbox-rs/src/proc_thread_attr.rs` 按 V'-b verbatim 落到 `crates/dasclaw_sandbox_windows/`。

## 与已有 `pty/win/procthreadattr.rs` 的关系（重要）

二者**完全不同**，零重叠：

| 文件 | 来源 | License | 依赖 | 用途 |
|---|---|---|---|---|
| 已落地 `pty/win/procthreadattr.rs`（PR #258） | WezTerm | MIT | `winapi` | PTY 子进程创建 |
| 本次新增 `proc_thread_attr.rs` | openai/codex 自研 | Apache-2.0 | `windows-sys` | sandbox 进程创建（双 setter：PSEUDOCONSOLE + HANDLE_LIST） |

API 签名 (`new(u32)` vs `with_capacity(DWORD)`)、struct 字段 (`buffer/handle_list` vs `data`)、底层 binding 全部不同，无法合并。

## Cross-cuts

- ADR-114：**类A**（无新增 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量）

## 改动范围

- 新增 `crates/dasclaw_sandbox_windows/src/proc_thread_attr.rs`（100 LOC，verbatim + attribution header）
- `Cargo.toml`：windows-sys feature 集追加 `Win32_System_Threading`（保持最小特性集纪律）
- `lib.rs`：`#[cfg(windows)] pub mod proc_thread_attr;`，phase doc 1.1.4c → 1.1.4d，doc 列出新模块

## 非目标（What's NOT in this PR）

- 不重构 / 不合并已有 `pty/win/procthreadattr.rs`
- 不引入 acl/token/process 等其它 sandbox 大块
- 不增加 windows-sys feature 集到 proc_thread_attr 之外的需求

## 验证

```
$ cargo check -p dasclaw_sandbox_windows --tests
    Finished `dev` profile

$ cargo nextest run -p dasclaw_sandbox_windows
     Summary [   3.957s] 33 tests run: 33 passed, 0 skipped

$ cargo fmt --all
$ python3.12 scripts/check_no_panics.py --base origin/xClaw
OK: No panic-inducing calls in changed production code.

$ python3.12 scripts/check_no_new_ironclaw_literal.py --base origin/xClaw
OK: No new .ironclaw / IRONCLAW_BASE_DIR literals introduced.

$ cargo clippy --no-deps -p dasclaw_sandbox_windows --all-targets -- -D warnings
    Finished `dev` profile
```

注：proc_thread_attr.rs 在 macOS 本地不被 `cfg(windows)` 编译；Windows 实际编译验证由 `windows-ci.yml` 兜底。

## 关联

Closes #270
Refs #263（1.1.4 parent）#246（W4 epic）#250（windows-sandbox-rs port plan）

Stacked-on-pipeline：基于 PR #269（已 merge `b179e28c`）的流水重叠产物，rebase 后已直接落到 origin/xClaw。

## Skills 自查

- V'-b verbatim：100% 与上游一致，仅加 attribution header
- attribution header 钉到 `openai/codex 6e838a19fa`，SPDX-License-Identifier: Apache-2.0
- 无新 `unwrap` / `expect` / `panic`
- 上游本就有 `unsafe` 块（Win32 调用），保持不变
- 无 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量
- windows-sys 仅追加 `Win32_System_Threading` 一个 feature，不扩散
- 不是补丁式：单一语义模块；不动已有 `pty/win/procthreadattr.rs`（语义不同）
- 应用了"手段 1 = 流水线重叠"：1.1.4d 本地准备与 1.1.4c CI 重叠完成，节省 ~5 min
