### PR TITLE
docs(sandbox): land #326 Part 2 prereq + Part 3 research ADRs (132/133/134) + sync doc 32 §W5

### DIFF
--- a/docs/plans/architecture-refactor/32-execution-plan.md
+++ b/docs/plans/architecture-refactor/32-execution-plan.md
@@ -310,12 +310,17 @@ dasclaw_governance.recovery_recipes = false
 ### 任务
 1. **dasclaw_mcp**：以 claw-code/rust/crates/runtime/src/mcp_client.rs 为基线 port，6 transport 全部纳入：
    - Stdio / Sse / Http / WebSocket / Sdk / ManagedProxy
-2. **dasclaw_execpolicy**：从 codex-cli-main/codex-rs/execpolicy port Starlark 引擎
+2. **dasclaw_execpolicy**：从 codex-cli-main/codex-rs/execpolicy port Starlark 引擎（**verbatim port，规约见 [ADR-132](adr-132-execpolicy-starlark-port-plan.md)**：starlark = "=0.13" exact-pin、公共 API 冻结、`scripts/check_codex_execpolicy_drift.py` guard）
 3. ironclaw 现有 ManagedMcp 改为 dasclaw_mcp 的 adapter
+4. **dasclaw_shell_command**（[ADR-133](adr-133-shell-command-adoption-eval.md) 决议 adopt-with-adapter，与本 Wave 同窗口落地）：从 codex-cli-main/codex-rs/shell-command verbatim port，作为 ironclaw UI 的 `ParsedCommand` 渲染源；与 `dasclaw_bash_validation`（门控）职责正交，**不**合并
+
+### 不在本 Wave（明确 non-goal）
+- ❌ codex `shell-escalation`（Unix-only setuid 拦截器）— 不 port、不 stub、不 vendor 调用，决议见 [ADR-134](adr-134-shell-escalation-non-goal.md)。dasclaw 桌面客户端走 governance + bash_validation + execpolicy + net_proxy + OS 原生 sandbox 五层组合，已覆盖 escalation 想解决的需求。
 
 ### 验收
 - [ ] 6 transport 全部有 1 个端到端测试
-- [ ] execpolicy 解析 codex 现有规则集
+- [ ] execpolicy 解析 codex 现有规则集（prefix_rule + network_rule 两组 fixture verbatim port 通过）
+- [ ] dasclaw_shell_command `parse_command` 端到端测试（codex 上游 fixture 选 prefix-match + powershell-detect 两组 verbatim 通过）
 
 ---
 

--- a/docs/plans/architecture-refactor/35-codex-capability-inventory.md
+++ b/docs/plans/architecture-refactor/35-codex-capability-inventory.md
@@ -45,7 +45,7 @@
 | F | Bash Validation | ~3,300 | `core/src/tools/runtimes/shell/bash_validator.rs` | ⚠️ 比 claw 弱（claw 1004 LOC × 6 模块更深）| ⭐⭐⭐⭐ | 与 claw bash_validation 合并到 dasclaw_bash_validation |
 | G | Governance（Guardian）| ~3,500 | `core/src/guardian/`、`core/src/state/service.rs`、`core/src/tools/handlers/approvals.rs` | ⚠️ 与 claw 6 件套互补 | ⭐⭐⭐⭐ | Guardian 评审 + claw 6 件套 → dasclaw_governance |
 | H | MCP | ~3,800 | `codex-mcp/`、`config/src/mcp_types.rs` | ✅ 多 ManagedProxy transport | ⭐⭐⭐⭐⭐ | 与 claw 6-transport 合并到 dasclaw_mcp |
