### PR TITLE
feat(sandbox-windows): port command_runner.rs + dasclaw-command-runner bin (Wave i-7b, closes Phase 1.1.4j)

### DIFF
--- a/crates/dasclaw_sandbox_windows/Cargo.toml
+++ b/crates/dasclaw_sandbox_windows/Cargo.toml
@@ -15,6 +15,10 @@ path = "src/lib.rs"
 name = "dasclaw-sandbox-setup"
 path = "src/bin/setup_main.rs"
 
+[[bin]]
+name = "dasclaw-command-runner"
+path = "src/bin/command_runner.rs"
+
 [dependencies]
 anyhow = "1"
 base64 = "0.22"

--- a/crates/dasclaw_sandbox_windows/src/bin/command_runner.rs
+++ b/crates/dasclaw_sandbox_windows/src/bin/command_runner.rs
@@ -1,0 +1,21 @@
+// Derived from openai/codex commit 6e838a19fa
+//   path: codex-rs/windows-sandbox-rs/src/bin/command_runner.rs
+// SPDX-License-Identifier: Apache-2.0
+//
+// Verbatim port. Mechanical edits:
+//   * panic message: "codex-command-runner is Windows-only"
+//     -> "dasclaw-command-runner is Windows-only" (binary rename per
+//     ADR-130 §2).
+
+#[path = "../elevated/command_runner_win.rs"]
+mod win;
+
+#[cfg(target_os = "windows")]
+fn main() -> anyhow::Result<()> {
+    win::main()
+}
+
+#[cfg(not(target_os = "windows"))]
+fn main() {
+    panic!("dasclaw-command-runner is Windows-only"); // safety: verbatim from codex 6e838a19fa command_runner.rs (binary refuses to run on non-Windows targets)
+}

