### PR TITLE
feat(sandbox-windows): port desktop.rs (Phase 1.1.4h, replaces #289)

### DIFF
--- a/crates/dasclaw_sandbox_windows/Cargo.toml
+++ b/crates/dasclaw_sandbox_windows/Cargo.toml
@@ -55,6 +55,7 @@ features = [
   "Win32_Storage_FileSystem",
   "Win32_System_Diagnostics_Debug",
   "Win32_System_Registry",
+  "Win32_System_StationsAndDesktops",
   "Win32_System_Threading",
 ]
 

--- a/crates/dasclaw_sandbox_windows/src/desktop.rs
+++ b/crates/dasclaw_sandbox_windows/src/desktop.rs
@@ -1,0 +1,202 @@
+// Derived from openai/codex commit 6e838a19fa
+//   path: codex-rs/windows-sandbox-rs/src/desktop.rs
+// SPDX-License-Identifier: Apache-2.0
+
+#![cfg(target_os = "windows")]
+
+use crate::logging;
+use crate::token::get_current_token_for_restriction;
+use crate::token::get_logon_sid_bytes;
+use crate::winutil::format_last_error;
+use crate::winutil::to_wide;
+use anyhow::Result;
+use rand::Rng;
+use rand::SeedableRng;
+use rand::rngs::SmallRng;
+use std::ffi::c_void;
+use std::path::Path;
+use std::ptr;
+use windows_sys::Win32::Foundation::CloseHandle;
+use windows_sys::Win32::Foundation::ERROR_SUCCESS;
+use windows_sys::Win32::Foundation::GetLastError;
+use windows_sys::Win32::Foundation::HLOCAL;
+use windows_sys::Win32::Foundation::LocalFree;
+use windows_sys::Win32::Security::Authorization::EXPLICIT_ACCESS_W;
+use windows_sys::Win32::Security::Authorization::GRANT_ACCESS;
+use windows_sys::Win32::Security::Authorization::SE_WINDOW_OBJECT;
+use windows_sys::Win32::Security::Authorization::SetEntriesInAclW;
+use windows_sys::Win32::Security::Authorization::SetSecurityInfo;
+use windows_sys::Win32::Security::Authorization::TRUSTEE_IS_SID;
+use windows_sys::Win32::Security::Authorization::TRUSTEE_IS_UNKNOWN;
+use windows_sys::Win32::Security::Authorization::TRUSTEE_W;
+use windows_sys::Win32::Security::DACL_SECURITY_INFORMATION;
+use windows_sys::Win32::System::StationsAndDesktops::CloseDesktop;
+use windows_sys::Win32::System::StationsAndDesktops::CreateDesktopW;
+use windows_sys::Win32::System::StationsAndDesktops::DESKTOP_CREATEMENU;
+use windows_sys::Win32::System::StationsAndDesktops::DESKTOP_CREATEWINDOW;
+use windows_sys::Win32::System::StationsAndDesktops::DESKTOP_DELETE;
+use windows_sys::Win32::System::StationsAndDesktops::DESKTOP_ENUMERATE;
+use windows_sys::Win32::System::StationsAndDesktops::DESKTOP_HOOKCONTROL;
+use windows_sys::Win32::System::StationsAndDesktops::DESKTOP_JOURNALPLAYBACK;
+use windows_sys::Win32::System::StationsAndDesktops::DESKTOP_JOURNALRECORD;
+use windows_sys::Win32::System::StationsAndDesktops::DESKTOP_READ_CONTROL;
+use windows_sys::Win32::System::StationsAndDesktops::DESKTOP_READOBJECTS;
+use windows_sys::Win32::System::StationsAndDesktops::DESKTOP_SWITCHDESKTOP;
+use windows_sys::Win32::System::StationsAndDesktops::DESKTOP_WRITE_DAC;
+use windows_sys::Win32::System::StationsAndDesktops::DESKTOP_WRITE_OWNER;
+use windows_sys::Win32::System::StationsAndDesktops::DESKTOP_WRITEOBJECTS;
+
+const DESKTOP_ALL_ACCESS: u32 = DESKTOP_READOBJECTS
+    | DESKTOP_CREATEWINDOW
+    | DESKTOP_CREATEMENU
+    | DESKTOP_HOOKCONTROL
+    | DESKTOP_JOURNALRECORD
+    | DESKTOP_JOURNALPLAYBACK
+    | DESKTOP_ENUMERATE
+    | DESKTOP_WRITEOBJECTS
+    | DESKTOP_SWITCHDESKTOP
+    | DESKTOP_DELETE
+    | DESKTOP_READ_CONTROL
+    | DESKTOP_WRITE_DAC
+    | DESKTOP_WRITE_OWNER;
+
+pub struct LaunchDesktop {
+    _private_desktop: Option<PrivateDesktop>,
+    startup_name: Vec<u16>,
+}
+
+impl LaunchDesktop {
+    pub fn prepare(use_private_desktop: bool, logs_base_dir: Option<&Path>) -> Result<Self> {
+        if use_private_desktop {
+            let private_desktop = PrivateDesktop::create(logs_base_dir)?;
+            let startup_name = to_wide(format!("Winsta0\\{}", private_desktop.name));
+            Ok(Self {
+                _private_desktop: Some(private_desktop),
+                startup_name,
+            })
+        } else {
+            Ok(Self {
+                _private_desktop: None,
+                startup_name: to_wide("Winsta0\\Default"),
+            })
+        }
+    }
+
+    pub fn startup_info_desktop(&self) -> *mut u16 {
+        self.startup_name.as_ptr() as *mut u16
+    }
+}
+
+struct PrivateDesktop {
+    handle: isize,
+    name: String,
+}
+
+impl PrivateDesktop {
+    fn create(logs_base_dir: Option<&Path>) -> Result<Self> {
+        let mut rng = SmallRng::from_entropy();
+        let name = format!("CodexSandboxDesktop-{:x}", rng.r#gen::<u128>());
+        let name_wide = to_wide(&name);
+        let handle = unsafe {
+            CreateDesktopW(
+                name_wide.as_ptr(),
+                ptr::null(),
+                ptr::null_mut(),
+                0,
+                DESKTOP_ALL_ACCESS,
+                ptr::null_mut(),
+            )
+        };
+        if handle == 0 {
+            let err = unsafe { GetLastError() } as i32;
+            logging::debug_log(
+                &format!(
+                    "CreateDesktopW failed for {name}: {} ({})",
+                    err,
+                    format_last_error(err),
+                ),
+                logs_base_dir,
+            );
+            return Err(anyhow::anyhow!("CreateDesktopW failed: {err}"));
+        }
+
+        unsafe {
+            if let Err(err) = grant_desktop_access(handle, logs_base_dir) {
+                let _ = CloseDesktop(handle);
+                return Err(err);
+            }
+        }
+
+        Ok(Self { handle, name })
+    }
+}
+
+unsafe fn grant_desktop_access(handle: isize, logs_base_dir: Option<&Path>) -> Result<()> {
+    let token = get_current_token_for_restriction()?;
+    let mut logon_sid = get_logon_sid_bytes(token)?;
+    CloseHandle(token);
+
+    let entries = [EXPLICIT_ACCESS_W {
+        grfAccessPermissions: DESKTOP_ALL_ACCESS,
+        grfAccessMode: GRANT_ACCESS,
+        grfInheritance: 0,
+        Trustee: TRUSTEE_W {
+            pMultipleTrustee: ptr::null_mut(),
+            MultipleTrusteeOperation: 0,
+            TrusteeForm: TRUSTEE_IS_SID,
+            TrusteeType: TRUSTEE_IS_UNKNOWN,
+            ptstrName: logon_sid.as_mut_ptr() as *mut c_void as *mut u16,
+        },
+    }];
+
+    let mut updated_dacl = ptr::null_mut();
+    let set_entries_code = SetEntriesInAclW(
+        entries.len() as u32,
+        entries.as_ptr(),
+        ptr::null_mut(),
+        &mut updated_dacl,
+    );
+    if set_entries_code != ERROR_SUCCESS {
+        logging::debug_log(
+            &format!("SetEntriesInAclW failed for private desktop: {set_entries_code}"),
+            logs_base_dir,
+        );
+        return Err(anyhow::anyhow!(
+            "SetEntriesInAclW failed for private desktop: {set_entries_code}"
+        ));
+    }
+
+    let set_security_code = SetSecurityInfo(
+        handle,
+        SE_WINDOW_OBJECT,
+        DACL_SECURITY_INFORMATION,
+        ptr::null_mut(),
+        ptr::null_mut(),
+        updated_dacl,
+        ptr::null_mut(),
+    );
+    if !updated_dacl.is_null() {
+        LocalFree(updated_dacl as HLOCAL);
+    }
+    if set_security_code != ERROR_SUCCESS {
+        logging::debug_log(
+            &format!("SetSecurityInfo failed for private desktop: {set_security_code}"),
+            logs_base_dir,
+        );
+        return Err(anyhow::anyhow!(
+            "SetSecurityInfo failed for private desktop: {set_security_code}"
+        ));
+    }
+
+    Ok(())
+}
+
+impl Drop for PrivateDesktop {
+    fn drop(&mut self) {
+        unsafe {
+            if self.handle != 0 {
+                let _ = CloseDesktop(self.handle);
+            }
+        }
+    }
+}

--- a/crates/dasclaw_sandbox_windows/src/lib.rs
+++ b/crates/dasclaw_sandbox_windows/src/lib.rs
@@ -9,7 +9,7 @@
 //! See `vendor/codex-windows-sandbox/README.md` for the reference snapshot
 //! and the porting plan in tracker issue #250.
 //!
-//! ## Crate status (Phase 1.1.4g)
+//! ## Crate status (Phase 1.1.4h)
 //!
 //! V'-b "port-on-demand" subset. The cross-platform PTY/process plumbing
 //! (`pty::process`) and the `cfg(windows)`-only ConPTY backend
@@ -55,6 +55,8 @@
 //!   `token::create_readonly_token_with_cap_from`,
 //!   `token::create_readonly_token_with_caps_from`,
 //!   `token::create_workspace_write_token_with_caps_from`, `cfg(windows)`).
+//! - Private-desktop launcher (`desktop::LaunchDesktop::prepare`,
+//!   `desktop::LaunchDesktop::startup_info_desktop`, `cfg(windows)`).
 //! - On non-Windows targets, [`unsupported`] returns a typed error indicating
 //!   that the Windows sandbox runtime is unavailable.
 //!
@@ -63,6 +65,8 @@
 
 pub mod absolute_path;
 pub mod cap;
+#[cfg(windows)]
+pub mod desktop;
 #[cfg(windows)]
 pub mod dpapi;
 pub mod env;


### PR DESCRIPTION
## 背景 / 目标

W4 ADR-121 D3-3 Phase 1.1.4h: 移植 openai/codex `windows-sandbox-rs` 的 `desktop.rs`（私有桌面启动器），用于沙箱进程在隔离 desktop 上启动。

> 本 PR 取代已被 GitHub 自动关闭的 #289（base 分支 `feat/sandbox-windows-1.1.4g-token` 随 #287 合并被删除）。代码内容与 #289 一致，已 rebase 到 xClaw HEAD。

Closes #288

## 改动范围

- 新增 `crates/dasclaw_sandbox_windows/src/desktop.rs`（196 LOC，verbatim port from upstream commit `6e838a19fa`）
  - `pub struct LaunchDesktop` + `prepare()` / `startup_info_desktop()`
  - 内部 `PrivateDesktop`：`CreateDesktopW` + `SetSecurityInfo`（授予当前 token + logon SID 访问权）
  - `Drop` 调用 `CloseDesktop`
- `Cargo.toml`：windows-sys features 新增 `Win32_System_StationsAndDesktops`
- `lib.rs`：注册 `#[cfg(windows)] pub mod desktop;`，phase doc bump 到 1.1.4h

## 非目标

- 不接入 `LaunchDesktop` 到 spawn 流程（属于 Phase 1.1.4i+）
- 不改其他模块

## 验证

```
cargo check -p dasclaw_sandbox_windows --tests   # 0 错 0 警
cargo nextest run -p dasclaw_sandbox_windows      # 37/37 passed
cargo fmt --all                                   # clean
python3.12 scripts/check_no_panics.py --base origin/xClaw  # OK
python3 scripts/check_no_new_ironclaw_literal.py --base origin/xClaw  # OK
cargo clippy --no-deps -p dasclaw_sandbox_windows --all-targets -- -D warnings  # 0 warning
```

## Cross-cuts

- ADR-114: **类A**（无新增 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量）

## 后续 PR

Phase 1.1.4i: acl.rs / sandbox_users.rs / setup_main_win.rs ...
