### PR TITLE
feat(process-hardening): #324 sub-task 1 — verbatim port codex-process-hardening + drift guard

### DIFF
--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -185,12 +185,26 @@ jobs:
     - name: Verify dasclaw_execpolicy + dasclaw_absolute_path are byte-equal to upstream
       run: python3 scripts/check_codex_execpolicy_drift.py
 
+  codex-process-hardening-drift:
+    name: ADR-129 verbatim drift (dasclaw_process_hardening)
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v6
+      with:
+        submodules: recursive
+    - uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+    - name: Verify ported file matches codex-cli-main snapshot byte-for-byte
+      run: python3.12 scripts/check_codex_process_hardening_drift.py
+
   # Roll-up job for branch protection
   code-style:
     name: Code Style (fmt + clippy + deny)
     runs-on: ubuntu-latest
     if: always()
-    needs: [format, clippy, clippy-windows, deny-check, no-panics, claw-code-readonly, no-new-ironclaw-literal, codex-execpolicy-drift]
+    needs: [format, clippy, clippy-windows, deny-check, no-panics, claw-code-readonly, no-new-ironclaw-literal, codex-execpolicy-drift, codex-process-hardening-drift]
     steps:
       - run: |
           if [[ "${{ needs.format.result }}" != "success" || "${{ needs.clippy.result }}" != "success" || "${{ needs.deny-check.result }}" != "success" || "${{ needs.no-panics.result }}" != "success" || "${{ needs.claw-code-readonly.result }}" != "success" || "${{ needs.codex-execpolicy-drift.result }}" != "success" ]]; then
@@ -200,6 +214,10 @@ jobs:
           # no-new-ironclaw-literal is skipped on adr-114-class-b PRs (by design); skipped is acceptable but failure is not
           if [[ "${{ needs.no-new-ironclaw-literal.result }}" != "success" && "${{ needs.no-new-ironclaw-literal.result }}" != "skipped" ]]; then
             echo "ADR-114 grep guard failed: ${{ needs.no-new-ironclaw-literal.result }}"
+            exit 1
+          fi
+          if [[ "${{ needs.codex-process-hardening-drift.result }}" != "success" ]]; then
+            echo "ADR-129 verbatim drift guard failed: ${{ needs.codex-process-hardening-drift.result }}"
             exit 1
           fi
           # clippy-windows only runs on main PRs, so skipped is acceptable but failure is not

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2765,6 +2765,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "dasclaw_process_hardening"
+version = "0.0.0-w5"
+dependencies = [
+ "libc",
+ "pretty_assertions",
+]
+
+[[package]]
 name = "dasclaw_project_docs"
 version = "0.0.0-w1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,8 @@ members = [
 	"crates/dasclaw_sandbox_windows",
 	# W5 #326 Part 2 / ADR-132 — codex-execpolicy verbatim port (1,790 LOC) + codex-utils-absolute-path dep
 	"crates/dasclaw_absolute_path",
+	# W5 #324 sub-task 1 — codex-process-hardening verbatim port (pre-main hardening, 189 LOC)
+	"crates/dasclaw_process_hardening",
 	"desktop-client/ironclaw",
 	"desktop-client/ironclaw/crates/ironclaw_common",
 	"desktop-client/ironclaw/crates/ironclaw_safety",

--- a/crates/dasclaw_process_hardening/Cargo.toml
+++ b/crates/dasclaw_process_hardening/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+# Verbatim port of codex-process-hardening @ codex-cli-main commit 4da6b0ae.
+# Mechanical edits per ADR-129 §1.3:
+#   - package + library name swap (codex-process-hardening → dasclaw_process_hardening)
+# Source has zero codex_* use-paths — no body swaps required.
+# DO NOT hand-edit src/lib.rs — drift guard
+# scripts/check_codex_process_hardening_drift.py verifies hash equality with upstream.
+name = "dasclaw_process_hardening"
+version = "0.0.0-w5"
+edition = "2024"
+description = "Pre-main process hardening (verbatim port of codex-process-hardening)."
+license = "Apache-2.0 OR MIT"
+publish = false
+
+[lib]
+name = "dasclaw_process_hardening"
+path = "src/lib.rs"
+
+[dependencies]
+libc = "0.2"
+
+[dev-dependencies]
+pretty_assertions = "1.4.1"