--- a/crates/dasclaw_sandbox_windows/src/elevated/command_runner_win.rs
+++ b/crates/dasclaw_sandbox_windows/src/elevated/command_runner_win.rs
@@ -1,0 +1,586 @@
+// Derived from openai/codex commit 6e838a19fa
+//   path: codex-rs/windows-sandbox-rs/src/elevated/command_runner_win.rs
+// SPDX-License-Identifier: Apache-2.0
+//
+// Verbatim port. Mechanical edits applied:
+//   * `codex_windows_sandbox::` -> `dasclaw_sandbox_windows::` (crate rename).
+//
+// This file is the source body of the `dasclaw-command-runner` bin entry
+// (`src/bin/command_runner.rs`) per ADR-130 §2. It is included via
+// `#[path = "../elevated/command_runner_win.rs"] mod win;` and is NOT a lib
+// module. The local `mod cwd_junction;` (`#[path = "cwd_junction.rs"]`)
+// resolves to `elevated/cwd_junction.rs` (already ported in Wave i-6a) and
+// `mod read_acl_mutex;` (`#[path = "../read_acl_mutex.rs"]`) resolves to the
+// top-level `src/read_acl_mutex.rs` module -- both intentionally double-
+// compiled (once into the lib, once into this bin) to mirror upstream
+// byte-for-byte.
+
+//! Windows command runner used by the **elevated** sandbox path.
+//!
+//! The CLI launches this binary under the sandbox user when Windows sandbox level is
+//! Elevated. It connects to the IPC pipes, reads the framed `SpawnRequest`, derives a
+//! restricted token from the sandbox user, and spawns the child process via ConPTY
+//! (`tty=true`) or pipes (`tty=false`). It then streams output frames back to the parent,
+//! accepts stdin/terminate frames, and emits a final exit frame. The legacy restricted‑token
+//! path spawns the child directly and does not use this runner.
+
+#![cfg(target_os = "windows")]
+#![allow(unsafe_op_in_unsafe_fn)]
+
+use anyhow::Context;
+use anyhow::Result;
+use dasclaw_sandbox_windows::ErrorPayload;
+use dasclaw_sandbox_windows::ExitPayload;
+use dasclaw_sandbox_windows::FramedMessage;
+use dasclaw_sandbox_windows::LaunchDesktop;
+use dasclaw_sandbox_windows::Message;
+use dasclaw_sandbox_windows::OutputPayload;
+use dasclaw_sandbox_windows::OutputStream;
+use dasclaw_sandbox_windows::PipeSpawnHandles;
+use dasclaw_sandbox_windows::ResizePayload;
+use dasclaw_sandbox_windows::SandboxPolicy;
+use dasclaw_sandbox_windows::SpawnReady;
+use dasclaw_sandbox_windows::SpawnRequest;
+use dasclaw_sandbox_windows::StderrMode;
+use dasclaw_sandbox_windows::StdinMode;
+use dasclaw_sandbox_windows::allow_null_device;
+use dasclaw_sandbox_windows::convert_string_sid_to_sid;
+use dasclaw_sandbox_windows::create_readonly_token_with_caps_from;
+use dasclaw_sandbox_windows::create_workspace_write_token_with_caps_from;
+use dasclaw_sandbox_windows::decode_bytes;
+use dasclaw_sandbox_windows::encode_bytes;
+use dasclaw_sandbox_windows::get_current_token_for_restriction;
+use dasclaw_sandbox_windows::hide_current_user_profile_dir;
+use dasclaw_sandbox_windows::log_note;
+use dasclaw_sandbox_windows::parse_policy;
+use dasclaw_sandbox_windows::read_frame;
+use dasclaw_sandbox_windows::read_handle_loop;
+use dasclaw_sandbox_windows::spawn_process_with_pipes;
+use dasclaw_sandbox_windows::to_wide;
+use dasclaw_sandbox_windows::write_frame;
+use std::ffi::c_void;
+use std::fs::File;
+use std::os::windows::io::FromRawHandle;
+use std::path::Path;
+use std::path::PathBuf;
+use std::ptr;
+use std::sync::Arc;
+use std::sync::Mutex as StdMutex;
+use windows_sys::Win32::Foundation::CloseHandle;
+use windows_sys::Win32::Foundation::GetLastError;
+use windows_sys::Win32::Foundation::HANDLE;
+use windows_sys::Win32::Foundation::HLOCAL;
+use windows_sys::Win32::Foundation::LocalFree;
+use windows_sys::Win32::Storage::FileSystem::CreateFileW;
+use windows_sys::Win32::Storage::FileSystem::FILE_GENERIC_READ;
+use windows_sys::Win32::Storage::FileSystem::FILE_GENERIC_WRITE;
+use windows_sys::Win32::Storage::FileSystem::OPEN_EXISTING;
+use windows_sys::Win32::System::Console::COORD;
+use windows_sys::Win32::System::Console::ClosePseudoConsole;
+use windows_sys::Win32::System::Console::ResizePseudoConsole;
+use windows_sys::Win32::System::JobObjects::AssignProcessToJobObject;
+use windows_sys::Win32::System::JobObjects::CreateJobObjectW;
+use windows_sys::Win32::System::JobObjects::JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+use windows_sys::Win32::System::JobObjects::JOBOBJECT_EXTENDED_LIMIT_INFORMATION;
+use windows_sys::Win32::System::JobObjects::JobObjectExtendedLimitInformation;
+use windows_sys::Win32::System::JobObjects::SetInformationJobObject;
+use windows_sys::Win32::System::Threading::GetExitCodeProcess;
+use windows_sys::Win32::System::Threading::GetProcessId;
+use windows_sys::Win32::System::Threading::INFINITE;
+use windows_sys::Win32::System::Threading::PROCESS_INFORMATION;
+use windows_sys::Win32::System::Threading::TerminateProcess;
+use windows_sys::Win32::System::Threading::WaitForSingleObject;
+
+#[path = "cwd_junction.rs"]
+mod cwd_junction;
+
+#[allow(dead_code)]
+#[path = "../read_acl_mutex.rs"]
+mod read_acl_mutex;
+
+const WAIT_TIMEOUT: u32 = 0x0000_0102;
+
+struct IpcSpawnedProcess {
+    log_dir: PathBuf,
+    pi: PROCESS_INFORMATION,
+    stdout_handle: HANDLE,
+    stderr_handle: HANDLE,
+    stdin_handle: Option<HANDLE>,
+    hpc_handle: Option<HANDLE>,
+    _desktop_owner: Option<LaunchDesktop>,
+    _pipe_handles: Option<PipeSpawnHandles>,
+}
+
+unsafe fn create_job_kill_on_close() -> Result<HANDLE> {
+    let h = CreateJobObjectW(std::ptr::null_mut(), std::ptr::null());
+    if h == 0 {
+        return Err(anyhow::anyhow!("CreateJobObjectW failed"));
+    }
+    let mut limits: JOBOBJECT_EXTENDED_LIMIT_INFORMATION = std::mem::zeroed();
+    limits.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+    let ok = SetInformationJobObject(
+        h,
+        JobObjectExtendedLimitInformation,
+        &mut limits as *mut _ as *mut _,
+        std::mem::size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as u32,
+    );
+    if ok == 0 {
+        return Err(anyhow::anyhow!("SetInformationJobObject failed"));
+    }
+    Ok(h)
+}
+
+/// Open a named pipe created by the parent process.
+fn open_pipe(name: &str, access: u32) -> Result<HANDLE> {
+    let path = to_wide(name);
+    let handle = unsafe {
+        CreateFileW(
+            path.as_ptr(),
+            access,
+            0,
+            std::ptr::null_mut(),
+            OPEN_EXISTING,
+            0,
+            0,
+        )
+    };
+    if handle == windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE {
+        let err = unsafe { GetLastError() };
+        return Err(anyhow::anyhow!("CreateFileW failed for pipe {name}: {err}"));
+    }
+    Ok(handle)
+}
+
+/// Send an error frame back to the parent process.
+fn send_error(writer: &Arc<StdMutex<File>>, code: &str, message: String) -> Result<()> {
+    let msg = FramedMessage {
+        version: 1,
+        message: Message::Error {
+            payload: ErrorPayload {
+                message,
+                code: code.to_string(),
+            },
+        },
+    };
+    if let Ok(mut guard) = writer.lock() {
+        write_frame(&mut *guard, &msg)?;
+    }
+    Ok(())
+}
+
+/// Read and validate the initial spawn request frame.
+fn read_spawn_request(reader: &mut File) -> Result<SpawnRequest> {
+    let Some(msg) = read_frame(reader)? else {
+        anyhow::bail!("runner: pipe closed before spawn_request");
+    };
+    if msg.version != 1 {
+        anyhow::bail!("runner: unsupported protocol version {}", msg.version);
+    }
+    match msg.message {
+        Message::SpawnRequest { payload } => Ok(*payload),
+        other => anyhow::bail!("runner: expected spawn_request, got {other:?}"),
+    }
+}
+
+/// Pick an effective CWD, using a junction if the ACL helper is active.
+fn effective_cwd(req_cwd: &Path, log_dir: Option<&Path>) -> PathBuf {
+    let use_junction = match read_acl_mutex::read_acl_mutex_exists() {
+        Ok(exists) => exists,
+        Err(err) => {
+            log_note(
+                &format!(
+                    "junction: failed to probe ACL mutex state: {err}; defaulting to junction cwd"
+                ),
+                log_dir,
+            );
+            true
+        }
+    };
+    if use_junction {
+        cwd_junction::create_cwd_junction(req_cwd, log_dir).unwrap_or_else(|| req_cwd.to_path_buf())
+    } else {
+        req_cwd.to_path_buf()
+    }
+}
+
+fn spawn_ipc_process(req: &SpawnRequest) -> Result<IpcSpawnedProcess> {
+    let log_dir = req.codex_home.clone();
+    hide_current_user_profile_dir(req.codex_home.as_path());
+    let policy = parse_policy(&req.policy_json_or_preset).context("parse policy_json_or_preset")?;
+    let mut cap_psids: Vec<*mut c_void> = Vec::new();
+    for sid in &req.cap_sids {
+        let Some(psid) = (unsafe { convert_string_sid_to_sid(sid) }) else {
+            anyhow::bail!("ConvertStringSidToSidW failed for capability SID");
+        };
+        cap_psids.push(psid);
+    }
+    if cap_psids.is_empty() {
+        anyhow::bail!("runner: empty capability SID list");
+    }
+
+    let base = unsafe { get_current_token_for_restriction()? };
+    let token_res: Result<(HANDLE, *mut c_void)> = unsafe {
+        match &policy {
+            SandboxPolicy::ReadOnly { .. } => {
+                create_readonly_token_with_caps_from(base, &cap_psids)
+                    .map(|h_token| (h_token, cap_psids[0]))
+            }
+            SandboxPolicy::WorkspaceWrite { .. } => {
+                create_workspace_write_token_with_caps_from(base, &cap_psids)
+                    .map(|h_token| (h_token, cap_psids[0]))
+            }
+            SandboxPolicy::DangerFullAccess | SandboxPolicy::ExternalSandbox { .. } => {
+                unreachable!()
+            }
+        }
+    };
+    let (h_token, psid_to_use) = token_res?;
+    unsafe {
+        CloseHandle(base);
+        allow_null_device(psid_to_use);
+        for psid in &cap_psids {
+            allow_null_device(*psid);
+        }
+        for psid in cap_psids {
+            if !psid.is_null() {
+                LocalFree(psid as HLOCAL);
+            }
+        }
+    }
+
+    let effective_cwd = effective_cwd(&req.cwd, Some(log_dir.as_path()));
+
+    let mut hpc_handle: Option<HANDLE> = None;
+    let mut desktop_owner = None;
+    let mut pipe_handles = None;
+    let (pi, stdout_handle, stderr_handle, stdin_handle) = if req.tty {
+        let (pi, conpty) = dasclaw_sandbox_windows::spawn_conpty_process_as_user(
+            h_token,
+            &req.command,
+            &effective_cwd,
+            &req.env,
+            req.use_private_desktop,
+            Some(log_dir.as_path()),
+        )?;
+        let (hpc, input_write, output_read, desktop) = conpty.into_raw();
+        hpc_handle = Some(hpc);
+        desktop_owner = desktop;
+        let stdin_handle = if req.stdin_open {
+            Some(input_write)
+        } else {
+            unsafe {
+                CloseHandle(input_write);
+            }
+            None
+        };
+        (
+            pi,
+            output_read,
+            windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE,
+            stdin_handle,
+        )
+    } else {
+        let stdin_mode = if req.stdin_open {
+            StdinMode::Open
+        } else {
+            StdinMode::Closed
+        };
+        let spawned_pipes: PipeSpawnHandles = spawn_process_with_pipes(
+            h_token,
+            &req.command,
+            &effective_cwd,
+            &req.env,
+            stdin_mode,
+            StderrMode::Separate,
+            req.use_private_desktop,
+            Some(log_dir.as_path()),
+        )?;
+        let pi = spawned_pipes.process;
+        let stdout_handle = spawned_pipes.stdout_read;
+        let stderr_handle = spawned_pipes
+            .stderr_read
+            .unwrap_or(windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE);
+        let stdin_handle = spawned_pipes.stdin_write;
+        pipe_handles = Some(spawned_pipes);
+        (pi, stdout_handle, stderr_handle, stdin_handle)
+    };
+
+    unsafe {
+        CloseHandle(h_token);
+    }
+    Ok(IpcSpawnedProcess {
+        log_dir,
+        pi,
+        stdout_handle,
+        stderr_handle,
+        stdin_handle,
+        hpc_handle,
+        _desktop_owner: desktop_owner,
+        _pipe_handles: pipe_handles,
+    })
+}
+
+/// Stream stdout/stderr from the child into Output frames.
+fn spawn_output_reader(
+    writer: Arc<StdMutex<File>>,
+    handle: HANDLE,
+    stream: OutputStream,
+    log_dir: Option<PathBuf>,
+) -> std::thread::JoinHandle<()> {
+    read_handle_loop(handle, move |chunk| {
+        let msg = FramedMessage {
+            version: 1,
+            message: Message::Output {
+                payload: OutputPayload {
+                    data_b64: encode_bytes(chunk),
+                    stream,
+                },
+            },
+        };
+        if let Ok(mut guard) = writer.lock()
+            && let Err(err) = write_frame(&mut *guard, &msg)
+        {
+            log_note(
+                &format!("runner output write failed: {err}"),
+                log_dir.as_deref(),
+            );
+        }
+    })
+}
+
+/// Read stdin/terminate frames and forward to the child process.
+fn spawn_input_loop(
+    mut reader: File,
+    stdin_handle: Option<HANDLE>,
+    hpc_handle: Arc<StdMutex<Option<HANDLE>>>,
+    process_handle: Arc<StdMutex<Option<HANDLE>>>,
+    _log_dir: Option<PathBuf>,
+) -> std::thread::JoinHandle<()> {
+    std::thread::spawn(move || {
+        let mut stdin_handle = stdin_handle;
+        loop {
+            let msg = match read_frame(&mut reader) {
+                Ok(Some(v)) => v,
+                Ok(None) => break,
+                Err(_) => break,
+            };
+            match msg.message {
+                Message::Stdin { payload } => {
+                    let Ok(bytes) = decode_bytes(&payload.data_b64) else {
+                        continue;
+                    };
+                    if let Some(handle) = stdin_handle {
+                        let mut written: u32 = 0;
+                        unsafe {
+                            let _ = windows_sys::Win32::Storage::FileSystem::WriteFile(
+                                handle,
+                                bytes.as_ptr(),
+                                bytes.len() as u32,
+                                &mut written,
+                                ptr::null_mut(),
+                            );
+                        }
+                    }
+                }
+                Message::CloseStdin { .. } => {
+                    if let Some(handle) = stdin_handle.take() {
+                        unsafe {
+                            CloseHandle(handle);
+                        }
+                    }
+                }
+                Message::Resize {
+                    payload: ResizePayload { rows, cols },
+                } => {
+                    if let Ok(guard) = hpc_handle.lock()
+                        && let Some(hpc) = guard.as_ref()
+                    {
+                        unsafe {
+                            let _ = ResizePseudoConsole(
+                                *hpc,
+                                COORD {
+                                    X: cols as i16,
+                                    Y: rows as i16,
+                                },
+                            );
+                        }
+                    }
+                }
+                Message::Terminate { .. } => {
+                    if let Ok(guard) = process_handle.lock()
+                        && let Some(handle) = guard.as_ref()
+                    {
+                        unsafe {
+                            let _ = TerminateProcess(*handle, 1);
+                        }
+                    }
+                }
+                Message::SpawnRequest { .. } => {}
+                Message::SpawnReady { .. } => {}
+                Message::Output { .. } => {}
+                Message::Exit { .. } => {}
+                Message::Error { .. } => {}
+            }
+        }
+        if let Some(handle) = stdin_handle {
+            unsafe {
+                CloseHandle(handle);
+            }
+        }
+    })
+}
+
+/// Entry point for the Windows command runner process.
+pub fn main() -> Result<()> {
+    let mut pipe_in = None;
+    let mut pipe_out = None;
+    for arg in std::env::args().skip(1) {
+        if let Some(rest) = arg.strip_prefix("--pipe-in=") {
+            pipe_in = Some(rest.to_string());
+        } else if let Some(rest) = arg.strip_prefix("--pipe-out=") {
+            pipe_out = Some(rest.to_string());
+        }
+    }
+
+    let Some(pipe_in) = pipe_in else {
+        anyhow::bail!("runner: no pipe-in provided");
+    };
+    let Some(pipe_out) = pipe_out else {
+        anyhow::bail!("runner: no pipe-out provided");
+    };
+
+    let h_pipe_in = open_pipe(&pipe_in, FILE_GENERIC_READ)?;
+    let h_pipe_out = open_pipe(&pipe_out, FILE_GENERIC_WRITE)?;
+    let mut pipe_read = unsafe { File::from_raw_handle(h_pipe_in as _) };
+    let pipe_write = Arc::new(StdMutex::new(unsafe {
+        File::from_raw_handle(h_pipe_out as _)
+    }));
+
+    let req = match read_spawn_request(&mut pipe_read) {
+        Ok(v) => v,
+        Err(err) => {
+            let _ = send_error(&pipe_write, "spawn_failed", err.to_string());
+            return Err(err);
+        }
+    };
+
+    let ipc_spawn = match spawn_ipc_process(&req) {
+        Ok(value) => value,
+        Err(err) => {
+            let _ = send_error(&pipe_write, "spawn_failed", err.to_string());
+            return Err(err);
+        }
+    };
+    let log_dir = Some(ipc_spawn.log_dir.as_path());
+    let pi = ipc_spawn.pi;
+    let stdout_handle = ipc_spawn.stdout_handle;
+    let stderr_handle = ipc_spawn.stderr_handle;
+    let stdin_handle = ipc_spawn.stdin_handle;
+    let hpc_handle = Arc::new(StdMutex::new(ipc_spawn.hpc_handle));
+
+    let h_job = unsafe { create_job_kill_on_close().ok() };
+    if let Some(job) = h_job {
+        unsafe {
+            let _ = AssignProcessToJobObject(job, pi.hProcess);
+        }
+    }
+
+    let process_handle = Arc::new(StdMutex::new(Some(pi.hProcess)));
+
+    let msg = FramedMessage {
+        version: 1,
+        message: Message::SpawnReady {
+            payload: SpawnReady {
+                process_id: unsafe { GetProcessId(pi.hProcess) },
+            },
+        },
+    };
+    if let Err(err) = if let Ok(mut guard) = pipe_write.lock() {
+        write_frame(&mut *guard, &msg)
+    } else {
+        anyhow::bail!("runner spawn_ready write failed: pipe_write lock poisoned");
+    } {
+        let _ = send_error(&pipe_write, "spawn_failed", err.to_string());
+        return Err(err);
+    }
+    let log_dir_owned = log_dir.map(Path::to_path_buf);
+    let out_thread = spawn_output_reader(
+        Arc::clone(&pipe_write),
+        stdout_handle,
+        OutputStream::Stdout,
+        log_dir_owned.clone(),
+    );
+    let err_thread = if stderr_handle != windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE {
+        Some(spawn_output_reader(
+            Arc::clone(&pipe_write),
+            stderr_handle,
+            OutputStream::Stderr,
+            log_dir_owned.clone(),
+        ))
+    } else {
+        None
+    };
+
+    let _input_thread = spawn_input_loop(
+        pipe_read,
+        stdin_handle,
+        Arc::clone(&hpc_handle),
+        Arc::clone(&process_handle),
+        log_dir_owned,
+    );
+
+    let timeout = req.timeout_ms.map(|ms| ms as u32).unwrap_or(INFINITE);
+    let wait_res = unsafe { WaitForSingleObject(pi.hProcess, timeout) };
+    let timed_out = wait_res == WAIT_TIMEOUT;
+
+    let exit_code: i32;
+    unsafe {
+        if timed_out {
+            let _ = TerminateProcess(pi.hProcess, 1);
+            exit_code = 128 + 64;
+        } else {
+            let mut raw_exit: u32 = 1;
+            GetExitCodeProcess(pi.hProcess, &mut raw_exit);
+            exit_code = raw_exit as i32;
+        }
+        if pi.hThread != 0 {
+            CloseHandle(pi.hThread);
+        }
+        if pi.hProcess != 0 {
+            CloseHandle(pi.hProcess);
+        }
+        if let Some(job) = h_job {
+            CloseHandle(job);
+        }
+    }
+
+    if let Ok(mut guard) = hpc_handle.lock()
+        && let Some(hpc) = guard.take()
+    {
+        unsafe {
+            ClosePseudoConsole(hpc);
+        }
+    }
+
+    let _ = out_thread.join();
+    if let Some(thread) = err_thread {
+        let _ = thread.join();
+    }
+
+    let exit_msg = FramedMessage {
+        version: 1,
+        message: Message::Exit {
+            payload: ExitPayload {
+                exit_code,
+                timed_out,
+            },
+        },
+    };
+    if let Ok(mut guard) = pipe_write.lock()
+        && let Err(err) = write_frame(&mut *guard, &exit_msg)
+    {
+        log_note(&format!("runner exit write failed: {err}"), log_dir);
+    }
+
+    std::process::exit(exit_code);
+}

