### PR TITLE
feat(sandbox-windows): port allow/audit/workspace_acl (Phase 1.1.4i Wave i-2 batch)

### DIFF
--- a/crates/dasclaw_sandbox_windows/src/allow.rs
+++ b/crates/dasclaw_sandbox_windows/src/allow.rs
@@ -1,0 +1,273 @@
+// Derived from openai/codex commit 6e838a19fa
+//   path: codex-rs/windows-sandbox-rs/src/allow.rs
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::policy::SandboxPolicy;
+use dunce::canonicalize;
+use std::collections::HashMap;
+use std::collections::HashSet;
+use std::path::Path;
+use std::path::PathBuf;
+
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct AllowDenyPaths {
+    pub allow: HashSet<PathBuf>,
+    pub deny: HashSet<PathBuf>,
+}
+
+pub fn compute_allow_paths(
+    policy: &SandboxPolicy,
+    policy_cwd: &Path,
+    command_cwd: &Path,
+    env_map: &HashMap<String, String>,
+) -> AllowDenyPaths {
+    let mut allow: HashSet<PathBuf> = HashSet::new();
+    let mut deny: HashSet<PathBuf> = HashSet::new();
+
+    let mut add_allow_path = |p: PathBuf| {
+        if p.exists() {
+            allow.insert(p);
+        }
+    };
+    let mut add_deny_path = |p: PathBuf| {
+        if p.exists() {
+            deny.insert(p);
+        }
+    };
+    let include_tmp_env_vars = matches!(
+        policy,
+        SandboxPolicy::WorkspaceWrite {
+            exclude_tmpdir_env_var: false,
+            ..
+        }
+    );
+
+    if matches!(policy, SandboxPolicy::WorkspaceWrite { .. }) {
+        let add_writable_root =
+            |root: PathBuf,
+             policy_cwd: &Path,
+             add_allow: &mut dyn FnMut(PathBuf),
+             add_deny: &mut dyn FnMut(PathBuf)| {
+                let candidate = if root.is_absolute() {
+                    root
+                } else {
+                    policy_cwd.join(root)
+                };
+                let canonical = canonicalize(&candidate).unwrap_or(candidate);
+                add_allow(canonical.clone());
+
+                for protected_subdir in [".git", ".codex", ".agents"] {
+                    let protected_entry = canonical.join(protected_subdir);
+                    if protected_entry.exists() {
+                        add_deny(protected_entry);
+                    }
+                }
+            };
+
+        add_writable_root(
+            command_cwd.to_path_buf(),
+            policy_cwd,
+            &mut add_allow_path,
+            &mut add_deny_path,
+        );
+
+        if let SandboxPolicy::WorkspaceWrite { writable_roots, .. } = policy {
+            for root in writable_roots {
+                add_writable_root(
+                    root.clone().into(),
+                    policy_cwd,
+                    &mut add_allow_path,
+                    &mut add_deny_path,
+                );
+            }
+        }
+    }
+    if include_tmp_env_vars {
+        for key in ["TEMP", "TMP"] {
+            if let Some(v) = env_map.get(key) {
+                let abs = PathBuf::from(v);
+                add_allow_path(abs);
+            } else if let Ok(v) = std::env::var(key) {
+                let abs = PathBuf::from(v);
+                add_allow_path(abs);
+            }
+        }
+    }
+    AllowDenyPaths { allow, deny }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::absolute_path::AbsolutePathBuf;
+    use crate::types::SandboxPolicy;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[test]
+    fn includes_additional_writable_roots() {
+        let tmp = TempDir::new().expect("tempdir");
+        let command_cwd = tmp.path().join("workspace");
+        let extra_root = tmp.path().join("extra");
+        let _ = fs::create_dir_all(&command_cwd);
+        let _ = fs::create_dir_all(&extra_root);
+
+        let policy = SandboxPolicy::WorkspaceWrite {
+            writable_roots: vec![AbsolutePathBuf::try_from(extra_root.as_path()).unwrap()],
+            network_access: false,
+            exclude_tmpdir_env_var: false,
+            exclude_slash_tmp: false,
+        };
+
+        let paths = compute_allow_paths(&policy, &command_cwd, &command_cwd, &HashMap::new());
+
+        assert!(
+            paths
+                .allow
+                .contains(&dunce::canonicalize(&command_cwd).unwrap())
+        );
+        assert!(
+            paths
+                .allow
+                .contains(&dunce::canonicalize(&extra_root).unwrap())
+        );
+        assert!(paths.deny.is_empty(), "no deny paths expected");
+    }
+
+    #[test]
+    fn excludes_tmp_env_vars_when_requested() {
+        let tmp = TempDir::new().expect("tempdir");
+        let command_cwd = tmp.path().join("workspace");
+        let temp_dir = tmp.path().join("temp");
+        let _ = fs::create_dir_all(&command_cwd);
+        let _ = fs::create_dir_all(&temp_dir);
+
+        let policy = SandboxPolicy::WorkspaceWrite {
+            writable_roots: vec![],
+            network_access: false,
+            exclude_tmpdir_env_var: true,
+            exclude_slash_tmp: false,
+        };
+        let mut env_map = HashMap::new();
+        env_map.insert("TEMP".into(), temp_dir.to_string_lossy().to_string());
+
+        let paths = compute_allow_paths(&policy, &command_cwd, &command_cwd, &env_map);
+
+        assert!(
+            paths
+                .allow
+                .contains(&dunce::canonicalize(&command_cwd).unwrap())
+        );
+        assert!(
+            !paths
+                .allow
+                .contains(&dunce::canonicalize(&temp_dir).unwrap())
+        );
+        assert!(paths.deny.is_empty(), "no deny paths expected");
+    }
+
+    #[test]
+    fn denies_git_dir_inside_writable_root() {
+        let tmp = TempDir::new().expect("tempdir");
+        let command_cwd = tmp.path().join("workspace");
+        let git_dir = command_cwd.join(".git");
+        let _ = fs::create_dir_all(&git_dir);
+
+        let policy = SandboxPolicy::WorkspaceWrite {
+            writable_roots: vec![],
+            network_access: false,
+            exclude_tmpdir_env_var: true,
+            exclude_slash_tmp: false,
+        };
+
+        let paths = compute_allow_paths(&policy, &command_cwd, &command_cwd, &HashMap::new());
+        let expected_allow: HashSet<PathBuf> = [dunce::canonicalize(&command_cwd).unwrap()]
+            .into_iter()
+            .collect();
+        let expected_deny: HashSet<PathBuf> = [dunce::canonicalize(&git_dir).unwrap()]
+            .into_iter()
+            .collect();
+
+        assert_eq!(expected_allow, paths.allow);
+        assert_eq!(expected_deny, paths.deny);
+    }
+
+    #[test]
+    fn denies_git_file_inside_writable_root() {
+        let tmp = TempDir::new().expect("tempdir");
+        let command_cwd = tmp.path().join("workspace");
+        let git_file = command_cwd.join(".git");
+        let _ = fs::create_dir_all(&command_cwd);
+        let _ = fs::write(&git_file, "gitdir: .git/worktrees/example");
+
+        let policy = SandboxPolicy::WorkspaceWrite {
+            writable_roots: vec![],
+            network_access: false,
+            exclude_tmpdir_env_var: true,
+            exclude_slash_tmp: false,
+        };
+
+        let paths = compute_allow_paths(&policy, &command_cwd, &command_cwd, &HashMap::new());
+        let expected_allow: HashSet<PathBuf> = [dunce::canonicalize(&command_cwd).unwrap()]
+            .into_iter()
+            .collect();
+        let expected_deny: HashSet<PathBuf> = [dunce::canonicalize(&git_file).unwrap()]
+            .into_iter()
+            .collect();
+
+        assert_eq!(expected_allow, paths.allow);
+        assert_eq!(expected_deny, paths.deny);
+    }
+
+    #[test]
+    fn denies_codex_and_agents_inside_writable_root() {
+        let tmp = TempDir::new().expect("tempdir");
+        let command_cwd = tmp.path().join("workspace");
+        let codex_dir = command_cwd.join(".codex");
+        let agents_dir = command_cwd.join(".agents");
+        let _ = fs::create_dir_all(&codex_dir);
+        let _ = fs::create_dir_all(&agents_dir);
+
+        let policy = SandboxPolicy::WorkspaceWrite {
+            writable_roots: vec![],
+            network_access: false,
+            exclude_tmpdir_env_var: true,
+            exclude_slash_tmp: false,
+        };
+
+        let paths = compute_allow_paths(&policy, &command_cwd, &command_cwd, &HashMap::new());
+        let expected_allow: HashSet<PathBuf> = [dunce::canonicalize(&command_cwd).unwrap()]
+            .into_iter()
+            .collect();
+        let expected_deny: HashSet<PathBuf> = [
+            dunce::canonicalize(&codex_dir).unwrap(),
+            dunce::canonicalize(&agents_dir).unwrap(),
+        ]
+        .into_iter()
+        .collect();
+
+        assert_eq!(expected_allow, paths.allow);
+        assert_eq!(expected_deny, paths.deny);
+    }
+
+    #[test]
+    fn skips_protected_subdirs_when_missing() {
+        let tmp = TempDir::new().expect("tempdir");
+        let command_cwd = tmp.path().join("workspace");
+        let _ = fs::create_dir_all(&command_cwd);
+
+        let policy = SandboxPolicy::WorkspaceWrite {
+            writable_roots: vec![],
+            network_access: false,
+            exclude_tmpdir_env_var: true,
+            exclude_slash_tmp: false,
+        };
+
+        let paths = compute_allow_paths(&policy, &command_cwd, &command_cwd, &HashMap::new());
+        assert_eq!(paths.allow.len(), 1);
+        assert!(
+            paths.deny.is_empty(),
+            "no deny when protected dirs are absent"
+        );
+    }
+}

