### PR TITLE
feat(sandbox): adapter spawns launcher; outer Job Object enforced (ADR-131 Slice B3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2668,6 +2668,7 @@ dependencies = [
 name = "dasclaw_sandbox"
 version = "0.0.0-w1"
 dependencies = [
+ "base64 0.22.1",
  "dasclaw_sandbox_windows",
  "dirs 6.0.0",
  "libc",

--- a/crates/dasclaw_sandbox/Cargo.toml
+++ b/crates/dasclaw_sandbox/Cargo.toml
@@ -46,6 +46,10 @@ seccompiler = "0.5"
 dasclaw_sandbox_windows = { path = "../dasclaw_sandbox_windows" }
 dirs = "6"
 
+# ADR-131 / Slice B3 — base64 编码 launcher IPC 的 stdout / stderr 字节流。
+# 仅 Windows 用：launcher binary 编码 + adapter launcher_client 解码。
+base64 = "0.22"
+
 # ADR-131 / Slice B2 — Outer Job Object FFI for resource limits wrapper.
 # 仅在 Windows target 启用；features 与 dasclaw_sandbox_windows 0.52 对齐。
 # JobObjects = CreateJobObjectW / SetInformationJobObject / AssignProcessToJobObject

--- a/crates/dasclaw_sandbox/src/bin/resource_launcher_win.rs
+++ b/crates/dasclaw_sandbox/src/bin/resource_launcher_win.rs
@@ -1,133 +1,121 @@
-//! `dasclaw-sandbox-resource-launcher` binary — Slice B1 of ADR-131.
+//! `dasclaw-sandbox-resource-launcher` binary — Slice B3 of ADR-131.
 //!
 //! ## 角色
 //!
-//! 这个 binary 是 ADR-131 决议的 **side-by-side wrapper** 入口（Option B）：
+//! 这个 binary 是 [ADR-131](../../../../docs/plans/architecture-refactor/adr-131-windows-job-object-resource-limits-wrapper.md)
+//! 决议的 **side-by-side wrapper** 入口（Option B）：
 //!
 //! 1. 从 stdin 读 [`LauncherRequest`] JSON
-//! 2. （B3 后续）创建 outer Job Object（Slice B2 的 `JobObject`）+ 设资源限制 +
-//!    `AssignProcessToJobObject(GetCurrentProcess())`
-//! 3. （B3 后续）调 `dasclaw_sandbox_windows::run_windows_sandbox_capture`
+//! 2. 若 `outer_limits` 非空：创建 outer [`JobObject`] + 设资源限制 +
+//!    `AssignProcessToJobObject(GetCurrentProcess())` —— 之后任何子孙进程
+//!    （包括 `run_windows_sandbox_capture` spawn 出来的沙箱目标）会**默认**
+//!    继承到该外层 Job Object（Win 8+ 嵌套 Job Object 语义）
+//! 3. 同进程内调 `dasclaw_sandbox_windows::run_windows_sandbox_capture`
+//!    —— `dasclaw_sandbox_windows` crate 是 codex `windows-sandbox-rs` 的 1:1
+//!    verbatim port（ADR-129 §1.3 红线，禁止修改）
 //! 4. 把 [`LauncherResponse`] JSON 写到 stdout
 //!
-//! ## 当前 slice (B1) 范围
-//!
-//! 本 PR 只完成 **骨架 + IPC 协议**，**不**调任何 FFI / lib API：
-//!
-//! - 解析 stdin → [`LauncherRequest`]
-//! - 校验 [`PROTOCOL_VERSION`] 匹配
-//! - 写一个 dry-run 响应（`exit_code = 0`，`stdout_b64 = base64("dry-run B1")`）
-//!   到 stdout
-//! - 退出码 0 / 1 / 2，分别对应 OK / 协议不匹配 / 解析失败
-//!
-//! Slice B3 会替换这里的 dry-run 逻辑为真实的 Job Object + sandbox 调用。
+//! Slice B1 起骨架，B2 补 [`JobObject`] FFI，本 slice (B3) 把它们组合并接
+//! `run_windows_sandbox_capture`，同时把内嵌 base64 替换为 `base64` crate。
 //!
 //! ## 平台
 //!
 //! 真实逻辑只在 `cfg(target_os = "windows")` 下编译。其他平台编 stub main，
-//! 退出码 1 + stderr 提示。理由见 [ADR-131 §7 Q4](../../../docs/plans/architecture-refactor/adr-131-windows-job-object-resource-limits-wrapper.md#7-open-questions----已签字回答)：
-//! Cargo `[[bin]]` 不支持 `[target.'cfg(...)'.bin]`；`required-features` 方案
-//! 增加 CI 复杂度与误用风险。stub 让全平台 `cargo build` 可靠通过。
+//! 退出码 1 + stderr 提示。理由见 ADR-131 §7 Q4：Cargo `[[bin]]` 不支持
+//! `[target.'cfg(...)'.bin]`；stub 让全平台 `cargo build` 可靠通过。
 
 #[cfg(target_os = "windows")]
 fn main() -> std::process::ExitCode {
     use std::io::{Read, Write};
 
-    use dasclaw_sandbox::launcher_ipc::{LauncherRequest, LauncherResponse, PROTOCOL_VERSION};
+    use base64::engine::general_purpose::STANDARD as BASE64;
+    use base64::Engine as _;
 
-    let stdin = std::io::stdin();
+    use dasclaw_sandbox::launcher_ipc::{LauncherRequest, LauncherResponse, PROTOCOL_VERSION};
+    use dasclaw_sandbox::windows::job_object::{JobObject, OuterJobLimits};
+    use dasclaw_sandbox_windows::run_windows_sandbox_capture;
+
+    fn write_response(resp: &LauncherResponse) -> std::io::Result<()> {
+        let json = serde_json::to_vec(resp)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+        let stdout = std::io::stdout();
+        let mut handle = stdout.lock();
+        handle.write_all(&json)?;
+        handle.flush()
+    }
+
+    fn fail(detail: impl Into<String>, code: u8) -> std::process::ExitCode {
+        let _ = write_response(&LauncherResponse::error(detail));
+        std::process::ExitCode::from(code)
+    }
+
     let mut buf = String::new();
-    if let Err(e) = stdin.lock().read_to_string(&mut buf) {
-        let resp = LauncherResponse::error(format!("read stdin failed: {e}"));
-        let _ = write_response(&resp);
-        return std::process::ExitCode::from(2);
+    if let Err(e) = std::io::stdin().lock().read_to_string(&mut buf) {
+        return fail(format!("read stdin: {e}"), 2);
     }
 
     let req: LauncherRequest = match serde_json::from_str(&buf) {
         Ok(r) => r,
-        Err(e) => {
-            let resp = LauncherResponse::error(format!("parse LauncherRequest failed: {e}"));
-            let _ = write_response(&resp);
-            return std::process::ExitCode::from(2);
-        }
+        Err(e) => return fail(format!("parse LauncherRequest: {e}"), 2),
     };
 
     if req.protocol_version != PROTOCOL_VERSION {
-        let resp =
-            LauncherResponse::error_protocol_mismatch(req.protocol_version, PROTOCOL_VERSION);
-        let _ = write_response(&resp);
+        let _ = write_response(&LauncherResponse::error_protocol_mismatch(
+            req.protocol_version,
+            PROTOCOL_VERSION,
+        ));
         return std::process::ExitCode::from(1);
     }
 
-    // B1 dry-run: 不调 FFI / lib API。echo 一个 OK 响应。
-    // B3 会把以下整段替换为：
-    //   let outer = JobObject::create_with_limits(...)?;
-    //   outer.assign_current_process()?;
-    //   let capture = run_windows_sandbox_capture(...)?;
-    //   build response from capture
+    // outer Job Object（仅当请求带限制时）。RAII guard 必须存活到
+    // run_windows_sandbox_capture 返回之后，所以绑定到 main 局部。
+    let _outer_guard = match req.outer_limits {
+        None => None,
+        Some(wire) => {
+            let limits = OuterJobLimits {
+                max_process_memory_bytes: wire.max_process_memory_bytes,
+                max_job_memory_bytes: wire.max_job_memory_bytes,
+                max_active_processes: wire.max_active_processes,
+            };
+            let job = match JobObject::create_with_limits(limits) {
+                Ok(j) => j,
+                Err(e) => return fail(format!("JobObject::create_with_limits: {e}"), 1),
+            };
+            if let Err(e) = job.assign_current_process() {
+                return fail(format!("JobObject::assign_current_process: {e}"), 1);
+            }
+            Some(job)
+        }
+    };
+
+    let capture = match run_windows_sandbox_capture(
+        &req.policy_json,
+        &req.cwd,
+        &req.dasclaw_home,
+        req.argv,
+        &req.cwd,
+        req.env,
+        None, // timeout — adapter 上层（OsExecutor）用 tokio timeout 包裹
+        req.use_private_desktop,
+    ) {
+        Ok(c) => c,
+        Err(e) => return fail(format!("run_windows_sandbox_capture: {e}"), 1),
+    };
+
     let resp = LauncherResponse {
         protocol_version: PROTOCOL_VERSION,
-        exit_code: 0,
-        stdout_b64: base64_encode(format!(
-            "dry-run B1: argv={argv:?}, outer_limits={lim:?}",
-            argv = req.argv,
-            lim = req.outer_limits
-        )),
-        stderr_b64: String::new(),
+        exit_code: capture.exit_code,
+        stdout_b64: BASE64.encode(&capture.stdout),
+        stderr_b64: BASE64.encode(&capture.stderr),
         error: None,
     };
 
     if let Err(e) = write_response(&resp) {
-        eprintln!("write response failed: {e}");
+        eprintln!("write LauncherResponse: {e}");
         return std::process::ExitCode::from(2);
     }
 
     std::process::ExitCode::SUCCESS
-}
-
-#[cfg(target_os = "windows")]
-fn write_response(resp: &dasclaw_sandbox::launcher_ipc::LauncherResponse) -> std::io::Result<()> {
-    let json = serde_json::to_string(resp)
-        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
-    let stdout = std::io::stdout();
-    let mut handle = stdout.lock();
-    use std::io::Write;
-    handle.write_all(json.as_bytes())?;
-    handle.write_all(b"\n")?;
-    handle.flush()
-}
-
-/// 极小的 base64 实现（避免本 slice 引入新依赖）。
-/// dry-run 用，B3 会换 `base64` crate（已在 workspace 其他 crate 用过，复用）。
-#[cfg(target_os = "windows")]
-fn base64_encode(s: impl AsRef<[u8]>) -> String {
-    const TABLE: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-    let bytes = s.as_ref();
-    let mut out = String::with_capacity((bytes.len() + 2) / 3 * 4);
-    let mut i = 0;
-    while i + 3 <= bytes.len() {
-        let n = ((bytes[i] as u32) << 16) | ((bytes[i + 1] as u32) << 8) | (bytes[i + 2] as u32);
-        out.push(TABLE[((n >> 18) & 0x3F) as usize] as char);
-        out.push(TABLE[((n >> 12) & 0x3F) as usize] as char);
-        out.push(TABLE[((n >> 6) & 0x3F) as usize] as char);
-        out.push(TABLE[(n & 0x3F) as usize] as char);
-        i += 3;
-    }
-    let rem = bytes.len() - i;
-    if rem == 1 {
-        let n = (bytes[i] as u32) << 16;
-        out.push(TABLE[((n >> 18) & 0x3F) as usize] as char);
-        out.push(TABLE[((n >> 12) & 0x3F) as usize] as char);
-        out.push('=');
-        out.push('=');
-    } else if rem == 2 {
-        let n = ((bytes[i] as u32) << 16) | ((bytes[i + 1] as u32) << 8);
-        out.push(TABLE[((n >> 18) & 0x3F) as usize] as char);
-        out.push(TABLE[((n >> 12) & 0x3F) as usize] as char);
-        out.push(TABLE[((n >> 6) & 0x3F) as usize] as char);
-        out.push('=');
-    }
-    out
 }
 
 #[cfg(not(target_os = "windows"))]

--- a/crates/dasclaw_sandbox/src/windows/launcher_client.rs
+++ b/crates/dasclaw_sandbox/src/windows/launcher_client.rs
@@ -1,0 +1,220 @@
+//! Spawns `dasclaw-sandbox-resource-launcher.exe` and brokers IPC between
+//! adapter and launcher (Slice B3 of ADR-131).
+//!
+//! ## 角色
+//!
+//! 这个模块是 [ADR-131](../../../../docs/plans/architecture-refactor/adr-131-windows-job-object-resource-limits-wrapper.md)
+//! 决议 **side-by-side wrapper** 在 adapter 端的客户端：
+//!
+//! 1. 用 [`std::process::Command`] spawn launcher binary
+//! 2. 把 [`crate::launcher_ipc::LauncherRequest`] JSON 写到 stdin
+//! 3. wait + 读 stdout 全量 → 反序列化 [`crate::launcher_ipc::LauncherResponse`]
+//! 4. base64 解码 stdout / stderr → 组装 [`std::process::Output`]
+//!
+//! ## launcher 路径解析
+//!
+//! [`resolve_launcher_path`] 按优先级尝试：
+//!
+//! 1. `DASCLAW_SANDBOX_LAUNCHER_PATH` 环境变量（部署 / 测试 override）
+//! 2. 当前 exe 同目录下的 `dasclaw-sandbox-resource-launcher.exe`
+//!    （生产部署形态：把 launcher 与主 binary 一起 ship）
+//! 3. fallback：仅文件名（让 OS 走 PATH 查找，dev 场景）
+//!
+//! ## 失败语义
+//!
+//! 所有 IPC / spawn / 解码错误统一映射到
+//! [`crate::SandboxError::WindowsLauncherFailed`]，与
+//! [`crate::SandboxError::WindowsSetupPending`] 严格区分（详见 ADR-131 §7 Q2）。
+
+#![cfg(target_os = "windows")]
+
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+
+use base64::engine::general_purpose::STANDARD as BASE64;
+use base64::Engine as _;
+
+use crate::launcher_ipc::{LauncherRequest, LauncherResponse, PROTOCOL_VERSION};
+use crate::SandboxError;
+
+const LAUNCHER_BIN: &str = "dasclaw-sandbox-resource-launcher.exe";
+const LAUNCHER_PATH_ENV: &str = "DASCLAW_SANDBOX_LAUNCHER_PATH";
+
+/// Spawn launcher，发请求，等响应，转 [`std::process::Output`]。
+pub(super) fn spawn_and_capture(
+    request: LauncherRequest,
+) -> Result<std::process::Output, SandboxError> {
+    debug_assert_eq!(request.protocol_version, PROTOCOL_VERSION);
+
+    let exe = resolve_launcher_path();
+
+    let req_json =
+        serde_json::to_vec(&request).map_err(|e| SandboxError::WindowsLauncherFailed {
+            detail: format!("serialize LauncherRequest: {e}"),
+        })?;
+
+    let mut child = Command::new(&exe)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|e| SandboxError::WindowsLauncherFailed {
+            detail: format!("spawn launcher {}: {e}", exe.display()),
+        })?;
+
+    {
+        let stdin = child
+            .stdin
+            .as_mut()
+            .ok_or_else(|| SandboxError::WindowsLauncherFailed {
+                detail: "launcher child stdin not piped".into(),
+            })?;
+        stdin
+            .write_all(&req_json)
+            .map_err(|e| SandboxError::WindowsLauncherFailed {
+                detail: format!("write LauncherRequest to launcher stdin: {e}"),
+            })?;
+    }
+
+    let raw = child
+        .wait_with_output()
+        .map_err(|e| SandboxError::WindowsLauncherFailed {
+            detail: format!("wait launcher: {e}"),
+        })?;
+
+    let response: LauncherResponse =
+        serde_json::from_slice(&raw.stdout).map_err(|e| SandboxError::WindowsLauncherFailed {
+            detail: format!(
+                "parse LauncherResponse: {e} (launcher stderr: {})",
+                String::from_utf8_lossy(&raw.stderr).trim()
+            ),
+        })?;
+
+    if response.protocol_version != PROTOCOL_VERSION {
+        return Err(SandboxError::WindowsLauncherFailed {
+            detail: format!(
+                "launcher protocol mismatch: response v{}, expected v{PROTOCOL_VERSION}",
+                response.protocol_version
+            ),
+        });
+    }
+
+    if let Some(err) = response.error {
+        return Err(SandboxError::WindowsLauncherFailed { detail: err });
+    }
+
+    let stdout =
+        BASE64
+            .decode(&response.stdout_b64)
+            .map_err(|e| SandboxError::WindowsLauncherFailed {
+                detail: format!("decode stdout_b64: {e}"),
+            })?;
+    let stderr =
+        BASE64
+            .decode(&response.stderr_b64)
+            .map_err(|e| SandboxError::WindowsLauncherFailed {
+                detail: format!("decode stderr_b64: {e}"),
+            })?;
+
+    use std::os::windows::process::ExitStatusExt;
+    let status = std::process::ExitStatus::from_raw(response.exit_code as u32);
+
+    Ok(std::process::Output {
+        status,
+        stdout,
+        stderr,
+    })
+}
+
+fn resolve_launcher_path() -> PathBuf {
+    if let Ok(p) = std::env::var(LAUNCHER_PATH_ENV) {
+        if !p.is_empty() {
+            let pb = PathBuf::from(p);
+            if pb.exists() {
+                return pb;
+            }
+        }
+    }
+
+    if let Ok(cur) = std::env::current_exe() {
+        if let Some(dir) = cur.parent() {
+            let candidate = dir.join(LAUNCHER_BIN);
+            if candidate.exists() {
+                return candidate;
+            }
+        }
+    }
+
+    PathBuf::from(LAUNCHER_BIN)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn launcher_path_falls_back_to_bin_name() {
+        // safety: tests-only env mutation; restored at end.
+        let prev = std::env::var_os(LAUNCHER_PATH_ENV);
+        unsafe {
+            std::env::remove_var(LAUNCHER_PATH_ENV);
+        }
+        let p = resolve_launcher_path();
+        // 至少包含 launcher 可执行文件名；可能是 sibling-of-exe 真实路径或裸文件名
+        assert!(
+            p.file_name().is_some_and(|n| n == LAUNCHER_BIN),
+            "expected path to end with {LAUNCHER_BIN}, got {}",
+            p.display()
+        );
+        if let Some(v) = prev {
+            unsafe {
+                std::env::set_var(LAUNCHER_PATH_ENV, v);
+            }
+        }
+    }
+
+    #[test]
+    fn launcher_path_env_override_when_exists() {
+        // 用 current_exe 自身（一定存在）做 override target
+        let exe = std::env::current_exe().expect("current_exe");
+        let prev = std::env::var_os(LAUNCHER_PATH_ENV);
+        // safety: tests-only env mutation; restored at end.
+        unsafe {
+            std::env::set_var(LAUNCHER_PATH_ENV, &exe);
+        }
+        let p = resolve_launcher_path();
+        assert_eq!(p, exe);
+        unsafe {
+            match prev {
+                Some(v) => std::env::set_var(LAUNCHER_PATH_ENV, v),
+                None => std::env::remove_var(LAUNCHER_PATH_ENV),
+            }
+        }
+    }
+
+    #[test]
+    fn launcher_path_env_ignored_when_path_missing() {
+        let prev = std::env::var_os(LAUNCHER_PATH_ENV);
+        // safety: tests-only env mutation; restored at end.
+        unsafe {
+            std::env::set_var(
+                LAUNCHER_PATH_ENV,
+                r"C:\definitely\not\there\dasclaw-sandbox-resource-launcher.exe",
+            );
+        }
+        let p = resolve_launcher_path();
+        // override 路径不存在 → 跌回 sibling-of-exe 或裸文件名
+        assert!(
+            p.file_name().is_some_and(|n| n == LAUNCHER_BIN),
+            "expected fallback to {LAUNCHER_BIN}, got {}",
+            p.display()
+        );
+        unsafe {
+            match prev {
+                Some(v) => std::env::set_var(LAUNCHER_PATH_ENV, v),
+                None => std::env::remove_var(LAUNCHER_PATH_ENV),
+            }
+        }
+    }
+}

--- a/crates/dasclaw_sandbox/src/windows/mod.rs
+++ b/crates/dasclaw_sandbox/src/windows/mod.rs
@@ -51,15 +51,19 @@
 #![cfg(target_os = "windows")]
 
 pub mod job_object;
+mod launcher_client;
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use dasclaw_sandbox_windows::absolute_path::AbsolutePathBuf;
+use dasclaw_sandbox_windows::sandbox_setup_is_complete;
 use dasclaw_sandbox_windows::types::{NetworkAccess, SandboxPolicy as UpstreamPolicy};
-use dasclaw_sandbox_windows::{run_windows_sandbox_capture, sandbox_setup_is_complete};
 
-use crate::{Sandbox, SandboxBackendConfig, SandboxError, SandboxExecRequest, SandboxType};
+use crate::launcher_ipc::{LauncherRequest, OuterJobLimitsWire, PROTOCOL_VERSION};
+use crate::{
+    ResourceLimits, Sandbox, SandboxBackendConfig, SandboxError, SandboxExecRequest, SandboxType,
+};
 
 /// Windows restricted-token sandbox backend.
 ///
@@ -106,27 +110,45 @@ impl Sandbox for WindowsRestrictedTokenSandbox {
         let policy_json = serde_json::to_string(&upstream_policy)
             .map_err(|e| SandboxError::PolicyTransform(format!("serialize policy: {e}")))?;
 
-        // 3. dispatch
-        let capture = run_windows_sandbox_capture(
-            &policy_json,
-            &parts.cwd,
-            &dasclaw_home,
-            parts.argv,
-            &parts.cwd,
-            parts.env,
-            None,  // timeout — outer caller (OsExecutor) wraps with tokio timeout
-            false, // use_private_desktop=false: keep first-use UX simple; flip in Phase 1.3 / hardening
-        )
-        .map_err(|e| {
-            SandboxError::Io(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                e.to_string(),
-            ))
-        })?;
+        // 3. ResourceLimits → outer Job Object wire form
+        let outer_limits = build_outer_limits(&req.policy.resource_limits);
 
-        // 4. CaptureResult → std::process::Output
-        Ok(capture_result_to_output(capture))
+        // 4. spawn launcher binary（ADR-131 side-by-side wrapper）
+        let request = LauncherRequest {
+            protocol_version: PROTOCOL_VERSION,
+            argv: parts.argv,
+            cwd: parts.cwd,
+            env: parts.env,
+            dasclaw_home,
+            policy_json,
+            outer_limits,
+            // use_private_desktop=false：维持 first-use UX 简单；Phase 1.3 / hardening 时再切换。
+            use_private_desktop: false,
+        };
+
+        launcher_client::spawn_and_capture(request)
     }
+}
+
+/// 把 [`ResourceLimits`] 投影到 launcher IPC 的 [`OuterJobLimitsWire`]。
+///
+/// 全部字段为 `None` 时返回 `None`，让 launcher 跳过 outer Job Object 创建
+/// （它仍会调 `run_windows_sandbox_capture`，沙箱内层自身的 inner Job Object
+/// 由 `dasclaw_sandbox_windows` 上游负责）。
+///
+/// `max_processes` 是 `Option<u64>`，但 Windows `JOB_OBJECT_BASIC_LIMIT.ActiveProcessLimit`
+/// 是 `u32`。`u64 → u32` 失败时静默丢弃该字段（保留其它限制），不让
+/// 整个 outer 配置失败 —— 因为 4 GiB 内存上限仍然有意义。
+fn build_outer_limits(rl: &ResourceLimits) -> Option<OuterJobLimitsWire> {
+    let any = rl.max_memory_bytes.is_some() || rl.max_processes.is_some();
+    if !any {
+        return None;
+    }
+    Some(OuterJobLimitsWire {
+        max_process_memory_bytes: rl.max_memory_bytes,
+        max_job_memory_bytes: None,
+        max_active_processes: rl.max_processes.and_then(|n| u32::try_from(n).ok()),
+    })
 }
 
 /// Decomposed [`std::process::Command`] suitable for the upstream
@@ -220,19 +242,6 @@ fn backend_config_to_upstream_policy(
             exclude_tmpdir_env_var: false,
             exclude_slash_tmp: false,
         })
