### PR TITLE
feat(sandbox-windows): port desktop.rs (Phase 1.1.4h, stacked on #287)

### DIFF
--- a/crates/dasclaw_sandbox_windows/Cargo.toml
+++ b/crates/dasclaw_sandbox_windows/Cargo.toml
@@ -53,6 +53,7 @@ features = [
   "Win32_Security_Authorization",
   "Win32_Security_Cryptography",
   "Win32_System_Diagnostics_Debug",
+  "Win32_System_StationsAndDesktops",
   "Win32_System_Threading",
 ]
 

--- a/crates/dasclaw_sandbox_windows/src/desktop.rs
+++ b/crates/dasclaw_sandbox_windows/src/desktop.rs
@@ -1,0 +1,202 @@
+// Derived from openai/codex commit 6e838a19fa
+//   path: codex-rs/windows-sandbox-rs/src/desktop.rs
+// SPDX-License-Identifier: Apache-2.0
+
+#![cfg(target_os = "windows")]
+
+use crate::logging;
+use crate::token::get_current_token_for_restriction;
+use crate::token::get_logon_sid_bytes;
+use crate::winutil::format_last_error;
+use crate::winutil::to_wide;
+use anyhow::Result;
+use rand::Rng;
+use rand::SeedableRng;
+use rand::rngs::SmallRng;
+use std::ffi::c_void;
+use std::path::Path;
+use std::ptr;
+use windows_sys::Win32::Foundation::CloseHandle;
+use windows_sys::Win32::Foundation::ERROR_SUCCESS;
+use windows_sys::Win32::Foundation::GetLastError;
+use windows_sys::Win32::Foundation::HLOCAL;
+use windows_sys::Win32::Foundation::LocalFree;
+use windows_sys::Win32::Security::Authorization::EXPLICIT_ACCESS_W;
+use windows_sys::Win32::Security::Authorization::GRANT_ACCESS;
+use windows_sys::Win32::Security::Authorization::SE_WINDOW_OBJECT;
+use windows_sys::Win32::Security::Authorization::SetEntriesInAclW;
+use windows_sys::Win32::Security::Authorization::SetSecurityInfo;
+use windows_sys::Win32::Security::Authorization::TRUSTEE_IS_SID;
+use windows_sys::Win32::Security::Authorization::TRUSTEE_IS_UNKNOWN;
+use windows_sys::Win32::Security::Authorization::TRUSTEE_W;
+use windows_sys::Win32::Security::DACL_SECURITY_INFORMATION;
+use windows_sys::Win32::System::StationsAndDesktops::CloseDesktop;
+use windows_sys::Win32::System::StationsAndDesktops::CreateDesktopW;
+use windows_sys::Win32::System::StationsAndDesktops::DESKTOP_CREATEMENU;
+use windows_sys::Win32::System::StationsAndDesktops::DESKTOP_CREATEWINDOW;
+use windows_sys::Win32::System::StationsAndDesktops::DESKTOP_DELETE;
+use windows_sys::Win32::System::StationsAndDesktops::DESKTOP_ENUMERATE;
+use windows_sys::Win32::System::StationsAndDesktops::DESKTOP_HOOKCONTROL;
+use windows_sys::Win32::System::StationsAndDesktops::DESKTOP_JOURNALPLAYBACK;
+use windows_sys::Win32::System::StationsAndDesktops::DESKTOP_JOURNALRECORD;
+use windows_sys::Win32::System::StationsAndDesktops::DESKTOP_READ_CONTROL;
+use windows_sys::Win32::System::StationsAndDesktops::DESKTOP_READOBJECTS;
+use windows_sys::Win32::System::StationsAndDesktops::DESKTOP_SWITCHDESKTOP;
+use windows_sys::Win32::System::StationsAndDesktops::DESKTOP_WRITE_DAC;
+use windows_sys::Win32::System::StationsAndDesktops::DESKTOP_WRITE_OWNER;
+use windows_sys::Win32::System::StationsAndDesktops::DESKTOP_WRITEOBJECTS;
+
+const DESKTOP_ALL_ACCESS: u32 = DESKTOP_READOBJECTS
+    | DESKTOP_CREATEWINDOW
+    | DESKTOP_CREATEMENU
+    | DESKTOP_HOOKCONTROL
+    | DESKTOP_JOURNALRECORD
+    | DESKTOP_JOURNALPLAYBACK
+    | DESKTOP_ENUMERATE
+    | DESKTOP_WRITEOBJECTS
+    | DESKTOP_SWITCHDESKTOP
+    | DESKTOP_DELETE
+    | DESKTOP_READ_CONTROL
+    | DESKTOP_WRITE_DAC
+    | DESKTOP_WRITE_OWNER;
+
+pub struct LaunchDesktop {
+    _private_desktop: Option<PrivateDesktop>,
+    startup_name: Vec<u16>,
+}
+
+impl LaunchDesktop {
+    pub fn prepare(use_private_desktop: bool, logs_base_dir: Option<&Path>) -> Result<Self> {
+        if use_private_desktop {
+            let private_desktop = PrivateDesktop::create(logs_base_dir)?;
+            let startup_name = to_wide(format!("Winsta0\\{}", private_desktop.name));
+            Ok(Self {
+                _private_desktop: Some(private_desktop),
+                startup_name,
+            })
+        } else {
+            Ok(Self {
+                _private_desktop: None,
+                startup_name: to_wide("Winsta0\\Default"),
+            })
+        }
+    }
+
+    pub fn startup_info_desktop(&self) -> *mut u16 {
+        self.startup_name.as_ptr() as *mut u16
+    }
+}
+
+struct PrivateDesktop {
+    handle: isize,
+    name: String,
+}
+
+impl PrivateDesktop {
+    fn create(logs_base_dir: Option<&Path>) -> Result<Self> {
+        let mut rng = SmallRng::from_entropy();
+        let name = format!("CodexSandboxDesktop-{:x}", rng.r#gen::<u128>());
+        let name_wide = to_wide(&name);
+        let handle = unsafe {
+            CreateDesktopW(
+                name_wide.as_ptr(),
+                ptr::null(),
+                ptr::null_mut(),
+                0,
+                DESKTOP_ALL_ACCESS,
+                ptr::null_mut(),
+            )
+        };
+        if handle == 0 {
+            let err = unsafe { GetLastError() } as i32;
+            logging::debug_log(
+                &format!(
+                    "CreateDesktopW failed for {name}: {} ({})",
+                    err,
+                    format_last_error(err),
+                ),
+                logs_base_dir,
+            );
+            return Err(anyhow::anyhow!("CreateDesktopW failed: {err}"));
+        }
+
+        unsafe {
+            if let Err(err) = grant_desktop_access(handle, logs_base_dir) {
+                let _ = CloseDesktop(handle);
+                return Err(err);
+            }
+        }
+
+        Ok(Self { handle, name })
+    }
+}
+
+unsafe fn grant_desktop_access(handle: isize, logs_base_dir: Option<&Path>) -> Result<()> {
+    let token = get_current_token_for_restriction()?;
+    let mut logon_sid = get_logon_sid_bytes(token)?;
+    CloseHandle(token);
+
+    let entries = [EXPLICIT_ACCESS_W {
+        grfAccessPermissions: DESKTOP_ALL_ACCESS,
+        grfAccessMode: GRANT_ACCESS,
+        grfInheritance: 0,
+        Trustee: TRUSTEE_W {
+            pMultipleTrustee: ptr::null_mut(),
+            MultipleTrusteeOperation: 0,
+            TrusteeForm: TRUSTEE_IS_SID,
+            TrusteeType: TRUSTEE_IS_UNKNOWN,
+            ptstrName: logon_sid.as_mut_ptr() as *mut c_void as *mut u16,
+        },
+    }];
+
+    let mut updated_dacl = ptr::null_mut();
+    let set_entries_code = SetEntriesInAclW(
+        entries.len() as u32,
+        entries.as_ptr(),
+        ptr::null_mut(),
+        &mut updated_dacl,
+    );
+    if set_entries_code != ERROR_SUCCESS {
+        logging::debug_log(
+            &format!("SetEntriesInAclW failed for private desktop: {set_entries_code}"),
+            logs_base_dir,
+        );
+        return Err(anyhow::anyhow!(
+            "SetEntriesInAclW failed for private desktop: {set_entries_code}"
+        ));
+    }
+
+    let set_security_code = SetSecurityInfo(
+        handle,
+        SE_WINDOW_OBJECT,
+        DACL_SECURITY_INFORMATION,
+        ptr::null_mut(),
+        ptr::null_mut(),
+        updated_dacl,
+        ptr::null_mut(),
+    );
+    if !updated_dacl.is_null() {
+        LocalFree(updated_dacl as HLOCAL);
+    }
+    if set_security_code != ERROR_SUCCESS {
+        logging::debug_log(
+            &format!("SetSecurityInfo failed for private desktop: {set_security_code}"),
+            logs_base_dir,
+        );
+        return Err(anyhow::anyhow!(
+            "SetSecurityInfo failed for private desktop: {set_security_code}"
+        ));
+    }
+
+    Ok(())
+}
+
+impl Drop for PrivateDesktop {
+    fn drop(&mut self) {
+        unsafe {
+            if self.handle != 0 {
+                let _ = CloseDesktop(self.handle);
+            }
+        }
+    }
+}

--- a/crates/dasclaw_sandbox_windows/src/lib.rs
+++ b/crates/dasclaw_sandbox_windows/src/lib.rs
@@ -9,7 +9,7 @@
 //! See `vendor/codex-windows-sandbox/README.md` for the reference snapshot
 //! and the porting plan in tracker issue #250.
 //!
-//! ## Crate status (Phase 1.1.4g)
+//! ## Crate status (Phase 1.1.4h)
 //!
 //! V'-b "port-on-demand" subset. The cross-platform PTY/process plumbing
 //! (`pty::process`) and the `cfg(windows)`-only ConPTY backend
@@ -52,6 +52,8 @@
 //!   `token::create_readonly_token_with_cap_from`,
 //!   `token::create_readonly_token_with_caps_from`,
 //!   `token::create_workspace_write_token_with_caps_from`, `cfg(windows)`).
+//! - Private-desktop launcher (`desktop::LaunchDesktop::prepare`,
+//!   `desktop::LaunchDesktop::startup_info_desktop`, `cfg(windows)`).
 //! - On non-Windows targets, [`unsupported`] returns a typed error indicating
 //!   that the Windows sandbox runtime is unavailable.
 //!
@@ -60,6 +62,8 @@
 
 pub mod absolute_path;
 pub mod cap;
+#[cfg(windows)]
+pub mod desktop;
 #[cfg(windows)]
 pub mod dpapi;
 pub mod env;


### PR DESCRIPTION
## 背景 / 目标

W4 ADR-121 D3-3 阶段 1.1.4h：把 `openai/codex` `windows-sandbox-rs/src/desktop.rs`（commit `6e838a19fa`，196 LOC）逐字移植到 `crates/dasclaw_sandbox_windows/src/desktop.rs`。

继续推进 tracker issue #263（W4 sandbox-windows 端口）/ #250（垂直 sandbox 重构）的子任务。

## 改动范围

- **新文件** `crates/dasclaw_sandbox_windows/src/desktop.rs`（196 LOC，verbatim 移植）：
  - 文件级 `#![cfg(target_os = "windows")]` + 上游 attribution 头（commit `6e838a19fa`，SPDX Apache-2.0）。
  - `LaunchDesktop::prepare(use_private_desktop, logs_base_dir)` — 私桌面模式调用 `CreateDesktopW`，并通过 `SetEntriesInAclW` + `SetSecurityInfo` 给 logon SID 授予 `DESKTOP_ALL_ACCESS`；非私桌面模式回退到 `Winsta0\Default` startup name。
  - `LaunchDesktop::startup_info_desktop()` 暴露给 `STARTUPINFOEXW.lpDesktop` 的 `*mut u16`。
  - 内部 `PrivateDesktop`（handle + name；Drop 调用 `CloseDesktop`）+ `unsafe fn grant_desktop_access`。
- `Cargo.toml`：`windows-sys` features 追加 `Win32_System_StationsAndDesktops`（其余依赖已在 1.1.4f/1.1.4g 落地）。
- `src/lib.rs`：
  - 在 `cap` 与 `dpapi` 之间注册 `#[cfg(windows)] pub mod desktop;`。
  - 头注释加 `desktop::LaunchDesktop::prepare` / `startup_info_desktop` API bullet。
  - 阶段标识 `Phase 1.1.4g` → `Phase 1.1.4h`。

## 非目标（What's NOT in this PR）

- 不引入新的 sandbox 行为（与上游字节级一致，仅做 import path 重写为 `crate::*`）。
- 不调整 `LaunchDesktop` 的可见性 / API 形态。
- 不增加单元测试：本模块全部依赖 Win32 系统调用（`CreateDesktopW` / `SetSecurityInfo` / 当前进程 token），上游同样未提供单元测试；正确性由后续 1.1.4i+ 集成 + W4 收尾 e2e 验证。
- 不动其他 1.1.4 兄弟 PR（#286 hide_users / #287 token）。
- 不动 ADR-114 命名（**类A**：本 PR 不新增 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量）。

## Cross-cuts

- ADR-114：**类A**（grep guard `scripts/check_no_new_ironclaw_literal.py --base origin/xClaw` 已绿）。
- ADR-121：D3-3 阶段 1.1.4h 单 PR（无 sibling 计划）。

## 验证

```text
cargo check -p dasclaw_sandbox_windows --tests   ✅ 0 错 0 警
cargo nextest run -p dasclaw_sandbox_windows     ✅ 37/37 passed
cargo fmt --all                                  ✅
python3.12 scripts/check_no_panics.py --base origin/xClaw                     ✅ OK
python3   scripts/check_no_new_ironclaw_literal.py --base origin/xClaw         ✅ OK
cargo clippy --no-deps -p dasclaw_sandbox_windows --all-targets -- -D warnings ✅ 0 warning
```

> macOS host 下 `desktop.rs` 由 `#[cfg(windows)]` 门控，编译器只走非 Windows 分支；Win32 路径 + `Win32_System_StationsAndDesktops` feature gate 由 CI Windows runner 兜底。

## 后续步骤

1. **依赖 / merge 顺序**：本 PR 是 stacked PR
   - base 分支：`feat/sandbox-windows-1.1.4g-token`（PR #287）
   - merge 顺序：**先 merge #287，再 rebase 本 PR 到 `xClaw`，再 merge 本 PR**。
   - 与 sibling PR #286 (hide_users) 文件零重叠（hide_users 不动 lib.rs 的 `cap`/`dpapi` 之间区域，desktop 不动 `env`/`logging` 之间区域；Cargo.toml 上 #286 加 `Win32_Storage_FileSystem` + `Win32_System_Registry`，本 PR 加 `Win32_System_StationsAndDesktops`，三者互不冲突）。但本 PR 严格依赖 token，所以**只 stack 在 #287 上**，不 stack 在 #286 上。
2. 1.1.4i+ 后续：`acl.rs` / `sandbox_users.rs` / `setup_main_win.rs` / `setup_orchestrator.rs` / `helper_materialization.rs` / `spawn_prep.rs` / `process.rs` / `firewall.rs` / `audit.rs` / `policy.rs` / `identity.rs` / `read_acl_mutex.rs` / `workspace_acl.rs` / `ssh_config_dependencies.rs` / `elevated_impl.rs` / `elevated/` / `conpty/` / `bin/`。

Closes #288  
Refs #263 #250