--- a/crates/dasclaw_sandbox_windows/src/lib.rs
+++ b/crates/dasclaw_sandbox_windows/src/lib.rs
@@ -228,6 +228,66 @@ pub use setup_error::write_setup_error_report;
 pub use token::convert_string_sid_to_sid;
 
 // ---------------------------------------------------------------------------
+// Re-exports consumed by `bin/command_runner.rs` (Wave i-7b).
+//
+// Same provenance as the i-7a block above: mirrors codex
+// `windows-sandbox-rs/src/lib.rs` (commit 6e838a19fa) 1:1 so the verbatim
+// port of `elevated/command_runner_win.rs` compiles with only an
+// `codex_windows_sandbox::` -> `dasclaw_sandbox_windows::` crate-name
+// rewrite. See ADR-130 §2.
+// ---------------------------------------------------------------------------
+#[cfg(windows)]
+pub use acl::allow_null_device;
+#[cfg(windows)]
+pub use desktop::LaunchDesktop;
+#[cfg(windows)]
+pub use hide_users::hide_current_user_profile_dir;
+#[cfg(windows)]
+pub use ipc_framed::ErrorPayload;
+#[cfg(windows)]
+pub use ipc_framed::ExitPayload;
+#[cfg(windows)]
+pub use ipc_framed::FramedMessage;
+#[cfg(windows)]
+pub use ipc_framed::Message;
+#[cfg(windows)]
+pub use ipc_framed::OutputPayload;
+#[cfg(windows)]
+pub use ipc_framed::OutputStream;
+#[cfg(windows)]
+pub use ipc_framed::ResizePayload;
+#[cfg(windows)]
+pub use ipc_framed::SpawnReady;
+#[cfg(windows)]
+pub use ipc_framed::SpawnRequest;
+#[cfg(windows)]
+pub use ipc_framed::decode_bytes;
+#[cfg(windows)]
+pub use ipc_framed::encode_bytes;
+#[cfg(windows)]
+pub use ipc_framed::read_frame;
+#[cfg(windows)]
+pub use ipc_framed::write_frame;
+pub use policy::SandboxPolicy;
+pub use policy::parse_policy;
+#[cfg(windows)]
+pub use process::PipeSpawnHandles;
+#[cfg(windows)]
+pub use process::StderrMode;
+#[cfg(windows)]
+pub use process::StdinMode;
+#[cfg(windows)]
+pub use process::read_handle_loop;
+#[cfg(windows)]
+pub use process::spawn_process_with_pipes;
+#[cfg(windows)]
+pub use token::create_readonly_token_with_caps_from;
+#[cfg(windows)]
+pub use token::create_workspace_write_token_with_caps_from;
+#[cfg(windows)]
+pub use token::get_current_token_for_restriction;
+
+// ---------------------------------------------------------------------------
 // elevated_impl + inline windows_impl/stub blocks (Wave i-6b)
 //
 // Verbatim port of upstream `codex-rs/windows-sandbox-rs/src/{elevated_impl.rs,


