### PR TITLE
feat(sandbox-windows): port read_acl_mutex.rs (Phase 1.1.4i-3)

### DIFF
--- a/crates/dasclaw_sandbox_windows/src/lib.rs
+++ b/crates/dasclaw_sandbox_windows/src/lib.rs
@@ -9,7 +9,7 @@
 //! See `vendor/codex-windows-sandbox/README.md` for the reference snapshot
 //! and the porting plan in tracker issue #250.
 //!
-//! ## Crate status (Phase 1.1.4i-2)
+//! ## Crate status (Phase 1.1.4i-3)
 //!
 //! V'-b "port-on-demand" subset. The cross-platform PTY/process plumbing
 //! (`pty::process`) and the `cfg(windows)`-only ConPTY backend
@@ -62,6 +62,10 @@
 //! - Restricted-token-aware process spawner
 //!   (`process::create_process_as_user`, `process::spawn_process_with_pipes`,
 //!   `process::read_handle_loop`, `cfg(windows)`).
+//! - Read-ACL named-mutex guard
+//!   (`read_acl_mutex::acquire_read_acl_mutex`,
+//!   `read_acl_mutex::read_acl_mutex_exists`,
+//!   `read_acl_mutex::ReadAclMutexGuard`, `cfg(windows)`).
 //! - On non-Windows targets, [`unsupported`] returns a typed error indicating
 //!   that the Windows sandbox runtime is unavailable.
 //!
@@ -85,6 +89,8 @@ pub mod proc_thread_attr;
 #[cfg(windows)]
 pub mod process;
 pub mod pty;
+#[cfg(windows)]
+pub mod read_acl_mutex;
 pub mod sandbox_utils;
 pub mod setup_error;
 pub mod string_util;

--- a/crates/dasclaw_sandbox_windows/src/read_acl_mutex.rs
+++ b/crates/dasclaw_sandbox_windows/src/read_acl_mutex.rs
@@ -1,0 +1,68 @@
+// Derived from openai/codex commit 6e838a19fa
+//   path: codex-rs/windows-sandbox-rs/src/read_acl_mutex.rs
+// SPDX-License-Identifier: Apache-2.0
+
+#![cfg(target_os = "windows")]
+
+use anyhow::Result;
+use std::ffi::OsStr;
+use windows_sys::Win32::Foundation::CloseHandle;
+use windows_sys::Win32::Foundation::ERROR_ALREADY_EXISTS;
+use windows_sys::Win32::Foundation::ERROR_FILE_NOT_FOUND;
+use windows_sys::Win32::Foundation::GetLastError;
+use windows_sys::Win32::Foundation::HANDLE;
+use windows_sys::Win32::System::Threading::CreateMutexW;
+use windows_sys::Win32::System::Threading::MUTEX_ALL_ACCESS;
+use windows_sys::Win32::System::Threading::OpenMutexW;
+use windows_sys::Win32::System::Threading::ReleaseMutex;
+
+use crate::winutil::to_wide;
+
+const READ_ACL_MUTEX_NAME: &str = "Local\\CodexSandboxReadAcl";
+
+pub struct ReadAclMutexGuard {
+    handle: HANDLE,
+}
+
+impl Drop for ReadAclMutexGuard {
+    fn drop(&mut self) {
+        unsafe {
+            let _ = ReleaseMutex(self.handle);
+            CloseHandle(self.handle);
+        }
+    }
+}
+
+pub fn read_acl_mutex_exists() -> Result<bool> {
+    let name = to_wide(OsStr::new(READ_ACL_MUTEX_NAME));
+    let handle = unsafe { OpenMutexW(MUTEX_ALL_ACCESS, 0, name.as_ptr()) };
+    if handle == 0 {
+        let err = unsafe { GetLastError() };
+        if err == ERROR_FILE_NOT_FOUND {
+            return Ok(false);
+        }
+        return Err(anyhow::anyhow!("OpenMutexW failed: {err}"));
+    }
+    unsafe {
+        CloseHandle(handle);
+    }
+    Ok(true)
+}
+
+pub fn acquire_read_acl_mutex() -> Result<Option<ReadAclMutexGuard>> {
+    let name = to_wide(OsStr::new(READ_ACL_MUTEX_NAME));
+    let handle = unsafe { CreateMutexW(std::ptr::null_mut(), 1, name.as_ptr()) };
+    if handle == 0 {
+        return Err(anyhow::anyhow!("CreateMutexW failed: {}", unsafe {
+            GetLastError()
+        }));
+    }
+    let err = unsafe { GetLastError() };
+    if err == ERROR_ALREADY_EXISTS {
+        unsafe {
+            CloseHandle(handle);
+        }
+        return Ok(None);
+    }
+    Ok(Some(ReadAclMutexGuard { handle }))
+}


### PR DESCRIPTION
## 背景 / 目标

W4 ADR-121 D3-3 Phase **1.1.4i-3**：Wave i-1 第 3 个切片，移植 openai/codex `windows-sandbox-rs/src/read_acl_mutex.rs`（62 LOC）—— read-ACL 全局命名互斥量保护。

Closes #297

## 改动范围

- 新增 `crates/dasclaw_sandbox_windows/src/read_acl_mutex.rs`（verbatim port from upstream `6e838a19fa`，+ SPDX header + `#![cfg(target_os = "windows")]`）
  - `pub struct ReadAclMutexGuard`（Drop 释放并关闭 handle）
  - `pub fn read_acl_mutex_exists() -> Result<bool>`（OpenMutexW 探测）
  - `pub fn acquire_read_acl_mutex() -> Result<Option<ReadAclMutexGuard>>`（CreateMutexW，已存在返回 Ok(None)）
  - 命名："Local\\CodexSandboxReadAcl"（与 desktop.rs 中 "CodexSandboxDesktop-..." 一致，verbatim 保留）
- `lib.rs`：注册模块、phase doc bump 1.1.4i-2 → 1.1.4i-3、API 描述追加

Import rewrite：`super::to_wide` → `crate::winutil::to_wide`。

## 非目标（What's NOT in this PR）

- 不接入 acl.rs / setup_main_win.rs 调用方（属后续切片）
- 不改 winutil（依赖已合并）

## 验证

```
cargo check -p dasclaw_sandbox_windows --tests   # 0 错 0 警
cargo nextest run -p dasclaw_sandbox_windows      # 40/40 passed
cargo fmt --all                                   # clean
python3.12 scripts/check_no_panics.py --base origin/xClaw  # OK
python3 scripts/check_no_new_ironclaw_literal.py --base origin/xClaw  # OK
cargo clippy --no-deps -p dasclaw_sandbox_windows --all-targets -- -D warnings  # 0 warning
```

## Cross-cuts

- ADR-114: **类A**（无新 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量）
- 平台: cfg(windows) 模块；Windows 编译验证由 Windows CI 兜底

## 后续

Wave i-1 剩余：acl.rs (638 LOC) / sandbox_users.rs (496 LOC)
