### PR TITLE
feat(sandbox-windows): port elevated/ subdir (Phase 1.1.4j Wave i-6a)

### DIFF
--- a/crates/dasclaw_sandbox_windows/src/elevated/cwd_junction.rs
+++ b/crates/dasclaw_sandbox_windows/src/elevated/cwd_junction.rs
@@ -1,0 +1,149 @@
+// Derived from openai/codex commit 6e838a19fa
+//   path: codex-rs/windows-sandbox-rs/src/elevated/cwd_junction.rs
+// SPDX-License-Identifier: Apache-2.0
+//
+// Mechanical import rewrite: `codex_windows_sandbox::log_note`
+// → `crate::logging::log_note`. Logic is otherwise verbatim.
+
+#![cfg(target_os = "windows")]
+
+use crate::logging::log_note;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::Hash;
+use std::hash::Hasher;
+use std::os::windows::fs::MetadataExt as _;
+use std::os::windows::process::CommandExt as _;
+use std::path::Path;
+use std::path::PathBuf;
+use windows_sys::Win32::Storage::FileSystem::FILE_ATTRIBUTE_REPARSE_POINT;
+
+fn junction_name_for_path(path: &Path) -> String {
+    let mut hasher = DefaultHasher::new();
+    path.to_string_lossy().hash(&mut hasher);
+    format!("{:x}", hasher.finish())
+}
+
+fn junction_root_for_userprofile(userprofile: &str) -> PathBuf {
+    PathBuf::from(userprofile)
+        .join(".codex")
+        .join(".sandbox")
+        .join("cwd")
+}
+
+pub fn create_cwd_junction(requested_cwd: &Path, log_dir: Option<&Path>) -> Option<PathBuf> {
+    let userprofile = std::env::var("USERPROFILE").ok()?;
+    let junction_root = junction_root_for_userprofile(&userprofile);
+    if let Err(err) = std::fs::create_dir_all(&junction_root) {
+        log_note(
+            &format!(
+                "junction: failed to create {}: {err}",
+                junction_root.display()
+            ),
+            log_dir,
+        );
+        return None;
+    }
+
+    let junction_path = junction_root.join(junction_name_for_path(requested_cwd));
+    if junction_path.exists() {
+        // Reuse an existing junction if it looks like a reparse point; this keeps the hot path
+        // cheap and avoids repeatedly shelling out to mklink.
+        match std::fs::symlink_metadata(&junction_path) {
+            Ok(md) if (md.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT) != 0 => {
+                log_note(
+                    &format!("junction: reusing existing {}", junction_path.display()),
+                    log_dir,
+                );
+                return Some(junction_path);
+            }
+            Ok(_) => {
+                // Unexpected: something else exists at this path (regular directory/file). We'll
+                // try to remove it if possible and recreate the junction.
+                log_note(
+                    &format!(
+                        "junction: existing path is not a reparse point, recreating {}",
+                        junction_path.display()
+                    ),
+                    log_dir,
+                );
+            }
+            Err(err) => {
+                log_note(
+                    &format!(
+                        "junction: failed to stat existing {}: {err}",
+                        junction_path.display()
+                    ),
+                    log_dir,
+                );
+                return None;
+            }
+        }
+
+        if let Err(err) = std::fs::remove_dir(&junction_path) {
+            log_note(
+                &format!(
+                    "junction: failed to remove existing {}: {err}",
+                    junction_path.display()
+                ),
+                log_dir,
+            );
+            return None;
+        }
+    }
+
+    let link = junction_path.to_string_lossy().to_string();
+    let target = requested_cwd.to_string_lossy().to_string();
+
+    // Use `cmd /c` so we can call `mklink` (a cmd builtin). We must quote paths so CWDs
+    // containing spaces work reliably.
+    //
+    // IMPORTANT: `std::process::Command::args()` will apply Windows quoting/escaping rules when
+    // constructing the command line. Passing a single argument that itself contains quotes can
+    // confuse `cmd.exe` and cause mklink to fail with "syntax is incorrect". We avoid that by
+    // using `raw_arg` to pass the tokens exactly as `cmd.exe` expects to parse them.
+    //
+    // Paths cannot contain quotes on Windows, so no extra escaping is needed here.
+    let link_quoted = format!("\"{link}\"");
+    let target_quoted = format!("\"{target}\"");
+    log_note(
+        &format!("junction: creating via cmd /c mklink /J {link_quoted} {target_quoted}"),
+        log_dir,
+    );
+    let output = match std::process::Command::new("cmd")
+        .raw_arg("/c")
+        .raw_arg("mklink")
+        .raw_arg("/J")
+        .raw_arg(&link_quoted)
+        .raw_arg(&target_quoted)
+        .output()
+    {
+        Ok(output) => output,
+        Err(err) => {
+            log_note(&format!("junction: mklink failed to run: {err}"), log_dir);
+            return None;
+        }
+    };
+    if output.status.success() && junction_path.exists() {
+        log_note(
+            &format!(
+                "junction: created {} -> {}",
+                junction_path.display(),
+                requested_cwd.display()
+            ),
+            log_dir,
+        );
+        return Some(junction_path);
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    log_note(
+        &format!(
+            "junction: mklink failed status={:?} stdout={} stderr={}",
+            output.status,
+            stdout.trim(),
+            stderr.trim()
+        ),
+        log_dir,
+    );
+    None
+}

--- a/crates/dasclaw_sandbox_windows/src/elevated/ipc_framed.rs
+++ b/crates/dasclaw_sandbox_windows/src/elevated/ipc_framed.rs
@@ -1,0 +1,195 @@
+// Derived from openai/codex commit 6e838a19fa
+//   path: codex-rs/windows-sandbox-rs/src/elevated/ipc_framed.rs
+// SPDX-License-Identifier: Apache-2.0
+//! Framed IPC protocol used between the parent (CLI) and the elevated command runner.
+//!
+//! This module defines the JSON message schema (spawn request/ready, output, stdin,
+//! exit, error, terminate) plus length‑prefixed framing helpers for a byte stream.
+//! It is **elevated-path only**: the parent uses it to bootstrap the runner and
+//! stream unified_exec I/O over named pipes. The legacy restricted‑token path does
+//! not use this protocol, and non‑unified exec capture uses it only when running
+//! through the elevated runner.
+
+use anyhow::Result;
+use base64::Engine as _;
+use base64::engine::general_purpose::STANDARD;
+use serde::Deserialize;
+use serde::Serialize;
+use std::collections::HashMap;
+use std::io::Read;
+use std::io::Write;
+use std::path::PathBuf;
+
+/// Safety cap for a single framed message payload.
+///
+/// This is not a protocol requirement; it simply bounds memory use and rejects
+/// obviously invalid frames.
+const MAX_FRAME_LEN: usize = 8 * 1024 * 1024;
+
+/// Length-prefixed, JSON-encoded frame.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct FramedMessage {
+    pub version: u8,
+    #[serde(flatten)]
+    pub message: Message,
+}
+
+/// IPC message variants exchanged between parent and runner.
+///
+/// `SpawnRequest`, `Stdin`, `CloseStdin`, `Resize`, and `Terminate` are parent->runner commands.
+/// `SpawnReady`, `Output`, `Exit`, and `Error` are runner->parent events/results.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum Message {
+    SpawnRequest { payload: Box<SpawnRequest> },
+    SpawnReady { payload: SpawnReady },
+    Output { payload: OutputPayload },
+    Stdin { payload: StdinPayload },
+    CloseStdin { payload: EmptyPayload },
+    Resize { payload: ResizePayload },
+    Exit { payload: ExitPayload },
+    Error { payload: ErrorPayload },
+    Terminate { payload: EmptyPayload },
+}
+
+/// Spawn parameters sent from parent to runner.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct SpawnRequest {
+    pub command: Vec<String>,
+    pub cwd: PathBuf,
+    pub env: HashMap<String, String>,
+    pub policy_json_or_preset: String,
+    pub sandbox_policy_cwd: PathBuf,
+    pub codex_home: PathBuf,
+    pub real_codex_home: PathBuf,
+    pub cap_sids: Vec<String>,
+    pub timeout_ms: Option<u64>,
+    pub tty: bool,
+    #[serde(default)]
+    pub stdin_open: bool,
+    #[serde(default)]
+    pub use_private_desktop: bool,
+}
+
+/// Ack from runner after it spawns the child process.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct SpawnReady {
+    pub process_id: u32,
+}
+
+/// Output data sent from runner to parent.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct OutputPayload {
+    pub data_b64: String,
+    pub stream: OutputStream,
+}
+
+/// Output stream identifier for `OutputPayload`.
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum OutputStream {
+    Stdout,
+    Stderr,
+}
+
+/// Stdin bytes sent from parent to runner.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct StdinPayload {
+    pub data_b64: String,
+}
+
+/// PTY resize request sent from parent to runner.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ResizePayload {
+    pub rows: u16,
+    pub cols: u16,
+}
+
+/// Exit status sent from runner to parent.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ExitPayload {
+    pub exit_code: i32,
+    pub timed_out: bool,
+}
+
+/// Error payload sent when the runner fails to spawn or stream.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ErrorPayload {
+    pub message: String,
+    pub code: String,
+}
+
+/// Empty payload for control messages.
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
+pub struct EmptyPayload {}
+
+/// Base64-encode raw bytes for IPC payloads.
+pub fn encode_bytes(data: &[u8]) -> String {
+    STANDARD.encode(data)
+}
+
+/// Decode base64 payload data into raw bytes.
+pub fn decode_bytes(data: &str) -> Result<Vec<u8>> {
+    Ok(STANDARD.decode(data.as_bytes())?)
+}
+
+/// Write a length-prefixed JSON frame.
+pub fn write_frame<W: Write>(mut writer: W, msg: &FramedMessage) -> Result<()> {
+    let payload = serde_json::to_vec(msg)?;
+    if payload.len() > MAX_FRAME_LEN {
+        anyhow::bail!("frame too large: {}", payload.len());
+    }
+    let len = payload.len() as u32;
+    writer.write_all(&len.to_le_bytes())?;
+    writer.write_all(&payload)?;
+    writer.flush()?;
+    Ok(())
+}
+
+/// Read a length-prefixed JSON frame; returns `Ok(None)` on EOF.
+pub fn read_frame<R: Read>(mut reader: R) -> Result<Option<FramedMessage>> {
+    let mut len_buf = [0u8; 4];
+    match reader.read_exact(&mut len_buf) {
+        Ok(()) => {}
+        Err(err) if err.kind() == std::io::ErrorKind::UnexpectedEof => return Ok(None),
+        Err(err) => return Err(err.into()),
+    }
+    let len = u32::from_le_bytes(len_buf) as usize;
+    if len > MAX_FRAME_LEN {
+        anyhow::bail!("frame too large: {len}");
+    }
+    let mut payload = vec![0u8; len];
+    reader.read_exact(&mut payload)?;
+    let msg: FramedMessage = serde_json::from_slice(&payload)?;
+    Ok(Some(msg))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn framed_round_trip() {
+        let msg = FramedMessage {
+            version: 1,
+            message: Message::Output {
+                payload: OutputPayload {
+                    data_b64: encode_bytes(b"hello"),
+                    stream: OutputStream::Stdout,
+                },
+            },
+        };
+        let mut buf = Vec::new();
+        write_frame(&mut buf, &msg).expect("write");
+        let decoded = read_frame(buf.as_slice()).expect("read").expect("some");
+        assert_eq!(decoded.version, 1);
+        match decoded.message {
+            Message::Output { payload } => {
+                assert_eq!(payload.stream, OutputStream::Stdout);
+                let data = decode_bytes(&payload.data_b64).expect("decode");
+                assert_eq!(data, b"hello");
+            }
+            other => panic!("unexpected message: {other:?}"),
+        }
+    }
+}

