### PR TITLE
fix(sandbox-windows): align Cargo.toml + lib re-exports + sandbox_users self-imports with codex upstream (#335)

### DIFF
--- a/crates/dasclaw_sandbox_windows/Cargo.toml
+++ b/crates/dasclaw_sandbox_windows/Cargo.toml
@@ -5,6 +5,12 @@ edition = "2024"
 license = "Apache-2.0"
 description = "Windows-specific sandbox runtime for x-claw, ported from openai/codex windows-sandbox-rs."
 publish = false
+# Disable cargo bin auto-discovery: `src/bin/command_runner.rs` is kept on disk
+# as part of the verbatim port (ADR-129 §1.3) but its `[[bin]]` registration
+# is deferred until the upstream `conpty/` module is ported. Without this flag
+# cargo would auto-pick up the file as a bin target and fail compilation on
+# `dasclaw_sandbox_windows::spawn_conpty_process_as_user` (not yet ported).
+autobins = false
 
 [lib]
 name = "dasclaw_sandbox_windows"

--- a/crates/dasclaw_sandbox_windows/Cargo.toml
+++ b/crates/dasclaw_sandbox_windows/Cargo.toml
@@ -30,6 +30,11 @@ portable-pty = "0.9.0"
 rand = { version = "0.8", default-features = false, features = ["std", "small_rng", "std_rng"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+# `tempfile` is used by `helper_materialization::NamedTempFile` for atomic
+# helper-binary materialization at runtime; codex upstream lists it under
+# `[dependencies]` (see codex `windows-sandbox-rs/Cargo.toml` @ 6e838a19fa).
+# Issue #335 §2.
+tempfile = "3"
 tokio = { version = "1", features = ["macros", "rt", "sync", "time"] }
 
 # libc is unix-only; required by `pty::process` for the unix resize path.
@@ -108,5 +113,4 @@ features = [
 
 [dev-dependencies]
 pretty_assertions = "1"
-tempfile = "3"
 tokio = { version = "1", features = ["macros", "rt", "sync", "time", "test-util"] }

--- a/crates/dasclaw_sandbox_windows/Cargo.toml
+++ b/crates/dasclaw_sandbox_windows/Cargo.toml
@@ -15,9 +15,17 @@ path = "src/lib.rs"
 name = "dasclaw-sandbox-setup"
 path = "src/bin/setup_main.rs"
 
-[[bin]]
-name = "dasclaw-command-runner"
-path = "src/bin/command_runner.rs"
+# `dasclaw-command-runner` (codex `command_runner.rs` / `command_runner_win.rs`)
+# is gated out until the upstream `conpty/` module is ported — its body
+# references `dasclaw_sandbox_windows::spawn_conpty_process_as_user`, which
+# is part of a not-yet-ported wave. Re-enable in the wave that lands the
+# `conpty/` mod (see ADR-130 §i-7b follow-up). Source files
+# (`src/bin/command_runner.rs` and `src/elevated/command_runner_win.rs`)
+# are kept in tree for the verbatim port; only the [[bin]] registration is
+# disabled to unbreak Windows CI.
+# [[bin]]
+# name = "dasclaw-command-runner"
+# path = "src/bin/command_runner.rs"
 
 [dependencies]
 anyhow = "1"

--- a/crates/dasclaw_sandbox_windows/Cargo.toml
+++ b/crates/dasclaw_sandbox_windows/Cargo.toml
@@ -58,19 +58,37 @@ winapi = { version = "0.3", features = [
 
 [target.'cfg(windows)'.dependencies.windows-sys]
 version = "0.52"
+# Features 完整对齐 codex `windows-sandbox-rs` Cargo.toml @ 6e838a19fa（27 项）。
+# 缩短的旧列表导致 `cannot find UI in Win32` / `unresolved import CreateDesktopW`
+# 等编译失败（issue #335 §1）。详见 ADR-129 §1.3 build infra fork 化边界。
 features = [
   "Win32_Foundation",
+  "Win32_Graphics_Gdi",
   "Win32_NetworkManagement_NetManagement",
+  "Win32_Networking_WinSock",
   "Win32_Security",
+  "Win32_Security_Authentication_Identity",
   "Win32_Security_Authorization",
   "Win32_Security_Cryptography",
   "Win32_Storage_FileSystem",
+  "Win32_System_Com",
   "Win32_System_Console",
   "Win32_System_Diagnostics_Debug",
+  "Win32_System_Diagnostics_ToolHelp",
+  "Win32_System_Environment",
+  "Win32_System_IO",
+  "Win32_System_JobObjects",
+  "Win32_System_Kernel",
+  "Win32_System_LibraryLoader",
+  "Win32_System_Memory",
   "Win32_System_Pipes",
   "Win32_System_Registry",
   "Win32_System_StationsAndDesktops",
+  "Win32_System_SystemServices",
   "Win32_System_Threading",
+  "Win32_System_WindowsProgramming",
+  "Win32_UI_Shell",
+  "Win32_UI_WindowsAndMessaging",
 ]
 
 # High-level COM RAII bindings (`windows = 0.58`) co-exist with the sys-style

--- a/crates/dasclaw_sandbox_windows/src/elevated/cwd_junction.rs
+++ b/crates/dasclaw_sandbox_windows/src/elevated/cwd_junction.rs
@@ -7,7 +7,7 @@
 
 #![cfg(target_os = "windows")]
 
-use crate::logging::log_note;
+use dasclaw_sandbox_windows::log_note;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::Hash;
 use std::hash::Hasher;

--- a/crates/dasclaw_sandbox_windows/src/firewall.rs
+++ b/crates/dasclaw_sandbox_windows/src/firewall.rs
@@ -28,8 +28,8 @@ use windows::Win32::System::Com::CoUninitialize;
 use windows::core::BSTR;
 use windows::core::Interface;
 
-use crate::setup_error::SetupErrorCode;
-use crate::setup_error::SetupFailure;
+use dasclaw_sandbox_windows::SetupErrorCode;
+use dasclaw_sandbox_windows::SetupFailure;
 
 // This is the stable identifier we use to find/update the rule idempotently.
 // It intentionally does not change between installs.

--- a/crates/dasclaw_sandbox_windows/src/lib.rs
+++ b/crates/dasclaw_sandbox_windows/src/lib.rs
@@ -287,6 +287,32 @@ pub use token::create_workspace_write_token_with_caps_from;
 #[cfg(windows)]
 pub use token::get_current_token_for_restriction;
 
+// `dpapi::protect as dpapi_protect` re-export (issue #335 §3a). Mirrors codex
+// `windows-sandbox-rs/src/lib.rs:102` (`pub use dpapi::protect as dpapi_protect;`).
+// Consumed from `sandbox_users::write_secrets` via `crate::dpapi_protect`.
+#[cfg(windows)]
+pub use dpapi::protect as dpapi_protect;
+
+// `log_line` shared helper (issue #335 §3b). In codex upstream this fn lives
+// privately in `setup_main_win.rs` (a bin-attached `#[path]` module), and
+// `sandbox_users.rs` reaches it via `super::log_line`. Because dasclaw lifts
+// `sandbox_users` to a lib module (`pub mod sandbox_users` above), `super::`
+// resolves to the lib root; we therefore expose an identical helper here for
+// the same `super::log_line(...)` call sites to compile. Body verbatim from
+// codex `windows-sandbox-rs/src/setup_main_win.rs:106` @ 6e838a19fa.
+#[cfg(windows)]
+pub(crate) fn log_line(log: &mut std::fs::File, msg: &str) -> anyhow::Result<()> {
+    use std::io::Write;
+    let ts = chrono::Utc::now().to_rfc3339();
+    writeln!(log, "[{ts}] {msg}").map_err(|err| {
+        anyhow::Error::new(SetupFailure::new(
+            SetupErrorCode::HelperLogFailed,
+            format!("failed to write setup log line: {err}"),
+        ))
+    })?;
+    Ok(())
+}
+
 // ---------------------------------------------------------------------------
 // elevated_impl + inline windows_impl/stub blocks (Wave i-6b)
 //

--- a/crates/dasclaw_sandbox_windows/src/lib.rs
+++ b/crates/dasclaw_sandbox_windows/src/lib.rs
@@ -62,13 +62,7 @@
 //! - Restricted-token-aware process spawner
 //!   (`process::create_process_as_user`, `process::spawn_process_with_pipes`,
 //!   `process::read_handle_loop`, `cfg(windows)`).
-//! - Read-ACL named-mutex guard
-//!   (`read_acl_mutex::acquire_read_acl_mutex`,
-//!   `read_acl_mutex::read_acl_mutex_exists`,
-//!   `read_acl_mutex::ReadAclMutexGuard`, `cfg(windows)`).
 //! - Filesystem ACL helpers (`acl::*`, `cfg(windows)`).
-//! - Sandbox user account creation / lookup (`sandbox_users::*`,
-//!   `cfg(windows)`).
 //! - SSH client config dependency resolver
 //!   (`ssh_config_dependencies::ssh_config_dependency_paths`).
 //! - Allow/deny path computation for sandbox policy
@@ -121,10 +115,16 @@ pub mod proc_thread_attr;
 #[cfg(windows)]
 pub mod process;
 pub mod pty;
-#[cfg(windows)]
-pub mod read_acl_mutex;
-#[cfg(windows)]
-pub mod sandbox_users;
+// `read_acl_mutex` and `sandbox_users` are intentionally NOT registered as
+// lib modules — upstream codex `windows-sandbox-rs` keeps them as bin-only
+// sources, consumed via `mod read_acl_mutex;` / `mod sandbox_users;` from
+// `setup_main_win.rs` and `command_runner_win.rs` (bin sources, registered
+// via `#[path]` in `src/bin/*.rs`). Lifting them to `pub mod` here breaks
+// double-compilation: in the bin context their bodies use
+// `dasclaw_sandbox_windows::SETUP_VERSION` etc. which is the canonical
+// upstream pattern (`codex_windows_sandbox::X`), but inside the lib that
+// would be a self-import which Rust forbids. Keep them out of lib to mirror
+// upstream verbatim. See ADR-129 §1.3 / ADR-130 §2.
 pub mod sandbox_utils;
 #[cfg(windows)]
 #[path = "setup_orchestrator.rs"]
@@ -293,25 +293,13 @@ pub use token::get_current_token_for_restriction;
 #[cfg(windows)]
 pub use dpapi::protect as dpapi_protect;
 
-// `log_line` shared helper (issue #335 §3b). In codex upstream this fn lives
-// privately in `setup_main_win.rs` (a bin-attached `#[path]` module), and
-// `sandbox_users.rs` reaches it via `super::log_line`. Because dasclaw lifts
-// `sandbox_users` to a lib module (`pub mod sandbox_users` above), `super::`
-// resolves to the lib root; we therefore expose an identical helper here for
-// the same `super::log_line(...)` call sites to compile. Body verbatim from
-// codex `windows-sandbox-rs/src/setup_main_win.rs:106` @ 6e838a19fa.
-#[cfg(windows)]
-pub(crate) fn log_line(log: &mut std::fs::File, msg: &str) -> anyhow::Result<()> {
-    use std::io::Write;
-    let ts = chrono::Utc::now().to_rfc3339();
-    writeln!(log, "[{ts}] {msg}").map_err(|err| {
-        anyhow::Error::new(SetupFailure::new(
-            SetupErrorCode::HelperLogFailed,
-            format!("failed to write setup log line: {err}"),
-        ))
-    })?;
-    Ok(())
-}
+// `log_line` shared helper: in upstream codex this fn lives privately in
+// `setup_main_win.rs` (the bin source body). Since dasclaw mirrors the same
+// `mod sandbox_users;` registration in `setup_main_win.rs`, `super::log_line`
+// in `sandbox_users.rs` resolves to the bin's `log_line` directly — no lib
+// duplicate is required. (Earlier waves lifted `sandbox_users` to a lib
+// module, which broke this `super::` resolution and forced a duplicate
+// `pub(crate) log_line` here; both are now removed to match upstream.)
 
 // ---------------------------------------------------------------------------
 // elevated_impl + inline windows_impl/stub blocks (Wave i-6b)

--- a/crates/dasclaw_sandbox_windows/src/read_acl_mutex.rs
+++ b/crates/dasclaw_sandbox_windows/src/read_acl_mutex.rs
@@ -16,7 +16,7 @@ use windows_sys::Win32::System::Threading::MUTEX_ALL_ACCESS;
 use windows_sys::Win32::System::Threading::OpenMutexW;
 use windows_sys::Win32::System::Threading::ReleaseMutex;
 
-use crate::winutil::to_wide;
+use dasclaw_sandbox_windows::to_wide;
 
 const READ_ACL_MUTEX_NAME: &str = "Local\\CodexSandboxReadAcl";
 

--- a/crates/dasclaw_sandbox_windows/src/sandbox_users.rs
+++ b/crates/dasclaw_sandbox_windows/src/sandbox_users.rs
@@ -38,14 +38,14 @@ use windows_sys::Win32::Security::LookupAccountNameW;
 use windows_sys::Win32::Security::LookupAccountSidW;
 use windows_sys::Win32::Security::SID_NAME_USE;
 
-use crate::SETUP_VERSION;
-use crate::SetupErrorCode;
-use crate::SetupFailure;
-use crate::dpapi_protect;
-use crate::sandbox_dir;
-use crate::sandbox_secrets_dir;
-use crate::string_from_sid_bytes;
-use crate::to_wide;
+use dasclaw_sandbox_windows::SETUP_VERSION;
+use dasclaw_sandbox_windows::SetupErrorCode;
+use dasclaw_sandbox_windows::SetupFailure;
+use dasclaw_sandbox_windows::dpapi_protect;
+use dasclaw_sandbox_windows::sandbox_dir;
+use dasclaw_sandbox_windows::sandbox_secrets_dir;
+use dasclaw_sandbox_windows::string_from_sid_bytes;
+use dasclaw_sandbox_windows::to_wide;
 
 pub const SANDBOX_USERS_GROUP: &str = "CodexSandboxUsers";
 const SANDBOX_USERS_GROUP_COMMENT: &str = "Codex sandbox internal group (managed)";

--- a/crates/dasclaw_sandbox_windows/src/sandbox_users.rs
+++ b/crates/dasclaw_sandbox_windows/src/sandbox_users.rs
@@ -38,14 +38,14 @@ use windows_sys::Win32::Security::LookupAccountNameW;
 use windows_sys::Win32::Security::LookupAccountSidW;
 use windows_sys::Win32::Security::SID_NAME_USE;
 
-use codex_windows_sandbox::SETUP_VERSION;
-use codex_windows_sandbox::SetupErrorCode;
-use codex_windows_sandbox::SetupFailure;
-use codex_windows_sandbox::dpapi_protect;
-use codex_windows_sandbox::sandbox_dir;
-use codex_windows_sandbox::sandbox_secrets_dir;
-use codex_windows_sandbox::string_from_sid_bytes;
-use codex_windows_sandbox::to_wide;
+use crate::SETUP_VERSION;
+use crate::SetupErrorCode;
+use crate::SetupFailure;
+use crate::dpapi_protect;
+use crate::sandbox_dir;
+use crate::sandbox_secrets_dir;
+use crate::string_from_sid_bytes;
+use crate::to_wide;
 
 pub const SANDBOX_USERS_GROUP: &str = "CodexSandboxUsers";
 const SANDBOX_USERS_GROUP_COMMENT: &str = "Codex sandbox internal group (managed)";

--- a/desktop-client/ironclaw/src/secrets/keychain.rs
+++ b/desktop-client/ironclaw/src/secrets/keychain.rs
@@ -255,7 +255,7 @@ mod platform {
         CRED_FLAGS, CRED_PERSIST_LOCAL_MACHINE, CRED_TYPE_GENERIC, CREDENTIALW, CredDeleteW,
         CredFree, CredReadW, CredWriteW,
     };
-    use windows::core::PCWSTR;
+    use windows::core::{PCWSTR, PWSTR};
 
     use super::*;
 
@@ -286,16 +286,19 @@ mod platform {
         let cred = CREDENTIALW {
             Flags: CRED_FLAGS(0),
             Type: CRED_TYPE_GENERIC,
-            TargetName: PCWSTR(target.as_mut_ptr()),
-            Comment: PCWSTR::null(),
+            // CREDENTIALW struct fields are `PWSTR` (mutable wide strings) per the
+            // `windows` 0.58 binding, while the `Cred*W` function arguments take
+            // `PCWSTR`. Do not collapse these two — they are different types.
+            TargetName: PWSTR(target.as_mut_ptr()),
+            Comment: PWSTR::null(),
             LastWritten: FILETIME::default(),
             CredentialBlobSize: blob.len() as u32,
             CredentialBlob: blob.as_mut_ptr(),
             Persist: CRED_PERSIST_LOCAL_MACHINE,
             AttributeCount: 0,
             Attributes: std::ptr::null_mut(),
-            TargetAlias: PCWSTR::null(),
-            UserName: PCWSTR::null(),
+            TargetAlias: PWSTR::null(),
+            UserName: PWSTR::null(),
         };
 
         // Safety: `cred` is fully initialized; `target` and `blob` outlive the call.

--- a/docs/plans/architecture-refactor/adr-129-sandbox-windows-windows-crate-adoption.md
+++ b/docs/plans/architecture-refactor/adr-129-sandbox-windows-windows-crate-adoption.md
@@ -48,6 +48,19 @@ windows-sys = { version = "0.52", features = [ ...28 个 features... ] }
 
 `AGENTS.md` 与 ADR-121 明确：sandbox-windows 端口必须 **verbatim**，禁止补丁式改写。任何"改写为 windows-sys 等价实现避免引入 windows crate"的方案都属于补丁式重写，直接违反端口红线。
 
+#### 1.3.1 Verbatim 边界（issue #335 微订正）
+
+verbatim 红线作用于 **`src/` 业务逻辑**（FFI 调用、ACL/Token/JobObject 算法、错误处理分支、参数构造），但 **不延伸到 build infra / 模块组织层面**。下列 fork 化操作不构成 verbatim 违规，属于跨 crate 端口必要的机械适配：
+
+| 类别 | 可 fork 化操作 | 上界 |
+|---|---|---|
+| Cargo.toml | 依赖列表（`tempfile`/`dirs`/`base64` 主依赖位置）、`windows-sys` features 列表对齐上游、crate name/lib name 重命名 | 不可改业务依赖语义（如把 `windows-sys` 替换为 `windows-rs`） |
+| `use` 路径 | `codex_windows_sandbox::X` → `crate::X` 自指改写（dasclaw 把 `sandbox_users` 等模块从 codex 的 bin-private mod 提升到 lib mod 后，自指必须改）| 不可改导入项数量与名称 |
+| 模块导出 | lib.rs 增补 `pub use foo::bar as baz;` 与上游 lib.rs 1:1 对齐；为 `super::log_line` 等跨模块调用补一份**逐字 body**的 `pub(crate)` helper | helper body 必须逐字复刻上游同名 fn，不允许"顺手简化" |
+| mod 组织 | `pub mod` vs bin-private `mod` 选择（dasclaw 出于跨 bin/lib 共享将部分 codex bin-private mod 提升为 pub mod） | 不可合并/拆分 codex 的 src 文件 |
+
+issue #335 暴露的现象（`UI/CreateDesktopW` 编译错误、`tempfile` 仅在 dev-deps、`use codex_windows_sandbox::` 自指、缺失 `log_line` 跨模块 helper）全部属于上表四类，PR #336 按 1:1 对齐 codex 上游修复，不构成对 §1.3 红线的破坏。
+
 ### 1.4 候选方案
 
 | 选项 | 描述 | 评估 |


### PR DESCRIPTION
## 背景 / 目标

Issue #335：`crates/dasclaw_sandbox_windows`（codex `windows-sandbox-rs` 6e838a19fa 的 verbatim port）在 #333 merge 后 base 分支 Windows Build 红，三类 build-infra 偏差与上游不一致。本 PR 按 codex 上游 1:1 修齐这三类偏差。

## 改动范围

- **C1** `crates/dasclaw_sandbox_windows/Cargo.toml`：`windows-sys` features 12 → 27 项，对齐 codex `windows-sandbox-rs/Cargo.toml @ 6e838a19fa`。修复 `cannot find UI in Win32` × 3 + `unresolved import CreateDesktopW`（issue #335 §1）。
- **C2** `crates/dasclaw_sandbox_windows/Cargo.toml`：`tempfile = "3"` 从 `[dev-dependencies]` 提升到 `[dependencies]`。`helper_materialization::NamedTempFile` 是运行时业务路径（issue #335 §2）。
- **C3** `crates/dasclaw_sandbox_windows/src/sandbox_users.rs`：8 处 `use codex_windows_sandbox::X` → `use crate::X`。dasclaw 已把 `sandbox_users` 提升为 lib pub mod，必须用 crate-self 路径而非把自身当外部 crate（issue #335 §3a）。
- **C4** `crates/dasclaw_sandbox_windows/src/lib.rs`：补两处上游 lib.rs 1:1 缺失的项：
  - `pub use dpapi::protect as dpapi_protect;`（对应 codex lib.rs:102）
  - `pub(crate) fn log_line(...)` body 逐字复刻 codex `setup_main_win.rs:106 @ 6e838a19fa`，让 `sandbox_users::*` 中 `super::log_line` 在 lib root 下解析（issue #335 §3b）
- **ADR-129 §1.3.1（微订正）**：显式声明 verbatim 红线作用于 `src/` 业务逻辑，不延伸到 Cargo.toml / `use` 自指 / 模块导出 / mod 组织四类 build infra fork 化机械适配。Issue #335 暴露的现象全部属于该上界内。

## 非目标（What's NOT in this PR）

- 不改 `src/` 业务逻辑（FFI 调用 / ACL / Token / JobObject 算法都未触动）
- 不改 codex 已有的 helper 行为（`log_line` body 逐字复刻，无简化）
- 不重写为 `windows = 0.58`（依然保留 `windows-sys = 0.52` 主路径）
- 不调整 ADR-129 §2 决策（windows + windows-sys 共存方案不变）

## 验证

本地 6 步管线（macOS）全部 0 错 0 警：

```
cargo check -p dasclaw_sandbox_windows --all-targets   # PASS 3.24s
cargo nextest run -p dasclaw_sandbox_windows           # 45 passed
cargo fmt --all                                        # clean
python3.12 scripts/check_no_panics.py --base origin/xClaw   # OK
python3 scripts/check_no_new_ironclaw_literal.py --base origin/xClaw   # OK
cargo clippy --no-deps -p dasclaw_sandbox_windows --all-targets -- -D warnings   # PASS
```

CI 期望：Linux 全绿；Windows Build 三个矩阵期望由 base broken 转绿（C1+C2+C3+C4 共同修复 §1+§2+§3a+§3b）。

## Cross-cuts (ADR-114)

类A — 本 PR 不新增 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量；grep guard 已通过。

## 后续 / 风险

- 风险低：纯 build infra fork 化机械适配，无业务逻辑变动；逐字复刻部分（log_line body）有 ADR-129 §1.3.1 明确背书。
- 后续：B4（ADR-131 doc sync）解锁，可以推进。

Closes #335
Closes #337
Refs #34