-    }
-}
-
-fn capture_result_to_output(
-    capture: dasclaw_sandbox_windows::CaptureResult,
-) -> std::process::Output {
-    use std::os::windows::process::ExitStatusExt;
-
-    let status = std::process::ExitStatus::from_raw(capture.exit_code as u32);
-    std::process::Output {
-        status,
-        stdout: capture.stdout,
-        stderr: capture.stderr,
     }
 }
 


### PR DESCRIPTION
## 背景 / 目标

ADR-131 §4 **Slice B3 — adapter 接入**：把 `WindowsRestrictedTokenSandbox::execute` 重构为 spawn `dasclaw-sandbox-resource-launcher.exe`；launcher 真实创建外层 Job Object（B2 `JobObject::create_with_limits`）+ `AssignProcessToJobObject(GetCurrentProcess())`，再同进程调 `run_windows_sandbox_capture`。Win 8+ 嵌套 Job Object 默认继承让沙箱目标进程**自动**收到外层资源限制，无需修改 `dasclaw_sandbox_windows` verbatim crate（ADR-129 §1.3 红线）。

依赖：B1 PR #329 + B2 PR #328（已 merge）。

## 改动范围

| 文件 | 性质 | 说明 |
|---|---|---|
| `crates/dasclaw_sandbox/src/windows/launcher_client.rs` | 新增 | spawn launcher / IPC / base64 解码 / `Output` 组装；`resolve_launcher_path` 三层优先级；3 个路径解析单元测试 |
| `crates/dasclaw_sandbox/src/windows/mod.rs` | 改 | `execute` 改 spawn launcher；新增 `build_outer_limits(&ResourceLimits) -> Option<OuterJobLimitsWire>`；**删除** dead `capture_result_to_output` |
| `crates/dasclaw_sandbox/src/bin/resource_launcher_win.rs` | 重写 | dry-run → 真实 `JobObject` + `assign_current_process` + `run_windows_sandbox_capture`；`base64` crate 替换内嵌实现；RAII guard 绑 main 局部 |
| `crates/dasclaw_sandbox/Cargo.toml` | 改 | windows-only deps 加 `base64 = "0.22"` |
| `Cargo.lock` | 改 | 同步 |