### PR DESCRIPTION
## 背景 / 目标

按 ADR-130 + 上游 codex `windows-sandbox-rs` 1:1 镜像，推进 Phase 1.1.4j 的 **Wave i-7b**（也是 Phase 1.1.4j 的最后一个 wave）：把 `elevated/command_runner_win.rs`（569 LOC 上游 / 586 LOC 含 SPDX 头）+ 其 bin 入口 `bin/command_runner.rs` 一起搬过来。

这是 `dasclaw-command-runner` 二进制的源体，负责在 Elevated 沙箱模式下接收 IPC `SpawnRequest`、派生受限 token、用 ConPTY/pipes 启动子进程并双向流式 stdio。

## 改动范围

| 文件 | 行数 | 性质 |
|---|---|---|
| `src/elevated/command_runner_win.rs` | +586 | **逐字 port**，仅做 `codex_windows_sandbox::` → `dasclaw_sandbox_windows::` 字符串重写 + SPDX 头 |
| `src/bin/command_runner.rs` | +21 | **逐字 port**，仅 panic 文案改 `dasclaw-command-runner`（ADR-130 §2 命名） |
| `src/lib.rs` | +60 | 补 27 个 crate-root re-export，**1:1 镜像**上游 lib.rs 对应位置（`allow_null_device` / `LaunchDesktop` / `hide_current_user_profile_dir` / `ipc_framed::{ErrorPayload, ExitPayload, FramedMessage, Message, OutputPayload, OutputStream, ResizePayload, SpawnReady, SpawnRequest, decode_bytes, encode_bytes, read_frame, write_frame}` / `SandboxPolicy` / `parse_policy` / `PipeSpawnHandles` / `StderrMode` / `StdinMode` / `read_handle_loop` / `spawn_process_with_pipes` / `create_readonly_token_with_caps_from` / `create_workspace_write_token_with_caps_from` / `get_current_token_for_restriction`）|
| `Cargo.toml` | +4 | `[[bin]] name = "dasclaw-command-runner"` |

