### PR TITLE
feat(sandbox-windows): port identity.rs + spawn_prep.rs (Phase 1.1.4i Wave i-4)

### DIFF
--- a/crates/dasclaw_sandbox_windows/src/identity.rs
+++ b/crates/dasclaw_sandbox_windows/src/identity.rs
@@ -1,0 +1,239 @@
+// Derived from openai/codex commit 6e838a19fa
+//   path: codex-rs/windows-sandbox-rs/src/identity.rs
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::dpapi;
+use crate::logging::debug_log;
+use crate::policy::SandboxPolicy;
+use crate::setup::SandboxNetworkIdentity;
+use crate::setup::SandboxUserRecord;
+use crate::setup::SandboxUsersFile;
+use crate::setup::SetupMarker;
+use crate::setup::gather_read_roots;
+use crate::setup::gather_write_roots;
+use crate::setup::offline_proxy_settings_from_env;
+use crate::setup::run_elevated_setup;
+use crate::setup::run_setup_refresh_with_overrides;
+use crate::setup::sandbox_users_path;
+use crate::setup::setup_marker_path;
+use anyhow::Context;
+use anyhow::Result;
+use anyhow::anyhow;
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
+use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
+use std::path::PathBuf;
+
+#[derive(Debug, Clone)]
+struct SandboxIdentity {
+    username: String,
+    password: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct SandboxCreds {
+    pub username: String,
+    pub password: String,
+}
+
+/// Returns true when the on-disk setup artifacts exist and match the current
+/// setup version.
+///
+/// This is a coarse readiness check; `require_logon_sandbox_creds` performs the
+/// additional runtime validation for offline firewall settings.
+pub fn sandbox_setup_is_complete(codex_home: &Path) -> bool {
+    let marker_ok = matches!(load_marker(codex_home), Ok(Some(marker)) if marker.version_matches());
+    if !marker_ok {
+        return false;
+    }
+    matches!(load_users(codex_home), Ok(Some(users)) if users.version_matches())
+}
+
+fn load_marker(codex_home: &Path) -> Result<Option<SetupMarker>> {
+    let path = setup_marker_path(codex_home);
+    let marker = match fs::read_to_string(&path) {
+        Ok(contents) => match serde_json::from_str::<SetupMarker>(&contents) {
+            Ok(m) => Some(m),
+            Err(err) => {
+                debug_log(
+                    &format!("sandbox setup marker parse failed: {err}"),
+                    Some(codex_home),
+                );
+                None
+            }
+        },
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => None,
+        Err(err) => {
+            debug_log(
+                &format!("sandbox setup marker read failed: {err}"),
+                Some(codex_home),
+            );
+            None
+        }
+    };
+    Ok(marker)
+}
+
+fn load_users(codex_home: &Path) -> Result<Option<SandboxUsersFile>> {
+    let path = sandbox_users_path(codex_home);
+    let file = match fs::read_to_string(&path) {
+        Ok(contents) => contents,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(err) => {
+            debug_log(
+                &format!("sandbox users read failed: {err}"),
+                Some(codex_home),
+            );
+            return Ok(None);
+        }
+    };
+    match serde_json::from_str::<SandboxUsersFile>(&file) {
+        Ok(users) => Ok(Some(users)),
+        Err(err) => {
+            debug_log(
+                &format!("sandbox users parse failed: {err}"),
+                Some(codex_home),
+            );
+            Ok(None)
+        }
+    }
+}
+
+fn decode_password(record: &SandboxUserRecord) -> Result<String> {
+    let blob = BASE64_STANDARD
+        .decode(record.password.as_bytes())
+        .context("base64 decode password")?;
+    let decrypted = dpapi::unprotect(&blob)?;
+    let pwd = String::from_utf8(decrypted).context("sandbox password not utf-8")?;
+    Ok(pwd)
+}
+
+fn select_identity(
+    network_identity: SandboxNetworkIdentity,
+    codex_home: &Path,
+) -> Result<Option<SandboxIdentity>> {
+    let _marker = match load_marker(codex_home)? {
+        Some(m) if m.version_matches() => m,
+        _ => return Ok(None),
+    };
+    let users = match load_users(codex_home)? {
+        Some(u) if u.version_matches() => u,
+        _ => return Ok(None),
+    };
+    let chosen = match network_identity {
+        SandboxNetworkIdentity::Offline => users.offline,
+        SandboxNetworkIdentity::Online => users.online,
+    };
+    let password = decode_password(&chosen)?;
+    Ok(Some(SandboxIdentity {
+        username: chosen.username,
+        password,
+    }))
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn require_logon_sandbox_creds(
+    policy: &SandboxPolicy,
+    policy_cwd: &Path,
+    command_cwd: &Path,
+    env_map: &HashMap<String, String>,
+    codex_home: &Path,
+    read_roots_override: Option<&[PathBuf]>,
+    read_roots_include_platform_defaults: bool,
+    write_roots_override: Option<&[PathBuf]>,
+    deny_write_paths_override: &[PathBuf],
+    proxy_enforced: bool,
+) -> Result<SandboxCreds> {
+    let sandbox_dir = crate::setup::sandbox_dir(codex_home);
+    let needed_read = read_roots_override
+        .map(<[PathBuf]>::to_vec)
+        .unwrap_or_else(|| gather_read_roots(command_cwd, policy, codex_home));
+    let needed_write = write_roots_override
+        .map(<[PathBuf]>::to_vec)
+        .unwrap_or_else(|| gather_write_roots(policy, policy_cwd, command_cwd, env_map));
+    let network_identity = SandboxNetworkIdentity::from_policy(policy, proxy_enforced);
+    let desired_offline_proxy_settings = offline_proxy_settings_from_env(env_map, network_identity);
+    // NOTE: Do not add CODEX_HOME/.sandbox to `needed_write`; it must remain non-writable by the
+    // restricted capability token. The setup helper's `lock_sandbox_dir` is responsible for
+    // granting the sandbox group access to this directory without granting the capability SID.
+    let mut setup_reason: Option<String> = None;
+
+    let mut identity = match load_marker(codex_home)? {
+        Some(marker) if marker.version_matches() => {
+            if let Some(reason) =
+                marker.request_mismatch_reason(network_identity, &desired_offline_proxy_settings)
+            {
+                setup_reason = Some(reason);
+                None
+            } else {
+                let selected = select_identity(network_identity, codex_home)?;
+                if selected.is_none() {
+                    setup_reason = Some(
+                        "sandbox users missing or incompatible with marker version".to_string(),
+                    );
+                }
+                selected
+            }
+        }
+        _ => {
+            setup_reason = Some("sandbox setup marker missing or incompatible".to_string());
+            None
+        }
+    };
+
+    if identity.is_none() {
+        if let Some(reason) = &setup_reason {
+            crate::logging::log_note(
+                &format!("sandbox setup required: {reason}"),
+                Some(&sandbox_dir),
+            );
+        } else {
+            crate::logging::log_note("sandbox setup required", Some(&sandbox_dir));
+        }
+        run_elevated_setup(
+            crate::setup::SandboxSetupRequest {
+                policy,
+                policy_cwd,
+                command_cwd,
+                env_map,
+                codex_home,
+                proxy_enforced,
+            },
+            crate::setup::SetupRootOverrides {
+                read_roots: Some(needed_read.clone()),
+                read_roots_include_platform_defaults,
+                write_roots: Some(needed_write.clone()),
+                deny_write_paths: Some(deny_write_paths_override.to_vec()),
+            },
+        )?;
+        identity = select_identity(network_identity, codex_home)?;
+    }
+    // Always refresh ACLs (non-elevated) for current roots via the setup binary.
+    run_setup_refresh_with_overrides(
+        crate::setup::SandboxSetupRequest {
+            policy,
+            policy_cwd,
+            command_cwd,
+            env_map,
+            codex_home,
+            proxy_enforced,
+        },
+        crate::setup::SetupRootOverrides {
+            read_roots: Some(needed_read),
+            read_roots_include_platform_defaults,
+            write_roots: Some(needed_write),
+            deny_write_paths: Some(deny_write_paths_override.to_vec()),
+        },
+    )?;
+    let identity = identity.ok_or_else(|| {
+        anyhow!(
+            "Windows sandbox setup is missing or out of date; rerun the sandbox setup with elevation"
+        )
+    })?;
+    Ok(SandboxCreds {
+        username: identity.username,
+        password: identity.password,
+    })
+}

--- a/crates/dasclaw_sandbox_windows/src/lib.rs
+++ b/crates/dasclaw_sandbox_windows/src/lib.rs
@@ -9,7 +9,7 @@
 //! See `vendor/codex-windows-sandbox/README.md` for the reference snapshot
 //! and the porting plan in tracker issue #250.
 //!
-//! ## Crate status (Phase 1.1.4i-8)
+//! ## Crate status (Phase 1.1.4i-9)
 //!
 //! V'-b "port-on-demand" subset. The cross-platform PTY/process plumbing
 //! (`pty::process`) and the `cfg(windows)`-only ConPTY backend
@@ -111,6 +111,8 @@ pub mod env;
 pub mod helper_materialization;
 #[cfg(windows)]
 pub mod hide_users;
+#[cfg(windows)]
+pub mod identity;
 pub mod logging;
 pub mod path_normalization;
 pub mod policy;
@@ -129,6 +131,8 @@ pub mod sandbox_utils;
 pub mod setup;
 #[cfg(windows)]
 pub mod setup_error;
+#[cfg(windows)]
+pub mod spawn_prep;
 // Consumed by setup (setup_orchestrator) on Windows; on non-Windows targets
 // the consumer is cfg-gated out, so allow dead_code to keep the cross-platform
 // build clean.
@@ -145,6 +149,10 @@ pub mod workspace_acl;
 
 #[cfg(windows)]
 pub use helper_materialization::resolve_current_exe_for_launch;
+#[cfg(windows)]
+pub use identity::require_logon_sandbox_creds;
+#[cfg(windows)]
+pub use identity::sandbox_setup_is_complete;
 #[cfg(windows)]
 pub use setup::SETUP_VERSION;
 #[cfg(windows)]

--- a/crates/dasclaw_sandbox_windows/src/spawn_prep.rs
+++ b/crates/dasclaw_sandbox_windows/src/spawn_prep.rs
@@ -1,0 +1,415 @@
+// Derived from openai/codex commit 6e838a19fa
+//   path: codex-rs/windows-sandbox-rs/src/spawn_prep.rs
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::acl::add_allow_ace;
+use crate::acl::add_deny_write_ace;
+use crate::acl::allow_null_device;
+use crate::allow::AllowDenyPaths;
+use crate::allow::compute_allow_paths;
+use crate::cap::load_or_create_cap_sids;
+use crate::cap::workspace_cap_sid_for_cwd;
+use crate::env::apply_no_network_to_env;
+use crate::env::ensure_non_interactive_pager;
+use crate::env::inherit_path_env;
+use crate::env::normalize_null_device_env;
+use crate::identity::SandboxCreds;
+use crate::identity::require_logon_sandbox_creds;
+use crate::logging::log_start;
+use crate::path_normalization::canonicalize_path;
+use crate::policy::SandboxPolicy;
+use crate::policy::parse_policy;
+use crate::sandbox_utils::ensure_codex_home_exists;
+use crate::sandbox_utils::inject_git_safe_directory;
+use crate::token::convert_string_sid_to_sid;
+use crate::token::create_readonly_token_with_cap;
+use crate::token::create_workspace_write_token_with_caps_from;
+use crate::token::get_current_token_for_restriction;
+use crate::token::get_logon_sid_bytes;
+use crate::workspace_acl::is_command_cwd_root;
+use crate::workspace_acl::protect_workspace_agents_dir;
+use crate::workspace_acl::protect_workspace_codex_dir;
+use anyhow::Result;
+use std::collections::HashMap;
+use std::ffi::c_void;
+use std::path::Path;
+use std::path::PathBuf;
+use windows_sys::Win32::Foundation::CloseHandle;
+use windows_sys::Win32::Foundation::HANDLE;
+use windows_sys::Win32::Foundation::HLOCAL;
+use windows_sys::Win32::Foundation::LocalFree;
+
+pub(crate) struct SpawnContext {
+    pub(crate) policy: SandboxPolicy,
+    pub(crate) current_dir: PathBuf,
+    pub(crate) sandbox_base: PathBuf,
+    pub(crate) logs_base_dir: Option<PathBuf>,
+    pub(crate) is_workspace_write: bool,
+}
+
+pub(crate) struct ElevatedSpawnContext {
+    pub(crate) common: SpawnContext,
+    pub(crate) sandbox_creds: SandboxCreds,
+    pub(crate) cap_sids: Vec<String>,
+}
+
+pub(crate) struct LegacySessionSecurity {
+    pub(crate) h_token: HANDLE,
+    pub(crate) psid_generic: LocalSid,
+    pub(crate) psid_workspace: Option<LocalSid>,
+    pub(crate) cap_sid_str: String,
+}
+
+pub(crate) struct LocalSid {
+    psid: *mut c_void,
+}
+
+impl LocalSid {
+    pub(crate) fn from_string(sid: &str) -> Result<Self> {
+        let psid = unsafe { convert_string_sid_to_sid(sid) }
+            .ok_or_else(|| anyhow::anyhow!("invalid SID string: {sid}"))?;
+        Ok(Self { psid })
+    }
+
+    pub(crate) fn as_ptr(&self) -> *mut c_void {
+        self.psid
+    }
+}
+
+impl Drop for LocalSid {
+    fn drop(&mut self) {
+        if !self.psid.is_null() {
+            unsafe {
+                LocalFree(self.psid as HLOCAL);
+            }
+        }
+    }
+}
+
+pub(crate) fn should_apply_network_block(policy: &SandboxPolicy) -> bool {
+    !policy.has_full_network_access()
+}
+
+fn prepare_spawn_context_common(
+    policy_json_or_preset: &str,
+    codex_home: &Path,
+    cwd: &Path,
+    env_map: &mut HashMap<String, String>,
+    command: &[String],
+    inherit_path: bool,
+    add_git_safe_directory: bool,
+) -> Result<SpawnContext> {
+    let policy = parse_policy(policy_json_or_preset)?;
+    if matches!(
+        &policy,
+        SandboxPolicy::DangerFullAccess | SandboxPolicy::ExternalSandbox { .. }
+    ) {
+        anyhow::bail!("DangerFullAccess and ExternalSandbox are not supported for sandboxing")
+    }
+
+    normalize_null_device_env(env_map);
+    ensure_non_interactive_pager(env_map);
+    if inherit_path {
+        inherit_path_env(env_map);
+    }
+    if add_git_safe_directory {
+        inject_git_safe_directory(env_map, cwd);
+    }
+
+    ensure_codex_home_exists(codex_home)?;
+    let sandbox_base = codex_home.join(".sandbox");
+    std::fs::create_dir_all(&sandbox_base)?;
+    let logs_base_dir = Some(sandbox_base.clone());
+    log_start(command, logs_base_dir.as_deref());
+
+    let is_workspace_write = matches!(&policy, SandboxPolicy::WorkspaceWrite { .. });
+
+    Ok(SpawnContext {
+        policy,
+        current_dir: cwd.to_path_buf(),
+        sandbox_base,
+        logs_base_dir,
+        is_workspace_write,
+    })
+}
+
+pub(crate) fn prepare_legacy_spawn_context(
+    policy_json_or_preset: &str,
+    codex_home: &Path,
+    cwd: &Path,
+    env_map: &mut HashMap<String, String>,
+    command: &[String],
+    inherit_path: bool,
+    add_git_safe_directory: bool,
+) -> Result<SpawnContext> {
+    let common = prepare_spawn_context_common(
+        policy_json_or_preset,
+        codex_home,
+        cwd,
+        env_map,
+        command,
+        inherit_path,
+        add_git_safe_directory,
+    )?;
+    if should_apply_network_block(&common.policy) {
+        apply_no_network_to_env(env_map)?;
+    }
+    Ok(common)
+}
+
+pub(crate) fn prepare_legacy_session_security(
+    policy: &SandboxPolicy,
+    codex_home: &Path,
+    cwd: &Path,
+) -> Result<LegacySessionSecurity> {
+    let caps = load_or_create_cap_sids(codex_home)?;
+    let (h_token, psid_generic, psid_workspace, cap_sid_str) = unsafe {
+        match policy {
+            SandboxPolicy::ReadOnly { .. } => {
+                let psid = LocalSid::from_string(&caps.readonly)?;
+                let (h_token, _psid) = create_readonly_token_with_cap(psid.as_ptr())?;
+                (h_token, psid, None, caps.readonly)
+            }
+            SandboxPolicy::WorkspaceWrite { .. } => {
+                let psid_generic = LocalSid::from_string(&caps.workspace)?;
+                let workspace_sid = workspace_cap_sid_for_cwd(codex_home, cwd)?;
+                let psid_workspace = LocalSid::from_string(&workspace_sid)?;
+                let base = get_current_token_for_restriction()?;
+                let h_token = create_workspace_write_token_with_caps_from(
+                    base,
+                    &[psid_generic.as_ptr(), psid_workspace.as_ptr()],
+                );
+                CloseHandle(base);
+                let h_token = h_token?;
+                (h_token, psid_generic, Some(psid_workspace), caps.workspace)
+            }
+            SandboxPolicy::DangerFullAccess | SandboxPolicy::ExternalSandbox { .. } => {
+                unreachable!("dangerous policies rejected before legacy session prep")
+            }
+        }
+    };
+
+    Ok(LegacySessionSecurity {
+        h_token,
+        psid_generic,
+        psid_workspace,
+        cap_sid_str,
+    })
+}
+
+pub(crate) fn allow_null_device_for_workspace_write(is_workspace_write: bool) {
+    if !is_workspace_write {
+        return;
+    }
+
+    unsafe {
+        if let Ok(base) = get_current_token_for_restriction() {
+            if let Ok(bytes) = get_logon_sid_bytes(base) {
+                let mut tmp = bytes;
+                let psid = tmp.as_mut_ptr() as *mut c_void;
+                allow_null_device(psid);
+            }
+            CloseHandle(base);
+        }
+    }
+}
+
+pub(crate) fn apply_legacy_session_acl_rules(
+    policy: &SandboxPolicy,
+    sandbox_policy_cwd: &Path,
+    current_dir: &Path,
+    env_map: &HashMap<String, String>,
+    psid_generic: &LocalSid,
+    psid_workspace: Option<&LocalSid>,
+    persist_aces: bool,
+) -> Vec<PathBuf> {
+    let AllowDenyPaths { allow, deny } =
+        compute_allow_paths(policy, sandbox_policy_cwd, current_dir, env_map);
+    let mut guards: Vec<PathBuf> = Vec::new();
+    let canonical_cwd = canonicalize_path(current_dir);
+    unsafe {
+        for p in &allow {
+            let psid = if matches!(policy, SandboxPolicy::WorkspaceWrite { .. })
+                && is_command_cwd_root(p, &canonical_cwd)
+            {
+                psid_workspace.unwrap_or(psid_generic).as_ptr()
+            } else {
+                psid_generic.as_ptr()
+            };
+            if matches!(add_allow_ace(p, psid), Ok(true)) && !persist_aces {
+                guards.push(p.clone());
+            }
+        }
+        for p in &deny {
+            if let Ok(added) = add_deny_write_ace(p, psid_generic.as_ptr())
+                && added
+                && !persist_aces
+            {
+                guards.push(p.clone());
+            }
+        }
+        allow_null_device(psid_generic.as_ptr());
+        if let Some(psid_workspace) = psid_workspace {
+            allow_null_device(psid_workspace.as_ptr());
+            if persist_aces && matches!(policy, SandboxPolicy::WorkspaceWrite { .. }) {
+                let _ = protect_workspace_codex_dir(current_dir, psid_workspace.as_ptr());
+                let _ = protect_workspace_agents_dir(current_dir, psid_workspace.as_ptr());
+            }
+        }
+    }
+    guards
+}
+
+pub(crate) fn prepare_elevated_spawn_context(
+    policy_json_or_preset: &str,
+    sandbox_policy_cwd: &Path,
+    codex_home: &Path,
+    cwd: &Path,
+    env_map: &mut HashMap<String, String>,
+    command: &[String],
+) -> Result<ElevatedSpawnContext> {
+    let common = prepare_spawn_context_common(
+        policy_json_or_preset,
+        codex_home,
+        cwd,
+        env_map,
+        command,
+        /*inherit_path*/ true,
+        /*add_git_safe_directory*/ true,
+    )?;
+
+    let AllowDenyPaths { allow, deny } = compute_allow_paths(
+        &common.policy,
+        sandbox_policy_cwd,
+        &common.current_dir,
+        env_map,
+    );
+    let write_roots: Vec<PathBuf> = allow.into_iter().collect();
+    let deny_write_paths: Vec<PathBuf> = deny.into_iter().collect();
+    let write_roots_override = if common.is_workspace_write {
+        Some(write_roots.as_slice())
+    } else {
+        None
+    };
+    let sandbox_creds = require_logon_sandbox_creds(
+        &common.policy,
+        sandbox_policy_cwd,
+        cwd,
+        env_map,
+        codex_home,
+        /*read_roots_override*/ None,
+        /*read_roots_include_platform_defaults*/ false,
+        write_roots_override,
+        &deny_write_paths,
+        /*proxy_enforced*/ false,
+    )?;
+    let caps = load_or_create_cap_sids(codex_home)?;
+    let (psid_to_use, cap_sids) = match &common.policy {
+        SandboxPolicy::ReadOnly { .. } => (
+            LocalSid::from_string(&caps.readonly)?,
+            vec![caps.readonly.clone()],
+        ),
+        SandboxPolicy::WorkspaceWrite { .. } => {
+            let cap_sid = workspace_cap_sid_for_cwd(codex_home, cwd)?;
+            (
+                LocalSid::from_string(&caps.workspace)?,
+                vec![caps.workspace.clone(), cap_sid],
+            )
+        }
+        SandboxPolicy::DangerFullAccess | SandboxPolicy::ExternalSandbox { .. } => {
+            unreachable!("dangerous policies rejected before elevated session prep")
+        }
+    };
+
+    unsafe {
+        allow_null_device(psid_to_use.as_ptr());
+    }
+
+    Ok(ElevatedSpawnContext {
+        common,
+        sandbox_creds,
+        cap_sids,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SandboxPolicy;
+    use super::prepare_legacy_spawn_context;
+    use super::prepare_spawn_context_common;
+    use super::should_apply_network_block;
+    use pretty_assertions::assert_eq;
+    use std::collections::HashMap;
+    use tempfile::TempDir;
+
+    #[test]
+    fn no_network_env_rewrite_applies_for_workspace_write() {
+        assert!(should_apply_network_block(
+            &SandboxPolicy::new_workspace_write_policy(),
+        ));
+    }
+
+    #[test]
+    fn no_network_env_rewrite_skips_when_network_access_is_allowed() {
+        assert!(!should_apply_network_block(
+            &SandboxPolicy::WorkspaceWrite {
+                writable_roots: Vec::new(),
+                network_access: true,
+                exclude_tmpdir_env_var: false,
+                exclude_slash_tmp: false,
+            },
+        ));
+    }
+
+    #[test]
+    fn legacy_spawn_env_applies_offline_network_rewrite() {
+        let codex_home = TempDir::new().expect("tempdir");
+        let cwd = TempDir::new().expect("tempdir");
+        let mut env_map = HashMap::new();
+
+        let _context = prepare_legacy_spawn_context(
+            "workspace-write",
+            codex_home.path(),
+            cwd.path(),
+            &mut env_map,
+            &["cmd.exe".to_string()],
+            /*inherit_path*/ true,
+            /*add_git_safe_directory*/ false,
+        )
+        .expect("legacy env prep");
+
+        assert_eq!(env_map.get("SBX_NONET_ACTIVE"), Some(&"1".to_string()));
+        assert_eq!(
+            env_map.get("HTTP_PROXY"),
+            Some(&"http://127.0.0.1:9".to_string())
+        );
+    }
+
+    #[test]
+    fn common_spawn_env_keeps_network_env_unchanged() {
+        let codex_home = TempDir::new().expect("tempdir");
+        let cwd = TempDir::new().expect("tempdir");
+        let mut env_map = HashMap::from([(
+            "HTTP_PROXY".to_string(),
+            "http://user.proxy:8080".to_string(),
+        )]);
+
+        let context = prepare_spawn_context_common(
+            "workspace-write",
+            codex_home.path(),
+            cwd.path(),
+            &mut env_map,
+            &["cmd.exe".to_string()],
+            /*inherit_path*/ true,
+            /*add_git_safe_directory*/ true,
+        )
+        .expect("preserve existing env prep");
+        assert_eq!(context.policy, SandboxPolicy::new_workspace_write_policy());
+
+        assert_eq!(env_map.get("SBX_NONET_ACTIVE"), None);
+        assert_eq!(
+            env_map.get("HTTP_PROXY"),
+            Some(&"http://user.proxy:8080".to_string())
+        );
+    }
+}


### PR DESCRIPTION
## 背景/目标

Wave i-4 verbatim port of two next files from upstream `openai/codex` `codex-rs/windows-sandbox-rs/` (commit `6e838a19fa`) into `crates/dasclaw_sandbox_windows`:

- `identity.rs` (235 LOC) — sandbox-user logon credential cache + setup-completion check.
- `spawn_prep.rs` (411 LOC) — pre-spawn token/ACL preparation; depends on `crate::identity`.

Both files use only `crate::`-rooted imports — no external import rewrites required. Internal serial dep (spawn_prep → identity) is resolved within the same crate compilation unit.

## 改动范围

- 新增 `crates/dasclaw_sandbox_windows/src/identity.rs` (verbatim + SPDX header).
- 新增 `crates/dasclaw_sandbox_windows/src/spawn_prep.rs` (verbatim + SPDX header).
- `lib.rs`:
  - `#[cfg(windows)] pub mod identity;`
  - `#[cfg(windows)] pub mod spawn_prep;`
  - `pub use identity::require_logon_sandbox_creds;` (mirrors upstream)
  - `pub use identity::sandbox_setup_is_complete;` (mirrors upstream)
  - phase doc bumped to `1.1.4i-9`.

## 非目标 (What's NOT in this PR)

- `firewall.rs` (Wave i-5 — 需引入 `windows = 0.58` 重型 COM crate + `Win32_NetworkManagement_WindowsFirewall` 系列特性，需独立设计)。
- `elevated_impl.rs` (Wave i-6 — 需先 port `elevated/ipc_framed.rs` 子目录)。
- `setup_main_win.rs` (Wave i-7 — 899 LOC，bin 入口，需要 lib/bin split 设计)。
- 新增功能逻辑、refactor、wrap helpers、test 增删 — 全部 verbatim。

## 验证

本地完整六步管线 (macOS, branch off origin/xClaw):

```
cargo check -p dasclaw_sandbox_windows --tests        # OK
cargo nextest run -p dasclaw_sandbox_windows          # 45 passed, 0 skipped
cargo fmt --all                                       # clean
python3.12 scripts/check_no_panics.py --base origin/xClaw    # OK
python3 scripts/check_no_new_ironclaw_literal.py --base origin/xClaw  # OK
cargo clippy --no-deps -p dasclaw_sandbox_windows --all-targets -- -D warnings  # clean
```

完整 `cargo build` / workspace clippy / Windows-only integration 由 CI 兜底。

Closes #309
Tracker: #263 (Phase 1.1.4 parent), #250 (Phase 1.1).