### PR TITLE
feat(sandbox-windows): port hide_users.rs (Phase 1.1.4g, sibling A)

### DIFF
--- a/crates/dasclaw_sandbox_windows/Cargo.toml
+++ b/crates/dasclaw_sandbox_windows/Cargo.toml
@@ -52,7 +52,9 @@ features = [
   "Win32_Security",
   "Win32_Security_Authorization",
   "Win32_Security_Cryptography",
+  "Win32_Storage_FileSystem",
   "Win32_System_Diagnostics_Debug",
+  "Win32_System_Registry",
   "Win32_System_Threading",
 ]
 

--- a/crates/dasclaw_sandbox_windows/src/hide_users.rs
+++ b/crates/dasclaw_sandbox_windows/src/hide_users.rs
@@ -1,0 +1,164 @@
+// Derived from openai/codex commit 6e838a19fa
+//   path: codex-rs/windows-sandbox-rs/src/hide_users.rs
+// SPDX-License-Identifier: Apache-2.0
+
+#![cfg(target_os = "windows")]
+
+use crate::logging::log_note;
+use crate::winutil::format_last_error;
+use crate::winutil::to_wide;
+use anyhow::anyhow;
+use std::ffi::OsStr;
+use std::path::Path;
+use std::path::PathBuf;
+use windows_sys::Win32::Foundation::GetLastError;
+use windows_sys::Win32::Storage::FileSystem::FILE_ATTRIBUTE_HIDDEN;
+use windows_sys::Win32::Storage::FileSystem::FILE_ATTRIBUTE_SYSTEM;
+use windows_sys::Win32::Storage::FileSystem::GetFileAttributesW;
+use windows_sys::Win32::Storage::FileSystem::INVALID_FILE_ATTRIBUTES;
+use windows_sys::Win32::Storage::FileSystem::SetFileAttributesW;
+use windows_sys::Win32::System::Registry::HKEY;
+use windows_sys::Win32::System::Registry::HKEY_LOCAL_MACHINE;
+use windows_sys::Win32::System::Registry::KEY_WRITE;
+use windows_sys::Win32::System::Registry::REG_DWORD;
+use windows_sys::Win32::System::Registry::REG_OPTION_NON_VOLATILE;
+use windows_sys::Win32::System::Registry::RegCloseKey;
+use windows_sys::Win32::System::Registry::RegCreateKeyExW;
+use windows_sys::Win32::System::Registry::RegSetValueExW;
+
+const USERLIST_KEY_PATH: &str =
+    r"SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon\SpecialAccounts\UserList";
+
+pub fn hide_newly_created_users(usernames: &[String], log_base: &Path) {
+    if usernames.is_empty() {
+        return;
+    }
+    if let Err(err) = hide_users_in_winlogon(usernames, log_base) {
+        log_note(
+            &format!("hide users: failed to update Winlogon UserList: {err}"),
+            Some(log_base),
+        );
+    }
+}
+
+/// Best-effort: hides the current sandbox user's profile directory once it exists.
+///
+/// Windows only creates profile directories when that user first logs in.
+/// This intentionally runs in the command-runner (as the sandbox user) because
+/// command running is what causes us to log in as a particular sandbox user.
+pub fn hide_current_user_profile_dir(log_base: &Path) {
+    let Some(profile) = std::env::var_os("USERPROFILE") else {
+        return;
+    };
+    let profile_dir = PathBuf::from(profile);
+    if !profile_dir.exists() {
+        return;
+    }
+
+    match hide_directory(&profile_dir) {
+        Ok(true) => {
+            // Log only when we actually change attributes, so this stays one-time per profile dir.
+            log_note(
+                &format!(
+                    "hide users: profile dir hidden for current user ({})",
+                    profile_dir.display()
+                ),
+                Some(log_base),
+            );
+        }
+        Ok(false) => {}
+        Err(err) => {
+            log_note(
+                &format!(
+                    "hide users: failed to hide current user profile dir ({}): {err}",
+                    profile_dir.display()
+                ),
+                Some(log_base),
+            );
+        }
+    }
+}
+
+fn hide_users_in_winlogon(usernames: &[String], log_base: &Path) -> anyhow::Result<()> {
+    let key = create_userlist_key()?;
+    for username in usernames {
+        let name_w = to_wide(OsStr::new(username));
+        let value: u32 = 0;
+        let status = unsafe {
+            RegSetValueExW(
+                key,
+                name_w.as_ptr(),
+                0,
+                REG_DWORD,
+                &value as *const u32 as *const u8,
+                std::mem::size_of_val(&value) as u32,
+            )
+        };
+        if status != 0 {
+            log_note(
+                &format!(
+                    "hide users: failed to set UserList value for {username}: {status} ({error})",
+                    error = format_last_error(status as i32)
+                ),
+                Some(log_base),
+            );
+        }
+    }
+    unsafe {
+        RegCloseKey(key);
+    }
+    Ok(())
+}
+
+fn create_userlist_key() -> anyhow::Result<HKEY> {
+    let key_path = to_wide(USERLIST_KEY_PATH);
+    let mut key: HKEY = 0;
+    let status = unsafe {
+        RegCreateKeyExW(
+            HKEY_LOCAL_MACHINE,
+            key_path.as_ptr(),
+            0,
+            std::ptr::null_mut(),
+            REG_OPTION_NON_VOLATILE,
+            KEY_WRITE,
+            std::ptr::null_mut(),
+            &mut key,
+            std::ptr::null_mut(),
+        )
+    };
+    if status != 0 {
+        return Err(anyhow!(
+            "RegCreateKeyExW failed: {status} ({error})",
+            error = format_last_error(status as i32)
+        ));
+    }
+    Ok(key)
+}
+
+/// Sets HIDDEN|SYSTEM on `path` if needed, returning whether it changed anything.
+fn hide_directory(path: &Path) -> anyhow::Result<bool> {
+    let wide = to_wide(path);
+    let attrs = unsafe { GetFileAttributesW(wide.as_ptr()) };
+    if attrs == INVALID_FILE_ATTRIBUTES {
+        let err = unsafe { GetLastError() } as i32;
+        return Err(anyhow!(
+            "GetFileAttributesW failed for {}: {err} ({error})",
+            path.display(),
+            error = format_last_error(err)
+        ));
+    }
+    let new_attrs = attrs | FILE_ATTRIBUTE_HIDDEN | FILE_ATTRIBUTE_SYSTEM;
+    if new_attrs == attrs {
+        return Ok(false);
+    }
+    let ok = unsafe { SetFileAttributesW(wide.as_ptr(), new_attrs) };
+    if ok == 0 {
+        let err = unsafe { GetLastError() } as i32;
+        return Err(anyhow!(
+            "SetFileAttributesW failed for {}: {err} ({error})",
+            path.display(),
+            error = format_last_error(err)
+        ));
+    }
+    Ok(true)
+}