`elevated/cwd_junction.rs`（i-6a 已 port）+ `read_acl_mutex.rs`（早期 wave 已在 lib）经 `#[path]` 机制双重编译（lib + bin 各一份），与上游字节级一致。

## 非目标（What's NOT in this PR）

- ❌ 业务逻辑改动 — 全部 verbatim port
- ❌ 改动 lib 既有任何路径 — re-export 是纯加法
- ❌ 后续 ADR / 集成测试 — 留给独立 PR

## 验证（命令 + 结果，本地全过）

```bash
cargo check -p dasclaw_sandbox_windows --all-targets         # ✅ 0 错 0 警
cargo nextest run -p dasclaw_sandbox_windows                  # ✅ 45/45 passed
cargo fmt --all                                                # ✅ clean
python3.12 scripts/check_no_panics.py --base origin/xClaw     # ✅ OK
python3   scripts/check_no_new_ironclaw_literal.py --base origin/xClaw   # ✅ OK
cargo clippy --no-deps -p dasclaw_sandbox_windows --all-targets -- -D warnings   # ✅ clean
```

`command_runner_win.rs` 整体在 `#![cfg(target_os = "windows")]` 之下；bin 在非 Windows 下走 `panic!("dasclaw-command-runner is Windows-only")`（与上游同语义）。Windows Build job 在 PR 阶段 SKIP（per Windows CI policy），CI 完整 build 在 main push 后由 windows-ci.yml 兜底。

