### PR TITLE
docs(plans): refresh 32/35 sandbox docs to match Phase 1.1.4j+1.2 reality (#326 Part 1)

### DIFF
--- a/docs/plans/architecture-refactor/32-execution-plan.md
+++ b/docs/plans/architecture-refactor/32-execution-plan.md
@@ -143,6 +143,7 @@
 2. **新建 crate 骨架**（无实现，仅目录 + Cargo.toml + lib.rs trait）
    - crates/dasclaw_core                ← 由 x_claw_agent 升级，文件保留原路径，crate name 在 W6 切换
    - crates/dasclaw_sandbox
+   - crates/dasclaw_sandbox_windows    ← v2.5+ 新增（verbatim port from codex `windows-sandbox-rs`，见 ADR-129 / ADR-130；已实际落地 Phase 1.1.4j）
    - crates/dasclaw_pty                  ← v2 新增
    - crates/dasclaw_hooks
    - crates/dasclaw_apply_patch
@@ -188,7 +189,7 @@ W1 失败：恢复 desktop-client/ironclaw 子模块（git revert）。
 1. **从 codex-cli-main port sandbox**（参见 [35 §C](35-codex-capability-inventory.md)）：
    - codex-cli-main/codex-rs/linux-sandbox → dasclaw_sandbox/src/linux/
    - codex-cli-main/codex-rs/sandboxing（macOS seatbelt + .sbpl） → dasclaw_sandbox/src/macos/
-   - codex-cli-main/codex-rs/core/windows_sandbox.rs + windows_sandbox_read_grants.rs → dasclaw_sandbox/src/windows/
+   - codex-cli-main/codex-rs/windows-sandbox-rs/ → dasclaw_sandbox_windows/（verbatim，ADR-129） + dasclaw_sandbox/src/windows/（adapter 代 dasclaw_sandbox 调用 verbatim crate，ADR-130）。注：v2.5 之前计划为 `core/src/windows_sandbox.rs + windows_sandbox_read_grants.rs`，codex 上游已拆为独立 crate，dasclaw 跟进拆分。
    - codex-cli-main/codex-rs/process-hardening → dasclaw_sandbox/src/hardening.rs
 2. **抽 trait**：`pub trait Sandbox { fn execute(&self, cmd: Command) -> Result<Output>; }`
 3. **保留 ironclaw Docker 沙箱**作为高隔离备选实现（trait 多实现）
@@ -215,7 +216,7 @@ W1 失败：恢复 desktop-client/ironclaw 子模块（git revert）。
 ### 验收
 - [ ] 三平台单元测试通过（CI matrix 覆盖 ubuntu/macos/windows）
 - [ ] 失败路径测试：沙箱不可用时工具调用被拒绝，不降级为直接 exec
-- [ ] **WritableRoot 洞中洞契约测试**：sandbox 在 WorkspaceWrite 模式下写 `.git/hooks/*`、`.codex/*`、`.git/config` 必须返回 SandboxError，且无任何 fallback
+- [ ] **WritableRoot 洞中洞契约测试**：sandbox 在 WorkspaceWrite 模式下写 `.git/hooks/*`、`.codex/*`、`.git/config` 必须返回 SandboxError，且无任何 fallback。**已知限制（v2.5 补充）**：当前仅在 `dasclaw_sandbox` adapter 层检查，内核层强制（Linux Landlock-based subpath deny / macOS Seatbelt subpath deny / Windows Restricted Token DACL）跟进补强由 [#324 sub-task 2](https://github.com/Linnanli/xClaw/issues/324) 追踪
 - [ ] **ExternalSandbox 嵌套测试**：在 docker 容器内启动 desktop-client，agent 工具调用走 ExternalSandbox 模式，network_access 由 NetworkAccess 枚举决定
 - [ ] 性能基准：进程沙箱启动 < 50ms（对比 codex 基线）
 - [ ] PTY resize/信号转发 在 macOS+Linux 各 1 个示例脚本过

--- a/docs/plans/architecture-refactor/35-codex-capability-inventory.md
+++ b/docs/plans/architecture-refactor/35-codex-capability-inventory.md
@@ -39,18 +39,18 @@
 |---|---|------:|---|:---:|:---:|---|
 | A | Agent Runtime | ~5,000 | `core/src/session/`、`core/src/agent/` | ⚠️ 各有所长 | ⭐⭐⭐⭐⭐ | 选择性移植 AgentControl fork 策略 |
 | B | Tool 系统 | ~8,000 | `core/src/tools/`、`apply-patch/`、`unified_exec/`、`code_mode/` | ⚠️ 工具不同 | ⭐⭐⭐⭐⭐ | apply-patch + portable-pty + code_mode 移植 |
-| C | Sandbox | ~4,500 | `sandboxing/`、`linux-sandbox/`、`core/src/windows_sandbox.rs`、`process-hardening/` | ✅ 三平台覆盖更全 | ⭐⭐⭐⭐⭐ | **完整移植到 dasclaw_sandbox** |
+| C | Sandbox | ~4,500 | `sandboxing/`、`linux-sandbox/`、`windows-sandbox-rs/`（独立 crate，上游 · 之前为 `core/src/windows_sandbox.rs ~1200 行`，v2.5 拆出）、`process-hardening/` | ✅ 三平台覆盖更全 | ⭐⭐⭐⭐⭐ | **完整移植到 dasclaw_sandbox + dasclaw_sandbox_windows（verbatim，ADR-129/130）** |
 | D | Hooks | ~2,150 | `hooks/`（schema/registry/engine 三分离） | ✅ 设计更干净 | ⭐⭐⭐⭐ | 移植到 dasclaw_hooks |
 | E | Project Docs | ~3,300 | `core/src/agents_md.rs`、`config/src/agents_md_index.rs` | ⚠️ 多层加载等价 | ⭐⭐⭐⭐ | 移植到 dasclaw_project_docs |
 | F | Bash Validation | ~3,300 | `core/src/tools/runtimes/shell/bash_validator.rs` | ⚠️ 比 claw 弱（claw 1004 LOC × 6 模块更深）| ⭐⭐⭐⭐ | 与 claw bash_validation 合并到 dasclaw_bash_validation |
 | G | Governance（Guardian）| ~3,500 | `core/src/guardian/`、`core/src/state/service.rs`、`core/src/tools/handlers/approvals.rs` | ⚠️ 与 claw 6 件套互补 | ⭐⭐⭐⭐ | Guardian 评审 + claw 6 件套 → dasclaw_governance |
 | H | MCP | ~3,800 | `codex-mcp/`、`config/src/mcp_types.rs` | ✅ 多 ManagedProxy transport | ⭐⭐⭐⭐⭐ | 与 claw 6-transport 合并到 dasclaw_mcp |
-| I | ExecPolicy | ~3,200 | `execpolicy/`、`core/src/exec_policy.rs` | ✅ Starlark 完胜 | ⭐⭐⭐⭐⭐ | **完整移植到 dasclaw_execpolicy** |
+| I | ExecPolicy | ~3,200 | `execpolicy/`、`core/src/exec_policy.rs` | ✅ Starlark 完胜 | ⭐⭐⭐⭐⭐ | **完整移植到 dasclaw_execpolicy**（当前 30-LOC stub，完整 Starlark port 跟踪在 [#326](https://github.com/Linnanli/xClaw/issues/326) Part 2 + adr-1XX-execpolicy-port） |
 | J | Feature Flags | ~3,100 | `features/` | ✅ 4-stage 生命周期完整 | ⭐⭐⭐⭐ | 完整移植到 dasclaw_features |
 | K | Observability | ~2,000 | `otel/`、`rollout-trace/`、`analytics/` | ⚠️ 各有强项 | ⭐⭐⭐ | rollout-trace 移植到 dasclaw_observability |
 | L | Identity | ~1,200 | `agent-identity/`、`device-key/`、`login/`、`keyring-store/` | ❌ 弱于 ironclaw | ⭐⭐ | OAuth PKCE 借鉴；device-key 留 ironclaw |
 | M | Crash & Panic | ~0 | （**完全缺失**）| ❌ 都弱 | ⭐ | dasclaw_crash 自建 |
-| N | Network Proxy | ~3,500 | `network-proxy/` | ✅ 与 ironclaw 持平 | ⭐⭐⭐⭐ | 完整移植到 dasclaw_net_proxy |
+| N | Network Proxy | ~3,500 | `network-proxy/` | ✅ 与 ironclaw 持平 | ⭐⭐⭐⭐ | 完整移植到 dasclaw_net_proxy（当前为 ironclaw HTTP forward proxy port，ADR-43；完整 codex `network-proxy/` port 由 [#324](https://github.com/Linnanli/xClaw/issues/324) sub-task 3 追踪） |
 | O | App-Server / Channels / SDK / Login / TUI | ~7,000 | `app-server/`、`tui/`、`cli/`、`login/` | ⚠️ codex 独家 | ⭐ | **non-goal**（ADR-104） |
 
 **合计估算**：~53,500 LOC 是 codex 的"可借鉴/移植"核心，约占 codex 总产能的 11.6%。


### PR DESCRIPTION
## 背景 / 目标

doc 32 与 doc 35 在 Phase 1.1.4j（`dasclaw_sandbox_windows` verbatim port，ADR-129/130/131）和 Phase 1.2 落地后未刷新，仍指向旧的 codex 路径与"未拆分"的 crate 骨架，与现实不符。本 PR 是 #326 的 **Part 1**——纯文档对账，把 32/35 这两份"高频被引用"的总览刷到现实。

后续 Part 2/3（execpolicy Starlark 完整 port、network-proxy 完整 port）由独立 ADR 与 PR 推进，不在本 PR 范围。

## 改动范围

### `docs/plans/architecture-refactor/32-execution-plan.md`

1. §W1 任务 2 crate 骨架清单：在 `crates/dasclaw_sandbox` 之后追加 `crates/dasclaw_sandbox_windows`（verbatim port，ADR-129/130）。
2. §W2 任务 1 第 3 行：路径从 `core/src/windows_sandbox.rs + windows_sandbox_read_grants.rs → dasclaw_sandbox/src/windows/` 改为 `codex-cli-main/codex-rs/windows-sandbox-rs/ → dasclaw_sandbox_windows/（verbatim，ADR-129）+ dasclaw_sandbox/src/windows/（adapter，ADR-130）`，并加 v2.5 路径迁移说明。
3. §W2 验收 WritableRoot 行：在"无任何 fallback"后追加"已知限制（v2.5 补充）"——当前 adapter 层检查、内核层强制（Linux Landlock subpath deny / macOS Seatbelt subpath deny / Windows Restricted Token DACL）由 #324 sub-task 2 跟踪。

### `docs/plans/architecture-refactor/35-codex-capability-inventory.md`

4. §C Sandbox 行：source 列更新为 `windows-sandbox-rs/（独立 crate，之前为 core/src/windows_sandbox.rs ~1200 行，v2.5 拆出）`；recommendation 改为"完整移植到 dasclaw_sandbox + dasclaw_sandbox_windows（verbatim，ADR-129/130）"。
5. §I ExecPolicy 行：recommendation 末尾加注"当前 30-LOC stub，完整 Starlark port 跟踪在 #326 Part 2 + adr-1XX-execpolicy-port"。
6. §N Network Proxy 行：recommendation 末尾加注"当前为 ironclaw HTTP forward proxy port（ADR-43），完整 codex `network-proxy/` port 由 #324 sub-task 3 跟踪"。

## 非目标（What's NOT in this PR）

- ❌ 实质性的 sandbox / execpolicy / network-proxy 代码改动——本 PR 纯文档。
- ❌ #326 Part 2（ExecPolicy 完整 Starlark port）——独立 ADR + PR。
- ❌ #324 sub-task 2（WritableRoot 内核层强制）/ sub-task 3（network-proxy 完整 port）——由 #324 epic 推进。
- ❌ 32/35 之外的其它 doc（如 33/34/36/37）刷新——按需另开 PR。

## 验证

```
cargo fmt --all                                                              # 0 改动
python3.12 scripts/check_no_panics.py --base origin/xClaw                    # OK
python3 scripts/check_no_new_ironclaw_literal.py --base origin/xClaw         # OK
git diff --stat origin/xClaw...HEAD                                          # 2 files, +6/-5
```

纯文档 PR，无 .rs 改动 → 跳过 `cargo check / clippy / nextest`（CI 兜底）。

## Cross-cuts

ADR-114 **类A**（no new `.ironclaw` / `IRONCLAW_BASE_DIR` literals）。

## Cat-scan：与并行 PR 零文件重叠

本 PR 触及的文件：
```
docs/plans/architecture-refactor/32-execution-plan.md
docs/plans/architecture-refactor/35-codex-capability-inventory.md
```

- vs **#336**（`fix/sandbox-windows-windows-sys-features-c1`）：触及 `crates/dasclaw_sandbox_windows/{Cargo.toml,src/lib.rs,src/sandbox_users.rs}` + `adr-129-...md` —— **零重叠**。
- vs **#338**（`docs/adr-131-roadmap-sync`）：触及 `crates/dasclaw_sandbox/src/lib.rs` + `45-resource-limits-adr.md` + `51-sandbox-cross-platform-support-matrix.md` + `adr-131-...md` —— **零重叠**。

merge 顺序：先到先 merge；本 PR 与 #336 / #338 互不依赖，rebase 后即可合入。

## 后续

- Part 2：ExecPolicy 完整 Starlark port（独立 ADR 起草中）。
- Part 3：network-proxy 完整 codex port（由 #324 sub-task 3 跟踪）。

Refs #326
Refs #324
