### PR TITLE
feat(sandbox-windows): port token.rs (Phase 1.1.4g, sibling B)

### DIFF
--- a/crates/dasclaw_sandbox_windows/src/lib.rs
+++ b/crates/dasclaw_sandbox_windows/src/lib.rs
@@ -9,7 +9,7 @@
 //! See `vendor/codex-windows-sandbox/README.md` for the reference snapshot
 //! and the porting plan in tracker issue #250.
 //!
-//! ## Crate status (Phase 1.1.4f)
+//! ## Crate status (Phase 1.1.4g)
 //!
 //! V'-b "port-on-demand" subset. The cross-platform PTY/process plumbing
 //! (`pty::process`) and the `cfg(windows)`-only ConPTY backend
@@ -45,6 +45,13 @@
 //!   `cfg(windows)`).
 //! - Cross-platform PTY/process driver adapter (`pty::ProcessDriver`,
 //!   `pty::SpawnedProcess`, `pty::TerminalSize`, `pty::spawn_from_driver`).
+//! - Restricted-token builders for AppContainer / capability sandboxing
+//!   (`token::world_sid`, `token::convert_string_sid_to_sid`,
+//!   `token::get_current_token_for_restriction`,
+//!   `token::get_logon_sid_bytes`, `token::create_readonly_token_with_cap`,
+//!   `token::create_readonly_token_with_cap_from`,
+//!   `token::create_readonly_token_with_caps_from`,
+//!   `token::create_workspace_write_token_with_caps_from`, `cfg(windows)`).
 //! - On non-Windows targets, [`unsupported`] returns a typed error indicating
 //!   that the Windows sandbox runtime is unavailable.
 //!
@@ -64,6 +71,8 @@ pub mod pty;
 pub mod sandbox_utils;
 pub mod setup_error;
 pub mod string_util;
+#[cfg(windows)]
+pub mod token;
 pub mod types;
 #[cfg(windows)]
 pub mod winutil;