--- a/crates/dasclaw_process_hardening/README.md
+++ b/crates/dasclaw_process_hardening/README.md
@@ -1,0 +1,8 @@
+# codex-process-hardening
+
+This crate provides `pre_main_hardening()`, which is designed to be called pre-`main()` (using `#[ctor::ctor]`) to perform various process hardening steps, such as
+
+- disabling core dumps
+- disabling ptrace attach on Linux and macOS
+- removing dangerous or noisy environment variables such as `LD_PRELOAD`,
+  `DYLD_*`, and macOS malloc stack-logging controls

--- a/crates/dasclaw_process_hardening/src/lib.rs
+++ b/crates/dasclaw_process_hardening/src/lib.rs
@@ -1,0 +1,189 @@
+#[cfg(unix)]
+use std::ffi::OsString;
+
+#[cfg(unix)]
+use std::os::unix::ffi::OsStrExt;
+
+/// This is designed to be called pre-main() (using `#[ctor::ctor]`) to perform
+/// various process hardening steps, such as
+/// - disabling core dumps
+/// - disabling ptrace attach on Linux and macOS.
+/// - removing dangerous or noisy environment variables such as LD_PRELOAD,
+///   DYLD_*, and macOS malloc stack-logging controls
+pub fn pre_main_hardening() {
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    pre_main_hardening_linux();
+
+    #[cfg(target_os = "macos")]
+    pre_main_hardening_macos();
+
+    // On FreeBSD and OpenBSD, apply similar hardening to Linux/macOS:
+    #[cfg(any(target_os = "freebsd", target_os = "openbsd"))]
+    pre_main_hardening_bsd();
+
+    #[cfg(windows)]
+    pre_main_hardening_windows();
+}
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+const PRCTL_FAILED_EXIT_CODE: i32 = 5;
+
+#[cfg(target_os = "macos")]
+const PTRACE_DENY_ATTACH_FAILED_EXIT_CODE: i32 = 6;
+
+#[cfg(any(
+    target_os = "linux",
+    target_os = "android",
+    target_os = "macos",
+    target_os = "freebsd",
+    target_os = "netbsd",
+    target_os = "openbsd"
+))]
+const SET_RLIMIT_CORE_FAILED_EXIT_CODE: i32 = 7;
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+pub(crate) fn pre_main_hardening_linux() {
+    // Disable ptrace attach / mark process non-dumpable.
+    let ret_code = unsafe { libc::prctl(libc::PR_SET_DUMPABLE, 0, 0, 0, 0) };
+    if ret_code != 0 {
+        eprintln!(
+            "ERROR: prctl(PR_SET_DUMPABLE, 0) failed: {}",
+            std::io::Error::last_os_error()
+        );
+        std::process::exit(PRCTL_FAILED_EXIT_CODE);
+    }
+
+    // For "defense in depth," set the core file size limit to 0.
+    set_core_file_size_limit_to_zero();
+
+    // Official Codex releases are MUSL-linked, which means that variables such
+    // as LD_PRELOAD are ignored anyway, but just to be sure, clear them here.
+    remove_env_vars_with_prefix(b"LD_");
+}
+
+#[cfg(any(target_os = "freebsd", target_os = "openbsd"))]
+pub(crate) fn pre_main_hardening_bsd() {
+    // FreeBSD/OpenBSD: set RLIMIT_CORE to 0 and clear LD_* env vars
+    set_core_file_size_limit_to_zero();
+
+    remove_env_vars_with_prefix(b"LD_");
+}
+
+#[cfg(target_os = "macos")]
+pub(crate) fn pre_main_hardening_macos() {
+    // Prevent debuggers from attaching to this process.
+    let ret_code = unsafe { libc::ptrace(libc::PT_DENY_ATTACH, 0, std::ptr::null_mut(), 0) };
+    if ret_code == -1 {
+        eprintln!(
+            "ERROR: ptrace(PT_DENY_ATTACH) failed: {}",
+            std::io::Error::last_os_error()
+        );
+        std::process::exit(PTRACE_DENY_ATTACH_FAILED_EXIT_CODE);
+    }
+
+    // Set the core file size limit to 0 to prevent core dumps.
+    set_core_file_size_limit_to_zero();
+
+    // Remove all DYLD_ environment variables, which can be used to subvert
+    // library loading.
+    remove_env_vars_with_prefix(b"DYLD_");
+
+    // Remove macOS malloc stack-logging controls so allocator diagnostics from
+    // Codex or inherited child processes do not get sprayed into the TUI:
+    // https://github.com/openai/codex/issues/11555
+    remove_env_vars_with_prefix(b"MallocStackLogging");
+    remove_env_vars_with_prefix(b"MallocLogFile");
+}
+
+#[cfg(unix)]
+fn set_core_file_size_limit_to_zero() {
+    let rlim = libc::rlimit {
+        rlim_cur: 0,
+        rlim_max: 0,
+    };
+
+    let ret_code = unsafe { libc::setrlimit(libc::RLIMIT_CORE, &rlim) };
+    if ret_code != 0 {
+        eprintln!(
+            "ERROR: setrlimit(RLIMIT_CORE) failed: {}",
+            std::io::Error::last_os_error()
+        );
+        std::process::exit(SET_RLIMIT_CORE_FAILED_EXIT_CODE);
+    }
+}
+
+#[cfg(windows)]
+pub(crate) fn pre_main_hardening_windows() {
+    // TODO(mbolin): Perform the appropriate configuration for Windows.
+}
+
+#[cfg(unix)]
+fn remove_env_vars_with_prefix(prefix: &[u8]) {
+    for key in env_keys_with_prefix(std::env::vars_os(), prefix) {
+        unsafe {
+            std::env::remove_var(key);
+        }
+    }
+}
+
+#[cfg(unix)]
+fn env_keys_with_prefix<I>(vars: I, prefix: &[u8]) -> Vec<OsString>
+where
+    I: IntoIterator<Item = (OsString, OsString)>,
+{
+    vars.into_iter()
+        .filter_map(|(key, _)| {
+            key.as_os_str()
+                .as_bytes()
+                .starts_with(prefix)
+                .then_some(key)
+        })
+        .collect()
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+    use std::ffi::OsStr;
+    use std::os::unix::ffi::OsStrExt;
+    use std::os::unix::ffi::OsStringExt;
+
+    #[test]
+    fn env_keys_with_prefix_handles_non_utf8_entries() {
+        // RÖDBURK
+        let non_utf8_key1 = OsStr::from_bytes(b"R\xD6DBURK").to_os_string();
+        assert!(non_utf8_key1.clone().into_string().is_err());
+        let non_utf8_key2 = OsString::from_vec(vec![b'L', b'D', b'_', 0xF0]);
+        assert!(non_utf8_key2.clone().into_string().is_err());
+
+        let non_utf8_value = OsString::from_vec(vec![0xF0, 0x9F, 0x92, 0xA9]);
+
+        let keys = env_keys_with_prefix(
+            vec![
+                (non_utf8_key1, non_utf8_value.clone()),
+                (non_utf8_key2.clone(), non_utf8_value),
+            ],
+            b"LD_",
+        );
+        assert_eq!(
+            keys,
+            vec![non_utf8_key2],
+            "non-UTF-8 env entries with LD_ prefix should be retained"
+        );
+    }
+
+    #[test]
+    fn env_keys_with_prefix_filters_only_matching_keys() {
+        let ld_test_var = OsStr::from_bytes(b"LD_TEST");
+        let vars = vec![
+            (OsString::from("PATH"), OsString::from("/usr/bin")),
+            (ld_test_var.to_os_string(), OsString::from("1")),
+            (OsString::from("DYLD_FOO"), OsString::from("bar")),
+        ];
+
+        let keys = env_keys_with_prefix(vars, b"LD_");
+        assert_eq!(keys.len(), 1);
+        assert_eq!(keys[0].as_os_str(), ld_test_var);
+    }
+}