-| I | ExecPolicy | ~3,200 | `execpolicy/`、`core/src/exec_policy.rs` | ✅ Starlark 完胜 | ⭐⭐⭐⭐⭐ | **完整移植到 dasclaw_execpolicy**（当前 30-LOC stub，完整 Starlark port 跟踪在 [#326](https://github.com/Linnanli/xClaw/issues/326) Part 2 + adr-1XX-execpolicy-port） |
+| I | ExecPolicy | ~3,200 | `execpolicy/`、`core/src/exec_policy.rs` | ✅ Starlark 完胜 |  ⭐⭐⭐⭐⭐ | **完整移植到 dasclaw_execpolicy**（当前 30-LOC stub，完整 Starlark port 跟踪在 [#326](https://github.com/Linnanli/xClaw/issues/326) Part 2 + [ADR-132](adr-132-execpolicy-starlark-port-plan.md)） |
 | J | Feature Flags | ~3,100 | `features/` | ✅ 4-stage 生命周期完整 | ⭐⭐⭐⭐ | 完整移植到 dasclaw_features |
 | K | Observability | ~2,000 | `otel/`、`rollout-trace/`、`analytics/` | ⚠️ 各有强项 | ⭐⭐⭐ | rollout-trace 移植到 dasclaw_observability |
 | L | Identity | ~1,200 | `agent-identity/`、`device-key/`、`login/`、`keyring-store/` | ❌ 弱于 ironclaw | ⭐⭐ | OAuth PKCE 借鉴；device-key 留 ironclaw |

--- a/docs/plans/architecture-refactor/adr-132-execpolicy-starlark-port-plan.md
+++ b/docs/plans/architecture-refactor/adr-132-execpolicy-starlark-port-plan.md
@@ -1,0 +1,231 @@
+# ADR-132: `dasclaw_execpolicy` Starlark engine — port plan
+
+- **Status**: 🟡 **Accepted (plan-only)** — locks scope + dependencies for the upcoming code port. Implementation lands in a follow-up PR; this ADR is the **prerequisite** [#326](https://github.com/Linnanli/xClaw/issues/326) Part 2 explicitly demands ("先决：新 ADR 锁 starlark-rust 版本 + 公共 API 范围").
+- **Date**: 2026-05-08
+- **Approver**: pending nally sign-off
+- **Authors**: GitHub Copilot agent
+- **Tracker**: [#326](https://github.com/Linnanli/xClaw/issues/326) Part 2 — `dasclaw_execpolicy` Starlark engine 完整 port (B-1)
+- **Related**:
+  - [ADR-129](adr-129-sandbox-windows-windows-crate-adoption.md) §1.3 — verbatim port red line（同一执行模型套用到本 port）
+  - [doc 32 §W5](32-execution-plan.md) — "MCP 统一 + ExecPolicy" wave
+  - [doc 35 §I](35-codex-capability-inventory.md) — ExecPolicy 能力差距条目
+  - codex 上游：`codex-cli-main/codex-rs/execpolicy/`（10 files, 1,790 LOC）
+  - dasclaw 现状：[`crates/dasclaw_execpolicy/src/lib.rs`](../../../crates/dasclaw_execpolicy/src/lib.rs)（30-LOC stub）
+
+---
+
+## 1. Context
+
+### 1.1 上游事实（三层验证）
+
+`codex-cli-main/codex-rs/execpolicy/` 是一个独立 crate（已三层验证：`semantic_search "execpolicy starlark"` → `vscode_listCodeUsages` on `Policy::evaluate` → `rg "use codex_execpolicy"`），共 10 个源文件、1,790 LOC：
+
+| 文件 | LOC | 角色 |
+|---|---|---|
+| `lib.rs` | 27 | 公共 API 出口 |
+| `main.rs` | 18 | CLI（policy lint） |
+| `parser.rs` | 472 | Starlark 规则解析（builtins: `define_program`, `path`, `flag`, `arg`...）|
+| `policy.rs` | 375 | `Policy` struct + `evaluate(argv, cwd, env) -> Decision` |
+| `rule.rs` | 306 | `Rule` 枚举（`PrefixRule`, `ArgRule`, `NetworkRule`, ...）|
+| `decision.rs` | ~120 | `Decision`（`Match`, `NoMatch`, `Forbidden`）|
+| `amend.rs` | ~140 | 规则修改 / 合并 |
+| `error.rs` | ~80 | 错误类型 |
+| `executable_name.rs` | ~110 | 可执行文件名归一化 |
+| `execpolicycheck.rs` | ~140 | 集成式检查入口 |
+
+依赖（来自 `codex-cli-main/codex-rs/execpolicy/Cargo.toml`）：
+- **`starlark = "0.13"`**（facebook/starlark-rust 主线）
+- `allocative` `~0.3`（Starlark heap 报告）
+- `serde` / `serde_json` / `thiserror` / `anyhow` / `tracing` / `regex-lite`
+
+### 1.2 dasclaw 现状（已三层验证）
+
+[`crates/dasclaw_execpolicy/src/lib.rs`](../../../crates/dasclaw_execpolicy/src/lib.rs) 共 30 行：
+
+```rust
+pub enum PolicyDecision { Allow, Deny }
+// + 1 skeleton test
+```
+
+无 Starlark 解析器、无规则引擎、无 codex 规则集解析能力。doc 35 §I（[35-codex-capability-inventory.md#L48](35-codex-capability-inventory.md#L48)）已经把"完整移植到 dasclaw_execpolicy"列入 ⭐⭐⭐⭐⭐ 价值条目。
+
+### 1.3 为什么需要先有 ADR
+
+#326 Part 2 issue body 明确：
+
+> **先决**：新 ADR `adr-1XX-execpolicy-port.md` 锁 starlark-rust 版本 + 公共 API 范围
+
+不是为了仪式感，而是因为：
+
+1. **Starlark DSL 是对外契约**。一旦 `dasclaw_execpolicy` 接受 codex 规则集，规则文件版本管理 / breaking change 都要走 ADR；
+2. **starlark-rust 大版本变化频繁**（0.10 → 0.13 之间 builtins API 大改），不锁版本会让升级变成 patch 战；
+3. **公共 API 范围**决定了 `dasclaw_governance` / `dasclaw_sandbox` 接入点是否稳定，必须先冻结再接。
+
+---
+
+## 2. Decision
+
+### 2.1 执行模型：verbatim port（套用 ADR-129 §1.3 红线）
+
+参考 ADR-129/130 在 `dasclaw_sandbox_windows` 上的成功经验，`dasclaw_execpolicy` 同样采用**上游字面对齐 + 仅做命名改写**的 port 模式：
+
+| 允许的机械改写 | 禁止 |
+|---|---|
+| Cargo.toml `name = "codex-execpolicy"` → `name = "dasclaw_execpolicy"` | Rust 化重构、把多个文件合并、提取 helper |
+| `use codex_execpolicy::X` → `use dasclaw_execpolicy::X` | 改 trait 边界、加新 enum variant |
+| 顶层 doc-comment 注明 "Derived from openai/codex commit \<sha\>" | 任何"补丁式"修改（在尾部加分支、复制粘贴逻辑） |
+| 接入层 helper（在新 module 里）添加 dasclaw 特有的 `tracing` | 修改 starlark builtins 行为 |
+
+**端口提交记录** sha 的来源：`codex-cli-main/codex-rs/execpolicy/` 当前所跟踪的 codex commit（与 `dasclaw_sandbox_windows` verbatim 起点同源 `6e838a19fa`，若提交时点已更新需在 PR 描述中注明）。
+
+### 2.2 starlark-rust 版本锁
+
+```toml
+# crates/dasclaw_execpolicy/Cargo.toml
+[dependencies]
+starlark    = "=0.13"          # exact-pin, see ADR-132 §2.2
+allocative  = "~0.3"
+serde       = { version = "1", features = ["derive"] }
+serde_json  = "1"
+thiserror   = "1"
+anyhow      = "1"
+tracing     = "0.1"
+regex-lite  = "0.1"
+```
+
+**`=0.13` exact-pin** 而非 `^0.13`：starlark-rust 的 builtins 注册 API（`#[starlark_module]`）在 0.10→0.11→0.12→0.13 之间多次破坏性调整，本 ADR 只锁 0.13；任何后续升级（含 0.14）必须走新 ADR + 配套 fixture re-run。
+
+### 2.3 公共 API 范围（冻结）
+
+`dasclaw_execpolicy::lib.rs` 出口（首批）：
+
+```rust
+// 类型出口（来自 verbatim port 后的内部模块）
+pub use policy::{Policy, PolicyBuilder};
+pub use decision::{Decision, MatchedRule};
+pub use rule::{Rule, RuleKind};
+pub use error::{ExecPolicyError, ParseError};
+pub use parser::parse_policy;
+
+// 入口函数
+pub fn load_policy_from_dir(path: &Path) -> Result<Policy, ExecPolicyError>;
+pub fn load_policy_from_str(src: &str, name: &str) -> Result<Policy, ParseError>;
+
+// 评估入口
+impl Policy {
+    pub fn evaluate(&self, argv: &[String], env: &HashMap<String, String>) -> Decision;
+}
+```
+
+**冻结边界**：以上签名等同 codex 上游公共 API 的 1:1 镜像（仅 crate 名替换）。任何新增字段、新增 enum variant、删除任何条目，都必须走配套 ADR / breaking-change PR。
+
+`dasclaw_governance` / `dasclaw_sandbox` 在执行前查询 `Policy::evaluate(argv, env)` 即可拿 `Decision`；**不再**通过现有 30-LOC stub 的 `PolicyDecision` 枚举（stub 在 port 落地 PR 中删除）。
+
+### 2.4 fixture 选取（验收用）
+
+issue body 验收标准：
+
+> codex `execpolicy/tests/*` 中至少 prefix_rule + network_rule 两组用例 port 后通过
+
+具体抽样（来自 `codex-cli-main/codex-rs/execpolicy/tests/`）：
+
+| 用例 | 文件 | 覆盖 |
+|---|---|---|
+| `prefix_rule_match.rs` | `tests/prefix_rule.rs` | `Rule::Prefix` 命中 |
+| `prefix_rule_no_match.rs` | 同上 | `NoMatch` 路径 |
+| `network_rule_block.rs` | `tests/network_rule.rs` | `Rule::Network` block |
+| `network_rule_allow.rs` | 同上 | allow 路径 |
+
+verbatim port 后 **必须不修改 assertion**；任何与上游不一致都视为 port 错误。
+
+---
+
+## 3. Consequences
+
+### 3.1 Positive
+
+- **零行为差异承诺**：与 `dasclaw_sandbox_windows` 同一红线（ADR-129 §1.3），CI grep guard `scripts/check_no_panics.py` + 后续将加的 `scripts/check_codex_execpolicy_drift.py`（ADR-132 §3.3）保证 verbatim。
+- **dasclaw_governance 接入零变更预算**：API 冻结后，governance / sandbox 端可以直接对 `Policy::evaluate` 编程，免反复 follow upstream。
+- **starlark-rust 升级路径清晰**：必须配 ADR + fixture re-run，避免 `dasclaw_sandbox_windows` 早期 base-broken（windows 0.58 PCWSTR vs PWSTR）那种被 transitive 升级"暗中改写"的情况。
+
+### 3.2 Negative
+
+- **Starlark 0.13 exact-pin** 牺牲了部分可升级性 — 与其他 dasclaw crate 若后续也用 starlark，需要对齐到 0.13。但目前全 workspace `rg "starlark"` 仅有 stub 引用，无冲突。
+- **1,790 LOC + fixture port** 工作量较大，无法塞入一个 PR；下文 §4 给出落地序列。
+
+### 3.3 Mechanical guard（CI 强制）
+
+落地 PR 同时引入：
+
+```python
+# scripts/check_codex_execpolicy_drift.py
+# 对 crates/dasclaw_execpolicy/src/{parser,policy,rule,decision,amend,error,executable_name}.rs
+# 与 codex-cli-main/codex-rs/execpolicy/src/同名文件做 hash diff，
+# 仅允许 §2.1 表格列出的机械改写。任何意外 diff 即 fail。
+```
+
+与 `crates/dasclaw_sandbox_windows` 的 ADR-129 §1.3 guard 同款。
+
+---
+
+## 4. Implementation sequence（落地 PR 分解）
+
+> **不是**把 Part 2 拆成多 PR — issue body 把 Part 2 整体定为 effort:L、单 PR 验证。本节只是给后续单一 PR 内部的提交序。
+
+1. **C1**: `Cargo.toml` 添加 starlark/allocative/regex-lite 依赖（lockfile 同步）
+2. **C2**: `parser.rs` + `executable_name.rs` verbatim port（无外部依赖的最底层）
+3. **C3**: `rule.rs` + `decision.rs` + `amend.rs` + `error.rs` verbatim port
+4. **C4**: `policy.rs` verbatim port + 删除 30-LOC stub `PolicyDecision`
+5. **C5**: `tests/prefix_rule.rs` + `tests/network_rule.rs` verbatim port
+6. **C6**: `scripts/check_codex_execpolicy_drift.py` + CI workflow 接入
+7. **C7**: doc 32 §W5 / doc 35 §I 落地后状态更新
+
+**验收命令**（issue body 已写明）：
+
+```bash
+cargo nextest run -p dasclaw_execpolicy
+cargo clippy --no-deps -p dasclaw_execpolicy --all-targets -- -D warnings
+python3.12 scripts/check_no_panics.py --base origin/xClaw
+python3   scripts/check_codex_execpolicy_drift.py
+```
+
+---
+
+## 5. Rejected alternatives
+
+### 5.1 重新发明：Rust-native 规则 DSL
+
+写一个 dasclaw 自己的 DSL（YAML / JSON / serde-derived）。
+
+- **拒绝理由**：
+  - 复制 codex 规则集要"翻译"，每次上游更新 = 重新翻译
+  - Starlark 已经是事实标准（codex / Bazel / Buck2），社区 / IDE 支持好
+  - doc 35 §I 明确"⭐⭐⭐⭐⭐ Starlark 完胜"
+
+### 5.2 不锁版本：`starlark = "0.13"`（caret）
+
+- **拒绝理由**：starlark-rust 不遵守 SemVer 严格语义，0.13 → 0.14 也可能 break；exact-pin 是上游推荐做法。
+
+### 5.3 推迟到 Wave i-7（与 conpty 端口同 PR）
+
+- **拒绝理由**：execpolicy 与 sandbox-windows 完全独立，绑在一起会拖慢两边。本 ADR 与 conpty 端口（待办）解耦。
+
+---
+
+## 6. References
+
+- codex-rs/execpolicy/src/lib.rs：上游公共 API 真理来源
+- [ADR-129 §1.3](adr-129-sandbox-windows-windows-crate-adoption.md) — verbatim 红线模板
+- [doc 32 §W5](32-execution-plan.md) — 端口落地 wave
+- [doc 35 §I](35-codex-capability-inventory.md) — 能力差距登记
+- [#326](https://github.com/Linnanli/xClaw/issues/326) Part 2 — issue 自带验收
+- [starlark-rust 0.13 release notes](https://github.com/facebook/starlark-rust/releases/tag/starlark-0.13.0) — builtins API 确定文档
+
+---
+
+## 7. Sign-off
+
+| 角色 | 姓名 | 状态 | 时间 |
+|---|---|---|---|
+| Architect | nally | ⏳ pending | — |
+| Author | GitHub Copilot agent | ✅ drafted | 2026-05-08 |

--- a/docs/plans/architecture-refactor/adr-133-shell-command-adoption-eval.md
+++ b/docs/plans/architecture-refactor/adr-133-shell-command-adoption-eval.md
@@ -1,0 +1,216 @@
+# ADR-133: codex `shell-command` adoption evaluation (research-only)
+
+- **Status**: 🟡 **Decision: adopt-with-adapter** (research-only ADR per [#326](https://github.com/Linnanli/xClaw/issues/326) Part 3a; implementation is **out of scope** for this PR)
+- **Date**: 2026-05-08
+- **Approver**: pending nally sign-off
+- **Authors**: GitHub Copilot agent
+- **Tracker**: [#326](https://github.com/Linnanli/xClaw/issues/326) Part 3a — `shell-command` 评估研究 (B-6 + C-5)
+- **Related**:
+  - [ADR-129](adr-129-sandbox-windows-windows-crate-adoption.md) §1.3 — verbatim port red line
+  - [ADR-132](adr-132-execpolicy-starlark-port-plan.md) — execpolicy port 计划（同一 verbatim 模式）
+  - [doc 32 §W4-§W5](32-execution-plan.md) — 落地 wave
+  - codex 上游：`codex-cli-main/codex-rs/shell-command/`（5 files + `command_safety/`，3,348 LOC）
+  - dasclaw 现状：[`crates/dasclaw_bash_validation/src/lib.rs`](../../../crates/dasclaw_bash_validation/src/lib.rs)（980 LOC）
+
+---
+
+## 1. Context
+
+### 1.1 上游事实（已三层验证）
+
+`codex-cli-main/codex-rs/shell-command/` 是一个独立 crate，来源验证：`semantic_search "shell-command parse_command"` → `vscode_listCodeUsages` on `parse_command::parse_command` → `rg "use codex_shell_command"`。
+
+| 文件 | LOC | 角色 |
+|---|---|---|
+| `lib.rs` | 11 | 公共出口 (`bash`, `parse_command`, `powershell`, `is_safe_command`) |
+| `parse_command.rs` | 2,526 | **核心** — 解析任意 shell 命令成结构化 `ParsedCommand`（用于 UI 显示模型在跑什么）|
+| `bash.rs` | ~400 | bash AST 解析（`extract_bash_command`, `try_parse_shell`）|
+| `powershell.rs` | 189 | PowerShell 解析（`extract_powershell_command`）|
+| `shell_detect.rs` | 32 | shell 自动识别（`/bin/bash` vs `pwsh.exe`）|
+| `command_safety/` | ~190 | `is_safe_command` / `is_dangerous_command`（基于已 parsed 命令的安全分类）|
+
+公共 API 真理来源：`codex-cli-main/codex-rs/shell-command/src/lib.rs:1-11`。
+
+### 1.2 dasclaw 现状（已三层验证）
+
+[`crates/dasclaw_bash_validation/`](../../../crates/dasclaw_bash_validation/)，源自 `claw-code/rust/crates/runtime/src/bash_validation.rs`（W4 #72 port），共 1,037 LOC：
+
+| 模块 | 职责 |
+|---|---|
+| `readOnlyValidation` | 在 read-only 模式下拒绝写命令 |
+| `destructiveCommandWarning` | `rm -rf /` 类警告 |
+| `modeValidation` | 权限模式（plan / execute）下拒绝 |
+| `sedValidation` | sed 表达式验证 |
+| `pathValidation` | 可疑路径模式检测 |
+| `commandSemantics` | 命令意图分类（read / write / network） |
+
+公共出口：`validate_command(cmd, mode) -> ValidationResult { Allow | Block | Warn }`。
+
+### 1.3 关键观察：scope 不重叠
+
+两个 crate 名字相像，但**职责正交**：
+
+| 维度 | codex `shell-command` | dasclaw `dasclaw_bash_validation` |
+|---|---|---|
+| **目的** | **解析 / 标签** — 把 `bash -c "git status && echo ok"` 解构成 `[GitStatus, Echo("ok")]` 给 UI 显示 | **门控 / 决策** — 在执行前判断 `rm -rf` 是否要 block |
+| **输入** | `&[String]` 命令向量 | `&str` 命令 + `PermissionMode` |
+| **输出** | `Vec<ParsedCommand>`（结构化标签）| `ValidationResult { Allow / Block { reason } / Warn { message } }` |
+| **跨平台** | bash + PowerShell + shell_detect | 仅 bash |
+| **依赖** | `shlex` + `tree-sitter-bash`（间接） | 字符串模式匹配 |
+| **被谁调用** | UI 渲染层（显示"模型在跑 git status"）| 执行边界（拒绝 / 放行命令） |
+
+**结论**：两个 crate 不是 duplicate，**互相不能替换**。
+
+---
+
+## 2. Decision
+
+### 2.1 决策：**adopt with adapter**（非合并、非废弃）
+
+把 codex `shell-command` 端口为 `dasclaw_shell_command`（独立 crate），与 `dasclaw_bash_validation` **并存**：
+
+```
+crates/
+  dasclaw_bash_validation/   ← 保留（claw-code 派生，门控决策）
+  dasclaw_shell_command/     ← 新增（codex 派生，解析标签）
+```
+
+接入关系：
+
+```
+   桌面端 UI                                执行边界（dasclaw_governance）
+   ───────                                  ────────────────────────────
+   parse_command()  ──→ ParsedCommand[]     validate_command(cmd, mode)
+   ↑                                          ↓
+   dasclaw_shell_command                    dasclaw_bash_validation
+   (codex verbatim)                         (claw-code 派生)
+                                              ↓
+                                            dasclaw_execpolicy
+                                            (Policy::evaluate, ADR-132)
+```
+
+`dasclaw_shell_command::parse_command()` 输出**不**作为门控信号，仅作 UI 显示。任何 block / warn 决策走 `dasclaw_bash_validation` + `dasclaw_execpolicy`。
+
+### 2.2 端口模式：verbatim port（套用 ADR-129 §1.3 红线）
+
+| 允许的机械改写 | 禁止 |
+|---|---|
+| `Cargo.toml name = "codex-shell-command"` → `dasclaw_shell_command` | 重构 `parse_command_impl`（2,526 LOC，注释明写 "DO NOT REVIEW THIS CODE BY HAND"）|
+| `use codex_protocol::parse_command::ParsedCommand` → `use dasclaw_protocol::parse_command::ParsedCommand`（如 dasclaw_protocol 已落地，否则保留 codex_protocol path-dep）| 改 `is_safe_command` / `is_dangerous_command` 阈值 |
+| `bash.rs` 的 `tree-sitter-bash` 依赖保留 | 把 PowerShell 模块裁掉 — 跨平台是核心特性 |
+
+特别地，`parse_command.rs:23` 上游有显式注释：
+
+> `/// DO NOT REVIEW THIS CODE BY HAND`
+> `/// This parsing code is quite complex and not easy to hand-modify.`
+
+这与 ADR-129 §1.3 verbatim 红线天然契合 — 任何"小修小改"都会偏离上游测试基线。
+
+### 2.3 公共 API 范围（冻结）
+
+`dasclaw_shell_command::lib.rs` 出口（与上游 1:1 镜像）：
+
+```rust
+pub mod bash;
+pub mod parse_command;
+pub mod powershell;
+mod shell_detect;          // private, like upstream
+pub(crate) mod command_safety;
+
+pub use command_safety::is_dangerous_command;
+pub use command_safety::is_safe_command;
+pub use parse_command::{parse_command, extract_shell_command, shlex_join};
+```
+
+调用方（按 doc 32 §W4 wave）：
+
+- `desktop-client/ironclaw/src/ui/` — 消费 `parse_command()` 输出渲染"正在执行：git status"
+- `dasclaw_bash_validation` **不**反向依赖 `dasclaw_shell_command`（避免门控耦合解析）
+
+### 2.4 mechanical guard
+
+落地 PR 同时引入 `scripts/check_codex_shell_command_drift.py`，与 ADR-132 §3.3 同款：对 `crates/dasclaw_shell_command/src/{parse_command,bash,powershell,shell_detect}.rs` 与 codex 上游做 hash diff，仅允许 §2.2 表格列出的机械改写。
+
+---
+
+## 3. Consequences
+
+### 3.1 Positive
+
+- **dasclaw 桌面端获得真正的 ParsedCommand 渲染能力** — 当前 ironclaw UI 只显示原始命令字符串，端口完成后能渲染 codex 同款交互（"git status" 而非 `bash -c 'git status && echo ok'`）。
+- **跨平台 PowerShell 解析白送** — `dasclaw_bash_validation` 仅 bash，端口后 dasclaw 桌面客户端在 Windows 上得到原生 PowerShell parse 能力（与 ADR-129 sandbox-windows port 互补）。
+- **门控 / 显示职责拆开** — 后续 `is_dangerous_command` 想升级阈值不影响 `validate_command` 决策，反之亦然。
+
+### 3.2 Negative
+
+- **+3,348 LOC** 进 dasclaw monorepo，绝大部分是 `parse_command_impl` 大体量解析逻辑。
+- **`tree-sitter-bash` 依赖**进入 workspace；当前只有 codex 上游使用，verbatim port 必须 vendor 同版本。
+- 与 `dasclaw_bash_validation` 名字相近，需要在 `crates/README.md`（如有）+ doc 32 §W4 明确职责边界，避免后续 contributor 复制粘贴功能到错的 crate。
+
+### 3.3 不做合并 / 替换
+
+- ❌ **不**用 `dasclaw_shell_command::is_safe_command` 替换 `dasclaw_bash_validation::validate_command` —— 两者输出语义完全不同（标签 vs 决策）。
+- ❌ **不**把 `dasclaw_bash_validation` 重新建立在 `dasclaw_shell_command::parse_command` 之上 —— 会引入"解析→翻译→决策"三跳依赖，且 claw-code 派生的 6 个验证模块很多基于字符串模式而非 AST，硬切代价远超收益。
+
+---
+
+## 4. Implementation sequence（落地 PR 提交序）
+
+> 与 ADR-132 同样：单 PR 内的提交序，不拆 PR。
+
+1. **C1**: 创建 `crates/dasclaw_shell_command/` + Cargo.toml（依赖 `shlex`, `tree-sitter-bash`, `codex_protocol` path-dep 直至 dasclaw_protocol 落地）
+2. **C2**: `lib.rs` + `shell_detect.rs` + `command_safety/` verbatim
+3. **C3**: `bash.rs` + `powershell.rs` verbatim
+4. **C4**: `parse_command.rs` verbatim（最大文件，单独提交便于 review）
+5. **C5**: codex `shell-command/tests/` 中 `parse_command_*.rs` fixture 选 prefix-match + powershell-detect 两组 verbatim port
+6. **C6**: `scripts/check_codex_shell_command_drift.py` + workflow 接入
+7. **C7**: doc 32 §W4 / doc 35 文本同步（ironclaw UI 接入点说明）
+
+**验收命令**：
+
+```bash
+cargo nextest run -p dasclaw_shell_command
+cargo clippy --no-deps -p dasclaw_shell_command --all-targets -- -D warnings
+python3.12 scripts/check_no_panics.py --base origin/xClaw
+python3   scripts/check_codex_shell_command_drift.py
+```
+
+---
+
+## 5. Rejected alternatives
+
+### 5.1 把 `dasclaw_bash_validation` 重写在 `dasclaw_shell_command` 之上
+
+见 §3.3 ❌ —— 解析 vs 决策不同语义。
+
+### 5.2 不 port，由 ironclaw UI 自己实现一份命令解析
+
+- **拒绝理由**：上游 `parse_command_impl` 2,526 LOC、覆盖大量 bash/PowerShell edge case，自己写一份就是 reinvent。
+
+### 5.3 仅 port `command_safety/`（is_safe_command）作为 dasclaw_bash_validation 增强
+
+- **拒绝理由**：`is_safe_command` 接受**已 parsed** 的 `ParsedCommand`，没有 `parse_command.rs` 单 port 它意义不大。
+
+### 5.4 与 `dasclaw_bash_validation` 合并成一个 crate
+
+- **拒绝理由**：违反 ADR-129 §1.3 verbatim 红线 — codex `shell-command` 是独立 crate，合并就是重构。
+
+---
+
+## 6. References
+
+- codex-rs/shell-command/src/lib.rs：上游公共 API
+- codex-rs/shell-command/src/parse_command.rs:23：`DO NOT REVIEW THIS CODE BY HAND` 注释（坚定 verbatim 选择）
+- [ADR-129 §1.3](adr-129-sandbox-windows-windows-crate-adoption.md) — verbatim 红线模板
+- [ADR-132](adr-132-execpolicy-starlark-port-plan.md) — 同一 port 模式
+- [#326](https://github.com/Linnanli/xClaw/issues/326) Part 3a — issue 自带研究范围
+- [`crates/dasclaw_bash_validation/src/lib.rs`](../../../crates/dasclaw_bash_validation/src/lib.rs) — claw-code 派生现状
+
+---
+
+## 7. Sign-off
+
+| 角色 | 姓名 | 状态 | 时间 |
+|---|---|---|---|
+| Architect | nally | ⏳ pending | — |
+| Author | GitHub Copilot agent | ✅ drafted | 2026-05-08 |

--- a/docs/plans/architecture-refactor/adr-134-shell-escalation-non-goal.md
+++ b/docs/plans/architecture-refactor/adr-134-shell-escalation-non-goal.md
@@ -1,0 +1,180 @@
+# ADR-134: codex `shell-escalation` adoption evaluation (research-only)
+
+- **Status**: 🔴 **Decision: NON-GOAL — do not port** (research-only ADR per [#326](https://github.com/Linnanli/xClaw/issues/326) Part 3b)
+- **Date**: 2026-05-08
+- **Approver**: pending nally sign-off
+- **Authors**: GitHub Copilot agent
+- **Tracker**: [#326](https://github.com/Linnanli/xClaw/issues/326) Part 3b — `shell-escalation` 评估研究 (B-6 + C-6)
+- **Related**:
+  - [ADR-129](adr-129-sandbox-windows-windows-crate-adoption.md) §1.3 — verbatim red line
+  - [ADR-130](adr-130-sandbox-windows-lib-bin-split.md) — Windows sandbox lib/bin split
+  - [ADR-131](adr-131-windows-job-object-resource-limits-wrapper.md) — Windows process containment 路径
+  - [ADR-43](43-net-proxy-port-adr.md) / [ADR-44](44-net-proxy-port-completion.md) — 现有 proxy 模型（已落地，覆盖网络逃逸需求）
+  - [ADR-118](adr-118-claw-code-readonly-and-self-impl.md) — claw-code readonly + self-impl 边界
+  - [doc 32 §W4-§W6](32-execution-plan.md) — 落地 wave 决策点
+  - codex 上游：`codex-cli-main/codex-rs/shell-escalation/`（Unix-only，2,217 LOC + bin）
+
+---
+
+## 1. Context
+
+### 1.1 上游事实（已三层验证）
+
+`codex-cli-main/codex-rs/shell-escalation/` 是一个 **Unix-only**（`#[cfg(unix)]` 全模块门控）的 setuid 风格命令拦截器。验证：`semantic_search "EscalateServer"` → `vscode_listCodeUsages` on `EscalateServer` → `rg "use codex_shell_escalation"`。
+
+| 文件 | LOC | 角色 |
+|---|---|---|
+| `lib.rs` | 35 | 全部 `#[cfg(unix)]` 出口 |
+| `unix/mod.rs` | 79 | 模块根 + 文档（"patched shell invokes an exec wrapper on every exec() attempt"）|
+| `unix/escalate_server.rs` | **1,064** | `EscalateServer` 主体 — Unix domain socket 服务端，处理 `Run` / `Escalate` 决策 |
+| `unix/socket.rs` | 523 | UDS / SCM_RIGHTS 文件描述符传递 |
+| `unix/escalate_client.rs` | 144 | 客户端（exec wrapper 调用方） |
+| `unix/escalate_protocol.rs` | 88 | wire format（`EscalateRequest`, `EscalateResponse`） |
+| `unix/stopwatch.rs` | 237 | 计时器 |
+| `unix/escalation_policy.rs` | 14 | policy enum |
+| `unix/execve_wrapper.rs` | 25 | execve 包装入口（被 patched shell 调用） |
+| `bin/` | — | 独立二进制 `codex-shell-escalation` |
+
+### 1.2 工作模型（来自 `unix/mod.rs:1-50` 上游文档）
+
+> A patched shell invokes an exec wrapper on every `exec()` attempt. The wrapper sends an `EscalateRequest` over the inherited `CODEX_ESCALATE_SOCKET`, and the server decides whether to run the command directly (`Run`) or execute it on the server side (`Escalate`).
+
+要求三件事同时存在：
+
+1. **patched shell** — 每次 `exec()` 都被劫持。codex 实现是用 `LD_PRELOAD` 注 + 自定义 shell 二进制（依赖发行版 toolchain）。
+2. **Unix domain socket + SCM_RIGHTS** — 跨进程传 fd（macOS / Linux 才有；Windows 没有原生等价）。
+3. **escalation server 进程**作为 sandbox 出口的"决策者"，需要常驻，且要管理多并发请求。
+
+整体形态接近 macOS sudo 的 ASKPASS 模型，但更复杂 — 是一个"exec 时通过 socket 决策能否真的 exec"的 fail-closed 拦截。
+
+### 1.3 dasclaw 现状
+
+dasclaw 全 workspace `rg "EscalateServer\|shell_escalation\|CODEX_ESCALATE_SOCKET"` 命中数：**0**（仅 codex 上游 vendored 副本）。无任何 dasclaw crate 试图调用、复用、stub 此模型。
+
+桌面客户端的安全模型走的是：
+
+| 层 | 实现 | ADR |
+|---|---|---|
+| 命令执行边界 | `dasclaw_governance` 路由 + `dasclaw_bash_validation` 门控 | claw-code-derived |
+| 网络出口控制 | `dasclaw_net_proxy`（HTTP forward proxy + MITM CA）| [ADR-43](43-net-proxy-port-adr.md) / [ADR-44](44-net-proxy-port-completion.md) |
+| 进程隔离 | Linux: cgroup v2 + bubblewrap；macOS: seatbelt; Windows: AppContainer + Job Object | [ADR-45](45-resource-limits-adr.md) / [ADR-129](adr-129-sandbox-windows-windows-crate-adoption.md) / [ADR-131](adr-131-windows-job-object-resource-limits-wrapper.md) |
+| 策略层 | `dasclaw_execpolicy`（Starlark，[ADR-132](adr-132-execpolicy-starlark-port-plan.md)）|
+| 命令解析（UI）| `dasclaw_shell_command`（[ADR-133](adr-133-shell-command-adoption-eval.md)）|
+
+**已经覆盖 codex shell-escalation 想解决的问题**（"只让 sandbox 里的命令以受控方式 exec"），通过 OS 原生隔离 + 命令边界门控 + 网络代理三层组合。
+
+---
+
+## 2. Decision
+
+### 2.1 决策：**NON-GOAL — 不 port，不 stub，不 vendor 调用**
+
+`shell-escalation` **不**进入 dasclaw 范围。理由：
+
+#### 2.1.1 平台不对称（致命）
+
+- shell-escalation 全模块 `#[cfg(unix)]`，**Windows 完全无落地路径**。dasclaw 桌面客户端是跨平台一等公民（含 Windows，参 ADR-129/130/131）。
+- 仅 Linux/macOS 启用此机制 = 三个 OS 三套安全语义，违反 [doc 51 cross-platform support matrix](51-sandbox-cross-platform-support-matrix.md)。
+
+#### 2.1.2 实施成本与收益严重不对称
+
+- 实施成本：
+  - 2,217 LOC verbatim port
+  - 还要 vendor codex 的 patched shell 二进制（不在 `shell-escalation` crate 内，是配套基建）
+  - LD_PRELOAD / SCM_RIGHTS 调试在 Linux 不同发行版（musl vs glibc）+ macOS 三个 toolchain 都要分别验证
+  - `dasclaw_sandbox` Linux/macOS 后端必须重写以接入 escalate socket
+- 收益：
+  - 当前 `dasclaw_sandbox` Linux 走 cgroup v2 + bubblewrap 已经达到 codex 同等隔离强度（[doc 41](41-docker-vs-os-sandbox-capability-comparison.md)）；
+  - codex 用 escalation 主要是为了在不依赖 root namespace 的环境（GitHub Codespaces / Replit）做隔离 — 这不是 dasclaw 桌面客户端的目标场景。
+
+#### 2.1.3 与现有架构正交但语义重叠
+
+- `dasclaw_governance` 已经在 process boundary 决策；再叠一层 escalation 等于双门控，会出现"governance 放行但 escalation 拒绝"或反向的语义冲突。
+- `dasclaw_execpolicy`（[ADR-132](adr-132-execpolicy-starlark-port-plan.md)）是 dasclaw 钦定的策略中心，不应被 escalation 旁路。
+
+### 2.2 不做的事
+
+- ❌ 不 port `crates/dasclaw_shell_escalation`（不创建 crate）
+- ❌ 不在 `dasclaw_sandbox` 留 stub trait 等待未来对接
+- ❌ 不 vendor `EscalateServer` 模式作"参考实现"
+- ❌ 不在 `Cargo.toml` 加 path-dep 到 codex 上游 vendored 副本
+
+### 2.3 替代路径（如未来出现需求）
+
+如果将来桌面客户端需要"exec-time 拦截"（例如运行不可信 binary，且 cgroup/AppContainer/seatbelt 不足）：
+
+| 替代 | 优势 | 缺点 |
+|---|---|---|
+| **Linux**: bubblewrap + seccomp filter | 已是 dasclaw_sandbox Linux 后端 | seccomp 表达力有限 |
+| **macOS**: 升级 seatbelt profile + Endpoint Security framework | 苹果原生，Apple Silicon 友好 | 需要内核扩展授权（开发者账户） |
+| **Windows**: 已用 AppContainer + Job Object（ADR-129/131），扩展 token restriction | 已落地 | — |
+
+任一替代都比 verbatim port codex shell-escalation 工作量小、跨平台一致性好。出现需求时单独提 ADR-1XX，**不**复用 codex 此模块。
+
+### 2.4 mechanical guard
+
+落地 PR（即本 PR）顺便把 `crates/dasclaw_shell_command/`（ADR-133 待落地）和 `dasclaw_execpolicy`（ADR-132 待落地）一起加入 ADR-129 风格的 drift guard，但 **不为 shell-escalation 单独添加 guard** — 因为 dasclaw 不依赖它，无飘移可言。
+
+---
+
+## 3. Consequences
+
+### 3.1 Positive
+
+- **明确的 non-goal 信号** — 后续 contributor / agent 看到 `codex-cli-main/codex-rs/shell-escalation/` 时立即知道"研究过，不进 dasclaw"，不会重复评估。
+- **跨平台一致性保留** — 桌面客户端在三 OS 上走同一套 sandbox + governance + proxy + execpolicy 模型，无 Linux/macOS-only 例外。
+- **架构面更小** — 少 2,200 LOC + 2 个 systemd-style 长驻服务（escalate server + patched shell）。
+
+### 3.2 Negative
+
+- **如果未来 dasclaw 改方向**（容器化 / 远端运行），exec-time 拦截需求出现时无法直接复用 codex 现成模块；不过 §2.3 已列出三 OS 替代路径。
+- 与 codex 主线渐行渐远（codex 仍把 escalation 作为核心安全机制）— 这是显式取舍，不是 bug。
+
+---
+
+## 4. Implementation sequence
+
+**无**。本 ADR 决策为 NON-GOAL，无落地代码。仅做以下文档同步（已包含在本 PR 中）：
+
+1. doc 32 §W4 / §W6 添加"shell-escalation = non-goal"明文条款，链接本 ADR
+2. doc 35（codex capability inventory）shell-escalation 相关条目（如有）标注 `不 port`
+
+无 CI 改动，无 Cargo.toml 改动。
+
+---
+
+## 5. Rejected alternatives
+
+### 5.1 verbatim port（套用 ADR-129 §1.3 模式）
+
+- **拒绝理由**：见 §2.1，平台不对称 + 收益不对称。
+
+### 5.2 stub-only port（仅出 trait + `unimplemented!`）
+
+- **拒绝理由**：违反 `scripts/check_no_panics.py` 红线（生产代码不允许 `panic!`/`unimplemented!`）；且 stub 会诱导 contributor 误以为 dasclaw 计划支持。
+
+### 5.3 仅 port `escalate_protocol.rs`（88 LOC wire format）作为协议储备
+
+- **拒绝理由**：协议 byte 层与 patched shell + execve_wrapper 强耦合，单独 port 协议没有任何使用方。
+
+---
+
+## 6. References
+
+- codex-rs/shell-escalation/src/unix/mod.rs:1-50 — 上游模型描述
+- [ADR-43](43-net-proxy-port-adr.md) / [ADR-44](44-net-proxy-port-completion.md) — 网络出口控制（替代 escalation 的网络维度）
+- [ADR-129](adr-129-sandbox-windows-windows-crate-adoption.md) — Windows 进程隔离（替代 escalation 的进程维度）
+- [ADR-131](adr-131-windows-job-object-resource-limits-wrapper.md) — Job Object containment
+- [ADR-132](adr-132-execpolicy-starlark-port-plan.md) — Policy 中心（替代 escalation 的策略维度）
+- [ADR-133](adr-133-shell-command-adoption-eval.md) — 命令解析维度
+- [doc 51](51-sandbox-cross-platform-support-matrix.md) — 跨平台一致性原则
+- [#326](https://github.com/Linnanli/xClaw/issues/326) Part 3b — issue 自带研究范围
+
+---
+
+## 7. Sign-off
+
+| 角色 | 姓名 | 状态 | 时间 |
+|---|---|---|---|
+| Architect | nally | ⏳ pending | — |
+| Author | GitHub Copilot agent | ✅ drafted | 2026-05-08 |


### PR DESCRIPTION
## 背景 / 目标

完成 [#326](https://github.com/Linnanli/xClaw/issues/326) Part 2 先决 + Part 3a + Part 3b 的研究决策落地，作为单一 PR 提交（Part 1 doc refresh 已通过 #339 单独落地）。

按"不要把一块功能拆成好几份"的指导原则：**三份 ADR + doc 32 §W5 文本同步**视为同一块"研究决策"功能，不再拆 PR。具体的代码端口（execpolicy 1,790 LOC + shell_command 3,348 LOC）由 #326 Part 2 / Part 3a 各自的代码落地 PR 承担，本 PR 只做先决条件 + 决议。

## 改动范围

| 新增 / 修改 | 类型 | 说明 |
|---|---|---|
| `docs/plans/architecture-refactor/adr-132-execpolicy-starlark-port-plan.md` | 新增 ADR | **Accepted (plan-only)**：锁 `starlark = "=0.13"` exact-pin、冻结 `dasclaw_execpolicy` 公共 API、套用 ADR-129 §1.3 verbatim 红线、`scripts/check_codex_execpolicy_drift.py` guard、给出单 PR 内 7-step 提交序与 prefix_rule + network_rule fixture 验收。**Part 2 实施 PR 的先决**。 |
| `docs/plans/architecture-refactor/adr-133-shell-command-adoption-eval.md` | 新增 ADR | **Decision: adopt-with-adapter**：codex `shell-command` (3,348 LOC) verbatim port 为新 crate `dasclaw_shell_command`，与 `dasclaw_bash_validation`（claw-code 派生，门控决策）**并存且不合并**——前者是解析/标签（UI 渲染），后者是门控/拒绝（执行边界），职责正交。 |
| `docs/plans/architecture-refactor/adr-134-shell-escalation-non-goal.md` | 新增 ADR | **Decision: NON-GOAL — 不 port、不 stub、不 vendor**：Unix-only（全模块 `#[cfg(unix)]`）setuid 风格 exec 拦截器，2,217 LOC + patched shell + LD_PRELOAD 配套基建。dasclaw 桌面客户端走 governance + bash_validation + execpolicy + net_proxy + OS 原生 sandbox 五层模型，已覆盖 escalation 想解决的 exec-time 拦截需求。跨平台一致性 + 实施成本/收益不对称使 verbatim port 不划算。 |
| `docs/plans/architecture-refactor/32-execution-plan.md` §W5 | 修改 | 任务 2 引用 ADR-132；新增任务 4 dasclaw_shell_command（引 ADR-133）；新增"不在本 Wave (明确 non-goal)" 块（引 ADR-134）；验收增加 execpolicy/shell_command fixture 两条。 |
| `docs/plans/architecture-refactor/35-codex-capability-inventory.md` §I | 修改 | "adr-1XX-execpolicy-port" 占位符 → ADR-132 实链接。 |

合计 5 files, +635 / -3。

## 非目标（What's NOT in this PR）

- ❌ `dasclaw_execpolicy` 的 1,790 LOC verbatim 代码 port — 由 #326 Part 2 代码 PR 单独承担，本 PR 是其**先决条件**（ADR-132）。
- ❌ `dasclaw_shell_command` 的 3,348 LOC verbatim 代码 port — 由 #326 Part 3a 代码 PR 单独承担，本 PR 是其**决议**（ADR-133）。
- ❌ 任何 shell-escalation 相关 stub / vendor / path-dep — ADR-134 已明确拒绝。
- ❌ 触碰 [#324](https://github.com/Linnanli/xClaw/issues/324)（mainline 补强 Epic）。
- ❌ 触碰 [#28](https://github.com/Linnanli/xClaw/issues/28)（adr-redline，禁止 agent 操作）。
- ❌ 触碰 [#241](https://github.com/Linnanli/xClaw/issues/241) sandbox-windows Epic 后续 wave（conpty/ port 等）。

## 验证

doc-only PR，按规约只跑非编译类 guard：

```bash
cargo fmt --all                                                                # ✅
python3.12 scripts/check_no_panics.py --base origin/xClaw                      # ✅ OK: No panic-inducing calls in changed production code.
python3   scripts/check_no_new_ironclaw_literal.py --base origin/xClaw         # ✅ OK: No new .ironclaw / IRONCLAW_BASE_DIR literals introduced.
```

## 与 ADR-129/130 verbatim 红线的关系

ADR-132 / ADR-133 都明确套用 **ADR-129 §1.3 verbatim port 红线**模式，这是 #336 暴露 4 层 base-broken（PCWSTR vs PWSTR、`crate::X` vs `dasclaw_sandbox_windows::X`、私自 `pub mod` 提升、`autobins` 默认开启）后凝固下的最佳实践：

| 共用条款 | ADR-132 / 133 落实位置 |
|---|---|
| 仅允许"机械改写"（crate 名替换、use path 替换、顶层 doc-comment 注 sha） | §2.1 / §2.2 表格 |
| `scripts/check_codex_*_drift.py` CI guard | §3.3 / §2.4 |
| 公共 API 冻结，breaking change 需配套新 ADR | §2.3 |
| 单 PR 落地 + 内部提交序 | §4 (实施序列) |
| 不接受 `panic!` / `unwrap!` 非 verbatim 引入（`scripts/check_no_panics.py` 拦） | 全 ADR 通用 |

## 与 #336 关联

#336 验证了 verbatim port 模式在 `dasclaw_sandbox_windows` 上的**完整**正确性（4 层 base-broken 全部用"回归上游字面对齐"路径修复、最终 12/12 CI 全绿）。本 PR 以同一规约把同一模式扩展到 execpolicy + shell_command。

## Skills 自查

- doc-only 改动，不触发 `code-quality-audit` / `code-simplifier` / `code-review-expert` 三件套（仅适用于 ≥1 crate 的核心 trait 实现 / ≥300 LOC 新代码 / 涉及安全或 IPC 边界的 wave 验收）。
- 文档逻辑自查：三份 ADR 互相 cross-link、与 ADR-129/130/131/43/44/45/118/121/132/133/134 引用环闭合，doc 32 §W5 + doc 35 §I 引用 ADR-132 实链接（曾占位的 "adr-1XX-execpolicy-port" 已替换）。

Refs #326