--- a/crates/dasclaw_sandbox_windows/src/token.rs
+++ b/crates/dasclaw_sandbox_windows/src/token.rs
@@ -1,0 +1,381 @@
+// Derived from openai/codex commit 6e838a19fa
+//   path: codex-rs/windows-sandbox-rs/src/token.rs
+// SPDX-License-Identifier: Apache-2.0
+
+#![cfg(target_os = "windows")]
+
+use crate::winutil::to_wide;
+use anyhow::Result;
+use anyhow::anyhow;
+use std::ffi::c_void;
+use windows_sys::Win32::Foundation::CloseHandle;
+use windows_sys::Win32::Foundation::ERROR_SUCCESS;
+use windows_sys::Win32::Foundation::GetLastError;
+use windows_sys::Win32::Foundation::HANDLE;
+use windows_sys::Win32::Foundation::HLOCAL;
+use windows_sys::Win32::Foundation::LUID;
+use windows_sys::Win32::Foundation::LocalFree;
+use windows_sys::Win32::Security::AdjustTokenPrivileges;
+use windows_sys::Win32::Security::Authorization::EXPLICIT_ACCESS_W;
+use windows_sys::Win32::Security::Authorization::GRANT_ACCESS;
+use windows_sys::Win32::Security::Authorization::SetEntriesInAclW;
+use windows_sys::Win32::Security::Authorization::TRUSTEE_IS_SID;
+use windows_sys::Win32::Security::Authorization::TRUSTEE_IS_UNKNOWN;
+use windows_sys::Win32::Security::Authorization::TRUSTEE_W;
+use windows_sys::Win32::Security::CopySid;
+use windows_sys::Win32::Security::CreateRestrictedToken;
+use windows_sys::Win32::Security::CreateWellKnownSid;
+use windows_sys::Win32::Security::GetLengthSid;
+use windows_sys::Win32::Security::GetTokenInformation;
+use windows_sys::Win32::Security::LookupPrivilegeValueW;
+use windows_sys::Win32::Security::SetTokenInformation;
+
+use windows_sys::Win32::Security::ACL;
+use windows_sys::Win32::Security::SID_AND_ATTRIBUTES;
+use windows_sys::Win32::Security::TOKEN_ADJUST_DEFAULT;
+use windows_sys::Win32::Security::TOKEN_ADJUST_PRIVILEGES;
+use windows_sys::Win32::Security::TOKEN_ADJUST_SESSIONID;
+use windows_sys::Win32::Security::TOKEN_ASSIGN_PRIMARY;
+use windows_sys::Win32::Security::TOKEN_DUPLICATE;
+use windows_sys::Win32::Security::TOKEN_PRIVILEGES;
+use windows_sys::Win32::Security::TOKEN_QUERY;
+use windows_sys::Win32::Security::TokenDefaultDacl;
+use windows_sys::Win32::Security::TokenGroups;
+use windows_sys::Win32::System::Threading::GetCurrentProcess;
+
+const DISABLE_MAX_PRIVILEGE: u32 = 0x01;
+const LUA_TOKEN: u32 = 0x04;
+const WRITE_RESTRICTED: u32 = 0x08;
+const GENERIC_ALL: u32 = 0x1000_0000;
+const WIN_WORLD_SID: i32 = 1;
+const SE_GROUP_LOGON_ID: u32 = 0xC0000000;
+
+#[repr(C)]
+struct TokenDefaultDaclInfo {
+    default_dacl: *mut ACL,
+}
+
+/// Sets a permissive default DACL so sandboxed processes can create pipes/IPC objects
+/// without hitting ACCESS_DENIED when PowerShell builds pipelines.
+unsafe fn set_default_dacl(h_token: HANDLE, sids: &[*mut c_void]) -> Result<()> {
+    if sids.is_empty() {
+        return Ok(());
+    }
+    let entries: Vec<EXPLICIT_ACCESS_W> = sids
+        .iter()
+        .map(|sid| EXPLICIT_ACCESS_W {
+            grfAccessPermissions: GENERIC_ALL,
+            grfAccessMode: GRANT_ACCESS,
+            grfInheritance: 0,
+            Trustee: TRUSTEE_W {
+                pMultipleTrustee: std::ptr::null_mut(),
+                MultipleTrusteeOperation: 0,
+                TrusteeForm: TRUSTEE_IS_SID,
+                TrusteeType: TRUSTEE_IS_UNKNOWN,
+                ptstrName: *sid as *mut u16,
+            },
+        })
+        .collect();
+    let mut p_new_dacl: *mut ACL = std::ptr::null_mut();
+    let res = SetEntriesInAclW(
+        entries.len() as u32,
+        entries.as_ptr(),
+        std::ptr::null_mut(),
+        &mut p_new_dacl,
+    );
+    if res != ERROR_SUCCESS {
+        return Err(anyhow!("SetEntriesInAclW failed: {res}"));
+    }
+    let mut info = TokenDefaultDaclInfo {
+        default_dacl: p_new_dacl,
+    };
+    let ok = SetTokenInformation(
+        h_token,
+        TokenDefaultDacl,
+        &mut info as *mut _ as *mut c_void,
+        std::mem::size_of::<TokenDefaultDaclInfo>() as u32,
+    );
+    if ok == 0 {
+        let err = GetLastError();
+        if !p_new_dacl.is_null() {
+            LocalFree(p_new_dacl as HLOCAL);
+        }
+        return Err(anyhow!(
+            "SetTokenInformation(TokenDefaultDacl) failed: {err}",
+        ));
+    }
+    if !p_new_dacl.is_null() {
+        LocalFree(p_new_dacl as HLOCAL);
+    }
+    Ok(())
+}
+
+pub unsafe fn world_sid() -> Result<Vec<u8>> {
+    let mut size: u32 = 0;
+    CreateWellKnownSid(
+        WIN_WORLD_SID,
+        std::ptr::null_mut(),
+        std::ptr::null_mut(),
+        &mut size,
+    );
+    let mut buf: Vec<u8> = vec![0u8; size as usize];
+    let ok = CreateWellKnownSid(
+        WIN_WORLD_SID,
+        std::ptr::null_mut(),
+        buf.as_mut_ptr() as *mut c_void,
+        &mut size,
+    );
+    if ok == 0 {
+        return Err(anyhow!("CreateWellKnownSid failed: {}", GetLastError()));
+    }
+    Ok(buf)
+}
+
+/// # Safety
+/// Caller is responsible for freeing the returned SID with `LocalFree`.
+pub unsafe fn convert_string_sid_to_sid(s: &str) -> Option<*mut c_void> {
+    #[link(name = "advapi32")]
+    unsafe extern "system" {
+        fn ConvertStringSidToSidW(StringSid: *const u16, Sid: *mut *mut c_void) -> i32;
+    }
+    let mut psid: *mut c_void = std::ptr::null_mut();
+    let ok = unsafe { ConvertStringSidToSidW(to_wide(s).as_ptr(), &mut psid) };
+    if ok != 0 { Some(psid) } else { None }
+}
+
+/// # Safety
+/// Caller must close the returned token handle.
+pub unsafe fn get_current_token_for_restriction() -> Result<HANDLE> {
+    let desired = TOKEN_DUPLICATE
+        | TOKEN_QUERY
+        | TOKEN_ASSIGN_PRIMARY
+        | TOKEN_ADJUST_DEFAULT
+        | TOKEN_ADJUST_SESSIONID
+        | TOKEN_ADJUST_PRIVILEGES;
+    let mut h: HANDLE = 0;
+    #[link(name = "advapi32")]
+    unsafe extern "system" {
+        fn OpenProcessToken(
+            ProcessHandle: HANDLE,
+            DesiredAccess: u32,
+            TokenHandle: *mut HANDLE,
+        ) -> i32;
+    }
+    let ok = unsafe { OpenProcessToken(GetCurrentProcess(), desired, &mut h) };
+    if ok == 0 {
+        return Err(anyhow!("OpenProcessToken failed: {}", GetLastError()));
+    }
+    Ok(h)
+}
+
+pub unsafe fn get_logon_sid_bytes(h_token: HANDLE) -> Result<Vec<u8>> {
+    unsafe fn scan_token_groups_for_logon(h: HANDLE) -> Option<Vec<u8>> {
+        let mut needed: u32 = 0;
+        GetTokenInformation(h, TokenGroups, std::ptr::null_mut(), 0, &mut needed);
+        if needed == 0 {
+            return None;
+        }
+        let mut buf: Vec<u8> = vec![0u8; needed as usize];
+        let ok = GetTokenInformation(
+            h,
+            TokenGroups,
+            buf.as_mut_ptr() as *mut c_void,
+            needed,
+            &mut needed,
+        );
+        if ok == 0 || (needed as usize) < std::mem::size_of::<u32>() {
+            return None;
+        }
+        let group_count = std::ptr::read_unaligned(buf.as_ptr() as *const u32) as usize;
+        // TOKEN_GROUPS layout is: DWORD GroupCount; SID_AND_ATTRIBUTES Groups[];
+        // On 64-bit, Groups is aligned to pointer alignment after 4-byte GroupCount.
+        let after_count = unsafe { buf.as_ptr().add(std::mem::size_of::<u32>()) } as usize;
+        let align = std::mem::align_of::<SID_AND_ATTRIBUTES>();
+        let aligned = (after_count + (align - 1)) & !(align - 1);
+        let groups_ptr = aligned as *const SID_AND_ATTRIBUTES;
+        for i in 0..group_count {
+            let entry: SID_AND_ATTRIBUTES = std::ptr::read_unaligned(groups_ptr.add(i));
+            if (entry.Attributes & SE_GROUP_LOGON_ID) == SE_GROUP_LOGON_ID {
+                let sid = entry.Sid;
+                let sid_len = GetLengthSid(sid);
+                if sid_len == 0 {
+                    return None;
+                }
+                let mut out = vec![0u8; sid_len as usize];
+                if CopySid(sid_len, out.as_mut_ptr() as *mut c_void, sid) == 0 {
+                    return None;
+                }
+                return Some(out);
+            }
+        }
+        None
+    }
+
+    if let Some(v) = scan_token_groups_for_logon(h_token) {
+        return Ok(v);
+    }
+
+    #[repr(C)]
+    struct TOKEN_LINKED_TOKEN {
+        linked_token: HANDLE,
+    }
+    const TOKEN_LINKED_TOKEN_CLASS: i32 = 19; // TokenLinkedToken
+    let mut ln_needed: u32 = 0;
+    GetTokenInformation(
+        h_token,
+        TOKEN_LINKED_TOKEN_CLASS,
+        std::ptr::null_mut(),
+        0,
+        &mut ln_needed,
+    );
+    if ln_needed >= std::mem::size_of::<TOKEN_LINKED_TOKEN>() as u32 {
+        let mut ln_buf: Vec<u8> = vec![0u8; ln_needed as usize];
+        let ok = GetTokenInformation(
+            h_token,
+            TOKEN_LINKED_TOKEN_CLASS,
+            ln_buf.as_mut_ptr() as *mut c_void,
+            ln_needed,
+            &mut ln_needed,
+        );
+        if ok != 0 {
+            let lt: TOKEN_LINKED_TOKEN =
+                std::ptr::read_unaligned(ln_buf.as_ptr() as *const TOKEN_LINKED_TOKEN);
+            if lt.linked_token != 0 {
+                let res = scan_token_groups_for_logon(lt.linked_token);
+                CloseHandle(lt.linked_token);
+                if let Some(v) = res {
+                    return Ok(v);
+                }
+            }
+        }
+    }
+
+    Err(anyhow!("Logon SID not present on token"))
+}
+unsafe fn enable_single_privilege(h_token: HANDLE, name: &str) -> Result<()> {
+    let mut luid = LUID {
+        LowPart: 0,
+        HighPart: 0,
+    };
+    let ok = LookupPrivilegeValueW(std::ptr::null(), to_wide(name).as_ptr(), &mut luid);
+    if ok == 0 {
+        return Err(anyhow!("LookupPrivilegeValueW failed: {}", GetLastError()));
+    }
+    let mut tp: TOKEN_PRIVILEGES = std::mem::zeroed();
+    tp.PrivilegeCount = 1;
+    tp.Privileges[0].Luid = luid;
+    tp.Privileges[0].Attributes = 0x00000002; // SE_PRIVILEGE_ENABLED
+    let ok2 = AdjustTokenPrivileges(
+        h_token,
+        0,
+        &tp,
+        0,
+        std::ptr::null_mut(),
+        std::ptr::null_mut(),
+    );
+    if ok2 == 0 {
+        return Err(anyhow!("AdjustTokenPrivileges failed: {}", GetLastError()));
+    }
+    let err = GetLastError();
+    if err != 0 {
+        return Err(anyhow!("AdjustTokenPrivileges error {err}"));
+    }
+    Ok(())
+}
+
+/// # Safety
+/// Caller must close the returned token handle.
+pub unsafe fn create_readonly_token_with_cap(
+    psid_capability: *mut c_void,
+) -> Result<(HANDLE, *mut c_void)> {
+    let base = get_current_token_for_restriction()?;
+    let res = create_readonly_token_with_cap_from(base, psid_capability);
+    CloseHandle(base);
+    res
+}
+
+/// # Safety
+/// Caller must close the returned token handle; base_token must be a valid primary token.
+/// # Safety
+/// Caller must close the returned token handle; base_token must be a valid primary token.
+pub unsafe fn create_readonly_token_with_cap_from(
+    base_token: HANDLE,
+    psid_capability: *mut c_void,
+) -> Result<(HANDLE, *mut c_void)> {
+    let new_token = create_token_with_caps_from(base_token, &[psid_capability])?;
+    Ok((new_token, psid_capability))
+}
+
+/// Create a restricted token that includes all provided capability SIDs.
+///
+/// # Safety
+/// Caller must close the returned token handle; base_token must be a valid primary token.
+pub unsafe fn create_workspace_write_token_with_caps_from(
+    base_token: HANDLE,
+    psid_capabilities: &[*mut c_void],
+) -> Result<HANDLE> {
+    create_token_with_caps_from(base_token, psid_capabilities)
+}
+
+/// Create a restricted token that includes all provided capability SIDs.
+///
+/// # Safety
+/// Caller must close the returned token handle; base_token must be a valid primary token.
+pub unsafe fn create_readonly_token_with_caps_from(
+    base_token: HANDLE,
+    psid_capabilities: &[*mut c_void],
+) -> Result<HANDLE> {
+    create_token_with_caps_from(base_token, psid_capabilities)
+}
+
+unsafe fn create_token_with_caps_from(
+    base_token: HANDLE,
+    psid_capabilities: &[*mut c_void],
+) -> Result<HANDLE> {
+    if psid_capabilities.is_empty() {
+        return Err(anyhow!("no capability SIDs provided"));
+    }
+    let mut logon_sid_bytes = get_logon_sid_bytes(base_token)?;
+    let psid_logon = logon_sid_bytes.as_mut_ptr() as *mut c_void;
+    let mut everyone = world_sid()?;
+    let psid_everyone = everyone.as_mut_ptr() as *mut c_void;
+
+    // Exact order: Capabilities..., Logon, Everyone
+    let mut entries: Vec<SID_AND_ATTRIBUTES> =
+        vec![std::mem::zeroed(); psid_capabilities.len() + 2];
+    for (i, psid) in psid_capabilities.iter().enumerate() {
+        entries[i].Sid = *psid;
+        entries[i].Attributes = 0;
+    }
+    let logon_idx = psid_capabilities.len();
+    entries[logon_idx].Sid = psid_logon;
+    entries[logon_idx].Attributes = 0;
+    entries[logon_idx + 1].Sid = psid_everyone;
+    entries[logon_idx + 1].Attributes = 0;
+
+    let mut new_token: HANDLE = 0;
+    let flags = DISABLE_MAX_PRIVILEGE | LUA_TOKEN | WRITE_RESTRICTED;
+    let ok = CreateRestrictedToken(
+        base_token,
+        flags,
+        0,
+        std::ptr::null(),
+        0,
+        std::ptr::null(),
+        entries.len() as u32,
+        entries.as_mut_ptr(),
+        &mut new_token,
+    );
+    if ok == 0 {
+        return Err(anyhow!("CreateRestrictedToken failed: {}", GetLastError()));
+    }
+
+    let mut dacl_sids: Vec<*mut c_void> = Vec::with_capacity(psid_capabilities.len() + 2);
+    dacl_sids.push(psid_logon);
+    dacl_sids.push(psid_everyone);
+    dacl_sids.extend_from_slice(psid_capabilities);
+    set_default_dacl(new_token, &dacl_sids)?;
+
+    enable_single_privilege(new_token, "SeChangeNotifyPrivilege")?;
+    Ok(new_token)
+}


