### PR TITLE
feat(cert-trust): X.509 validation before installing root CA (#375)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2750,14 +2750,17 @@ dependencies = [
  "base64 0.22.1",
  "dirs 6.0.0",
  "pretty_assertions",
+ "rcgen",
  "rustls-pemfile 2.2.0",
  "security-framework 3.7.0",
  "serde",
  "sha2",
  "tempfile",
  "thiserror 2.0.18",
+ "time",
  "tracing",
  "windows 0.58.0",
+ "x509-parser",
 ]
 
 [[package]]
@@ -8657,6 +8660,7 @@ checksum = "10b99e0098aa4082912d4c649628623db6aba77335e4f4569ff5083a6448b32e"
 dependencies = [
  "aws-lc-rs",
  "pem",
+ "ring",
  "rustls-pki-types",
  "time",
  "x509-parser",

--- a/crates/dasclaw_cert_trust/Cargo.toml
+++ b/crates/dasclaw_cert_trust/Cargo.toml
@@ -33,6 +33,13 @@ rustls-pemfile = "2"
 sha2 = "0.10"
 base64 = "0.22"
 dirs = "6"
+# X.509 body validation before installing a CA — issue #375. Rejects
+# leaf certs (BasicConstraints CA:FALSE), expired CAs (notAfter in the
+# past), and non-self-signed intermediates so the caller cannot promote
+# an arbitrary cert into the OS root store. Already a transitive
+# dependency via the rustls-pki-types ecosystem; promoting to a direct
+# dependency lets us call the parser API explicitly.
+x509-parser = "0.18"
 # Atomic fingerprint sentinel writes (tempfile + rename) — see
 # `paths::write_fingerprint`. A non-atomic write would let a mid-write
 # crash leave the file truncated while the OS keychain still trusts the
@@ -57,3 +64,9 @@ windows = { version = "0.58", features = [
 [dev-dependencies]
 pretty_assertions = "1"
 tempfile = "3"
+# rcgen builds tailored X.509 fixtures (leaf / expired / non-self-signed)
+# for `pem::validate_root_ca` tests. Already in the workspace lockfile
+# via desktop-client/dasclaw_net_proxy, so adding it as a dev-dep does
+# not pull in a new transitive tree.
+rcgen = "0.14"
+time = "0.3"

--- a/crates/dasclaw_cert_trust/src/error.rs
+++ b/crates/dasclaw_cert_trust/src/error.rs
@@ -25,6 +25,20 @@ pub enum Error {
     #[error("dasclaw_cert_trust: invalid CA PEM: {0}")]
     InvalidPem(String),
 
+    /// The PEM decoded successfully but the X.509 body is unfit to be
+    /// installed as a per-user root CA.
+    ///
+    /// Examples (issue #375 / ADR-139 §3.7 fail-safe):
+    /// - `BasicConstraints` extension absent or `cA: false` (leaf cert)
+    /// - `notAfter` already in the past (expired CA)
+    /// - issuer ≠ subject (non-self-signed intermediate)
+    ///
+    /// Distinguished from [`Error::InvalidPem`] (which means the input
+    /// was not even syntactically a certificate) so the CLI can give a
+    /// more actionable message.
+    #[error("dasclaw_cert_trust: CA cert rejected: {0}")]
+    InvalidCa(String),
+
     /// Underlying OS / I/O failure.
     #[error("dasclaw_cert_trust: I/O error: {0}")]
     Io(#[from] io::Error),
@@ -63,6 +77,14 @@ mod tests {
     fn invalid_pem_includes_reason() {
         let err = Error::InvalidPem("missing -----BEGIN CERTIFICATE-----".into());
         assert!(err.to_string().contains("missing -----BEGIN"));
+    }
+
+    #[test]
+    fn invalid_ca_includes_reason() {
+        let err = Error::InvalidCa("BasicConstraints CA:FALSE".into());
+        let msg = err.to_string();
+        assert!(msg.contains("CA cert rejected"), "wrong prefix: {msg}");
+        assert!(msg.contains("BasicConstraints"), "missing reason: {msg}");
     }
 
     #[test]

--- a/crates/dasclaw_cert_trust/src/pem.rs
+++ b/crates/dasclaw_cert_trust/src/pem.rs
@@ -5,6 +5,7 @@
 //! `TrustStore` impls are exposed.
 
 use sha2::Digest;
+use x509_parser::prelude::FromDer as _;
 
 use crate::Result;
 use crate::error::Error;
@@ -27,6 +28,96 @@ pub(crate) fn decode_first_certificate(ca_pem: &[u8]) -> Result<Vec<u8>> {
         )),
         Err(err) => Err(Error::InvalidPem(format!("PEM decode failed: {err}"))),
     }
+}
+
+/// Validate that a DER-encoded X.509 certificate is fit to be installed
+/// as a per-user **root** CA.
+///
+/// Implements the three RFC 5280 sanity checks called out in issue #375 /
+/// ADR-139 §3.7 (fail-safe error handling). The OS keychain APIs do not
+/// perform these checks themselves: they accept any well-formed DER and
+/// will then trust it as a root, so without this gate a caller could
+/// promote an arbitrary leaf cert into the user's trust store.
+///
+/// Rejected cases (each returns [`Error::InvalidCa`] with a specific
+/// reason string so the CLI can give an actionable message):
+///
+/// 1. **Not a CA** — `BasicConstraints` extension is absent or has
+///    `cA: false`. RFC 5280 §4.2.1.9 requires `cA: TRUE` for any cert
+///    that issues other certificates.
+/// 2. **Expired** — `notAfter` is already in the past. We only check
+///    `notAfter` (not `notBefore`); a not-yet-valid CA is unusual but
+///    legitimate (e.g. pre-staged rotation), while an already-expired CA
+///    cannot validate any TLS handshake.
+/// 3. **Not self-signed** — issuer DN ≠ subject DN. Only self-signed
+///    roots belong in a root store; an intermediate placed there would
+///    silently fail chain validation against any legitimate root.
+///
+/// Comparison of issuer and subject uses the **DER-encoded** name bytes
+/// per RFC 5280 §4.1.2.4 — string-form comparison would normalize whitespace
+/// and case in ways that don't match what the validator does at handshake
+/// time.
+///
+/// We deliberately do **not** verify the self-signature here. That would
+/// require a parsed public key + signature algorithm ladder, which
+/// `dasclaw_net_proxy` will already have done when generating the CA;
+/// re-doing it on the consumer side adds attack surface (parsing new
+/// algorithm OIDs) for no extra safety beyond the three checks above.
+pub(crate) fn validate_root_ca(der: &[u8]) -> Result<()> {
+    let (_rest, cert) = x509_parser::certificate::X509Certificate::from_der(der)
+        .map_err(|err| Error::InvalidCa(format!("X.509 parse failed: {err}")))?;
+
+    // Check 1: BasicConstraints CA:TRUE.
+    match cert
+        .basic_constraints()
+        .map_err(|err| Error::InvalidCa(format!("BasicConstraints parse failed: {err}")))?
+    {
+        Some(ext) if ext.value.ca => {}
+        Some(_) => {
+            return Err(Error::InvalidCa(
+                "BasicConstraints extension present but cA:FALSE (leaf cert, not a CA)".into(),
+            ));
+        }
+        None => {
+            return Err(Error::InvalidCa(
+                "BasicConstraints extension absent (cannot confirm cA:TRUE)".into(),
+            ));
+        }
+    }
+
+    // Check 2: notAfter not in the past (no clock-skew tolerance — the OS
+    // will reject expired certs at handshake time, and a CA that is "barely
+    // valid right now" is itself a problem we want to surface early).
+    let now = x509_parser::time::ASN1Time::now();
+    if !cert.validity().is_valid_at(now) {
+        return Err(Error::InvalidCa(format!(
+            "certificate not valid at current time (notBefore={}, notAfter={})",
+            cert.validity().not_before,
+            cert.validity().not_after,
+        )));
+    }
+
+    // Check 3: self-signed (issuer DN == subject DN, byte-equal in DER).
+    if cert.subject().as_raw() != cert.issuer().as_raw() {
+        return Err(Error::InvalidCa(
+            "issuer DN ≠ subject DN (not a self-signed root)".into(),
+        ));
+    }
+
+    Ok(())
+}
+
+/// Decode + validate a PEM-encoded root CA in one step.
+///
+/// Equivalent to `decode_first_certificate` followed by `validate_root_ca`.
+/// This is the entry point every `TrustStore::install` impl must use, so
+/// that platform backends never see an unvalidated PEM. The two-step
+/// composition is exposed so unit tests can target each stage in
+/// isolation.
+pub(crate) fn decode_and_validate_root_ca(ca_pem: &[u8]) -> Result<Vec<u8>> {
+    let der = decode_first_certificate(ca_pem)?;
+    validate_root_ca(&der)?;
+    Ok(der)
 }
 
 /// Compute the lowercase-hex SHA-256 fingerprint of a DER-encoded certificate.
@@ -167,6 +258,170 @@ mod tests {
         assert_eq!(
             pem,
             b"-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----\n"
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // validate_root_ca / decode_and_validate_root_ca — issue #375.
+    //
+    // Each fixture builder produces a freshly-generated cert via `rcgen`
+    // so the assertions don't drift when system time crosses any
+    // hard-coded `notAfter`. Builders return the DER bytes (the input
+    // shape of `validate_root_ca`).
+    // ------------------------------------------------------------------
+
+    /// Build a self-signed CA whose `notBefore`/`notAfter` are set
+    /// relative to "now" by the supplied offsets in days. Negative values
+    /// move the window into the past.
+    fn build_self_signed_ca_with_validity(days_before: i64, days_after: i64) -> Vec<u8> {
+        use rcgen::{
+            BasicConstraints, CertificateParams, DistinguishedName, DnType, IsCa, KeyPair,
+        };
+        use time::{Duration, OffsetDateTime};
+
+        let mut params = CertificateParams::new(Vec::<String>::new()).expect("CertificateParams");
+        let mut dn = DistinguishedName::new();
+        dn.push(DnType::CommonName, "dasclaw-test-root");
+        params.distinguished_name = dn;
+        params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+        let now = OffsetDateTime::now_utc();
+        params.not_before = now + Duration::days(days_before);
+        params.not_after = now + Duration::days(days_after);
+
+        let key = KeyPair::generate().expect("keypair");
+        let cert = params.self_signed(&key).expect("self-sign");
+        cert.der().to_vec()
+    }
+
+    /// Build a self-signed leaf certificate (`BasicConstraints CA:FALSE`).
+    fn build_self_signed_leaf() -> Vec<u8> {
+        use rcgen::{CertificateParams, DistinguishedName, DnType, IsCa, KeyPair};
+        use time::{Duration, OffsetDateTime};
+
+        let mut params = CertificateParams::new(Vec::<String>::new()).expect("CertificateParams");
+        let mut dn = DistinguishedName::new();
+        dn.push(DnType::CommonName, "dasclaw-test-leaf");
+        params.distinguished_name = dn;
+        params.is_ca = IsCa::ExplicitNoCa;
+        let now = OffsetDateTime::now_utc();
+        params.not_before = now - Duration::days(1);
+        params.not_after = now + Duration::days(30);
+
+        let key = KeyPair::generate().expect("keypair");
+        let cert = params.self_signed(&key).expect("self-sign");
+        cert.der().to_vec()
+    }
+
+    /// Build an intermediate CA signed by a separate root, so issuer DN ≠
+    /// subject DN.
+    fn build_non_self_signed_intermediate() -> Vec<u8> {
+        use rcgen::{
+            BasicConstraints, CertificateParams, DistinguishedName, DnType, IsCa, Issuer, KeyPair,
+            SignatureAlgorithm,
+        };
+        use time::{Duration, OffsetDateTime};
+
+        // Root.
+        let mut root_params =
+            CertificateParams::new(Vec::<String>::new()).expect("CertificateParams");
+        let mut root_dn = DistinguishedName::new();
+        root_dn.push(DnType::CommonName, "dasclaw-test-root");
+        root_params.distinguished_name = root_dn;
+        root_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+        let now = OffsetDateTime::now_utc();
+        root_params.not_before = now - Duration::days(1);
+        root_params.not_after = now + Duration::days(365);
+        let root_key = KeyPair::generate().expect("root keypair");
+        let root_alg: &'static SignatureAlgorithm = root_key.algorithm();
+        let issuer = Issuer::new(root_params, root_key);
+
+        // Intermediate signed by root.
+        let mut int_params =
+            CertificateParams::new(Vec::<String>::new()).expect("CertificateParams");
+        let mut int_dn = DistinguishedName::new();
+        int_dn.push(DnType::CommonName, "dasclaw-test-intermediate");
+        int_params.distinguished_name = int_dn;
+        int_params.is_ca = IsCa::Ca(BasicConstraints::Constrained(0));
+        int_params.not_before = now - Duration::days(1);
+        int_params.not_after = now + Duration::days(180);
+        let int_key = KeyPair::generate_for(root_alg).expect("intermediate keypair");
+        let int_cert = int_params
+            .signed_by(&int_key, &issuer)
+            .expect("intermediate sign");
+        int_cert.der().to_vec()
+    }
+
+    #[test]
+    fn validate_root_ca_accepts_self_signed_ca() {
+        let der = build_self_signed_ca_with_validity(-1, 30);
+        validate_root_ca(&der).expect("freshly-minted self-signed CA must validate");
+    }
+
+    #[test]
+    fn validate_root_ca_rejects_leaf_cert_without_ca_true() {
+        let der = build_self_signed_leaf();
+        match validate_root_ca(&der).expect_err("leaf cert must be rejected") {
+            Error::InvalidCa(msg) => {
+                assert!(
+                    msg.contains("cA:FALSE") || msg.contains("BasicConstraints"),
+                    "unexpected reason: {msg}"
+                );
+            }
+            other => panic!("expected InvalidCa, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_root_ca_rejects_expired_ca() {
+        // notAfter 1 day ago.
+        let der = build_self_signed_ca_with_validity(-30, -1);
+        match validate_root_ca(&der).expect_err("expired CA must be rejected") {
+            Error::InvalidCa(msg) => {
+                assert!(
+                    msg.contains("not valid"),
+                    "expected validity message, got: {msg}"
+                );
+            }
+            other => panic!("expected InvalidCa, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_root_ca_rejects_non_self_signed_intermediate() {
+        let der = build_non_self_signed_intermediate();
+        match validate_root_ca(&der).expect_err("intermediate must be rejected") {
+            Error::InvalidCa(msg) => {
+                assert!(msg.contains("self-signed"), "unexpected reason: {msg}");
+            }
+            other => panic!("expected InvalidCa, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_root_ca_rejects_garbage_der() {
+        let err = validate_root_ca(b"not der at all").expect_err("garbage DER must be rejected");
+        assert!(matches!(err, Error::InvalidCa(_)));
+    }
+
+    #[test]
+    fn decode_and_validate_root_ca_accepts_valid_pem() {
+        // The fixture `sample-ca.pem` is a valid self-signed CA whose
+        // notAfter is far in the future (`-days 36500` when generated).
+        // If this assertion ever fires in CI it means the fixture has
+        // genuinely expired and needs regeneration.
+        decode_and_validate_root_ca(SAMPLE_CA_PEM)
+            .expect("sample-ca.pem must validate as a root CA");
+    }
+
+    #[test]
+    fn decode_and_validate_root_ca_surfaces_pem_errors_first() {
+        // PEM-syntax error should produce InvalidPem, not InvalidCa, so
+        // the CLI can give the right diagnosis.
+        let err =
+            decode_and_validate_root_ca(b"not a pem at all").expect_err("garbage input must fail");
+        assert!(
+            matches!(err, Error::InvalidPem(_)),
+            "expected InvalidPem, got {err:?}"
         );
     }
 }

--- a/crates/dasclaw_cert_trust/src/platform/macos.rs
+++ b/crates/dasclaw_cert_trust/src/platform/macos.rs
@@ -65,7 +65,7 @@ impl TrustStore for MacOsTrustStore {
     }
 
     fn install(&self, ca_pem: &[u8]) -> Result<()> {
-        let der = pem::decode_first_certificate(ca_pem)?;
+        let der = pem::decode_and_validate_root_ca(ca_pem)?;
         let fingerprint = pem::sha256_hex(&der);
         // If an *older* dasclaw CA is still recorded, reap it before
         // adding the new one. Without this step a fresh `install` after

--- a/crates/dasclaw_cert_trust/src/platform/windows.rs
+++ b/crates/dasclaw_cert_trust/src/platform/windows.rs
@@ -57,7 +57,7 @@ impl TrustStore for WindowsTrustStore {
     }
 
     fn install(&self, ca_pem: &[u8]) -> Result<()> {
-        let der = pem::decode_first_certificate(ca_pem)?;
+        let der = pem::decode_and_validate_root_ca(ca_pem)?;
         let fingerprint = pem::sha256_hex(&der);
         let store = open_root_store()?;
         let result = unsafe {


### PR DESCRIPTION
## 背景 / 目标

实现 issue #375：在把 dasclaw 自签 root CA 写入系统信任库之前，对 X.509 证书做最小但充分的语义校验，避免畸形 / 不合规的证书被安装。

ADR-139 §3.7 列出了"验证 root CA 的合理性"作为 W8 cert-trust crate 的硬性要求；这是 PR2 (#373) 之后的 PR3。

## 改动范围

**生产代码**（`crates/dasclaw_cert_trust/src/`）

- `Cargo.toml`：新增直接依赖 `x509-parser = "0.18"`（之前以 transitive 形式存在）。
- `error.rs`：新增 `Error::InvalidCa(String)` 变体，与 `InvalidPem` 区分，便于 CLI 给出准确诊断。
- `pem.rs`：
  - 新增 `pub(crate) fn validate_root_ca(der: &[u8]) -> Result<()>`，对 DER 执行三条 RFC 5280 规则：
    1. `BasicConstraints CA:TRUE`（§4.2.1.9）— 拒绝叶子证书 / 缺扩展的证书
    2. `validity().is_valid_at(now)`（§4.1.2.5）— 拒绝过期 / 未生效证书，无时钟容忍
    3. `subject == issuer`（DER 字节相等）— 拒绝非自签证书
  - 新增 `pub(crate) fn decode_and_validate_root_ca(ca_pem: &[u8])`，组合 `decode_first_certificate` + `validate_root_ca`。
- `platform/macos.rs` / `platform/windows.rs`：`install()` 入口改用新组合函数。每个文件 1 行替换，**未在已有函数尾部追加 `if` 分支，未复制粘贴逻辑**。

**测试**（`pem.rs` 新增 7 个；`error.rs` 新增 1 个）

- `validate_root_ca_accepts_self_signed_ca`
- `validate_root_ca_rejects_leaf_cert_without_ca_true`
- `validate_root_ca_rejects_expired_ca`
- `validate_root_ca_rejects_non_self_signed_intermediate`
- `validate_root_ca_rejects_garbage_der`
- `decode_and_validate_root_ca_accepts_valid_pem`
- `decode_and_validate_root_ca_surfaces_pem_errors_first`
- `error::tests::invalid_ca_includes_reason`

3 个 fixture builder（基于 `rcgen` 0.14）现场生成证书，断言不会随系统时钟漂移。`rcgen` + `time` 是 dev-deps，已在 workspace lockfile（被 `dasclaw_net_proxy` 使用），未引入新 transitive 树。

## 非目标（What's NOT in this PR）

- ❌ **不验证 self-signature**。CA 由 `dasclaw_net_proxy` 刚刚生成、签名已在生成端验证；在这里再跑一遍 X.509 算法链验证只会增加新 OID 的攻击面而无收益。
- ❌ **不实现 Linux NSS 后端**（沿用 #373 范围）。
- ❌ **不引入 Mozilla revocation 列表 / OCSP / CRL** 检查。这是新装根 CA 而非链路证书。
- ❌ **不重构 `decode_first_certificate`**（仍在 PEM 错误维度负责，不掺杂 X.509 语义）。

## 验证

```text
cargo check -p dasclaw_cert_trust --tests          → clean
cargo nextest run -p dasclaw_cert_trust            → 36 passed, 2 skipped (was 28)
cargo fmt --all                                    → clean
python3.12 scripts/check_no_panics.py --base origin/xClaw → OK
cargo clippy --no-deps -p dasclaw_cert_trust --all-targets -- -D warnings → clean
cargo deny check advisories                        → advisories ok
```

完整 `cargo build --workspace` / workspace clippy 由 CI 兜底。

## Cross-cuts

- ADR-114（`.ironclaw` → `.dasclaw` 命名迁移）：**类A**（本 PR 不新增任何 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量）。
- ADR-129 verbatim port：不涉及（cert-trust 是 dasclaw 原生 crate，非 verbatim port）。
- ADR-139 §3.7：本 PR 直接落实"安装前验证 CA 合理性"。

## 后续

- PR4（W8 收尾）：`cli` integration test、Linux NSS 后端（如需）、ADR-139 W8 状态从 in-progress 推进。

Refs: ADR-139 §3.7
Closes #375
