### PR TITLE
feat(utils): #324 sub-task 3 PR-α — verbatim port codex utils-home-dir + utils-rustls-provider

### DIFF
--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -213,12 +213,40 @@ jobs:
     - name: Verify ported files match codex-cli-main snapshot byte-for-byte
       run: python3.12 scripts/check_codex_shell_command_drift.py
 
+  codex-utils-home-dir-drift:
+    name: ADR-137 verbatim drift (dasclaw_utils_home_dir)
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v6
+      with:
+        submodules: recursive
+    - uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+    - name: Verify ported files match codex-cli-main snapshot byte-for-byte
+      run: python3.12 scripts/check_codex_utils_home_dir_drift.py
+
+  codex-utils-rustls-provider-drift:
+    name: ADR-137 verbatim drift (dasclaw_utils_rustls_provider)
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v6
+      with:
+        submodules: recursive
+    - uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+    - name: Verify ported files match codex-cli-main snapshot byte-for-byte
+      run: python3.12 scripts/check_codex_utils_rustls_provider_drift.py
+
   # Roll-up job for branch protection
   code-style:
     name: Code Style (fmt + clippy + deny)
     runs-on: ubuntu-latest
     if: always()
-    needs: [format, clippy, clippy-windows, deny-check, no-panics, claw-code-readonly, no-new-ironclaw-literal, codex-execpolicy-drift, codex-process-hardening-drift, codex-shell-command-drift]
+    needs: [format, clippy, clippy-windows, deny-check, no-panics, claw-code-readonly, no-new-ironclaw-literal, codex-execpolicy-drift, codex-process-hardening-drift, codex-shell-command-drift, codex-utils-home-dir-drift, codex-utils-rustls-provider-drift]
     steps:
       - run: |
           if [[ "${{ needs.format.result }}" != "success" || "${{ needs.clippy.result }}" != "success" || "${{ needs.deny-check.result }}" != "success" || "${{ needs.no-panics.result }}" != "success" || "${{ needs.claw-code-readonly.result }}" != "success" || "${{ needs.codex-execpolicy-drift.result }}" != "success" ]]; then
@@ -236,6 +264,14 @@ jobs:
           fi
           if [[ "${{ needs.codex-shell-command-drift.result }}" != "success" ]]; then
             echo "ADR-133 verbatim drift guard failed: ${{ needs.codex-shell-command-drift.result }}"