### PR DESCRIPTION
## 背景 / 目标
W4 ADR-121 D3-3 阶段 1.1.4g 第二个 sibling。把 `openai/codex` `windows-sandbox-rs/src/token.rs` (379 LOC) 逐字移植到 `crates/dasclaw_sandbox_windows/`，提供 `CreateRestrictedToken` / `SetTokenInformation` / `AdjustTokenPrivileges` 等受限 token 构造原语，供后续 `desktop.rs`（1.1.4h）/ `setup_main_win.rs`（1.1.4i+）/ `spawn_prep.rs` 等阶段使用。

## 改动范围
- `crates/dasclaw_sandbox_windows/src/token.rs`（**新文件**）：
  - `world_sid()` / `convert_string_sid_to_sid()` — Win32 SID 构造与字符串转换。
  - `get_current_token_for_restriction()` — `OpenProcessToken` 拉取 `TOKEN_DUPLICATE | TOKEN_QUERY | TOKEN_ASSIGN_PRIMARY | TOKEN_ADJUST_DEFAULT | TOKEN_ADJUST_SESSIONID | TOKEN_ADJUST_PRIVILEGES`。
  - `get_logon_sid_bytes()` — 扫描 `TokenGroups` 找 `SE_GROUP_LOGON_ID`，UAC 拆分时还原 fallback 走 `TokenLinkedToken`。
  - `create_readonly_token_with_cap` / `*_from` / `_caps_from` / `create_workspace_write_token_with_caps_from` — `CreateRestrictedToken` 带 `DISABLE_MAX_PRIVILEGE | LUA_TOKEN | WRITE_RESTRICTED`，按 Capabilities/Logon/Everyone 顺序拼 SID，permissive default DACL（`SetEntriesInAclW`），最后 `enable_single_privilege("SeChangeNotifyPrivilege")`。
  - 内部 helper：`set_default_dacl`、`enable_single_privilege`、`create_token_with_caps_from`。
  - 文件级 `#![cfg(target_os = "windows")]`；attribution header（commit 6e838a19fa, SPDX Apache-2.0）。