--- a/crates/dasclaw_sandbox_windows/src/audit.rs
+++ b/crates/dasclaw_sandbox_windows/src/audit.rs
@@ -1,0 +1,342 @@
+// Derived from openai/codex commit 6e838a19fa
+//   path: codex-rs/windows-sandbox-rs/src/audit.rs
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::acl::add_deny_write_ace;
+use crate::acl::path_mask_allows;
+use crate::cap::cap_sid_file;
+use crate::cap::load_or_create_cap_sids;
+use crate::logging::{debug_log, log_note};
+use crate::path_normalization::canonical_path_key;
+use crate::policy::SandboxPolicy;
+use crate::token::convert_string_sid_to_sid;
+use crate::token::world_sid;
+use anyhow::Result;
+use anyhow::anyhow;
+use std::collections::HashSet;
+use std::ffi::OsStr;
+use std::ffi::c_void;
+use std::path::Path;
+use std::path::PathBuf;
+use std::time::Duration;
+use std::time::Instant;
+use windows_sys::Win32::Storage::FileSystem::FILE_APPEND_DATA;
+use windows_sys::Win32::Storage::FileSystem::FILE_WRITE_ATTRIBUTES;
+use windows_sys::Win32::Storage::FileSystem::FILE_WRITE_DATA;
+use windows_sys::Win32::Storage::FileSystem::FILE_WRITE_EA;
+
+// Preflight scan limits
+const MAX_ITEMS_PER_DIR: i32 = 1000;
+const AUDIT_TIME_LIMIT_SECS: i64 = 2;
+const MAX_CHECKED_LIMIT: i32 = 50000;
+// Case-insensitive suffixes (normalized to forward slashes) to skip during one-level child scan
+const SKIP_DIR_SUFFIXES: &[&str] = &[
+    "/windows/installer",
+    "/windows/registration",
+    "/programdata",
+];
+
+fn unique_push(set: &mut HashSet<PathBuf>, out: &mut Vec<PathBuf>, p: PathBuf) {
+    if let Ok(abs) = p.canonicalize()
+        && set.insert(abs.clone())
+    {
+        out.push(abs);
+    }
+}
+
+fn gather_candidates(cwd: &Path, env: &std::collections::HashMap<String, String>) -> Vec<PathBuf> {
+    let mut set: HashSet<PathBuf> = HashSet::new();
+    let mut out: Vec<PathBuf> = Vec::new();
+    // 1) CWD first (so immediate children get scanned early)
+    unique_push(&mut set, &mut out, cwd.to_path_buf());
+    // 2) TEMP/TMP next (often small, quick to scan)
+    for k in ["TEMP", "TMP"] {
+        if let Some(v) = env.get(k).cloned().or_else(|| std::env::var(k).ok()) {
+            unique_push(&mut set, &mut out, PathBuf::from(v));
+        }
+    }
+    // 3) User roots
+    if let Some(up) = std::env::var_os("USERPROFILE") {
+        unique_push(&mut set, &mut out, PathBuf::from(up));
+    }
+    if let Some(pubp) = std::env::var_os("PUBLIC") {
+        unique_push(&mut set, &mut out, PathBuf::from(pubp));
+    }
+    // 4) PATH entries (best-effort)
+    if let Some(path) = env
+        .get("PATH")
+        .cloned()
+        .or_else(|| std::env::var("PATH").ok())
+    {
+        for part in std::env::split_paths(OsStr::new(&path)) {
+            if !part.as_os_str().is_empty() {
+                unique_push(&mut set, &mut out, part);
+            }
+        }
+    }
+    // 5) Core system roots last
+    for p in [PathBuf::from("C:/"), PathBuf::from("C:/Windows")] {
+        unique_push(&mut set, &mut out, p);
+    }
+    out
+}
+
+unsafe fn path_has_world_write_allow(path: &Path) -> Result<bool> {
+    let mut world = world_sid()?;
+    let psid_world = world.as_mut_ptr() as *mut c_void;
+    let write_mask = FILE_WRITE_DATA | FILE_APPEND_DATA | FILE_WRITE_EA | FILE_WRITE_ATTRIBUTES;
+    path_mask_allows(
+        path,
+        &[psid_world],
+        write_mask,
+        /*require_all_bits*/ false,
+    )
+}
+
+pub fn audit_everyone_writable(
+    cwd: &Path,
+    env: &std::collections::HashMap<String, String>,
+    logs_base_dir: Option<&Path>,
+) -> Result<Vec<PathBuf>> {
+    let start = Instant::now();
+    let mut flagged: Vec<PathBuf> = Vec::new();
+    let mut seen: HashSet<String> = HashSet::new();
+    let mut checked = 0usize;
+    let check_world_writable = |path: &Path| -> bool {
+        match unsafe { path_has_world_write_allow(path) } {
+            Ok(has) => has,
+            Err(err) => {
+                debug_log(
+                    &format!(
+                        "AUDIT: treating unreadable ACL as not world-writable: {} ({err})",
+                        path.display()
+                    ),
+                    logs_base_dir,
+                );
+                false
+            }
+        }
+    };
+    // Fast path: check CWD immediate children first so workspace issues are caught early.
+    if let Ok(read) = std::fs::read_dir(cwd) {
+        for ent in read.flatten().take(MAX_ITEMS_PER_DIR as usize) {
+            if start.elapsed() > Duration::from_secs(AUDIT_TIME_LIMIT_SECS as u64)
+                || checked > MAX_CHECKED_LIMIT as usize
+            {
+                break;
+            }
+            let ft = match ent.file_type() {
+                Ok(ft) => ft,
+                Err(_) => continue,
+            };
+            if ft.is_symlink() || !ft.is_dir() {
+                continue;
+            }
+            let p = ent.path();
+            checked += 1;
+            let has = check_world_writable(&p);
+            if has {
+                let key = canonical_path_key(&p);
+                if seen.insert(key) {
+                    flagged.push(p);
+                }
+            }
+        }
+    }
+    // Continue with broader candidate sweep
+    let candidates = gather_candidates(cwd, env);
+    for root in candidates {
+        if start.elapsed() > Duration::from_secs(AUDIT_TIME_LIMIT_SECS as u64)
+            || checked > MAX_CHECKED_LIMIT as usize
+        {
+            break;
+        }
+        checked += 1;
+        let has_root = check_world_writable(&root);
+        if has_root {
+            let key = canonical_path_key(&root);
+            if seen.insert(key) {
+                flagged.push(root.clone());
+            }
+        }
+        // one level down best-effort
+        if let Ok(read) = std::fs::read_dir(&root) {
+            for ent in read.flatten().take(MAX_ITEMS_PER_DIR as usize) {
+                let p = ent.path();
+                if start.elapsed() > Duration::from_secs(AUDIT_TIME_LIMIT_SECS as u64)
+                    || checked > MAX_CHECKED_LIMIT as usize
+                {
+                    break;
+                }
+                // Skip reparse points (symlinks/junctions) to avoid auditing link ACLs
+                let ft = match ent.file_type() {
+                    Ok(ft) => ft,
+                    Err(_) => continue,
+                };
+                if ft.is_symlink() {
+                    continue;
+                }
+                // Skip noisy/irrelevant Windows system subdirectories
+                let pl = p.to_string_lossy().to_ascii_lowercase();
+                let norm = pl.replace('\\', "/");
+                if SKIP_DIR_SUFFIXES.iter().any(|s| norm.ends_with(s)) {
+                    continue;
+                }
+                if ft.is_dir() {
+                    checked += 1;
+                    let has_child = check_world_writable(&p);
+                    if has_child {
+                        let key = canonical_path_key(&p);
+                        if seen.insert(key) {
+                            flagged.push(p);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    let elapsed_ms = start.elapsed().as_millis();
+    if !flagged.is_empty() {
+        let mut list = String::new();
+        for p in &flagged {
+            list.push_str(&format!("\n - {}", p.display()));
+        }
+        crate::logging::log_note(
+            &format!(
+                "AUDIT: world-writable scan FAILED; cwd={cwd:?}; checked={checked}; duration_ms={elapsed_ms}; flagged:{list}",
+            ),
+            logs_base_dir,
+        );
+
+        return Ok(flagged);
+    }
+    // Log success once if nothing flagged
+    crate::logging::log_note(
+        &format!("AUDIT: world-writable scan OK; checked={checked}; duration_ms={elapsed_ms}"),
+        logs_base_dir,
+    );
+    Ok(Vec::new())
+}
+
+pub fn apply_world_writable_scan_and_denies(
+    codex_home: &Path,
+    cwd: &Path,
+    env_map: &std::collections::HashMap<String, String>,
+    sandbox_policy: &SandboxPolicy,
+    logs_base_dir: Option<&Path>,
+) -> Result<()> {
+    let flagged = audit_everyone_writable(cwd, env_map, logs_base_dir)?;
+    if flagged.is_empty() {
+        return Ok(());
+    }
+    if let Err(err) = apply_capability_denies_for_world_writable(
+        codex_home,
+        &flagged,
+        sandbox_policy,
+        cwd,
+        logs_base_dir,
+    ) {
+        log_note(
+            &format!("AUDIT: failed to apply capability deny ACEs: {err}"),
+            logs_base_dir,
+        );
+    }
+    Ok(())
+}
+
+pub fn apply_capability_denies_for_world_writable(
+    codex_home: &Path,
+    flagged: &[PathBuf],
+    sandbox_policy: &SandboxPolicy,
+    cwd: &Path,
+    logs_base_dir: Option<&Path>,
+) -> Result<()> {
+    if flagged.is_empty() {
+        return Ok(());
+    }
+    std::fs::create_dir_all(codex_home)?;
+    let cap_path = cap_sid_file(codex_home);
+    let caps = load_or_create_cap_sids(codex_home)?;
+    std::fs::write(&cap_path, serde_json::to_string(&caps)?)?;
+    let (active_sid, workspace_roots): (*mut c_void, Vec<PathBuf>) = match sandbox_policy {
+        SandboxPolicy::WorkspaceWrite { writable_roots, .. } => {
+            let sid = unsafe { convert_string_sid_to_sid(&caps.workspace) }
+                .ok_or_else(|| anyhow!("ConvertStringSidToSidW failed for workspace capability"))?;
+            let mut roots: Vec<PathBuf> =
+                vec![dunce::canonicalize(cwd).unwrap_or_else(|_| cwd.to_path_buf())];
+            for root in writable_roots {
+                let candidate = root.as_path();
+                roots.push(dunce::canonicalize(candidate).unwrap_or_else(|_| root.to_path_buf()));
+            }
+            (sid, roots)
+        }
+        SandboxPolicy::ReadOnly { .. } => (
+            unsafe { convert_string_sid_to_sid(&caps.readonly) }
+                .ok_or_else(|| anyhow!("ConvertStringSidToSidW failed for readonly capability"))?,
+            Vec::new(),
+        ),
+        SandboxPolicy::DangerFullAccess | SandboxPolicy::ExternalSandbox { .. } => {
+            return Ok(());
+        }
+    };
+    for path in flagged {
+        if workspace_roots.iter().any(|root| path.starts_with(root)) {
+            continue;
+        }
+        let res = unsafe { add_deny_write_ace(path, active_sid) };
+        match res {
+            Ok(true) => log_note(
+                &format!("AUDIT: applied capability deny ACE to {}", path.display()),
+                logs_base_dir,
+            ),
+            Ok(false) => {}
+            Err(err) => log_note(
+                &format!(
+                    "AUDIT: failed to apply capability deny ACE to {}: {}",
+                    path.display(),
+                    err
+                ),
+                logs_base_dir,
+            ),
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::gather_candidates;
+    use std::collections::HashMap;
+    use std::fs;
+
+    #[test]
+    fn gathers_path_entries_by_list_separator() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let dir_a = tmp.path().join("Tools");
+        let dir_b = tmp.path().join("Bin");
+        let dir_space = tmp.path().join("Program Files");
+        fs::create_dir_all(&dir_a).expect("dir a");
+        fs::create_dir_all(&dir_b).expect("dir b");
+        fs::create_dir_all(&dir_space).expect("dir space");
+
+        let mut env_map = HashMap::new();
+        env_map.insert(
+            "PATH".to_string(),
+            format!(
+                "{};{};{}",
+                dir_a.display(),
+                dir_b.display(),
+                dir_space.display()
+            ),
+        );
+
+        let candidates = gather_candidates(tmp.path(), &env_map);
+        let canon_a = dir_a.canonicalize().expect("canon a");
+        let canon_b = dir_b.canonicalize().expect("canon b");
+        let canon_space = dir_space.canonicalize().expect("canon space");
+
+        assert!(candidates.contains(&canon_a));
+        assert!(candidates.contains(&canon_b));
+        assert!(candidates.contains(&canon_space));
+    }
+}

--- a/crates/dasclaw_sandbox_windows/src/lib.rs
+++ b/crates/dasclaw_sandbox_windows/src/lib.rs
@@ -9,7 +9,7 @@
 //! See `vendor/codex-windows-sandbox/README.md` for the reference snapshot
 //! and the porting plan in tracker issue #250.
 //!
-//! ## Crate status (Phase 1.1.4i-6)
+//! ## Crate status (Phase 1.1.4i-7)
 //!
 //! V'-b "port-on-demand" subset. The cross-platform PTY/process plumbing
 //! (`pty::process`) and the `cfg(windows)`-only ConPTY backend
@@ -71,6 +71,15 @@
 //!   `cfg(windows)`).
 //! - SSH client config dependency resolver
 //!   (`ssh_config_dependencies::ssh_config_dependency_paths`).
+//! - Allow/deny path computation for sandbox policy
+//!   (`allow::AllowDenyPaths`, `allow::compute_allow_paths`).
+//! - Workspace ACL protection helpers
+//!   (`workspace_acl::is_command_cwd_root`,
+//!   `workspace_acl::protect_workspace_codex_dir`,
+//!   `workspace_acl::protect_workspace_agents_dir`, `cfg(windows)`).
+//! - Sandbox audit / world-writable scan
+//!   (`audit::apply_world_writable_scan_and_denies`,
+//!   `audit::gather_candidates`, `cfg(windows)`).
 //! - On non-Windows targets, [`unsupported`] returns a typed error indicating
 //!   that the Windows sandbox runtime is unavailable.
 //!
@@ -80,6 +89,9 @@
 pub mod absolute_path;
 #[cfg(windows)]
 pub mod acl;
+pub mod allow;
+#[cfg(windows)]
+pub mod audit;
 pub mod cap;
 #[cfg(windows)]
 pub mod desktop;
@@ -111,6 +123,8 @@ pub mod token;
 pub mod types;
 #[cfg(windows)]
 pub mod winutil;
+#[cfg(windows)]
+pub mod workspace_acl;
 
 /// Returned by sandbox entry points on platforms where the Windows sandbox is
 /// unavailable.

--- a/crates/dasclaw_sandbox_windows/src/workspace_acl.rs
+++ b/crates/dasclaw_sandbox_windows/src/workspace_acl.rs
@@ -1,0 +1,34 @@
+// Derived from openai/codex commit 6e838a19fa
+//   path: codex-rs/windows-sandbox-rs/src/workspace_acl.rs
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::acl::add_deny_write_ace;
+use crate::path_normalization::canonicalize_path;
+use anyhow::Result;
+use std::ffi::c_void;
+use std::path::Path;
+
+pub fn is_command_cwd_root(root: &Path, canonical_command_cwd: &Path) -> bool {
+    canonicalize_path(root) == canonical_command_cwd
+}
+
+/// # Safety
+/// Caller must ensure `psid` is a valid SID pointer.
+pub unsafe fn protect_workspace_codex_dir(cwd: &Path, psid: *mut c_void) -> Result<bool> {
+    protect_workspace_subdir(cwd, psid, ".codex")
+}
+
+/// # Safety
+/// Caller must ensure `psid` is a valid SID pointer.
+pub unsafe fn protect_workspace_agents_dir(cwd: &Path, psid: *mut c_void) -> Result<bool> {
+    protect_workspace_subdir(cwd, psid, ".agents")
+}
+
+unsafe fn protect_workspace_subdir(cwd: &Path, psid: *mut c_void, subdir: &str) -> Result<bool> {
+    let path = cwd.join(subdir);
+    if path.is_dir() {
+        add_deny_write_ace(&path, psid)
+    } else {
+        Ok(false)
+    }
+}


### PR DESCRIPTION
## 背景/目标
Phase 1.1.4i Wave i-2 — 切换到 **Wave 批量合并 PR** 策略，替代 1 文件 1 PR 节奏。
Source: ADR-121 D3-3 codex windows-sandbox port at `6e838a19fa`.

## 改动范围
verbatim 移植 3 个就绪文件到 `crates/dasclaw_sandbox_windows/src/`：

| 文件 | LOC | cfg | 内部依赖（已就位） |
|---|---|---|---|
| `allow.rs` | 258 | cross-platform | `crate::policy` ✓ |
| `audit.rs` | 334 | `cfg(windows)` | `crate::acl, cap, logging, path_normalization, policy, token` ✓ |
| `workspace_acl.rs` | 30 | `cfg(windows)` | `crate::acl, path_normalization` ✓ |

**总计 622 LOC，零新增 dep。**

### 机械化重写（仅路径，无逻辑改动）
- 三个文件均添加 SPDX 出处头
- `allow.rs` 的 `#[cfg(test)]` 模块：`codex_protocol::protocol::SandboxPolicy` → `crate::types::SandboxPolicy`，`codex_utils_absolute_path::AbsolutePathBuf` → `crate::absolute_path::AbsolutePathBuf`（同形态类型，仅替换路径）
- `lib.rs`：注册 3 个新模块、phase doc bump `1.1.4i-6 → 1.1.4i-7`、新增 3 条 API bullets

## 非目标（What's NOT in this PR）
- **`firewall.rs`（512 LOC）暂缓**：upstream 仅作为 bin 模块存在（lib.rs 未通过 `windows_modules!` 宏注册），并依赖 `windows = 0.58` crate（heavy COM dep），需独立设计 lib/bin 拆分，下一切片处理。
- **`elevated_impl / helper_materialization / identity / setup_main_win / setup_orchestrator / spawn_prep`**：依赖未移植的模块（`identity` / `ipc_framed` / `sandbox_bin_dir` / `setup::*`），后续切片解锁。
- 不修改任何已移植文件的逻辑（仅新增）
- 不引入功能 flag、不复制粘贴、不补丁式改动

## 验证

```
cargo check -p dasclaw_sandbox_windows --tests       # OK
cargo nextest run -p dasclaw_sandbox_windows         # 48/48 passed (was 42; +6 from allow.rs tests)
cargo fmt --all                                       # OK
python3.12 scripts/check_no_panics.py --base origin/xClaw    # OK
python3 scripts/check_no_new_ironclaw_literal.py --base origin/xClaw  # OK
cargo clippy --no-deps -p dasclaw_sandbox_windows --all-targets -- -D warnings  # OK
```

cfg(windows)-gated `audit` / `workspace_acl` 在 macOS 不参与编译；CI 的 Windows runner 会覆盖。

Closes #305