--- a/crates/dasclaw_sandbox_windows/src/elevated/runner_client.rs
+++ b/crates/dasclaw_sandbox_windows/src/elevated/runner_client.rs
@@ -1,0 +1,222 @@
+// Derived from openai/codex commit 6e838a19fa
+//   path: codex-rs/windows-sandbox-rs/src/elevated/runner_client.rs
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::identity::SandboxCreds;
+use crate::ipc_framed::FramedMessage;
+use crate::ipc_framed::Message;
+use crate::ipc_framed::SpawnRequest;
+use crate::ipc_framed::read_frame;
+use crate::ipc_framed::write_frame;
+use crate::runner_pipe::PIPE_ACCESS_INBOUND;
+use crate::runner_pipe::PIPE_ACCESS_OUTBOUND;
+use crate::runner_pipe::connect_pipe;
+use crate::runner_pipe::create_named_pipe;
+use crate::runner_pipe::find_runner_exe;
+use crate::runner_pipe::pipe_pair;
+use crate::winutil::quote_windows_arg;
+use crate::winutil::to_wide;
+use anyhow::Result;
+use std::ffi::c_void;
+use std::fs::File;
+use std::os::windows::io::AsRawHandle;
+use std::os::windows::io::FromRawHandle;
+use std::path::Path;
+use std::ptr;
+use std::time::Duration;
+use std::time::Instant;
+use windows_sys::Win32::Foundation::CloseHandle;
+use windows_sys::Win32::Foundation::GetLastError;
+use windows_sys::Win32::Foundation::HANDLE;
+use windows_sys::Win32::System::Diagnostics::Debug::SetErrorMode;
+use windows_sys::Win32::System::Pipes::PeekNamedPipe;
+use windows_sys::Win32::System::Threading::CreateProcessWithLogonW;
+use windows_sys::Win32::System::Threading::LOGON_WITH_PROFILE;
+use windows_sys::Win32::System::Threading::PROCESS_INFORMATION;
+use windows_sys::Win32::System::Threading::STARTUPINFOW;
+
+const RUNNER_SPAWN_READY_TIMEOUT: Duration = Duration::from_secs(15);
+const RUNNER_SPAWN_READY_POLL_INTERVAL: Duration = Duration::from_millis(50);
+const RUNNER_ERROR_MODE_FLAGS: u32 = 0x0001 | 0x0002;
+
+pub(crate) struct RunnerTransport {
+    pipe_write: File,
+    pipe_read: File,
+}
+
+impl RunnerTransport {
+    pub(crate) fn send_spawn_request(&mut self, request: SpawnRequest) -> Result<()> {
+        let spawn_request = FramedMessage {
+            version: 1,
+            message: Message::SpawnRequest {
+                payload: Box::new(request),
+            },
+        };
+        write_frame(&mut self.pipe_write, &spawn_request)
+    }
+
+    pub(crate) fn read_spawn_ready(&mut self) -> Result<()> {
+        let msg = read_frame(&mut self.pipe_read)?
+            .ok_or_else(|| anyhow::anyhow!("runner pipe closed before spawn_ready"))?;
+        match msg.message {
+            Message::SpawnReady { .. } => Ok(()),
+            Message::Error { payload } => Err(anyhow::anyhow!("runner error: {}", payload.message)),
+            other => Err(anyhow::anyhow!(
+                "expected spawn_ready from runner, got {other:?}"
+            )),
+        }
+    }
+
+    pub(crate) fn read_spawn_ready_with_timeout(&mut self) -> Result<()> {
+        wait_for_complete_frame(&self.pipe_read, RUNNER_SPAWN_READY_TIMEOUT)?;
+        self.read_spawn_ready()
+    }
+
+    pub(crate) fn into_files(self) -> (File, File) {
+        (self.pipe_write, self.pipe_read)
+    }
+}
+
+pub(crate) fn spawn_runner_transport(
+    codex_home: &Path,
+    cwd: &Path,
+    sandbox_creds: &SandboxCreds,
+    log_dir: Option<&Path>,
+) -> Result<RunnerTransport> {
+    let (pipe_in_name, pipe_out_name) = pipe_pair();
+    let h_pipe_in =
+        create_named_pipe(&pipe_in_name, PIPE_ACCESS_OUTBOUND, &sandbox_creds.username)?;
+    let h_pipe_out =
+        create_named_pipe(&pipe_out_name, PIPE_ACCESS_INBOUND, &sandbox_creds.username)?;
+
+    let runner_exe = find_runner_exe(codex_home, log_dir);
+    let runner_cmdline = runner_exe
+        .to_str()
+        .map(str::to_owned)
+        .unwrap_or_else(|| "codex-command-runner.exe".to_string());
+    let runner_full_cmd = format!(
+        "{} {} {}",
+        quote_windows_arg(&runner_cmdline),
+        quote_windows_arg(&format!("--pipe-in={pipe_in_name}")),
+        quote_windows_arg(&format!("--pipe-out={pipe_out_name}"))
+    );
+    let mut cmdline_vec = to_wide(&runner_full_cmd);
+    let exe_w = to_wide(&runner_cmdline);
+    let cwd_w = to_wide(cwd);
+    let user_w = to_wide(&sandbox_creds.username);
+    let domain_w = to_wide(".");
+    let password_w = to_wide(&sandbox_creds.password);
+    let mut si: STARTUPINFOW = unsafe { std::mem::zeroed() };
+    si.cb = std::mem::size_of::<STARTUPINFOW>() as u32;
+    let mut pi: PROCESS_INFORMATION = unsafe { std::mem::zeroed() };
+    let env_block: Option<Vec<u16>> = None;
+
+    let previous_error_mode = unsafe { SetErrorMode(RUNNER_ERROR_MODE_FLAGS) };
+    let spawn_res = unsafe {
+        CreateProcessWithLogonW(
+            user_w.as_ptr(),
+            domain_w.as_ptr(),
+            password_w.as_ptr(),
+            LOGON_WITH_PROFILE,
+            exe_w.as_ptr(),
+            cmdline_vec.as_mut_ptr(),
+            windows_sys::Win32::System::Threading::CREATE_NO_WINDOW
+                | windows_sys::Win32::System::Threading::CREATE_UNICODE_ENVIRONMENT,
+            env_block
+                .as_ref()
+                .map(|block| block.as_ptr() as *const c_void)
+                .unwrap_or(ptr::null()),
+            cwd_w.as_ptr(),
+            &si,
+            &mut pi,
+        )
+    };
+    unsafe {
+        SetErrorMode(previous_error_mode);
+    }
+    if spawn_res == 0 {
+        let err = unsafe { GetLastError() } as i32;
+        unsafe {
+            CloseHandle(h_pipe_in);
+            CloseHandle(h_pipe_out);
+        }
+        return Err(anyhow::anyhow!("CreateProcessWithLogonW failed: {err}"));
+    }
+    let expected_runner_pid = pi.dwProcessId;
+
+    let connect_result = (|| -> Result<()> {
+        connect_pipe(h_pipe_in, expected_runner_pid)?;
+        connect_pipe(h_pipe_out, expected_runner_pid)?;
+        Ok(())
+    })();
+
+    unsafe {
+        if pi.hThread != 0 {
+            CloseHandle(pi.hThread);
+        }
+        if pi.hProcess != 0 {
+            CloseHandle(pi.hProcess);
+        }
+    }
+
+    if let Err(err) = connect_result {
+        unsafe {
+            CloseHandle(h_pipe_in);
+            CloseHandle(h_pipe_out);
+        }
+        return Err(err);
+    }
+
+    let pipe_write = unsafe { File::from_raw_handle(h_pipe_in as _) };
+    let pipe_read = unsafe { File::from_raw_handle(h_pipe_out as _) };
+    Ok(RunnerTransport {
+        pipe_write,
+        pipe_read,
+    })
+}
+
+fn wait_for_complete_frame(pipe_read: &File, timeout: Duration) -> Result<()> {
+    let handle = pipe_read.as_raw_handle() as HANDLE;
+    let deadline = Instant::now() + timeout;
+    let mut len_buf = [0u8; 4];
+
+    loop {
+        let mut bytes_read = 0u32;
+        let mut total_available = 0u32;
+        let ok = unsafe {
+            PeekNamedPipe(
+                handle,
+                len_buf.as_mut_ptr() as *mut c_void,
+                len_buf.len() as u32,
+                &mut bytes_read,
+                &mut total_available,
+                ptr::null_mut(),
+            )
+        };
+        if ok == 0 {
+            let err = unsafe { GetLastError() } as i32;
+            return Err(anyhow::anyhow!(
+                "PeekNamedPipe failed while waiting for spawn_ready: {err}"
+            ));
+        }
+
+        if bytes_read == len_buf.len() as u32 {
+            let frame_len = u32::from_le_bytes(len_buf) as usize;
+            let total_len = frame_len
+                .checked_add(len_buf.len())
+                .ok_or_else(|| anyhow::anyhow!("runner frame length overflow"))?;
+            if total_available as usize >= total_len {
+                return Ok(());
+            }
+        }
+
+        if Instant::now() >= deadline {
+            return Err(anyhow::anyhow!(
+                "timed out after {}ms waiting for runner spawn_ready",
+                timeout.as_millis()
+            ));
+        }
+
+        std::thread::sleep(RUNNER_SPAWN_READY_POLL_INTERVAL);
+    }
+}