- `crates/dasclaw_sandbox_windows/src/lib.rs`：
  - 注册 `#[cfg(windows)] pub mod token;`，插入到 `string_util` 与 `types` 之间（**远离** sibling A 在 `env`/`logging` 之间的插入点）。
  - 更新 phase doc `Phase 1.1.4f` → `Phase 1.1.4g`（本 sibling 为 phase doc owner）。
  - 在 API bullet 列表中 `pty` bullet 之后追加 token bullet（远离 sibling A 在 `winutil` bullet 之后追加的 hide_users bullet）。
- `Cargo.toml`：**未触碰**。所需 windows-sys features 已由 1.1.4e/f 引入（`Win32_Foundation`、`Win32_Security`、`Win32_Security_Authorization`、`Win32_System_Threading`）。

## 非目标（What's NOT in this PR）
- 不实现 `hide_users.rs`（在 sibling A #286 / issue #284，不依赖本 PR）。
- 不实现 `desktop.rs`（依赖本 PR 的 `create_readonly_token_with_cap`，归入 1.1.4h）。
- 不串接到任何 sandbox spawn 路径；本 PR 只补齐 token 构造叶子能力。
- 不引入 `unwrap()` / `panic!`（FFI 失败一律 anyhow，符合 `scripts/check_no_panics.py`）。