--- a/crates/dasclaw_sandbox_windows/src/lib.rs
+++ b/crates/dasclaw_sandbox_windows/src/lib.rs
@@ -43,6 +43,9 @@
 //!   `winutil::resolve_sid`, `winutil::string_from_sid_bytes`,
 //!   `winutil::quote_windows_arg`, `winutil::argv_to_command_line`,
 //!   `cfg(windows)`).
+//! - Hide newly-created sandbox users from Winlogon and hide the current
+//!   user's profile dir (`hide_users::hide_newly_created_users`,
+//!   `hide_users::hide_current_user_profile_dir`, `cfg(windows)`).
 //! - Cross-platform PTY/process driver adapter (`pty::ProcessDriver`,
 //!   `pty::SpawnedProcess`, `pty::TerminalSize`, `pty::spawn_from_driver`).
 //! - On non-Windows targets, [`unsupported`] returns a typed error indicating
@@ -56,6 +59,8 @@ pub mod cap;
 #[cfg(windows)]
 pub mod dpapi;
 pub mod env;
+#[cfg(windows)]
+pub mod hide_users;
 pub mod logging;
 pub mod path_normalization;
 #[cfg(windows)]


### PR DESCRIPTION
## 背景 / 目标
W4 ADR-121 D3-3 阶段 1.1.4g 第一个 sibling。把 `openai/codex` `windows-sandbox-rs/src/hide_users.rs` (160 LOC) 逐字移植到 `crates/dasclaw_sandbox_windows/`，提供 Winlogon UserList 注册表写入与 USERPROFILE 隐藏属性能力，供后续 `desktop.rs` / `setup_orchestrator.rs` 移植阶段使用。

