### PR TITLE
chore(meta): add issue templates + Sources-read PR discipline

### DIFF
--- a/.github/ISSUE_TEMPLATE/architecture-refactor.yml
+++ b/.github/ISSUE_TEMPLATE/architecture-refactor.yml
@@ -1,0 +1,121 @@
+name: 架构重构任务（Architecture Refactor）
+description: 派给 Coding Agent 的架构重构 / ADR 落地 / verbatim port / 计划性改动
+title: "<area>: <one-line goal>"
+labels: ["architecture-refactor"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        > ⚠️ **Coding Agent 阅读契约**
+        > 在调用任何工具之前，必须按下列顺序读完本 issue 引用的全部文档：
+        > 1. [`AGENTS.md`](../AGENTS.md)
+        > 2. 下方 **Source 文档** 字段的链接（架构 / 执行计划 / ADR）
+        > 3. 下方 **关联 ADR** 字段中列出的全部 ADR 编号对应的 `adr-XXX-*.md`
+        > 4. 触及 crate 的 `lib.rs` 模块文档
+        >
+        > PR body 必须有 `## Sources read` 段落，回声每份文档的相对路径 + 引用过的 §/标题。
+
+  - type: input
+    id: source_doc
+    attributes:
+      label: Source 文档（必填）
+      description: |
+        本任务派单的真理来源。粘贴 `docs/plans/architecture-refactor/` 下的相对路径 + 锚点。
+        例如：`docs/plans/architecture-refactor/32-execution-plan.md §W7` 或 `adr-137-net-proxy-port-plan.md §3.2 PR-N23`
+      placeholder: docs/plans/architecture-refactor/32-execution-plan.md §W?
+    validations:
+      required: true
+
+  - type: input
+    id: parent_or_track
+    attributes:
+      label: 上游 / 轨道
+      description: |
+        所属 milestone / wave / parent issue。例如 `W7 / parent #324` 或 `Track C / ADR-137`
+      placeholder: W? / parent #?
+    validations:
+      required: true
+
+  - type: textarea
+    id: background_goal
+    attributes:
+      label: 背景 / 目标
+      description: 1–3 段，说明现状、痛点、本 issue 期望达成的终态。**链接到 Source 文档对应小节**，禁止脱离文档自由发挥。
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope_in
+    attributes:
+      label: 改动范围（What's IN）
+      description: |
+        枚举要改的文件 / crate / 模块。**最大化可反推**：列得越具体越好。
+      value: |
+        | 路径 | 改动 |
+        |---|---|
+        |   |   |
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope_out
+    attributes:
+      label: 非目标（What's NOT in this PR）
+      description: 显式列出不会动的范围，避免 scope creep。
+      placeholder: |
+        - ❌ 不动 X
+        - ❌ 不引入 Y
+    validations:
+      required: true
+
+  - type: textarea
+    id: related_adrs
+    attributes:
+      label: 关联 ADR（Coding Agent 必读）
+      description: |
+        逐条列 ADR 编号 + 一句话摘要 + `docs/plans/architecture-refactor/adr-XXX-*.md` 链接。
+        没有就写 `None`。
+      placeholder: |
+        - ADR-137 §3.2 PR-N23 — codex/network-proxy verbatim port 红线（rama-* alpha pin）
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: red_lines
+    attributes:
+      label: 红线自检（提交者勾选）
+      description: 每一条都必须勾，**勾不上的 issue 不要派给 agent**。
+      options:
+        - label: 我已读完 Source 文档对应小节，本 issue 描述与文档一致，没有脱离文档加目标
+          required: true
+        - label: 本 issue 不属于 `adr-redline` 范畴；或确认已加 `adr-redline` label 留给人类
+          required: true
+        - label: 改动不引入 `unwrap() / expect() / panic!()` 到生产代码
+          required: true
+        - label: 不通过补丁式代码（尾部追加 if、复制粘贴、flag 切换大块逻辑）规避结构问题
+          required: true
+        - label: 不绕过编译期红线（const_assert / drift guard / count_hook_systems 等）
+          required: true
+        - label: 涉及 verbatim port 的：上游版本 commit 已写入"改动范围"字段并将由 CI drift guard 守护
+          required: true
+
+  - type: textarea
+    id: acceptance_criteria
+    attributes:
+      label: 验收标准（机器可校验）
+      description: |
+        必须可由 CI / 单元测试 / `gh` 命令机械验证的 checklist。禁止"看起来 OK"。
+      value: |
+        - [ ] `cargo check -p <crate> --tests` 绿
+        - [ ] `cargo nextest run -p <crate>` 绿
+        - [ ] `cargo clippy --no-deps -p <crate> --all-targets -- -D warnings` 绿
+        - [ ] `python3.12 scripts/check_no_panics.py --base origin/xClaw` 通过
+        - [ ] PR body 含 `Closes #<本 issue>` + 4 块结构 + `## Sources read` 自检
+    validations:
+      required: true
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: 备注 / 阻塞 / 上下文
+      description: 选填。Stacked PR 顺序、待 nally 决议项、外部依赖等。

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,37 @@
+name: Bug 报告
+description: 已发布行为与预期不符
+title: "fix(<area>): <one-line bug>"
+labels: ["bug"]
+body:
+  - type: textarea
+    id: repro
+    attributes:
+      label: 复现步骤
+      description: 列出最小复现路径（命令、输入、环境）
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: 预期 vs 实际
+    validations:
+      required: true
+  - type: input
+    id: source_doc
+    attributes:
+      label: 关联文档（选填）
+      description: |
+        如本 bug 涉及架构红线，粘贴 `docs/plans/architecture-refactor/...md §...`
+        Coding Agent 会按 `copilot-instructions.md §1` 阅读链接内容。
+      placeholder: docs/plans/architecture-refactor/?.md §?
+  - type: input
+    id: env
+    attributes:
+      label: 环境
+      description: OS / rustc / 涉及 crate 版本
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: 日志 / 栈

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 一般问题 / 提问
+    url: https://github.com/Linnanli/xClaw/discussions
+    about: 不属于架构重构 / bug / 跟踪类的提问，请去 Discussions。

--- a/.github/ISSUE_TEMPLATE/tracking.yml
+++ b/.github/ISSUE_TEMPLATE/tracking.yml
@@ -1,0 +1,27 @@
+name: 跟踪 / 元 issue
+description: 跟踪一组改动 / 长期问题 / 非派单类元 issue
+title: "tracking: <topic>"
+labels: ["tracking"]
+body:
+  - type: textarea
+    id: scope
+    attributes:
+      label: 跟踪范围
+    validations:
+      required: true
+  - type: textarea
+    id: subtasks
+    attributes:
+      label: 子任务 / 关联 issue
+      placeholder: |
+        - [ ] #N — desc
+  - type: input
+    id: source_doc
+    attributes:
+      label: 关联文档（选填）
+      placeholder: docs/plans/architecture-refactor/?.md §?
+  - type: textarea
+    id: unblock_triggers
+    attributes:
+      label: 解除条件
+      description: 什么发生了这个 tracking 才能 close

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,10 +6,16 @@
 ## 1. 强制阅读顺序（开任何 PR 之前）
 
 1. [`AGENTS.md`](../AGENTS.md) — 中文规约总入口
-2. 本 issue body 顶部的 `**Source**:` 链接（指向 `docs/plans/architecture-refactor/...`）
+2. 本 issue body 顶部的 `**Source**:` 链接（指向 `docs/plans/architecture-refactor/...`） — **必须 `read_file` 至少一次**，禁止只看标题猜内容
 3. 涉及红线的 ADR：[`docs/plans/architecture-refactor/adr-112-compatibility-evaluation.md`](../docs/plans/architecture-refactor/adr-112-compatibility-evaluation.md)、
-   [`adr-113-hook-engine-unification.md`](../docs/plans/architecture-refactor/adr-113-hook-engine-unification.md)
+   [`adr-113-hook-engine-unification.md`](../docs/plans/architecture-refactor/adr-113-hook-engine-unification.md) +
+   issue body **关联 ADR** 字段中的全部条目 — 同样必须 `read_file`
 4. 触及 crate 的 `lib.rs` 模块文档
+
+> **Sources read 自检**（PR 必填）：在 PR body 的 `## Sources read` 段落中
+> 逐条回声你实际打开过的文件路径 + § 标题。**只写"已阅"会被视为未读**。
+> 模板见 [`.github/pull_request_template.md`](pull_request_template.md)。
+
 
 ## 2. 不要碰的红线
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,6 +20,23 @@
 
 <!-- Closes #N, or "None" -->
 
+## Sources read
+
+<!--
+强制：列出本 PR 派单 issue body 中 **Source 文档** 字段、**关联 ADR** 字段引用的全部文件 +
+你实际打开过的 §/标题。Coding Agent 必须如实回声路径与小节，禁止只写 "已阅"。
+
+例：
+  - docs/plans/architecture-refactor/32-execution-plan.md §W7
+  - docs/plans/architecture-refactor/adr-137-net-proxy-port-plan.md §3.2 PR-N23
+  - AGENTS.md §"Skills 强制使用规范"
+  - crates/dasclaw_net_proxy/src/lib.rs（模块文档）
+
+如确实无 source（trivial chore PR），写 "None — chore PR with no architecture impact"。
+-->
+
+-
+
 ## Cross-cuts
 
 <!--


### PR DESCRIPTION
## 背景 / 目标

让 Coding Agent 不可能"忘记读架构文档"。当前缺失两道关：
1. 仓库无 issue 模板，Source 字段全靠手写
2. PR 无"我读了哪些文档"回声字段，无法验证 agent 是否真读过派单 issue 的 Source / ADR

## 改动范围

- `.github/ISSUE_TEMPLATE/config.yml` — 禁用 blank issue
- `.github/ISSUE_TEMPLATE/architecture-refactor.yml` — 强 schema（Source / parent / 关联 ADR / 红线 checklist / 验收标准 全部 required）
- `.github/ISSUE_TEMPLATE/bug.yml` / `tracking.yml` — 轻量模板
- `.github/pull_request_template.md` — 新增 `## Sources read` 必填段
- `.github/copilot-instructions.md §1` — "必须 `read_file` 至少一次"硬化 + 指向 PR Sources read 自检

## What's NOT in this PR

- ❌ 不动既有 CI gate（closes-link / regression / project-automation）
- ❌ 不强制 backfill 旧 issue
- ❌ 不引入 board 状态机字段
- ❌ 0 行 Rust

## Sources read

- AGENTS.md（中文规约总入口）
- .github/copilot-instructions.md §1（强制阅读顺序，被本 PR 修改）
- .github/pull_request_template.md（4 块结构基线，被本 PR 扩展）

## 验证

- yml schema 由 GitHub 渲染时校验
- 合并后 `New Issue` 页面预期出现 3 个模板入口 + blank 入口禁用
- 后续任何派单 issue 走 `architecture-refactor.yml` 模板，Source 字段强制非空

Closes #360
