### PR TITLE
fix(ci): regression-test-check tolerate missing refs/pull/N/head on stacked PRs

### DIFF
--- a/.github/workflows/regression-test-check.yml
+++ b/.github/workflows/regression-test-check.yml
@@ -22,9 +22,21 @@ jobs:
           fetch-depth: 0
 
       - name: Fetch PR head and base
+        env:
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
+          set -euo pipefail
           git fetch origin ${{ github.event.pull_request.base.ref }}
-          git fetch origin pull/${{ github.event.pull_request.number }}/head:pr-head
+          # GitHub does not always create refs/pull/N/head for stacked PRs whose
+          # base is another open PR's branch (only refs/pull/N/merge appears).
+          # Fall back to the PR head SHA from the event payload, which
+          # actions/checkout@v4 with fetch-depth: 0 has already pulled in.
+          if git fetch origin "pull/${{ github.event.pull_request.number }}/head:pr-head" 2>/dev/null; then
+            echo "pr-head fetched from refs/pull/N/head."
+          else
+            echo "refs/pull/N/head missing (likely stacked PR); falling back to PR head SHA $PR_HEAD_SHA."
+            git update-ref refs/heads/pr-head "$PR_HEAD_SHA"
+          fi
 
       - name: Check for regression tests
         env:


### PR DESCRIPTION
## 背景 / 目标

修复 `.github/workflows/regression-test-check.yml` 在 **stacked PR** 上的结构性 bug。

## 现象

GitHub 对 base 为另一个 open PR head 的 PR **不创建 `refs/pull/N/head`**（只生成 `refs/pull/N/merge`）。`Fetch PR head and base` step 的 `git fetch origin pull/N/head:pr-head` 因此 fatal，并且因为 step 默认 `set -e`，整个 job 在还没走到业务逻辑（`feat:` PR auto-skip）之前就挂掉。

实证（PR #289 base 为 #287 head 分支）：

```bash
$ git ls-remote https://github.com/Linnanli/xClaw.git 'refs/pull/289/*'
refs/pull/289/merge   ← only this, no head ref
```

## 改动范围

- `.github/workflows/regression-test-check.yml`
  - `Fetch PR head and base` step 加 `set -euo pipefail`
  - `git fetch origin pull/N/head:pr-head` 失败时回落到 `git update-ref refs/heads/pr-head "$PR_HEAD_SHA"`，用 `github.event.pull_request.head.sha` 兜底
  - actions/checkout@v4 + `fetch-depth: 0` 已把 head SHA 拉到本地，update-ref 一定成功

## 非目标（What's NOT in this PR）

- 不改业务逻辑（fix PR 检测、skip-regression-check 标记、static-only 豁免）。
- 不改 `paths-ignore` 触发条件。
- 不影响非 stacked PR：fast path 仍走 fetch ref。

## Cross-cuts

- ADR-114：**不涉及**（仅 workflow YAML，无 `.ironclaw` 字面量）。
- 关联 PR #289（1.1.4h desktop，stacked on #287）：本 fix merge 后 #289 的 `Regression test enforcement` 应自动转绿（`feat:` PR auto-skip）。

## 验证

- YAML 语法：本机 `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/regression-test-check.yml'))"` ✅
- 行为模拟：
  - 非 stacked PR（refs/pull/N/head 存在）：`if git fetch ... 2>/dev/null` 走 then 分支，与原版一致
  - stacked PR（ref 缺失）：fetch 返回非 0 → 走 else 分支，`git update-ref` 用 head SHA 建立本地 pr-head → 后续 `git diff "${BASE_REF}...pr-head"` 与正常情况一致

> 此 workflow 自身只在 `pull_request` events 触发，不影响其他 jobs。

## 后续步骤

1. merge 本 PR 后，PR #289 应自动绿（auto-skip 规则生效）。
2. 长期收益：所有未来 stacked PR 的 regression-check 不再因 GitHub 数据层 quirk fail。

Closes #290
