### PR TITLE
ci(test): speed up Tests job + prevent linker OOM (Closes #363)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,6 +119,15 @@ jobs:
       - name: Run Tests
         run: |
           set -euo pipefail
+          # sccache fail-soft: GHA Cache backend has occasional outages
+          # (HTTP 400 "Our services aren't available"). Probe before use;
+          # if unavailable, fall back to plain rustc instead of failing the
+          # whole job. Cache miss costs minutes; outage costs the whole PR.
+          if ! sccache --start-server >/dev/null 2>&1; then
+            echo "::warning::sccache unavailable (likely GHA Cache outage); disabling RUSTC_WRAPPER for this run"
+            unset RUSTC_WRAPPER
+            unset SCCACHE_GHA_ENABLED
+          fi
           SCOPE="${{ steps.scope.outputs.scope || '--workspace' }}"
           echo "Test scope: $SCOPE"
           cargo nextest run $SCOPE ${{ matrix.flags }} --no-fail-fast

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,21 @@ jobs:
     # below). Full multi-feature suite still only runs on push-to-xClaw and
     # workflow_call. This is the local-fast / CI-strict workflow handoff
     # described in AGENTS.md "本地快速开发节奏".
+    #
+    # NOTE: keep on `ubuntu-latest` (4 vCPU / 16GB). Migration to
+    # `ubuntu-latest-large` / `ubuntu-22.04-8core` requires GitHub Larger
+    # Runner billing approval; tracked separately. The dev profile +
+    # mold linker + nextest combo below should keep peak link RAM under
+    # 12GB so the standard runner no longer OOMs.
     runs-on: ubuntu-latest
+    env:
+      # sccache via GitHub Actions cache backend
+      SCCACHE_GHA_ENABLED: "true"
+      RUSTC_WRAPPER: "sccache"
+      # mold linker for x86_64-linux (huge RAM/time savings on the
+      # 350+ rlib ironclaw lib-test link step). Scoped to Linux only.
+      RUSTFLAGS: "-C link-arg=-fuse-ld=mold"
+      CARGO_TERM_COLOR: always
     strategy:
       fail-fast: false
       matrix:
@@ -37,6 +51,8 @@ jobs:
         uses: actions/checkout@v6
         with:
           submodules: recursive
+          # need history to diff against base for path scoping
+          fetch-depth: 0
       - name: Install Linux system dependencies (GTK / WebKit for Tauri desktop-client)
         run: |
           sudo apt-get update -qq
@@ -46,18 +62,69 @@ jobs:
             libayatana-appindicator3-dev \
             librsvg2-dev \
             libsoup-3.0-dev \
-            libssl-dev
+            libssl-dev \
+            mold
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:
           key: ${{ matrix.name }}
-      # NOTE(xClaw fork): removed the `Install cargo-component` and
-      # `Build WASM channels` steps inherited from ironclaw — channels-src/
-      # is not active in xClaw and `./scripts/build-wasm-extensions.sh` does
-      # not exist at the workspace root.
+          # save cache even on partial-match restore so next run benefits
+          save-if: ${{ github.ref == 'refs/heads/xClaw' || github.event_name == 'workflow_call' }}
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.6
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest
+      # AGENTS.md §3: PR scope = touched crate, full workspace 由 push-to-xClaw 兜底。
+      # 对 PR 事件，比较 base...HEAD 的改动文件，映射到 -p <crate> 列表；
+      # 任何非 crate 路径（workspace Cargo.toml / scripts / desktop-client / submodule）
+      # 触发 fallback 到 --workspace。
+      - name: Compute changed-crate scope (PR only)
+        id: scope
+        if: github.event_name == 'pull_request' && matrix.name == 'default'
+        run: |
+          set -euo pipefail
+          base="${{ github.event.pull_request.base.sha }}"
+          head="${{ github.event.pull_request.head.sha }}"
+          changed=$(git diff --name-only "$base" "$head" || true)
+          echo "Changed files:"; echo "$changed"
+          fallback=0
+          declare -A crates=()
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            case "$f" in
+              crates/*)
+                name=$(echo "$f" | cut -d/ -f2)
+                crates[$name]=1 ;;
+              admin-backend/*|desktop-client/*|claw-code/*|codex-cli-main/*|ironclaw-main/*|claw-decode-main/*|decode-claude-code-main/*|vendor/*)
+                fallback=1 ;;
+              Cargo.toml|Cargo.lock|build.rs|deny.toml|rust-toolchain.toml|.cargo/*)
+                fallback=1 ;;
+              *)
+                # docs / .github / scripts → don't trigger compile
+                ;;
+            esac
+          done <<< "$changed"
+          if [ "$fallback" = "1" ] || [ ${#crates[@]} -eq 0 ]; then
+            echo "scope=--workspace" >> "$GITHUB_OUTPUT"
+            echo "Using --workspace (fallback or no crate-only change)"
+          else
+            args=""
+            for c in "${!crates[@]}"; do args="$args -p $c"; done
+            echo "scope=$args" >> "$GITHUB_OUTPUT"
+            echo "Using scoped: $args"
+          fi
       - name: Run Tests
-        run: cargo test ${{ matrix.flags }} -- --nocapture
+        run: |
+          set -euo pipefail
+          SCOPE="${{ steps.scope.outputs.scope || '--workspace' }}"
+          echo "Test scope: $SCOPE"
+          cargo nextest run $SCOPE ${{ matrix.flags }} --no-fail-fast
+      - name: sccache stats
+        if: always()
+        run: sccache --show-stats || true
 
   heavy-integration-tests:
     name: Heavy Integration Tests

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,11 +48,18 @@ exclude = ["ironclaw", "claw-code", "vendor"]
 resolver = "2"
 
 [profile.dev]
-opt-level = 0          # 本 crate 不优化，编译快
-incremental = true     # 增量编译
+opt-level = 0                       # 本 crate 不优化，编译快
+incremental = true                  # 增量编译
+# CI OOM 防护：debug=2 时 ironclaw lib-test 链接 RAM 峰值 ~7GB，
+# 在 ubuntu-latest（4 vCPU / 16GB）上必现 ld signal 7。
+# line-tables-only 保留 backtrace 行号但砍 60-80% debug-info；
+# split-debuginfo=unpacked 把 .dwo 文件外置，进一步降低链接器内存。
+debug = "line-tables-only"
+split-debuginfo = "unpacked"
 
 [profile.dev.package."*"]
 opt-level = 1          # 第三方依赖 O1，编译一次后不再重编且运行更快
+debug = "line-tables-only"
 
 [profile.release]
 strip = true


### PR DESCRIPTION
## 背景 / 目标

`Tests (default)` job 在 PR #355 上耗时 1h5m 后被 GitHub runner 因 OOM 杀掉
（`ld terminated with signal 7 [Bus error]` 链接 ironclaw lib-test 二进制）。

详细根因分析与 7 个放大因子记录在 #363。本 PR 一次性落地 P0~P2 优化。

## 改动范围

### Cargo.toml `[profile.dev]`
- `debug = "line-tables-only"`：debug-info 砍 ~70%，保留 backtrace 行号
- `split-debuginfo = "unpacked"`：`.dwo` 外置，链接器峰值 RAM 大幅下降
- 同步应用到 `[profile.dev.package."*"]`

预期：ironclaw lib-test 链接 RAM 峰值 ~7GB → ~3-4GB，消除 ubuntu-latest（4 vCPU/16GB）的 signal-7 OOM。

### `.github/workflows/test.yml` :: `tests` job

| 改动 | 收益 |
|---|---|
| 安装 mold + `RUSTFLAGS=-C link-arg=-fuse-ld=mold`（仅 x86_64-linux） | 链接时间 -50%、RAM -30% |
| `mozilla-actions/sccache-action@v0.0.6` + GHA cache backend | rama / hickory / wasmtime 二次 PR cache 命中提升 |
| `cargo test ... -- --nocapture` → `cargo nextest run` | 测试执行 -50%；落地 AGENTS.md §测试纪律 |
| 新增 `Compute changed-crate scope (PR only)` 步骤 | `crates/*` 单 crate PR 仅 `-p <crate>` 编译；workspace Cargo.toml/.lock/desktop-client/submodules/.cargo/build.rs 改动自动 fallback `--workspace` |
| `Swatinem/rust-cache@v2` `save-if` 限定 push-to-xClaw + workflow_call | PR 只 restore 不污染 cache key |
| Larger runner（ubuntu-latest-large / 22.04-8core） | **延后**——需要 GitHub Billing approval；以 TODO 注释标记 |

## 非目标（What's NOT in this PR）

- 不升级到 Larger Runner（profile + mold 后预期无需，留 TODO）
- 不动 `heavy-integration-tests` / `telegram-tests` / `wasm-wit-compat` 等 `if: false` job
- 不改 `cargo deny` / `clippy` / `code_style.yml` 等其他 CI 工作流
- 不调整 release / dist profile

## 验证

```bash
# YAML 合法性
python3 -c "import yaml; d=yaml.safe_load(open('.github/workflows/test.yml')); print(list(d['jobs'].keys()))"
# → ['tests', 'heavy-integration-tests', 'telegram-tests', 'windows-build',
#    'wasm-wit-compat', 'bench-compile', 'docker-build', 'version-check', 'run-tests']

# 本地 cargo check 范围验证（profile 改动透明）
cargo check -p dasclaw_net_proxy --tests
cargo fmt --all -- --check
python3.12 scripts/check_no_panics.py --base origin/xClaw
```

最终判断本 PR 是否真能把 Tests 时间从 ~50min 降到 < 20min，需要 CI 自身的实际运行结果。

## Sources read

- [AGENTS.md](AGENTS.md) §3 必跑的本地管线 / §测试纪律 / §会话轮换
- [.github/copilot-instructions.md](.github/copilot-instructions.md) §1, §3, §5
- [.github/workflows/test.yml](.github/workflows/test.yml) tests 矩阵 + Run Tests 步骤
- [Cargo.toml](Cargo.toml) 既有 [profile.dev] / [profile.release] / [profile.dist]
- [.cargo/config.toml](.cargo/config.toml) 既有 mold 注释引导

## Skills 自查

- code-quality-audit：无新增 `unwrap()` / `expect()` / `panic!()`，无生产 Rust 改动；改动仅 CI / profile
- code-simplifier：未引入新抽象、未复制代码；shell 步骤为单次任务的本地脚本
- code-review-expert：YAML 已合法性校验；改动严格闭环 #363 的 6 个验收 checkbox（P2a 显式延后）

Closes #363