## Cross-cuts

- **ADR-114（`.ironclaw` → `.dasclaw`）关系**：**类A**（无新增 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量；grep guard 已通过）

## Refs

- 推进的 ADR：[`adr-130-sandbox-windows-lib-bin-split.md`](docs/plans/architecture-refactor/adr-130-sandbox-windows-lib-bin-split.md) §2
- 兼容前置 ADR：[`adr-129-sandbox-windows-windows-crate-adoption.md`](docs/plans/architecture-refactor/adr-129-sandbox-windows-windows-crate-adoption.md)
- Tracker：**closes #263**（Phase 1.1.4j Wave i Windows port 全部完成）
- 上游基准：openai/codex commit `6e838a19fa` `codex-rs/windows-sandbox-rs/`

## Phase 1.1.4j 全量回顾

| Wave | 文件 | PR |
|---|---|---|
| ADR-129/130 | windows crate + lib/bin 拆分决策 | #313 |
| i-5 | `firewall.rs` (windows = 0.58 引入) | #314 |
| i-6a | `elevated/cwd_junction.rs` | #315 |
| i-6b | `elevated_impl.rs` (含 inline `mod windows_impl`/`mod stub`) | #316 |
| i-7a | `setup_main_win.rs` + `dasclaw-sandbox-setup` bin | #317 |
| **i-7b** | **`elevated/command_runner_win.rs` + `dasclaw-command-runner` bin** | **本 PR** |

## 后续 / 下一步

- Phase 1.1.4j 收尾 hand-off 文档（独立小 PR）
- Phase 1.1.4k：sandbox 集成测试 + Windows CI 验证（独立 issue）

Closes #263