--- a/crates/dasclaw_sandbox_windows/src/elevated/runner_pipe.rs
+++ b/crates/dasclaw_sandbox_windows/src/elevated/runner_pipe.rs
@@ -1,0 +1,138 @@
+// Derived from openai/codex commit 6e838a19fa
+//   path: codex-rs/windows-sandbox-rs/src/elevated/runner_pipe.rs
+// SPDX-License-Identifier: Apache-2.0
+//! Named pipe helpers for the elevated Windows sandbox runner.
+//!
+//! This module generates paired pipe names, creates server‑side pipes with
+//! sandbox-user-scoped ACLs, and waits for the runner to connect. It is
+//! **elevated-path only** and is
+//! used by the parent to establish the IPC channel for both unified_exec sessions
+//! and elevated capture. The legacy restricted‑token path spawns the child directly
+//! and does not use these helpers.
+
+use crate::helper_materialization::HelperExecutable;
+use crate::helper_materialization::resolve_helper_for_launch;
+use crate::winutil::resolve_sid;
+use crate::winutil::string_from_sid_bytes;
+use crate::winutil::to_wide;
+use rand::Rng;
+use rand::SeedableRng;
+use rand::rngs::SmallRng;
+use std::io;
+use std::path::Path;
+use std::path::PathBuf;
+use std::ptr;
+use windows_sys::Win32::Foundation::GetLastError;
+use windows_sys::Win32::Foundation::HANDLE;
+use windows_sys::Win32::Foundation::HLOCAL;
+use windows_sys::Win32::Foundation::LocalFree;
+use windows_sys::Win32::Security::Authorization::ConvertStringSecurityDescriptorToSecurityDescriptorW;
+use windows_sys::Win32::Security::PSECURITY_DESCRIPTOR;
+use windows_sys::Win32::Security::SECURITY_ATTRIBUTES;
+use windows_sys::Win32::System::Pipes::ConnectNamedPipe;
+use windows_sys::Win32::System::Pipes::CreateNamedPipeW;
+use windows_sys::Win32::System::Pipes::GetNamedPipeClientProcessId;
+use windows_sys::Win32::System::Pipes::PIPE_READMODE_BYTE;
+use windows_sys::Win32::System::Pipes::PIPE_TYPE_BYTE;
+use windows_sys::Win32::System::Pipes::PIPE_WAIT;
+
+/// PIPE_ACCESS_INBOUND (win32 constant), not exposed in windows-sys 0.52.
+pub const PIPE_ACCESS_INBOUND: u32 = 0x0000_0001;
+/// PIPE_ACCESS_OUTBOUND (win32 constant), not exposed in windows-sys 0.52.
+pub const PIPE_ACCESS_OUTBOUND: u32 = 0x0000_0002;
+
+/// Resolves the elevated command runner path, preferring the copied helper under
+/// `.sandbox-bin` and falling back to the legacy sibling lookup when needed.
+pub fn find_runner_exe(codex_home: &Path, log_dir: Option<&Path>) -> PathBuf {
+    resolve_helper_for_launch(HelperExecutable::CommandRunner, codex_home, log_dir)
+}
+
+/// Generates a unique named-pipe path used to communicate with the runner process.
+pub fn pipe_pair() -> (String, String) {
+    let mut rng = SmallRng::from_entropy();
+    let nonce: u128 = rng.r#gen();
+    let base = format!(r"\\.\pipe\codex-runner-{nonce:x}");
+    (format!("{base}-in"), format!("{base}-out"))
+}
+
+/// Creates a named pipe whose DACL only allows the sandbox user to connect.
+pub fn create_named_pipe(name: &str, access: u32, sandbox_username: &str) -> io::Result<HANDLE> {
+    let sandbox_sid = resolve_sid(sandbox_username)
+        .map_err(|err| io::Error::new(io::ErrorKind::PermissionDenied, err.to_string()))?;
+    let sandbox_sid = string_from_sid_bytes(&sandbox_sid)
+        .map_err(|err| io::Error::new(io::ErrorKind::PermissionDenied, err))?;
+    let sddl = to_wide(format!("D:(A;;GA;;;{sandbox_sid})"));
+    let mut sd: PSECURITY_DESCRIPTOR = ptr::null_mut();
+    let ok = unsafe {
+        ConvertStringSecurityDescriptorToSecurityDescriptorW(
+            sddl.as_ptr(),
+            1, // SDDL_REVISION_1
+            &mut sd,
+            ptr::null_mut(),
+        )
+    };
+    if ok == 0 {
+        return Err(io::Error::from_raw_os_error(unsafe {
+            GetLastError() as i32
+        }));
+    }
+    let mut sa = SECURITY_ATTRIBUTES {
+        nLength: std::mem::size_of::<SECURITY_ATTRIBUTES>() as u32,
+        lpSecurityDescriptor: sd,
+        bInheritHandle: 0,
+    };
+    let wide = to_wide(name);
+    let h = unsafe {
+        CreateNamedPipeW(
+            wide.as_ptr(),
+            access,
+            PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_WAIT,
+            1,
+            65536,
+            65536,
+            0,
+            &mut sa as *mut SECURITY_ATTRIBUTES,
+        )
+    };
+    unsafe {
+        LocalFree(sd as HLOCAL);
+    }
+    if h == 0 || h == windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE {
+        return Err(io::Error::from_raw_os_error(unsafe {
+            GetLastError() as i32
+        }));
+    }
+    Ok(h)
+}
+
+/// Waits for the runner to connect to a parent-created server pipe.
+///
+/// This is parent-side only: the runner opens the pipe with `CreateFileW`, while the
+/// parent calls `ConnectNamedPipe`, tolerates the already-connected case, and
+/// verifies that the connected client is the runner process we just spawned.
+pub fn connect_pipe(h: HANDLE, expected_runner_pid: u32) -> io::Result<()> {
+    let ok = unsafe { ConnectNamedPipe(h, ptr::null_mut()) };
+    if ok == 0 {
+        let err = unsafe { GetLastError() };
+        const ERROR_PIPE_CONNECTED: u32 = 535;
+        if err != ERROR_PIPE_CONNECTED {
+            return Err(io::Error::from_raw_os_error(err as i32));
+        }
+    }
+    let mut client_pid = 0;
+    let ok = unsafe { GetNamedPipeClientProcessId(h, &mut client_pid) };
+    if ok == 0 {
+        return Err(io::Error::from_raw_os_error(unsafe {
+            GetLastError() as i32
+        }));
+    }
+    if client_pid != expected_runner_pid {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            format!(
+                "named pipe client pid {client_pid} did not match runner pid {expected_runner_pid}"
+            ),
+        ));
+    }
+    Ok(())
+}