## 改动范围
- `crates/dasclaw_sandbox_windows/src/hide_users.rs`（**新文件**）：
  - `pub fn hide_newly_created_users(usernames: &[String], log_base: &Path)` — `HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon\SpecialAccounts\UserList` 写入 `REG_DWORD=0`（best-effort，失败仅 log_note）。
  - `pub fn hide_current_user_profile_dir(log_base: &Path)` — `USERPROFILE` 路径加 `FILE_ATTRIBUTE_HIDDEN | FILE_ATTRIBUTE_SYSTEM`。
  - 文件级 `#![cfg(target_os = "windows")]`；attribution header（commit 6e838a19fa, SPDX Apache-2.0）。
- `crates/dasclaw_sandbox_windows/Cargo.toml`：`windows-sys` features +
  `Win32_Storage_FileSystem`, `Win32_System_Registry`。
- `crates/dasclaw_sandbox_windows/src/lib.rs`：`#[cfg(windows)] pub mod hide_users;` 插入到 `env` 与 `logging` 之间；API 文档 bullet 紧随 `winutil` bullet 之后。

依赖均已就绪（`logging::log_note` 1.1.1；`winutil::{to_wide, format_last_error}` 1.1.4f）。

## 非目标（What's NOT in this PR）
- 不实现 token.rs（在 sibling B PR / issue #285，不依赖本 PR）。
- 不实现 desktop.rs（依赖 token，归入 1.1.4h）。
- 不实现实际的调用方；本 PR 只补齐叶子能力。
- 不引入 `unwrap()` / `panic!`（FFI 处理使用 anyhow + log_note 降级，符合 `scripts/check_no_panics.py`）。

## 验证（命令 + 结果）
```
cargo check -p dasclaw_sandbox_windows --tests   # 0 错 0 警
cargo nextest run -p dasclaw_sandbox_windows     # 37 passed, 0 failed
cargo fmt --all                                  # clean
python3.12 scripts/check_no_panics.py --base origin/xClaw           # OK
python3.12 scripts/check_no_new_ironclaw_literal.py --base origin/xClaw  # OK
cargo clippy --no-deps -p dasclaw_sandbox_windows --all-targets -- -D warnings  # 0 警告
```

注：`hide_users.rs` 整体 `cfg(target_os="windows")`，本机 macOS 只能验证 lib.rs 注册不会破坏 non-windows 构建；Win32 链接由 CI Windows job 兜底（与上游 winutil / proc_thread_attr / dpapi 走同样路径）。

## Cross-cuts
- ADR-114 类A：本 PR 无新增 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量（grep guard 通过）。

## Sibling 协议（手段 2）
- Sibling B：#285 (token.rs)。
- File-disjoint：A 写 `hide_users.rs`，B 写 `token.rs`，零文件重叠。
- `Cargo.toml` 仅本 PR 修改（B 无需新 features）。
- `lib.rs` 插入点错开：A 在 `env` 与 `logging` 之间；B 在末尾区域。
- Phase doc 文本归 sibling B（token PR）所有，本 PR 不动 phase doc 文本。

## 后续 PR / 下一步
- 1.1.4g sibling B：#285 token.rs（并行）。
- 1.1.4h：`desktop.rs`（依赖 token + winutil + logging + rand）。

Closes #284
Refs: #263 #250
