### PR TITLE
feat(sandbox-windows): port setup_error.rs (Phase 1.1.4f, parallel sibling of #274)

### DIFF
--- a/crates/dasclaw_sandbox_windows/src/lib.rs
+++ b/crates/dasclaw_sandbox_windows/src/lib.rs
@@ -29,6 +29,11 @@
 //! - DPAPI wrappers (`dpapi::protect` / `dpapi::unprotect`, `cfg(windows)`).
 //! - Process/thread attribute list builder
 //!   (`proc_thread_attr::ProcThreadAttributeList`, `cfg(windows)`).
+//! - Setup error report types & redaction
+//!   (`setup_error::SetupFailure`, `setup_error::SetupErrorCode`,
+//!   `setup_error::write_setup_error_report`,
+//!   `setup_error::read_setup_error_report`,
+//!   `setup_error::sanitize_setup_metric_tag_value`).
 //! - Per-workspace capability SID store (`cap::CapSids`,
 //!   `cap::load_or_create_cap_sids`, `cap::workspace_cap_sid_for_cwd`).
 //! - Sandbox environment scrubbers (`env::normalize_null_device_env`,
@@ -53,6 +58,7 @@ pub mod path_normalization;
 pub mod proc_thread_attr;
 pub mod pty;
 pub mod sandbox_utils;
+pub mod setup_error;
 pub mod string_util;
 pub mod types;
 

--- a/crates/dasclaw_sandbox_windows/src/setup_error.rs
+++ b/crates/dasclaw_sandbox_windows/src/setup_error.rs
@@ -1,0 +1,288 @@
+// Derived from openai/codex commit 6e838a19fa
+//   path: codex-rs/windows-sandbox-rs/src/setup_error.rs
+// SPDX-License-Identifier: Apache-2.0
+//
+// Port note: upstream `use codex_utils_string::sanitize_metric_tag_value;`
+// is rewritten to `use crate::string_util::sanitize_metric_tag_value;`
+// (already exposed in this crate by phase 1.1.1).
+
+use crate::string_util::sanitize_metric_tag_value;
+use anyhow::Context;
+use anyhow::Result;
+use serde::Deserialize;
+use serde::Serialize;
+use std::fs;
+use std::io::ErrorKind;
+use std::path::Path;
+use std::path::PathBuf;
+
+/// These represent the most common failures for the elevated sandbox setup.
+///
+/// Codes are used as metric tags.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SetupErrorCode {
+    // Orchestrator (run in CLI) failures.
+    /// Failed to create `codex_home/.sandbox` in the orchestrator.
+    OrchestratorSandboxDirCreateFailed,
+    /// Failed to determine whether the current process is elevated.
+    OrchestratorElevationCheckFailed,
+    /// Failed to serialize the elevation payload before launching the helper.
+    OrchestratorPayloadSerializeFailed,
+    /// Failed to launch the setup helper process (spawn or ShellExecuteExW).
+    OrchestratorHelperLaunchFailed,
+    /// User canceled the UAC prompt while launching the helper.
+    OrchestratorHelperLaunchCanceled,
+    /// Helper exited non-zero and no structured report was available.
+    OrchestratorHelperExitNonzero,
+    /// Helper exited non-zero and reading `setup_error.json` failed.
+    OrchestratorHelperReportReadFailed,
+    // Helper (elevated process) failures.
+    /// Helper failed while validating or decoding the request payload.
+    HelperRequestArgsFailed,
+    /// Helper failed to create `codex_home/.sandbox`.
+    HelperSandboxDirCreateFailed,
+    /// Helper failed to open or write the setup log.
+    HelperLogFailed,
+    /// Helper failed in the provisioning phase (fallback bucket).
+    HelperUserProvisionFailed,
+    /// Helper failed to create the sandbox users local group.
+    HelperUsersGroupCreateFailed,
+    /// Helper failed to create or update a sandbox user account.
+    HelperUserCreateOrUpdateFailed,
+    /// Helper failed to protect user passwords with DPAPI.
+    HelperDpapiProtectFailed,
+    /// Helper failed to write the sandbox users secrets file.
+    HelperUsersFileWriteFailed,
+    /// Helper failed to write the setup marker file.
+    HelperSetupMarkerWriteFailed,
+    /// Helper failed to resolve a SID or convert it to a PSID.
+    HelperSidResolveFailed,
+    /// Helper failed to load or convert capability SIDs.
+    HelperCapabilitySidFailed,
+    /// Helper failed to initialize COM for firewall configuration.
+    HelperFirewallComInitFailed,
+    /// Helper failed to access firewall policy or rule collections.
+    HelperFirewallPolicyAccessFailed,
+    /// Helper failed to create, update, or add the firewall rule.
+    HelperFirewallRuleCreateOrAddFailed,
+    /// Helper failed to verify the configured firewall rule scope.
+    HelperFirewallRuleVerifyFailed,
+    /// Helper failed to spawn the read-ACL helper process.
+    HelperReadAclHelperSpawnFailed,
+    /// Helper failed to lock down sandbox directories via ACLs.
+    HelperSandboxLockFailed,
+    /// Helper failed for an unmapped or unexpected reason.
+    HelperUnknownError,
+}
+
+impl SetupErrorCode {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::OrchestratorSandboxDirCreateFailed => "orchestrator_sandbox_dir_create_failed",
+            Self::OrchestratorElevationCheckFailed => "orchestrator_elevation_check_failed",
+            Self::OrchestratorPayloadSerializeFailed => "orchestrator_payload_serialize_failed",
+            Self::OrchestratorHelperLaunchFailed => "orchestrator_helper_launch_failed",
+            Self::OrchestratorHelperLaunchCanceled => "orchestrator_helper_launch_canceled",
+            Self::OrchestratorHelperExitNonzero => "orchestrator_helper_exit_nonzero",
+            Self::OrchestratorHelperReportReadFailed => "orchestrator_helper_report_read_failed",
+            Self::HelperRequestArgsFailed => "helper_request_args_failed",
+            Self::HelperSandboxDirCreateFailed => "helper_sandbox_dir_create_failed",
+            Self::HelperLogFailed => "helper_log_failed",
+            Self::HelperUserProvisionFailed => "helper_user_provision_failed",
+            Self::HelperUsersGroupCreateFailed => "helper_users_group_create_failed",
+            Self::HelperUserCreateOrUpdateFailed => "helper_user_create_or_update_failed",
+            Self::HelperDpapiProtectFailed => "helper_dpapi_protect_failed",
+            Self::HelperUsersFileWriteFailed => "helper_users_file_write_failed",
+            Self::HelperSetupMarkerWriteFailed => "helper_setup_marker_write_failed",
+            Self::HelperSidResolveFailed => "helper_sid_resolve_failed",
+            Self::HelperCapabilitySidFailed => "helper_capability_sid_failed",
+            Self::HelperFirewallComInitFailed => "helper_firewall_com_init_failed",
+            Self::HelperFirewallPolicyAccessFailed => "helper_firewall_policy_access_failed",
+            Self::HelperFirewallRuleCreateOrAddFailed => {
+                "helper_firewall_rule_create_or_add_failed"
+            }
+            Self::HelperFirewallRuleVerifyFailed => "helper_firewall_rule_verify_failed",
+            Self::HelperReadAclHelperSpawnFailed => "helper_read_acl_helper_spawn_failed",
+            Self::HelperSandboxLockFailed => "helper_sandbox_lock_failed",
+            Self::HelperUnknownError => "helper_unknown_error",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SetupErrorReport {
+    pub code: SetupErrorCode,
+    pub message: String,
+}
+
+#[derive(Debug)]
+pub struct SetupFailure {
+    pub code: SetupErrorCode,
+    pub message: String,
+}
+
+impl SetupFailure {
+    pub fn new(code: SetupErrorCode, message: impl Into<String>) -> Self {
+        Self {
+            code,
+            message: message.into(),
+        }
+    }
+
+    pub fn from_report(report: SetupErrorReport) -> Self {
+        Self::new(report.code, report.message)
+    }
+
+    pub fn metric_message(&self) -> String {
+        sanitize_setup_metric_tag_value(&self.message)
+    }
+}
+
+impl std::fmt::Display for SetupFailure {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}: {}", self.code.as_str(), self.message)
+    }
+}
+
+impl std::error::Error for SetupFailure {}
+
+pub fn failure(code: SetupErrorCode, message: impl Into<String>) -> anyhow::Error {
+    anyhow::Error::new(SetupFailure::new(code, message))
+}
+
+pub fn extract_failure(err: &anyhow::Error) -> Option<&SetupFailure> {
+    err.downcast_ref::<SetupFailure>()
+}
+
+pub fn setup_error_path(codex_home: &Path) -> PathBuf {
+    codex_home.join(".sandbox").join("setup_error.json")
+}
+
+pub fn clear_setup_error_report(codex_home: &Path) -> Result<()> {
+    let path = setup_error_path(codex_home);
+    match fs::remove_file(&path) {
+        Ok(()) => Ok(()),
+        Err(err) if err.kind() == ErrorKind::NotFound => Ok(()),
+        Err(err) => Err(err).with_context(|| format!("remove {}", path.display())),
+    }
+}
+
+pub fn write_setup_error_report(codex_home: &Path, report: &SetupErrorReport) -> Result<()> {
+    let sandbox_dir = codex_home.join(".sandbox");
+    fs::create_dir_all(&sandbox_dir)
+        .with_context(|| format!("create sandbox dir {}", sandbox_dir.display()))?;
+    let path = setup_error_path(codex_home);
+    let json = serde_json::to_vec_pretty(report)?;
+    fs::write(&path, json).with_context(|| format!("write {}", path.display()))?;
+    Ok(())
+}
+
+pub fn read_setup_error_report(codex_home: &Path) -> Result<Option<SetupErrorReport>> {
+    let path = setup_error_path(codex_home);
+    let bytes = match fs::read(&path) {
+        Ok(bytes) => bytes,
+        Err(err) if err.kind() == ErrorKind::NotFound => return Ok(None),
+        Err(err) => return Err(err).with_context(|| format!("read {}", path.display())),
+    };
+    let report = serde_json::from_slice::<SetupErrorReport>(&bytes)
+        .with_context(|| format!("parse {}", path.display()))?;
+    Ok(Some(report))
+}
+
+/// Sanitize a setup error message for use as a metric tag.
+pub fn sanitize_setup_metric_tag_value(value: &str) -> String {
+    sanitize_metric_tag_value(redact_home_paths(value).as_str())
+}
+
+fn redact_home_paths(value: &str) -> String {
+    let mut usernames: Vec<String> = Vec::new();
+    if let Ok(username) = std::env::var("USERNAME")
+        && !username.trim().is_empty()
+    {
+        usernames.push(username);
+    }
+    if let Ok(user) = std::env::var("USER")
+        && !user.trim().is_empty()
+        && !usernames.iter().any(|v| v.eq_ignore_ascii_case(&user))
+    {
+        usernames.push(user);
+    }
+
+    redact_username_segments(value, &usernames)
+}
+
+fn redact_username_segments(value: &str, usernames: &[String]) -> String {
+    if usernames.is_empty() {
+        return value.to_string();
+    }
+
+    let mut segments: Vec<String> = Vec::new();
+    let mut separators: Vec<char> = Vec::new();
+    let mut current = String::new();
+
+    for ch in value.chars() {
+        if ch == '\\' || ch == '/' {
+            segments.push(std::mem::take(&mut current));
+            separators.push(ch);
+        } else {
+            current.push(ch);
+        }
+    }
+    segments.push(current);
+
+    for segment in &mut segments {
+        let matches = if cfg!(windows) {
+            usernames
+                .iter()
+                .any(|name| segment.eq_ignore_ascii_case(name))
+        } else {
+            usernames.iter().any(|name| segment == name)
+        };
+        if matches {
+            *segment = "<user>".to_string();
+        }
+    }
+
+    let mut out = String::new();
+    for (idx, segment) in segments.iter().enumerate() {
+        out.push_str(segment);
+        if let Some(sep) = separators.get(idx) {
+            out.push(*sep);
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::redact_username_segments;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn sanitize_tag_value_redacts_username_segments() {
+        let usernames = vec!["Alice".to_string(), "Bob".to_string()];
+        let msg = "failed to write C:\\Users\\Alice\\file.txt; fallback D:\\Profiles\\Bob\\x";
+        let redacted = redact_username_segments(msg, &usernames);
+        assert_eq!(
+            redacted,
+            "failed to write C:\\Users\\<user>\\file.txt; fallback D:\\Profiles\\<user>\\x"
+        );
+    }
+
+    #[test]
+    fn sanitize_tag_value_leaves_unknown_segments() {
+        let usernames = vec!["Alice".to_string()];
+        let msg = "failed to write E:\\data\\file.txt";
+        let redacted = redact_username_segments(msg, &usernames);
+        assert_eq!(redacted, msg);
+    }
+
+    #[test]
+    fn sanitize_tag_value_redacts_multiple_occurrences() {
+        let usernames = vec!["Alice".to_string()];
+        let msg = "C:\\Users\\Alice\\a and C:\\Users\\Alice\\b";
+        let redacted = redact_username_segments(msg, &usernames);
+        assert_eq!(redacted, "C:\\Users\\<user>\\a and C:\\Users\\<user>\\b");
+    }
+}


### PR DESCRIPTION
## 背景 / 目标

W4 ADR-121 D3-3 阶段 1.1.4f：把 `openai/codex` `windows-sandbox-rs/src/setup_error.rs` 直译为 `crates/dasclaw_sandbox_windows/src/setup_error.rs`。

`setup_error` 提供提权 sandbox setup helper 的故障分类（25 个 `SetupErrorCode` 变体）、JSON 报告读写、SID/用户名去敏（`<user>` 替换）、以及用于 metric tag 的 sanitize 包装。后续 setup_helper / orchestrator 实现会复用。

**Stacked on #273**（1.1.4e cap+env）。**与 #274（winutil）并行 sibling**，二者 file-disjoint（`setup_error.rs` ↔ `winutil.rs` + `Cargo.toml`），lib.rs 改动行不重叠。#274 拥有 phase doc 升号（1.1.4e → 1.1.4f），本 PR 不触碰 phase doc。

## 改动范围

- ✅ 新增 `crates/dasclaw_sandbox_windows/src/setup_error.rs`（294 LOC）
  - 公共类型：`SetupErrorCode`（25 variants）、`SetupErrorReport`、`SetupFailure`
  - 公共函数：`failure` / `extract_failure` / `setup_error_path` / `clear_setup_error_report` / `write_setup_error_report` / `read_setup_error_report` / `sanitize_setup_metric_tag_value`
  - 3 个跨平台单元测试（`redact_username_segments` 三场景）
- ✅ `src/lib.rs`：注册 `pub mod setup_error;`、API bullet 列出 setup_error 导出。**不改 phase doc**。

### Port 修改清单（仅 1 处）

```diff
-use codex_utils_string::sanitize_metric_tag_value;
+use crate::string_util::sanitize_metric_tag_value;
```

`string_util::sanitize_metric_tag_value` 在 Phase 1.1.1 已暴露，签名一致，行为一致（同样 8 个测试覆盖）。port-note 写在文件头部，方便后续 review 跟上游 diff。

## 非目标 (What's NOT in this PR)

- ❌ 不引入 `setup_helper.rs` / `orchestrator.rs`（更高层调用方，1.1.4h+ 单独 PR）
- ❌ 不改 cap.rs / env.rs / 其它 1.1.4e 已落地模块
- ❌ 不改 phase doc（#274 owns）
- ❌ 不动 windows-sys features（setup_error 不依赖 Win32 API）
- ❌ 不触及 `ironclaw-main/` / `vendor/` 上游快照

## 验证

本地流水线（macOS，base = `feat/sandbox-windows-1-1-4e-cap-env`）：

```bash
cargo check -p dasclaw_sandbox_windows --tests
# Finished `dev` profile in 2.35s

cargo nextest run -p dasclaw_sandbox_windows
# 37 tests run: 37 passed, 0 skipped
# (34 base + 3 setup_error::tests::*)

cargo fmt --all
python3.12 scripts/check_no_panics.py --base origin/xClaw
# OK: No panic-inducing calls in changed production code.

python3.12 scripts/check_no_new_ironclaw_literal.py --base origin/xClaw
# OK: No new .ironclaw / IRONCLAW_BASE_DIR literals introduced.

cargo clippy --no-deps -p dasclaw_sandbox_windows --all-targets -- -D warnings
# Finished, no warnings.
```

CI Tests / Clippy / cargo-deny 由 PR pipeline 兜底。

## Cross-cuts

**ADR-114 类A**：本 PR diff 不含 `.ironclaw` 或 `IRONCLAW_BASE_DIR` 字面量；grep guard 已自查通过。

## 后续步骤

- merge 顺序：先 merge #273，再 merge #274（winutil，含 phase 升号），最后 rebase + merge 本 PR。如本 PR 先于 #274 merge，#274 rebase 时仅需保留自己的 phase bump（行不冲突）。
- 1.1.4g 起 `hide_users.rs` / `desktop.rs` / `setup_helper.rs` 等模块即可基于 winutil + setup_error + cap + env 推进。

Refs: tracker issue #250 / #263。



## 关联

Closes #278
Refs #263 (1.1.4 parent) #246 (W4 epic) #250 (windows-sandbox-rs port plan)