--- a/crates/dasclaw_sandbox_windows/src/lib.rs
+++ b/crates/dasclaw_sandbox_windows/src/lib.rs
@@ -147,6 +147,23 @@ pub mod winutil;
 #[cfg(windows)]
 pub mod workspace_acl;
 
+// `elevated/` subdirectory — modules used by the elevated command runner /
+// IPC bootstrap path. Mirrors codex `windows-sandbox-rs` `lib.rs` declarations
+// 1:1 (visibility kept verbatim: `pub(crate)` for `ipc_framed`, private for
+// `runner_pipe` / `runner_client`). The remaining file in that subdirectory,
+// `cwd_junction.rs`, is intentionally NOT registered here: upstream consumes
+// it only from the `command_runner_win.rs` bin source via `mod cwd_junction;`,
+// which lands in Wave i-7b. See ADR-130 §2.
+#[cfg(windows)]
+#[path = "elevated/ipc_framed.rs"]
+pub(crate) mod ipc_framed;
+#[cfg(windows)]
+#[path = "elevated/runner_client.rs"]
+mod runner_client;
+#[cfg(windows)]
+#[path = "elevated/runner_pipe.rs"]
+mod runner_pipe;
+
 #[cfg(windows)]
 pub use helper_materialization::resolve_current_exe_for_launch;
 #[cfg(windows)]


