### PR TITLE
feat(cert-trust): scaffold dasclaw_cert_trust crate + dasclaw cert CLI (ADR-139 §4.5 PR1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2625,6 +2625,7 @@ dependencies = [
  "ctor 0.2.9",
  "dasclaw",
  "dasclaw_apply_patch",
+ "dasclaw_cert_trust",
  "dasclaw_exec",
  "dasclaw_hooks",
  "dasclaw_llm_provider",
@@ -2740,6 +2741,16 @@ name = "dasclaw_bash_validation"
 version = "0.0.0-w1"
 dependencies = [
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "dasclaw_cert_trust"
+version = "0.0.0-w8"
+dependencies = [
+ "pretty_assertions",
+ "serde",
+ "thiserror 2.0.18",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,8 @@ members = [
 	# W5 #324 sub-task 3 / ADR-137 — codex-network-proxy transitive deps (verbatim port)
 	"crates/dasclaw_utils_home_dir",
 	"crates/dasclaw_utils_rustls_provider",
+	# W8 ADR-139 §4.5 PR1 — MITM CA trust-chain manager (dasclaw original, not verbatim)
+	"crates/dasclaw_cert_trust",
 	"desktop-client/ironclaw",
 	"desktop-client/ironclaw/crates/ironclaw_common",
 	"desktop-client/ironclaw/crates/ironclaw_safety",

--- a/crates/dasclaw_cert_trust/Cargo.toml
+++ b/crates/dasclaw_cert_trust/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+# ADR-139 §4 — MITM CA trust-chain manager.
+#
+# This crate is **dasclaw original code**, not a verbatim port from codex
+# upstream (codex does not implement this layer). It centralizes:
+#   - CA install / uninstall / rotation against per-user OS keychains
+#   - env-var fallback (`SSL_CERT_FILE` / `REQUESTS_CA_BUNDLE` / `NODE_EXTRA_CA_CERTS`)
+#   - status / export utilities
+#
+# Implementation is cfg-gated per platform (macOS / Windows / Linux). PR1
+# (this commit) ships the API surface + module skeleton with all platform
+# entry points returning `Err(Error::NotImplemented)`. PR2 wires macOS +
+# Windows keychain code; PR3 wires Linux NSS DB. See ADR-139 §4.5.
+name = "dasclaw_cert_trust"
+version = "0.0.0-w8"
+edition = "2024"
+description = "MITM CA trust-chain manager (per-user keychain + env-var fallback)."
+license = "Apache-2.0 OR MIT"
+publish = false
+
+[lib]
+name = "dasclaw_cert_trust"
+path = "src/lib.rs"
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+thiserror = "2"
+tracing = "0.1"
+
+[dev-dependencies]
+pretty_assertions = "1"

--- a/crates/dasclaw_cert_trust/src/error.rs
+++ b/crates/dasclaw_cert_trust/src/error.rs
@@ -1,0 +1,60 @@
+//! Error types for `dasclaw_cert_trust`.
+
+use std::io;
+
+/// Errors returned by the trust-chain manager.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum Error {
+    /// The requested operation is not yet implemented for this platform.
+    ///
+    /// PR1 (ADR-139 §4.5) ships only API + skeleton; PR2/PR3 replace these.
+    #[error("dasclaw_cert_trust: {operation} not yet implemented on {platform}")]
+    NotImplemented {
+        /// The operation that was attempted (e.g. `"install"`).
+        operation: &'static str,
+        /// The current platform name (e.g. `"macos"`, `"windows"`, `"linux"`).
+        platform: &'static str,
+    },
+
+    /// The user denied a keychain prompt or lacks the required permission.
+    #[error("dasclaw_cert_trust: permission denied accessing trust store")]
+    PermissionDenied,
+
+    /// The CA bytes could not be parsed as a PEM certificate.
+    #[error("dasclaw_cert_trust: invalid CA PEM: {0}")]
+    InvalidPem(String),
+
+    /// Underlying OS / I/O failure.
+    #[error("dasclaw_cert_trust: I/O error: {0}")]
+    Io(#[from] io::Error),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn not_implemented_display_includes_operation_and_platform() {
+        let err = Error::NotImplemented {
+            operation: "install",
+            platform: "macos",
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("install"), "missing operation: {msg}");
+        assert!(msg.contains("macos"), "missing platform: {msg}");
+    }
+
+    #[test]
+    fn invalid_pem_includes_reason() {
+        let err = Error::InvalidPem("missing -----BEGIN CERTIFICATE-----".into());
+        assert!(err.to_string().contains("missing -----BEGIN"));
+    }
+
+    #[test]
+    fn io_error_converts_via_from() {
+        let io_err = io::Error::new(io::ErrorKind::NotFound, "no such file");
+        let err: Error = io_err.into();
+        assert!(matches!(err, Error::Io(_)));
+    }
+}

--- a/crates/dasclaw_cert_trust/src/lib.rs
+++ b/crates/dasclaw_cert_trust/src/lib.rs
@@ -1,0 +1,72 @@
+//! MITM CA trust-chain manager — ADR-139 implementation skeleton.
+//!
+//! This crate centralizes per-user CA install / uninstall / rotation logic
+//! used by `dasclaw_net_proxy`'s MITM TLS audit path. It is **dasclaw
+//! original code** (not a verbatim port from codex upstream — codex does
+//! not provide an equivalent).
+//!
+//! # Status (PR1 / ADR-139 §4.5)
+//!
+//! All platform-specific entry points currently return
+//! [`Error::NotImplemented`]. PR2 (macOS + Windows keychain) and PR3
+//! (Linux NSS DB) will replace those stubs with real implementations.
+//!
+//! # API
+//!
+//! The five public functions correspond 1:1 with the `dasclaw cert`
+//! CLI subcommands documented in ADR-139 §4.3:
+//!
+//! - [`install_ca`] — write the CA into the per-user trust store
+//! - [`uninstall_ca`] — remove the CA and clear `$CODEX_HOME/proxy/`
+//! - [`rotate_ca`] — regenerate the CA and re-inject
+//! - [`status`] — report CA fingerprint / expiry / store state
+//! - [`export_ca_pem`] — return the raw PEM bytes for manual import
+
+#![deny(missing_docs)]
+
+pub mod error;
+pub mod platform;
+pub mod status;
+
+pub use error::Error;
+pub use status::CertStatus;
+
+/// Result alias used across the crate.
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// Install the dasclaw MITM CA into the current user's OS trust store.
+///
+/// `ca_pem` is the PEM-encoded CA certificate produced by `dasclaw_net_proxy`.
+/// Returns `Ok(())` once the CA is registered. On platforms that lack a
+/// supported trust store, falls back to writing env-var hints to
+/// `$CODEX_HOME/proxy/env`.
+pub fn install_ca(ca_pem: &[u8]) -> Result<()> {
+    platform::current().install(ca_pem)
+}
+
+/// Remove the dasclaw MITM CA from the current user's trust store.
+///
+/// Idempotent: returns `Ok(())` even if no CA is currently installed.
+pub fn uninstall_ca() -> Result<()> {
+    platform::current().uninstall()
+}
+
+/// Rotate the CA: uninstall the previous certificate and install `new_ca_pem`.
+///
+/// Equivalent to `uninstall_ca` followed by `install_ca`, but implemented as
+/// a single call so PR2/PR3 can perform it atomically per-platform.
+pub fn rotate_ca(new_ca_pem: &[u8]) -> Result<()> {
+    platform::current().rotate(new_ca_pem)
+}
+
+/// Report the current CA install state.
+pub fn status() -> Result<CertStatus> {
+    platform::current().status()
+}
+
+/// Return the PEM bytes of the currently-installed CA, if any.
+///
+/// Useful for `dasclaw cert export` (manual Firefox / NSS import).
+pub fn export_ca_pem() -> Result<Vec<u8>> {
+    platform::current().export()
+}

--- a/crates/dasclaw_cert_trust/src/platform/fallback.rs
+++ b/crates/dasclaw_cert_trust/src/platform/fallback.rs
@@ -1,0 +1,43 @@
+//! Env-var fallback backend.
+//!
+//! Used on platforms not covered by macOS/Windows/Linux modules. ADR-139
+//! §2.C describes the fallback strategy: write `SSL_CERT_FILE` /
+//! `REQUESTS_CA_BUNDLE` / `NODE_EXTRA_CA_CERTS` hints to
+//! `$CODEX_HOME/proxy/env`. PR1 stubs the operations.
+
+#[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
+use super::{TrustStore, not_implemented};
+#[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
+use crate::Result;
+#[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
+use crate::status::CertStatus;
+
+#[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
+const PLATFORM: &str = "fallback";
+
+/// Env-var fallback backend (no-keychain platforms).
+#[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
+pub struct FallbackTrustStore;
+
+#[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
+impl TrustStore for FallbackTrustStore {
+    fn platform(&self) -> &'static str {
+        PLATFORM
+    }
+
+    fn install(&self, _ca_pem: &[u8]) -> Result<()> {
+        not_implemented("install", PLATFORM)
+    }
+
+    fn uninstall(&self) -> Result<()> {
+        not_implemented("uninstall", PLATFORM)
+    }
+
+    fn status(&self) -> Result<CertStatus> {
+        Ok(CertStatus::not_installed(PLATFORM))
+    }
+
+    fn export(&self) -> Result<Vec<u8>> {
+        not_implemented("export", PLATFORM)
+    }
+}

--- a/crates/dasclaw_cert_trust/src/platform/linux.rs
+++ b/crates/dasclaw_cert_trust/src/platform/linux.rs
@@ -1,0 +1,35 @@
+//! Linux trust-store backend (NSS DB via `certutil` fork-exec).
+//!
+//! PR1 stub: every method returns [`Error::NotImplemented`]. PR3 (ADR-139
+//! §4.5) wires `certutil -d sql:$HOME/.pki/nssdb -A …`.
+
+use super::{TrustStore, not_implemented};
+use crate::Result;
+use crate::status::CertStatus;
+
+const PLATFORM: &str = "linux";
+
+/// Backend selected on `cfg(target_os = "linux")`.
+pub struct LinuxTrustStore;
+
+impl TrustStore for LinuxTrustStore {
+    fn platform(&self) -> &'static str {
+        PLATFORM
+    }
+
+    fn install(&self, _ca_pem: &[u8]) -> Result<()> {
+        not_implemented("install", PLATFORM)
+    }
+
+    fn uninstall(&self) -> Result<()> {
+        not_implemented("uninstall", PLATFORM)
+    }
+
+    fn status(&self) -> Result<CertStatus> {
+        Ok(CertStatus::not_installed(PLATFORM))
+    }
+
+    fn export(&self) -> Result<Vec<u8>> {
+        not_implemented("export", PLATFORM)
+    }
+}

--- a/crates/dasclaw_cert_trust/src/platform/macos.rs
+++ b/crates/dasclaw_cert_trust/src/platform/macos.rs
@@ -1,0 +1,35 @@
+//! macOS trust-store backend (per-user keychain via `security-framework`).
+//!
+//! PR1 stub: every method returns [`Error::NotImplemented`]. PR2 (ADR-139
+//! §4.5) wires `SecKeychain*` calls.
+
+use super::{TrustStore, not_implemented};
+use crate::Result;
+use crate::status::CertStatus;
+
+const PLATFORM: &str = "macos";
+
+/// Backend selected on `cfg(target_os = "macos")`.
+pub struct MacOsTrustStore;
+
+impl TrustStore for MacOsTrustStore {
+    fn platform(&self) -> &'static str {
+        PLATFORM
+    }
+
+    fn install(&self, _ca_pem: &[u8]) -> Result<()> {
+        not_implemented("install", PLATFORM)
+    }
+
+    fn uninstall(&self) -> Result<()> {
+        not_implemented("uninstall", PLATFORM)
+    }
+
+    fn status(&self) -> Result<CertStatus> {
+        Ok(CertStatus::not_installed(PLATFORM))
+    }
+
+    fn export(&self) -> Result<Vec<u8>> {
+        not_implemented("export", PLATFORM)
+    }
+}

--- a/crates/dasclaw_cert_trust/src/platform/mod.rs
+++ b/crates/dasclaw_cert_trust/src/platform/mod.rs
@@ -1,0 +1,76 @@
+//! Per-platform trust-store backends.
+//!
+//! PR1 ships only the dispatch trait and stub implementations; PR2 fills in
+//! macOS / Windows keychain code and PR3 adds Linux NSS DB.
+
+use crate::Result;
+use crate::error::Error;
+use crate::status::CertStatus;
+
+mod fallback;
+#[cfg(target_os = "linux")]
+mod linux;
+#[cfg(target_os = "macos")]
+mod macos;
+#[cfg(target_os = "windows")]
+mod windows;
+
+/// Trust-store backend interface.
+///
+/// Each platform module implements [`TrustStore`] for a unit struct and the
+/// active platform is selected by [`current`].
+pub trait TrustStore {
+    /// Platform name reported by `status()` and `Error::NotImplemented`.
+    fn platform(&self) -> &'static str;
+
+    /// Install a CA into the trust store.
+    fn install(&self, ca_pem: &[u8]) -> Result<()>;
+
+    /// Remove the dasclaw CA from the trust store. Idempotent.
+    fn uninstall(&self) -> Result<()>;
+
+    /// Default `rotate` is `uninstall` followed by `install`. Platform
+    /// modules MAY override to perform an atomic swap.
+    fn rotate(&self, new_ca_pem: &[u8]) -> Result<()> {
+        self.uninstall()?;
+        self.install(new_ca_pem)
+    }
+
+    /// Snapshot of the current install state.
+    fn status(&self) -> Result<CertStatus>;
+
+    /// Return the PEM bytes of the installed CA, if available.
+    fn export(&self) -> Result<Vec<u8>>;
+}
+
+/// Helper for stubs that are not yet implemented.
+pub(crate) fn not_implemented<T>(operation: &'static str, platform: &'static str) -> Result<T> {
+    Err(Error::NotImplemented {
+        operation,
+        platform,
+    })
+}
+
+/// Return the active backend for the current target platform.
+///
+/// On unsupported platforms returns the env-var fallback backend, which
+/// always reports `installed: false` and writes hints to `$CODEX_HOME/proxy/`
+/// (PR1: stub returning `NotImplemented`).
+pub fn current() -> Box<dyn TrustStore> {
+    #[cfg(target_os = "macos")]
+    {
+        Box::new(macos::MacOsTrustStore)
+    }
+    #[cfg(target_os = "windows")]
+    {
+        Box::new(windows::WindowsTrustStore)
+    }
+    #[cfg(target_os = "linux")]
+    {
+        Box::new(linux::LinuxTrustStore)
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
+    {
+        Box::new(fallback::FallbackTrustStore)
+    }
+}

--- a/crates/dasclaw_cert_trust/src/platform/windows.rs
+++ b/crates/dasclaw_cert_trust/src/platform/windows.rs
@@ -1,0 +1,35 @@
+//! Windows trust-store backend (`CurrentUser\Root` via `windows-rs`).
+//!
+//! PR1 stub: every method returns [`Error::NotImplemented`]. PR2 wires
+//! `windows::Win32::Security::Cryptography` calls.
+
+use super::{TrustStore, not_implemented};
+use crate::Result;
+use crate::status::CertStatus;
+
+const PLATFORM: &str = "windows";
+
+/// Backend selected on `cfg(target_os = "windows")`.
+pub struct WindowsTrustStore;
+
+impl TrustStore for WindowsTrustStore {
+    fn platform(&self) -> &'static str {
+        PLATFORM
+    }
+
+    fn install(&self, _ca_pem: &[u8]) -> Result<()> {
+        not_implemented("install", PLATFORM)
+    }
+
+    fn uninstall(&self) -> Result<()> {
+        not_implemented("uninstall", PLATFORM)
+    }
+
+    fn status(&self) -> Result<CertStatus> {
+        Ok(CertStatus::not_installed(PLATFORM))
+    }
+
+    fn export(&self) -> Result<Vec<u8>> {
+        not_implemented("export", PLATFORM)
+    }
+}

--- a/crates/dasclaw_cert_trust/src/status.rs
+++ b/crates/dasclaw_cert_trust/src/status.rs
@@ -1,0 +1,59 @@
+//! Reported state of the dasclaw MITM CA in the user's trust store.
+
+use serde::{Deserialize, Serialize};
+
+/// Snapshot of the install state used by `dasclaw cert status`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CertStatus {
+    /// `true` when the CA is registered with the OS trust store.
+    pub installed: bool,
+    /// SHA-256 fingerprint of the installed CA, if any (lowercase hex).
+    pub fingerprint_sha256: Option<String>,
+    /// CA expiry (RFC 3339 timestamp), if known.
+    pub expires_at: Option<String>,
+    /// Human-readable platform name (e.g. `"macos"`, `"windows"`, `"linux"`).
+    pub platform: &'static str,
+    /// Whether the env-var fallback (`SSL_CERT_FILE` etc.) is active.
+    pub env_fallback_active: bool,
+}
+
+impl CertStatus {
+    /// Build a "no CA installed" status for a given platform.
+    pub fn not_installed(platform: &'static str) -> Self {
+        Self {
+            installed: false,
+            fingerprint_sha256: None,
+            expires_at: None,
+            platform,
+            env_fallback_active: false,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn not_installed_constructor_sets_platform() {
+        let s = CertStatus::not_installed("macos");
+        assert!(!s.installed);
+        assert_eq!(s.platform, "macos");
+        assert!(s.fingerprint_sha256.is_none());
+        assert!(!s.env_fallback_active);
+    }
+
+    #[test]
+    fn installed_status_carries_fingerprint() {
+        let s = CertStatus {
+            installed: true,
+            fingerprint_sha256: Some("abc123".into()),
+            expires_at: Some("2027-01-01T00:00:00Z".into()),
+            platform: "linux",
+            env_fallback_active: true,
+        };
+        assert!(s.installed);
+        assert_eq!(s.fingerprint_sha256.as_deref(), Some("abc123"));
+        assert_eq!(s.platform, "linux");
+    }
+}

--- a/crates/dasclaw_cert_trust/tests/smoke.rs
+++ b/crates/dasclaw_cert_trust/tests/smoke.rs
@@ -1,0 +1,52 @@
+//! Smoke tests for the public scaffold API.
+//!
+//! These verify PR1 contracts only: every operation is callable, returns
+//! the expected `NotImplemented` shape (or a successful "not installed"
+//! status), and the platform name flows through correctly. PR2/PR3 will
+//! add real-backend integration tests.
+
+use dasclaw_cert_trust::{Error, install_ca, rotate_ca, status, uninstall_ca};
+
+const FAKE_PEM: &[u8] = b"-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----\n";
+
+#[test]
+fn install_returns_not_implemented_on_current_platform() {
+    let err = install_ca(FAKE_PEM).expect_err("install must be a stub in PR1");
+    match err {
+        Error::NotImplemented {
+            operation,
+            platform,
+        } => {
+            assert_eq!(operation, "install");
+            assert!(!platform.is_empty(), "platform must be non-empty");
+        }
+        other => panic!("expected NotImplemented, got {other:?}"),
+    }
+}
+
+#[test]
+fn uninstall_returns_not_implemented() {
+    let err = uninstall_ca().expect_err("uninstall must be a stub in PR1");
+    assert!(matches!(
+        err,
+        Error::NotImplemented {
+            operation: "uninstall",
+            ..
+        }
+    ));
+}
+
+#[test]
+fn rotate_uses_default_uninstall_then_install_path() {
+    // Default trait impl tries `uninstall` first → that stub fires first.
+    let err = rotate_ca(FAKE_PEM).expect_err("rotate must be a stub in PR1");
+    assert!(matches!(err, Error::NotImplemented { .. }));
+}
+
+#[test]
+fn status_returns_not_installed_on_supported_platforms() {
+    let s = status().expect("status must succeed even when stubbed");
+    assert!(!s.installed);
+    assert!(s.fingerprint_sha256.is_none());
+    assert!(!s.platform.is_empty());
+}

--- a/desktop-client/ironclaw/Cargo.toml
+++ b/desktop-client/ironclaw/Cargo.toml
@@ -126,6 +126,8 @@ dasclaw_process_hardening = { path = "../../crates/dasclaw_process_hardening" }
 ctor = "0.2"
 # W3.2b: audited HTTP egress proxy (allowlist + credential injection)
 dasclaw_net_proxy = { path = "../../crates/dasclaw_net_proxy", version = "=0.0.0-w7" }
+# ADR-139 §4.5 PR1: MITM CA trust-chain manager (per-user keychain + env-var fallback)
+dasclaw_cert_trust = { path = "../../crates/dasclaw_cert_trust", version = "=0.0.0-w8" }
 # P0-3 (ADR-113): unified hook engine — single front-door for event hooks + trait seams
 dasclaw_hooks = { path = "../../crates/dasclaw_hooks", version = "0.1.0" }
 # W3 #53: codex-protocol apply_patch parser + minimal apply layer

--- a/desktop-client/ironclaw/src/cli/cert.rs
+++ b/desktop-client/ironclaw/src/cli/cert.rs
@@ -1,0 +1,127 @@
+//! `dasclaw cert` CLI — MITM CA trust-chain management.
+//!
+//! ADR-139 §4.3 — five subcommands dispatching to `dasclaw_cert_trust`.
+//! PR1 wires the subcommand surface; the underlying lib stubs return
+//! `NotImplemented` until PR2/PR3.
+
+use clap::Subcommand;
+use dasclaw_cert_trust::Error as TrustError;
+
+/// `dasclaw cert <subcommand>` operations (ADR-139 §4.3).
+#[derive(Subcommand, Debug, Clone)]
+pub enum CertCommand {
+    /// Install the dasclaw MITM CA into the per-user trust store.
+    Install,
+    /// Remove the dasclaw MITM CA and clear `$CODEX_HOME/proxy/`.
+    Revoke,
+    /// Regenerate the CA and re-inject it.
+    Rotate,
+    /// Show CA fingerprint, expiry, and trust-store state.
+    Status {
+        /// Emit JSON instead of human-readable output.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Print the installed CA in PEM format on stdout.
+    Export,
+}
+
+/// Run a `dasclaw cert` subcommand.
+///
+/// PR1: every operation routes to the `dasclaw_cert_trust` stub layer and
+/// surfaces `NotImplemented` as a friendly error. The `Status` subcommand
+/// is the one path that succeeds end-to-end (returns
+/// `installed: false`).
+pub fn run_cert_command(cmd: CertCommand) -> anyhow::Result<()> {
+    match cmd {
+        CertCommand::Install => {
+            // PR1 has no CA bytes to install yet; a placeholder is fine
+            // because the stub never inspects the input.
+            map_trust_result(dasclaw_cert_trust::install_ca(b""))
+        }
+        CertCommand::Revoke => map_trust_result(dasclaw_cert_trust::uninstall_ca()),
+        CertCommand::Rotate => map_trust_result(dasclaw_cert_trust::rotate_ca(b"")),
+        CertCommand::Status { json } => print_status(json),
+        CertCommand::Export => match dasclaw_cert_trust::export_ca_pem() {
+            Ok(pem) => {
+                use std::io::Write as _;
+                std::io::stdout().write_all(&pem)?;
+                Ok(())
+            }
+            Err(err) => Err(format_trust_error(err)),
+        },
+    }
+}
+
+fn map_trust_result(result: Result<(), TrustError>) -> anyhow::Result<()> {
+    match result {
+        Ok(()) => Ok(()),
+        Err(err) => Err(format_trust_error(err)),
+    }
+}
+
+fn format_trust_error(err: TrustError) -> anyhow::Error {
+    // PR2/PR3 will replace `NotImplemented` with real backend errors;
+    // surface a stable user-facing string until then.
+    anyhow::anyhow!("{err}")
+}
+
+fn print_status(json: bool) -> anyhow::Result<()> {
+    let status = dasclaw_cert_trust::status().map_err(format_trust_error)?;
+    if json {
+        let payload = serde_json::to_string_pretty(&status)?;
+        println!("{payload}");
+    } else {
+        println!("Platform:           {}", status.platform);
+        println!("Installed:          {}", status.installed);
+        println!(
+            "Fingerprint SHA-256: {}",
+            status.fingerprint_sha256.as_deref().unwrap_or("(none)")
+        );
+        println!(
+            "Expires at:         {}",
+            status.expires_at.as_deref().unwrap_or("(unknown)")
+        );
+        println!("Env-var fallback:   {}", status.env_fallback_active);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    #[derive(clap::Parser, Debug)]
+    struct Wrapper {
+        #[command(subcommand)]
+        cmd: CertCommand,
+    }
+
+    #[test]
+    fn parses_each_subcommand() {
+        for argv in [
+            vec!["test", "install"],
+            vec!["test", "revoke"],
+            vec!["test", "rotate"],
+            vec!["test", "status"],
+            vec!["test", "status", "--json"],
+            vec!["test", "export"],
+        ] {
+            Wrapper::try_parse_from(&argv).unwrap_or_else(|e| panic!("parse {argv:?}: {e}"));
+        }
+    }
+
+    #[test]
+    fn install_routes_to_trust_lib_stub() {
+        let err = run_cert_command(CertCommand::Install).expect_err("PR1 install must error");
+        assert!(err.to_string().contains("not yet implemented"));
+    }
+
+    #[test]
+    fn status_text_succeeds_on_stub() {
+        // `status` is the only subcommand that does not return NotImplemented
+        // in PR1 — the stub backends report `installed: false`.
+        run_cert_command(CertCommand::Status { json: true }).expect("status must succeed");
+    }
+}

--- a/desktop-client/ironclaw/src/cli/mod.rs
+++ b/desktop-client/ironclaw/src/cli/mod.rs
@@ -14,6 +14,7 @@
 //! - Viewing gateway logs (`logs`)
 //! - Checking system health (`status`)
 
+mod cert;
 mod channels;
 mod completion;
 mod config;
@@ -36,6 +37,7 @@ mod skills;
 pub mod status;
 mod tool;
 
+pub use cert::{CertCommand, run_cert_command};
 pub use channels::{ChannelsCommand, run_channels_command};
 pub use completion::Completion;
 pub use config::{ConfigCommand, run_config_command};
@@ -212,6 +214,14 @@ pub enum Command {
         long_about = "List, search, and inspect SKILL.md-based skills.\nExamples:\n  ironclaw skills list\n  ironclaw skills search 'writing'\n  ironclaw skills info my-skill"
     )]
     Skills(SkillsCommand),
+
+    /// Manage MITM CA trust chain (ADR-139)
+    #[command(
+        subcommand,
+        about = "Manage MITM CA trust chain",
+        long_about = "Install, revoke, rotate, inspect, or export the per-user MITM CA used by the audited HTTP egress proxy.\nExamples:\n  dasclaw cert status\n  dasclaw cert install\n  dasclaw cert export > ca.pem"
+    )]
+    Cert(CertCommand),
 
     /// Manage lifecycle hooks
     #[command(

--- a/desktop-client/ironclaw/src/cli/snapshots/ironclaw__cli__tests__help_output_without_import.snap
+++ b/desktop-client/ironclaw/src/cli/snapshots/ironclaw__cli__tests__help_output_without_import.snap
@@ -19,6 +19,7 @@ Commands:
   pairing     Manage DM pairing
   service     Manage OS service
   skills      Manage skills
+  cert        Manage MITM CA trust chain
   hooks       Manage lifecycle hooks
   models      Manage LLM providers and models
   doctor      Run diagnostics

--- a/desktop-client/ironclaw/src/cli/snapshots/ironclaw__cli__tests__long_help_output_without_import.snap
+++ b/desktop-client/ironclaw/src/cli/snapshots/ironclaw__cli__tests__long_help_output_without_import.snap
@@ -22,6 +22,7 @@ Commands:
   pairing     Manage DM pairing
   service     Manage OS service
   skills      Manage skills
+  cert        Manage MITM CA trust chain
   hooks       Manage lifecycle hooks
   models      Manage LLM providers and models
   doctor      Run diagnostics

--- a/desktop-client/ironclaw/src/main.rs
+++ b/desktop-client/ironclaw/src/main.rs
@@ -164,6 +164,10 @@ async fn async_main() -> anyhow::Result<()> {
             return ironclaw::cli::run_skills_command(skills_cmd.clone(), cli.config.as_deref())
                 .await;
         }
+        Some(Command::Cert(cert_cmd)) => {
+            init_cli_tracing();
+            return ironclaw::cli::run_cert_command(cert_cmd.clone());
+        }
         Some(Command::Hooks(hooks_cmd)) => {
             init_cli_tracing();
             return ironclaw::cli::run_hooks_command(hooks_cmd.clone(), cli.config.as_deref())


### PR DESCRIPTION
Closes #368

## 背景/目标

ADR-139 §4.5 PR1（S）。为 W8（MITM CA 信任链管理）落地最小骨架：
- 新增 crate `dasclaw_cert_trust`（dasclaw 原创，非 codex 逐字搬运）；
- 在已有 `dasclaw` 二进制下新增 `dasclaw cert {install,revoke,rotate,status,export}` 子命令；
- 所有跨平台后端实现以 `Err(NotImplemented)` 占位（`status` 例外，返回未安装态），把 PR2/PR3 的真实实现窗口留出来。

ADR-139 §4 明确把 W8 拆为三个 PR。本 PR 只做 PR1 骨架，不引入任何真实的 keychain/NSS DB 交互。

## 改动范围

**新增 crate `crates/dasclaw_cert_trust/`**（lib only，version `=0.0.0-w8`）：
- `src/lib.rs` — `install_ca / uninstall_ca / rotate_ca / status / export_ca_pem` 五个公开函数，统一委托给 `platform::current()`。
- `src/error.rs` — `Error::{NotImplemented, PermissionDenied, InvalidPem, Io}`，`#[non_exhaustive]`。
- `src/status.rs` — `CertStatus { installed, fingerprint_sha256, expires_at, platform, env_fallback_active }`，serde derive。
- `src/platform/mod.rs` — `TrustStore` trait + `cfg`-gated dispatch（macos/windows/linux/fallback）。
- `src/platform/{macos,windows,linux,fallback}.rs` — 全部 stub，返回 `Err(NotImplemented)`；`status()` 返回 `not_installed(PLATFORM)`。
- `tests/smoke.rs` — 4 个集成测试验证当前平台 stub 行为。

**`dasclaw` CLI 接线**：
- `desktop-client/ironclaw/src/cli/cert.rs` — `CertCommand` enum + `run_cert_command()` 调度器；3 个单元测试。
- `desktop-client/ironclaw/src/cli/mod.rs` — 注册 `mod cert`、`pub use`、`Command::Cert(CertCommand)` 变体。
- `desktop-client/ironclaw/src/main.rs` — 在已有 `Command::Skills` 派发分支后增加 `Command::Cert` 派发。
- `desktop-client/ironclaw/Cargo.toml` — 添加 `dasclaw_cert_trust = { path = ..., version = "=0.0.0-w8" }`。

**workspace**：
- `Cargo.toml` — 在 `dasclaw_utils_rustls_provider` 之后新增 member `crates/dasclaw_cert_trust`。
- `Cargo.lock` — 自动更新。

## 非目标（What's NOT in this PR）

- ❌ macOS Security framework / Windows CertOpenSystemStoreW 真实写入（PR2）。
- ❌ Linux NSS DB / `~/.pki/nssdb` 真实写入（PR3）。
- ❌ `IRONCLAW_PROXY_CA_BUNDLE` 环境回退路径联动（PR2 一起）。
- ❌ 与 `dasclaw_net_proxy` 的运行期注入串联（PR2/PR3）。
- ❌ 任何 ADR-redline（#28 / #84 / #85 / #94）相关改动；本 PR 不触及 `dasclaw_sandbox_windows/src/bin/{setup_main,command_runner}.rs`，不为 `dasclaw_execpolicy::main` 增加 `pre_main_hardening`。

## 验证

```bash
cargo check -p dasclaw_cert_trust --tests
# Finished `dev` profile in 32.30s

cargo check -p dasclaw --tests --bin dasclaw
# Finished `dev` profile in 6m 37s

cargo nextest run -p dasclaw_cert_trust
# 9 tests run: 9 passed, 0 skipped

cargo nextest run -p dasclaw -E 'test(/cert/)'
# 8 tests run: 8 passed (其中 cli::cert::tests::* 3 个 + 5 个无关命中)

cargo fmt --all
python3.12 scripts/check_no_panics.py --base origin/xClaw
# OK: No panic-inducing calls in changed production code.

cargo clippy --no-deps -p dasclaw_cert_trust --all-targets -- -D warnings
# Finished in 2.86s（clean）

cargo clippy --no-deps -p dasclaw --lib --bin dasclaw -- -D warnings
# Finished in 39.35s（clean；预先存在的 test 文件 clippy 噪音不在本 PR 范围内）
```

## Cross-cuts

- **ADR-114（IRONCLAW_BASE_DIR / `.ironclaw` 字面量）**：类 A — 本 PR 未引入任何 `.ironclaw` 或 `IRONCLAW_BASE_DIR` 字面量；CA 文件路径将由 PR2 通过 `dasclaw_utils_home_dir` 统一抽象，不在本 PR 中决定。
- **ADR-112 / ADR-113（hook engine / 兼容矩阵）**：未触及。
- **ADR-redline (#28/#84/#85/#94)**：未触及。

## Sources read

- [`AGENTS.md`](AGENTS.md) §1–3（强制阅读顺序、红线、本地管线）。
- [`docs/plans/architecture-refactor/adr-139-mitm-and-trust-chain.md`](docs/plans/architecture-refactor/adr-139-mitm-and-trust-chain.md) §3（受信范围）、§4（实施分阶段，PR1/PR2/PR3 拆分）、§4.3（CLI 子命令）、§4.5（验收口径）。
- [`docs/plans/architecture-refactor/adr-114-base-dir-canonicalization.md`](docs/plans/architecture-refactor/adr-114-base-dir-canonicalization.md) §2（类 A 改造规则）。
- [`crates/dasclaw_net_proxy/src/lib.rs`](crates/dasclaw_net_proxy/src/lib.rs)（理解上游 W7 出站代理边界，PR1 不与之联动）。

## Self-audit（skills pipeline 自查）

**code-quality-audit**：
- 模块拆分（`error` / `status` / `platform/*`）边界清晰，单一职责；
- 无 `unwrap()` / `expect()` / `panic!()` 在生产代码（脚本验证通过）；
- `#![deny(missing_docs)]` 开启，所有 `pub` API 有文档；
- `#[non_exhaustive]` 用于 `Error`，便于未来扩展。

**code-simplifier**：
- `TrustStore` trait 提供 `rotate` 默认实现（uninstall→install），避免每个后端重复样板；
- `current()` 用 `cfg` 静态分发，运行期零开销；
- stub 后端通过单一 `not_implemented::<T>()` 辅助函数收敛错误构造。

**code-review-expert**：
- Fail-Safe：所有未实现路径返回 `Err`，绝不静默成功；
- `status()` 返回 `installed=false` 而非错误，符合 ADR-139 §4.3「status 必须可在未安装状态下成功返回」；
- API 表面冻结：`install_ca/uninstall_ca/rotate_ca/status/export_ca_pem` 是 PR2/PR3 的实现契约；
- 无新增 panic、无 unsafe、无 `.ironclaw` 字面量。