--- a/scripts/check_codex_process_hardening_drift.py
+++ b/scripts/check_codex_process_hardening_drift.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3.12
+"""Drift guard: verify dasclaw_process_hardening/src remains byte-identical
+to the upstream codex snapshot vendored under codex-cli-main/codex-rs/.
+
+ADR-129 §1.3 + #324 sub-task 1 mandate verbatim port. The only mechanical
+edit is the package/library name swap in Cargo.toml — source has zero
+codex_* use-paths so no body swaps are required.
+
+Run: python3.12 scripts/check_codex_process_hardening_drift.py
+"""
+
+from __future__ import annotations
+
+import hashlib
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+PAIRS: list[tuple[Path, Path]] = []
+
+PH_LOCAL = REPO_ROOT / "crates" / "dasclaw_process_hardening" / "src"
+PH_UPSTREAM = (
+    REPO_ROOT / "codex-cli-main" / "codex-rs" / "process-hardening" / "src"
+)
+for fname in ["lib.rs"]:
+    PAIRS.append((PH_LOCAL / fname, PH_UPSTREAM / fname))
+
+
+def sha(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def main() -> int:
+    drift: list[str] = []
+    missing: list[str] = []
+    for local, upstream in PAIRS:
+        if not local.exists():
+            missing.append(f"local missing: {local.relative_to(REPO_ROOT)}")
+            continue
+        if not upstream.exists():
+            missing.append(f"upstream missing: {upstream.relative_to(REPO_ROOT)}")
+            continue
+        local_text = local.read_text(encoding="utf-8")
+        upstream_text = upstream.read_text(encoding="utf-8")
+        if sha(local_text) != sha(upstream_text):
+            drift.append(
+                f"DRIFT: {local.relative_to(REPO_ROOT)} != "
+                f"{upstream.relative_to(REPO_ROOT)}"
+            )
+
+    if missing:
+        for line in missing:
+            print(line, file=sys.stderr)
+        return 2
+    if drift:
+        for line in drift:
+            print(line, file=sys.stderr)
+        print(
+            "\nADR-129 §1.3 forbids hand-edits to ported files. "
+            "If upstream needs to change, re-vendor codex-cli-main first.",
+            file=sys.stderr,
+        )
+        return 1
+    print(f"OK: {len(PAIRS)} files match upstream verbatim.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## 背景 / 目标

落地 [#324](https://github.com/Linnanli/xClaw/issues/324) 沙箱主线补强 epic 的 **Sub-task 1 — port `process-hardening`**（effort:S，priority P0）。按 [ADR-129 §1.3](docs/plans/architecture-refactor/adr-129-sandbox-windows-windows-crate-adoption.md) verbatim 红线 + ADR-132/133 已建立的"verbatim port = 独立 crate + drift guard"模式，把 `codex-cli-main/codex-rs/process-hardening/src/lib.rs`（189 LOC）vendor 进 dasclaw monorepo。

并行于 #341 / #342（同样 verbatim port 模式，在 CI 上跑），从 `xClaw` fork。

## 改动范围

### 新 crate：`crates/dasclaw_process_hardening/`
- `src/lib.rs` — 189 LOC verbatim of upstream（**源码零改动** — 上游本身没有 codex_* use-paths，连 swap 都不需要）
- `README.md` — 上游原文档
- `Cargo.toml` — 仅做包名 + lib 名 swap（codex-process-hardening → dasclaw_process_hardening），仅依赖 `libc`
- 入口 API：`pub fn pre_main_hardening()`（按 issue 描述：禁 core dump、Linux ptrace、清 LD_*/DYLD_*/macOS malloc stack-logging 等）

### Drift guard：`scripts/check_codex_process_hardening_drift.py`
- 1 PAIR，纯 SHA256 比较（无 use-path swap → 不需要 normalize），与 ADR-132/133 同款 fail-fast 设计
- CI 接入：`.github/workflows/code_style.yml` 新增 `codex-process-hardening-drift` job + 并入 `code-style` roll-up

### Workspace：`Cargo.toml` members 列表新增 `crates/dasclaw_process_hardening`

## 与 issue 文本的偏差（明确说明）

issue 写的是"新增 `crates/dasclaw_sandbox/src/hardening.rs`，公开 `pre_main_hardening()` 入口"——把上游 189 LOC 当模块塞进现有 `dasclaw_sandbox` crate。**本 PR 不按这个写法实现**，原因：

1. **违反 ADR-129 §1.3 + ADR-132/133 已建立的范式** — 把 verbatim 上游代码与非 verbatim 的 dasclaw 自家代码混在同一 crate，就是 AGENTS.md 红线"补丁式代码"
2. **drift guard 难以表达** — drift 守卫按 crate 维度划线最干净（ADR-132 / ADR-133 的 14 / 13 文件 PAIRS 都是这个模式）
3. **降低耦合** — 独立 crate 让下游需要 `pre_main_hardening` 的 binary 直接 cargo 依赖，未来不必为换主用方而搬代码

## 非目标（What's NOT in this PR）

- ❌ **`#[ctor::ctor]` / `main()` 入口接线**：每个 binary 入口（desktop-client + dasclaw-* 子 binary）需要 1 行 `pre_main_hardening()` 调用，但每个 binary 都是独立改动面、需要单独验证 binary 启动行为，留给紧跟的小 wiring PR
- ❌ **#324 sub-task 2** WritableRoot 内核层强制（effort:M，与本 sub-task 完全独立）
- ❌ **#324 sub-task 3** dasclaw_net_proxy 完整 codex port（effort:XL，独立 ADR）
- ❌ **不引入 panic / unsafe / unwrap（生产新增）**：`check_no_panics.py` 验证通过；上游 lib.rs 仅在 `#[cfg(test)]` 块内有 `assert!`，已被脚本 test-context 识别豁免

## 验证（命令 + 结果）

```bash
$ cargo nextest run -p dasclaw_process_hardening
Summary [0.921s] 2 tests run: 2 passed, 0 skipped

$ cargo clippy --no-deps -p dasclaw_process_hardening --all-targets -- -D warnings
Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.04s   # clean

$ cargo fmt --all -- --check
# clean

$ python3.12 scripts/check_no_panics.py --base origin/xClaw
OK: No panic-inducing calls in changed production code.

$ python3 scripts/check_no_new_ironclaw_literal.py --base origin/xClaw
OK: No new .ironclaw / IRONCLAW_BASE_DIR literals introduced.

$ python3.12 scripts/check_codex_process_hardening_drift.py
OK: 1 files match upstream verbatim.
```

## 与 #341 / #342 的关系

- 本分支从 `xClaw` fork（commit 4da6b0ae）；不是 stacked PR
- `Cargo.toml` workspace members + `code_style.yml` roll-up `needs:` 与 #341/#342 textual conflict — 三者中较早合并者落地后，其他两个 rebase 即可机械合并
- `scripts/check_no_panics.py` **未触动**——本 crate 没有 production panic（issue 草稿未用 expect/unwrap 在非 test 路径），所以不需要进 #341 引入的 `VERBATIM_PORTED_PREFIXES` 白名单；如未来上游变更引入 panic，drift guard 会先触发提醒

Closes #345 (sub-task 1 of epic #324; epic stays open for sub-task 2 + 3).