## 验证（命令 + 结果）
```
cargo check -p dasclaw_sandbox_windows --tests   # 0 错 0 警
cargo nextest run -p dasclaw_sandbox_windows     # 37 passed, 0 failed
cargo fmt --all                                  # clean
python3.12 scripts/check_no_panics.py --base origin/xClaw           # OK
python3.12 scripts/check_no_new_ironclaw_literal.py --base origin/xClaw  # OK
cargo clippy --no-deps -p dasclaw_sandbox_windows --all-targets -- -D warnings  # 0 警告
```

注：`token.rs` 整体 `cfg(target_os="windows")`，本机 macOS 只能验证 lib.rs 注册不会破坏 non-windows 构建；Win32 链接由 CI Windows job 兜底（与上游 winutil / proc_thread_attr / dpapi 走同样路径）。所有 `unsafe` 函数均带 `# Safety` 文档（含原文 caller-must-CloseHandle / caller-must-LocalFree 契约）。

## Cross-cuts
- ADR-114 类A：本 PR 无新增 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量（grep guard 通过）。

## Sibling 协议（手段 2）
- Sibling A：#286 (hide_users.rs)。
- File-disjoint：A 写 `hide_users.rs`，B 写 `token.rs`，零文件重叠。
- `Cargo.toml` 仅 sibling A 修改（B 无需新 features，本 PR 完全不动）。
- `lib.rs` 插入点错开：A 在 `env` 与 `logging` 之间；B 在 `string_util` 与 `types` 之间（**位于文件不同段落，3-way merge 无冲突**）。
- Phase doc 文本归本 sibling B 所有，sibling A 不动 phase doc 文本。

## 后续 PR / 下一步
- 1.1.4h：`desktop.rs`（依赖本 PR 的 `create_readonly_token_with_cap` + `winutil` + `logging` + `rand`）。
- 1.1.4i+：`setup_main_win.rs` / `spawn_prep.rs` / `process.rs` 等。

Closes #285
Refs: #263 #250