+            exit 1
+          fi
+          if [[ "${{ needs.codex-utils-home-dir-drift.result }}" != "success" ]]; then
+            echo "ADR-137 utils-home-dir verbatim drift guard failed: ${{ needs.codex-utils-home-dir-drift.result }}"
+            exit 1
+          fi
+          if [[ "${{ needs.codex-utils-rustls-provider-drift.result }}" != "success" ]]; then
+            echo "ADR-137 utils-rustls-provider verbatim drift guard failed: ${{ needs.codex-utils-rustls-provider-drift.result }}"
             exit 1
           fi
           # clippy-windows only runs on main PRs, so skipped is acceptable but failure is not

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2881,6 +2881,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "dasclaw_utils_home_dir"
+version = "0.0.0-w5"
+dependencies = [
+ "dasclaw_absolute_path",
+ "dirs 6.0.0",
+ "pretty_assertions",
+ "tempfile",
+]
+
+[[package]]
+name = "dasclaw_utils_rustls_provider"
+version = "0.0.0-w5"
+dependencies = [
+ "rustls 0.23.37",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8482,6 +8499,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
  "aws-lc-rs",
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,9 @@ members = [
 	# W5 #326 Part 3a / ADR-133 — codex-shell-command verbatim port (3,348 LOC + command_safety 2,420 LOC)
 	"crates/dasclaw_parsed_command",
 	"crates/dasclaw_shell_command",
+	# W5 #324 sub-task 3 / ADR-137 — codex-network-proxy transitive deps (verbatim port)
+	"crates/dasclaw_utils_home_dir",
+	"crates/dasclaw_utils_rustls_provider",
 	"desktop-client/ironclaw",
 	"desktop-client/ironclaw/crates/ironclaw_common",
 	"desktop-client/ironclaw/crates/ironclaw_safety",

--- a/crates/dasclaw_utils_home_dir/Cargo.toml
+++ b/crates/dasclaw_utils_home_dir/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+# Verbatim port of codex-utils-home-dir @ codex-cli-main snapshot vendored
+# under codex-cli-main/codex-rs/utils/home-dir.
+# Mechanical edits per ADR-129 §1.3:
+#   - package name swap: codex-utils-home-dir → dasclaw_utils_home_dir
+#   - dep swap: codex-utils-absolute-path → dasclaw_absolute_path
+#   - use-path swap (in src/lib.rs):
+#       codex_utils_absolute_path → dasclaw_absolute_path
+# DO NOT hand-edit src/lib.rs — drift guard
+# scripts/check_codex_utils_home_dir_drift.py verifies hash equality with
+# upstream after normalizing the use-path swap.
+#
+# Required transitively by codex-network-proxy (#324 sub-task 3 / ADR-137).
+name = "dasclaw_utils_home_dir"
+version = "0.0.0-w5"
+edition = "2024"
+description = "CODEX_HOME resolution helper (verbatim port of codex-utils-home-dir)."
+license = "Apache-2.0 OR MIT"
+publish = false
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+dasclaw_absolute_path = { path = "../dasclaw_absolute_path", version = "0.0.0-w5" }
+dirs = "6"
+
+[dev-dependencies]
+pretty_assertions = "1.4.1"
+tempfile = "3.23.0"

--- a/crates/dasclaw_utils_home_dir/src/lib.rs
+++ b/crates/dasclaw_utils_home_dir/src/lib.rs
@@ -1,0 +1,134 @@
+use dasclaw_absolute_path::AbsolutePathBuf;
+use dirs::home_dir;
+use std::path::PathBuf;
+
+/// Returns the path to the Codex configuration directory, which can be
+/// specified by the `CODEX_HOME` environment variable. If not set, defaults to
+/// `~/.codex`.
+///
+/// - If `CODEX_HOME` is set, the value must exist and be a directory. The
+///   value will be canonicalized and this function will Err otherwise.
+/// - If `CODEX_HOME` is not set, this function does not verify that the
+///   directory exists.
+pub fn find_codex_home() -> std::io::Result<AbsolutePathBuf> {
+    let codex_home_env = std::env::var("CODEX_HOME")
+        .ok()
+        .filter(|val| !val.is_empty());
+    find_codex_home_from_env(codex_home_env.as_deref())
+}
+
+fn find_codex_home_from_env(codex_home_env: Option<&str>) -> std::io::Result<AbsolutePathBuf> {
+    // Honor the `CODEX_HOME` environment variable when it is set to allow users
+    // (and tests) to override the default location.
+    match codex_home_env {
+        Some(val) => {
+            let path = PathBuf::from(val);
+            let metadata = std::fs::metadata(&path).map_err(|err| match err.kind() {
+                std::io::ErrorKind::NotFound => std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    format!("CODEX_HOME points to {val:?}, but that path does not exist"),
+                ),
+                _ => std::io::Error::new(
+                    err.kind(),
+                    format!("failed to read CODEX_HOME {val:?}: {err}"),
+                ),
+            })?;
+
+            if !metadata.is_dir() {
+                Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    format!("CODEX_HOME points to {val:?}, but that path is not a directory"),
+                ))
+            } else {
+                let canonical = path.canonicalize().map_err(|err| {
+                    std::io::Error::new(
+                        err.kind(),
+                        format!("failed to canonicalize CODEX_HOME {val:?}: {err}"),
+                    )
+                })?;
+                AbsolutePathBuf::from_absolute_path(canonical)
+            }
+        }
+        None => {
+            let mut p = home_dir().ok_or_else(|| {
+                std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    "Could not find home directory",
+                )
+            })?;
+            p.push(".codex");
+            AbsolutePathBuf::from_absolute_path(p)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::find_codex_home_from_env;
+    use dasclaw_absolute_path::AbsolutePathBuf;
+    use dirs::home_dir;
+    use pretty_assertions::assert_eq;
+    use std::fs;
+    use std::io::ErrorKind;
+    use tempfile::TempDir;
+
+    #[test]
+    fn find_codex_home_env_missing_path_is_fatal() {
+        let temp_home = TempDir::new().expect("temp home");
+        let missing = temp_home.path().join("missing-codex-home");
+        let missing_str = missing
+            .to_str()
+            .expect("missing codex home path should be valid utf-8");
+
+        let err = find_codex_home_from_env(Some(missing_str)).expect_err("missing CODEX_HOME");
+        assert_eq!(err.kind(), ErrorKind::NotFound);
+        assert!(
+            err.to_string().contains("CODEX_HOME"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn find_codex_home_env_file_path_is_fatal() {
+        let temp_home = TempDir::new().expect("temp home");
+        let file_path = temp_home.path().join("codex-home.txt");
+        fs::write(&file_path, "not a directory").expect("write temp file");
+        let file_str = file_path
+            .to_str()
+            .expect("file codex home path should be valid utf-8");
+
+        let err = find_codex_home_from_env(Some(file_str)).expect_err("file CODEX_HOME");
+        assert_eq!(err.kind(), ErrorKind::InvalidInput);
+        assert!(
+            err.to_string().contains("not a directory"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn find_codex_home_env_valid_directory_canonicalizes() {
+        let temp_home = TempDir::new().expect("temp home");
+        let temp_str = temp_home
+            .path()
+            .to_str()
+            .expect("temp codex home path should be valid utf-8");
+
+        let resolved = find_codex_home_from_env(Some(temp_str)).expect("valid CODEX_HOME");
+        let expected = temp_home
+            .path()
+            .canonicalize()
+            .expect("canonicalize temp home");
+        let expected = AbsolutePathBuf::from_absolute_path(expected).expect("absolute home");
+        assert_eq!(resolved, expected);
+    }
+
+    #[test]
+    fn find_codex_home_without_env_uses_default_home_dir() {
+        let resolved =
+            find_codex_home_from_env(/*codex_home_env*/ None).expect("default CODEX_HOME");
+        let mut expected = home_dir().expect("home dir");
+        expected.push(".codex");
+        let expected = AbsolutePathBuf::from_absolute_path(expected).expect("absolute home");
+        assert_eq!(resolved, expected);
+    }
+}

--- a/crates/dasclaw_utils_rustls_provider/Cargo.toml
+++ b/crates/dasclaw_utils_rustls_provider/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+# Verbatim port of codex-utils-rustls-provider @ codex-cli-main snapshot
+# vendored under codex-cli-main/codex-rs/utils/rustls-provider.
+# Mechanical edits per ADR-129 §1.3:
+#   - package name swap: codex-utils-rustls-provider → dasclaw_utils_rustls_provider
+# src/lib.rs has zero codex_* use-paths so no body swap is required.
+# DO NOT hand-edit src/lib.rs — drift guard
+# scripts/check_codex_utils_rustls_provider_drift.py verifies byte-for-byte
+# hash equality with upstream.
+#
+# Required transitively by codex-network-proxy (#324 sub-task 3 / ADR-137)
+# to install a process-wide rustls crypto provider when both `ring` and
+# `aws-lc-rs` are present in the dependency graph.
+name = "dasclaw_utils_rustls_provider"
+version = "0.0.0-w5"
+edition = "2024"
+description = "Rustls crypto provider installer (verbatim port of codex-utils-rustls-provider)."
+license = "Apache-2.0 OR MIT"
+publish = false
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+# `ring` feature provides `rustls::crypto::ring::default_provider()` used by
+# the verbatim source. Codex's workspace pins rustls with `ring` enabled by
+# default; we mirror that explicitly here since we have no
+# [workspace.dependencies] table.
+rustls = { version = "0.23", features = ["ring"] }

--- a/crates/dasclaw_utils_rustls_provider/src/lib.rs
+++ b/crates/dasclaw_utils_rustls_provider/src/lib.rs
@@ -1,0 +1,12 @@
+use std::sync::Once;
+
+/// Ensures a process-wide rustls crypto provider is installed.
+///
+/// rustls cannot auto-select a provider when both `ring` and `aws-lc-rs`
+/// features are enabled in the dependency graph.
+pub fn ensure_rustls_crypto_provider() {
+    static RUSTLS_PROVIDER_INIT: Once = Once::new();
+    RUSTLS_PROVIDER_INIT.call_once(|| {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+    });
+}

--- a/scripts/check_codex_utils_home_dir_drift.py
+++ b/scripts/check_codex_utils_home_dir_drift.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3.12
+"""Drift guard: verify dasclaw_utils_home_dir/src remains byte-identical
+to the upstream codex snapshot vendored under codex-cli-main/codex-rs/.
+
+ADR-129 §1.3 + #324 sub-task 3 (ADR-137) mandate verbatim port. The only
+mechanical edits allowed are:
+
+  1. `Cargo.toml` package/dep name swap (codex-utils-home-dir →
+     dasclaw_utils_home_dir, codex-utils-absolute-path → dasclaw_absolute_path).
+  2. `use codex_utils_absolute_path::X` → `use dasclaw_absolute_path::X`
+     inside `crates/dasclaw_utils_home_dir/src/lib.rs`.
+
+This script normalizes (2) before hashing, then compares each Rust file
+against its upstream peer. Any other diff is treated as drift and exits
+non-zero so CI / pre-commit can block patch-style edits.
+
+Run: python3.12 scripts/check_codex_utils_home_dir_drift.py
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+PAIRS: list[tuple[Path, Path]] = []
+
+LOCAL = REPO_ROOT / "crates" / "dasclaw_utils_home_dir" / "src"
+UPSTREAM = REPO_ROOT / "codex-cli-main" / "codex-rs" / "utils" / "home-dir" / "src"
+for fname in ["lib.rs"]:
+    PAIRS.append((LOCAL / fname, UPSTREAM / fname))
+
+
+SWAP_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    # Reverse the use-path swap so we compare against upstream verbatim.
+    (re.compile(r"\bdasclaw_absolute_path\b"), "codex_utils_absolute_path"),
+]
+
+
+def normalize(text: str) -> str:
+    for pat, repl in SWAP_PATTERNS:
+        text = pat.sub(repl, text)
+    return text
+
+
+def sha(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def main() -> int:
+    drift: list[str] = []
+    missing: list[str] = []
+    for local, upstream in PAIRS:
+        if not local.exists():
+            missing.append(f"local missing: {local.relative_to(REPO_ROOT)}")
+            continue
+        if not upstream.exists():
+            missing.append(f"upstream missing: {upstream.relative_to(REPO_ROOT)}")
+            continue
+        local_norm = normalize(local.read_text(encoding="utf-8"))
+        upstream_text = upstream.read_text(encoding="utf-8")
+        if sha(local_norm) != sha(upstream_text):
+            drift.append(
+                f"DRIFT: {local.relative_to(REPO_ROOT)} != "
+                f"{upstream.relative_to(REPO_ROOT)} "
+                f"(after use-path normalization)"
+            )
+
+    if missing:
+        for line in missing:
+            print(line, file=sys.stderr)
+        return 2
+    if drift:
+        for line in drift:
+            print(line, file=sys.stderr)
+        print(
+            "\nADR-129 §1.3 forbids hand-edits to ported files. "
+            "If upstream needs to change, re-vendor codex-cli-main first.",
+            file=sys.stderr,
+        )
+        return 1
+    print(f"OK: {len(PAIRS)} files match upstream verbatim.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_codex_utils_rustls_provider_drift.py
+++ b/scripts/check_codex_utils_rustls_provider_drift.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3.12
+"""Drift guard: verify dasclaw_utils_rustls_provider/src remains byte-identical
+to the upstream codex snapshot vendored under codex-cli-main/codex-rs/.
+
+ADR-129 §1.3 + #324 sub-task 3 (ADR-137) mandate verbatim port. The only
+mechanical edit is the package name swap in Cargo.toml — source has zero
+codex_* use-paths so no body swaps are required.
+
+Run: python3.12 scripts/check_codex_utils_rustls_provider_drift.py
+"""
+
+from __future__ import annotations
+
+import hashlib
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+PAIRS: list[tuple[Path, Path]] = []
+
+LOCAL = REPO_ROOT / "crates" / "dasclaw_utils_rustls_provider" / "src"
+UPSTREAM = (
+    REPO_ROOT / "codex-cli-main" / "codex-rs" / "utils" / "rustls-provider" / "src"
+)
+for fname in ["lib.rs"]:
+    PAIRS.append((LOCAL / fname, UPSTREAM / fname))
+
+
+def sha(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def main() -> int:
+    drift: list[str] = []
+    missing: list[str] = []
+    for local, upstream in PAIRS:
+        if not local.exists():
+            missing.append(f"local missing: {local.relative_to(REPO_ROOT)}")
+            continue
+        if not upstream.exists():
+            missing.append(f"upstream missing: {upstream.relative_to(REPO_ROOT)}")
+            continue
+        local_text = local.read_text(encoding="utf-8")
+        upstream_text = upstream.read_text(encoding="utf-8")
+        if sha(local_text) != sha(upstream_text):
+            drift.append(
+                f"DRIFT: {local.relative_to(REPO_ROOT)} != "
+                f"{upstream.relative_to(REPO_ROOT)}"
+            )
+
+    if missing:
+        for line in missing:
+            print(line, file=sys.stderr)
+        return 2
+    if drift:
+        for line in drift:
+            print(line, file=sys.stderr)
+        print(
+            "\nADR-129 §1.3 forbids hand-edits to ported files. "
+            "If upstream needs to change, re-vendor codex-cli-main first.",
+            file=sys.stderr,
+        )
+        return 1
+    print(f"OK: {len(PAIRS)} files match upstream verbatim.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
# PR-α: verbatim port codex `utils-home-dir` + `utils-rustls-provider`

## 背景 / 目标

`#324` sub-task 3 要求将 ironclaw 的 `dasclaw_net_proxy` 替换为 codex 的 `network-proxy` 验证版本（ADR-137 已合并）。codex `network-proxy` 依赖两个尚未在本仓库存在的 utils crate：

- `codex-utils-home-dir` — `CODEX_HOME` 解析助手
- `codex-utils-rustls-provider` — 进程级 rustls crypto provider 安装器

本 PR（PR-α）按 ADR-129 §1.3 verbatim port 模式独立先落地这两个传递依赖，PR-β 再做 `dasclaw_net_proxy` 主体替换并 `Closes #349`。拆分理由：保证每个 PR 单一目的、便于 review、避免单 PR 体量过大。

Refs #349

## 改动范围

| 类别 | 文件 |
| --- | --- |
| 新 crate | `crates/dasclaw_utils_home_dir/{Cargo.toml,src/lib.rs}` (134 LOC verbatim) |
| 新 crate | `crates/dasclaw_utils_rustls_provider/{Cargo.toml,src/lib.rs}` (12 LOC verbatim) |
| Workspace | `Cargo.toml` 新增两个成员 |
| Drift guard | `scripts/check_codex_utils_home_dir_drift.py`（含 `dasclaw_absolute_path` ↔ `codex_utils_absolute_path` use-path 归一化） |
| Drift guard | `scripts/check_codex_utils_rustls_provider_drift.py`（纯字节比对，无 use-path swap） |
| CI | `.github/workflows/code_style.yml` 新增两个 drift job + roll-up `needs:` + 两个 failure-check stanza |

ADR-129 §1.3 允许的机械编辑：

1. `Cargo.toml` 包名/依赖名 swap：`codex-utils-home-dir` → `dasclaw_utils_home_dir`、`codex-utils-rustls-provider` → `dasclaw_utils_rustls_provider`、`codex-utils-absolute-path` → `dasclaw_absolute_path`
2. `src/lib.rs` use-path swap（仅 `home-dir`）：`use codex_utils_absolute_path::AbsolutePathBuf` → `use dasclaw_absolute_path::AbsolutePathBuf`（共 2 处：顶部 + tests 模块）
3. `rustls = { version = "0.23", features = ["ring"] }` 显式开启 `ring` feature（codex workspace 默认开启；本仓无 `[workspace.dependencies]` 表，必须按 crate 显式声明，否则 `rustls::crypto::ring::default_provider()` 在编译期 gated out）

drift guard 脚本将以上 (2) 在 hash 前归一化，CI 拦截任何额外手改。

env var 字符串字面量（`CODEX_HOME`）、目录后缀（`.codex`）、函数名（`find_codex_home`）一律 verbatim 保留——drift guard 字节比对要求如此，亦符合 verbatim 协议。

## 非目标（What's NOT in this PR）

- ❌ 不删除/不替换 `crates/dasclaw_net_proxy`（PR-β 处理，留给 #349 闭环）
- ❌ 不引入任何 `rama-*` alpha 0.3.0-alpha.4 依赖（PR-β 处理）
- ❌ 不修改 `desktop-client/ironclaw/src/sandbox/net_proxy.rs`（PR-β 处理）
- ❌ 不更新 `deny.toml` 的 alpha 例外（PR-β 处理）
- ❌ 不接入 ADR-139 MITM CA 信任链（#350 单独 issue）

## 验证（命令 + 结果）

```bash
# 1. crate 编译 + 测试
cargo check -p dasclaw_utils_home_dir -p dasclaw_utils_rustls_provider --tests
# → Finished in 11.51s
cargo test -p dasclaw_utils_home_dir
# → 4 passed; 0 failed (verbatim 自带的单元测试)

# 2. drift guard
python3.12 scripts/check_codex_utils_home_dir_drift.py
# → OK: 1 files match upstream verbatim.
python3.12 scripts/check_codex_utils_rustls_provider_drift.py
# → OK: 1 files match upstream verbatim.

# 3. 仓库管线
cargo fmt --all -- --check
# → (no diff)
python3.12 scripts/check_no_panics.py --base origin/xClaw
# → OK: No panic-inducing calls in changed production code.
python3 scripts/check_no_new_ironclaw_literal.py --base origin/xClaw
# → OK: No new .ironclaw / IRONCLAW_BASE_DIR literals introduced.
```

## ADR / Issue 引用

- ADR-129 §1.3：verbatim port 模式
- ADR-137：`dasclaw_net_proxy` port plan（已合并）
- Refs #349（PR-β 才 `Closes`）
- Refs #324 sub-task 3
