### PR TITLE
feat(shell-command): #326 Part 3a — verbatim port codex-shell-command + parsed_command slice + drift guard

### DIFF
--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -199,12 +199,26 @@ jobs:
     - name: Verify ported file matches codex-cli-main snapshot byte-for-byte
       run: python3.12 scripts/check_codex_process_hardening_drift.py
 
+  codex-shell-command-drift:
+    name: ADR-133 verbatim drift (dasclaw_shell_command + dasclaw_parsed_command)
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v6
+      with:
+        submodules: recursive
+    - uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+    - name: Verify ported files match codex-cli-main snapshot byte-for-byte
+      run: python3.12 scripts/check_codex_shell_command_drift.py
+
   # Roll-up job for branch protection
   code-style:
     name: Code Style (fmt + clippy + deny)
     runs-on: ubuntu-latest
     if: always()
-    needs: [format, clippy, clippy-windows, deny-check, no-panics, claw-code-readonly, no-new-ironclaw-literal, codex-execpolicy-drift, codex-process-hardening-drift]
+    needs: [format, clippy, clippy-windows, deny-check, no-panics, claw-code-readonly, no-new-ironclaw-literal, codex-execpolicy-drift, codex-process-hardening-drift, codex-shell-command-drift]
     steps:
       - run: |
           if [[ "${{ needs.format.result }}" != "success" || "${{ needs.clippy.result }}" != "success" || "${{ needs.deny-check.result }}" != "success" || "${{ needs.no-panics.result }}" != "success" || "${{ needs.claw-code-readonly.result }}" != "success" || "${{ needs.codex-execpolicy-drift.result }}" != "success" ]]; then
@@ -218,6 +232,10 @@ jobs:
           fi
           if [[ "${{ needs.codex-process-hardening-drift.result }}" != "success" ]]; then
             echo "ADR-129 verbatim drift guard failed: ${{ needs.codex-process-hardening-drift.result }}"
+            exit 1
+          fi
+          if [[ "${{ needs.codex-shell-command-drift.result }}" != "success" ]]; then
+            echo "ADR-133 verbatim drift guard failed: ${{ needs.codex-shell-command-drift.result }}"
             exit 1
           fi
           # clippy-windows only runs on main PRs, so skipped is acceptable but failure is not

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1151,7 +1151,7 @@ dependencies = [
  "rustc-hash 1.1.0",
  "shlex",
  "syn 2.0.117",
- "which",
+ "which 4.4.2",
 ]
 
 [[package]]