### PR DESCRIPTION
## 背景 / 目标

Phase 1.1.4j Wave i-6a — verbatim port `codex-rs/windows-sandbox-rs/src/elevated/` 子目录的 4 个文件（687 LOC），并按上游可见性 1:1 在 `lib.rs` 注册其中 3 个。这一波解锁后续 i-6b（`elevated_impl.rs` + 上游 inline `mod windows_impl`）的依赖。

**Stacked 关系**: 本 PR base 为 `xClaw`，与已开的 #314 (Wave i-5) 文件零重叠（i-5 改 `firewall.rs` + `Cargo.toml`；i-6a 改 `lib.rs` + 新增 `elevated/*.rs`）。建议合并顺序：先 #314，再本 PR。如顺序倒置也可，git 自动无冲突 fast-forward。

Refs: #263, #241, ADR-130.

## 改动范围

**新增 4 个文件**（`crates/dasclaw_sandbox_windows/src/elevated/`，全部 verbatim 上游 + 3 行 SPDX 头）：

| 文件 | LOC | Import 改写 | lib.rs 注册 |
|---|---|---|---|
| `ipc_framed.rs` | 192 | 无（仅 anyhow 等外部 deps） | `#[path = ...] pub(crate) mod ipc_framed;` |
| `runner_pipe.rs` | 135 | 无（已用 `crate::*`） | `#[path = ...] mod runner_pipe;` |
| `runner_client.rs` | 218 | 无（已用 `crate::*`） | `#[path = ...] mod runner_client;` |
| `cwd_junction.rs` | 142 | `codex_windows_sandbox::log_note` → `crate::logging::log_note` | **不注册**（见非目标） |

