### PR TITLE
feat(sandbox-windows): port ssh_config_dependencies.rs (Phase 1.1.4i-6)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2684,6 +2684,7 @@ dependencies = [
  "dirs 6.0.0",
  "dunce",
  "filedescriptor",
+ "glob",
  "lazy_static",
  "libc",
  "log",

--- a/crates/dasclaw_sandbox_windows/Cargo.toml
+++ b/crates/dasclaw_sandbox_windows/Cargo.toml
@@ -16,6 +16,7 @@ base64 = "0.22"
 chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
 dirs = "6"
 dunce = "1.0"
+glob = "0.3"
 portable-pty = "0.9.0"
 rand = { version = "0.8", default-features = false, features = ["std", "small_rng", "std_rng"] }
 serde = { version = "1", features = ["derive"] }

--- a/crates/dasclaw_sandbox_windows/src/lib.rs
+++ b/crates/dasclaw_sandbox_windows/src/lib.rs
@@ -9,7 +9,7 @@
 //! See `vendor/codex-windows-sandbox/README.md` for the reference snapshot
 //! and the porting plan in tracker issue #250.
 //!
-//! ## Crate status (Phase 1.1.4i-5)
+//! ## Crate status (Phase 1.1.4i-6)
 //!
 //! V'-b "port-on-demand" subset. The cross-platform PTY/process plumbing
 //! (`pty::process`) and the `cfg(windows)`-only ConPTY backend
@@ -69,6 +69,8 @@
 //! - Filesystem ACL helpers (`acl::*`, `cfg(windows)`).
 //! - Sandbox user account creation / lookup (`sandbox_users::*`,
 //!   `cfg(windows)`).
+//! - SSH client config dependency resolver
+//!   (`ssh_config_dependencies::ssh_config_dependency_paths`).
 //! - On non-Windows targets, [`unsupported`] returns a typed error indicating
 //!   that the Windows sandbox runtime is unavailable.
 //!
@@ -100,6 +102,9 @@ pub mod read_acl_mutex;
 pub mod sandbox_users;
 pub mod sandbox_utils;
 pub mod setup_error;
+// Currently unused outside the crate; consumed by setup_orchestrator (later slice).
+#[allow(dead_code)]
+pub mod ssh_config_dependencies;
 pub mod string_util;
 #[cfg(windows)]
 pub mod token;

--- a/crates/dasclaw_sandbox_windows/src/ssh_config_dependencies.rs
+++ b/crates/dasclaw_sandbox_windows/src/ssh_config_dependencies.rs
@@ -1,0 +1,253 @@
+// Derived from openai/codex commit 6e838a19fa
+//   path: codex-rs/windows-sandbox-rs/src/ssh_config_dependencies.rs
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::HashSet;
+use std::path::Path;
+use std::path::PathBuf;
+
+const SSH_PROFILE_PATH_DIRECTIVES: &[&str] = &[
+    "certificatefile",
+    "controlpath",
+    "globalknownhostsfile",
+    "identityagent",
+    "identityfile",
+    "revokedhostkeys",
+    "userknownhostsfile",
+];
+
+pub(crate) fn ssh_config_dependency_paths(user_profile: &Path) -> Vec<PathBuf> {
+    let ssh_dir = user_profile.join(".ssh");
+    let mut paths = vec![ssh_dir.join("config")];
+    visit_config(
+        &ssh_dir.join("config"),
+        user_profile,
+        &ssh_dir,
+        &mut HashSet::new(),
+        &mut paths,
+        /*depth*/ 0,
+    );
+    paths
+}
+
+fn visit_config(
+    path: &Path,
+    user_profile: &Path,
+    ssh_dir: &Path,
+    visited: &mut HashSet<PathBuf>,
+    paths: &mut Vec<PathBuf>,
+    depth: usize,
+) {
+    if depth == 32 {
+        return;
+    }
+    let key = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+    if !visited.insert(key) {
+        return;
+    }
+
+    let Ok(contents) = std::fs::read_to_string(path) else {
+        return;
+    };
+    for (key, args) in contents.lines().filter_map(directive) {
+        match key.to_ascii_lowercase().as_str() {
+            "include" => {
+                for arg in args {
+                    for include in include_paths(&arg, user_profile, ssh_dir) {
+                        paths.push(include.clone());
+                        visit_config(&include, user_profile, ssh_dir, visited, paths, depth + 1);
+                    }
+                }
+            }
+            key if SSH_PROFILE_PATH_DIRECTIVES.contains(&key) => {
+                for arg in args {
+                    if let Some(path) =
+                        profile_path_arg(&arg, user_profile, /*relative_base*/ None)
+                    {
+                        paths.push(path);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+fn include_paths(arg: &str, user_profile: &Path, ssh_dir: &Path) -> Vec<PathBuf> {
+    let Some(pattern_path) = profile_path_arg(arg, user_profile, Some(ssh_dir)) else {
+        return Vec::new();
+    };
+    let pattern = pattern_path.to_string_lossy().replace('\\', "/");
+    let Ok(paths) = glob::glob(&pattern) else {
+        return Vec::new();
+    };
+    paths.filter_map(Result::ok).collect()
+}
+
+fn directive(line: &str) -> Option<(String, Vec<String>)> {
+    let mut words = words(line);
+    let first = words.first()?.to_string();
+    if let Some((key, value)) = first.split_once('=')
+        && !key.is_empty()
+    {
+        let mut args = Vec::new();
+        if !value.is_empty() {
+            args.push(value.to_string());
+        }
+        args.extend(words.drain(1..));
+        Some((key.to_string(), args))
+    } else {
+        let key = words.remove(0);
+        if let Some(arg) = words.first_mut()
+            && let Some(value) = arg.strip_prefix('=')
+        {
+            *arg = value.to_string();
+        }
+        words.retain(|arg| !arg.is_empty());
+        Some((key, words))
+    }
+}
+
+fn words(line: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut word = String::new();
+    let mut quote = None;
+    let mut chars = line.chars().peekable();
+
+    while let Some(ch) = chars.next() {
+        match ch {
+            '#' if quote.is_none() => break,
+            '\'' | '"' if quote == Some(ch) => quote = None,
+            '\'' | '"' if quote.is_none() => quote = Some(ch),
+            '\\' => {
+                if let Some(&next) = chars.peek() {
+                    if matches!(next, '\'' | '"' | '\\') || (quote.is_none() && next == ' ') {
+                        if let Some(escaped) = chars.next() {
+                            word.push(escaped);
+                        }
+                    } else {
+                        word.push(ch);
+                    }
+                } else {
+                    word.push(ch);
+                }
+            }
+            ch if ch.is_whitespace() && quote.is_none() => {
+                if !word.is_empty() {
+                    out.push(std::mem::take(&mut word));
+                }
+            }
+            ch => word.push(ch),
+        }
+    }
+    if !word.is_empty() {
+        out.push(word);
+    }
+    out
+}
+
+fn profile_path_arg(
+    arg: &str,
+    user_profile: &Path,
+    relative_base: Option<&Path>,
+) -> Option<PathBuf> {
+    if arg.eq_ignore_ascii_case("none") {
+        return None;
+    }
+    if arg == "~" || arg == "%d" || arg == "${HOME}" {
+        return Some(user_profile.to_path_buf());
+    }
+    if let Some(rest) = arg
+        .strip_prefix("~/")
+        .or_else(|| arg.strip_prefix(r"~\"))
+        .or_else(|| arg.strip_prefix("%d/"))
+        .or_else(|| arg.strip_prefix(r"%d\"))
+        .or_else(|| arg.strip_prefix("${HOME}/"))
+        .or_else(|| arg.strip_prefix(r"${HOME}\"))
+    {
+        return Some(user_profile.join(rest));
+    }
+
+    let path = PathBuf::from(arg);
+    if path.is_absolute() {
+        Some(path)
+    } else {
+        relative_base.map(|base| base.join(path))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ssh_config_dependency_paths;
+    use pretty_assertions::assert_eq;
+    use std::fs;
+    use std::path::PathBuf;
+    use tempfile::TempDir;
+
+    #[test]
+    fn collects_path_directive_profile_entries() {
+        let tmp = TempDir::new().expect("tempdir");
+        let home = tmp.path();
+        fs::create_dir_all(home.join(".ssh")).expect("create .ssh");
+        fs::write(
+            home.join(".ssh/config"),
+            r#"
+Host devbox
+  IdentityFile ~/.keys/id_ed25519
+  IdentityFile '~/.keys/quoted key'
+  CertificateFile = %d/.certs/devbox-cert.pub
+  UserKnownHostsFile ${HOME}/.known_hosts_custom
+  GlobalKnownHostsFile ~/.global_known_hosts
+  ControlPath ~/.control/%h-%p-%r
+  IdentityAgent=%d/.agent/socket
+  RevokedHostKeys ~/.revoked/keys
+"#,
+        )
+        .expect("write config");
+
+        assert_eq!(
+            vec![
+                home.join(".ssh/config"),
+                home.join(".keys/id_ed25519"),
+                home.join(".keys/quoted key"),
+                home.join(".certs/devbox-cert.pub"),
+                home.join(".known_hosts_custom"),
+                home.join(".global_known_hosts"),
+                home.join(".control/%h-%p-%r"),
+                home.join(".agent/socket"),
+                home.join(".revoked/keys"),
+            ],
+            slash_paths(ssh_config_dependency_paths(home))
+        );
+    }
+
+    #[test]
+    fn recursively_collects_include_dependencies() {
+        let tmp = TempDir::new().expect("tempdir");
+        let home = tmp.path();
+        let ssh_dir = home.join(".ssh");
+        fs::create_dir_all(ssh_dir.join("conf.d")).expect("create conf.d");
+        fs::write(ssh_dir.join("config"), "Include conf.d/*.conf\n").expect("write config");
+        fs::write(
+            ssh_dir.join("conf.d/devbox.conf"),
+            "CertificateFile ~/.included/devbox-cert.pub\n",
+        )
+        .expect("write include");
+
+        assert_eq!(
+            vec![
+                home.join(".ssh/config"),
+                ssh_dir.join("conf.d/devbox.conf"),
+                home.join(".included/devbox-cert.pub"),
+            ],
+            slash_paths(ssh_config_dependency_paths(home))
+        );
+    }
+
+    fn slash_paths(paths: Vec<PathBuf>) -> Vec<PathBuf> {
+        paths
+            .into_iter()
+            .map(|path| PathBuf::from(path.to_string_lossy().replace('\\', "/")))
+            .collect()
+    }
+}


### PR DESCRIPTION
## 背景 / 目标

W4 ADR-121 D3-3 Phase **1.1.4i-6**：Wave i-2 入口切片，移植 openai/codex `windows-sandbox-rs/src/ssh_config_dependencies.rs`（249 LOC）—— 纯 std 跨平台 SSH 客户端配置依赖解析器。

Closes #303

## 改动范围

- 新增 `crates/dasclaw_sandbox_windows/src/ssh_config_dependencies.rs`（verbatim port from `6e838a19fa`，+ SPDX header；无 cfg gate，跨平台）
  - `pub(crate) fn ssh_config_dependency_paths(user_profile) -> Vec<PathBuf>`
  - 私有 helpers: `visit_config` / `include_paths` / `directive` / `words` / `profile_path_arg`
- `Cargo.toml`：新增 `glob = "0.3"`（include 模式展开）
- `lib.rs`：
  - `#[allow(dead_code)] pub mod ssh_config_dependencies;` —— 因 setup_orchestrator（消费方）尚未移植，先抑制本切片内 dead_code 误报；后续切片接入后可移除该 allow
  - phase doc bump 1.1.4i-4 → 1.1.4i-6、API 描述追加

## 与 #302 (Phase 1.1.4i-5) 并行

本 PR 与 PR #302 (sandbox_users.rs) 同时开启，两者：
- 文件不重叠
- 仅 `lib.rs` 同时被改：phase doc 行 + 各自模块注册块。先合并者免冲突，后合并者需 rebase（≈30s 范围）

## 非目标

- 不接入任何调用方
- 不改其它模块

## 验证

```
cargo check / nextest (42/42, +2 inline tests) / fmt / check_no_panics / check_no_new_ironclaw_literal / clippy  全绿
```

## Cross-cuts

- ADR-114: **类A**
- 平台: 跨平台模块（无 cfg gate）

## 后续

Wave i-2 剩余：elevated_impl.rs / firewall.rs / setup_main_win.rs。
