### PR TITLE
feat(sandbox): launcher binary skeleton + IPC protocol (ADR-131 Slice B1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2672,6 +2672,7 @@ dependencies = [
  "dirs 6.0.0",
  "libc",
  "seccompiler",
+ "serde",
  "serde_json",
  "thiserror 1.0.69",
  "url",

--- a/crates/dasclaw_sandbox/Cargo.toml
+++ b/crates/dasclaw_sandbox/Cargo.toml
@@ -9,7 +9,17 @@ publish = false
 [lib]
 path = "src/lib.rs"
 
+# ADR-131 / Slice B1 — `dasclaw-sandbox-resource-launcher` binary.
+# 详见 docs/plans/architecture-refactor/adr-131-windows-job-object-resource-limits-wrapper.md。
+# 在非 Windows 平台编译为 stub main（cfg-gated），保证 workspace 全平台
+# `cargo build` 可靠通过（ADR-131 §7 Q4 决议方案 (a)）。
+[[bin]]
+name = "dasclaw-sandbox-resource-launcher"
+path = "src/bin/resource_launcher_win.rs"
+
 [dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 thiserror = "1"
 url = "2"
 
@@ -35,7 +45,6 @@ seccompiler = "0.5"
 [target.'cfg(target_os = "windows")'.dependencies]
 dasclaw_sandbox_windows = { path = "../dasclaw_sandbox_windows" }
 dirs = "6"
-serde_json = "1"
 
 # ADR-131 / Slice B2 — Outer Job Object FFI for resource limits wrapper.
 # 仅在 Windows target 启用；features 与 dasclaw_sandbox_windows 0.52 对齐。
@@ -49,3 +58,4 @@ features = [
   "Win32_System_JobObjects",
   "Win32_System_Threading",
 ]
+

--- a/crates/dasclaw_sandbox/src/bin/resource_launcher_win.rs
+++ b/crates/dasclaw_sandbox/src/bin/resource_launcher_win.rs
@@ -1,0 +1,141 @@
+//! `dasclaw-sandbox-resource-launcher` binary — Slice B1 of ADR-131.
+//!
+//! ## 角色
+//!
+//! 这个 binary 是 ADR-131 决议的 **side-by-side wrapper** 入口（Option B）：
+//!
+//! 1. 从 stdin 读 [`LauncherRequest`] JSON
+//! 2. （B3 后续）创建 outer Job Object（Slice B2 的 `JobObject`）+ 设资源限制 +
+//!    `AssignProcessToJobObject(GetCurrentProcess())`
+//! 3. （B3 后续）调 `dasclaw_sandbox_windows::run_windows_sandbox_capture`
+//! 4. 把 [`LauncherResponse`] JSON 写到 stdout
+//!
+//! ## 当前 slice (B1) 范围
+//!
+//! 本 PR 只完成 **骨架 + IPC 协议**，**不**调任何 FFI / lib API：
+//!
+//! - 解析 stdin → [`LauncherRequest`]
+//! - 校验 [`PROTOCOL_VERSION`] 匹配
+//! - 写一个 dry-run 响应（`exit_code = 0`，`stdout_b64 = base64("dry-run B1")`）
+//!   到 stdout
+//! - 退出码 0 / 1 / 2，分别对应 OK / 协议不匹配 / 解析失败
+//!
+//! Slice B3 会替换这里的 dry-run 逻辑为真实的 Job Object + sandbox 调用。
+//!
+//! ## 平台
+//!
+//! 真实逻辑只在 `cfg(target_os = "windows")` 下编译。其他平台编 stub main，
+//! 退出码 1 + stderr 提示。理由见 [ADR-131 §7 Q4](../../../docs/plans/architecture-refactor/adr-131-windows-job-object-resource-limits-wrapper.md#7-open-questions----已签字回答)：
+//! Cargo `[[bin]]` 不支持 `[target.'cfg(...)'.bin]`；`required-features` 方案
+//! 增加 CI 复杂度与误用风险。stub 让全平台 `cargo build` 可靠通过。
+
+#[cfg(target_os = "windows")]
+fn main() -> std::process::ExitCode {
+    use std::io::{Read, Write};
+
+    use dasclaw_sandbox::launcher_ipc::{LauncherRequest, LauncherResponse, PROTOCOL_VERSION};
+
+    let stdin = std::io::stdin();
+    let mut buf = String::new();
+    if let Err(e) = stdin.lock().read_to_string(&mut buf) {
+        let resp = LauncherResponse::error(format!("read stdin failed: {e}"));
+        let _ = write_response(&resp);
+        return std::process::ExitCode::from(2);
+    }
+
+    let req: LauncherRequest = match serde_json::from_str(&buf) {
+        Ok(r) => r,
+        Err(e) => {
+            let resp = LauncherResponse::error(format!("parse LauncherRequest failed: {e}"));
+            let _ = write_response(&resp);
+            return std::process::ExitCode::from(2);
+        }
+    };
+
+    if req.protocol_version != PROTOCOL_VERSION {
+        let resp =
+            LauncherResponse::error_protocol_mismatch(req.protocol_version, PROTOCOL_VERSION);
+        let _ = write_response(&resp);
+        return std::process::ExitCode::from(1);
+    }
+
+    // B1 dry-run: 不调 FFI / lib API。echo 一个 OK 响应。
+    // B3 会把以下整段替换为：
+    //   let outer = JobObject::create_with_limits(...)?;
+    //   outer.assign_current_process()?;
+    //   let capture = run_windows_sandbox_capture(...)?;
+    //   build response from capture
+    let resp = LauncherResponse {
+        protocol_version: PROTOCOL_VERSION,
+        exit_code: 0,
+        stdout_b64: base64_encode(format!(
+            "dry-run B1: argv={argv:?}, outer_limits={lim:?}",
+            argv = req.argv,
+            lim = req.outer_limits
+        )),
+        stderr_b64: String::new(),
+        error: None,
+    };
+
+    if let Err(e) = write_response(&resp) {
+        eprintln!("write response failed: {e}");
+        return std::process::ExitCode::from(2);
+    }
+
+    std::process::ExitCode::SUCCESS
+}
+
+#[cfg(target_os = "windows")]
+fn write_response(resp: &dasclaw_sandbox::launcher_ipc::LauncherResponse) -> std::io::Result<()> {
+    let json = serde_json::to_string(resp)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+    let stdout = std::io::stdout();
+    let mut handle = stdout.lock();
+    use std::io::Write;
+    handle.write_all(json.as_bytes())?;
+    handle.write_all(b"\n")?;
+    handle.flush()
+}
+
+/// 极小的 base64 实现（避免本 slice 引入新依赖）。
+/// dry-run 用，B3 会换 `base64` crate（已在 workspace 其他 crate 用过，复用）。
+#[cfg(target_os = "windows")]
+fn base64_encode(s: impl AsRef<[u8]>) -> String {
+    const TABLE: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let bytes = s.as_ref();
+    let mut out = String::with_capacity((bytes.len() + 2) / 3 * 4);
+    let mut i = 0;
+    while i + 3 <= bytes.len() {
+        let n = ((bytes[i] as u32) << 16) | ((bytes[i + 1] as u32) << 8) | (bytes[i + 2] as u32);
+        out.push(TABLE[((n >> 18) & 0x3F) as usize] as char);
+        out.push(TABLE[((n >> 12) & 0x3F) as usize] as char);
+        out.push(TABLE[((n >> 6) & 0x3F) as usize] as char);
+        out.push(TABLE[(n & 0x3F) as usize] as char);
+        i += 3;
+    }
+    let rem = bytes.len() - i;
+    if rem == 1 {
+        let n = (bytes[i] as u32) << 16;
+        out.push(TABLE[((n >> 18) & 0x3F) as usize] as char);
+        out.push(TABLE[((n >> 12) & 0x3F) as usize] as char);
+        out.push('=');
+        out.push('=');
+    } else if rem == 2 {
+        let n = ((bytes[i] as u32) << 16) | ((bytes[i + 1] as u32) << 8);
+        out.push(TABLE[((n >> 18) & 0x3F) as usize] as char);
+        out.push(TABLE[((n >> 12) & 0x3F) as usize] as char);
+        out.push(TABLE[((n >> 6) & 0x3F) as usize] as char);
+        out.push('=');
+    }
+    out
+}
+
+#[cfg(not(target_os = "windows"))]
+fn main() -> std::process::ExitCode {
+    eprintln!(
+        "dasclaw-sandbox-resource-launcher is Windows-only; \
+         building on this platform only ensures workspace-wide cargo build passes. \
+         See ADR-131 §7 Q4 for rationale."
+    );
+    std::process::ExitCode::from(1)
+}

--- a/crates/dasclaw_sandbox/src/launcher_ipc.rs
+++ b/crates/dasclaw_sandbox/src/launcher_ipc.rs
@@ -1,0 +1,201 @@
+//! IPC protocol for `dasclaw-sandbox-resource-launcher.exe` (Slice B1 of ADR-131).
+//!
+//! ## 角色
+//!
+//! 这个模块定义 ADR-131 决议的 **side-by-side wrapper** 中的进程间协议
+//! （详见 [`docs/plans/architecture-refactor/adr-131-windows-job-object-resource-limits-wrapper.md`](../../../docs/plans/architecture-refactor/adr-131-windows-job-object-resource-limits-wrapper.md)）：
+//!
+//! - adapter（`WindowsRestrictedTokenSandbox::execute`）spawn launcher binary
+//! - 把 [`LauncherRequest`] 用 JSON 写到子进程 stdin
+//! - launcher 在自身进程上创建 outer Job Object（Slice B2）→ 设资源限制 →
+//!   调 `dasclaw_sandbox_windows::run_windows_sandbox_capture`（不在本模块）
+//! - launcher 把 [`LauncherResponse`] 用 JSON 写回 stdout
+//! - adapter 读 stdout 反序列化 → 转 `std::process::Output`
+//!
+//! ## 平台
+//!
+//! 本模块**跨平台**（不 cfg-gate），便于 macOS / Linux 本地单元测试 IPC 数据
+//! 结构 round-trip。真实使用只在 Windows binary 与 Windows adapter 之间发生。
+//!
+//! ## 二进制 vs 文本
+//!
+//! `stdout_b64` / `stderr_b64` 用 base64 编码原始字节，避免 JSON 字符串对
+//! 非-UTF-8 输出（Windows 原生 GBK / UTF-16 命令）的损失。adapter 解码后
+//! 回填 `std::process::Output { stdout: Vec<u8>, stderr: Vec<u8> }`。
+//!
+//! ## 协议版本
+//!
+//! [`LauncherRequest::protocol_version`] / [`LauncherResponse::protocol_version`]
+//! 字段固定为 [`PROTOCOL_VERSION`]。launcher 收到不匹配的版本会立即 fail
+//! 并回 `LauncherResponse::error_protocol_mismatch`，不尝试继续。
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+/// 当前协议版本。bump 时同时更新 launcher binary 的解析逻辑。
+pub const PROTOCOL_VERSION: u32 = 1;
+
+/// adapter → launcher 的请求。
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LauncherRequest {
+    /// 协议版本。固定为 [`PROTOCOL_VERSION`]。
+    pub protocol_version: u32,
+
+    /// 要执行的命令（含 program）。`argv[0]` 是 program，`argv[1..]` 是参数。
+    pub argv: Vec<String>,
+
+    /// 工作目录。launcher 直接传给 `run_windows_sandbox_capture`。
+    pub cwd: PathBuf,
+
+    /// 环境变量。launcher 直接传给 `run_windows_sandbox_capture`。
+    pub env: HashMap<String, String>,
+
+    /// dasclaw_home（DPAPI key / setup state 根目录）。
+    pub dasclaw_home: PathBuf,
+
+    /// 序列化后的上游 `windows_sandbox::SandboxPolicy` JSON。
+    /// adapter 已经做完 `SandboxBackendConfig → UpstreamPolicy` 的转换。
+    pub policy_json: String,
+
+    /// 外层 Job Object 资源限制（None = 不施加 / 兼容现状）。
+    /// launcher 收到 Some(...) 时调 Slice B2 的 `JobObject::create_with_limits`。
+    pub outer_limits: Option<OuterJobLimitsWire>,
+
+    /// 是否使用 Alternate Desktop（透传上游 API）。
+    pub use_private_desktop: bool,
+}
+
+/// `OuterJobLimits` 的 wire 形式。
+///
+/// 与 [`crate::windows::job_object::OuterJobLimits`] 字段一致，但**跨平台**
+/// 可序列化（`OuterJobLimits` 本身在 macOS / Linux 不可见，因为它依赖
+/// windows-sys 类型）。
+#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct OuterJobLimitsWire {
+    pub max_process_memory_bytes: Option<u64>,
+    pub max_job_memory_bytes: Option<u64>,
+    pub max_active_processes: Option<u32>,
+}
+
+/// launcher → adapter 的响应。
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LauncherResponse {
+    pub protocol_version: u32,
+
+    /// 子进程退出码（i32 透传上游 `CaptureResult::exit_code`）。
+    /// launcher 自身错误时为 -1。
+    pub exit_code: i32,
+
+    /// stdout 字节（base64）。空字符串表示空输出。
+    pub stdout_b64: String,
+    pub stderr_b64: String,
+
+    /// launcher 自身错误时的人类可读详情。`Some(_)` ↔ `exit_code == -1`。
+    pub error: Option<String>,
+}
+
+impl LauncherResponse {
+    /// 构造一个表示 launcher 自身错误的响应。
+    pub fn error(detail: impl Into<String>) -> Self {
+        Self {
+            protocol_version: PROTOCOL_VERSION,
+            exit_code: -1,
+            stdout_b64: String::new(),
+            stderr_b64: String::new(),
+            error: Some(detail.into()),
+        }
+    }
+
+    /// 构造一个协议版本不匹配的响应。
+    pub fn error_protocol_mismatch(got: u32, expected: u32) -> Self {
+        Self::error(format!(
+            "launcher protocol version mismatch: got {got}, expected {expected}"
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_request() -> LauncherRequest {
+        let mut env = HashMap::new();
+        env.insert("PATH".into(), r"C:\Windows\System32".into());
+        env.insert("DASCLAW_HOME".into(), r"C:\Users\u\.dasclaw".into());
+
+        LauncherRequest {
+            protocol_version: PROTOCOL_VERSION,
+            argv: vec![
+                "powershell.exe".into(),
+                "-NoProfile".into(),
+                "Get-Date".into(),
+            ],
+            cwd: PathBuf::from(r"C:\Users\u\workspace"),
+            env,
+            dasclaw_home: PathBuf::from(r"C:\Users\u\.dasclaw"),
+            policy_json: r#"{"ReadOnly":{"network_access":false}}"#.into(),
+            outer_limits: Some(OuterJobLimitsWire {
+                max_process_memory_bytes: Some(2 * 1024 * 1024 * 1024),
+                max_job_memory_bytes: None,
+                max_active_processes: Some(64),
+            }),
+            use_private_desktop: false,
+        }
+    }
+
+    #[test]
+    fn request_round_trips_through_json() {
+        let req = sample_request();
+        let json = serde_json::to_string(&req).expect("serialize");
+        let back: LauncherRequest = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(req, back);
+    }
+
+    #[test]
+    fn request_with_no_outer_limits_round_trips() {
+        let mut req = sample_request();
+        req.outer_limits = None;
+        let json = serde_json::to_string(&req).expect("serialize");
+        let back: LauncherRequest = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(req, back);
+    }
+
+    #[test]
+    fn response_round_trips_through_json() {
+        let resp = LauncherResponse {
+            protocol_version: PROTOCOL_VERSION,
+            exit_code: 0,
+            stdout_b64: "aGVsbG8=".into(), // "hello"
+            stderr_b64: String::new(),
+            error: None,
+        };
+        let json = serde_json::to_string(&resp).expect("serialize");
+        let back: LauncherResponse = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(resp, back);
+    }
+
+    #[test]
+    fn response_error_helper_marks_exit_code_minus_one() {
+        let resp = LauncherResponse::error("CreateJobObjectW failed: GetLastError=5");
+        assert_eq!(resp.exit_code, -1);
+        assert!(resp.error.is_some());
+        assert!(resp.error.as_ref().unwrap().contains("CreateJobObjectW"));
+    }
+
+    #[test]
+    fn response_protocol_mismatch_helper_describes_versions() {
+        let resp = LauncherResponse::error_protocol_mismatch(2, PROTOCOL_VERSION);
+        assert_eq!(resp.exit_code, -1);
+        assert_eq!(resp.protocol_version, PROTOCOL_VERSION);
+        let msg = resp.error.unwrap();
+        assert!(msg.contains("got 2"));
+        assert!(msg.contains(&format!("expected {PROTOCOL_VERSION}")));
+    }
+
+    #[test]
+    fn protocol_version_is_one() {
+        assert_eq!(PROTOCOL_VERSION, 1);
+    }
+}

--- a/crates/dasclaw_sandbox/src/lib.rs
+++ b/crates/dasclaw_sandbox/src/lib.rs
@@ -23,6 +23,11 @@
 
 #![allow(dead_code)]
 
+/// ADR-131 / Slice B1 — IPC protocol for `dasclaw-sandbox-resource-launcher`.
+///
+/// 跨平台公开（serde 数据结构），便于本地测试与 macOS/Linux 构建检查通过。
+pub mod launcher_ipc;
+
 #[cfg(target_os = "macos")]
 pub mod macos;
 #[cfg(target_os = "macos")]
@@ -58,6 +63,14 @@ pub enum SandboxError {
     /// unsupported. See ADR-121 D3-3 / Phase 1.2 (issue #320).
     #[error("windows sandbox setup pending: {detail}")]
     WindowsSetupPending { detail: String },
+
+    /// Windows resource-limits launcher (`dasclaw-sandbox-resource-launcher.exe`)
+    /// failed at spawn / IPC / Job Object FFI / sub-process invocation.
+    /// **Distinct** from [`Self::WindowsSetupPending`]: setup is already done,
+    /// but this particular invocation's wrapper failed. Callers should not
+    /// prompt the user to re-run setup. See ADR-131 §7 Q2.
+    #[error("windows sandbox resource launcher failed: {detail}")]
+    WindowsLauncherFailed { detail: String },
 
     #[error("io error: {0}")]
     Io(#[from] std::io::Error),


### PR DESCRIPTION
## 背景 / 目标

ADR-131 决议（已签字 Accepted，PR #327 合入）的 **side-by-side wrapper** 入口骨架。
本 slice B1 与 [#328（B2 FFI）](https://github.com/Linnanli/xClaw/pull/328) **并行**，互不依赖。

## 改动范围

| 文件 | 性质 | 说明 |
| --- | --- | --- |
| `crates/dasclaw_sandbox/src/launcher_ipc.rs` | 新增 | 跨平台 serde 数据结构：`LauncherRequest` / `LauncherResponse` / `OuterJobLimitsWire` + `PROTOCOL_VERSION = 1` |
| `crates/dasclaw_sandbox/src/bin/resource_launcher_win.rs` | 新增 | `dasclaw-sandbox-resource-launcher` binary。cfg(windows) main 读 stdin / 写 stdout 的 dry-run；cfg(not(windows)) stub `exit(1)` |
| `crates/dasclaw_sandbox/Cargo.toml` | 改 | 顶层加 `serde` / `serde_json`；新增 `[[bin]]`；删 windows-only 段重复的 `serde_json` |
| `crates/dasclaw_sandbox/src/lib.rs` | 改 | `pub mod launcher_ipc;`；`SandboxError` 新增 `WindowsLauncherFailed { detail }` variant（ADR-131 §7 Q2 决议）|

**API 表面**：

| 名称 | 说明 |
| --- | --- |
| `launcher_ipc::PROTOCOL_VERSION: u32` | 当前 = 1 |
| `LauncherRequest { protocol_version, argv, cwd, env, dasclaw_home, policy_json, outer_limits, use_private_desktop }` | adapter → launcher |
| `LauncherResponse { protocol_version, exit_code, stdout_b64, stderr_b64, error }` | launcher → adapter |
| `OuterJobLimitsWire { max_process_memory_bytes, max_job_memory_bytes, max_active_processes }` | 与 B2 `OuterJobLimits` 一一映射的跨平台 wire |
| `LauncherResponse::error(detail)` / `error_protocol_mismatch(got, expected)` | 失败构造助手 |
| `SandboxError::WindowsLauncherFailed { detail }` | 与 `WindowsSetupPending` 严格区分，避免误诱导 setup 提示 |

## 非目标（What's NOT in this PR）

- **不**调任何 FFI / Job Object —— B2（#328）已实现 `JobObject`，B3 才会让 launcher 调用
- **不**调 `dasclaw_sandbox_windows::run_windows_sandbox_capture` —— 仍在 `windows/mod.rs` adapter 内同进程调用（B3 会迁移）
- adapter 仍**不** spawn launcher binary；本 PR 的 binary 是孤立可执行文件
- 不引入 `base64` crate 依赖（dry-run 用极小内联实现，B3 替换）
- 不修改 `windows/mod.rs`（避免与 #328 的 `pub mod job_object;` 行冲突）
- 不刷新 doc-comment / 不动 ADR-45 / ADR-50 / ADR-51（B4 处理）

## 验证

6 步本地流水线全绿：

| Step | 命令 | 结果 |
| --- | --- | --- |
| 1 | `cargo check -p dasclaw_sandbox --all-targets` | ✅ Finished |
| 2 | `cargo nextest run -p dasclaw_sandbox` | ✅ **40 passed** (B1 新增 6 个 IPC round-trip + helper) |
| 3 | `cargo fmt --all` | ✅ |
| 4 | `python3.12 scripts/check_no_panics.py --base origin/xClaw` | ✅ No panic-inducing calls |
| 5 | `python3 scripts/check_no_new_ironclaw_literal.py --base origin/xClaw` | ✅ No new literals |
| 6 | `cargo clippy --no-deps -p dasclaw_sandbox --all-targets -- -D warnings` | ✅ Finished |

Windows-only 真机测试（spawn launcher、Job Object 资源 cap 触发）由 B3 覆盖，本 slice 暂不需要。

## 设计要点

- `launcher_ipc.rs` **跨平台**（无 cfg gate），让 macOS / Linux 本地 `cargo check / test` 能验证 serde round-trip，避免 Windows-only 表面回归只能等 CI
- `[[bin]]` 在 Cargo 不支持 `[target.'cfg(...)'.bin]`，按 ADR-131 §7 Q4 决议方案 (a)：unconditional build + cfg-gated stub main，全平台 `cargo build` 可靠通过
- `stdout_b64` / `stderr_b64` 用 base64 表达原始字节，避免 JSON 字符串对非-UTF-8 输出（GBK / UTF-16）的损失
- 协议版本不匹配时 launcher 立即回 `LauncherResponse::error_protocol_mismatch` + exit(1)，不尝试继续解析

## 后续

- B3：refactor `WindowsRestrictedTokenSandbox::execute` 改 spawn launcher binary；launcher 真正调 `JobObject::create_with_limits` + `assign_current_process` + `run_windows_sandbox_capture`；引入 `base64` crate；新增 Windows-only 集成测试
- B4：刷新 `lib.rs` `ResourceLimits` doc / ADR-45 §"Axis 3 — Windows" / ADR-50 status / ADR-51 cross-platform matrix

Closes #331
Refs #34