### PR TITLE
feat(sandbox-windows): port policy.rs (Phase 1.1.4i-1)

### DIFF
--- a/crates/dasclaw_sandbox_windows/src/lib.rs
+++ b/crates/dasclaw_sandbox_windows/src/lib.rs
@@ -9,7 +9,7 @@
 //! See `vendor/codex-windows-sandbox/README.md` for the reference snapshot
 //! and the porting plan in tracker issue #250.
 //!
-//! ## Crate status (Phase 1.1.4h)
+//! ## Crate status (Phase 1.1.4i-1)
 //!
 //! V'-b "port-on-demand" subset. The cross-platform PTY/process plumbing
 //! (`pty::process`) and the `cfg(windows)`-only ConPTY backend
@@ -57,6 +57,8 @@
 //!   `token::create_workspace_write_token_with_caps_from`, `cfg(windows)`).
 //! - Private-desktop launcher (`desktop::LaunchDesktop::prepare`,
 //!   `desktop::LaunchDesktop::startup_info_desktop`, `cfg(windows)`).
+//! - Sandbox policy parser (`policy::parse_policy`, re-export
+//!   `policy::SandboxPolicy`).
 //! - On non-Windows targets, [`unsupported`] returns a typed error indicating
 //!   that the Windows sandbox runtime is unavailable.
 //!
@@ -74,6 +76,7 @@ pub mod env;
 pub mod hide_users;
 pub mod logging;
 pub mod path_normalization;
+pub mod policy;
 #[cfg(windows)]
 pub mod proc_thread_attr;
 pub mod pty;

--- a/crates/dasclaw_sandbox_windows/src/policy.rs
+++ b/crates/dasclaw_sandbox_windows/src/policy.rs
@@ -1,0 +1,64 @@
+// Derived from openai/codex commit 6e838a19fa
+//   path: codex-rs/windows-sandbox-rs/src/policy.rs
+// SPDX-License-Identifier: Apache-2.0
+
+pub use crate::types::SandboxPolicy;
+use anyhow::Result;
+
+pub fn parse_policy(value: &str) -> Result<SandboxPolicy> {
+    match value {
+        "read-only" => Ok(SandboxPolicy::new_read_only_policy()),
+        "workspace-write" => Ok(SandboxPolicy::new_workspace_write_policy()),
+        "danger-full-access" | "external-sandbox" => {
+            anyhow::bail!("DangerFullAccess and ExternalSandbox are not supported for sandboxing")
+        }
+        other => {
+            let parsed: SandboxPolicy = serde_json::from_str(other)?;
+            if matches!(
+                parsed,
+                SandboxPolicy::DangerFullAccess | SandboxPolicy::ExternalSandbox { .. }
+            ) {
+                anyhow::bail!(
+                    "DangerFullAccess and ExternalSandbox are not supported for sandboxing"
+                );
+            }
+            Ok(parsed)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn rejects_external_sandbox_preset() {
+        let err = parse_policy("external-sandbox").unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("DangerFullAccess and ExternalSandbox are not supported")
+        );
+    }
+
+    #[test]
+    fn rejects_external_sandbox_json() {
+        let payload = serde_json::to_string(&crate::types::SandboxPolicy::ExternalSandbox {
+            network_access: crate::types::NetworkAccess::Enabled,
+        })
+        .unwrap();
+        let err = parse_policy(&payload).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("DangerFullAccess and ExternalSandbox are not supported")
+        );
+    }
+
+    #[test]
+    fn parses_read_only_policy() {
+        assert_eq!(
+            parse_policy("read-only").unwrap(),
+            SandboxPolicy::new_read_only_policy()
+        );
+    }
+}


### PR DESCRIPTION
## 背景 / 目标

W4 ADR-121 D3-3 Phase **1.1.4i-1**：Wave i-1 第 1 个切片，移植 openai/codex `windows-sandbox-rs/src/policy.rs`（60 LOC）—— 沙箱策略字符串/JSON 解析器。

Closes #293

## 改动范围

- 新增 `crates/dasclaw_sandbox_windows/src/policy.rs`（verbatim port from upstream commit `6e838a19fa`）
  - `pub fn parse_policy(value: &str) -> Result<SandboxPolicy>`
  - 仅 import 重写：`codex_protocol::protocol::{SandboxPolicy, NetworkAccess}` → `crate::types::{SandboxPolicy, NetworkAccess}`（本 crate 已有等价 wire-compatible 类型）
- `lib.rs`：注册 `pub mod policy;`，phase doc bump 1.1.4h → 1.1.4i-1，新增 API 描述

## 非目标（What's NOT in this PR）

- 不接入 `parse_policy` 到任何调用点（属 spawn_prep / setup_orchestrator 切片）
- 不改 `types.rs`
- 不修改其他模块

## 验证

```
cargo check -p dasclaw_sandbox_windows --tests   # 0 错 0 警
cargo nextest run -p dasclaw_sandbox_windows      # 40/40 passed
cargo fmt --all                                   # clean
python3.12 scripts/check_no_panics.py --base origin/xClaw  # OK
python3 scripts/check_no_new_ironclaw_literal.py --base origin/xClaw  # OK
cargo clippy --no-deps -p dasclaw_sandbox_windows --all-targets -- -D warnings  # 0 warning
```

## Cross-cuts

- ADR-114: **类A**（无新 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量）
- 平台: 跨平台（policy.rs 不依赖 Win32，无 cfg gate）

## 后续 PR

Wave i-1 后续：process.rs / read_acl_mutex.rs / acl.rs / sandbox_users.rs（pipeline overlap 模式，stacked 单线）