@@ -2765,6 +2765,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dasclaw_parsed_command"
+version = "0.0.0-w5"
+dependencies = [
+ "schemars 0.8.22",
+ "serde",
+ "ts-rs",
+]
+
+[[package]]
 name = "dasclaw_process_hardening"
 version = "0.0.0-w5"
 dependencies = [
@@ -2835,6 +2844,26 @@ dependencies = [
  "winapi",
  "windows 0.58.0",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "dasclaw_shell_command"
+version = "0.0.0-w5"
+dependencies = [
+ "anyhow",
+ "base64 0.22.1",
+ "dasclaw_absolute_path",
+ "dasclaw_parsed_command",
+ "once_cell",
+ "pretty_assertions",
+ "regex",
+ "serde",
+ "serde_json",
+ "shlex",
+ "tree-sitter",
+ "tree-sitter-bash",
+ "url",
+ "which 8.0.2",
 ]
 
 [[package]]
@@ -9008,6 +9037,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
+ "indexmap 2.13.0",
  "itoa",
  "memchr",
  "serde",
@@ -9802,6 +9832,12 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520"
 
 [[package]]
 name = "strict"
@@ -11237,6 +11273,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78f873475d258561b06f1c595d93308a7ed124d9977cb26b148c2084a4a3cc87"
+dependencies = [
+ "cc",
+ "regex",
+ "regex-syntax 0.8.10",
+ "serde_json",
+ "streaming-iterator",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-bash"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5ec769279cc91b561d3df0d8a5deb26b0ad40d183127f409494d6d8fc53062"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-language"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12318,6 +12384,15 @@ dependencies = [
  "home",
  "once_cell",
  "rustix 0.38.44",
+]
+
+[[package]]
+name = "which"
+version = "8.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81995fafaaaf6ae47a7d0cc83c67caf92aeb7e5331650ae6ff856f7c0c60c459"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,9 @@ members = [
 	"crates/dasclaw_absolute_path",
 	# W5 #324 sub-task 1 — codex-process-hardening verbatim port (pre-main hardening, 189 LOC)
 	"crates/dasclaw_process_hardening",
+	# W5 #326 Part 3a / ADR-133 — codex-shell-command verbatim port (3,348 LOC + command_safety 2,420 LOC)
+	"crates/dasclaw_parsed_command",
+	"crates/dasclaw_shell_command",
 	"desktop-client/ironclaw",
 	"desktop-client/ironclaw/crates/ironclaw_common",
 	"desktop-client/ironclaw/crates/ironclaw_safety",

--- a/crates/dasclaw_parsed_command/Cargo.toml
+++ b/crates/dasclaw_parsed_command/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+# Verbatim slice of codex-cli-main/codex-rs/protocol/src/parse_command.rs
+# (commit 4da6b0ae). The rest of codex-protocol is NOT vendored — only the
+# 31-line ParsedCommand enum needed by dasclaw_shell_command. Rationale + red
+# line in ADR-133 §amend; mechanical edits per ADR-129 §1.3.
+# DO NOT hand-edit src/parse_command.rs — drift guard
+# scripts/check_codex_shell_command_drift.py verifies hash equality with upstream.
+name = "dasclaw_parsed_command"
+version = "0.0.0-w5"
+edition = "2024"
+description = "ParsedCommand enum (verbatim slice of codex-protocol)."
+license = "Apache-2.0 OR MIT"
+publish = false
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+schemars = "0.8.22"
+serde = { version = "1", features = ["derive"] }
+ts-rs = { version = "11", features = ["serde-json-impl", "no-serde-warnings"] }

--- a/crates/dasclaw_parsed_command/src/lib.rs
+++ b/crates/dasclaw_parsed_command/src/lib.rs
@@ -1,0 +1,8 @@
+//! Verbatim slice of `codex-cli-main/codex-rs/protocol/src/parse_command.rs`.
+//!
+//! Only `ParsedCommand` is needed by `dasclaw_shell_command`; the rest of
+//! `codex-protocol` (16k LOC + 30+ transitive deps) is intentionally NOT
+//! vendored. See [ADR-133 §amend](../../docs/plans/architecture-refactor/adr-133-shell-command-adoption-eval.md)
+//! for the slicing rationale and ADR-129 §1.3 verbatim red-line.
+
+pub mod parse_command;

--- a/crates/dasclaw_parsed_command/src/parse_command.rs
+++ b/crates/dasclaw_parsed_command/src/parse_command.rs
@@ -1,0 +1,31 @@
+use schemars::JsonSchema;
+use serde::Deserialize;
+use serde::Serialize;
+use std::path::PathBuf;
+use ts_rs::TS;
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, JsonSchema, TS)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ParsedCommand {
+    Read {
+        cmd: String,
+        name: String,
+        /// (Best effort) Path to the file being read by the command. When
+        /// possible, this is an absolute path, though when relative, it should
+        /// be resolved against the `cwd`` that will be used to run the command
+        /// to derive the absolute path.
+        path: PathBuf,
+    },
+    ListFiles {
+        cmd: String,
+        path: Option<String>,
+    },
+    Search {
+        cmd: String,
+        query: Option<String>,
+        path: Option<String>,
+    },
+    Unknown {
+        cmd: String,
+    },
+}

--- a/crates/dasclaw_shell_command/Cargo.toml
+++ b/crates/dasclaw_shell_command/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+# Verbatim port of codex-shell-command @ codex-cli-main commit 4da6b0ae.
+# Mechanical edits per ADR-129 §1.3 + ADR-133:
+#   - package name swap (codex-shell-command → dasclaw_shell_command)
+#   - codex_utils_absolute_path → dasclaw_absolute_path use-path swap
+#   - codex_protocol::parse_command → dasclaw_parsed_command::parse_command use-path swap
+#   - codex_shell_command → dasclaw_shell_command use-path swap
+# DO NOT hand-edit src/*.rs — drift guard
+# scripts/check_codex_shell_command_drift.py verifies hash equality with upstream.
+name = "dasclaw_shell_command"
+version = "0.0.0-w5"
+edition = "2024"
+description = "Shell command parsing + safety classification (verbatim port of codex-shell-command)."
+license = "Apache-2.0 OR MIT"
+publish = false
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+base64 = "0.22.1"
+dasclaw_absolute_path = { path = "../dasclaw_absolute_path" }
+dasclaw_parsed_command = { path = "../dasclaw_parsed_command" }
+once_cell = "1.20.2"
+regex = "1.12.3"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+shlex = "1.3.0"
+tree-sitter = "0.25.10"
+tree-sitter-bash = "0.25"
+url = "2"
+which = "8"
+
+[dev-dependencies]
+anyhow = "1"
+pretty_assertions = "1.4.1"

--- a/crates/dasclaw_shell_command/src/bash.rs
+++ b/crates/dasclaw_shell_command/src/bash.rs
@@ -1,0 +1,590 @@
+use std::path::PathBuf;
+
+use tree_sitter::Node;
+use tree_sitter::Parser;
+use tree_sitter::Tree;
+use tree_sitter_bash::LANGUAGE as BASH;
+
+use crate::shell_detect::ShellType;
+use crate::shell_detect::detect_shell_type;
+
+/// Parse the provided bash source using tree-sitter-bash, returning a Tree on
+/// success or None if parsing failed.
+pub fn try_parse_shell(shell_lc_arg: &str) -> Option<Tree> {
+    let lang = BASH.into();
+    let mut parser = Parser::new();
+    #[expect(clippy::expect_used)]
+    parser.set_language(&lang).expect("load bash grammar");
+    let old_tree: Option<&Tree> = None;
+    parser.parse(shell_lc_arg, old_tree)
+}
+
+/// Parse a script which may contain multiple simple commands joined only by
+/// the safe logical/pipe/sequencing operators: `&&`, `||`, `;`, `|`.
+///
+/// Returns `Some(Vec<command_words>)` if every command is a plain word‑only
+/// command and the parse tree does not contain disallowed constructs
+/// (parentheses, redirections, substitutions, control flow, etc.). Otherwise
+/// returns `None`.
+pub fn try_parse_word_only_commands_sequence(tree: &Tree, src: &str) -> Option<Vec<Vec<String>>> {
+    if tree.root_node().has_error() {
+        return None;
+    }
+
+    // List of allowed (named) node kinds for a "word only commands sequence".
+    // If we encounter a named node that is not in this list we reject.
+    const ALLOWED_KINDS: &[&str] = &[
+        // top level containers
+        "program",
+        "list",
+        "pipeline",
+        // commands & words
+        "command",
+        "command_name",
+        "word",
+        "string",
+        "string_content",
+        "raw_string",
+        "number",
+        "concatenation",
+    ];
+    // Allow only safe punctuation / operator tokens; anything else causes reject.
+    const ALLOWED_PUNCT_TOKENS: &[&str] = &["&&", "||", ";", "|", "\"", "'"];
+
+    let root = tree.root_node();
+    let mut cursor = root.walk();
+    let mut stack = vec![root];
+    let mut command_nodes = Vec::new();
+    while let Some(node) = stack.pop() {
+        let kind = node.kind();
+        if node.is_named() {
+            if !ALLOWED_KINDS.contains(&kind) {
+                return None;
+            }
+            if kind == "command" {
+                command_nodes.push(node);
+            }
+        } else {
+            // Reject any punctuation / operator tokens that are not explicitly allowed.
+            if kind.chars().any(|c| "&;|".contains(c)) && !ALLOWED_PUNCT_TOKENS.contains(&kind) {
+                return None;
+            }
+            if !(ALLOWED_PUNCT_TOKENS.contains(&kind) || kind.trim().is_empty()) {
+                // If it's a quote token or operator it's allowed above; we also allow whitespace tokens.
+                // Any other punctuation like parentheses, braces, redirects, backticks, etc are rejected.
+                return None;
+            }
+        }
+        for child in node.children(&mut cursor) {
+            stack.push(child);
+        }
+    }
+
+    // Walk uses a stack (LIFO), so re-sort by position to restore source order.
+    command_nodes.sort_by_key(Node::start_byte);
+
+    let mut commands = Vec::new();
+    for node in command_nodes {
+        if let Some(words) = parse_plain_command_from_node(node, src) {
+            commands.push(words);
+        } else {
+            return None;
+        }
+    }
+    Some(commands)
+}
+
+pub fn extract_bash_command(command: &[String]) -> Option<(&str, &str)> {
+    let [shell, flag, script] = command else {
+        return None;
+    };
+    if !matches!(flag.as_str(), "-lc" | "-c")
+        || !matches!(
+            detect_shell_type(&PathBuf::from(shell)),
+            Some(ShellType::Zsh) | Some(ShellType::Bash) | Some(ShellType::Sh)
+        )
+    {
+        return None;
+    }
+    Some((shell, script))
+}
+
+/// Returns the sequence of plain commands within a `bash -lc "..."` or
+/// `zsh -lc "..."` invocation when the script only contains word-only commands
+/// joined by safe operators.
+pub fn parse_shell_lc_plain_commands(command: &[String]) -> Option<Vec<Vec<String>>> {
+    let (_, script) = extract_bash_command(command)?;
+
+    let tree = try_parse_shell(script)?;
+    try_parse_word_only_commands_sequence(&tree, script)
+}
+
+/// Returns the parsed argv for a single shell command in a here-doc style
+/// script (`<<`), as long as the script contains exactly one command node.
+pub fn parse_shell_lc_single_command_prefix(command: &[String]) -> Option<Vec<String>> {
+    let (_, script) = extract_bash_command(command)?;
+    let tree = try_parse_shell(script)?;
+    let root = tree.root_node();
+    if root.has_error() {
+        return None;
+    }
+    if !has_named_descendant_kind(root, "heredoc_redirect") {
+        return None;
+    }
+
+    let command_node = find_single_command_node(root)?;
+    parse_heredoc_command_words(command_node, script)
+}
+
+fn parse_plain_command_from_node(cmd: tree_sitter::Node, src: &str) -> Option<Vec<String>> {
+    if cmd.kind() != "command" {
+        return None;
+    }
+    let mut words = Vec::new();
+    let mut cursor = cmd.walk();
+    for child in cmd.named_children(&mut cursor) {
+        match child.kind() {
+            "command_name" => {
+                let word_node = child.named_child(0)?;
+                if word_node.kind() != "word" {
+                    return None;
+                }
+                words.push(word_node.utf8_text(src.as_bytes()).ok()?.to_owned());
+            }
+            "word" | "number" => {
+                words.push(child.utf8_text(src.as_bytes()).ok()?.to_owned());
+            }
+            "string" => {
+                let parsed = parse_double_quoted_string(child, src)?;
+                words.push(parsed);
+            }
+            "raw_string" => {
+                let parsed = parse_raw_string(child, src)?;
+                words.push(parsed);
+            }
+            "concatenation" => {
+                // Handle concatenated arguments like -g"*.py"
+                let mut concatenated = String::new();
+                let mut concat_cursor = child.walk();
+                for part in child.named_children(&mut concat_cursor) {
+                    match part.kind() {
+                        "word" | "number" => {
+                            concatenated
+                                .push_str(part.utf8_text(src.as_bytes()).ok()?.to_owned().as_str());
+                        }
+                        "string" => {
+                            let parsed = parse_double_quoted_string(part, src)?;
+                            concatenated.push_str(&parsed);
+                        }
+                        "raw_string" => {
+                            let parsed = parse_raw_string(part, src)?;
+                            concatenated.push_str(&parsed);
+                        }
+                        _ => return None,
+                    }
+                }
+                if concatenated.is_empty() {
+                    return None;
+                }
+                words.push(concatenated);
+            }
+            _ => return None,
+        }
+    }
+    Some(words)
+}
+
+fn parse_heredoc_command_words(cmd: Node<'_>, src: &str) -> Option<Vec<String>> {
+    if cmd.kind() != "command" {
+        return None;
+    }
+
+    let mut words = Vec::new();
+    let mut cursor = cmd.walk();
+    for child in cmd.named_children(&mut cursor) {
+        match child.kind() {
+            "command_name" => {
+                let word_node = child.named_child(0)?;
+                if !matches!(word_node.kind(), "word" | "number")
+                    || !is_literal_word_or_number(word_node)
+                {
+                    return None;
+                }
+                words.push(word_node.utf8_text(src.as_bytes()).ok()?.to_owned());
+            }
+            "word" | "number" => {
+                if !is_literal_word_or_number(child) {
+                    return None;
+                }
+                words.push(child.utf8_text(src.as_bytes()).ok()?.to_owned());
+            }
+            // Allow shell constructs that attach IO to a single command without
+            // changing argv matching semantics for the executable prefix.
+            "variable_assignment" | "comment" => {}
+            kind if is_allowed_heredoc_attachment_kind(kind) => {}
+            _ => return None,
+        }
+    }
+
+    if words.is_empty() { None } else { Some(words) }
+}
+
+fn is_literal_word_or_number(node: Node<'_>) -> bool {
+    if !matches!(node.kind(), "word" | "number") {
+        return false;
+    }
+    let mut cursor = node.walk();
+    node.named_children(&mut cursor).next().is_none()
+}
+
+fn is_allowed_heredoc_attachment_kind(kind: &str) -> bool {
+    matches!(
+        kind,
+        "heredoc_body"
+            | "simple_heredoc_body"
+            | "heredoc_redirect"
+            | "herestring_redirect"
+            | "file_redirect"
+            | "redirected_statement"
+    )
+}
+
+fn find_single_command_node(root: Node<'_>) -> Option<Node<'_>> {
+    let mut stack = vec![root];
+    let mut single_command = None;
+    while let Some(node) = stack.pop() {
+        if node.kind() == "command" {
+            if single_command.is_some() {
+                return None;
+            }
+            single_command = Some(node);
+        }
+
+        let mut cursor = node.walk();
+        for child in node.named_children(&mut cursor) {
+            stack.push(child);
+        }
+    }
+    single_command
+}
+
+fn has_named_descendant_kind(node: Node<'_>, kind: &str) -> bool {
+    let mut stack = vec![node];
+    while let Some(current) = stack.pop() {
+        if current.kind() == kind {
+            return true;
+        }
+        let mut cursor = current.walk();
+        for child in current.named_children(&mut cursor) {
+            stack.push(child);
+        }
+    }
+    false
+}
+
+fn parse_double_quoted_string(node: Node, src: &str) -> Option<String> {
+    if node.kind() != "string" {
+        return None;
+    }
+
+    let mut cursor = node.walk();
+    for part in node.named_children(&mut cursor) {
+        if part.kind() != "string_content" {
+            return None;
+        }
+    }
+    let raw = node.utf8_text(src.as_bytes()).ok()?;
+    let stripped = raw
+        .strip_prefix('"')
+        .and_then(|text| text.strip_suffix('"'))?;
+    Some(stripped.to_string())
+}
+
+fn parse_raw_string(node: Node, src: &str) -> Option<String> {
+    if node.kind() != "raw_string" {
+        return None;
+    }
+
+    let raw_string = node.utf8_text(src.as_bytes()).ok()?;
+    let stripped = raw_string
+        .strip_prefix('\'')
+        .and_then(|s| s.strip_suffix('\''));
+    stripped.map(str::to_owned)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    fn parse_seq(src: &str) -> Option<Vec<Vec<String>>> {
+        let tree = try_parse_shell(src)?;
+        try_parse_word_only_commands_sequence(&tree, src)
+    }
+
+    #[test]
+    fn accepts_single_simple_command() {
+        let cmds = parse_seq("ls -1").unwrap();
+        assert_eq!(cmds, vec![vec!["ls".to_string(), "-1".to_string()]]);
+    }
+
+    #[test]
+    fn accepts_multiple_commands_with_allowed_operators() {
+        let src = "ls && pwd; echo 'hi there' | wc -l";
+        let cmds = parse_seq(src).unwrap();
+        let expected: Vec<Vec<String>> = vec![
+            vec!["ls".to_string()],
+            vec!["pwd".to_string()],
+            vec!["echo".to_string(), "hi there".to_string()],
+            vec!["wc".to_string(), "-l".to_string()],
+        ];
+        assert_eq!(cmds, expected);
+    }
+
+    #[test]
+    fn extracts_double_and_single_quoted_strings() {
+        let cmds = parse_seq("echo \"hello world\"").unwrap();
+        assert_eq!(
+            cmds,
+            vec![vec!["echo".to_string(), "hello world".to_string()]]
+        );
+
+        let cmds2 = parse_seq("echo 'hi there'").unwrap();
+        assert_eq!(
+            cmds2,
+            vec![vec!["echo".to_string(), "hi there".to_string()]]
+        );
+    }
+
+    #[test]
+    fn accepts_double_quoted_strings_with_newlines() {
+        let cmds = parse_seq("git commit -m \"line1\nline2\"").unwrap();
+        assert_eq!(
+            cmds,
+            vec![vec![
+                "git".to_string(),
+                "commit".to_string(),
+                "-m".to_string(),
+                "line1\nline2".to_string(),
+            ]]
+        );
+    }
+
+    #[test]
+    fn accepts_mixed_quote_concatenation() {
+        assert_eq!(
+            parse_seq(r#"echo "/usr"'/'"local"/bin"#).unwrap(),
+            vec![vec!["echo".to_string(), "/usr/local/bin".to_string()]]
+        );
+        assert_eq!(
+            parse_seq(r#"echo '/usr'"/"'local'/bin"#).unwrap(),
+            vec![vec!["echo".to_string(), "/usr/local/bin".to_string()]]
+        );
+    }
+
+    #[test]
+    fn rejects_double_quoted_strings_with_expansions() {
+        assert!(parse_seq(r#"echo "hi ${USER}""#).is_none());
+        assert!(parse_seq(r#"echo "$HOME""#).is_none());
+    }
+
+    #[test]
+    fn accepts_numbers_as_words() {
+        let cmds = parse_seq("echo 123 456").unwrap();
+        assert_eq!(
+            cmds,
+            vec![vec![
+                "echo".to_string(),
+                "123".to_string(),
+                "456".to_string()
+            ]]
+        );
+    }
+
+    #[test]
+    fn rejects_parentheses_and_subshells() {
+        assert!(parse_seq("(ls)").is_none());
+        assert!(parse_seq("ls || (pwd && echo hi)").is_none());
+    }
+
+    #[test]
+    fn rejects_redirections_and_unsupported_operators() {
+        assert!(parse_seq("ls > out.txt").is_none());
+        assert!(parse_seq("echo hi & echo bye").is_none());
+    }
+
+    #[test]
+    fn rejects_command_and_process_substitutions_and_expansions() {
+        assert!(parse_seq("echo $(pwd)").is_none());
+        assert!(parse_seq("echo `pwd`").is_none());
+        assert!(parse_seq("echo $HOME").is_none());
+        assert!(parse_seq("echo \"hi $USER\"").is_none());
+    }
+
+    #[test]
+    fn rejects_variable_assignment_prefix() {
+        assert!(parse_seq("FOO=bar ls").is_none());
+    }
+
+    #[test]
+    fn rejects_trailing_operator_parse_error() {
+        assert!(parse_seq("ls &&").is_none());
+    }
+
+    #[test]
+    fn rejects_empty_command_position_with_leading_operator() {
+        assert!(parse_seq("&& ls").is_none());
+    }
+
+    #[test]
+    fn rejects_empty_command_position_with_double_separator() {
+        assert!(parse_seq("ls ;; pwd").is_none());
+    }
+
+    #[test]
+    fn rejects_empty_command_position_with_empty_pipeline_segment() {
+        assert!(parse_seq("ls | | wc").is_none());
+    }
+
+    #[test]
+    fn parse_zsh_lc_plain_commands() {
+        let command = vec!["zsh".to_string(), "-lc".to_string(), "ls".to_string()];
+        let parsed = parse_shell_lc_plain_commands(&command).unwrap();
+        assert_eq!(parsed, vec![vec!["ls".to_string()]]);
+    }
+
+    #[test]
+    fn accepts_concatenated_flag_and_value() {
+        // Test case: -g"*.py" (flag directly concatenated with quoted value)
+        let cmds = parse_seq("rg -n \"foo\" -g\"*.py\"").unwrap();
+        assert_eq!(
+            cmds,
+            vec![vec![
+                "rg".to_string(),
+                "-n".to_string(),
+                "foo".to_string(),
+                "-g*.py".to_string(),
+            ]]
+        );
+    }
+
+    #[test]
+    fn accepts_concatenated_flag_with_single_quotes() {
+        let cmds = parse_seq("grep -n 'pattern' -g'*.txt'").unwrap();
+        assert_eq!(
+            cmds,
+            vec![vec![
+                "grep".to_string(),
+                "-n".to_string(),
+                "pattern".to_string(),
+                "-g*.txt".to_string(),
+            ]]
+        );
+    }
+
+    #[test]
+    fn rejects_concatenation_with_variable_substitution() {
+        // Environment variables in concatenated strings should be rejected
+        assert!(parse_seq("rg -g\"$VAR\" pattern").is_none());
+        assert!(parse_seq("rg -g\"${VAR}\" pattern").is_none());
+    }
+
+    #[test]
+    fn rejects_concatenation_with_command_substitution() {
+        // Command substitution in concatenated strings should be rejected
+        assert!(parse_seq("rg -g\"$(pwd)\" pattern").is_none());
+        assert!(parse_seq("rg -g\"$(echo '*.py')\" pattern").is_none());
+    }
+
+    #[test]
+    fn parse_shell_lc_single_command_prefix_supports_heredoc() {
+        let command = vec![
+            "zsh".to_string(),
+            "-lc".to_string(),
+            "python3 <<'PY'\nprint('hello')\nPY".to_string(),
+        ];
+        let parsed = parse_shell_lc_single_command_prefix(&command);
+        assert_eq!(parsed, Some(vec!["python3".to_string()]));
+
+        let command_unquoted = vec![
+            "zsh".to_string(),
+            "-lc".to_string(),
+            "python3 << PY\nprint('hello')\nPY".to_string(),
+        ];
+        let parsed_unquoted = parse_shell_lc_single_command_prefix(&command_unquoted);
+        assert_eq!(parsed_unquoted, Some(vec!["python3".to_string()]));
+    }
+
+    #[test]
+    fn parse_shell_lc_single_command_prefix_rejects_multi_command_scripts() {
+        let command = vec![
+            "bash".to_string(),
+            "-lc".to_string(),
+            "python3 <<'PY'\nprint('hello')\nPY\necho done".to_string(),
+        ];
+        assert_eq!(parse_shell_lc_single_command_prefix(&command), None);
+    }
+
+    #[test]
+    fn parse_shell_lc_single_command_prefix_rejects_non_heredoc_redirects() {
+        let command = vec![
+            "bash".to_string(),
+            "-lc".to_string(),
+            "echo hello > /tmp/out.txt".to_string(),
+        ];
+        assert_eq!(parse_shell_lc_single_command_prefix(&command), None);
+    }
+
+    #[test]
+    fn parse_shell_lc_single_command_prefix_accepts_heredoc_with_extra_redirect() {
+        let command = vec![
+            "bash".to_string(),
+            "-lc".to_string(),
+            "python3 <<'PY' > /tmp/out.txt\nprint('hello')\nPY".to_string(),
+        ];
+        assert_eq!(
+            parse_shell_lc_single_command_prefix(&command),
+            Some(vec!["python3".to_string()])
+        );
+    }
+
+    #[test]
+    fn parse_shell_lc_single_command_prefix_rejects_herestring_with_chaining() {
+        let command = vec![
+            "bash".to_string(),
+            "-lc".to_string(),
+            r#"echo hello > /tmp/out.txt && cat /tmp/out.txt"#.to_string(),
+        ];
+        assert_eq!(parse_shell_lc_single_command_prefix(&command), None);
+    }
+
+    #[test]
+    fn parse_shell_lc_single_command_prefix_rejects_herestring_with_substitution() {
+        let command = vec![
+            "bash".to_string(),
+            "-lc".to_string(),
+            r#"python3 <<< "$(rm -rf /)""#.to_string(),
+        ];
+        assert_eq!(parse_shell_lc_single_command_prefix(&command), None);
+    }
+
+    #[test]
+    fn parse_shell_lc_single_command_prefix_rejects_arithmetic_shift_non_heredoc_script() {
+        let command = vec![
+            "bash".to_string(),
+            "-lc".to_string(),
+            "echo $((1<<2))".to_string(),
+        ];
+        assert_eq!(parse_shell_lc_single_command_prefix(&command), None);
+    }
+
+    #[test]
+    fn parse_shell_lc_single_command_prefix_rejects_heredoc_command_with_word_expansion() {
+        let command = vec![
+            "bash".to_string(),
+            "-lc".to_string(),
+            "python3 $((1<<2)) <<'PY'\nprint('hello')\nPY".to_string(),
+        ];
+        assert_eq!(parse_shell_lc_single_command_prefix(&command), None);
+    }
+}

--- a/crates/dasclaw_shell_command/src/command_safety/is_dangerous_command.rs
+++ b/crates/dasclaw_shell_command/src/command_safety/is_dangerous_command.rs
@@ -1,0 +1,184 @@
+use crate::bash::parse_shell_lc_plain_commands;
+use std::path::Path;
+#[cfg(windows)]
+#[path = "windows_dangerous_commands.rs"]
+mod windows_dangerous_commands;
+
+pub fn command_might_be_dangerous(command: &[String]) -> bool {
+    #[cfg(windows)]
+    {
+        if windows_dangerous_commands::is_dangerous_command_windows(command) {
+            return true;
+        }
+    }
+
+    if is_dangerous_to_call_with_exec(command) {
+        return true;
+    }
+
+    // Support `bash -lc "<script>"` where the any part of the script might contain a dangerous command.
+    if let Some(all_commands) = parse_shell_lc_plain_commands(command)
+        && all_commands
+            .iter()
+            .any(|cmd| is_dangerous_to_call_with_exec(cmd))
+    {
+        return true;
+    }
+
+    false
+}
+
+fn is_git_global_option_with_value(arg: &str) -> bool {
+    matches!(
+        arg,
+        "-C" | "-c"
+            | "--config-env"
+            | "--exec-path"
+            | "--git-dir"
+            | "--namespace"
+            | "--super-prefix"
+            | "--work-tree"
+    )
+}
+
+fn is_git_global_option_with_inline_value(arg: &str) -> bool {
+    matches!(
+        arg,
+        s if s.starts_with("--config-env=")
+            || s.starts_with("--exec-path=")
+            || s.starts_with("--git-dir=")
+            || s.starts_with("--namespace=")
+            || s.starts_with("--super-prefix=")
+            || s.starts_with("--work-tree=")
+    ) || ((arg.starts_with("-C") || arg.starts_with("-c")) && arg.len() > 2)
+}
+
+/// Git global options that can redirect config, repository, or helper lookup
+/// and therefore must never be auto-approved as "safe".
+pub(crate) fn git_global_option_requires_prompt(arg: &str) -> bool {
+    matches!(
+        arg,
+        "-c" | "--config-env"
+            | "--exec-path"
+            | "--git-dir"
+            | "--namespace"
+            | "--super-prefix"
+            | "--work-tree"
+    ) || matches!(
+        arg,
+        s if (s.starts_with("-c") && s.len() > 2)
+            || s.starts_with("--config-env=")
+            || s.starts_with("--exec-path=")
+            || s.starts_with("--git-dir=")
+            || s.starts_with("--namespace=")
+            || s.starts_with("--super-prefix=")
+            || s.starts_with("--work-tree=")
+    )
+}
+
+pub(crate) fn executable_name_lookup_key(raw: &str) -> Option<String> {
+    #[cfg(windows)]
+    {
+        Path::new(raw)
+            .file_name()
+            .and_then(|name| name.to_str())
+            .map(|name| {
+                let name = name.to_ascii_lowercase();
+                for suffix in [".exe", ".cmd", ".bat", ".com"] {
+                    if let Some(stripped) = name.strip_suffix(suffix) {
+                        return stripped.to_string();
+                    }
+                }
+                name
+            })
+    }
+
+    #[cfg(not(windows))]
+    {
+        Path::new(raw)
+            .file_name()
+            .and_then(|name| name.to_str())
+            .map(std::borrow::ToOwned::to_owned)
+    }
+}
+
+/// Find the first matching git subcommand, skipping known global options that
+/// may appear before it (e.g., `-C`, `-c`, `--git-dir`).
+///
+/// Shared with `is_safe_command` to avoid git-global-option bypasses.
+pub(crate) fn find_git_subcommand<'a>(
+    command: &'a [String],
+    subcommands: &[&str],
+) -> Option<(usize, &'a str)> {
+    let cmd0 = command.first().map(String::as_str)?;
+    if executable_name_lookup_key(cmd0).as_deref() != Some("git") {
+        return None;
+    }
+
+    let mut skip_next = false;
+    for (idx, arg) in command.iter().enumerate().skip(1) {
+        if skip_next {
+            skip_next = false;
+            continue;
+        }
+
+        let arg = arg.as_str();
+
+        if is_git_global_option_with_inline_value(arg) {
+            continue;
+        }
+
+        if is_git_global_option_with_value(arg) {
+            skip_next = true;
+            continue;
+        }
+
+        if arg == "--" || arg.starts_with('-') {
+            continue;
+        }
+
+        if subcommands.contains(&arg) {
+            return Some((idx, arg));
+        }
+
+        // In git, the first non-option token is the subcommand. If it isn't
+        // one of the subcommands we're looking for, we must stop scanning to
+        // avoid misclassifying later positional args (e.g., branch names).
+        return None;
+    }
+
+    None
+}
+
+fn is_dangerous_to_call_with_exec(command: &[String]) -> bool {
+    let cmd0 = command.first().map(String::as_str);
+
+    match cmd0 {
+        Some("rm") => matches!(command.get(1).map(String::as_str), Some("-f" | "-rf")),
+
+        // for sudo <cmd> simply do the check for <cmd>
+        Some("sudo") => is_dangerous_to_call_with_exec(&command[1..]),
+
+        // ── anything else ─────────────────────────────────────────────────
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn vec_str(items: &[&str]) -> Vec<String> {
+        items.iter().map(std::string::ToString::to_string).collect()
+    }
+
+    #[test]
+    fn rm_rf_is_dangerous() {
+        assert!(command_might_be_dangerous(&vec_str(&["rm", "-rf", "/"])));
+    }
+
+    #[test]
+    fn rm_f_is_dangerous() {
+        assert!(command_might_be_dangerous(&vec_str(&["rm", "-f", "/"])));
+    }
+}

--- a/crates/dasclaw_shell_command/src/command_safety/is_safe_command.rs
+++ b/crates/dasclaw_shell_command/src/command_safety/is_safe_command.rs
@@ -1,0 +1,633 @@
+use crate::bash::parse_shell_lc_plain_commands;
+use crate::command_safety::is_dangerous_command::executable_name_lookup_key;
+// Find the first matching git subcommand, skipping known global options that
+// may appear before it (e.g., `-C`, `-c`, `--git-dir`).
+// Implemented in `is_dangerous_command` and shared here.
+use crate::command_safety::is_dangerous_command::find_git_subcommand;
+use crate::command_safety::is_dangerous_command::git_global_option_requires_prompt;
+use crate::command_safety::windows_safe_commands::is_safe_command_windows;
+
+pub fn is_known_safe_command(command: &[String]) -> bool {
+    let command: Vec<String> = command
+        .iter()
+        .map(|s| {
+            if s == "zsh" {
+                "bash".to_string()
+            } else {
+                s.clone()
+            }
+        })
+        .collect();
+
+    if is_safe_command_windows(&command) {
+        return true;
+    }
+
+    if is_safe_to_call_with_exec(&command) {
+        return true;
+    }
+
+    // Support `bash -lc "..."` where the script consists solely of one or
+    // more "plain" commands (only bare words / quoted strings) combined with
+    // a conservative allow‑list of shell operators that themselves do not
+    // introduce side effects ( "&&", "||", ";", and "|" ). If every
+    // individual command in the script is itself a known‑safe command, then
+    // the composite expression is considered safe.
+    if let Some(all_commands) = parse_shell_lc_plain_commands(&command)
+        && !all_commands.is_empty()
+        && all_commands
+            .iter()
+            .all(|cmd| is_safe_to_call_with_exec(cmd))
+    {
+        return true;
+    }
+    false
+}
+
+fn is_safe_to_call_with_exec(command: &[String]) -> bool {
+    let Some(cmd0) = command.first().map(String::as_str) else {
+        return false;
+    };
+
+    match executable_name_lookup_key(cmd0).as_deref() {
+        Some(cmd) if cfg!(target_os = "linux") && matches!(cmd, "numfmt" | "tac") => true,
+
+        #[rustfmt::skip]
+        Some(
+            "cat" |
+            "cd" |
+            "cut" |
+            "echo" |
+            "expr" |
+            "false" |
+            "grep" |
+            "head" |
+            "id" |
+            "ls" |
+            "nl" |
+            "paste" |
+            "pwd" |
+            "rev" |
+            "seq" |
+            "stat" |
+            "tail" |
+            "tr" |
+            "true" |
+            "uname" |
+            "uniq" |
+            "wc" |
+            "which" |
+            "whoami") => {
+            true
+        },
+
+        Some("base64") => {
+            const UNSAFE_BASE64_OPTIONS: &[&str] = &["-o", "--output"];
+
+            !command.iter().skip(1).any(|arg| {
+                UNSAFE_BASE64_OPTIONS.contains(&arg.as_str())
+                    || arg.starts_with("--output=")
+                    || (arg.starts_with("-o") && arg != "-o")
+            })
+        }
+
+        Some("find") => {
+            // Certain options to `find` can delete files, write to files, or
+            // execute arbitrary commands, so we cannot auto-approve the
+            // invocation of `find` in such cases.
+            #[rustfmt::skip]
+            const UNSAFE_FIND_OPTIONS: &[&str] = &[
+                // Options that can execute arbitrary commands.
+                "-exec", "-execdir", "-ok", "-okdir",
+                // Option that deletes matching files.
+                "-delete",
+                // Options that write pathnames to a file.
+                "-fls", "-fprint", "-fprint0", "-fprintf",
+            ];
+
+            !command
+                .iter()
+                .any(|arg| UNSAFE_FIND_OPTIONS.contains(&arg.as_str()))
+        }
+
+        // Ripgrep
+        Some("rg") => {
+            const UNSAFE_RIPGREP_OPTIONS_WITH_ARGS: &[&str] = &[
+                // Takes an arbitrary command that is executed for each match.
+                "--pre",
+                // Takes a command that can be used to obtain the local hostname.
+                "--hostname-bin",
+            ];
+            const UNSAFE_RIPGREP_OPTIONS_WITHOUT_ARGS: &[&str] = &[
+                // Calls out to other decompression tools, so do not auto-approve
+                // out of an abundance of caution.
+                "--search-zip",
+                "-z",
+            ];
+
+            !command.iter().any(|arg| {
+                UNSAFE_RIPGREP_OPTIONS_WITHOUT_ARGS.contains(&arg.as_str())
+                    || UNSAFE_RIPGREP_OPTIONS_WITH_ARGS
+                        .iter()
+                        .any(|&opt| arg == opt || arg.starts_with(&format!("{opt}=")))
+            })
+        }
+
+        // Git
+        Some("git") => {
+            // Global options that redirect config, repository, or helper
+            // lookup can make otherwise read-only git commands execute
+            // attacker-controlled code, so they must never be auto-approved.
+            if git_has_unsafe_global_option(command) {
+                return false;
+            }
+
+            let Some((subcommand_idx, subcommand)) =
+                find_git_subcommand(command, &["status", "log", "diff", "show", "branch"])
+            else {
+                return false;
+            };
+
+            let subcommand_args = &command[subcommand_idx + 1..];
+
+            match subcommand {
+                "status" | "log" | "diff" | "show" => {
+                    git_subcommand_args_are_read_only(subcommand_args)
+                }
+                "branch" => {
+                    git_subcommand_args_are_read_only(subcommand_args)
+                        && git_branch_is_read_only(subcommand_args)
+                }
+                other => {
+                    debug_assert!(false, "unexpected git subcommand from matcher: {other}");
+                    false
+                }
+            }
+        }
+
+        // Special-case `sed -n {N|M,N}p`
+        Some("sed")
+            if {
+                command.len() <= 4
+                    && command.get(1).map(String::as_str) == Some("-n")
+                    && is_valid_sed_n_arg(command.get(2).map(String::as_str))
+            } =>
+        {
+            true
+        }
+
+        // ── anything else ─────────────────────────────────────────────────
+        _ => false,
+    }
+}
+
+// Treat `git branch` as safe only when the arguments clearly indicate
+// a read-only query, not a branch mutation (create/rename/delete).
+fn git_branch_is_read_only(branch_args: &[String]) -> bool {
+    if branch_args.is_empty() {
+        // `git branch` with no additional args lists branches.
+        return true;
+    }
+
+    let mut saw_read_only_flag = false;
+    for arg in branch_args.iter().map(String::as_str) {
+        match arg {
+            "--list" | "-l" | "--show-current" | "-a" | "--all" | "-r" | "--remotes" | "-v"
+            | "-vv" | "--verbose" => {
+                saw_read_only_flag = true;
+            }
+            _ if arg.starts_with("--format=") => {
+                saw_read_only_flag = true;
+            }
+            _ => {
+                // Any other flag or positional argument may create, rename, or delete branches.
+                return false;
+            }
+        }
+    }
+
+    saw_read_only_flag
+}
+
+fn git_has_unsafe_global_option(command: &[String]) -> bool {
+    command
+        .iter()
+        .skip(1)
+        .map(String::as_str)
+        .any(git_global_option_requires_prompt)
+}
+
+fn git_subcommand_args_are_read_only(args: &[String]) -> bool {
+    // Flags that can write to disk or execute external tools should never be
+    // auto-approved on an unsandboxed machine.
+    const UNSAFE_GIT_FLAGS: &[&str] = &[
+        "--output",
+        "--ext-diff",
+        "--textconv",
+        "--exec",
+        "--paginate",
+    ];
+
+    !args.iter().map(String::as_str).any(|arg| {
+        UNSAFE_GIT_FLAGS.contains(&arg)
+            || arg.starts_with("--output=")
+            || arg.starts_with("--exec=")
+    })
+}
+
+// (bash parsing helpers implemented in crate::bash)
+
+/* ----------------------------------------------------------
+Example
+---------------------------------------------------------- */
+
+/// Returns true if `arg` matches /^(\d+,)?\d+p$/
+fn is_valid_sed_n_arg(arg: Option<&str>) -> bool {
+    // unwrap or bail
+    let s = match arg {
+        Some(s) => s,
+        None => return false,
+    };
+
+    // must end with 'p', strip it
+    let core = match s.strip_suffix('p') {
+        Some(rest) => rest,
+        None => return false,
+    };
+
+    // split on ',' and ensure 1 or 2 numeric parts
+    let parts: Vec<&str> = core.split(',').collect();
+    match parts.as_slice() {
+        // single number, e.g. "10"
+        [num] => !num.is_empty() && num.chars().all(|c| c.is_ascii_digit()),
+
+        // two numbers, e.g. "1,5"
+        [a, b] => {
+            !a.is_empty()
+                && !b.is_empty()
+                && a.chars().all(|c| c.is_ascii_digit())
+                && b.chars().all(|c| c.is_ascii_digit())
+        }
+
+        // anything else (more than one comma) is invalid
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::string::ToString;
+
+    fn vec_str(args: &[&str]) -> Vec<String> {
+        args.iter().map(ToString::to_string).collect()
+    }
+
+    #[test]
+    fn known_safe_examples() {
+        assert!(is_safe_to_call_with_exec(&vec_str(&["ls"])));
+        assert!(is_safe_to_call_with_exec(&vec_str(&["git", "status"])));
+        assert!(is_safe_to_call_with_exec(&vec_str(&["git", "branch"])));
+        assert!(is_safe_to_call_with_exec(&vec_str(&[
+            "git",
+            "branch",
+            "--show-current"
+        ])));
+        assert!(is_safe_to_call_with_exec(&vec_str(&["base64"])));
+        assert!(is_safe_to_call_with_exec(&vec_str(&[
+            "sed", "-n", "1,5p", "file.txt"
+        ])));
+        assert!(is_safe_to_call_with_exec(&vec_str(&[
+            "nl",
+            "-nrz",
+            "Cargo.toml"
+        ])));
+
+        // Safe `find` command (no unsafe options).
+        assert!(is_safe_to_call_with_exec(&vec_str(&[
+            "find", ".", "-name", "file.txt"
+        ])));
+
+        if cfg!(target_os = "linux") {
+            assert!(is_safe_to_call_with_exec(&vec_str(&["numfmt", "1000"])));
+            assert!(is_safe_to_call_with_exec(&vec_str(&["tac", "Cargo.toml"])));
+        } else {
+            assert!(!is_safe_to_call_with_exec(&vec_str(&["numfmt", "1000"])));
+            assert!(!is_safe_to_call_with_exec(&vec_str(&["tac", "Cargo.toml"])));
+        }
+    }
+
+    #[test]
+    fn git_branch_mutating_flags_are_not_safe() {
+        assert!(!is_known_safe_command(&vec_str(&[
+            "git", "branch", "-d", "feature"
+        ])));
+        assert!(!is_known_safe_command(&vec_str(&[
+            "git",
+            "branch",
+            "new-branch"
+        ])));
+    }
+
+    #[test]
+    fn git_branch_global_options_respect_safety_rules() {
+        use pretty_assertions::assert_eq;
+
+        assert_eq!(
+            is_known_safe_command(&vec_str(&["git", "-C", ".", "branch", "--show-current"])),
+            true
+        );
+        assert_eq!(
+            is_known_safe_command(&vec_str(&["git", "-C", ".", "branch", "-d", "feature"])),
+            false
+        );
+        assert_eq!(
+            is_known_safe_command(&vec_str(&["bash", "-lc", "git -C . branch -d feature",])),
+            false
+        );
+    }
+
+    #[test]
+    fn git_first_positional_is_the_subcommand() {
+        // In git, the first non-option token is the subcommand. Later positional
+        // args (like branch names) must not be treated as subcommands.
+        assert!(!is_known_safe_command(&vec_str(&[
+            "git", "checkout", "status",
+        ])));
+    }
+
+    #[test]
+    fn git_output_flags_are_not_safe() {
+        assert!(!is_known_safe_command(&vec_str(&[
+            "git",
+            "log",
+            "--output=/tmp/git-log-out-test",
+            "-n",
+            "1",
+        ])));
+        assert!(!is_known_safe_command(&vec_str(&[
+            "git",
+            "diff",
+            "--output",
+            "/tmp/git-diff-out-test",
+        ])));
+        assert!(!is_known_safe_command(&vec_str(&[
+            "git",
+            "show",
+            "--output=/tmp/git-show-out-test",
+            "HEAD",
+        ])));
+    }
+
+    #[test]
+    fn git_global_override_flags_are_not_safe() {
+        assert!(!is_known_safe_command(&vec_str(&[
+            "git",
+            "-c",
+            "core.pager=cat",
+            "log",
+            "-n",
+            "1",
+        ])));
+        assert!(!is_known_safe_command(&vec_str(&[
+            "git",
+            "-ccore.pager=cat",
+            "status",
+        ])));
+
+        for args in [
+            vec_str(&["git", "--config-env", "core.pager=PAGER", "show", "HEAD"]),
+            vec_str(&["git", "--config-env=core.pager=PAGER", "show", "HEAD"]),
+            vec_str(&["git", "--git-dir", ".evil-git", "diff", "HEAD~1..HEAD"]),
+            vec_str(&["git", "--git-dir=.evil-git", "diff", "HEAD~1..HEAD"]),
+            vec_str(&["git", "--work-tree", ".", "status"]),
+            vec_str(&["git", "--work-tree=.", "status"]),
+            vec_str(&["git", "--exec-path", ".git/helpers", "show", "HEAD"]),
+            vec_str(&["git", "--exec-path=.git/helpers", "show", "HEAD"]),
+            vec_str(&["git", "--namespace", "attacker", "show", "HEAD"]),
+            vec_str(&["git", "--namespace=attacker", "show", "HEAD"]),
+            vec_str(&["git", "--super-prefix", "attacker/", "show", "HEAD"]),
+            vec_str(&["git", "--super-prefix=attacker/", "show", "HEAD"]),
+        ] {
+            assert!(
+                !is_known_safe_command(&args),
+                "expected {args:?} to require approval due to unsafe git global option",
+            );
+        }
+
+        assert!(!is_known_safe_command(&vec_str(&[
+            "bash",
+            "-lc",
+            "git --git-dir=.evil-git diff HEAD~1..HEAD",
+        ])));
+    }
+
+    #[test]
+    fn cargo_check_is_not_safe() {
+        assert!(!is_known_safe_command(&vec_str(&["cargo", "check"])));
+    }
+
+    #[test]
+    fn zsh_lc_safe_command_sequence() {
+        assert!(is_known_safe_command(&vec_str(&["zsh", "-lc", "ls"])));
+    }
+
+    #[test]
+    fn unknown_or_partial() {
+        assert!(!is_safe_to_call_with_exec(&vec_str(&["foo"])));
+        assert!(!is_safe_to_call_with_exec(&vec_str(&["git", "fetch"])));
+        assert!(!is_safe_to_call_with_exec(&vec_str(&[
+            "sed", "-n", "xp", "file.txt"
+        ])));
+
+        // Unsafe `find` commands.
+        for args in [
+            vec_str(&["find", ".", "-name", "file.txt", "-exec", "rm", "{}", ";"]),
+            vec_str(&[
+                "find", ".", "-name", "*.py", "-execdir", "python3", "{}", ";",
+            ]),
+            vec_str(&["find", ".", "-name", "file.txt", "-ok", "rm", "{}", ";"]),
+            vec_str(&["find", ".", "-name", "*.py", "-okdir", "python3", "{}", ";"]),
+            vec_str(&["find", ".", "-delete", "-name", "file.txt"]),
+            vec_str(&["find", ".", "-fls", "/etc/passwd"]),
+            vec_str(&["find", ".", "-fprint", "/etc/passwd"]),
+            vec_str(&["find", ".", "-fprint0", "/etc/passwd"]),
+            vec_str(&["find", ".", "-fprintf", "/root/suid.txt", "%#m %u %p\n"]),
+        ] {
+            assert!(
+                !is_safe_to_call_with_exec(&args),
+                "expected {args:?} to be unsafe"
+            );
+        }
+    }
+
+    #[test]
+    fn base64_output_options_are_unsafe() {
+        for args in [
+            vec_str(&["base64", "-o", "out.bin"]),
+            vec_str(&["base64", "--output", "out.bin"]),
+            vec_str(&["base64", "--output=out.bin"]),
+            vec_str(&["base64", "-ob64.txt"]),
+        ] {
+            assert!(
+                !is_safe_to_call_with_exec(&args),
+                "expected {args:?} to be considered unsafe due to output option"
+            );
+        }
+    }
+
+    #[test]
+    fn ripgrep_rules() {
+        // Safe ripgrep invocations – none of the unsafe flags are present.
+        assert!(is_safe_to_call_with_exec(&vec_str(&[
+            "rg",
+            "Cargo.toml",
+            "-n"
+        ])));
+
+        // Unsafe flags that do not take an argument (present verbatim).
+        for args in [
+            vec_str(&["rg", "--search-zip", "files"]),
+            vec_str(&["rg", "-z", "files"]),
+        ] {
+            assert!(
+                !is_safe_to_call_with_exec(&args),
+                "expected {args:?} to be considered unsafe due to zip-search flag",
+            );
+        }
+
+        // Unsafe flags that expect a value, provided in both split and = forms.
+        for args in [
+            vec_str(&["rg", "--pre", "pwned", "files"]),
+            vec_str(&["rg", "--pre=pwned", "files"]),
+            vec_str(&["rg", "--hostname-bin", "pwned", "files"]),
+            vec_str(&["rg", "--hostname-bin=pwned", "files"]),
+        ] {
+            assert!(
+                !is_safe_to_call_with_exec(&args),
+                "expected {args:?} to be considered unsafe due to external-command flag",
+            );
+        }
+    }
+
+    #[test]
+    fn windows_powershell_full_path_is_safe() {
+        if !cfg!(windows) {
+            // Windows only because on Linux path splitting doesn't handle `/` separators properly
+            return;
+        }
+
+        assert!(is_known_safe_command(&vec_str(&[
+            r"C:\Program Files\PowerShell\7\pwsh.exe",
+            "-Command",
+            "Get-Location",
+        ])));
+    }
+
+    #[test]
+    fn windows_git_full_path_is_safe() {
+        if !cfg!(windows) {
+            return;
+        }
+
+        assert!(is_known_safe_command(&vec_str(&[
+            r"C:\Program Files\Git\cmd\git.exe",
+            "status",
+        ])));
+    }
+
+    #[test]
+    fn bash_lc_safe_examples() {
+        assert!(is_known_safe_command(&vec_str(&["bash", "-lc", "ls"])));
+        assert!(is_known_safe_command(&vec_str(&["bash", "-lc", "ls -1"])));
+        assert!(is_known_safe_command(&vec_str(&[
+            "bash",
+            "-lc",
+            "git status"
+        ])));
+        assert!(is_known_safe_command(&vec_str(&[
+            "bash",
+            "-lc",
+            "grep -R \"Cargo.toml\" -n"
+        ])));
+        assert!(is_known_safe_command(&vec_str(&[
+            "bash",
+            "-lc",
+            "sed -n 1,5p file.txt"
+        ])));
+        assert!(is_known_safe_command(&vec_str(&[
+            "bash",
+            "-lc",
+            "sed -n '1,5p' file.txt"
+        ])));
+
+        assert!(is_known_safe_command(&vec_str(&[
+            "bash",
+            "-lc",
+            "find . -name file.txt"
+        ])));
+    }
+
+    #[test]
+    fn bash_lc_safe_examples_with_operators() {
+        assert!(is_known_safe_command(&vec_str(&[
+            "bash",
+            "-lc",
+            "grep -R \"Cargo.toml\" -n || true"
+        ])));
+        assert!(is_known_safe_command(&vec_str(&[
+            "bash",
+            "-lc",
+            "ls && pwd"
+        ])));
+        assert!(is_known_safe_command(&vec_str(&[
+            "bash",
+            "-lc",
+            "echo 'hi' ; ls"
+        ])));
+        assert!(is_known_safe_command(&vec_str(&[
+            "bash",
+            "-lc",
+            "ls | wc -l"
+        ])));
+    }
+
+    #[test]
+    fn bash_lc_unsafe_examples() {
+        assert!(
+            !is_known_safe_command(&vec_str(&["bash", "-lc", "git", "status"])),
+            "Four arg version is not known to be safe."
+        );
+        assert!(
+            !is_known_safe_command(&vec_str(&["bash", "-lc", "'git status'"])),
+            "The extra quoting around 'git status' makes it a program named 'git status' and is therefore unsafe."
+        );
+
+        assert!(
+            !is_known_safe_command(&vec_str(&["bash", "-lc", "find . -name file.txt -delete"])),
+            "Unsafe find option should not be auto-approved."
+        );
+
+        // Disallowed because of unsafe command in sequence.
+        assert!(
+            !is_known_safe_command(&vec_str(&["bash", "-lc", "ls && rm -rf /"])),
+            "Sequence containing unsafe command must be rejected"
+        );
+
+        // Disallowed because of parentheses / subshell.
+        assert!(
+            !is_known_safe_command(&vec_str(&["bash", "-lc", "(ls)"])),
+            "Parentheses (subshell) are not provably safe with the current parser"
+        );
+        assert!(
+            !is_known_safe_command(&vec_str(&["bash", "-lc", "ls || (pwd && echo hi)"])),
+            "Nested parentheses are not provably safe with the current parser"
+        );
+
+        // Disallowed redirection.
+        assert!(
+            !is_known_safe_command(&vec_str(&["bash", "-lc", "ls > out.txt"])),
+            "> redirection should be rejected"
+        );
+    }
+}

--- a/crates/dasclaw_shell_command/src/command_safety/mod.rs
+++ b/crates/dasclaw_shell_command/src/command_safety/mod.rs
@@ -1,0 +1,5 @@
+mod powershell_parser;
+
+pub mod is_dangerous_command;
+pub mod is_safe_command;
+pub(crate) mod windows_safe_commands;

--- a/crates/dasclaw_shell_command/src/command_safety/powershell_parser.ps1
+++ b/crates/dasclaw_shell_command/src/command_safety/powershell_parser.ps1
@@ -1,0 +1,257 @@
+$ErrorActionPreference = 'Stop'
+$ProgressPreference = 'SilentlyContinue'
+
+# Long-lived PowerShell AST parser used by the Rust command-safety layer on Windows.
+# The caller starts one child process per PowerShell executable variant and then sends
+# newline-delimited JSON requests over stdin:
+#   { "id": <u64>, "payload": "<base64-encoded UTF-16LE script>" }
+# We answer with one compact JSON line per request:
+#   { "id": <same>, "status": "ok", "commands": [["Get-Content", "foo.txt"]] }
+# or:
+#   { "id": <same>, "status": "parse_failed" | "parse_errors" | "unsupported" }
+#
+# "unsupported" is intentional: it means the script parsed successfully, but the AST
+# included constructs that we conservatively refuse to lower into argv-like command words.
+# The Rust side treats that the same way as an unsafe command.
+
+# Use BOM-free UTF-8 on the protocol stream so Rust sees clean JSON lines with no
+# leading BOM bytes on the first response.
+$utf8 = [System.Text.UTF8Encoding]::new($false)
+$stdin = [System.IO.StreamReader]::new([Console]::OpenStandardInput(), $utf8, $false)
+$stdout = [System.IO.StreamWriter]::new([Console]::OpenStandardOutput(), $utf8)
+$stdout.AutoFlush = $true
+
+function Invoke-ParseRequest {
+    param($RequestId, $Source)
+
+    $tokens = $null
+    $errors = $null
+
+    $ast = $null
+    try {
+        $ast = [System.Management.Automation.Language.Parser]::ParseInput(
+            $Source,
+            [ref]$tokens,
+            [ref]$errors
+        )
+    } catch {
+        return @{ id = $RequestId; status = 'parse_failed' }
+    }
+
+    if ($errors.Count -gt 0) {
+        return @{ id = $RequestId; status = 'parse_errors' }
+    }
+
+    # Only accept AST shapes we can flatten into a list of argv-like command words.
+    # Anything more dynamic than that becomes "unsupported" instead of being guessed at.
+    $commands = [System.Collections.ArrayList]::new()
+
+    foreach ($statement in $ast.EndBlock.Statements) {
+        if (-not (Add-CommandsFromPipelineBase $statement $commands)) {
+            $commands = $null
+            break
+        }
+    }
+
+    if ($commands -ne $null) {
+        $normalized = [System.Collections.ArrayList]::new()
+        foreach ($cmd in $commands) {
+            # Convert every successful parse result to an array-of-arrays shape so the Rust
+            # side can deserialize one uniform representation.
+            if ($cmd -is [string]) {
+                $null = $normalized.Add(@($cmd))
+                continue
+            }
+
+            if ($cmd -is [System.Array] -or $cmd -is [System.Collections.IEnumerable]) {
+                $null = $normalized.Add(@($cmd))
+                continue
+            }
+
+            $normalized = $null
+            break
+        }
+
+        $commands = $normalized
+    }
+
+    if ($commands -eq $null) {
+        return @{ id = $RequestId; status = 'unsupported' }
+    }
+
+    return @{ id = $RequestId; status = 'ok'; commands = $commands }
+}
+
+function Write-Response {
+    param($Response)
+
+    $stdout.WriteLine(($Response | ConvertTo-Json -Compress -Depth 3))
+}
+
+function Convert-CommandElement {
+    param($element)
+
+    # Accept only literal-ish command elements. Variable expansion, subexpressions, splats,
+    # and other dynamic forms return $null so the whole request becomes unsupported.
+    if ($element -is [System.Management.Automation.Language.StringConstantExpressionAst]) {
+        return @($element.Value)
+    }
+
+    if ($element -is [System.Management.Automation.Language.ExpandableStringExpressionAst]) {
+        if ($element.NestedExpressions.Count -gt 0) {
+            return $null
+        }
+        return @($element.Value)
+    }
+
+    if ($element -is [System.Management.Automation.Language.ConstantExpressionAst]) {
+        return @($element.Value.ToString())
+    }
+
+    if ($element -is [System.Management.Automation.Language.CommandParameterAst]) {
+        if ($element.Argument -eq $null) {
+            return @('-' + $element.ParameterName)
+        }
+
+        if ($element.Argument -is [System.Management.Automation.Language.StringConstantExpressionAst]) {
+            return @('-' + $element.ParameterName, $element.Argument.Value)
+        }
+
+        if ($element.Argument -is [System.Management.Automation.Language.ConstantExpressionAst]) {
+            return @('-' + $element.ParameterName, $element.Argument.Value.ToString())
+        }
+
+        return $null
+    }
+
+    return $null
+}
+
+function Convert-PipelineElement {
+    param($element)
+
+    if ($element -is [System.Management.Automation.Language.CommandAst]) {
+        # Redirections and invocation operators make the command harder to classify safely,
+        # so reject them rather than trying to normalize them.
+        if ($element.Redirections.Count -gt 0) {
+            return $null
+        }
+
+        if (
+            $element.InvocationOperator -ne $null -and
+            $element.InvocationOperator -ne [System.Management.Automation.Language.TokenKind]::Unknown
+        ) {
+            return $null
+        }
+
+        $parts = @()
+        foreach ($commandElement in $element.CommandElements) {
+            $converted = Convert-CommandElement $commandElement
+            if ($converted -eq $null) {
+                return $null
+            }
+            $parts += $converted
+        }
+        return $parts
+    }
+
+    if ($element -is [System.Management.Automation.Language.CommandExpressionAst]) {
+        if ($element.Redirections.Count -gt 0) {
+            return $null
+        }
+
+        # Allow a parenthesized single pipeline element like "(Get-Content foo.rs -Raw)" so
+        # the caller still sees the inner command words. More complex expressions stay unsupported.
+        if ($element.Expression -is [System.Management.Automation.Language.ParenExpressionAst]) {
+            $innerPipeline = $element.Expression.Pipeline
+            if ($innerPipeline -and $innerPipeline.PipelineElements.Count -eq 1) {
+                return Convert-PipelineElement $innerPipeline.PipelineElements[0]
+            }
+        }
+
+        return $null
+    }
+
+    return $null
+}
+
+function Add-CommandsFromPipelineAst {
+    param($pipeline, $commands)
+
+    if ($pipeline.PipelineElements.Count -eq 0) {
+        return $false
+    }
+
+    foreach ($element in $pipeline.PipelineElements) {
+        $words = Convert-PipelineElement $element
+        if ($words -eq $null -or $words.Count -eq 0) {
+            return $false
+        }
+        $null = $commands.Add($words)
+    }
+
+    return $true
+}
+
+function Add-CommandsFromPipelineChain {
+    param($chain, $commands)
+
+    if (-not (Add-CommandsFromPipelineBase $chain.LhsPipelineChain $commands)) {
+        return $false
+    }
+
+    if (-not (Add-CommandsFromPipelineAst $chain.RhsPipeline $commands)) {
+        return $false
+    }
+
+    return $true
+}
+
+function Add-CommandsFromPipelineBase {
+    param($pipeline, $commands)
+
+    if ($pipeline -is [System.Management.Automation.Language.PipelineAst]) {
+        return Add-CommandsFromPipelineAst $pipeline $commands
+    }
+
+    # Windows PowerShell 5.1 does not define PipelineChainAst, so avoid a direct type
+    # reference here and instead check the runtime type name.
+    if ($pipeline.GetType().FullName -eq 'System.Management.Automation.Language.PipelineChainAst') {
+        return Add-CommandsFromPipelineChain $pipeline $commands
+    }
+
+    return $false
+}
+
+# This script stays alive so the Rust caller can amortize PowerShell startup across
+# many parse requests. Each request and response is one compact JSON line.
+while (($requestLine = $stdin.ReadLine()) -ne $null) {
+    $request = $null
+    try {
+        $request = $requestLine | ConvertFrom-Json
+    } catch {
+        Write-Response @{ id = $null; status = 'parse_failed' }
+        continue
+    }
+
+    # We process requests serially, but still echo the id back so the Rust side can
+    # detect protocol desyncs instead of silently trusting mixed stdout.
+    $requestId = $request.id
+    $payload = $request.payload
+    if ([string]::IsNullOrEmpty($payload)) {
+        Write-Response @{ id = $requestId; status = 'parse_failed' }
+        continue
+    }
+
+    try {
+        $source =
+            [System.Text.Encoding]::Unicode.GetString(
+                [System.Convert]::FromBase64String($payload)
+            )
+    } catch {
+        Write-Response @{ id = $requestId; status = 'parse_failed' }
+        continue
+    }
+
+    Write-Response (Invoke-ParseRequest -RequestId $requestId -Source $source)
+}

--- a/crates/dasclaw_shell_command/src/command_safety/powershell_parser.rs
+++ b/crates/dasclaw_shell_command/src/command_safety/powershell_parser.rs
@@ -1,0 +1,289 @@
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
+use serde::Deserialize;
+use serde::Serialize;
+use std::collections::HashMap;
+use std::io::BufRead;
+use std::io::BufReader;
+use std::io::ErrorKind;
+use std::io::Write;
+use std::process::Child;
+use std::process::ChildStdin;
+use std::process::ChildStdout;
+use std::process::Command;
+use std::process::Stdio;
+use std::sync::LazyLock;
+use std::sync::Mutex;
+use std::sync::PoisonError;
+
+const POWERSHELL_PARSER_SCRIPT: &str = include_str!("powershell_parser.ps1");
+
+/// Cache one long-lived parser process per executable path so repeated safety checks reuse
+/// PowerShell startup work while still consulting the real parser every time.
+///
+/// We keep the cache behind one mutex because each child process speaks a simple
+/// request/response protocol over a single stdin/stdout pair, so callers targeting the same
+/// executable must serialize access anyway.
+pub(super) fn parse_with_powershell_ast(executable: &str, script: &str) -> PowershellParseOutcome {
+    static PARSER_PROCESSES: LazyLock<Mutex<HashMap<String, PowershellParserProcess>>> =
+        LazyLock::new(|| Mutex::new(HashMap::new()));
+
+    let mut parser_processes = PARSER_PROCESSES
+        .lock()
+        .unwrap_or_else(PoisonError::into_inner);
+    parse_with_cached_process(&mut parser_processes, executable, script)
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub(super) enum PowershellParseOutcome {
+    Commands(Vec<Vec<String>>),
+    Unsupported,
+    Failed,
+}
+
+fn parse_with_cached_process(
+    parser_processes: &mut HashMap<String, PowershellParserProcess>,
+    executable: &str,
+    script: &str,
+) -> PowershellParseOutcome {
+    // `powershell.exe` and `pwsh.exe` do not accept the same language surface, so each
+    // executable keeps its own parser process and request stream.
+    let parser_key = executable.to_string();
+    for attempt in 0..=1 {
+        if !parser_processes.contains_key(&parser_key) {
+            match PowershellParserProcess::spawn(executable) {
+                Ok(process) => {
+                    parser_processes.insert(parser_key.clone(), process);
+                }
+                Err(_) => return PowershellParseOutcome::Failed,
+            }
+        }
+
+        let Some(parser_process) = parser_processes.get_mut(&parser_key) else {
+            return PowershellParseOutcome::Failed;
+        };
+        let parse_result = parser_process.parse(script);
+        match parse_result {
+            Ok(outcome) => return outcome,
+            Err(_) if attempt == 0 => {
+                // The common failure mode here is that a previously cached child exited or its
+                // stdio stream became unusable between requests. Drop that process and retry once
+                // with a fresh child before giving up.
+                parser_processes.remove(&parser_key);
+            }
+            Err(_) => return PowershellParseOutcome::Failed,
+        }
+    }
+
+    PowershellParseOutcome::Failed
+}
+
+fn encode_powershell_base64(script: &str) -> String {
+    let mut utf16 = Vec::with_capacity(script.len() * 2);
+    for unit in script.encode_utf16() {
+        utf16.extend_from_slice(&unit.to_le_bytes());
+    }
+    BASE64_STANDARD.encode(utf16)
+}
+
+fn encoded_parser_script() -> &'static str {
+    static ENCODED: LazyLock<String> =
+        LazyLock::new(|| encode_powershell_base64(POWERSHELL_PARSER_SCRIPT));
+    &ENCODED
+}
+
+struct PowershellParserProcess {
+    child: Child,
+    stdin: ChildStdin,
+    stdout: BufReader<ChildStdout>,
+    // Request ids are monotonic within one child process so the caller can detect protocol
+    // desynchronization if stdout is contaminated or the child is unexpectedly replaced.
+    next_request_id: u64,
+}
+
+impl PowershellParserProcess {
+    fn spawn(executable: &str) -> std::io::Result<Self> {
+        let mut child = Command::new(executable)
+            .args([
+                "-NoLogo",
+                "-NoProfile",
+                "-NonInteractive",
+                "-EncodedCommand",
+                encoded_parser_script(),
+            ])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()?;
+        let stdin = match take_child_stdin(&mut child) {
+            Ok(stdin) => stdin,
+            Err(error) => {
+                kill_child(&mut child);
+                return Err(error);
+            }
+        };
+        let stdout = match take_child_stdout(&mut child) {
+            Ok(stdout) => stdout,
+            Err(error) => {
+                kill_child(&mut child);
+                return Err(error);
+            }
+        };
+        Ok(Self {
+            child,
+            stdin,
+            stdout,
+            next_request_id: 0,
+        })
+    }
+
+    fn parse(&mut self, script: &str) -> std::io::Result<PowershellParseOutcome> {
+        let request = PowershellParserRequest {
+            id: self.next_request_id,
+            payload: encode_powershell_base64(script),
+        };
+        self.next_request_id = self.next_request_id.wrapping_add(1);
+        let mut request_json = serialize_request(&request)?;
+        request_json.push('\n');
+        self.stdin.write_all(request_json.as_bytes())?;
+        self.stdin.flush()?;
+
+        let mut response_line = String::new();
+        if self.stdout.read_line(&mut response_line)? == 0 {
+            return Err(std::io::Error::new(
+                ErrorKind::UnexpectedEof,
+                "PowerShell parser closed stdout",
+            ));
+        }
+
+        let response = deserialize_response(&response_line)?;
+        // Requests are serialized today; the id still catches protocol desyncs if stdout is
+        // contaminated or the child process is unexpectedly replaced mid-request. That turns an
+        // ambiguous parser result into a hard failure so the caller can discard the cached child.
+        if response.id != request.id {
+            return Err(std::io::Error::new(
+                ErrorKind::InvalidData,
+                format!(
+                    "PowerShell parser returned response id {} for request {}",
+                    response.id, request.id
+                ),
+            ));
+        }
+
+        Ok(response.into_outcome())
+    }
+}
+
+impl Drop for PowershellParserProcess {
+    fn drop(&mut self) {
+        kill_child(&mut self.child);
+    }
+}
+
+fn take_child_stdin(child: &mut Child) -> std::io::Result<ChildStdin> {
+    child.stdin.take().ok_or_else(|| {
+        std::io::Error::new(
+            ErrorKind::BrokenPipe,
+            "PowerShell parser child did not expose stdin",
+        )
+    })
+}
+
+fn take_child_stdout(child: &mut Child) -> std::io::Result<BufReader<ChildStdout>> {
+    child.stdout.take().map(BufReader::new).ok_or_else(|| {
+        std::io::Error::new(
+            ErrorKind::BrokenPipe,
+            "PowerShell parser child did not expose stdout",
+        )
+    })
+}
+
+fn serialize_request(request: &PowershellParserRequest) -> std::io::Result<String> {
+    serde_json::to_string(request).map_err(|error| {
+        std::io::Error::new(
+            ErrorKind::InvalidData,
+            format!("failed to serialize PowerShell parser request: {error}"),
+        )
+    })
+}
+
+fn deserialize_response(response_line: &str) -> std::io::Result<PowershellParserResponse> {
+    serde_json::from_str(response_line).map_err(|error| {
+        std::io::Error::new(
+            ErrorKind::InvalidData,
+            format!("failed to parse PowerShell parser response: {error}"),
+        )
+    })
+}
+
+#[derive(Serialize)]
+struct PowershellParserRequest {
+    id: u64,
+    payload: String,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct PowershellParserResponse {
+    id: u64,
+    status: String,
+    commands: Option<Vec<Vec<String>>>,
+}
+
+impl PowershellParserResponse {
+    fn into_outcome(self) -> PowershellParseOutcome {
+        match self.status.as_str() {
+            "ok" => self
+                .commands
+                .filter(|commands| {
+                    !commands.is_empty()
+                        && commands
+                            .iter()
+                            .all(|cmd| !cmd.is_empty() && cmd.iter().all(|word| !word.is_empty()))
+                })
+                .map(PowershellParseOutcome::Commands)
+                .unwrap_or(PowershellParseOutcome::Unsupported),
+            "unsupported" => PowershellParseOutcome::Unsupported,
+            _ => PowershellParseOutcome::Failed,
+        }
+    }
+}
+
+fn kill_child(child: &mut Child) {
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+#[cfg(all(test, windows))]
+mod tests {
+    use super::*;
+    use crate::powershell::try_find_powershell_executable_blocking;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn parser_process_handles_multiple_requests() {
+        let Some(powershell) = try_find_powershell_executable_blocking() else {
+            return;
+        };
+        let powershell = powershell.as_path().to_str().unwrap();
+        let mut parser = PowershellParserProcess::spawn(powershell).unwrap();
+
+        let first = parser.parse("Get-Content 'foo bar'").unwrap();
+        assert_eq!(
+            first,
+            PowershellParseOutcome::Commands(vec![vec![
+                "Get-Content".to_string(),
+                "foo bar".to_string(),
+            ]]),
+        );
+
+        let second = parser.parse("Write-Output foo | Measure-Object").unwrap();
+        assert_eq!(
+            second,
+            PowershellParseOutcome::Commands(vec![
+                vec!["Write-Output".to_string(), "foo".to_string()],
+                vec!["Measure-Object".to_string()],
+            ]),
+        );
+    }
+}

--- a/crates/dasclaw_shell_command/src/command_safety/windows_dangerous_commands.rs
+++ b/crates/dasclaw_shell_command/src/command_safety/windows_dangerous_commands.rs
@@ -1,0 +1,755 @@
+use std::path::Path;
+
+use once_cell::sync::Lazy;
+use regex::Regex;
+use shlex::split as shlex_split;
+use url::Url;
+
+pub fn is_dangerous_command_windows(command: &[String]) -> bool {
+    // Prefer structured parsing for PowerShell/CMD so we can spot URL-bearing
+    // invocations of ShellExecute-style entry points before falling back to
+    // simple argv heuristics.
+    if is_dangerous_powershell(command) {
+        return true;
+    }
+
+    if is_dangerous_cmd(command) {
+        return true;
+    }
+
+    is_direct_gui_launch(command)
+}
+
+fn is_dangerous_powershell(command: &[String]) -> bool {
+    let Some((exe, rest)) = command.split_first() else {
+        return false;
+    };
+    if !is_powershell_executable(exe) {
+        return false;
+    }
+    // Parse the PowerShell invocation to get a flat token list we can scan for
+    // dangerous cmdlets/COM calls plus any URL-looking arguments. This is a
+    // best-effort shlex split of the script text, not a full PS parser.
+    let Some(parsed) = parse_powershell_invocation(rest) else {
+        return false;
+    };
+
+    let tokens_lc: Vec<String> = parsed
+        .tokens
+        .iter()
+        .map(|t| t.trim_matches('\'').trim_matches('"').to_ascii_lowercase())
+        .collect();
+    let has_url = args_have_url(&parsed.tokens);
+
+    if has_url
+        && tokens_lc.iter().any(|t| {
+            matches!(
+                t.as_str(),
+                "start-process" | "start" | "saps" | "invoke-item" | "ii"
+            ) || t.contains("start-process")
+                || t.contains("invoke-item")
+        })
+    {
+        return true;
+    }
+
+    if has_url
+        && tokens_lc
+            .iter()
+            .any(|t| t.contains("shellexecute") || t.contains("shell.application"))
+    {
+        return true;
+    }
+
+    if let Some(first) = tokens_lc.first() {
+        // Legacy ShellExecute path via url.dll
+        if first == "rundll32"
+            && tokens_lc
+                .iter()
+                .any(|t| t.contains("url.dll,fileprotocolhandler"))
+            && has_url
+        {
+            return true;
+        }
+        if first == "mshta" && has_url {
+            return true;
+        }
+        if is_browser_executable(first) && has_url {
+            return true;
+        }
+        if matches!(first.as_str(), "explorer" | "explorer.exe") && has_url {
+            return true;
+        }
+    }
+
+    // Check for force delete operations (e.g., Remove-Item -Force)
+    if has_force_delete_cmdlet(&tokens_lc) {
+        return true;
+    }
+
+    false
+}
+
+fn is_dangerous_cmd(command: &[String]) -> bool {
+    let Some((exe, rest)) = command.split_first() else {
+        return false;
+    };
+    let Some(base) = executable_basename(exe) else {
+        return false;
+    };
+    if base != "cmd" && base != "cmd.exe" {
+        return false;
+    }
+
+    let mut iter = rest.iter();
+    for arg in iter.by_ref() {
+        let lower = arg.to_ascii_lowercase();
+        match lower.as_str() {
+            "/c" | "/r" | "-c" => break,
+            _ if lower.starts_with('/') => continue,
+            // Unknown tokens before the command body => bail.
+            _ => return false,
+        }
+    }
+
+    let remaining: Vec<String> = iter.cloned().collect();
+    if remaining.is_empty() {
+        return false;
+    }
+
+    let cmd_tokens: Vec<String> = match remaining.as_slice() {
+        [only] => shlex_split(only).unwrap_or_else(|| vec![only.clone()]),
+        _ => remaining,
+    };
+
+    // Refine tokens by splitting concatenated CMD operators (e.g. "echo hi&del")
+    let tokens: Vec<String> = cmd_tokens
+        .into_iter()
+        .flat_map(|t| split_embedded_cmd_operators(&t))
+        .collect();
+
+    const CMD_SEPARATORS: &[&str] = &["&", "&&", "|", "||"];
+    tokens
+        .split(|t| CMD_SEPARATORS.contains(&t.as_str()))
+        .any(|segment| {
+            let Some(cmd) = segment.first() else {
+                return false;
+            };
+
+            // Classic `cmd /c ... start https://...` ShellExecute path.
+            if cmd.eq_ignore_ascii_case("start") && args_have_url(segment) {
+                return true;
+            }
+            // Force delete: del /f, erase /f
+            if (cmd.eq_ignore_ascii_case("del") || cmd.eq_ignore_ascii_case("erase"))
+                && has_force_flag_cmd(segment)
+            {
+                return true;
+            }
+            // Recursive directory removal: rd /s /q, rmdir /s /q
+            if (cmd.eq_ignore_ascii_case("rd") || cmd.eq_ignore_ascii_case("rmdir"))
+                && has_recursive_flag_cmd(segment)
+                && has_quiet_flag_cmd(segment)
+            {
+                return true;
+            }
+            false
+        })
+}
+
+fn is_direct_gui_launch(command: &[String]) -> bool {
+    let Some((exe, rest)) = command.split_first() else {
+        return false;
+    };
+    let Some(base) = executable_basename(exe) else {
+        return false;
+    };
+
+    // Explorer/rundll32/mshta or direct browser exe with a URL anywhere in args.
+    if matches!(base.as_str(), "explorer" | "explorer.exe") && args_have_url(rest) {
+        return true;
+    }
+    if matches!(base.as_str(), "mshta" | "mshta.exe") && args_have_url(rest) {
+        return true;
+    }
+    if (base == "rundll32" || base == "rundll32.exe")
+        && rest.iter().any(|t| {
+            t.to_ascii_lowercase()
+                .contains("url.dll,fileprotocolhandler")
+        })
+        && args_have_url(rest)
+    {
+        return true;
+    }
+    if is_browser_executable(&base) && args_have_url(rest) {
+        return true;
+    }
+
+    false
+}
+
+fn split_embedded_cmd_operators(token: &str) -> Vec<String> {
+    // Split concatenated CMD operators so `echo hi&del` becomes `["echo hi", "&", "del"]`.
+    // Handles `&`, `&&`, `|`, `||`. Best-effort (CMD escaping is weird by nature).
+    let mut parts = Vec::new();
+    let mut start = 0;
+    let mut it = token.char_indices().peekable();
+
+    while let Some((i, ch)) = it.next() {
+        if ch == '&' || ch == '|' {
+            if i > start {
+                parts.push(token[start..i].to_string());
+            }
+
+            // Detect doubled operator: && or ||
+            let op_len = match it.peek() {
+                Some(&(j, next)) if next == ch => {
+                    it.next(); // consume second char
+                    (j + next.len_utf8()) - i
+                }
+                _ => ch.len_utf8(),
+            };
+
+            parts.push(token[i..i + op_len].to_string());
+            start = i + op_len;
+        }
+    }
+
+    if start < token.len() {
+        parts.push(token[start..].to_string());
+    }
+
+    parts.retain(|s| !s.trim().is_empty());
+    parts
+}
+
+fn has_force_delete_cmdlet(tokens: &[String]) -> bool {
+    const DELETE_CMDLETS: &[&str] = &["remove-item", "ri", "rm", "del", "erase", "rd", "rmdir"];
+
+    // Hard separators that end a command segment (so -Force must be in same segment)
+    const SEG_SEPS: &[char] = &[';', '|', '&', '\n', '\r', '\t'];
+
+    // Soft separators: punctuation that can stick to tokens (blocks, parens, brackets, commas, etc.)
+    const SOFT_SEPS: &[char] = &['{', '}', '(', ')', '[', ']', ',', ';'];
+
+    // Build rough command segments first
+    let mut segments: Vec<Vec<String>> = vec![Vec::new()];
+    for tok in tokens {
+        // If token itself contains segment separators, split it (best-effort)
+        let mut cur = String::new();
+        for ch in tok.chars() {
+            if SEG_SEPS.contains(&ch) {
+                let s = cur.trim();
+                if let Some(msg) = segments.last_mut()
+                    && !s.is_empty()
+                {
+                    msg.push(s.to_string());
+                }
+                cur.clear();
+                if let Some(last) = segments.last()
+                    && !last.is_empty()
+                {
+                    segments.push(Vec::new());
+                }
+            } else {
+                cur.push(ch);
+            }
+        }
+        let s = cur.trim();
+        if let Some(segment) = segments.last_mut()
+            && !s.is_empty()
+        {
+            segment.push(s.to_string());
+        }
+    }
+
+    // Now, inside each segment, normalize tokens by splitting on soft punctuation
+    segments.into_iter().any(|seg| {
+        let atoms = seg
+            .iter()
+            .flat_map(|t| t.split(|c| SOFT_SEPS.contains(&c)))
+            .map(str::trim)
+            .filter(|s| !s.is_empty());
+
+        let mut has_delete = false;
+        let mut has_force = false;
+
+        for a in atoms {
+            if DELETE_CMDLETS.iter().any(|cmd| a.eq_ignore_ascii_case(cmd)) {
+                has_delete = true;
+            }
+            if a.eq_ignore_ascii_case("-force")
+                || a.get(..7)
+                    .is_some_and(|p| p.eq_ignore_ascii_case("-force:"))
+            {
+                has_force = true;
+            }
+        }
+
+        has_delete && has_force
+    })
+}
+
+/// Check for /f or /F flag in CMD del/erase arguments.
+fn has_force_flag_cmd(args: &[String]) -> bool {
+    args.iter().any(|a| a.eq_ignore_ascii_case("/f"))
+}
+
+/// Check for /s or /S flag in CMD rd/rmdir arguments.
+fn has_recursive_flag_cmd(args: &[String]) -> bool {
+    args.iter().any(|a| a.eq_ignore_ascii_case("/s"))
+}
+
+/// Check for /q or /Q flag in CMD rd/rmdir arguments.
+fn has_quiet_flag_cmd(args: &[String]) -> bool {
+    args.iter().any(|a| a.eq_ignore_ascii_case("/q"))
+}
+
+fn args_have_url(args: &[String]) -> bool {
+    args.iter().any(|arg| looks_like_url(arg))
+}
+
+fn looks_like_url(token: &str) -> bool {
+    // Strip common PowerShell punctuation around inline URLs (quotes, parens, trailing semicolons).
+    // Capture the middle token after trimming leading quotes/parens/whitespace and trailing semicolons/closing parens.
+    static RE: Lazy<Option<Regex>> =
+        Lazy::new(|| Regex::new(r#"^[ "'\(\s]*([^\s"'\);]+)[\s;\)]*$"#).ok());
+    // If the token embeds a URL alongside other text (e.g., Start-Process('https://...'))
+    // as a single shlex token, grab the substring starting at the first URL prefix.
+    let urlish = token
+        .find("https://")
+        .or_else(|| token.find("http://"))
+        .map(|idx| &token[idx..])
+        .unwrap_or(token);
+
+    let candidate = RE
+        .as_ref()
+        .and_then(|re| re.captures(urlish))
+        .and_then(|caps| caps.get(1))
+        .map(|m| m.as_str())
+        .unwrap_or(urlish);
+    let Ok(url) = Url::parse(candidate) else {
+        return false;
+    };
+    matches!(url.scheme(), "http" | "https")
+}
+
+fn executable_basename(exe: &str) -> Option<String> {
+    Path::new(exe)
+        .file_name()
+        .and_then(|osstr| osstr.to_str())
+        .map(str::to_ascii_lowercase)
+}
+
+fn is_powershell_executable(exe: &str) -> bool {
+    matches!(
+        executable_basename(exe).as_deref(),
+        Some("powershell") | Some("powershell.exe") | Some("pwsh") | Some("pwsh.exe")
+    )
+}
+
+fn is_browser_executable(name: &str) -> bool {
+    matches!(
+        name,
+        "chrome"
+            | "chrome.exe"
+            | "msedge"
+            | "msedge.exe"
+            | "firefox"
+            | "firefox.exe"
+            | "iexplore"
+            | "iexplore.exe"
+    )
+}
+
+struct ParsedPowershell {
+    tokens: Vec<String>,
+}
+
+fn parse_powershell_invocation(args: &[String]) -> Option<ParsedPowershell> {
+    if args.is_empty() {
+        return None;
+    }
+
+    let mut idx = 0;
+    while idx < args.len() {
+        let arg = &args[idx];
+        let lower = arg.to_ascii_lowercase();
+        match lower.as_str() {
+            "-command" | "/command" | "-c" => {
+                let script = args.get(idx + 1)?;
+                if idx + 2 != args.len() {
+                    return None;
+                }
+                let tokens = shlex_split(script)?;
+                return Some(ParsedPowershell { tokens });
+            }
+            _ if lower.starts_with("-command:") || lower.starts_with("/command:") => {
+                if idx + 1 != args.len() {
+                    return None;
+                }
+                let (_, script) = arg.split_once(':')?;
+                let tokens = shlex_split(script)?;
+                return Some(ParsedPowershell { tokens });
+            }
+            "-nologo" | "-noprofile" | "-noninteractive" | "-mta" | "-sta" => {
+                idx += 1;
+            }
+            _ if lower.starts_with('-') => {
+                idx += 1;
+            }
+            _ => {
+                let rest = args[idx..].to_vec();
+                return Some(ParsedPowershell { tokens: rest });
+            }
+        }
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_dangerous_command_windows;
+
+    fn vec_str(items: &[&str]) -> Vec<String> {
+        items.iter().map(std::string::ToString::to_string).collect()
+    }
+
+    #[test]
+    fn powershell_start_process_url_is_dangerous() {
+        assert!(is_dangerous_command_windows(&vec_str(&[
+            "powershell",
+            "-NoLogo",
+            "-Command",
+            "Start-Process 'https://example.com'"
+        ])));
+    }
+
+    #[test]
+    fn powershell_start_process_url_with_trailing_semicolon_is_dangerous() {
+        assert!(is_dangerous_command_windows(&vec_str(&[
+            "powershell",
+            "-Command",
+            "Start-Process('https://example.com');"
+        ])));
+    }
+
+    #[test]
+    fn powershell_start_process_local_is_not_flagged() {
+        assert!(!is_dangerous_command_windows(&vec_str(&[
+            "powershell",
+            "-Command",
+            "Start-Process notepad.exe"
+        ])));
+    }
+
+    #[test]
+    fn cmd_start_with_url_is_dangerous() {
+        assert!(is_dangerous_command_windows(&vec_str(&[
+            "cmd",
+            "/c",
+            "start",
+            "https://example.com"
+        ])));
+    }
+
+    #[test]
+    fn msedge_with_url_is_dangerous() {
+        assert!(is_dangerous_command_windows(&vec_str(&[
+            "msedge.exe",
+            "https://example.com"
+        ])));
+    }
+
+    #[test]
+    fn explorer_with_directory_is_not_flagged() {
+        assert!(!is_dangerous_command_windows(&vec_str(&[
+            "explorer.exe",
+            "."
+        ])));
+    }
+
+    // Force delete tests for PowerShell
+
+    #[test]
+    fn powershell_remove_item_force_is_dangerous() {
+        assert!(is_dangerous_command_windows(&vec_str(&[
+            "powershell",
+            "-Command",
+            "Remove-Item test -Force"
+        ])));
+    }
+
+    #[test]
+    fn powershell_remove_item_recurse_force_is_dangerous() {
+        assert!(is_dangerous_command_windows(&vec_str(&[
+            "powershell",
+            "-Command",
+            "Remove-Item test -Recurse -Force"
+        ])));
+    }
+
+    #[test]
+    fn powershell_ri_alias_force_is_dangerous() {
+        assert!(is_dangerous_command_windows(&vec_str(&[
+            "pwsh",
+            "-Command",
+            "ri test -Force"
+        ])));
+    }
+
+    #[test]
+    fn powershell_remove_item_without_force_is_not_flagged() {
+        assert!(!is_dangerous_command_windows(&vec_str(&[
+            "powershell",
+            "-Command",
+            "Remove-Item test"
+        ])));
+    }
+
+    // Force delete tests for CMD
+    #[test]
+    fn cmd_del_force_is_dangerous() {
+        assert!(is_dangerous_command_windows(&vec_str(&[
+            "cmd", "/c", "del", "/f", "test.txt"
+        ])));
+    }
+
+    #[test]
+    fn cmd_erase_force_is_dangerous() {
+        assert!(is_dangerous_command_windows(&vec_str(&[
+            "cmd", "/c", "erase", "/f", "test.txt"
+        ])));
+    }
+
+    #[test]
+    fn cmd_del_without_force_is_not_flagged() {
+        assert!(!is_dangerous_command_windows(&vec_str(&[
+            "cmd", "/c", "del", "test.txt"
+        ])));
+    }
+
+    #[test]
+    fn cmd_rd_recursive_is_dangerous() {
+        assert!(is_dangerous_command_windows(&vec_str(&[
+            "cmd", "/c", "rd", "/s", "/q", "test"
+        ])));
+    }
+
+    #[test]
+    fn cmd_rd_without_quiet_is_not_flagged() {
+        assert!(!is_dangerous_command_windows(&vec_str(&[
+            "cmd", "/c", "rd", "/s", "test"
+        ])));
+    }
+
+    #[test]
+    fn cmd_rmdir_recursive_is_dangerous() {
+        assert!(is_dangerous_command_windows(&vec_str(&[
+            "cmd", "/c", "rmdir", "/s", "/q", "test"
+        ])));
+    }
+
+    // Test exact scenario from issue #8567
+    #[test]
+    fn powershell_remove_item_path_recurse_force_is_dangerous() {
+        assert!(is_dangerous_command_windows(&vec_str(&[
+            "powershell",
+            "-Command",
+            "Remove-Item -Path 'test' -Recurse -Force"
+        ])));
+    }
+
+    #[test]
+    fn powershell_remove_item_force_with_semicolon_is_dangerous() {
+        assert!(is_dangerous_command_windows(&vec_str(&[
+            "powershell",
+            "-Command",
+            "Remove-Item test -Force; Write-Host done"
+        ])));
+    }
+
+    #[test]
+    fn powershell_remove_item_force_inside_block_is_dangerous() {
+        assert!(is_dangerous_command_windows(&vec_str(&[
+            "powershell",
+            "-Command",
+            "if ($true) { Remove-Item test -Force}"
+        ])));
+    }
+
+    #[test]
+    fn powershell_remove_item_force_inside_brackets_is_dangerous() {
+        assert!(is_dangerous_command_windows(&vec_str(&[
+            "powershell",
+            "-Command",
+            "[void]( Remove-Item test -Force)]"
+        ])));
+    }
+
+    #[test]
+    fn cmd_del_path_containing_f_is_not_flagged() {
+        assert!(!is_dangerous_command_windows(&vec_str(&[
+            "cmd",
+            "/c",
+            "del",
+            "C:/foo/bar.txt"
+        ])));
+    }
+
+    #[test]
+    fn cmd_rd_path_containing_s_is_not_flagged() {
+        assert!(!is_dangerous_command_windows(&vec_str(&[
+            "cmd",
+            "/c",
+            "rd",
+            "C:/source"
+        ])));
+    }
+
+    #[test]
+    fn cmd_bypass_chained_del_is_dangerous() {
+        assert!(is_dangerous_command_windows(&vec_str(&[
+            "cmd", "/c", "echo", "hello", "&", "del", "/f", "file.txt"
+        ])));
+    }
+
+    #[test]
+    fn powershell_chained_no_space_is_dangerous() {
+        assert!(is_dangerous_command_windows(&vec_str(&[
+            "powershell",
+            "-Command",
+            "Write-Host hi;Remove-Item -Force C:\\tmp"
+        ])));
+    }
+
+    #[test]
+    fn powershell_comma_separated_is_dangerous() {
+        assert!(is_dangerous_command_windows(&vec_str(&[
+            "powershell",
+            "-Command",
+            "del,-Force,C:\\foo"
+        ])));
+    }
+
+    #[test]
+    fn cmd_echo_del_is_not_dangerous() {
+        assert!(!is_dangerous_command_windows(&vec_str(&[
+            "cmd", "/c", "echo", "del", "/f"
+        ])));
+    }
+
+    #[test]
+    fn cmd_del_single_string_argument_is_dangerous() {
+        assert!(is_dangerous_command_windows(&vec_str(&[
+            "cmd",
+            "/c",
+            "del /f file.txt"
+        ])));
+    }
+
+    #[test]
+    fn cmd_del_chained_single_string_argument_is_dangerous() {
+        assert!(is_dangerous_command_windows(&vec_str(&[
+            "cmd",
+            "/c",
+            "echo hello & del /f file.txt"
+        ])));
+    }
+
+    #[test]
+    fn cmd_chained_no_space_del_is_dangerous() {
+        assert!(is_dangerous_command_windows(&vec_str(&[
+            "cmd",
+            "/c",
+            "echo hi&del /f file.txt"
+        ])));
+    }
+
+    #[test]
+    fn cmd_chained_andand_no_space_del_is_dangerous() {
+        assert!(is_dangerous_command_windows(&vec_str(&[
+            "cmd",
+            "/c",
+            "echo hi&&del /f file.txt"
+        ])));
+    }
+
+    #[test]
+    fn cmd_chained_oror_no_space_del_is_dangerous() {
+        assert!(is_dangerous_command_windows(&vec_str(&[
+            "cmd",
+            "/c",
+            "echo hi||del /f file.txt"
+        ])));
+    }
+
+    #[test]
+    fn cmd_start_url_single_string_is_dangerous() {
+        assert!(is_dangerous_command_windows(&vec_str(&[
+            "cmd",
+            "/c",
+            "start https://example.com"
+        ])));
+    }
+
+    #[test]
+    fn cmd_chained_no_space_rmdir_is_dangerous() {
+        assert!(is_dangerous_command_windows(&vec_str(&[
+            "cmd",
+            "/c",
+            "echo hi&rmdir /s /q testdir"
+        ])));
+    }
+
+    #[test]
+    fn cmd_del_force_uppercase_flag_is_dangerous() {
+        assert!(is_dangerous_command_windows(&vec_str(&[
+            "cmd", "/c", "DEL", "/F", "file.txt"
+        ])));
+    }
+
+    #[test]
+    fn cmdexe_r_del_force_is_dangerous() {
+        assert!(is_dangerous_command_windows(&vec_str(&[
+            "cmd.exe", "/r", "del", "/f", "file.txt"
+        ])));
+    }
+
+    #[test]
+    fn cmd_start_quoted_url_single_string_is_dangerous() {
+        assert!(is_dangerous_command_windows(&vec_str(&[
+            "cmd",
+            "/c",
+            r#"start "https://example.com""#
+        ])));
+    }
+
+    #[test]
+    fn cmd_start_title_then_url_is_dangerous() {
+        assert!(is_dangerous_command_windows(&vec_str(&[
+            "cmd",
+            "/c",
+            r#"start "" https://example.com"#
+        ])));
+    }
+
+    #[test]
+    fn powershell_rm_alias_force_is_dangerous() {
+        assert!(is_dangerous_command_windows(&vec_str(&[
+            "powershell",
+            "-Command",
+            "rm test -Force"
+        ])));
+    }
+
+    #[test]
+    fn powershell_benign_force_separate_command_is_not_dangerous() {
+        assert!(!is_dangerous_command_windows(&vec_str(&[
+            "powershell",
+            "-Command",
+            "Get-ChildItem -Force; Remove-Item test"
+        ])));
+    }
+}

--- a/crates/dasclaw_shell_command/src/command_safety/windows_safe_commands.rs
+++ b/crates/dasclaw_shell_command/src/command_safety/windows_safe_commands.rs
@@ -1,0 +1,554 @@
+use crate::command_safety::is_dangerous_command::git_global_option_requires_prompt;
+use crate::command_safety::powershell_parser::PowershellParseOutcome;
+use crate::command_safety::powershell_parser::parse_with_powershell_ast;
+use std::path::Path;
+
+/// On Windows, we conservatively allow only clearly read-only PowerShell invocations
+/// that match a small safelist. Anything else (including direct CMD commands) is unsafe.
+pub fn is_safe_command_windows(command: &[String]) -> bool {
+    if let Some(commands) = try_parse_powershell_command_sequence(command) {
+        commands
+            .iter()
+            .all(|cmd| is_safe_powershell_command(cmd.as_slice()))
+    } else {
+        // Only PowerShell invocations are allowed on Windows for now; anything else is unsafe.
+        false
+    }
+}
+
+/// Returns each command sequence if the invocation starts with a PowerShell binary.
+/// For example, the tokens from `pwsh Get-ChildItem | Measure-Object` become two sequences.
+fn try_parse_powershell_command_sequence(command: &[String]) -> Option<Vec<Vec<String>>> {
+    let (exe, rest) = command.split_first()?;
+    if is_powershell_executable(exe) {
+        parse_powershell_invocation(exe, rest)
+    } else {
+        None
+    }
+}
+
+/// Parses a PowerShell invocation into discrete command vectors, rejecting unsafe patterns.
+fn parse_powershell_invocation(executable: &str, args: &[String]) -> Option<Vec<Vec<String>>> {
+    if args.is_empty() {
+        // Examples rejected here: "pwsh" and "powershell.exe" with no additional arguments.
+        return None;
+    }
+
+    let mut idx = 0;
+    while idx < args.len() {
+        let arg = &args[idx];
+        let lower = arg.to_ascii_lowercase();
+        match lower.as_str() {
+            "-command" | "/command" | "-c" => {
+                let script = args.get(idx + 1)?;
+                if idx + 2 != args.len() {
+                    // Reject if there is more than one token representing the actual command.
+                    // Examples rejected here: "pwsh -Command foo bar" and "powershell -c ls extra".
+                    return None;
+                }
+                return parse_powershell_script(executable, script);
+            }
+            _ if lower.starts_with("-command:") || lower.starts_with("/command:") => {
+                if idx + 1 != args.len() {
+                    // Reject if there are more tokens after the command itself.
+                    // Examples rejected here: "pwsh -Command:dir C:\\" and "powershell /Command:dir C:\\" with trailing args.
+                    return None;
+                }
+                let script = arg.split_once(':')?.1;
+                return parse_powershell_script(executable, script);
+            }
+
+            // Benign, no-arg flags we tolerate.
+            "-nologo" | "-noprofile" | "-noninteractive" | "-mta" | "-sta" => {
+                idx += 1;
+                continue;
+            }
+
+            // Explicitly forbidden/opaque or unnecessary for read-only operations.
+            "-encodedcommand" | "-ec" | "-file" | "/file" | "-windowstyle" | "-executionpolicy"
+            | "-workingdirectory" => {
+                // Examples rejected here: "pwsh -EncodedCommand ..." and "powershell -File script.ps1".
+                return None;
+            }
+
+            // Unknown switch → bail conservatively.
+            _ if lower.starts_with('-') => {
+                // Examples rejected here: "pwsh -UnknownFlag" and "powershell -foo bar".
+                return None;
+            }
+
+            // If we hit non-flag tokens, treat the remainder as a command sequence.
+            // This happens if powershell is invoked without -Command, e.g.
+            // ["pwsh", "-NoLogo", "git", "-c", "core.pager=cat", "status"]
+            _ => {
+                let script = join_arguments_as_script(&args[idx..]);
+                return parse_powershell_script(executable, &script);
+            }
+        }
+    }
+
+    // Examples rejected here: "pwsh" and "powershell.exe -NoLogo" without a script.
+    None
+}
+
+/// Tokenizes an inline PowerShell script and delegates to the command splitter.
+/// Examples of when this is called: pwsh.exe -Command '<script>' or pwsh.exe -Command:<script>
+fn parse_powershell_script(executable: &str, script: &str) -> Option<Vec<Vec<String>>> {
+    if let PowershellParseOutcome::Commands(commands) =
+        parse_with_powershell_ast(executable, script)
+    {
+        Some(commands)
+    } else {
+        None
+    }
+}
+
+/// Returns true when the executable name is one of the supported PowerShell binaries.
+fn is_powershell_executable(exe: &str) -> bool {
+    let executable_name = Path::new(exe)
+        .file_name()
+        .and_then(|osstr| osstr.to_str())
+        .unwrap_or(exe)
+        .to_ascii_lowercase();
+
+    matches!(
+        executable_name.as_str(),
+        "powershell" | "powershell.exe" | "pwsh" | "pwsh.exe"
+    )
+}
+
+fn join_arguments_as_script(args: &[String]) -> String {
+    let mut words = Vec::with_capacity(args.len());
+    if let Some((first, rest)) = args.split_first() {
+        words.push(first.clone());
+        for arg in rest {
+            words.push(quote_argument(arg));
+        }
+    }
+    words.join(" ")
+}
+
+fn quote_argument(arg: &str) -> String {
+    if arg.is_empty() {
+        return "''".to_string();
+    }
+
+    if arg.chars().all(|ch| !ch.is_whitespace()) {
+        return arg.to_string();
+    }
+
+    format!("'{}'", arg.replace('\'', "''"))
+}
+
+/// Validates that a parsed PowerShell command stays within our read-only safelist.
+/// Everything before this is parsing, and rejecting things that make us feel uncomfortable.
+fn is_safe_powershell_command(words: &[String]) -> bool {
+    if words.is_empty() {
+        // Examples rejected here: "pwsh -Command ''" and "pwsh -Command \"\"".
+        return false;
+    }
+
+    // Reject nested unsafe cmdlets inside parentheses or arguments
+    for w in words.iter() {
+        let inner = w
+            .trim_matches(|c| c == '(' || c == ')')
+            .trim_start_matches('-')
+            .to_ascii_lowercase();
+        if matches!(
+            inner.as_str(),
+            "set-content"
+                | "add-content"
+                | "out-file"
+                | "new-item"
+                | "remove-item"
+                | "move-item"
+                | "copy-item"
+                | "rename-item"
+                | "start-process"
+                | "stop-process"
+        ) {
+            // Examples rejected here: "Write-Output (Set-Content foo6.txt 'abc')" and "Get-Content (New-Item bar.txt)".
+            return false;
+        }
+    }
+
+    let command = words[0]
+        .trim_matches(|c| c == '(' || c == ')')
+        .trim_start_matches('-')
+        .to_ascii_lowercase();
+    match command.as_str() {
+        "echo" | "write-output" | "write-host" => true, // (no redirection allowed)
+        "dir" | "ls" | "get-childitem" | "gci" => true,
+        "cat" | "type" | "gc" | "get-content" => true,
+        "select-string" | "sls" | "findstr" => true,
+        "measure-object" | "measure" => true,
+        "get-location" | "gl" | "pwd" => true,
+        "test-path" | "tp" => true,
+        "resolve-path" | "rvpa" => true,
+        "select-object" | "select" => true,
+        "get-item" => true,
+
+        "git" => is_safe_git_command(words),
+
+        "rg" => is_safe_ripgrep(words),
+
+        // Extra safety: explicitly prohibit common side-effecting cmdlets regardless of args.
+        "set-content" | "add-content" | "out-file" | "new-item" | "remove-item" | "move-item"
+        | "copy-item" | "rename-item" | "start-process" | "stop-process" => {
+            // Examples rejected here: "pwsh -Command 'Set-Content notes.txt data'" and "pwsh -Command 'Remove-Item temp.log'".
+            false
+        }
+
+        _ => {
+            // Examples rejected here: "pwsh -Command 'Invoke-WebRequest https://example.com'" and "pwsh -Command 'Start-Service Spooler'".
+            false
+        }
+    }
+}
+
+/// Checks that an `rg` invocation avoids options that can spawn arbitrary executables.
+fn is_safe_ripgrep(words: &[String]) -> bool {
+    const UNSAFE_RIPGREP_OPTIONS_WITH_ARGS: &[&str] = &["--pre", "--hostname-bin"];
+    const UNSAFE_RIPGREP_OPTIONS_WITHOUT_ARGS: &[&str] = &["--search-zip", "-z"];
+
+    !words.iter().skip(1).any(|arg| {
+        let arg_lc = arg.to_ascii_lowercase();
+        // Examples rejected here: "pwsh -Command 'rg --pre cat pattern'" and "pwsh -Command 'rg --search-zip pattern'".
+        UNSAFE_RIPGREP_OPTIONS_WITHOUT_ARGS.contains(&arg_lc.as_str())
+            || UNSAFE_RIPGREP_OPTIONS_WITH_ARGS
+                .iter()
+                .any(|opt| arg_lc == *opt || arg_lc.starts_with(&format!("{opt}=")))
+    })
+}
+
+/// Ensures a Git command sticks to whitelisted read-only subcommands and flags.
+fn is_safe_git_command(words: &[String]) -> bool {
+    const SAFE_SUBCOMMANDS: &[&str] = &["status", "log", "show", "diff", "cat-file"];
+
+    for arg in words.iter().skip(1) {
+        let arg_lc = arg.to_ascii_lowercase();
+
+        if arg.starts_with('-') {
+            if git_global_option_requires_prompt(&arg_lc)
+                || arg.eq_ignore_ascii_case("--config")
+                || arg_lc.starts_with("--config=")
+            {
+                // Examples rejected here: "pwsh -Command 'git --git-dir=.evil-git diff'" and
+                // "pwsh -Command 'git -c core.pager=cat show HEAD:foo.rs'".
+                return false;
+            }
+
+            continue;
+        }
+
+        return SAFE_SUBCOMMANDS.contains(&arg_lc.as_str());
+    }
+
+    // Examples rejected here: "pwsh -Command 'git'" and "pwsh -Command 'git status --short | Remove-Item foo'".
+    false
+}
+
+#[cfg(all(test, windows))]
+mod tests {
+    use super::*;
+    use crate::powershell::try_find_pwsh_executable_blocking;
+    use std::string::ToString;
+
+    /// Converts a slice of string literals into owned `String`s for the tests.
+    fn vec_str(args: &[&str]) -> Vec<String> {
+        args.iter().map(ToString::to_string).collect()
+    }
+
+    #[test]
+    fn recognizes_safe_powershell_wrappers() {
+        assert!(is_safe_command_windows(&vec_str(&[
+            "powershell.exe",
+            "-NoLogo",
+            "-Command",
+            "Get-ChildItem -Path .",
+        ])));
+
+        assert!(is_safe_command_windows(&vec_str(&[
+            "powershell.exe",
+            "-NoProfile",
+            "-Command",
+            "git status",
+        ])));
+
+        assert!(is_safe_command_windows(&vec_str(&[
+            "powershell.exe",
+            "Get-Content",
+            "Cargo.toml",
+        ])));
+
+        // pwsh parity
+        if let Some(pwsh) = try_find_pwsh_executable_blocking() {
+            assert!(is_safe_command_windows(&[
+                pwsh.as_path().to_str().unwrap().into(),
+                "-NoProfile".to_string(),
+                "-Command".to_string(),
+                "Get-ChildItem".to_string(),
+            ]));
+        }
+    }
+
+    #[test]
+    fn accepts_full_path_powershell_invocations() {
+        if !cfg!(windows) {
+            // Windows only because on Linux path splitting doesn't handle `/` separators properly
+            return;
+        }
+
+        if let Some(pwsh) = try_find_pwsh_executable_blocking() {
+            assert!(is_safe_command_windows(&[
+                pwsh.as_path().to_str().unwrap().into(),
+                "-NoProfile".to_string(),
+                "-Command".to_string(),
+                "Get-ChildItem -Path .".to_string(),
+            ]));
+        }
+
+        assert!(is_safe_command_windows(&vec_str(&[
+            r"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe",
+            "-Command",
+            "Get-Content Cargo.toml",
+        ])));
+    }
+
+    #[test]
+    fn allows_read_only_pipelines_and_git_usage() {
+        let Some(pwsh) = try_find_pwsh_executable_blocking() else {
+            return;
+        };
+
+        let pwsh: String = pwsh.as_path().to_str().unwrap().into();
+        assert!(is_safe_command_windows(&[
+            pwsh.clone(),
+            "-NoLogo".to_string(),
+            "-NoProfile".to_string(),
+            "-Command".to_string(),
+            "rg --files-with-matches foo | Measure-Object | Select-Object -ExpandProperty Count"
+                .to_string()
+        ]));
+
+        assert!(is_safe_command_windows(&[
+            pwsh.clone(),
+            "-NoLogo".to_string(),
+            "-NoProfile".to_string(),
+            "-Command".to_string(),
+            "Get-Content foo.rs | Select-Object -Skip 200".to_string()
+        ]));
+
+        assert!(is_safe_command_windows(&[
+            pwsh.clone(),
+            "-Command".to_string(),
+            "-git cat-file -p HEAD:foo.rs".to_string()
+        ]));
+
+        assert!(is_safe_command_windows(&[
+            pwsh.clone(),
+            "-Command".to_string(),
+            "(Get-Content foo.rs -Raw)".to_string()
+        ]));
+
+        assert!(is_safe_command_windows(&[
+            pwsh,
+            "-Command".to_string(),
+            "Get-Item foo.rs | Select-Object Length".to_string()
+        ]));
+    }
+
+    #[test]
+    fn rejects_git_global_override_options() {
+        let Some(pwsh) = try_find_pwsh_executable_blocking() else {
+            return;
+        };
+
+        let pwsh: String = pwsh.as_path().to_str().unwrap().into();
+        for script in [
+            "git -c core.pager=cat show HEAD:foo.rs",
+            "git --config-env core.pager=PAGER show HEAD:foo.rs",
+            "git --config-env=core.pager=PAGER show HEAD:foo.rs",
+            "git --git-dir .evil-git diff HEAD~1..HEAD",
+            "git --git-dir=.evil-git diff HEAD~1..HEAD",
+            "git --work-tree . status",
+            "git --work-tree=. status",
+            "git --exec-path .git/helpers show HEAD:foo.rs",
+            "git --exec-path=.git/helpers show HEAD:foo.rs",
+            "git --namespace attacker show HEAD:foo.rs",
+            "git --namespace=attacker show HEAD:foo.rs",
+            "git --super-prefix attacker/ show HEAD:foo.rs",
+            "git --super-prefix=attacker/ show HEAD:foo.rs",
+        ] {
+            assert!(
+                !is_safe_command_windows(&[
+                    pwsh.clone(),
+                    "-NoLogo".to_string(),
+                    "-NoProfile".to_string(),
+                    "-Command".to_string(),
+                    script.to_string(),
+                ]),
+                "expected {script:?} to require approval due to unsafe git global option",
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_powershell_commands_with_side_effects() {
+        assert!(!is_safe_command_windows(&vec_str(&[
+            "powershell.exe",
+            "-NoLogo",
+            "-Command",
+            "Remove-Item foo.txt",
+        ])));
+
+        assert!(!is_safe_command_windows(&vec_str(&[
+            "powershell.exe",
+            "-NoProfile",
+            "-Command",
+            "rg --pre cat",
+        ])));
+
+        assert!(!is_safe_command_windows(&vec_str(&[
+            "powershell.exe",
+            "-Command",
+            "Set-Content foo.txt 'hello'",
+        ])));
+
+        // Redirections are blocked
+        assert!(!is_safe_command_windows(&vec_str(&[
+            "powershell.exe",
+            "-Command",
+            "echo hi > out.txt",
+        ])));
+        assert!(!is_safe_command_windows(&vec_str(&[
+            "powershell.exe",
+            "-Command",
+            "Get-Content x | Out-File y",
+        ])));
+        assert!(!is_safe_command_windows(&vec_str(&[
+            "powershell.exe",
+            "-Command",
+            "Write-Output foo 2> err.txt",
+        ])));
+
+        // Call operator is blocked
+        assert!(!is_safe_command_windows(&vec_str(&[
+            "powershell.exe",
+            "-Command",
+            "& Remove-Item foo",
+        ])));
+
+        // Chained safe + unsafe must fail
+        assert!(!is_safe_command_windows(&vec_str(&[
+            "powershell.exe",
+            "-Command",
+            "Get-ChildItem; Remove-Item foo",
+        ])));
+        // Nested unsafe cmdlet inside safe command must fail
+        assert!(!is_safe_command_windows(&vec_str(&[
+            "powershell.exe",
+            "-Command",
+            "Write-Output (Set-Content foo6.txt 'abc')",
+        ])));
+        // Additional nested unsafe cmdlet examples must fail
+        assert!(!is_safe_command_windows(&vec_str(&[
+            "powershell.exe",
+            "-Command",
+            "Write-Host (Remove-Item foo.txt)",
+        ])));
+        assert!(!is_safe_command_windows(&vec_str(&[
+            "powershell.exe",
+            "-Command",
+            "Get-Content (New-Item bar.txt)",
+        ])));
+
+        // Unsafe @ expansion.
+        assert!(!is_safe_command_windows(&vec_str(&[
+            "powershell.exe",
+            "-Command",
+            "ls @(calc.exe)"
+        ])));
+
+        // Unsupported constructs that the AST parser refuses (no fallback to manual splitting).
+        assert!(!is_safe_command_windows(&vec_str(&[
+            "powershell.exe",
+            "-Command",
+            "ls && pwd"
+        ])));
+
+        // Sub-expressions are rejected even if they contain otherwise safe commands.
+        assert!(!is_safe_command_windows(&vec_str(&[
+            "powershell.exe",
+            "-Command",
+            "Write-Output $(Get-Content foo)"
+        ])));
+
+        // Empty words from the parser (e.g. '') are rejected.
+        assert!(!is_safe_command_windows(&vec_str(&[
+            "powershell.exe",
+            "-Command",
+            "''"
+        ])));
+    }
+
+    #[test]
+    fn accepts_constant_expression_arguments() {
+        assert!(is_safe_command_windows(&vec_str(&[
+            "powershell.exe",
+            "-Command",
+            "Get-Content 'foo bar'"
+        ])));
+
+        assert!(is_safe_command_windows(&vec_str(&[
+            "powershell.exe",
+            "-Command",
+            "Get-Content \"foo bar\""
+        ])));
+    }
+
+    #[test]
+    fn rejects_dynamic_arguments() {
+        assert!(!is_safe_command_windows(&vec_str(&[
+            "powershell.exe",
+            "-Command",
+            "Get-Content $foo"
+        ])));
+
+        assert!(!is_safe_command_windows(&vec_str(&[
+            "powershell.exe",
+            "-Command",
+            "Write-Output \"foo $bar\""
+        ])));
+    }
+
+    #[test]
+    fn uses_invoked_powershell_variant_for_parsing() {
+        if !cfg!(windows) {
+            return;
+        }
+
+        let chain = "pwd && ls";
+        assert!(
+            !is_safe_command_windows(&vec_str(&[
+                "powershell.exe",
+                "-NoProfile",
+                "-Command",
+                chain,
+            ])),
+            "`{chain}` is not recognized by powershell.exe"
+        );
+
+        if let Some(pwsh) = try_find_pwsh_executable_blocking() {
+            assert!(
+                is_safe_command_windows(&[
+                    pwsh.as_path().to_str().unwrap().into(),
+                    "-NoProfile".to_string(),
+                    "-Command".to_string(),
+                    chain.to_string(),
+                ]),
+                "`{chain}` should be considered safe to pwsh.exe"
+            );
+        }
+    }
+}

--- a/crates/dasclaw_shell_command/src/lib.rs
+++ b/crates/dasclaw_shell_command/src/lib.rs
@@ -1,0 +1,11 @@
+//! Command parsing and safety utilities shared across Codex crates.
+
+mod shell_detect;
+
+pub mod bash;
+pub(crate) mod command_safety;
+pub mod parse_command;
+pub mod powershell;
+
+pub use command_safety::is_dangerous_command;
+pub use command_safety::is_safe_command;

--- a/crates/dasclaw_shell_command/src/parse_command.rs
+++ b/crates/dasclaw_shell_command/src/parse_command.rs
@@ -1,0 +1,2526 @@
+use crate::bash::extract_bash_command;
+use crate::bash::try_parse_shell;
+use crate::bash::try_parse_word_only_commands_sequence;
+use crate::powershell::extract_powershell_command;
+use dasclaw_parsed_command::parse_command::ParsedCommand;
+use shlex::split as shlex_split;
+use shlex::try_join as shlex_try_join;
+use std::path::PathBuf;
+
+pub fn shlex_join(tokens: &[String]) -> String {
+    shlex_try_join(tokens.iter().map(String::as_str))
+        .unwrap_or_else(|_| "<command included NUL byte>".to_string())
+}
+
+/// Extracts the shell and script from a command, regardless of platform
+pub fn extract_shell_command(command: &[String]) -> Option<(&str, &str)> {
+    extract_bash_command(command).or_else(|| extract_powershell_command(command))
+}
+
+/// DO NOT REVIEW THIS CODE BY HAND
+/// This parsing code is quite complex and not easy to hand-modify.
+/// The easiest way to iterate is to add unit tests and have Codex fix the implementation.
+/// To encourage this, the tests have been put directly below this function rather than at the bottom of the
+///
+/// Parses metadata out of an arbitrary command.
+/// These commands are model driven and could include just about anything.
+/// The parsing is slightly lossy due to the ~infinite expressiveness of an arbitrary command.
+/// The goal of the parsed metadata is to be able to provide the user with a human readable gis
+/// of what it is doing.
+pub fn parse_command(command: &[String]) -> Vec<ParsedCommand> {
+    // Parse and then collapse consecutive duplicate commands to avoid redundant summaries.
+    let parsed = parse_command_impl(command);
+    let mut deduped: Vec<ParsedCommand> = Vec::with_capacity(parsed.len());
+    for cmd in parsed.into_iter() {
+        if deduped.last().is_some_and(|prev| prev == &cmd) {
+            continue;
+        }
+        deduped.push(cmd);
+    }
+    if deduped
+        .iter()
+        .any(|cmd| matches!(cmd, ParsedCommand::Unknown { .. }))
+    {
+        vec![single_unknown_for_command(command)]
+    } else {
+        deduped
+    }
+}
+
+fn single_unknown_for_command(command: &[String]) -> ParsedCommand {
+    if let Some((_, shell_command)) = extract_shell_command(command) {
+        ParsedCommand::Unknown {
+            cmd: shell_command.to_string(),
+        }
+    } else {
+        ParsedCommand::Unknown {
+            cmd: shlex_join(command),
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::items_after_test_module)]
+/// Tests are at the top to encourage using TDD + Codex to fix the implementation.
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+    use std::path::PathBuf;
+    use std::string::ToString;
+
+    fn shlex_split_safe(s: &str) -> Vec<String> {
+        shlex_split(s).unwrap_or_else(|| s.split_whitespace().map(ToString::to_string).collect())
+    }
+
+    fn vec_str(args: &[&str]) -> Vec<String> {
+        args.iter().map(ToString::to_string).collect()
+    }
+
+    fn assert_parsed(args: &[String], expected: Vec<ParsedCommand>) {
+        let out = parse_command(args);
+        assert_eq!(out, expected);
+    }
+
+    #[test]
+    fn git_status_is_unknown() {
+        assert_parsed(
+            &vec_str(&["git", "status"]),
+            vec![ParsedCommand::Unknown {
+                cmd: "git status".to_string(),
+            }],
+        );
+    }
+
+    #[test]
+    fn supports_git_grep_and_ls_files() {
+        assert_parsed(
+            &shlex_split_safe("git grep TODO src"),
+            vec![ParsedCommand::Search {
+                cmd: "git grep TODO src".to_string(),
+                query: Some("TODO".to_string()),
+                path: Some("src".to_string()),
+            }],
+        );
+        assert_parsed(
+            &shlex_split_safe("git grep -l TODO src"),
+            vec![ParsedCommand::Search {
+                cmd: "git grep -l TODO src".to_string(),
+                query: Some("TODO".to_string()),
+                path: Some("src".to_string()),
+            }],
+        );
+        assert_parsed(
+            &shlex_split_safe("git ls-files"),
+            vec![ParsedCommand::ListFiles {
+                cmd: "git ls-files".to_string(),
+                path: None,
+            }],
+        );
+        assert_parsed(
+            &shlex_split_safe("git ls-files src"),
+            vec![ParsedCommand::ListFiles {
+                cmd: "git ls-files src".to_string(),
+                path: Some("src".to_string()),
+            }],
+        );
+        assert_parsed(
+            &shlex_split_safe("git ls-files --exclude target src"),
+            vec![ParsedCommand::ListFiles {
+                cmd: "git ls-files --exclude target src".to_string(),
+                path: Some("src".to_string()),
+            }],
+        );
+    }
+
+    #[test]
+    fn handles_git_pipe_wc() {
+        let inner = "git status | wc -l";
+        assert_parsed(
+            &vec_str(&["bash", "-lc", inner]),
+            vec![ParsedCommand::Unknown {
+                cmd: inner.to_string(),
+            }],
+        );
+    }
+
+    #[test]
+    fn bash_lc_redirect_not_quoted() {
+        let inner = "echo foo > bar";
+        assert_parsed(
+            &vec_str(&["bash", "-lc", inner]),
+            vec![ParsedCommand::Unknown {
+                cmd: "echo foo > bar".to_string(),
+            }],
+        );
+    }
+
+    #[test]
+    fn handles_complex_bash_command_head() {
+        let inner =
+            "rg --version && node -v && pnpm -v && rg --files | wc -l && rg --files | head -n 40";
+        assert_parsed(
+            &vec_str(&["bash", "-lc", inner]),
+            vec![ParsedCommand::Unknown {
+                cmd: inner.to_string(),
+            }],
+        );
+    }
+
+    #[test]
+    fn supports_searching_for_navigate_to_route() -> anyhow::Result<()> {
+        let inner = "rg -n \"navigate-to-route\" -S";
+        assert_parsed(
+            &vec_str(&["bash", "-lc", inner]),
+            vec![ParsedCommand::Search {
+                cmd: "rg -n navigate-to-route -S".to_string(),
+                query: Some("navigate-to-route".to_string()),
+                path: None,
+            }],
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn handles_complex_bash_command() {
+        let inner = "rg -n \"BUG|FIXME|TODO|XXX|HACK\" -S | head -n 200";
+        assert_parsed(
+            &vec_str(&["bash", "-lc", inner]),
+            vec![ParsedCommand::Search {
+                cmd: "rg -n 'BUG|FIXME|TODO|XXX|HACK' -S".to_string(),
+                query: Some("BUG|FIXME|TODO|XXX|HACK".to_string()),
+                path: None,
+            }],
+        );
+    }
+
+    #[test]
+    fn supports_rg_files_with_path_and_pipe() {
+        let inner = "rg --files webview/src | sed -n";
+        assert_parsed(
+            &vec_str(&["bash", "-lc", inner]),
+            vec![ParsedCommand::ListFiles {
+                cmd: "rg --files webview/src".to_string(),
+                path: Some("webview".to_string()),
+            }],
+        );
+    }
+
+    #[test]
+    fn supports_rg_files_then_head() {
+        let inner = "rg --files | head -n 50";
+        assert_parsed(
+            &vec_str(&["bash", "-lc", inner]),
+            vec![ParsedCommand::ListFiles {
+                cmd: "rg --files".to_string(),
+                path: None,
+            }],
+        );
+    }
+
+    #[test]
+    fn keeps_mutating_xargs_pipeline() {
+        let inner = r#"rg -l QkBindingController presentation/src/main/java | xargs perl -pi -e 's/QkBindingController/QkController/g'"#;
+        assert_parsed(
+            &vec_str(&["bash", "-lc", inner]),
+            vec![ParsedCommand::Unknown {
+                cmd: inner.to_string(),
+            }],
+        );
+    }
+
+    #[test]
+    fn collapses_plain_pipeline_when_any_stage_is_unknown() {
+        let command = shlex_split_safe(
+            "rg -l QkBindingController presentation/src/main/java | xargs perl -pi -e 's/QkBindingController/QkController/g'",
+        );
+        assert_parsed(
+            &command,
+            vec![ParsedCommand::Unknown {
+                cmd: shlex_join(&command),
+            }],
+        );
+    }
+
+    #[test]
+    fn collapses_pipeline_with_helper_when_later_stage_is_unknown() {
+        let command = shlex_split_safe("rg --files | nl -ba | foo");
+        assert_parsed(
+            &command,
+            vec![ParsedCommand::Unknown {
+                cmd: shlex_join(&command),
+            }],
+        );
+    }
+
+    #[test]
+    fn rg_files_with_matches_flags_are_search() {
+        assert_parsed(
+            &shlex_split_safe("rg -l TODO src"),
+            vec![ParsedCommand::Search {
+                cmd: "rg -l TODO src".to_string(),
+                query: Some("TODO".to_string()),
+                path: Some("src".to_string()),
+            }],
+        );
+        assert_parsed(
+            &shlex_split_safe("rg --files-with-matches TODO src"),
+            vec![ParsedCommand::Search {
+                cmd: "rg --files-with-matches TODO src".to_string(),
+                query: Some("TODO".to_string()),
+                path: Some("src".to_string()),
+            }],
+        );
+        assert_parsed(
+            &shlex_split_safe("rg -L TODO src"),
+            vec![ParsedCommand::Search {
+                cmd: "rg -L TODO src".to_string(),
+                query: Some("TODO".to_string()),
+                path: Some("src".to_string()),
+            }],
+        );
+        assert_parsed(
+            &shlex_split_safe("rg --files-without-match TODO src"),
+            vec![ParsedCommand::Search {
+                cmd: "rg --files-without-match TODO src".to_string(),
+                query: Some("TODO".to_string()),
+                path: Some("src".to_string()),
+            }],
+        );
+        assert_parsed(
+            &shlex_split_safe("rga -l TODO src"),
+            vec![ParsedCommand::Search {
+                cmd: "rga -l TODO src".to_string(),
+                query: Some("TODO".to_string()),
+                path: Some("src".to_string()),
+            }],
+        );
+    }
+
+    #[test]
+    fn supports_cat() {
+        let inner = "cat webview/README.md";
+        assert_parsed(
+            &vec_str(&["bash", "-lc", inner]),
+            vec![ParsedCommand::Read {
+                cmd: inner.to_string(),
+                name: "README.md".to_string(),
+                path: PathBuf::from("webview/README.md"),
+            }],
+        );
+    }
+
+    #[test]
+    fn zsh_lc_supports_cat() {
+        let inner = "cat README.md";
+        assert_parsed(
+            &vec_str(&["zsh", "-lc", inner]),
+            vec![ParsedCommand::Read {
+                cmd: inner.to_string(),
+                name: "README.md".to_string(),
+                path: PathBuf::from("README.md"),
+            }],
+        );
+    }
+
+    #[test]
+    fn supports_bat() {
+        let inner = "bat --theme TwoDark README.md";
+        assert_parsed(
+            &vec_str(&["bash", "-lc", inner]),
+            vec![ParsedCommand::Read {
+                cmd: inner.to_string(),
+                name: "README.md".to_string(),
+                path: PathBuf::from("README.md"),
+            }],
+        );
+    }
+
+    #[test]
+    fn supports_batcat() {
+        let inner = "batcat README.md";
+        assert_parsed(
+            &vec_str(&["bash", "-lc", inner]),
+            vec![ParsedCommand::Read {
+                cmd: inner.to_string(),
+                name: "README.md".to_string(),
+                path: PathBuf::from("README.md"),
+            }],
+        );
+    }
+
+    #[test]
+    fn supports_less() {
+        let inner = "less -p TODO README.md";
+        assert_parsed(
+            &vec_str(&["bash", "-lc", inner]),
+            vec![ParsedCommand::Read {
+                cmd: inner.to_string(),
+                name: "README.md".to_string(),
+                path: PathBuf::from("README.md"),
+            }],
+        );
+    }
+
+    #[test]
+    fn supports_more() {
+        let inner = "more README.md";
+        assert_parsed(
+            &vec_str(&["bash", "-lc", inner]),
+            vec![ParsedCommand::Read {
+                cmd: inner.to_string(),
+                name: "README.md".to_string(),
+                path: PathBuf::from("README.md"),
+            }],
+        );
+    }
+
+    #[test]
+    fn cd_then_cat_is_single_read() {
+        assert_parsed(
+            &shlex_split_safe("cd foo && cat foo.txt"),
+            vec![ParsedCommand::Read {
+                cmd: "cat foo.txt".to_string(),
+                name: "foo.txt".to_string(),
+                path: PathBuf::from("foo/foo.txt"),
+            }],
+        );
+    }
+
+    #[test]
+    fn cd_with_double_dash_then_cat_is_read() {
+        assert_parsed(
+            &shlex_split_safe("cd -- -weird && cat foo.txt"),
+            vec![ParsedCommand::Read {
+                cmd: "cat foo.txt".to_string(),
+                name: "foo.txt".to_string(),
+                path: PathBuf::from("-weird/foo.txt"),
+            }],
+        );
+    }
+
+    #[test]
+    fn cd_with_multiple_operands_uses_last() {
+        assert_parsed(
+            &shlex_split_safe("cd dir1 dir2 && cat foo.txt"),
+            vec![ParsedCommand::Read {
+                cmd: "cat foo.txt".to_string(),
+                name: "foo.txt".to_string(),
+                path: PathBuf::from("dir2/foo.txt"),
+            }],
+        );
+    }
+
+    #[test]
+    fn bash_cd_then_bar_is_same_as_bar() {
+        // Ensure a leading `cd` inside bash -lc is dropped when followed by another command.
+        assert_parsed(
+            &shlex_split_safe("bash -lc 'cd foo && bar'"),
+            vec![ParsedCommand::Unknown {
+                cmd: "cd foo && bar".to_string(),
+            }],
+        );
+    }
+
+    #[test]
+    fn bash_cd_then_cat_is_read() {
+        assert_parsed(
+            &shlex_split_safe("bash -lc 'cd foo && cat foo.txt'"),
+            vec![ParsedCommand::Read {
+                cmd: "cat foo.txt".to_string(),
+                name: "foo.txt".to_string(),
+                path: PathBuf::from("foo/foo.txt"),
+            }],
+        );
+    }
+
+    #[test]
+    fn supports_ls_with_pipe() {
+        let inner = "ls -la | sed -n '1,120p'";
+        assert_parsed(
+            &vec_str(&["bash", "-lc", inner]),
+            vec![ParsedCommand::ListFiles {
+                cmd: "ls -la".to_string(),
+                path: None,
+            }],
+        );
+    }
+
+    #[test]
+    fn supports_eza_exa_tree_du() {
+        assert_parsed(
+            &shlex_split_safe("eza --color=always src"),
+            vec![ParsedCommand::ListFiles {
+                cmd: "eza '--color=always' src".to_string(),
+                path: Some("src".to_string()),
+            }],
+        );
+        assert_parsed(
+            &shlex_split_safe("exa -I target ."),
+            vec![ParsedCommand::ListFiles {
+                cmd: "exa -I target .".to_string(),
+                path: Some(".".to_string()),
+            }],
+        );
+        assert_parsed(
+            &shlex_split_safe("tree -L 2 src"),
+            vec![ParsedCommand::ListFiles {
+                cmd: "tree -L 2 src".to_string(),
+                path: Some("src".to_string()),
+            }],
+        );
+        assert_parsed(
+            &shlex_split_safe("du -d 2 ."),
+            vec![ParsedCommand::ListFiles {
+                cmd: "du -d 2 .".to_string(),
+                path: Some(".".to_string()),
+            }],
+        );
+    }
+
+    #[test]
+    fn supports_head_n() {
+        let inner = "head -n 50 Cargo.toml";
+        assert_parsed(
+            &vec_str(&["bash", "-lc", inner]),
+            vec![ParsedCommand::Read {
+                cmd: inner.to_string(),
+                name: "Cargo.toml".to_string(),
+                path: PathBuf::from("Cargo.toml"),
+            }],
+        );
+    }
+
+    #[test]
+    fn supports_head_file_only() {
+        let inner = "head Cargo.toml";
+        assert_parsed(
+            &vec_str(&["bash", "-lc", inner]),
+            vec![ParsedCommand::Read {
+                cmd: inner.to_string(),
+                name: "Cargo.toml".to_string(),
+                path: PathBuf::from("Cargo.toml"),
+            }],
+        );
+    }
+
+    #[test]
+    fn supports_cat_sed_n() {
+        let inner = "cat tui/Cargo.toml | sed -n '1,200p'";
+        assert_parsed(
+            &vec_str(&["bash", "-lc", inner]),
+            vec![ParsedCommand::Read {
+                cmd: inner.to_string(),
+                name: "Cargo.toml".to_string(),
+                path: PathBuf::from("tui/Cargo.toml"),
+            }],
+        );
+    }
+
+    #[test]
+    fn supports_tail_n_plus() {
+        let inner = "tail -n +522 README.md";
+        assert_parsed(
+            &vec_str(&["bash", "-lc", inner]),
+            vec![ParsedCommand::Read {
+                cmd: inner.to_string(),
+                name: "README.md".to_string(),
+                path: PathBuf::from("README.md"),
+            }],
+        );
+    }
+
+    #[test]
+    fn supports_tail_n_last_lines() {
+        let inner = "tail -n 30 README.md";
+        let out = parse_command(&vec_str(&["bash", "-lc", inner]));
+        assert_eq!(
+            out,
+            vec![ParsedCommand::Read {
+                cmd: inner.to_string(),
+                name: "README.md".to_string(),
+                path: PathBuf::from("README.md"),
+            }]
+        );
+    }
+
+    #[test]
+    fn supports_tail_file_only() {
+        let inner = "tail README.md";
+        assert_parsed(
+            &vec_str(&["bash", "-lc", inner]),
+            vec![ParsedCommand::Read {
+                cmd: inner.to_string(),
+                name: "README.md".to_string(),
+                path: PathBuf::from("README.md"),
+            }],
+        );
+    }
+
+    #[test]
+    fn supports_npm_run_build_is_unknown() {
+        assert_parsed(
+            &vec_str(&["npm", "run", "build"]),
+            vec![ParsedCommand::Unknown {
+                cmd: "npm run build".to_string(),
+            }],
+        );
+    }
+
+    #[test]
+    fn supports_grep_recursive_current_dir() {
+        assert_parsed(
+            &vec_str(&["grep", "-R", "CODEX_SANDBOX_ENV_VAR", "-n", "."]),
+            vec![ParsedCommand::Search {
+                cmd: "grep -R CODEX_SANDBOX_ENV_VAR -n .".to_string(),
+                query: Some("CODEX_SANDBOX_ENV_VAR".to_string()),
+                path: Some(".".to_string()),
+            }],
+        );
+    }
+
+    #[test]
+    fn supports_grep_recursive_specific_file() {
+        assert_parsed(
+            &vec_str(&[
+                "grep",
+                "-R",
+                "CODEX_SANDBOX_ENV_VAR",
+                "-n",
+                "core/src/spawn.rs",
+            ]),
+            vec![ParsedCommand::Search {
+                cmd: "grep -R CODEX_SANDBOX_ENV_VAR -n core/src/spawn.rs".to_string(),
+                query: Some("CODEX_SANDBOX_ENV_VAR".to_string()),
+                path: Some("spawn.rs".to_string()),
+            }],
+        );
+    }
+
+    #[test]
+    fn supports_egrep_and_fgrep() {
+        assert_parsed(
+            &shlex_split_safe("egrep -R TODO src"),
+            vec![ParsedCommand::Search {
+                cmd: "egrep -R TODO src".to_string(),
+                query: Some("TODO".to_string()),
+                path: Some("src".to_string()),
+            }],
+        );
+        assert_parsed(
+            &shlex_split_safe("fgrep -l TODO src"),
+            vec![ParsedCommand::Search {
+                cmd: "fgrep -l TODO src".to_string(),
+                query: Some("TODO".to_string()),
+                path: Some("src".to_string()),
+            }],
+        );
+    }
+
+    #[test]
+    fn grep_files_with_matches_flags_are_search() {
+        assert_parsed(
+            &shlex_split_safe("grep -l TODO src"),
+            vec![ParsedCommand::Search {
+                cmd: "grep -l TODO src".to_string(),
+                query: Some("TODO".to_string()),
+                path: Some("src".to_string()),
+            }],
+        );
+        assert_parsed(
+            &shlex_split_safe("grep --files-with-matches TODO src"),
+            vec![ParsedCommand::Search {
+                cmd: "grep --files-with-matches TODO src".to_string(),
+                query: Some("TODO".to_string()),
+                path: Some("src".to_string()),
+            }],
+        );
+        assert_parsed(
+            &shlex_split_safe("grep -L TODO src"),
+            vec![ParsedCommand::Search {
+                cmd: "grep -L TODO src".to_string(),
+                query: Some("TODO".to_string()),
+                path: Some("src".to_string()),
+            }],
+        );
+        assert_parsed(
+            &shlex_split_safe("grep --files-without-match TODO src"),
+            vec![ParsedCommand::Search {
+                cmd: "grep --files-without-match TODO src".to_string(),
+                query: Some("TODO".to_string()),
+                path: Some("src".to_string()),
+            }],
+        );
+    }
+
+    #[test]
+    fn supports_grep_query_with_slashes_not_shortened() {
+        // Query strings may contain slashes and should not be shortened to the basename.
+        // Previously, grep queries were passed through short_display_path, which is incorrect.
+        assert_parsed(
+            &shlex_split_safe("grep -R src/main.rs -n ."),
+            vec![ParsedCommand::Search {
+                cmd: "grep -R src/main.rs -n .".to_string(),
+                query: Some("src/main.rs".to_string()),
+                path: Some(".".to_string()),
+            }],
+        );
+    }
+
+    #[test]
+    fn supports_grep_weird_backtick_in_query() {
+        assert_parsed(
+            &shlex_split_safe("grep -R COD`EX_SANDBOX -n"),
+            vec![ParsedCommand::Search {
+                cmd: "grep -R 'COD`EX_SANDBOX' -n".to_string(),
+                query: Some("COD`EX_SANDBOX".to_string()),
+                path: None,
+            }],
+        );
+    }
+
+    #[test]
+    fn supports_cd_and_rg_files() {
+        assert_parsed(
+            &shlex_split_safe("cd codex-rs && rg --files"),
+            vec![ParsedCommand::ListFiles {
+                cmd: "rg --files".to_string(),
+                path: None,
+            }],
+        );
+    }
+
+    #[test]
+    fn supports_single_string_script_with_cd_and_pipe() {
+        let inner = r#"cd /Users/pakrym/code/codex && rg -n "codex_api" codex-rs -S | head -n 50"#;
+        assert_parsed(
+            &vec_str(&["bash", "-lc", inner]),
+            vec![ParsedCommand::Search {
+                cmd: "rg -n codex_api codex-rs -S".to_string(),
+                query: Some("codex_api".to_string()),
+                path: Some("codex-rs".to_string()),
+            }],
+        );
+    }
+
+    #[test]
+    fn supports_python_walks_files() {
+        let inner = r#"python -c "import os; print(os.listdir('.'))""#;
+        assert_parsed(
+            &vec_str(&["bash", "-lc", inner]),
+            vec![ParsedCommand::ListFiles {
+                cmd: shlex_join(&shlex_split_safe(inner)),
+                path: None,
+            }],
+        );
+    }
+
+    #[test]
+    fn supports_python3_walks_files() {
+        let inner = r#"python3 -c "import glob; print(glob.glob('*.rs'))""#;
+        assert_parsed(
+            &vec_str(&["bash", "-lc", inner]),
+            vec![ParsedCommand::ListFiles {
+                cmd: shlex_join(&shlex_split_safe(inner)),
+                path: None,
+            }],
+        );
+    }
+
+    #[test]
+    fn python_without_file_walk_is_unknown() {
+        let inner = r#"python -c "print('hello')""#;
+        assert_parsed(
+            &vec_str(&["bash", "-lc", inner]),
+            vec![ParsedCommand::Unknown {
+                cmd: shlex_join(&shlex_split_safe(inner)),
+            }],
+        );
+    }
+
+    // ---- is_small_formatting_command unit tests ----
+    #[test]
+    fn small_formatting_always_true_commands() {
+        for cmd in ["wc", "tr", "cut", "sort", "uniq", "xargs", "tee", "column"] {
+            assert!(is_small_formatting_command(&shlex_split_safe(cmd)));
+            assert!(is_small_formatting_command(&shlex_split_safe(&format!(
+                "{cmd} -x"
+            ))));
+        }
+    }
+
+    #[test]
+    fn awk_behavior() {
+        assert!(is_small_formatting_command(&shlex_split_safe(
+            "awk '{print $1}'"
+        )));
+        assert!(!is_small_formatting_command(&shlex_split_safe(
+            "awk '{print $1}' Cargo.toml"
+        )));
+        assert!(!is_small_formatting_command(&shlex_split_safe(
+            "awk -f script.awk Cargo.toml"
+        )));
+    }
+
+    #[test]
+    fn head_behavior() {
+        // No args -> small formatting
+        assert!(is_small_formatting_command(&vec_str(&["head"])));
+        // Numeric count only -> formatting
+        assert!(is_small_formatting_command(&shlex_split_safe("head -n 40")));
+        // With explicit file -> not small formatting
+        assert!(!is_small_formatting_command(&shlex_split_safe(
+            "head -n 40 file.txt"
+        )));
+        // File only (no count) -> not formatting
+        assert!(!is_small_formatting_command(&vec_str(&[
+            "head", "file.txt"
+        ])));
+    }
+
+    #[test]
+    fn tail_behavior() {
+        // No args -> small formatting
+        assert!(is_small_formatting_command(&vec_str(&["tail"])));
+        // Numeric with plus offset -> formatting
+        assert!(is_small_formatting_command(&shlex_split_safe(
+            "tail -n +10"
+        )));
+        assert!(!is_small_formatting_command(&shlex_split_safe(
+            "tail -n +10 file.txt"
+        )));
+        // Numeric count -> formatting
+        assert!(is_small_formatting_command(&shlex_split_safe("tail -n 30")));
+        assert!(!is_small_formatting_command(&shlex_split_safe(
+            "tail -n 30 file.txt"
+        )));
+        // Byte count -> formatting
+        assert!(is_small_formatting_command(&shlex_split_safe("tail -c 30")));
+        assert!(is_small_formatting_command(&shlex_split_safe(
+            "tail -c +10"
+        )));
+        // File only (no count) -> not formatting
+        assert!(!is_small_formatting_command(&vec_str(&[
+            "tail", "file.txt"
+        ])));
+    }
+
+    #[test]
+    fn sed_behavior() {
+        // Plain sed -> small formatting
+        assert!(is_small_formatting_command(&vec_str(&["sed"])));
+        // sed -n <range> (no file) -> still small formatting
+        assert!(is_small_formatting_command(&vec_str(&["sed", "-n", "10p"])));
+        // Valid range with file -> not small formatting
+        assert!(!is_small_formatting_command(&shlex_split_safe(
+            "sed -n 10p file.txt"
+        )));
+        assert!(!is_small_formatting_command(&shlex_split_safe(
+            "sed -n -e 10p file.txt"
+        )));
+        assert!(!is_small_formatting_command(&shlex_split_safe(
+            "sed -n 10p -- file.txt"
+        )));
+        assert!(!is_small_formatting_command(&shlex_split_safe(
+            "sed -n 1,200p file.txt"
+        )));
+        // Invalid ranges with file -> small formatting
+        assert!(is_small_formatting_command(&shlex_split_safe(
+            "sed -n p file.txt"
+        )));
+        assert!(is_small_formatting_command(&shlex_split_safe(
+            "sed -n +10p file.txt"
+        )));
+    }
+
+    #[test]
+    fn empty_tokens_is_not_small() {
+        let empty: Vec<String> = Vec::new();
+        assert!(!is_small_formatting_command(&empty));
+    }
+
+    #[test]
+    fn supports_nl_then_sed_reading() {
+        let inner = "nl -ba core/src/parse_command.rs | sed -n '1200,1720p'";
+        assert_parsed(
+            &vec_str(&["bash", "-lc", inner]),
+            vec![ParsedCommand::Read {
+                cmd: inner.to_string(),
+                name: "parse_command.rs".to_string(),
+                path: PathBuf::from("core/src/parse_command.rs"),
+            }],
+        );
+    }
+
+    #[test]
+    fn supports_sed_n() {
+        let inner = "sed -n '2000,2200p' tui/src/history_cell.rs";
+        assert_parsed(
+            &vec_str(&["bash", "-lc", inner]),
+            vec![ParsedCommand::Read {
+                cmd: inner.to_string(),
+                name: "history_cell.rs".to_string(),
+                path: PathBuf::from("tui/src/history_cell.rs"),
+            }],
+        );
+    }
+
+    #[test]
+    fn supports_awk_with_file() {
+        let inner = "awk '{print $1}' Cargo.toml";
+        assert_parsed(
+            &vec_str(&["bash", "-lc", inner]),
+            vec![ParsedCommand::Read {
+                cmd: inner.to_string(),
+                name: "Cargo.toml".to_string(),
+                path: PathBuf::from("Cargo.toml"),
+            }],
+        );
+    }
+
+    #[test]
+    fn filters_out_printf() {
+        let inner =
+            r#"printf "\n===== ansi-escape/Cargo.toml =====\n"; cat -- ansi-escape/Cargo.toml"#;
+        assert_parsed(
+            &vec_str(&["bash", "-lc", inner]),
+            vec![ParsedCommand::Read {
+                cmd: "cat -- ansi-escape/Cargo.toml".to_string(),
+                name: "Cargo.toml".to_string(),
+                path: PathBuf::from("ansi-escape/Cargo.toml"),
+            }],
+        );
+    }
+
+    #[test]
+    fn drops_yes_in_pipelines() {
+        // Inside bash -lc, `yes | rg --files` should focus on the primary command.
+        let inner = "yes | rg --files";
+        assert_parsed(
+            &vec_str(&["bash", "-lc", inner]),
+            vec![ParsedCommand::ListFiles {
+                cmd: "rg --files".to_string(),
+                path: None,
+            }],
+        );
+    }
+
+    #[test]
+    fn supports_sed_n_then_nl_as_search() {
+        // Ensure `sed -n '<range>' <file> | nl -ba` is summarized as a search for that file.
+        let args = shlex_split_safe(
+            "sed -n '260,640p' exec/src/event_processor_with_human_output.rs | nl -ba",
+        );
+        assert_parsed(
+            &args,
+            vec![ParsedCommand::Read {
+                cmd: "sed -n '260,640p' exec/src/event_processor_with_human_output.rs".to_string(),
+                name: "event_processor_with_human_output.rs".to_string(),
+                path: PathBuf::from("exec/src/event_processor_with_human_output.rs"),
+            }],
+        );
+    }
+
+    #[test]
+    fn preserves_rg_with_spaces() {
+        assert_parsed(
+            &shlex_split_safe("yes | rg -n 'foo bar' -S"),
+            vec![ParsedCommand::Search {
+                cmd: "rg -n 'foo bar' -S".to_string(),
+                query: Some("foo bar".to_string()),
+                path: None,
+            }],
+        );
+    }
+
+    #[test]
+    fn ls_with_glob() {
+        assert_parsed(
+            &shlex_split_safe("ls -I '*.test.js'"),
+            vec![ParsedCommand::ListFiles {
+                cmd: "ls -I '*.test.js'".to_string(),
+                path: None,
+            }],
+        );
+    }
+
+    #[test]
+    fn strips_true_in_sequence() {
+        // `true` should be dropped from parsed sequences
+        assert_parsed(
+            &shlex_split_safe("true && rg --files"),
+            vec![ParsedCommand::ListFiles {
+                cmd: "rg --files".to_string(),
+                path: None,
+            }],
+        );
+
+        assert_parsed(
+            &shlex_split_safe("rg --files && true"),
+            vec![ParsedCommand::ListFiles {
+                cmd: "rg --files".to_string(),
+                path: None,
+            }],
+        );
+    }
+
+    #[test]
+    fn strips_true_inside_bash_lc() {
+        let inner = "true && rg --files";
+        assert_parsed(
+            &vec_str(&["bash", "-lc", inner]),
+            vec![ParsedCommand::ListFiles {
+                cmd: "rg --files".to_string(),
+                path: None,
+            }],
+        );
+
+        let inner2 = "rg --files || true";
+        assert_parsed(
+            &vec_str(&["bash", "-lc", inner2]),
+            vec![ParsedCommand::ListFiles {
+                cmd: "rg --files".to_string(),
+                path: None,
+            }],
+        );
+    }
+
+    #[test]
+    fn shorten_path_on_windows() {
+        assert_parsed(
+            &shlex_split_safe(r#"cat "pkg\src\main.rs""#),
+            vec![ParsedCommand::Read {
+                cmd: r#"cat "pkg\\src\\main.rs""#.to_string(),
+                name: "main.rs".to_string(),
+                path: PathBuf::from(r#"pkg\src\main.rs"#),
+            }],
+        );
+    }
+
+    #[test]
+    fn head_with_no_space() {
+        assert_parsed(
+            &shlex_split_safe("bash -lc 'head -n50 Cargo.toml'"),
+            vec![ParsedCommand::Read {
+                cmd: "head -n50 Cargo.toml".to_string(),
+                name: "Cargo.toml".to_string(),
+                path: PathBuf::from("Cargo.toml"),
+            }],
+        );
+    }
+
+    #[test]
+    fn bash_dash_c_pipeline_parsing() {
+        // Ensure -c is handled similarly to -lc by shell parsing
+        let inner = "rg --files | head -n 1";
+        assert_parsed(
+            &vec_str(&["bash", "-c", inner]),
+            vec![ParsedCommand::ListFiles {
+                cmd: "rg --files".to_string(),
+                path: None,
+            }],
+        );
+    }
+
+    #[test]
+    fn tail_with_no_space() {
+        assert_parsed(
+            &shlex_split_safe("bash -lc 'tail -n+10 README.md'"),
+            vec![ParsedCommand::Read {
+                cmd: "tail -n+10 README.md".to_string(),
+                name: "README.md".to_string(),
+                path: PathBuf::from("README.md"),
+            }],
+        );
+    }
+
+    #[test]
+    fn grep_with_query_and_path() {
+        assert_parsed(
+            &shlex_split_safe("grep -R TODO src"),
+            vec![ParsedCommand::Search {
+                cmd: "grep -R TODO src".to_string(),
+                query: Some("TODO".to_string()),
+                path: Some("src".to_string()),
+            }],
+        );
+    }
+
+    #[test]
+    fn supports_ag_ack_pt_rga() {
+        assert_parsed(
+            &shlex_split_safe("ag TODO src"),
+            vec![ParsedCommand::Search {
+                cmd: "ag TODO src".to_string(),
+                query: Some("TODO".to_string()),
+                path: Some("src".to_string()),
+            }],
+        );
+        assert_parsed(
+            &shlex_split_safe("ack TODO src"),
+            vec![ParsedCommand::Search {
+                cmd: "ack TODO src".to_string(),
+                query: Some("TODO".to_string()),
+                path: Some("src".to_string()),
+            }],
+        );
+        assert_parsed(
+            &shlex_split_safe("pt TODO src"),
+            vec![ParsedCommand::Search {
+                cmd: "pt TODO src".to_string(),
+                query: Some("TODO".to_string()),
+                path: Some("src".to_string()),
+            }],
+        );
+        assert_parsed(
+            &shlex_split_safe("rga TODO src"),
+            vec![ParsedCommand::Search {
+                cmd: "rga TODO src".to_string(),
+                query: Some("TODO".to_string()),
+                path: Some("src".to_string()),
+            }],
+        );
+    }
+
+    #[test]
+    fn ag_ack_pt_files_with_matches_flags_are_search() {
+        assert_parsed(
+            &shlex_split_safe("ag -l TODO src"),
+            vec![ParsedCommand::Search {
+                cmd: "ag -l TODO src".to_string(),
+                query: Some("TODO".to_string()),
+                path: Some("src".to_string()),
+            }],
+        );
+        assert_parsed(
+            &shlex_split_safe("ack -l TODO src"),
+            vec![ParsedCommand::Search {
+                cmd: "ack -l TODO src".to_string(),
+                query: Some("TODO".to_string()),
+                path: Some("src".to_string()),
+            }],
+        );
+        assert_parsed(
+            &shlex_split_safe("pt -l TODO src"),
+            vec![ParsedCommand::Search {
+                cmd: "pt -l TODO src".to_string(),
+                query: Some("TODO".to_string()),
+                path: Some("src".to_string()),
+            }],
+        );
+    }
+
+    #[test]
+    fn rg_with_equals_style_flags() {
+        assert_parsed(
+            &shlex_split_safe("rg --colors=never -n foo src"),
+            vec![ParsedCommand::Search {
+                cmd: "rg '--colors=never' -n foo src".to_string(),
+                query: Some("foo".to_string()),
+                path: Some("src".to_string()),
+            }],
+        );
+    }
+
+    #[test]
+    fn cat_with_double_dash_and_sed_ranges() {
+        // cat -- <file> should be treated as a read of that file
+        assert_parsed(
+            &shlex_split_safe("cat -- ./-strange-file-name"),
+            vec![ParsedCommand::Read {
+                cmd: "cat -- ./-strange-file-name".to_string(),
+                name: "-strange-file-name".to_string(),
+                path: PathBuf::from("./-strange-file-name"),
+            }],
+        );
+
+        // sed -n <range> <file> should be treated as a read of <file>
+        assert_parsed(
+            &shlex_split_safe("sed -n '12,20p' Cargo.toml"),
+            vec![ParsedCommand::Read {
+                cmd: "sed -n '12,20p' Cargo.toml".to_string(),
+                name: "Cargo.toml".to_string(),
+                path: PathBuf::from("Cargo.toml"),
+            }],
+        );
+    }
+
+    #[test]
+    fn drop_trailing_nl_in_pipeline() {
+        // When an `nl` stage has only flags, it should be dropped from the summary
+        assert_parsed(
+            &shlex_split_safe("rg --files | nl -ba"),
+            vec![ParsedCommand::ListFiles {
+                cmd: "rg --files".to_string(),
+                path: None,
+            }],
+        );
+    }
+
+    #[test]
+    fn ls_with_time_style_and_path() {
+        assert_parsed(
+            &shlex_split_safe("ls --time-style=long-iso ./dist"),
+            vec![ParsedCommand::ListFiles {
+                cmd: "ls '--time-style=long-iso' ./dist".to_string(),
+                // short_display_path drops "dist" and shows "." as the last useful segment
+                path: Some(".".to_string()),
+            }],
+        );
+    }
+
+    #[test]
+    fn fd_file_finder_variants() {
+        assert_parsed(
+            &shlex_split_safe("fd -t f src/"),
+            vec![ParsedCommand::ListFiles {
+                cmd: "fd -t f src/".to_string(),
+                path: Some("src".to_string()),
+            }],
+        );
+
+        // fd with query and path should capture both
+        assert_parsed(
+            &shlex_split_safe("fd main src"),
+            vec![ParsedCommand::Search {
+                cmd: "fd main src".to_string(),
+                query: Some("main".to_string()),
+                path: Some("src".to_string()),
+            }],
+        );
+    }
+
+    #[test]
+    fn find_basic_name_filter() {
+        assert_parsed(
+            &shlex_split_safe("find . -name '*.rs'"),
+            vec![ParsedCommand::Search {
+                cmd: "find . -name '*.rs'".to_string(),
+                query: Some("*.rs".to_string()),
+                path: Some(".".to_string()),
+            }],
+        );
+    }
+
+    #[test]
+    fn find_type_only_path() {
+        assert_parsed(
+            &shlex_split_safe("find src -type f"),
+            vec![ParsedCommand::ListFiles {
+                cmd: "find src -type f".to_string(),
+                path: Some("src".to_string()),
+            }],
+        );
+    }
+
+    #[test]
+    fn bin_bash_lc_sed() {
+        assert_parsed(
+            &shlex_split_safe("/bin/bash -lc 'sed -n '1,10p' Cargo.toml'"),
+            vec![ParsedCommand::Read {
+                cmd: "sed -n '1,10p' Cargo.toml".to_string(),
+                name: "Cargo.toml".to_string(),
+                path: PathBuf::from("Cargo.toml"),
+            }],
+        );
+    }
+    #[test]
+    fn bin_zsh_lc_sed() {
+        assert_parsed(
+            &shlex_split_safe("/bin/zsh -lc 'sed -n '1,10p' Cargo.toml'"),
+            vec![ParsedCommand::Read {
+                cmd: "sed -n '1,10p' Cargo.toml".to_string(),
+                name: "Cargo.toml".to_string(),
+                path: PathBuf::from("Cargo.toml"),
+            }],
+        );
+    }
+
+    #[test]
+    fn powershell_command_is_stripped() {
+        assert_parsed(
+            &vec_str(&["powershell", "-Command", "Get-ChildItem"]),
+            vec![ParsedCommand::Unknown {
+                cmd: "Get-ChildItem".to_string(),
+            }],
+        );
+    }
+
+    #[test]
+    fn pwsh_with_noprofile_and_c_alias_is_stripped() {
+        assert_parsed(
+            &vec_str(&["pwsh", "-NoProfile", "-c", "Write-Host hi"]),
+            vec![ParsedCommand::Unknown {
+                cmd: "Write-Host hi".to_string(),
+            }],
+        );
+    }
+
+    #[test]
+    fn powershell_with_path_is_stripped() {
+        let command = if cfg!(windows) {
+            "C:\\windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe"
+        } else {
+            "/usr/local/bin/powershell.exe"
+        };
+
+        assert_parsed(
+            &vec_str(&[command, "-NoProfile", "-c", "Write-Host hi"]),
+            vec![ParsedCommand::Unknown {
+                cmd: "Write-Host hi".to_string(),
+            }],
+        );
+    }
+}
+
+pub fn parse_command_impl(command: &[String]) -> Vec<ParsedCommand> {
+    if let Some(commands) = parse_shell_lc_commands(command) {
+        return commands;
+    }
+
+    if let Some((_, script)) = extract_powershell_command(command) {
+        return vec![ParsedCommand::Unknown {
+            cmd: script.to_string(),
+        }];
+    }
+
+    let normalized = normalize_tokens(command);
+
+    let parts = if contains_connectors(&normalized) {
+        split_on_connectors(&normalized)
+    } else {
+        vec![normalized]
+    };
+
+    // Preserve left-to-right execution order for all commands, including bash -c/-lc
+    // so summaries reflect the order they will run.
+
+    // Map each pipeline segment to its parsed summary, tracking `cd` to compute paths.
+    let mut commands: Vec<ParsedCommand> = Vec::new();
+    let mut cwd: Option<String> = None;
+    for tokens in &parts {
+        if let Some((head, tail)) = tokens.split_first()
+            && head == "cd"
+        {
+            if let Some(dir) = cd_target(tail) {
+                cwd = Some(match &cwd {
+                    Some(base) => join_paths(base, &dir),
+                    None => dir.clone(),
+                });
+            }
+            continue;
+        }
+        let parsed = summarize_main_tokens(tokens);
+        let parsed = match parsed {
+            ParsedCommand::Read { cmd, name, path } => {
+                if let Some(base) = &cwd {
+                    let full = join_paths(base, &path.to_string_lossy());
+                    ParsedCommand::Read {
+                        cmd,
+                        name,
+                        path: PathBuf::from(full),
+                    }
+                } else {
+                    ParsedCommand::Read { cmd, name, path }
+                }
+            }
+            other => other,
+        };
+        commands.push(parsed);
+    }
+
+    while let Some(next) = simplify_once(&commands) {
+        commands = next;
+    }
+
+    commands
+}
+
+fn simplify_once(commands: &[ParsedCommand]) -> Option<Vec<ParsedCommand>> {
+    if commands.len() <= 1 {
+        return None;
+    }
+
+    // echo ... && ...rest => ...rest
+    if let ParsedCommand::Unknown { cmd } = &commands[0]
+        && shlex_split(cmd).is_some_and(|t| t.first().map(String::as_str) == Some("echo"))
+    {
+        return Some(commands[1..].to_vec());
+    }
+
+    // cd foo && [any command] => [any command] (keep non-cd when a cd is followed by something)
+    if let Some(idx) = commands.iter().position(|pc| match pc {
+        ParsedCommand::Unknown { cmd } => {
+            shlex_split(cmd).is_some_and(|t| t.first().map(String::as_str) == Some("cd"))
+        }
+        _ => false,
+    }) && commands.len() > idx + 1
+    {
+        let mut out = Vec::with_capacity(commands.len() - 1);
+        out.extend_from_slice(&commands[..idx]);
+        out.extend_from_slice(&commands[idx + 1..]);
+        return Some(out);
+    }
+
+    // cmd || true => cmd
+    if let Some(idx) = commands
+        .iter()
+        .position(|pc| matches!(pc, ParsedCommand::Unknown { cmd } if cmd == "true"))
+    {
+        let mut out = Vec::with_capacity(commands.len() - 1);
+        out.extend_from_slice(&commands[..idx]);
+        out.extend_from_slice(&commands[idx + 1..]);
+        return Some(out);
+    }
+
+    // nl -[any_flags] && ...rest => ...rest
+    if let Some(idx) = commands.iter().position(|pc| match pc {
+        ParsedCommand::Unknown { cmd } => {
+            if let Some(tokens) = shlex_split(cmd) {
+                tokens.first().is_some_and(|s| s.as_str() == "nl")
+                    && tokens.iter().skip(1).all(|t| t.starts_with('-'))
+            } else {
+                false
+            }
+        }
+        _ => false,
+    }) {
+        let mut out = Vec::with_capacity(commands.len() - 1);
+        out.extend_from_slice(&commands[..idx]);
+        out.extend_from_slice(&commands[idx + 1..]);
+        return Some(out);
+    }
+
+    None
+}
+
+/// Validates that this is a `sed -n 123,123p` command.
+fn is_valid_sed_n_arg(arg: Option<&str>) -> bool {
+    let s = match arg {
+        Some(s) => s,
+        None => return false,
+    };
+    let core = match s.strip_suffix('p') {
+        Some(rest) => rest,
+        None => return false,
+    };
+    let parts: Vec<&str> = core.split(',').collect();
+    match parts.as_slice() {
+        [num] => !num.is_empty() && num.chars().all(|c| c.is_ascii_digit()),
+        [a, b] => {
+            !a.is_empty()
+                && !b.is_empty()
+                && a.chars().all(|c| c.is_ascii_digit())
+                && b.chars().all(|c| c.is_ascii_digit())
+        }
+        _ => false,
+    }
+}
+
+fn sed_read_path(args: &[String]) -> Option<String> {
+    let args_no_connector = trim_at_connector(args);
+    if !args_no_connector.iter().any(|arg| arg == "-n") {
+        return None;
+    }
+    let mut has_range_script = false;
+    let mut i = 0;
+    while i < args_no_connector.len() {
+        let arg = &args_no_connector[i];
+        if matches!(arg.as_str(), "-e" | "--expression") {
+            if is_valid_sed_n_arg(args_no_connector.get(i + 1).map(String::as_str)) {
+                has_range_script = true;
+            }
+            i += 2;
+            continue;
+        }
+        if matches!(arg.as_str(), "-f" | "--file") {
+            i += 2;
+            continue;
+        }
+        i += 1;
+    }
+    if !has_range_script {
+        has_range_script = args_no_connector
+            .iter()
+            .any(|arg| !arg.starts_with('-') && is_valid_sed_n_arg(Some(arg)));
+    }
+    if !has_range_script {
+        return None;
+    }
+    let candidates = skip_flag_values(&args_no_connector, &["-e", "-f", "--expression", "--file"]);
+    let non_flags: Vec<String> = candidates
+        .into_iter()
+        .filter(|arg| !arg.starts_with('-'))
+        .cloned()
+        .collect();
+    match non_flags.as_slice() {
+        [] => None,
+        [first, rest @ ..] if is_valid_sed_n_arg(Some(first)) => rest.first().cloned(),
+        [first, ..] => Some(first.clone()),
+    }
+}
+
+/// Normalize a command by:
+/// - Removing `yes`/`no`/`bash -c`/`bash -lc`/`zsh -c`/`zsh -lc` prefixes.
+/// - Splitting on `|` and `&&`/`||`/`;
+fn normalize_tokens(cmd: &[String]) -> Vec<String> {
+    match cmd {
+        [first, pipe, rest @ ..] if (first == "yes" || first == "y") && pipe == "|" => {
+            // Do not re-shlex already-tokenized input; just drop the prefix.
+            rest.to_vec()
+        }
+        [first, pipe, rest @ ..] if (first == "no" || first == "n") && pipe == "|" => {
+            // Do not re-shlex already-tokenized input; just drop the prefix.
+            rest.to_vec()
+        }
+        [shell, flag, script]
+            if (shell == "bash" || shell == "zsh") && (flag == "-c" || flag == "-lc") =>
+        {
+            shlex_split(script).unwrap_or_else(|| vec![shell.clone(), flag.clone(), script.clone()])
+        }
+        _ => cmd.to_vec(),
+    }
+}
+
+fn contains_connectors(tokens: &[String]) -> bool {
+    tokens
+        .iter()
+        .any(|t| t == "&&" || t == "||" || t == "|" || t == ";")
+}
+
+fn split_on_connectors(tokens: &[String]) -> Vec<Vec<String>> {
+    let mut out: Vec<Vec<String>> = Vec::new();
+    let mut cur: Vec<String> = Vec::new();
+    for t in tokens {
+        if t == "&&" || t == "||" || t == "|" || t == ";" {
+            if !cur.is_empty() {
+                out.push(std::mem::take(&mut cur));
+            }
+        } else {
+            cur.push(t.clone());
+        }
+    }
+    if !cur.is_empty() {
+        out.push(cur);
+    }
+    out
+}
+
+fn trim_at_connector(tokens: &[String]) -> Vec<String> {
+    let idx = tokens
+        .iter()
+        .position(|t| t == "|" || t == "&&" || t == "||" || t == ";")
+        .unwrap_or(tokens.len());
+    tokens[..idx].to_vec()
+}
+
+/// Shorten a path to the last component, excluding `build`/`dist`/`node_modules`/`src`.
+/// It also pulls out a useful path from a directory such as:
+/// - webview/src -> webview
+/// - foo/src/ -> foo
+/// - packages/app/node_modules/ -> app
+fn short_display_path(path: &str) -> String {
+    // Normalize separators and drop any trailing slash for display.
+    let normalized = path.replace('\\', "/");
+    let trimmed = normalized.trim_end_matches('/');
+    let mut parts = trimmed.split('/').rev().filter(|p| {
+        !p.is_empty() && *p != "build" && *p != "dist" && *p != "node_modules" && *p != "src"
+    });
+    parts
+        .next()
+        .map(str::to_string)
+        .unwrap_or_else(|| trimmed.to_string())
+}
+
+// Skip values consumed by specific flags and ignore --flag=value style arguments.
+fn skip_flag_values<'a>(args: &'a [String], flags_with_vals: &[&str]) -> Vec<&'a String> {
+    let mut out: Vec<&'a String> = Vec::new();
+    let mut skip_next = false;
+    for (i, a) in args.iter().enumerate() {
+        if skip_next {
+            skip_next = false;
+            continue;
+        }
+        if a == "--" {
+            // From here on, everything is positional operands; push the rest and break.
+            for rest in &args[i + 1..] {
+                out.push(rest);
+            }
+            break;
+        }
+        if a.starts_with("--") && a.contains('=') {
+            // --flag=value form: treat as a flag taking a value; skip entirely.
+            continue;
+        }
+        if flags_with_vals.contains(&a.as_str()) {
+            // This flag consumes the next argument as its value.
+            if i + 1 < args.len() {
+                skip_next = true;
+            }
+            continue;
+        }
+        out.push(a);
+    }
+    out
+}
+
+fn first_non_flag_operand(args: &[String], flags_with_vals: &[&str]) -> Option<String> {
+    positional_operands(args, flags_with_vals)
+        .into_iter()
+        .next()
+        .cloned()
+}
+
+fn single_non_flag_operand(args: &[String], flags_with_vals: &[&str]) -> Option<String> {
+    let mut operands = positional_operands(args, flags_with_vals).into_iter();
+    let first = operands.next()?;
+    if operands.next().is_some() {
+        return None;
+    }
+    Some(first.clone())
+}
+
+fn positional_operands<'a>(args: &'a [String], flags_with_vals: &[&str]) -> Vec<&'a String> {
+    let mut out = Vec::new();
+    let mut after_double_dash = false;
+    let mut skip_next = false;
+    for (i, arg) in args.iter().enumerate() {
+        if skip_next {
+            skip_next = false;
+            continue;
+        }
+        if after_double_dash {
+            out.push(arg);
+            continue;
+        }
+        if arg == "--" {
+            after_double_dash = true;
+            continue;
+        }
+        if arg.starts_with("--") && arg.contains('=') {
+            continue;
+        }
+        if flags_with_vals.contains(&arg.as_str()) {
+            if i + 1 < args.len() {
+                skip_next = true;
+            }
+            continue;
+        }
+        if arg.starts_with('-') {
+            continue;
+        }
+        out.push(arg);
+    }
+    out
+}
+
+fn parse_grep_like(main_cmd: &[String], args: &[String]) -> ParsedCommand {
+    let args_no_connector = trim_at_connector(args);
+    let mut operands = Vec::new();
+    let mut pattern: Option<String> = None;
+    let mut after_double_dash = false;
+    let mut iter = args_no_connector.iter().peekable();
+    while let Some(arg) = iter.next() {
+        if after_double_dash {
+            operands.push(arg);
+            continue;
+        }
+        if arg == "--" {
+            after_double_dash = true;
+            continue;
+        }
+        match arg.as_str() {
+            "-e" | "--regexp" => {
+                if let Some(pat) = iter.next()
+                    && pattern.is_none()
+                {
+                    pattern = Some(pat.clone());
+                }
+                continue;
+            }
+            "-f" | "--file" => {
+                if let Some(pat_file) = iter.next()
+                    && pattern.is_none()
+                {
+                    pattern = Some(pat_file.clone());
+                }
+                continue;
+            }
+            "-m" | "--max-count" | "-C" | "--context" | "-A" | "--after-context" | "-B"
+            | "--before-context" => {
+                iter.next();
+                continue;
+            }
+            _ => {}
+        }
+        if arg.starts_with('-') {
+            continue;
+        }
+        operands.push(arg);
+    }
+    // Do not shorten the query: grep patterns may legitimately contain slashes
+    // and should be preserved verbatim. Only paths should be shortened.
+    let has_pattern = pattern.is_some();
+    let query = pattern.or_else(|| operands.first().cloned().map(String::from));
+    let path_index = if has_pattern { 0 } else { 1 };
+    let path = operands.get(path_index).map(|s| short_display_path(s));
+    ParsedCommand::Search {
+        cmd: shlex_join(main_cmd),
+        query,
+        path,
+    }
+}
+
+fn awk_data_file_operand(args: &[String]) -> Option<String> {
+    if args.is_empty() {
+        return None;
+    }
+    let args_no_connector = trim_at_connector(args);
+    let has_script_file = args_no_connector
+        .iter()
+        .any(|arg| arg == "-f" || arg == "--file");
+    let candidates = skip_flag_values(
+        &args_no_connector,
+        &["-F", "-v", "-f", "--field-separator", "--assign", "--file"],
+    );
+    let non_flags: Vec<&String> = candidates
+        .into_iter()
+        .filter(|arg| !arg.starts_with('-'))
+        .collect();
+    if has_script_file {
+        return non_flags.first().cloned().cloned();
+    }
+    if non_flags.len() >= 2 {
+        return Some(non_flags[1].clone());
+    }
+    None
+}
+
+fn python_walks_files(args: &[String]) -> bool {
+    let args_no_connector = trim_at_connector(args);
+    let mut iter = args_no_connector.iter();
+    while let Some(arg) = iter.next() {
+        if arg == "-c"
+            && let Some(script) = iter.next()
+        {
+            return script.contains("os.walk")
+                || script.contains("os.listdir")
+                || script.contains("os.scandir")
+                || script.contains("glob.glob")
+                || script.contains("glob.iglob")
+                || script.contains("pathlib.Path")
+                || script.contains(".rglob(");
+        }
+    }
+    false
+}
+
+fn is_python_command(cmd: &str) -> bool {
+    cmd == "python"
+        || cmd == "python2"
+        || cmd == "python3"
+        || cmd.starts_with("python2.")
+        || cmd.starts_with("python3.")
+}
+
+fn cd_target(args: &[String]) -> Option<String> {
+    if args.is_empty() {
+        return None;
+    }
+    let mut i = 0;
+    let mut target: Option<String> = None;
+    while i < args.len() {
+        let arg = &args[i];
+        if arg == "--" {
+            return args.get(i + 1).cloned();
+        }
+        if matches!(arg.as_str(), "-L" | "-P") {
+            i += 1;
+            continue;
+        }
+        if arg.starts_with('-') {
+            i += 1;
+            continue;
+        }
+        target = Some(arg.clone());
+        i += 1;
+    }
+    target
+}
+
+fn is_pathish(s: &str) -> bool {
+    s == "."
+        || s == ".."
+        || s.starts_with("./")
+        || s.starts_with("../")
+        || s.contains('/')
+        || s.contains('\\')
+}
+
+fn parse_fd_query_and_path(tail: &[String]) -> (Option<String>, Option<String>) {
+    let args_no_connector = trim_at_connector(tail);
+    // fd has several flags that take values (e.g., -t/--type, -e/--extension).
+    // Skip those values when extracting positional operands.
+    let candidates = skip_flag_values(
+        &args_no_connector,
+        &[
+            "-t",
+            "--type",
+            "-e",
+            "--extension",
+            "-E",
+            "--exclude",
+            "--search-path",
+        ],
+    );
+    let non_flags: Vec<&String> = candidates
+        .into_iter()
+        .filter(|p| !p.starts_with('-'))
+        .collect();
+    match non_flags.as_slice() {
+        [one] => {
+            if is_pathish(one) {
+                (None, Some(short_display_path(one)))
+            } else {
+                (Some((*one).clone()), None)
+            }
+        }
+        [q, p, ..] => (Some((*q).clone()), Some(short_display_path(p))),
+        _ => (None, None),
+    }
+}
+
+fn parse_find_query_and_path(tail: &[String]) -> (Option<String>, Option<String>) {
+    let args_no_connector = trim_at_connector(tail);
+    // First positional argument (excluding common unary operators) is the root path
+    let mut path: Option<String> = None;
+    for a in &args_no_connector {
+        if !a.starts_with('-') && *a != "!" && *a != "(" && *a != ")" {
+            path = Some(short_display_path(a));
+            break;
+        }
+    }
+    // Extract a common name/path/regex pattern if present
+    let mut query: Option<String> = None;
+    let mut i = 0;
+    while i < args_no_connector.len() {
+        let a = &args_no_connector[i];
+        if a == "-name" || a == "-iname" || a == "-path" || a == "-regex" {
+            if i + 1 < args_no_connector.len() {
+                query = Some(args_no_connector[i + 1].clone());
+            }
+            break;
+        }
+        i += 1;
+    }
+    (query, path)
+}
+
+fn parse_shell_lc_commands(original: &[String]) -> Option<Vec<ParsedCommand>> {
+    // Only handle bash/zsh here; PowerShell is stripped separately without bash parsing.
+    let (_, script) = extract_bash_command(original)?;
+
+    if let Some(tree) = try_parse_shell(script)
+        && let Some(all_commands) = try_parse_word_only_commands_sequence(&tree, script)
+        && !all_commands.is_empty()
+    {
+        let script_tokens = shlex_split(script).unwrap_or_else(|| vec![script.to_string()]);
+        // Strip small formatting helpers (e.g., head/tail/awk/wc/etc) so we
+        // bias toward the primary command when pipelines are present.
+        // First, drop obvious small formatting helpers (e.g., wc/awk/etc).
+        let had_multiple_commands = all_commands.len() > 1;
+        // Commands arrive in source order; drop formatting helpers while preserving it.
+        let filtered_commands = drop_small_formatting_commands(all_commands);
+        if filtered_commands.is_empty() {
+            return Some(vec![ParsedCommand::Unknown {
+                cmd: script.to_string(),
+            }]);
+        }
+        // Build parsed commands, tracking `cd` segments to compute effective file paths.
+        let mut commands: Vec<ParsedCommand> = Vec::new();
+        let mut cwd: Option<String> = None;
+        for tokens in filtered_commands.into_iter() {
+            if let Some((head, tail)) = tokens.split_first()
+                && head == "cd"
+            {
+                if let Some(dir) = cd_target(tail) {
+                    cwd = Some(match &cwd {
+                        Some(base) => join_paths(base, &dir),
+                        None => dir.clone(),
+                    });
+                }
+                continue;
+            }
+            let parsed = summarize_main_tokens(&tokens);
+            let parsed = match parsed {
+                ParsedCommand::Read { cmd, name, path } => {
+                    if let Some(base) = &cwd {
+                        let full = join_paths(base, &path.to_string_lossy());
+                        ParsedCommand::Read {
+                            cmd,
+                            name,
+                            path: PathBuf::from(full),
+                        }
+                    } else {
+                        ParsedCommand::Read { cmd, name, path }
+                    }
+                }
+                other => other,
+            };
+            commands.push(parsed);
+        }
+
+        if commands.len() > 1 {
+            commands.retain(|pc| !matches!(pc, ParsedCommand::Unknown { cmd } if cmd == "true"));
+            // Apply the same simplifications used for non-bash parsing, e.g., drop leading `cd`.
+            while let Some(next) = simplify_once(&commands) {
+                commands = next;
+            }
+        }
+        if commands.len() == 1 {
+            // If we reduced to a single command, attribute the full original script
+            // for clearer UX in file-reading and listing scenarios, or when there were
+            // no connectors in the original script. For pipeline commands (e.g.
+            // `rg --files | sed -n`), keep only the primary command.
+            let had_connectors = had_multiple_commands
+                || script_tokens
+                    .iter()
+                    .any(|t| t == "|" || t == "&&" || t == "||" || t == ";");
+            commands = commands
+                .into_iter()
+                .map(|pc| match pc {
+                    ParsedCommand::Read { name, cmd, path } => {
+                        if had_connectors {
+                            let has_pipe = script_tokens.iter().any(|t| t == "|");
+                            let has_sed_n = script_tokens.windows(2).any(|w| {
+                                w.first().map(String::as_str) == Some("sed")
+                                    && w.get(1).map(String::as_str) == Some("-n")
+                            });
+                            if has_pipe && has_sed_n {
+                                ParsedCommand::Read {
+                                    cmd: script.to_string(),
+                                    name,
+                                    path,
+                                }
+                            } else {
+                                ParsedCommand::Read { cmd, name, path }
+                            }
+                        } else {
+                            ParsedCommand::Read {
+                                cmd: shlex_join(&script_tokens),
+                                name,
+                                path,
+                            }
+                        }
+                    }
+                    ParsedCommand::ListFiles { path, cmd, .. } => {
+                        if had_connectors {
+                            ParsedCommand::ListFiles { cmd, path }
+                        } else {
+                            ParsedCommand::ListFiles {
+                                cmd: shlex_join(&script_tokens),
+                                path,
+                            }
+                        }
+                    }
+                    ParsedCommand::Search {
+                        query, path, cmd, ..
+                    } => {
+                        if had_connectors {
+                            ParsedCommand::Search { cmd, query, path }
+                        } else {
+                            ParsedCommand::Search {
+                                cmd: shlex_join(&script_tokens),
+                                query,
+                                path,
+                            }
+                        }
+                    }
+                    other => other,
+                })
+                .collect();
+        }
+        return Some(commands);
+    }
+    Some(vec![ParsedCommand::Unknown {
+        cmd: script.to_string(),
+    }])
+}
+
+/// Return true if this looks like a small formatting helper in a pipeline.
+/// Examples: `head -n 40`, `tail -n +10`, `wc -l`, `awk ...`, `cut ...`, `tr ...`.
+/// We try to keep variants that clearly include a file path (e.g. `tail -n 30 file`).
+fn is_small_formatting_command(tokens: &[String]) -> bool {
+    if tokens.is_empty() {
+        return false;
+    }
+    let cmd = tokens[0].as_str();
+    match cmd {
+        // Always formatting; typically used in pipes.
+        // `nl` is special-cased below to allow `nl <file>` to be treated as a read command.
+        "wc" | "tr" | "cut" | "sort" | "uniq" | "tee" | "column" | "yes" | "printf" => true,
+        "xargs" => !is_mutating_xargs_command(tokens),
+        "awk" => awk_data_file_operand(&tokens[1..]).is_none(),
+        "head" => {
+            // Treat as formatting when no explicit file operand is present.
+            // Common forms: `head -n 40`, `head -c 100`.
+            // Keep cases like `head -n 40 file`.
+            match tokens {
+                // `head`
+                [_] => true,
+                // `head <file>` or `head -n50`/`head -c100`
+                [_, arg] => arg.starts_with('-'),
+                // `head -n 40` / `head -c 100` (no file operand)
+                [_, flag, count]
+                    if (flag == "-n" || flag == "-c")
+                        && count.chars().all(|c| c.is_ascii_digit()) =>
+                {
+                    true
+                }
+                _ => false,
+            }
+        }
+        "tail" => {
+            // Treat as formatting when no explicit file operand is present.
+            // Common forms: `tail -n +10`, `tail -n 30`, `tail -c 100`.
+            // Keep cases like `tail -n 30 file`.
+            match tokens {
+                // `tail`
+                [_] => true,
+                // `tail <file>` or `tail -n30`/`tail -n+10`
+                [_, arg] => arg.starts_with('-'),
+                // `tail -n 30` / `tail -n +10` (no file operand)
+                [_, flag, count]
+                    if flag == "-n"
+                        && (count.chars().all(|c| c.is_ascii_digit())
+                            || (count.starts_with('+')
+                                && count[1..].chars().all(|c| c.is_ascii_digit()))) =>
+                {
+                    true
+                }
+                // `tail -c 100` / `tail -c +10` (no file operand)
+                [_, flag, count]
+                    if flag == "-c"
+                        && (count.chars().all(|c| c.is_ascii_digit())
+                            || (count.starts_with('+')
+                                && count[1..].chars().all(|c| c.is_ascii_digit()))) =>
+                {
+                    true
+                }
+                _ => false,
+            }
+        }
+        "sed" => {
+            // Keep `sed -n <range> file` (treated as a file read elsewhere);
+            // otherwise consider it a formatting helper in a pipeline.
+            sed_read_path(&tokens[1..]).is_none()
+        }
+        _ => false,
+    }
+}
+
+fn is_mutating_xargs_command(tokens: &[String]) -> bool {
+    xargs_subcommand(tokens).is_some_and(xargs_is_mutating_subcommand)
+}
+
+fn xargs_subcommand(tokens: &[String]) -> Option<&[String]> {
+    if tokens.first().map(String::as_str) != Some("xargs") {
+        return None;
+    }
+    let mut i = 1;
+    while i < tokens.len() {
+        let token = &tokens[i];
+        if token == "--" {
+            return tokens.get(i + 1..).filter(|rest| !rest.is_empty());
+        }
+        if !token.starts_with('-') {
+            return tokens.get(i..).filter(|rest| !rest.is_empty());
+        }
+        let takes_value = matches!(
+            token.as_str(),
+            "-E" | "-e" | "-I" | "-L" | "-n" | "-P" | "-s"
+        );
+        if takes_value && token.len() == 2 {
+            i += 2;
+        } else {
+            i += 1;
+        }
+    }
+    None
+}
+
+fn xargs_is_mutating_subcommand(tokens: &[String]) -> bool {
+    let Some((head, tail)) = tokens.split_first() else {
+        return false;
+    };
+    match head.as_str() {
+        "perl" | "ruby" => xargs_has_in_place_flag(tail),
+        "sed" => xargs_has_in_place_flag(tail) || tail.iter().any(|token| token == "--in-place"),
+        "rg" => tail.iter().any(|token| token == "--replace"),
+        _ => false,
+    }
+}
+
+fn xargs_has_in_place_flag(tokens: &[String]) -> bool {
+    tokens.iter().any(|token| {
+        token == "-i" || token.starts_with("-i") || token == "-pi" || token.starts_with("-pi")
+    })
+}
+
+fn drop_small_formatting_commands(mut commands: Vec<Vec<String>>) -> Vec<Vec<String>> {
+    commands.retain(|tokens| !is_small_formatting_command(tokens));
+    commands
+}
+
+fn summarize_main_tokens(main_cmd: &[String]) -> ParsedCommand {
+    match main_cmd.split_first() {
+        Some((head, tail)) if matches!(head.as_str(), "ls" | "eza" | "exa") => {
+            let flags_with_vals: &[&str] = match head.as_str() {
+                "ls" => &[
+                    "-I",
+                    "-w",
+                    "--block-size",
+                    "--format",
+                    "--time-style",
+                    "--color",
+                    "--quoting-style",
+                ],
+                "eza" | "exa" => &[
+                    "-I",
+                    "--ignore-glob",
+                    "--color",
+                    "--sort",
+                    "--time-style",
+                    "--time",
+                ],
+                _ => &[],
+            };
+            let path =
+                first_non_flag_operand(tail, flags_with_vals).map(|p| short_display_path(&p));
+            ParsedCommand::ListFiles {
+                cmd: shlex_join(main_cmd),
+                path,
+            }
+        }
+        Some((head, tail)) if head == "tree" => {
+            let path = first_non_flag_operand(
+                tail,
+                &["-L", "-P", "-I", "--charset", "--filelimit", "--sort"],
+            )
+            .map(|p| short_display_path(&p));
+            ParsedCommand::ListFiles {
+                cmd: shlex_join(main_cmd),
+                path,
+            }
+        }
+        Some((head, tail)) if head == "du" => {
+            let path = first_non_flag_operand(
+                tail,
+                &[
+                    "-d",
+                    "--max-depth",
+                    "-B",
+                    "--block-size",
+                    "--exclude",
+                    "--time-style",
+                ],
+            )
+            .map(|p| short_display_path(&p));
+            ParsedCommand::ListFiles {
+                cmd: shlex_join(main_cmd),
+                path,
+            }
+        }
+        Some((head, tail)) if head == "rg" || head == "rga" || head == "ripgrep-all" => {
+            let args_no_connector = trim_at_connector(tail);
+            let has_files_flag = args_no_connector.iter().any(|a| a == "--files");
+            let candidates = skip_flag_values(
+                &args_no_connector,
+                &[
+                    "-g",
+                    "--glob",
+                    "--iglob",
+                    "-t",
+                    "--type",
+                    "--type-add",
+                    "--type-not",
+                    "-m",
+                    "--max-count",
+                    "-A",
+                    "-B",
+                    "-C",
+                    "--context",
+                    "--max-depth",
+                ],
+            );
+            let non_flags: Vec<&String> = candidates
+                .into_iter()
+                .filter(|p| !p.starts_with('-'))
+                .collect();
+            if has_files_flag {
+                let path = non_flags.first().map(|s| short_display_path(s));
+                ParsedCommand::ListFiles {
+                    cmd: shlex_join(main_cmd),
+                    path,
+                }
+            } else {
+                let query = non_flags.first().cloned().map(String::from);
+                let path = non_flags.get(1).map(|s| short_display_path(s));
+                ParsedCommand::Search {
+                    cmd: shlex_join(main_cmd),
+                    query,
+                    path,
+                }
+            }
+        }
+        Some((head, tail)) if head == "git" => match tail.split_first() {
+            Some((subcmd, sub_tail)) if subcmd == "grep" => parse_grep_like(main_cmd, sub_tail),
+            Some((subcmd, sub_tail)) if subcmd == "ls-files" => {
+                let path = first_non_flag_operand(
+                    sub_tail,
+                    &["--exclude", "--exclude-from", "--pathspec-from-file"],
+                )
+                .map(|p| short_display_path(&p));
+                ParsedCommand::ListFiles {
+                    cmd: shlex_join(main_cmd),
+                    path,
+                }
+            }
+            _ => ParsedCommand::Unknown {
+                cmd: shlex_join(main_cmd),
+            },
+        },
+        Some((head, tail)) if head == "fd" => {
+            let (query, path) = parse_fd_query_and_path(tail);
+            if query.is_some() {
+                ParsedCommand::Search {
+                    cmd: shlex_join(main_cmd),
+                    query,
+                    path,
+                }
+            } else {
+                ParsedCommand::ListFiles {
+                    cmd: shlex_join(main_cmd),
+                    path,
+                }
+            }
+        }
+        Some((head, tail)) if head == "find" => {
+            // Basic find support: capture path and common name filter
+            let (query, path) = parse_find_query_and_path(tail);
+            if query.is_some() {
+                ParsedCommand::Search {
+                    cmd: shlex_join(main_cmd),
+                    query,
+                    path,
+                }
+            } else {
+                ParsedCommand::ListFiles {
+                    cmd: shlex_join(main_cmd),
+                    path,
+                }
+            }
+        }
+        Some((head, tail)) if matches!(head.as_str(), "grep" | "egrep" | "fgrep") => {
+            parse_grep_like(main_cmd, tail)
+        }
+        Some((head, tail)) if matches!(head.as_str(), "ag" | "ack" | "pt") => {
+            let args_no_connector = trim_at_connector(tail);
+            let candidates = skip_flag_values(
+                &args_no_connector,
+                &[
+                    "-G",
+                    "-g",
+                    "--file-search-regex",
+                    "--ignore-dir",
+                    "--ignore-file",
+                    "--path-to-ignore",
+                ],
+            );
+            let non_flags: Vec<&String> = candidates
+                .into_iter()
+                .filter(|p| !p.starts_with('-'))
+                .collect();
+            let query = non_flags.first().cloned().map(String::from);
+            let path = non_flags.get(1).map(|s| short_display_path(s));
+            ParsedCommand::Search {
+                cmd: shlex_join(main_cmd),
+                query,
+                path,
+            }
+        }
+        Some((head, tail)) if head == "cat" => {
+            if let Some(path) = single_non_flag_operand(tail, &[]) {
+                let name = short_display_path(&path);
+                ParsedCommand::Read {
+                    cmd: shlex_join(main_cmd),
+                    name,
+                    path: PathBuf::from(path),
+                }
+            } else {
+                ParsedCommand::Unknown {
+                    cmd: shlex_join(main_cmd),
+                }
+            }
+        }
+        Some((head, tail)) if matches!(head.as_str(), "bat" | "batcat") => {
+            if let Some(path) = single_non_flag_operand(
+                tail,
+                &[
+                    "--theme",
+                    "--language",
+                    "--style",
+                    "--terminal-width",
+                    "--tabs",
+                    "--line-range",
+                    "--map-syntax",
+                ],
+            ) {
+                let name = short_display_path(&path);
+                ParsedCommand::Read {
+                    cmd: shlex_join(main_cmd),
+                    name,
+                    path: PathBuf::from(path),
+                }
+            } else {
+                ParsedCommand::Unknown {
+                    cmd: shlex_join(main_cmd),
+                }
+            }
+        }
+        Some((head, tail)) if head == "less" => {
+            if let Some(path) = single_non_flag_operand(
+                tail,
+                &[
+                    "-p",
+                    "-P",
+                    "-x",
+                    "-y",
+                    "-z",
+                    "-j",
+                    "--pattern",
+                    "--prompt",
+                    "--tabs",
+                    "--shift",
+                    "--jump-target",
+                ],
+            ) {
+                let name = short_display_path(&path);
+                ParsedCommand::Read {
+                    cmd: shlex_join(main_cmd),
+                    name,
+                    path: PathBuf::from(path),
+                }
+            } else {
+                ParsedCommand::Unknown {
+                    cmd: shlex_join(main_cmd),
+                }
+            }
+        }
+        Some((head, tail)) if head == "more" => {
+            if let Some(path) = single_non_flag_operand(tail, &[]) {
+                let name = short_display_path(&path);
+                ParsedCommand::Read {
+                    cmd: shlex_join(main_cmd),
+                    name,
+                    path: PathBuf::from(path),
+                }
+            } else {
+                ParsedCommand::Unknown {
+                    cmd: shlex_join(main_cmd),
+                }
+            }
+        }
+        Some((head, tail)) if head == "head" => {
+            // Support `head -n 50 file` and `head -n50 file` forms.
+            let has_valid_n = match tail.split_first() {
+                Some((first, rest)) if first == "-n" => rest
+                    .first()
+                    .is_some_and(|n| n.chars().all(|c| c.is_ascii_digit())),
+                Some((first, _)) if first.starts_with("-n") => {
+                    first[2..].chars().all(|c| c.is_ascii_digit())
+                }
+                _ => false,
+            };
+            if has_valid_n {
+                // Build candidates skipping the numeric value consumed by `-n` when separated.
+                let mut candidates: Vec<&String> = Vec::new();
+                let mut i = 0;
+                while i < tail.len() {
+                    if i == 0 && tail[i] == "-n" && i + 1 < tail.len() {
+                        let n = &tail[i + 1];
+                        if n.chars().all(|c| c.is_ascii_digit()) {
+                            i += 2;
+                            continue;
+                        }
+                    }
+                    candidates.push(&tail[i]);
+                    i += 1;
+                }
+                if let Some(p) = candidates.into_iter().find(|p| !p.starts_with('-')) {
+                    let path = p.clone();
+                    let name = short_display_path(&path);
+                    return ParsedCommand::Read {
+                        cmd: shlex_join(main_cmd),
+                        name,
+                        path: PathBuf::from(path),
+                    };
+                }
+            }
+            if let [path] = tail
+                && !path.starts_with('-')
+            {
+                let name = short_display_path(path);
+                return ParsedCommand::Read {
+                    cmd: shlex_join(main_cmd),
+                    name,
+                    path: PathBuf::from(path),
+                };
+            }
+            ParsedCommand::Unknown {
+                cmd: shlex_join(main_cmd),
+            }
+        }
+        Some((head, tail)) if head == "tail" => {
+            // Support `tail -n +10 file` and `tail -n+10 file` forms.
+            let has_valid_n = match tail.split_first() {
+                Some((first, rest)) if first == "-n" => rest.first().is_some_and(|n| {
+                    let s = n.strip_prefix('+').unwrap_or(n);
+                    !s.is_empty() && s.chars().all(|c| c.is_ascii_digit())
+                }),
+                Some((first, _)) if first.starts_with("-n") => {
+                    let v = &first[2..];
+                    let s = v.strip_prefix('+').unwrap_or(v);
+                    !s.is_empty() && s.chars().all(|c| c.is_ascii_digit())
+                }
+                _ => false,
+            };
+            if has_valid_n {
+                // Build candidates skipping the numeric value consumed by `-n` when separated.
+                let mut candidates: Vec<&String> = Vec::new();
+                let mut i = 0;
+                while i < tail.len() {
+                    if i == 0 && tail[i] == "-n" && i + 1 < tail.len() {
+                        let n = &tail[i + 1];
+                        let s = n.strip_prefix('+').unwrap_or(n);
+                        if !s.is_empty() && s.chars().all(|c| c.is_ascii_digit()) {
+                            i += 2;
+                            continue;
+                        }
+                    }
+                    candidates.push(&tail[i]);
+                    i += 1;
+                }
+                if let Some(p) = candidates.into_iter().find(|p| !p.starts_with('-')) {
+                    let path = p.clone();
+                    let name = short_display_path(&path);
+                    return ParsedCommand::Read {
+                        cmd: shlex_join(main_cmd),
+                        name,
+                        path: PathBuf::from(path),
+                    };
+                }
+            }
+            if let [path] = tail
+                && !path.starts_with('-')
+            {
+                let name = short_display_path(path);
+                return ParsedCommand::Read {
+                    cmd: shlex_join(main_cmd),
+                    name,
+                    path: PathBuf::from(path),
+                };
+            }
+            ParsedCommand::Unknown {
+                cmd: shlex_join(main_cmd),
+            }
+        }
+        Some((head, tail)) if head == "awk" => {
+            if let Some(path) = awk_data_file_operand(tail) {
+                let name = short_display_path(&path);
+                ParsedCommand::Read {
+                    cmd: shlex_join(main_cmd),
+                    name,
+                    path: PathBuf::from(path),
+                }
+            } else {
+                ParsedCommand::Unknown {
+                    cmd: shlex_join(main_cmd),
+                }
+            }
+        }
+        Some((head, tail)) if head == "nl" => {
+            // Avoid treating option values as paths (e.g., nl -s "  ").
+            let candidates = skip_flag_values(tail, &["-s", "-w", "-v", "-i", "-b"]);
+            if let Some(p) = candidates.into_iter().find(|p| !p.starts_with('-')) {
+                let path = p.clone();
+                let name = short_display_path(&path);
+                ParsedCommand::Read {
+                    cmd: shlex_join(main_cmd),
+                    name,
+                    path: PathBuf::from(path),
+                }
+            } else {
+                ParsedCommand::Unknown {
+                    cmd: shlex_join(main_cmd),
+                }
+            }
+        }
+        Some((head, tail)) if head == "sed" => {
+            if let Some(path) = sed_read_path(tail) {
+                let name = short_display_path(&path);
+                ParsedCommand::Read {
+                    cmd: shlex_join(main_cmd),
+                    name,
+                    path: PathBuf::from(path),
+                }
+            } else {
+                ParsedCommand::Unknown {
+                    cmd: shlex_join(main_cmd),
+                }
+            }
+        }
+        Some((head, tail)) if is_python_command(head) => {
+            if python_walks_files(tail) {
+                ParsedCommand::ListFiles {
+                    cmd: shlex_join(main_cmd),
+                    path: None,
+                }
+            } else {
+                ParsedCommand::Unknown {
+                    cmd: shlex_join(main_cmd),
+                }
+            }
+        }
+        // Other commands
+        _ => ParsedCommand::Unknown {
+            cmd: shlex_join(main_cmd),
+        },
+    }
+}
+
+fn is_abs_like(path: &str) -> bool {
+    if std::path::Path::new(path).is_absolute() {
+        return true;
+    }
+    let mut chars = path.chars();
+    match (chars.next(), chars.next(), chars.next()) {
+        // Windows drive path like C:\
+        (Some(d), Some(':'), Some('\\')) if d.is_ascii_alphabetic() => return true,
+        // UNC path like \\server\share
+        (Some('\\'), Some('\\'), _) => return true,
+        _ => {}
+    }
+    false
+}
+
+fn join_paths(base: &str, rel: &str) -> String {
+    if is_abs_like(rel) {
+        return rel.to_string();
+    }
+    if base.is_empty() {
+        return rel.to_string();
+    }
+    let mut buf = PathBuf::from(base);
+    buf.push(rel);
+    buf.to_string_lossy().to_string()
+}

--- a/crates/dasclaw_shell_command/src/powershell.rs
+++ b/crates/dasclaw_shell_command/src/powershell.rs
@@ -1,0 +1,189 @@
+use std::path::PathBuf;
+
+use dasclaw_absolute_path::AbsolutePathBuf;
+
+use crate::shell_detect::ShellType;
+use crate::shell_detect::detect_shell_type;
+
+const POWERSHELL_FLAGS: &[&str] = &["-nologo", "-noprofile", "-command", "-c"];
+
+/// Prefixed command for powershell shell calls to force UTF-8 console output.
+pub const UTF8_OUTPUT_PREFIX: &str = "[Console]::OutputEncoding=[System.Text.Encoding]::UTF8;\n";
+
+pub fn prefix_powershell_script_with_utf8(command: &[String]) -> Vec<String> {
+    let Some((_, script)) = extract_powershell_command(command) else {
+        return command.to_vec();
+    };
+
+    let trimmed = script.trim_start();
+    let script = if trimmed.starts_with(UTF8_OUTPUT_PREFIX) {
+        script.to_string()
+    } else {
+        format!("{UTF8_OUTPUT_PREFIX}{script}")
+    };
+
+    let mut command: Vec<String> = command[..(command.len() - 1)]
+        .iter()
+        .map(std::string::ToString::to_string)
+        .collect();
+    command.push(script);
+    command
+}
+
+/// Extract the PowerShell script body from an invocation such as:
+///
+/// - ["pwsh", "-NoProfile", "-Command", "Get-ChildItem -Recurse | Select-String foo"]
+/// - ["powershell.exe", "-Command", "Write-Host hi"]
+/// - ["powershell", "-NoLogo", "-NoProfile", "-Command", "...script..."]
+///
+/// Returns (`shell`, `script`) when the first arg is a PowerShell executable and a
+/// `-Command` (or `-c`) flag is present followed by a script string.
+pub fn extract_powershell_command(command: &[String]) -> Option<(&str, &str)> {
+    if command.len() < 3 {
+        return None;
+    }
+
+    let shell = &command[0];
+    if !matches!(
+        detect_shell_type(&PathBuf::from(shell)),
+        Some(ShellType::PowerShell)
+    ) {
+        return None;
+    }
+
+    // Find the first occurrence of -Command (accept common short alias -c as well)
+    let mut i = 1usize;
+    while i + 1 < command.len() {
+        let flag = &command[i];
+        // Reject unknown flags
+        if !POWERSHELL_FLAGS.contains(&flag.to_ascii_lowercase().as_str()) {
+            return None;
+        }
+        if flag.eq_ignore_ascii_case("-Command") || flag.eq_ignore_ascii_case("-c") {
+            let script = &command[i + 1];
+            return Some((shell, script));
+        }
+        i += 1;
+    }
+    None
+}
+
+/// This function attempts to find a powershell.exe executable on the system.
+pub fn try_find_powershell_executable_blocking() -> Option<AbsolutePathBuf> {
+    try_find_powershellish_executable_in_path(&["powershell.exe"])
+}
+
+/// This function attempts to find a pwsh.exe executable on the system.
+/// Note that pwsh.exe and powershell.exe are different executables:
+///
+/// - pwsh.exe is the cross-platform PowerShell Core (v6+) executable
+/// - powershell.exe is the Windows PowerShell (v5.1 and earlier) executable
+///
+/// Further, while powershell.exe is included by default on Windows systems,
+/// pwsh.exe must be installed separately by the user. And even when the user
+/// has installed pwsh.exe, it may not be available in the system PATH, in which
+/// case we attempt to locate it via other means.
+pub fn try_find_pwsh_executable_blocking() -> Option<AbsolutePathBuf> {
+    if let Some(ps_home) = std::process::Command::new("cmd")
+        .args(["/C", "pwsh", "-NoProfile", "-Command", "$PSHOME"])
+        .output()
+        .ok()
+        .and_then(|out| {
+            if !out.status.success() {
+                return None;
+            }
+            let stdout = String::from_utf8_lossy(&out.stdout);
+            let trimmed = stdout.trim();
+            (!trimmed.is_empty()).then(|| trimmed.to_string())
+        })
+    {
+        let candidate = AbsolutePathBuf::resolve_path_against_base("pwsh.exe", &ps_home);
+
+        if is_powershellish_executable_available(candidate.as_path()) {
+            return Some(candidate);
+        }
+    }
+
+    try_find_powershellish_executable_in_path(&["pwsh.exe"])
+}
+
+fn try_find_powershellish_executable_in_path(candidates: &[&str]) -> Option<AbsolutePathBuf> {
+    for candidate in candidates {
+        let Ok(resolved_path) = which::which(candidate) else {
+            continue;
+        };
+
+        if !is_powershellish_executable_available(&resolved_path) {
+            continue;
+        }
+
+        let Ok(abs_path) = AbsolutePathBuf::from_absolute_path(resolved_path) else {
+            continue;
+        };
+
+        return Some(abs_path);
+    }
+
+    None
+}
+
+fn is_powershellish_executable_available(powershell_or_pwsh_exe: &std::path::Path) -> bool {
+    // This test works for both powershell.exe and pwsh.exe.
+    std::process::Command::new(powershell_or_pwsh_exe)
+        .args(["-NoLogo", "-NoProfile", "-Command", "Write-Output ok"])
+        .output()
+        .map(|output| output.status.success())
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::extract_powershell_command;
+
+    #[test]
+    fn extracts_basic_powershell_command() {
+        let cmd = vec![
+            "powershell".to_string(),
+            "-Command".to_string(),
+            "Write-Host hi".to_string(),
+        ];
+        let (_shell, script) = extract_powershell_command(&cmd).expect("extract");
+        assert_eq!(script, "Write-Host hi");
+    }
+
+    #[test]
+    fn extracts_lowercase_flags() {
+        let cmd = vec![
+            "powershell".to_string(),
+            "-nologo".to_string(),
+            "-command".to_string(),
+            "Write-Host hi".to_string(),
+        ];
+        let (_shell, script) = extract_powershell_command(&cmd).expect("extract");
+        assert_eq!(script, "Write-Host hi");
+    }
+
+    #[test]
+    fn extracts_full_path_powershell_command() {
+        let command = if cfg!(windows) {
+            "C:\\windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe".to_string()
+        } else {
+            "/usr/local/bin/powershell.exe".to_string()
+        };
+        let cmd = vec![command, "-Command".to_string(), "Write-Host hi".to_string()];
+        let (_shell, script) = extract_powershell_command(&cmd).expect("extract");
+        assert_eq!(script, "Write-Host hi");
+    }
+
+    #[test]
+    fn extracts_with_noprofile_and_alias() {
+        let cmd = vec![
+            "pwsh".to_string(),
+            "-NoProfile".to_string(),
+            "-c".to_string(),
+            "Get-ChildItem | Select-String foo".to_string(),
+        ];
+        let (_shell, script) = extract_powershell_command(&cmd).expect("extract");
+        assert_eq!(script, "Get-ChildItem | Select-String foo");
+    }
+}

--- a/crates/dasclaw_shell_command/src/shell_detect.rs
+++ b/crates/dasclaw_shell_command/src/shell_detect.rs
@@ -1,0 +1,32 @@
+use std::path::Path;
+use std::path::PathBuf;
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub(crate) enum ShellType {
+    Zsh,
+    Bash,
+    PowerShell,
+    Sh,
+    Cmd,
+}
+
+pub(crate) fn detect_shell_type(shell_path: &PathBuf) -> Option<ShellType> {
+    match shell_path.as_os_str().to_str() {
+        Some("zsh") => Some(ShellType::Zsh),
+        Some("sh") => Some(ShellType::Sh),
+        Some("cmd") => Some(ShellType::Cmd),
+        Some("bash") => Some(ShellType::Bash),
+        Some("pwsh") => Some(ShellType::PowerShell),
+        Some("powershell") => Some(ShellType::PowerShell),
+        _ => {
+            let shell_name = shell_path.file_stem();
+            if let Some(shell_name) = shell_name {
+                let shell_name_path = Path::new(shell_name);
+                if shell_name_path != Path::new(shell_path) {
+                    return detect_shell_type(&shell_name_path.to_path_buf());
+                }
+            }
+            None
+        }
+    }
+}

--- a/docs/plans/architecture-refactor/32-execution-plan.md
+++ b/docs/plans/architecture-refactor/32-execution-plan.md
@@ -320,7 +320,7 @@ dasclaw_governance.recovery_recipes = false
 ### 验收
 - [ ] 6 transport 全部有 1 个端到端测试
 - [ ] execpolicy 解析 codex 现有规则集（上游 `tests/basic.rs` verbatim port 33/33 `#[test]` 通过；ADR-132 §2.4 已修正为单文件 fixture，原"prefix_rule.rs + network_rule.rs"分文件抽样作废，门类覆盖不变）
-- [ ] dasclaw_shell_command `parse_command` 端到端测试（codex 上游 fixture 选 prefix-match + powershell-detect 两组 verbatim 通过）
+- [ ] dasclaw_shell_command `parse_command` 端到端测试（codex 上游 inline `#[cfg(test)]` 单测 129 个 verbatim 通过；ADR-133 §amend 记录上游无独立 tests/ 目录、所有测试随源文件 verbatim 落地）
 
 ---
 

--- a/docs/plans/architecture-refactor/adr-133-shell-command-adoption-eval.md
+++ b/docs/plans/architecture-refactor/adr-133-shell-command-adoption-eval.md
@@ -1,6 +1,6 @@
 # ADR-133: codex `shell-command` adoption evaluation (research-only)
 
-- **Status**: 🟡 **Decision: adopt-with-adapter** (research-only ADR per [#326](https://github.com/Linnanli/xClaw/issues/326) Part 3a; implementation is **out of scope** for this PR)
+- **Status**: � **Accepted (executed)** — verbatim port landed in PR for [#326](https://github.com/Linnanli/xClaw/issues/326) Part 3a. Original draft was research-only; §2.4 + §4 amended in-place during execution to record the actual file inventory + the codex-protocol slicing decision (see §amend below).
 - **Date**: 2026-05-08
 - **Approver**: pending nally sign-off
 - **Authors**: GitHub Copilot agent
@@ -96,8 +96,9 @@ crates/
 | 允许的机械改写 | 禁止 |
 |---|---|
 | `Cargo.toml name = "codex-shell-command"` → `dasclaw_shell_command` | 重构 `parse_command_impl`（2,526 LOC，注释明写 "DO NOT REVIEW THIS CODE BY HAND"）|
-| `use codex_protocol::parse_command::ParsedCommand` → `use dasclaw_protocol::parse_command::ParsedCommand`（如 dasclaw_protocol 已落地，否则保留 codex_protocol path-dep）| 改 `is_safe_command` / `is_dangerous_command` 阈值 |
-| `bash.rs` 的 `tree-sitter-bash` 依赖保留 | 把 PowerShell 模块裁掉 — 跨平台是核心特性 |
+| `use codex_protocol::parse_command::ParsedCommand` → `use dasclaw_parsed_command::parse_command::ParsedCommand`（**slicing**：见 §amend）| 改 `is_safe_command` / `is_dangerous_command` 阈值 |
+| `use codex_utils_absolute_path::X` → `use dasclaw_absolute_path::X`（与 ADR-132 同款机械改写）| 把 PowerShell 模块裁掉 — 跨平台是核心特性 |
+| `bash.rs` 的 `tree-sitter-bash` 依赖保留 | — |
 
 特别地，`parse_command.rs:23` 上游有显式注释：
 
@@ -129,7 +130,15 @@ pub use parse_command::{parse_command, extract_shell_command, shlex_join};
 
 ### 2.4 mechanical guard
 
-落地 PR 同时引入 `scripts/check_codex_shell_command_drift.py`，与 ADR-132 §3.3 同款：对 `crates/dasclaw_shell_command/src/{parse_command,bash,powershell,shell_detect}.rs` 与 codex 上游做 hash diff，仅允许 §2.2 表格列出的机械改写。
+落地 PR 同时引入 `scripts/check_codex_shell_command_drift.py`，与 ADR-132 §3.3 同款：对 13 个文件（dasclaw_parsed_command 1 个 + dasclaw_shell_command 12 个，含 `command_safety/` 子模块 + `powershell_parser.ps1`）与 codex 上游做 hash diff，仅允许 §2.2 表格列出的机械改写。drift guard 对两侧都执行 `_sort_use_blocks` 规范化，使 use-path swap 引发的 rustfmt 重排序不会被误判为 drift（与 ADR-132 §3.3 同款机制）。
+
+### 2.5 amend — codex-protocol 切片决定（执行期补记）
+
+严格 verbatim 红线意指"被端口的文件与上游字节一致"，**而非"必须连带 vendor 整棵传递依赖树"**。`dasclaw_shell_command` 在源码层面只引用 `codex_protocol::parse_command::ParsedCommand`（一个 31 LOC 的 enum，仅依赖 schemars/serde/ts-rs），整 codex-protocol crate 16,053 LOC + 30+ 传递依赖（reqwest, tokio, landlock, seccompiler, icu_*, codex-execpolicy, codex-network-proxy, codex-utils-image, …）远超本 PR 范围。
+
+**决定**：单独 vendor `protocol/src/parse_command.rs` 为新 crate `crates/dasclaw_parsed_command/`（verbatim，单文件 + 自己的 lib.rs 仅 `pub mod parse_command;`），并把这一文件加入 §2.4 drift guard。`use` 路径机械改写：`codex_protocol::parse_command::ParsedCommand` → `dasclaw_parsed_command::parse_command::ParsedCommand`。
+
+这一切片在精神上等价于 ADR-132 vendor `dasclaw_absolute_path` 而不 vendor 整棵 `codex-utils/`。后续若 dasclaw 真的需要更多 codex-protocol 类型，再扩 `dasclaw_parsed_command` 或拆 `dasclaw_protocol` 新 crate；本 PR 不预先扩展。
 
 ---
 
@@ -158,13 +167,15 @@ pub use parse_command::{parse_command, extract_shell_command, shlex_join};
 
 > 与 ADR-132 同样：单 PR 内的提交序，不拆 PR。
 
-1. **C1**: 创建 `crates/dasclaw_shell_command/` + Cargo.toml（依赖 `shlex`, `tree-sitter-bash`, `codex_protocol` path-dep 直至 dasclaw_protocol 落地）
-2. **C2**: `lib.rs` + `shell_detect.rs` + `command_safety/` verbatim
-3. **C3**: `bash.rs` + `powershell.rs` verbatim
-4. **C4**: `parse_command.rs` verbatim（最大文件，单独提交便于 review）
-5. **C5**: codex `shell-command/tests/` 中 `parse_command_*.rs` fixture 选 prefix-match + powershell-detect 两组 verbatim port
-6. **C6**: `scripts/check_codex_shell_command_drift.py` + workflow 接入
+1. **C1**: 创建 `crates/dasclaw_parsed_command/` + Cargo.toml（verbatim slice of `codex-rs/protocol/src/parse_command.rs` per §2.5）
+2. **C2**: 创建 `crates/dasclaw_shell_command/` + Cargo.toml（依赖 `shlex`, `tree-sitter-bash`, `regex`, `dasclaw_absolute_path`, `dasclaw_parsed_command`）
+3. **C3**: `lib.rs` + `shell_detect.rs` + `command_safety/`（含 `powershell_parser.ps1` 资源）verbatim
+4. **C4**: `bash.rs` + `powershell.rs` verbatim
+5. **C5**: `parse_command.rs` verbatim（最大文件 2,526 LOC；包含 inline `#[cfg(test)]` 测试 — 不需要单独 tests/ fixture，上游测试随 verbatim 一起到位）
+6. **C6**: `scripts/check_codex_shell_command_drift.py` + workflow 接入（13 PAIRS：1 + 12）
 7. **C7**: doc 32 §W4 / doc 35 文本同步（ironclaw UI 接入点说明）
+
+> **执行期补注（§amend）**：原 §2.4 / §4 设想 verbatim port 选 prefix-match + powershell-detect 两组 fixture，但上游 `shell-command/` 实际**没有** `tests/` 目录 — 所有测试以 `#[cfg(test)] mod tests` 内联在 `parse_command.rs` / `bash.rs` / `powershell.rs` / `command_safety/*.rs` 中（共 129 个测试用例），verbatim port 一并到位，无需额外 fixture 选择。
 
 **验收命令**：
 

--- a/scripts/check_codex_shell_command_drift.py
+++ b/scripts/check_codex_shell_command_drift.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3.12
+"""Drift guard: verify dasclaw_shell_command + dasclaw_parsed_command src
+remain byte-identical to the upstream codex snapshot vendored under
+codex-cli-main/codex-rs/.
+
+ADR-129 §1.3 + ADR-133 mandate verbatim port. The only mechanical edits
+allowed are:
+
+  1. `Cargo.toml` package name swap (codex-shell-command → dasclaw_shell_command,
+     codex-protocol parse_command slice → dasclaw_parsed_command).
+  2. `use codex_utils_absolute_path::X` → `use dasclaw_absolute_path::X`.
+  3. `use codex_protocol::parse_command::X` → `use dasclaw_parsed_command::parse_command::X`.
+  4. `use codex_shell_command::X` → `use dasclaw_shell_command::X`.
+
+Slicing note (ADR-133 §amend): only `protocol/src/parse_command.rs` (31 LOC)
+is vendored from codex-protocol — the other ~16k LOC + 30+ transitive deps
+are intentionally NOT pulled in. The drift guard therefore pairs only that
+one file, not the whole protocol crate.
+
+This script normalizes the swaps + sorts consecutive `use` blocks before
+hashing, then compares each file against its upstream peer. Any other diff
+is treated as drift and exits non-zero so CI can block patch-style edits.
+
+Run: python3.12 scripts/check_codex_shell_command_drift.py
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+PAIRS: list[tuple[Path, Path]] = []
+
+# ---- dasclaw_parsed_command ↔ codex protocol parse_command slice -----------
+PC_LOCAL = REPO_ROOT / "crates" / "dasclaw_parsed_command" / "src"
+PC_UPSTREAM = REPO_ROOT / "codex-cli-main" / "codex-rs" / "protocol" / "src"
+PAIRS.append((PC_LOCAL / "parse_command.rs", PC_UPSTREAM / "parse_command.rs"))
+
+# ---- dasclaw_shell_command ↔ codex shell-command ---------------------------
+SC_LOCAL = REPO_ROOT / "crates" / "dasclaw_shell_command" / "src"
+SC_UPSTREAM = REPO_ROOT / "codex-cli-main" / "codex-rs" / "shell-command" / "src"
+for fname in [
+    "bash.rs",
+    "lib.rs",
+    "parse_command.rs",
+    "powershell.rs",
+    "shell_detect.rs",
+    "command_safety/is_dangerous_command.rs",
+    "command_safety/is_safe_command.rs",
+    "command_safety/mod.rs",
+    "command_safety/powershell_parser.rs",
+    "command_safety/powershell_parser.ps1",
+    "command_safety/windows_dangerous_commands.rs",
+    "command_safety/windows_safe_commands.rs",
+]:
+    PAIRS.append((SC_LOCAL / fname, SC_UPSTREAM / fname))
+
+
+SWAP_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    # Reverse the use-path swap so we compare against upstream verbatim.
+    (re.compile(r"\bdasclaw_absolute_path\b"), "codex_utils_absolute_path"),
+    (re.compile(r"\bdasclaw_parsed_command\b"), "codex_protocol"),
+    (re.compile(r"\bdasclaw_shell_command\b"), "codex_shell_command"),
+]
+
+
+_USE_RE = re.compile(r"^use\s+")
+
+
+def _sort_use_blocks(text: str) -> str:
+    """Sort consecutive `use ...;` lines alphabetically.
+
+    rustfmt orders `use` blocks alphabetically; renames may shift items into
+    a new position. We canonicalize use-block ordering on both sides before
+    hashing so the verbatim guarantee survives the mechanical swap.
+    """
+    lines = text.split("\n")
+    out: list[str] = []
+    i = 0
+    while i < len(lines):
+        if _USE_RE.match(lines[i]):
+            j = i
+            block: list[str] = []
+            while j < len(lines) and _USE_RE.match(lines[j]):
+                block.append(lines[j])
+                j += 1
+            out.extend(sorted(block))
+            i = j
+        else:
+            out.append(lines[i])
+            i += 1
+    return "\n".join(out)
+
+
+def normalize(text: str) -> str:
+    for pat, repl in SWAP_PATTERNS:
+        text = pat.sub(repl, text)
+    return _sort_use_blocks(text)
+
+
+def normalize_upstream(text: str) -> str:
+    return _sort_use_blocks(text)
+
+
+def sha(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def main() -> int:
+    drift: list[str] = []
+    missing: list[str] = []
+    for local, upstream in PAIRS:
+        if not local.exists():
+            missing.append(f"local missing: {local.relative_to(REPO_ROOT)}")
+            continue
+        if not upstream.exists():
+            missing.append(f"upstream missing: {upstream.relative_to(REPO_ROOT)}")
+            continue
+        local_norm = normalize(local.read_text(encoding="utf-8"))
+        upstream_norm = normalize_upstream(upstream.read_text(encoding="utf-8"))
+        if sha(local_norm) != sha(upstream_norm):
+            drift.append(
+                f"DRIFT: {local.relative_to(REPO_ROOT)} != "
+                f"{upstream.relative_to(REPO_ROOT)} "
+                f"(after use-path normalization + use-block sort)"
+            )
+
+    if missing:
+        for line in missing:
+            print(line, file=sys.stderr)
+        return 2
+    if drift:
+        for line in drift:
+            print(line, file=sys.stderr)
+        print(
+            "\nADR-129 §1.3 + ADR-133 forbid hand-edits to ported files. "
+            "If upstream needs to change, re-vendor codex-cli-main first.",
+            file=sys.stderr,
+        )
+        return 1
+    print(f"OK: {len(PAIRS)} files match upstream verbatim.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## 背景 / 目标

落地 [#326](https://github.com/Linnanli/xClaw/issues/326) **Part 3a** — 按 [ADR-133](docs/plans/architecture-refactor/adr-133-shell-command-adoption-eval.md) 决议把 `codex-cli-main/codex-rs/shell-command/` **verbatim port** 进 dasclaw monorepo，给 ironclaw UI 提供 `ParsedCommand` 渲染源 + 跨平台 PowerShell 解析能力，与 `dasclaw_bash_validation`（门控）职责正交、**不**合并。

并行于 #341（Part 2 execpolicy port），从 `xClaw` fork — 待 #341 合并后会 rebase。

## 改动范围

### 新 crate
- **`crates/dasclaw_shell_command/`**（5,768 LOC verbatim）
  - `src/{lib,bash,parse_command,powershell,shell_detect}.rs` — 3,348 LOC
  - `src/command_safety/{is_safe_command,is_dangerous_command,powershell_parser,windows_safe_commands,windows_dangerous_commands,mod}.rs` + `powershell_parser.ps1` — 2,420 LOC
  - 公共 API：`parse_command`, `extract_shell_command`, `shlex_join`, `is_safe_command`, `is_dangerous_command`（与上游 1:1 镜像）
- **`crates/dasclaw_parsed_command/`**（31 LOC slice）
  - `src/parse_command.rs` — verbatim of `codex-rs/protocol/src/parse_command.rs`（仅 `ParsedCommand` enum + 自制 `lib.rs`）
  - **slicing 决策**：完整 codex-protocol 16,053 LOC + 30+ 传递依赖（reqwest/tokio/landlock/seccompiler/icu_\*/codex-execpolicy/codex-network-proxy/...）远超本 PR 范围；ADR-133 §2.5 已 in-place amend 记录此决策。
- **`crates/dasclaw_absolute_path/`** — 与 #341 同款（branch 从 xClaw fork，#341 合并后 rebase 会自动消除重复）

### 机械改写（ADR-129 §1.3）
- `name = "codex-shell-command"` → `dasclaw_shell_command`
- `use codex_protocol::parse_command::ParsedCommand` → `use dasclaw_parsed_command::parse_command::ParsedCommand`
- `use codex_utils_absolute_path::X` → `use dasclaw_absolute_path::X`
- `use codex_shell_command::X` → `use dasclaw_shell_command::X`

源代码主体 **零改动**，drift guard 一致性由 hash 校验。

### Drift guard
- `scripts/check_codex_shell_command_drift.py`（mirror of #341 的 execpolicy guard）
  - 13 PAIRS：dasclaw_parsed_command 1 + dasclaw_shell_command 12（含 `command_safety/` + `powershell_parser.ps1`）
  - 与 ADR-132 §3.3 同款 `_sort_use_blocks` 规范化，让 use-path swap 后 rustfmt 重排不被误判为 drift
- CI 接入：`.github/workflows/code_style.yml` 新增 `codex-shell-command-drift` job + 加入 `code-style` roll-up `needs:` 列表 + 失败检测

### Doc 同步
- `adr-133-shell-command-adoption-eval.md`：Status → 🟢 Accepted (executed)；§2.2 表格补 `dasclaw_absolute_path` swap 行；§2.4 改为"13 文件 hash diff"；新增 §2.5 amend（codex-protocol slicing 决策）；§4 改为 7 步（C1=parsed_command crate、C2=shell_command crate、C5=parse_command verbatim 含 inline tests，附"无独立 tests/"补注）
- `32-execution-plan.md` §W5 验收条款：从"上游 fixture 选 prefix-match + powershell-detect 两组"改为"inline `#[cfg(test)]` 单测 129 个 verbatim 通过"，并标注 ADR-133 §amend 来源

## 非目标（What's NOT in this PR）

- ❌ **接入 ironclaw UI**：本 PR 仅 port crate，不修改 `desktop-client/ironclaw/src/ui/`，不写 `ParsedCommand` → 渲染层适配器（属后续 Wave）
- ❌ **不合并 / 不替换 `dasclaw_bash_validation`**：解析 vs 决策语义不同，ADR-133 §3.3 / §5.4 明确拒绝
- ❌ **不 vendor 完整 codex-protocol**：仅切 31 LOC `ParsedCommand` enum；其余 16k LOC + 30+ 传递依赖（含 reqwest/tokio/landlock/seccompiler）不在本 PR 范围
- ❌ **不动 codex-cli-main/ 上游快照**：`codex-cli-main/codex-rs/shell-command/` 与 `codex-cli-main/codex-rs/protocol/src/parse_command.rs` 0 改动，drift guard 拿它们做 truth-source
- ❌ **不引入 panic / unsafe / unwrap**（生产代码）：`check_no_panics.py` 验证通过

## 验证（命令 + 结果）

```bash
$ cargo nextest run -p dasclaw_shell_command -p dasclaw_parsed_command
Summary [25.771s] 129 tests run: 129 passed, 0 skipped

$ cargo clippy --no-deps -p dasclaw_shell_command -p dasclaw_parsed_command --all-targets -- -D warnings
Finished `dev` profile [unoptimized + debuginfo] target(s) in 3.20s   # clean

$ cargo fmt --all -- --check
# clean

$ python3.12 scripts/check_no_panics.py --base origin/xClaw
OK: No panic-inducing calls in changed production code.

$ python3 scripts/check_no_new_ironclaw_literal.py --base origin/xClaw
OK: No new .ironclaw / IRONCLAW_BASE_DIR literals introduced.

$ python3.12 scripts/check_codex_shell_command_drift.py
OK: 13 files match upstream verbatim.
```

## 与 #341 的关系

- 本分支从 `xClaw` fork（commit 4da6b0ae），不是 stacked PR
- `Cargo.toml` workspace members + `code_style.yml` roll-up `needs:` 会与 #341 textual conflict — #341 合并后会 rebase 本分支，机械合并即可
- `crates/dasclaw_absolute_path/` 在两个 PR 中字节一致，rebase 时 git 会自动 dedupe

Closes #326 (Part 3a)
