### PR TITLE
feat(process-hardening): #324 sub-task 1 — wire pre_main_hardening into binaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2406,6 +2406,16 @@ dependencies = [
 
 [[package]]
 name = "ctor"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "ctor"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "352d39c2f7bef1d6ad73db6f5160efcaed66d94ef8c6c573a8410c00bf909a98"
@@ -2513,12 +2523,14 @@ dependencies = [
  "criterion",
  "cron",
  "crossterm",
+ "ctor 0.2.9",
  "dasclaw",
  "dasclaw_apply_patch",
  "dasclaw_exec",
  "dasclaw_hooks",
  "dasclaw_llm_provider",
  "dasclaw_net_proxy",
+ "dasclaw_process_hardening",
  "dasclaw_sandbox",
  "deadpool-postgres",
  "dirs 6.0.0",
@@ -2808,6 +2820,8 @@ name = "dasclaw_sandbox"
 version = "0.0.0-w1"
 dependencies = [
  "base64 0.22.1",
+ "ctor 0.2.9",
+ "dasclaw_process_hardening",
  "dasclaw_sandbox_windows",
  "dirs 6.0.0",
  "libc",

--- a/crates/dasclaw_sandbox/Cargo.toml
+++ b/crates/dasclaw_sandbox/Cargo.toml
@@ -23,6 +23,14 @@ serde_json = "1"
 thiserror = "1"
 url = "2"
 
+# #324 sub-task 1 — Pre-main process hardening for the
+# `dasclaw-sandbox-resource-launcher` binary. Wired via `#[ctor::ctor]` at the
+# top of `src/bin/resource_launcher_win.rs`. Pattern matches codex
+# `responses-api-proxy/src/main.rs:4-7`. Hardening is no-op on platforms
+# without a matching backend (lib.rs §pre_main_hardening cfg dispatch).
+dasclaw_process_hardening = { path = "../dasclaw_process_hardening" }
+ctor = "0.2"
+
 # W3.3 — `libc` 现需在所有 Unix 平台启用（macOS + Linux），用于 setrlimit。
 # 详见 docs/plans/architecture-refactor/45-resource-limits-adr.md。
 [target.'cfg(unix)'.dependencies]

--- a/crates/dasclaw_sandbox/src/bin/resource_launcher_win.rs
+++ b/crates/dasclaw_sandbox/src/bin/resource_launcher_win.rs
@@ -24,6 +24,17 @@
 //! 退出码 1 + stderr 提示。理由见 ADR-131 §7 Q4：Cargo `[[bin]]` 不支持
 //! `[target.'cfg(...)'.bin]`；stub 让全平台 `cargo build` 可靠通过。
 
+/// #324 sub-task 1 — Pre-main process hardening hook.
+///
+/// Runs before `fn main()` (via `#[ctor::ctor]`) to disable core dumps,
+/// block ptrace attach, and scrub dangerous environment variables. Applies to
+/// both the Windows real-impl and the cross-platform stub branches below.
+/// Pattern mirrors codex `responses-api-proxy/src/main.rs:4-7`.
+#[ctor::ctor]
+fn pre_main() {
+    dasclaw_process_hardening::pre_main_hardening();
+}
+
 #[cfg(target_os = "windows")]
 fn main() -> std::process::ExitCode {
     use std::io::{Read, Write};

--- a/desktop-client/ironclaw/Cargo.toml
+++ b/desktop-client/ironclaw/Cargo.toml
@@ -119,6 +119,11 @@ x_claw_agent = { path = "../../crates/x_claw_agent", version = "0.1.0" }
 # W3.1a: OS-level sandbox executor (replaces Docker sandbox path)
 dasclaw_exec = { path = "../../crates/dasclaw_exec", version = "0.1.0" }
 dasclaw_sandbox = { path = "../../crates/dasclaw_sandbox", version = "0.0.0-w1" }
+# #324 sub-task 1 — pre-main hardening (disable core dumps / ptrace / dangerous
+# env vars). Wired via `#[ctor::ctor] fn pre_main()` at the top of main.rs.
+# Pattern matches codex `responses-api-proxy/src/main.rs:4-7`.
+dasclaw_process_hardening = { path = "../../crates/dasclaw_process_hardening" }
+ctor = "0.2"
 # W3.2b: audited HTTP egress proxy (allowlist + credential injection)
 dasclaw_net_proxy = { path = "../../crates/dasclaw_net_proxy", version = "0.1.0" }
 # P0-3 (ADR-113): unified hook engine — single front-door for event hooks + trait seams

--- a/desktop-client/ironclaw/src/main.rs
+++ b/desktop-client/ironclaw/src/main.rs
@@ -1,5 +1,18 @@
 //! IronClaw - Main entry point.
 
+/// #324 sub-task 1 — Pre-main process hardening hook.
+///
+/// Runs before `fn main()` (via `#[ctor::ctor]`) to disable core dumps,
+/// block ptrace attach, and scrub dangerous environment variables
+/// (`LD_PRELOAD`, `DYLD_*`, macOS malloc stack-logging controls, …).
+///
+/// Pattern mirrors codex `responses-api-proxy/src/main.rs:4-7`. Applies to
+/// both the `dasclaw` and `ironclaw` binaries (same `[[bin]] path`).
+#[ctor::ctor]
+fn pre_main() {
+    dasclaw_process_hardening::pre_main_hardening();
+}
+
 use std::sync::Arc;
 use std::time::Duration;
 


### PR DESCRIPTION
## 背景/目标

#324 sub-task 1（`dasclaw_process_hardening` 已 verbatim 落地于 PR #343）的最后一步：把 `pre_main_hardening()` 真正接入所有 dasclaw native 二进制的 `#[ctor::ctor] fn pre_main()`，使进程启动即获得 disable core dumps / block ptrace / scrub 危险环境变量的硬化效果。

完成后 wrapper issue #345 即可关闭，#324 sub-task 1 闭环。

## 改动范围（5 文件，+51 行）

### 接入目标（2 个非 verbatim 二进制）
- [desktop-client/ironclaw/src/main.rs](desktop-client/ironclaw/src/main.rs#L1-L14) — 覆盖 `[[bin]] dasclaw` 与 `[[bin]] ironclaw`（同 path）
- [crates/dasclaw_sandbox/src/bin/resource_launcher_win.rs](crates/dasclaw_sandbox/src/bin/resource_launcher_win.rs#L27-L37) — 覆盖 Windows real-impl + 跨平台 stub

### Cargo.toml 加 deps
- `desktop-client/ironclaw/Cargo.toml`：`dasclaw_process_hardening` path dep + `ctor = "0.2"`
- `crates/dasclaw_sandbox/Cargo.toml`：同上

### Pattern 来源（canonical / verbatim from codex）
[codex-cli-main/codex-rs/responses-api-proxy/src/main.rs](codex-cli-main/codex-rs/responses-api-proxy/src/main.rs#L4-L7)：

```rust
#[ctor::ctor]
fn pre_main() {
    codex_process_hardening::pre_main_hardening();
}
```

## 非目标（What's NOT in this PR）

- ❌ **不接入** `crates/dasclaw_execpolicy/src/main.rs`：drift-locked verbatim port of codex `execpolicy/src/main.rs`，codex 上游本身不 wire ctor，diverging 会被 `scripts/check_codex_execpolicy_drift.py` 拦下（违反 ADR-129 §1.3）
- ❌ **不接入** `crates/dasclaw_sandbox_windows/*`：verbatim port，同理不可改
- ❌ 不修改 `dasclaw_process_hardening` crate 内部实现（PR #343 已 verbatim 落地）
- ❌ 不修改 `dasclaw_process_hardening` 公共 API（保持 codex 完全兼容）
- ❌ 不动 admin-backend / claw-code / desktop-client/src-ui Node 包

## 验证

本地（M-series macOS）执行：

```bash
cargo check -p dasclaw --bin ironclaw                                             # OK (7m15s)
cargo check -p dasclaw_sandbox --bin dasclaw-sandbox-resource-launcher            # OK (19s)
python3.12 scripts/check_no_panics.py --base origin/xClaw                         # OK
python3   scripts/check_no_new_ironclaw_literal.py --base origin/xClaw            # OK
cargo fmt --all -- --check                                                        # OK
```

CI 兜底覆盖：workspace check（含 windows + linux target）、clippy、code-style drift。

## 关联

- Closes #345
- Refs #324 sub-task 1
- Refs PR #343（`dasclaw_process_hardening` verbatim port）
- Refs ADR-129 §1.3（verbatim 红线，本 PR 不动 verbatim 文件）
- Pattern source：[codex responses-api-proxy/src/main.rs:4-7](codex-cli-main/codex-rs/responses-api-proxy/src/main.rs#L4-L7)