## 非目标（What's NOT in this PR — 禁止补丁式代码）

- ❌ 不修改 `dasclaw_sandbox_windows` verbatim crate（ADR-129 §1.3 红线）
- ❌ 不刷新 `ResourceLimits` doc-comment（B4 处理）
- ❌ 不动 ADR-45 / ADR-50 / ADR-51（B4 处理）
- ❌ 不写 Windows-only 集成测试（需 Windows runner + 真实 sandbox-setup 状态，Phase 1.3 hardening 统一覆盖）
- ❌ adapter 内**没有** flag 切换 / fallback 直调路径；新代码完全替换旧路径，旧 dead code 已删除

## 设计要点

1. **launcher 路径解析**：`DASCLAW_SANDBOX_LAUNCHER_PATH` env → `current_exe()` 同目录 → 裸文件名走 PATH。生产部署形态把 launcher 与主 binary 一起 ship。
2. **嵌套 Job Object**：launcher 自身被 outer job 覆盖；`run_windows_sandbox_capture` 同进程 spawn 的沙箱目标默认继承外层（Win 8+ semantics）。`dasclaw_sandbox_windows` 内层 Job Object 与外层互不冲突。
3. **`build_outer_limits` 投影**：`ResourceLimits.max_memory_bytes` → `OuterJobLimits.max_process_memory_bytes`；`max_processes: u64` → `max_active_processes: u32`（溢出时静默丢弃该字段，不让整个 outer 配置失败）。两字段全为 `None` 时整体返回 `None`，launcher 跳过 outer Job Object 创建。
4. **失败语义清晰分层**：spawn / IPC / base64 / 协议版本不匹配 → `WindowsLauncherFailed { detail }`；setup 未跑 → `WindowsSetupPending { detail }`（保留）。调用方按变体区分 UX。
5. **RAII 寿命**：launcher main 把 `JobObject` 绑到 `_outer_guard` 局部变量，**必须**横跨 `run_windows_sandbox_capture` 调用；guard drop 触发 `KILL_ON_JOB_CLOSE` 兜底。

