### PR TITLE
feat(sandbox): Windows Job Object FFI for outer resource-limits wrapper (ADR-131 Slice B2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2675,6 +2675,7 @@ dependencies = [
  "serde_json",
  "thiserror 1.0.69",
  "url",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/crates/dasclaw_sandbox/Cargo.toml
+++ b/crates/dasclaw_sandbox/Cargo.toml
@@ -36,3 +36,16 @@ seccompiler = "0.5"
 dasclaw_sandbox_windows = { path = "../dasclaw_sandbox_windows" }
 dirs = "6"
 serde_json = "1"
+
+# ADR-131 / Slice B2 — Outer Job Object FFI for resource limits wrapper.
+# 仅在 Windows target 启用；features 与 dasclaw_sandbox_windows 0.52 对齐。
+# JobObjects = CreateJobObjectW / SetInformationJobObject / AssignProcessToJobObject
+# Foundation = HANDLE / CloseHandle / GetLastError
+# Threading  = GetCurrentProcess
+[target.'cfg(target_os = "windows")'.dependencies.windows-sys]
+version = "0.52"
+features = [
+  "Win32_Foundation",
+  "Win32_System_JobObjects",
+  "Win32_System_Threading",
+]

--- a/crates/dasclaw_sandbox/src/windows/job_object.rs
+++ b/crates/dasclaw_sandbox/src/windows/job_object.rs
@@ -1,0 +1,290 @@
+//! Windows Job Object FFI for outer resource-limit wrapping (Slice B2 of ADR-131).
+//!
+//! ## 角色
+//!
+//! 这个模块实现 ADR-131 决议的 **side-by-side wrapper** 中的 Job Object
+//! FFI 部分（详见 [`docs/plans/architecture-refactor/adr-131-windows-job-object-resource-limits-wrapper.md`](../../../../docs/plans/architecture-refactor/adr-131-windows-job-object-resource-limits-wrapper.md)）：
+//!
+//! - 不修改 `dasclaw_sandbox_windows` verbatim crate（合规 ADR-129 §1.3 红线）
+//! - 创建一个 **outer** Job Object，设 `JOB_OBJECT_LIMIT_PROCESS_MEMORY` /
+//!   `JOB_OBJECT_LIMIT_ACTIVE_PROCESS` / `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`
+//! - `AssignProcessToJobObject` 把当前进程（launcher binary）放进 outer job
+//! - upstream `command_runner_win.rs` 之后再创建 inner job（仅
+//!   `KILL_ON_JOB_CLOSE`），是 outer 的 nested child（Win 8+ 嵌套 job 语义）
+//! - arbitrary command 跑在 inner job 中，受 outer job 的 memory/process
+//!   limits 自动 enforce
+//!
+//! ## 安全契约
+//!
+//! - [`JobObject`] 是 RAII guard：drop 时 `CloseHandle`。
+//!   配合 `KILL_ON_JOB_CLOSE`，guard drop 会让 OS 立即 kill 整条 job 链上
+//!   的所有进程（包括 upstream spawn 的 sandbox 子进程），保证不存在 orphan。
+//! - 所有 FFI 调用失败都返回 [`JobObjectError`]，不 panic、不 unwrap。
+//!
+//! ## 调用方
+//!
+//! Slice B3 (adapter 接入) 把这个模块和 [`crate::launcher_ipc`] (B1) 组合在
+//! `dasclaw-sandbox-resource-launcher.exe` 里使用。本模块自身不调用 lib API。
+
+#![cfg(target_os = "windows")]
+
+use std::mem::size_of;
+
+use windows_sys::Win32::Foundation::{CloseHandle, GetLastError, HANDLE};
+use windows_sys::Win32::System::JobObjects::{
+    AssignProcessToJobObject, CreateJobObjectW, JobObjectExtendedLimitInformation,
+    SetInformationJobObject, JOBOBJECT_EXTENDED_LIMIT_INFORMATION, JOB_OBJECT_LIMIT_ACTIVE_PROCESS,
+    JOB_OBJECT_LIMIT_JOB_MEMORY, JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+    JOB_OBJECT_LIMIT_PROCESS_MEMORY,
+};
+use windows_sys::Win32::System::Threading::GetCurrentProcess;
+
+/// Resource limits to apply to the outer job object.
+///
+/// `None` means "no limit on this axis"（OS 默认）。零值视为非法，构造函数会
+/// 拒绝（防误用）。
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct OuterJobLimits {
+    /// Per-process memory cap（bytes）。映射到 `JOB_OBJECT_LIMIT_PROCESS_MEMORY`。
+    /// 上游 sandbox 子进程超过此值会被 OS 立即终止。
+    pub max_process_memory_bytes: Option<u64>,
+
+    /// Job-wide memory cap（bytes）。映射到 `JOB_OBJECT_LIMIT_JOB_MEMORY`。
+    /// 整条 job 上所有进程（含 nested job 的孙进程）总内存超过此值会被终止。
+    pub max_job_memory_bytes: Option<u64>,
+
+    /// Active-process count cap。映射到 `JOB_OBJECT_LIMIT_ACTIVE_PROCESS`。
+    /// 防 fork bomb / DoS。值必须 >= 1（自身 launcher 已占 1）。
+    pub max_active_processes: Option<u32>,
+}
+
+impl OuterJobLimits {
+    /// 验证字段语义合规。零值（任何字段为 0）视为误用，返回 Err。
+    pub fn validate(&self) -> Result<(), JobObjectError> {
+        if self.max_process_memory_bytes == Some(0) {
+            return Err(JobObjectError::InvalidLimits {
+                detail: "max_process_memory_bytes=0 is invalid; use None for no limit".into(),
+            });
+        }
+        if self.max_job_memory_bytes == Some(0) {
+            return Err(JobObjectError::InvalidLimits {
+                detail: "max_job_memory_bytes=0 is invalid; use None for no limit".into(),
+            });
+        }
+        if self.max_active_processes == Some(0) {
+            return Err(JobObjectError::InvalidLimits {
+                detail: "max_active_processes=0 is invalid; use None for no limit".into(),
+            });
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum JobObjectError {
+    #[error("invalid OuterJobLimits: {detail}")]
+    InvalidLimits { detail: String },
+
+    #[error("CreateJobObjectW failed (GetLastError={code})")]
+    CreateFailed { code: u32 },
+
+    #[error(
+        "SetInformationJobObject(JobObjectExtendedLimitInformation) failed (GetLastError={code})"
+    )]
+    SetInfoFailed { code: u32 },
+
+    #[error("AssignProcessToJobObject failed (GetLastError={code})")]
+    AssignFailed { code: u32 },
+}
+
+/// RAII guard wrapping a Windows Job Object handle.
+///
+/// Drop closes the handle. Combined with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`
+/// (always set by [`OuterJobLimits::apply_to_new_job`]), drop will terminate
+/// every process associated with the job, including upstream-spawned
+/// grandchildren via Windows nested-job semantics.
+pub struct JobObject {
+    handle: HANDLE,
+}
+
+impl JobObject {
+    /// Create a new (unnamed, anonymous) Job Object and apply the given limits.
+    ///
+    /// Always sets `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` for hygiene (codex
+    /// upstream precedent: `command_runner_win.rs:120`).
+    ///
+    /// On any FFI failure the handle (if created) is closed before returning Err.
+    pub fn create_with_limits(limits: OuterJobLimits) -> Result<Self, JobObjectError> {
+        limits.validate()?;
+
+        // SAFETY: CreateJobObjectW with both pointers null is documented as
+        // creating an anonymous unnamed job. Returns 0 on failure.
+        let handle = unsafe { CreateJobObjectW(std::ptr::null(), std::ptr::null()) };
+        if handle == 0 {
+            let code = unsafe { GetLastError() };
+            return Err(JobObjectError::CreateFailed { code });
+        }
+
+        // SAFETY: zero-initialised JOBOBJECT_EXTENDED_LIMIT_INFORMATION, then
+        // populate the bits we care about.
+        let mut info: JOBOBJECT_EXTENDED_LIMIT_INFORMATION = unsafe { std::mem::zeroed() };
+
+        let mut flags: u32 = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+
+        if let Some(per_proc) = limits.max_process_memory_bytes {
+            flags |= JOB_OBJECT_LIMIT_PROCESS_MEMORY;
+            info.ProcessMemoryLimit = per_proc as usize;
+        }
+        if let Some(per_job) = limits.max_job_memory_bytes {
+            flags |= JOB_OBJECT_LIMIT_JOB_MEMORY;
+            info.JobMemoryLimit = per_job as usize;
+        }
+        if let Some(active) = limits.max_active_processes {
+            flags |= JOB_OBJECT_LIMIT_ACTIVE_PROCESS;
+            info.BasicLimitInformation.ActiveProcessLimit = active;
+        }
+
+        info.BasicLimitInformation.LimitFlags = flags;
+
+        // SAFETY: handle is valid (just-created), info pointer is valid for
+        // the duration of the call, size matches the struct.
+        let ok = unsafe {
+            SetInformationJobObject(
+                handle,
+                JobObjectExtendedLimitInformation,
+                &mut info as *mut _ as *mut _,
+                size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as u32,
+            )
+        };
+        if ok == 0 {
+            let code = unsafe { GetLastError() };
+            // SAFETY: handle was successfully created above; closing on error path.
+            unsafe { CloseHandle(handle) };
+            return Err(JobObjectError::SetInfoFailed { code });
+        }
+
+        Ok(JobObject { handle })
+    }
+
+    /// Attach the **current** process to this job. Children spawned afterwards
+    /// inherit the job association by default (no `CREATE_BREAKAWAY_FROM_JOB`
+    /// flag in upstream `command_runner_win.rs`'s spawn paths).
+    ///
+    /// Idempotent within a single OS process: Windows allows a process to
+    /// belong to multiple jobs only via nested-job semantics; calling this
+    /// twice on the same process is treated as caller error and returns Err.
+    pub fn assign_current_process(&self) -> Result<(), JobObjectError> {
+        // SAFETY: GetCurrentProcess returns a pseudo-handle (-1) that does not
+        // need closing; AssignProcessToJobObject is documented to accept it.
+        let ok = unsafe { AssignProcessToJobObject(self.handle, GetCurrentProcess()) };
+        if ok == 0 {
+            let code = unsafe { GetLastError() };
+            return Err(JobObjectError::AssignFailed { code });
+        }
+        Ok(())
+    }
+
+    /// Raw handle (for FFI re-use; do **not** close manually — RAII guard owns it).
+    #[inline]
+    pub fn raw_handle(&self) -> HANDLE {
+        self.handle
+    }
+}
+
+impl Drop for JobObject {
+    fn drop(&mut self) {
+        if self.handle != 0 {
+            // SAFETY: handle was created by CreateJobObjectW and not closed elsewhere.
+            unsafe { CloseHandle(self.handle) };
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_rejects_zero_per_process_memory() {
+        let limits = OuterJobLimits {
+            max_process_memory_bytes: Some(0),
+            ..Default::default()
+        };
+        assert!(matches!(
+            limits.validate(),
+            Err(JobObjectError::InvalidLimits { .. })
+        ));
+    }
+
+    #[test]
+    fn validate_rejects_zero_job_memory() {
+        let limits = OuterJobLimits {
+            max_job_memory_bytes: Some(0),
+            ..Default::default()
+        };
+        assert!(matches!(
+            limits.validate(),
+            Err(JobObjectError::InvalidLimits { .. })
+        ));
+    }
+
+    #[test]
+    fn validate_rejects_zero_active_processes() {
+        let limits = OuterJobLimits {
+            max_active_processes: Some(0),
+            ..Default::default()
+        };
+        assert!(matches!(
+            limits.validate(),
+            Err(JobObjectError::InvalidLimits { .. })
+        ));
+    }
+
+    #[test]
+    fn validate_accepts_default() {
+        let limits = OuterJobLimits::default();
+        assert!(limits.validate().is_ok());
+    }
+
+    #[test]
+    fn validate_accepts_typical_values() {
+        let limits = OuterJobLimits {
+            max_process_memory_bytes: Some(2 * 1024 * 1024 * 1024),
+            max_job_memory_bytes: Some(4 * 1024 * 1024 * 1024),
+            max_active_processes: Some(64),
+        };
+        assert!(limits.validate().is_ok());
+    }
+
+    #[test]
+    fn create_with_default_limits_succeeds() {
+        // 默认 limits 仅设 KILL_ON_JOB_CLOSE，应总能成功。
+        let job = JobObject::create_with_limits(OuterJobLimits::default())
+            .expect("create unnamed job object with default limits");
+        assert!(job.raw_handle() != 0);
+        // drop 自动 CloseHandle
+    }
+
+    #[test]
+    fn create_with_typical_limits_succeeds() {
+        let limits = OuterJobLimits {
+            max_process_memory_bytes: Some(2 * 1024 * 1024 * 1024),
+            max_job_memory_bytes: Some(4 * 1024 * 1024 * 1024),
+            max_active_processes: Some(64),
+        };
+        let job = JobObject::create_with_limits(limits).expect("create job with typical limits");
+        assert!(job.raw_handle() != 0);
+    }
+
+    #[test]
+    fn create_rejects_zero_limit_fields() {
+        let limits = OuterJobLimits {
+            max_process_memory_bytes: Some(0),
+            ..Default::default()
+        };
+        assert!(matches!(
+            JobObject::create_with_limits(limits),
+            Err(JobObjectError::InvalidLimits { .. })
+        ));
+    }
+}

--- a/crates/dasclaw_sandbox/src/windows/mod.rs
+++ b/crates/dasclaw_sandbox/src/windows/mod.rs
@@ -50,6 +50,8 @@
 
 #![cfg(target_os = "windows")]
 
+pub mod job_object;
+
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 


### PR DESCRIPTION
## 背景 / 目标

ADR-131（已 Accepted via #327）决议：为 [#34](https://github.com/Linnanli/xClaw/issues/34) 的 Windows process-level resource limits 采用 **side-by-side wrapper** 方案。本 PR 是 **Slice B2 — Job Object FFI + RAII guard**。

ADR-131 §4 把实施拆为 4 个独立 slice：
- **B1**：launcher binary 骨架 + IPC 协议（**并行 PR**，与 B2 同时起步）
- **B2 (本 PR)**：Job Object FFI + RAII guard
- B3：adapter 接入（依赖 B1 + B2 都 land）
- B4：doc 同步（ADR-45 / doc 51 / doc 50）

## 改动范围（What's in this PR）

### 新文件 [`crates/dasclaw_sandbox/src/windows/job_object.rs`](crates/dasclaw_sandbox/src/windows/job_object.rs)（~280 LOC）

公开 API：

| 类型 / 函数 | 作用 |
|---|---|
| `OuterJobLimits` struct | 描述外层 Job Object 的资源限制：`max_process_memory_bytes` / `max_job_memory_bytes` / `max_active_processes`，每个字段 `Option<u64/u32>`（None = 不限） |
| `OuterJobLimits::validate()` | 拒绝零值（防误用） |
| `JobObject` | RAII guard，包 `HANDLE`；`Drop` 调 `CloseHandle` |
| `JobObject::create_with_limits(OuterJobLimits)` | `CreateJobObjectW` + `SetInformationJobObject(JobObjectExtendedLimitInformation)`，**始终**设 `KILL_ON_JOB_CLOSE`（卫生），按字段叠加 `PROCESS_MEMORY` / `JOB_MEMORY` / `ACTIVE_PROCESS` flags |
| `JobObject::assign_current_process()` | `AssignProcessToJobObject(handle, GetCurrentProcess())` |
| `JobObject::raw_handle()` | 暴露原始 HANDLE（FFI 重用，禁止手动 close） |
| `JobObjectError` enum | `InvalidLimits` / `CreateFailed` / `SetInfoFailed` / `AssignFailed`，各带 `GetLastError()` 码 |

### Cargo.toml 改动

- `[target.'cfg(target_os = "windows")'.dependencies.windows-sys]` 0.52  
  features：`Win32_Foundation` + `Win32_System_JobObjects` + `Win32_System_Threading`（与 `dasclaw_sandbox_windows` 0.52 对齐）

### `windows/mod.rs` 改动
- 加一行 `pub mod job_object;`

### 7 个 unit tests（cfg(target_os="windows") 才跑）
- `validate_rejects_zero_per_process_memory`
- `validate_rejects_zero_job_memory`
- `validate_rejects_zero_active_processes`
- `validate_accepts_default`
- `validate_accepts_typical_values`
- `create_with_default_limits_succeeds` — 真 FFI smoke test
- `create_with_typical_limits_succeeds` — 真 FFI smoke test
- `create_rejects_zero_limit_fields`

## 非目标（What's NOT in this PR — 禁止补丁式代码）

- ❌ 不修改 `dasclaw_sandbox_windows` verbatim crate（ADR-129 §1.3 红线）
- ❌ 不接入 sandbox 运行时（B3 的事；新模块本 PR 内**没有任何 caller**）
- ❌ 不写 launcher binary（B1 的事）
- ❌ 不动 `WindowsRestrictedTokenSandbox::execute`（B3 的事）
- ❌ 不改 `ResourceLimits` struct 字段 doc-comment（B4 的事）
- ❌ 不在 `windows/mod.rs` 任何已有函数尾部追加分支或 cfg-flag 切换（**满足 AGENTS.md "禁止补丁式代码"**）

## 验证（6 步本地管线）

| Step | 命令 | 结果 |
|---|---|---|
| 1 | `cargo check -p dasclaw_sandbox --all-targets` | ✅ Finished |
| 2 | `cargo nextest run -p dasclaw_sandbox` | ✅ 34 tests / 34 passed (cfg-windows tests 在 macOS local skip，Windows CI 跑) |
| 3 | `cargo fmt --all` | ✅ no diff |
| 4 | `python3.12 scripts/check_no_panics.py --base origin/xClaw` | ✅ OK: No panic-inducing calls |
| 5 | `python3 scripts/check_no_new_ironclaw_literal.py --base origin/xClaw` | ✅ OK |
| 6 | `cargo clippy --no-deps -p dasclaw_sandbox --all-targets -- -D warnings` | ✅ Finished, no warnings |

Windows CI（`.github/workflows/windows-ci.yml`）会在 windows-latest runner 跑 7 个新 unit tests（PR #322 已加 path filter `crates/dasclaw_sandbox/**`）。

## 设计要点

1. **始终 `KILL_ON_JOB_CLOSE`**：guard drop 让 OS 立即 kill 整条 job 链上所有进程，杜绝 orphan。codex 上游 [`command_runner_win.rs:120`](crates/dasclaw_sandbox_windows/src/elevated/command_runner_win.rs) 同样做法。
2. **零值拒绝**：`OuterJobLimits` 字段为 `Some(0)` 时构造失败 → 防止误把 "无限制" 写成 0
3. **RAII**：`JobObject` 是 `!Send/!Sync` 默认（含 `HANDLE`），离开作用域自动 `CloseHandle`
4. **错误透传**：所有 FFI 失败抓 `GetLastError()` 入 `JobObjectError`，不 panic、不 unwrap
5. **接入点先冻结**：`assign_current_process` 名字明确指向"当前进程"，B3 的 launcher 调它把自己塞进 outer job

## 后续

B1 PR（launcher binary 骨架 + IPC）正在并行起步。B1 + B2 都 land 后开 B3 把它们组合到 `dasclaw-sandbox-resource-launcher.exe` 里。

Closes #330
Refs #34