**`lib.rs` 增量**: 在 `pub mod workspace_acl;` 之后插入一个 `elevated/` cluster 块（含解释为何 cwd_junction 不注册的 `// ADR-130 §2` 注释），共 14 行新增。可见性与上游 `windows-sandbox-rs/src/lib.rs` 第 42–60 行 1:1 一致：`pub(crate) mod ipc_framed`、`mod runner_pipe`、`mod runner_client`。

## 非目标（What's NOT in this PR）

- **不**注册 `cwd_junction.rs` 到 `lib.rs`。codex 上游姿势：`cwd_junction.rs` 仅被 `command_runner_win.rs` 通过 `#[path = "cwd_junction.rs"] mod cwd_junction;` bin-local 注册；`lib.rs` 全文零引用（`grep` 验证）。本 wave 把文件落到磁盘，i-7b 接 command-runner bin 时再走 bin-local 注册。这是 ADR-130 §2 既定拆分顺序。
- 不 port `elevated/command_runner_win.rs`（569 LOC，i-7b 与 bin 一起 port）。
- 不 port `elevated_impl.rs`（306 LOC，i-6b）。
- 不修改其他 crate 或 ADR。

## 验证（命令 + 结果）

```bash
$ cargo check -p dasclaw_sandbox_windows --tests
    Finished `dev` profile in 1.88s

$ cargo nextest run -p dasclaw_sandbox_windows
     Summary [   7.188s] 45 tests run: 45 passed, 0 skipped

$ cargo fmt --all
# clean

$ python3.12 scripts/check_no_panics.py --base origin/xClaw
OK: No panic-inducing calls in changed production code.

$ python3.12 scripts/check_no_new_ironclaw_literal.py --base origin/xClaw
OK: No new .ironclaw / IRONCLAW_BASE_DIR literals introduced.

$ cargo clippy --no-deps -p dasclaw_sandbox_windows --all-targets -- -D warnings
    Finished `dev` profile in 1.47s
# no warnings
```

`cfg(windows)` 模块在 macOS aarch64 不被编译，由 Windows CI（如 paths filter 命中）兜底。

## 跨模块依赖校验（提交前 grep 确认）

| 调用 | 来源 crate | 是否存在 |
|---|---|---|
| `crate::helper_materialization::HelperExecutable` | `helper_materialization.rs:25` `pub(crate) enum` | ✅（与上游签名 1:1） |
| `crate::helper_materialization::resolve_helper_for_launch` | `helper_materialization.rs` `pub(crate) fn` | ✅ |
| `crate::identity::SandboxCreds` | `identity.rs:36` `pub struct` | ✅ |
| `crate::winutil::quote_windows_arg` / `to_wide` | `winutil.rs` | ✅ |
| `crate::logging::log_note` | `logging.rs:80` `pub fn` | ✅ |
| `crate::runner_pipe::PIPE_ACCESS_INBOUND` 等 | 本 wave 注册 | ✅ |
| `crate::ipc_framed::FramedMessage` 等 | 本 wave 注册 | ✅ |

## 接力

按 ADR-130 §2 顺序：i-5（#314） → **i-6a（本 PR）** → i-6b → i-7a → i-7b。

Closes #263 partially (Wave i-6a).