## 验证（6 步本地流水线 — macOS 路径）

| Step | 命令 | 结果 |
|---|---|---|
| 1 | `cargo check -p dasclaw_sandbox --all-targets` | ✅ Finished |
| 2 | `cargo nextest run -p dasclaw_sandbox` | ✅ **40 passed**（cfg(windows) 测试在 macOS skip） |
| 3 | `cargo fmt --all` | ✅ |
| 4 | `python3.12 scripts/check_no_panics.py --base origin/xClaw` | ✅ No panic-inducing calls |
| 5 | `python3 scripts/check_no_new_ironclaw_literal.py --base origin/xClaw` | ✅ No new literals |
| 6 | `cargo clippy --no-deps -p dasclaw_sandbox --all-targets -- -D warnings` | ✅ Finished |

Windows-only 真实编译 + cfg(windows) 单元测试（B2 的 7 个 + B3 的 3 个 launcher_path 测试）由 Windows CI（`.github/workflows/windows-ci.yml`，已含 `crates/dasclaw_sandbox/**` path filter）兜底。

## 后续

**B4（doc 同步）**：刷新 `lib.rs` `ResourceLimits` doc-comment 中"future / silently ignored on Windows"标记；更新 ADR-45 §"Axis 3 — Windows" / ADR-50 status 表 / ADR-51 cross-platform matrix；ADR-131 状态从 Accepted 推进到 Implemented。

Closes #332
Refs #34


---

## Update — Windows CI 状态说明（2026-05-08）

打过 `windows-ci` label 后跑过一次 Windows Build，**3 个 matrix 全 fail**。已确认全部错误都在 `crates/dasclaw_sandbox_windows`（ADR-129 §1.3 verbatim port，禁止修改），**没有任何错误在本 PR 修改的 `crates/dasclaw_sandbox`**。

历史定时跑（`xClaw` 分支 2026-05-03 schedule run `25271298003`）也 fail，是 base 长期欠债，不是本 PR 引入。详见 #335。

按 AGENTS.md "Base 分支既有 broken 测试处置规范"：
- B3 不负担修 verbatim port 的 build infra（属红线之外的独立工作）
- 已移除 `windows-ci` label，避免本 PR 被 base 欠债阻塞
- 等 #335 解决后，B4 slice 内重新打 label 跑回归
