### PR TITLE
feat(sandbox-windows): port cap.rs + env.rs (Phase 1.1.4e)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2682,6 +2682,7 @@ dependencies = [
  "log",
  "portable-pty 0.9.0",
  "pretty_assertions",
+ "rand 0.8.5",
  "serde",
  "serde_json",
  "shared_library",

--- a/crates/dasclaw_sandbox_windows/Cargo.toml
+++ b/crates/dasclaw_sandbox_windows/Cargo.toml
@@ -16,6 +16,7 @@ chrono = { version = "0.4", default-features = false, features = ["clock", "std"
 dirs = "6"
 dunce = "1.0"
 portable-pty = "0.9.0"
+rand = { version = "0.8", default-features = false, features = ["std", "small_rng", "std_rng"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["macros", "rt", "sync", "time"] }

--- a/crates/dasclaw_sandbox_windows/src/cap.rs
+++ b/crates/dasclaw_sandbox_windows/src/cap.rs
@@ -1,0 +1,131 @@
+// Derived from openai/codex commit 6e838a19fa
+//   path: codex-rs/windows-sandbox-rs/src/cap.rs
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Context;
+use anyhow::Result;
+use rand::RngCore;
+use rand::SeedableRng;
+use rand::rngs::SmallRng;
+use serde::Deserialize;
+use serde::Serialize;
+use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
+use std::path::PathBuf;
+
+use crate::path_normalization::canonical_path_key;
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct CapSids {
+    pub workspace: String,
+    pub readonly: String,
+    /// Per-workspace capability SIDs keyed by canonicalized CWD string.
+    ///
+    /// This is used to isolate workspaces from other workspace sandbox writes and to
+    /// apply per-workspace denies (e.g. protect `CWD/.codex`)
+    /// without permanently affecting other workspaces.
+    #[serde(default)]
+    pub workspace_by_cwd: HashMap<String, String>,
+}
+
+pub fn cap_sid_file(codex_home: &Path) -> PathBuf {
+    codex_home.join("cap_sid")
+}
+
+fn make_random_cap_sid_string() -> String {
+    let mut rng = SmallRng::from_entropy();
+    let a = rng.next_u32();
+    let b = rng.next_u32();
+    let c = rng.next_u32();
+    let d = rng.next_u32();
+    format!("S-1-5-21-{a}-{b}-{c}-{d}")
+}
+
+fn persist_caps(path: &Path, caps: &CapSids) -> Result<()> {
+    if let Some(dir) = path.parent() {
+        fs::create_dir_all(dir).with_context(|| format!("create cap sid dir {}", dir.display()))?;
+    }
+    let json = serde_json::to_string(caps)?;
+    fs::write(path, json).with_context(|| format!("write cap sid file {}", path.display()))?;
+    Ok(())
+}
+
+pub fn load_or_create_cap_sids(codex_home: &Path) -> Result<CapSids> {
+    let path = cap_sid_file(codex_home);
+    if path.exists() {
+        let txt = fs::read_to_string(&path)
+            .with_context(|| format!("read cap sid file {}", path.display()))?;
+        let t = txt.trim();
+        if t.starts_with('{') && t.ends_with('}') {
+            if let Ok(obj) = serde_json::from_str::<CapSids>(t) {
+                return Ok(obj);
+            }
+        } else if !t.is_empty() {
+            let caps = CapSids {
+                workspace: t.to_string(),
+                readonly: make_random_cap_sid_string(),
+                workspace_by_cwd: HashMap::new(),
+            };
+            persist_caps(&path, &caps)?;
+            return Ok(caps);
+        }
+    }
+    let caps = CapSids {
+        workspace: make_random_cap_sid_string(),
+        readonly: make_random_cap_sid_string(),
+        workspace_by_cwd: HashMap::new(),
+    };
+    persist_caps(&path, &caps)?;
+    Ok(caps)
+}
+
+/// Returns the workspace-specific capability SID for `cwd`, creating and persisting it if missing.
+pub fn workspace_cap_sid_for_cwd(codex_home: &Path, cwd: &Path) -> Result<String> {
+    let path = cap_sid_file(codex_home);
+    let mut caps = load_or_create_cap_sids(codex_home)?;
+    let key = canonical_path_key(cwd);
+    if let Some(sid) = caps.workspace_by_cwd.get(&key) {
+        return Ok(sid.clone());
+    }
+    let sid = make_random_cap_sid_string();
+    caps.workspace_by_cwd.insert(key, sid.clone());
+    persist_caps(&path, &caps)?;
+    Ok(sid)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::load_or_create_cap_sids;
+    use super::workspace_cap_sid_for_cwd;
+    use pretty_assertions::assert_eq;
+    use std::path::PathBuf;
+
+    #[test]
+    fn equivalent_cwd_spellings_share_workspace_sid_key() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let codex_home = temp.path().join("codex-home");
+        std::fs::create_dir_all(&codex_home).expect("create codex home");
+
+        let workspace = temp.path().join("WorkspaceRoot");
+        std::fs::create_dir_all(&workspace).expect("create workspace root");
+
+        let canonical = dunce::canonicalize(&workspace).expect("canonical workspace root");
+        let alt_spelling = PathBuf::from(
+            canonical
+                .to_string_lossy()
+                .replace('\\', "/")
+                .to_ascii_uppercase(),
+        );
+
+        let first_sid =
+            workspace_cap_sid_for_cwd(&codex_home, canonical.as_path()).expect("first sid");
+        let second_sid =
+            workspace_cap_sid_for_cwd(&codex_home, alt_spelling.as_path()).expect("second sid");
+
+        assert_eq!(first_sid, second_sid);
+
+        let caps = load_or_create_cap_sids(&codex_home).expect("load caps");
+        assert_eq!(caps.workspace_by_cwd.len(), 1);
+    }
+}

--- a/crates/dasclaw_sandbox_windows/src/env.rs
+++ b/crates/dasclaw_sandbox_windows/src/env.rs
@@ -1,0 +1,182 @@
+// Derived from openai/codex commit 6e838a19fa
+//   path: codex-rs/windows-sandbox-rs/src/env.rs
+// SPDX-License-Identifier: Apache-2.0
+//
+// Port note: upstream uses `dirs_next::home_dir`; x-claw already depends on
+// `dirs = "6"` whose `home_dir()` is API-equivalent. To avoid introducing an
+// extra crate we use `dirs::home_dir`. No behavior change.
+
+use anyhow::{Result, anyhow};
+use dirs::home_dir;
+use std::collections::HashMap;
+use std::env;
+use std::fs::{self, File};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+pub fn normalize_null_device_env(env_map: &mut HashMap<String, String>) {
+    let keys: Vec<String> = env_map.keys().cloned().collect();
+    for k in keys {
+        if let Some(v) = env_map.get(&k).cloned() {
+            let t = v.trim().to_ascii_lowercase();
+            if t == "/dev/null" || t == "\\\\\\\\dev\\\\\\\\null" {
+                env_map.insert(k, "NUL".to_string());
+            }
+        }
+    }
+}
+
+pub fn ensure_non_interactive_pager(env_map: &mut HashMap<String, String>) {
+    env_map
+        .entry("GIT_PAGER".into())
+        .or_insert_with(|| "more.com".into());
+    env_map
+        .entry("PAGER".into())
+        .or_insert_with(|| "more.com".into());
+    env_map.entry("LESS".into()).or_insert_with(|| "".into());
+}
+
+// Keep PATH and PATHEXT stable for callers that rely on inheriting the parent process env.
+pub fn inherit_path_env(env_map: &mut HashMap<String, String>) {
+    if !env_map.contains_key("PATH")
+        && let Ok(path) = env::var("PATH")
+    {
+        env_map.insert("PATH".into(), path);
+    }
+    if !env_map.contains_key("PATHEXT")
+        && let Ok(pathext) = env::var("PATHEXT")
+    {
+        env_map.insert("PATHEXT".into(), pathext);
+    }
+}
+
+fn prepend_path(env_map: &mut HashMap<String, String>, prefix: &str) {
+    let existing = env_map
+        .get("PATH")
+        .cloned()
+        .or_else(|| env::var("PATH").ok())
+        .unwrap_or_default();
+    let parts: Vec<String> = existing.split(';').map(ToString::to_string).collect();
+    if parts
+        .first()
+        .map(|p| p.eq_ignore_ascii_case(prefix))
+        .unwrap_or(false)
+    {
+        return;
+    }
+    let mut new_path = String::new();
+    new_path.push_str(prefix);
+    if !existing.is_empty() {
+        new_path.push(';');
+        new_path.push_str(&existing);
+    }
+    env_map.insert("PATH".into(), new_path);
+}
+
+fn reorder_pathext_for_stubs(env_map: &mut HashMap<String, String>) {
+    let default = env_map
+        .get("PATHEXT")
+        .cloned()
+        .or_else(|| env::var("PATHEXT").ok())
+        .unwrap_or(".COM;.EXE;.BAT;.CMD".to_string());
+    let exts: Vec<String> = default
+        .split(';')
+        .filter(|e| !e.is_empty())
+        .map(ToString::to_string)
+        .collect();
+    let exts_norm: Vec<String> = exts.iter().map(|e| e.to_ascii_uppercase()).collect();
+    let want = [".BAT", ".CMD"];
+    let mut front: Vec<String> = Vec::new();
+    for w in want {
+        if let Some(idx) = exts_norm.iter().position(|e| e == w) {
+            front.push(exts[idx].clone());
+        }
+    }
+    let rest: Vec<String> = exts
+        .into_iter()
+        .enumerate()
+        .filter(|(i, _)| {
+            let up = &exts_norm[*i];
+            up != ".BAT" && up != ".CMD"
+        })
+        .map(|(_, e)| e)
+        .collect();
+    let mut combined = Vec::new();
+    combined.extend(front);
+    combined.extend(rest);
+    env_map.insert("PATHEXT".into(), combined.join(";"));
+}
+
+fn ensure_denybin(tools: &[&str], denybin_dir: Option<&Path>) -> Result<PathBuf> {
+    let base = match denybin_dir {
+        Some(p) => p.to_path_buf(),
+        None => {
+            let home = home_dir().ok_or_else(|| anyhow!("no home dir"))?;
+            home.join(".sbx-denybin")
+        }
+    };
+    fs::create_dir_all(&base)?;
+    for tool in tools {
+        for ext in [".bat", ".cmd"] {
+            let path = base.join(format!("{tool}{ext}"));
+            if !path.exists() {
+                let mut f = File::create(&path)?;
+                f.write_all(b"@echo off\\r\\nexit /b 1\\r\\n")?;
+            }
+        }
+    }
+    Ok(base)
+}
+
+pub fn apply_no_network_to_env(env_map: &mut HashMap<String, String>) -> Result<()> {
+    env_map.insert("SBX_NONET_ACTIVE".into(), "1".into());
+    env_map
+        .entry("HTTP_PROXY".into())
+        .or_insert_with(|| "http://127.0.0.1:9".into());
+    env_map
+        .entry("HTTPS_PROXY".into())
+        .or_insert_with(|| "http://127.0.0.1:9".into());
+    env_map
+        .entry("ALL_PROXY".into())
+        .or_insert_with(|| "http://127.0.0.1:9".into());
+    env_map
+        .entry("NO_PROXY".into())
+        .or_insert_with(|| "localhost,127.0.0.1,::1".into());
+    env_map
+        .entry("PIP_NO_INDEX".into())
+        .or_insert_with(|| "1".into());
+    env_map
+        .entry("PIP_DISABLE_PIP_VERSION_CHECK".into())
+        .or_insert_with(|| "1".into());
+    env_map
+        .entry("NPM_CONFIG_OFFLINE".into())
+        .or_insert_with(|| "true".into());
+    env_map
+        .entry("CARGO_NET_OFFLINE".into())
+        .or_insert_with(|| "true".into());
+    env_map
+        .entry("GIT_HTTP_PROXY".into())
+        .or_insert_with(|| "http://127.0.0.1:9".into());
+    env_map
+        .entry("GIT_HTTPS_PROXY".into())
+        .or_insert_with(|| "http://127.0.0.1:9".into());
+    env_map
+        .entry("GIT_SSH_COMMAND".into())
+        .or_insert_with(|| "cmd /c exit 1".into());
+    env_map
+        .entry("GIT_ALLOW_PROTOCOLS".into())
+        .or_insert_with(|| "".into());
+
+    let base = ensure_denybin(&["ssh", "scp"], /*denybin_dir*/ None)?;
+    for tool in ["curl", "wget"] {
+        for ext in [".bat", ".cmd"] {
+            let p = base.join(format!("{tool}{ext}"));
+            if p.exists() {
+                let _ = fs::remove_file(&p);
+            }
+        }
+    }
+    prepend_path(env_map, &base.to_string_lossy());
+    reorder_pathext_for_stubs(env_map);
+    Ok(())
+}

--- a/crates/dasclaw_sandbox_windows/src/lib.rs
+++ b/crates/dasclaw_sandbox_windows/src/lib.rs
@@ -9,7 +9,7 @@
 //! See `vendor/codex-windows-sandbox/README.md` for the reference snapshot
 //! and the porting plan in tracker issue #250.
 //!
-//! ## Crate status (Phase 1.1.4d)
+//! ## Crate status (Phase 1.1.4e)
 //!
 //! V'-b "port-on-demand" subset. The cross-platform PTY/process plumbing
 //! (`pty::process`) and the `cfg(windows)`-only ConPTY backend
@@ -29,6 +29,11 @@
 //! - DPAPI wrappers (`dpapi::protect` / `dpapi::unprotect`, `cfg(windows)`).
 //! - Process/thread attribute list builder
 //!   (`proc_thread_attr::ProcThreadAttributeList`, `cfg(windows)`).
+//! - Per-workspace capability SID store (`cap::CapSids`,
+//!   `cap::load_or_create_cap_sids`, `cap::workspace_cap_sid_for_cwd`).
+//! - Sandbox environment scrubbers (`env::normalize_null_device_env`,
+//!   `env::ensure_non_interactive_pager`, `env::inherit_path_env`,
+//!   `env::apply_no_network_to_env`).
 //! - Cross-platform PTY/process driver adapter (`pty::ProcessDriver`,
 //!   `pty::SpawnedProcess`, `pty::TerminalSize`, `pty::spawn_from_driver`).
 //! - On non-Windows targets, [`unsupported`] returns a typed error indicating
@@ -38,8 +43,10 @@
 //! lands in subsequent PRs under tracker issue #263 / #250.
 
 pub mod absolute_path;
+pub mod cap;
 #[cfg(windows)]
 pub mod dpapi;
+pub mod env;
 pub mod logging;
 pub mod path_normalization;
 #[cfg(windows)]


### PR DESCRIPTION
## 背景 / 目标

W4 ADR-121 §D3-3 1.1.4 拆分图推进 — 1.1.4e 移植 codex `windows-sandbox-rs` 中两个**互不依赖、互不重叠**的叶子模块（295 LOC）：

- **`cap.rs`** (121 LOC) — 工作区能力 SID 存储，按 canonical-cwd 键索引。仅依赖 1.1.4a 已移植的 `path_normalization::canonical_path_key`。
- **`env.rs`** (174 LOC) — 沙箱环境变量净化（NUL 规范化、非交互 pager、PATH/PATHEXT 继承、no-network 代理 + denybin stubs）。无内部依赖，纯 stdlib + anyhow + dirs。

cat-scan 也覆盖了同语义层另两个候选，说明为什么本 PR 不收：

| 候选 | LOC | 阻塞 |
|---|---|---|
| `hide_users.rs` | 160 | `crate::winutil::{to_wide, format_last_error}` 未移植 |
| `desktop.rs` | 196 | `crate::token::*` + `crate::winutil::*` 未移植 |

后续 1.1.4f 将单独移植 `winutil.rs`（hub 模块），解锁 hide_users 与 desktop。这一刀走"batch-leaf 单 PR + 单线推进"，不上手段 2 双分支并行 — 共 295 LOC 太小，并行收益被 rebase 成本抵消。

## 改动范围

- `crates/dasclaw_sandbox_windows/src/cap.rs`：新增，verbatim port + attribution header。
- `crates/dasclaw_sandbox_windows/src/env.rs`：新增，verbatim port + attribution header + port note：upstream `dirs_next::home_dir` → x-claw 已有 `dirs::home_dir`（API 等价，不引入新 crate）。
- `crates/dasclaw_sandbox_windows/Cargo.toml`：新增 `rand = "0.8"`（`default-features=false, features=["std","small_rng","std_rng"]`），cap.rs 用于生成随机 SID。
- `crates/dasclaw_sandbox_windows/src/lib.rs`：phase doc 升 1.1.4d → 1.1.4e；模块清单加 `pub mod cap;` 和 `pub mod env;`；docstring 列出新暴露的 API。

二者都是纯 / 跨平台模块（无 `cfg(windows)` gate），所有 target 都参与编译。

## 非目标（What's NOT in this PR）

- ❌ 不移植 `hide_users.rs` / `desktop.rs`（阻塞于 winutil/token）
- ❌ 不移植 `winutil.rs`（留 1.1.4f 独立 PR，因它会被多文件依赖，hub 模块单独 review 更利落）
- ❌ 不引入任何新的 windows-sys feature（`Win32_Foundation` / `Win32_Security_Cryptography` / `Win32_System_Threading` 维持 1.1.4d 集合）
- ❌ 不接入 dasclaw / desktop-client 任何 caller（仅扩充 `dasclaw_sandbox_windows` 内部能力清单）
- ❌ 不修改 `unsupported()` 兜底
- ❌ 不引入 `dirs_next`（用现有 `dirs = "6"` 替代，节约一个依赖项）

## 验证

```bash
cargo check -p dasclaw_sandbox_windows --tests
# Finished `dev` in 17.07s

cargo nextest run -p dasclaw_sandbox_windows
# Summary [4.488s] 34 tests run: 34 passed, 0 skipped
# (1.1.4d 是 33 个，本 PR cap::tests 新增 1 个)

cargo fmt --all
python3.12 scripts/check_no_panics.py --base origin/xClaw
# OK: No panic-inducing calls in changed production code.
python3.12 scripts/check_no_new_ironclaw_literal.py --base origin/xClaw
# OK: No new .ironclaw / IRONCLAW_BASE_DIR literals introduced.
cargo clippy --no-deps -p dasclaw_sandbox_windows --all-targets -- -D warnings
# Finished, 0 warnings
```

windows-ci.yml 在 GitHub Actions 上跑 Windows 真机编译，本地不做 cross-compile（macOS dev 上 `x86_64-pc-windows-gnu` 缺 std）。

## Cross-cuts

`类A`（无新增 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量；grep guard 已验证通过）

## 后续 PR / 下一步

- **1.1.4f**：移植 `winutil.rs`（解锁 hide_users + desktop + 多个未来文件）
- **1.1.4g**：候选用手段 2 双分支并行 — `hide_users.rs` 与 `desktop.rs` 二者文件零重叠且 LOC ~360，并行 in-flight 收益开始显著（参考 PR #272 新加的 AGENTS.md "PR 加速策略" §手段 2）
- W4 1.1.4 剩余 ~8730 LOC / 23 文件



## 关联

Closes #276
Refs #263 (1.1.4 parent) #246 (W4 epic) #250 (windows-sandbox-rs port plan)
