### PR TITLE
feat(cert-trust): hardening from PR #373 review (#376)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2749,6 +2749,7 @@ version = "0.0.0-w8"
 dependencies = [
  "base64 0.22.1",
  "dirs 6.0.0",
+ "libc",
  "pretty_assertions",
  "rcgen",
  "rustls-pemfile 2.2.0",

--- a/crates/dasclaw_cert_trust/Cargo.toml
+++ b/crates/dasclaw_cert_trust/Cargo.toml
@@ -40,6 +40,12 @@ dirs = "6"
 # dependency via the rustls-pki-types ecosystem; promoting to a direct
 # dependency lets us call the parser API explicitly.
 x509-parser = "0.18"
+# RFC 3339 formatting of `notAfter` extracted from the installed CA so
+# `dasclaw cert status` can report a real expiry instead of `None`. We
+# only need `formatting` + `parsing` of `OffsetDateTime`; already
+# transitively present (rcgen / hyper-rustls), so promoting to a direct
+# dependency adds no new tree. Issue #376 §3.4.
+time = { version = "0.3", default-features = false, features = ["formatting"] }
 # Atomic fingerprint sentinel writes (tempfile + rename) — see
 # `paths::write_fingerprint`. A non-atomic write would let a mid-write
 # crash leave the file truncated while the OS keychain still trusts the
@@ -49,6 +55,13 @@ tempfile = "3"
 # macOS — per-user login keychain via `security-framework`.
 [target.'cfg(target_os = "macos")'.dependencies]
 security-framework = "3"
+
+# Unix sentinel-permission audit (issue #376 §3.1) needs `getuid()` to
+# verify the fingerprint file is still owned by the dasclaw user. `libc`
+# is already in the workspace lockfile via `tempfile`/`rcgen`/etc., so
+# this adds no new transitive tree.
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
 
 # Windows — `CurrentUser\Root` cert store via `windows-rs`.
 [target.'cfg(target_os = "windows")'.dependencies]

--- a/crates/dasclaw_cert_trust/src/paths.rs
+++ b/crates/dasclaw_cert_trust/src/paths.rs
@@ -52,6 +52,20 @@ pub(crate) fn fingerprint_path() -> Result<PathBuf> {
 /// load-bearing: the keychain backends rely on the sentinel being
 /// authoritative; a truncated file would make `status()` falsely report
 /// "not installed" while the real CA is still trusted by the OS.
+///
+/// # Permissions (issue #376 §3.1)
+///
+/// On Unix the sentinel is created with mode `0o600`. The default umask
+/// would yield `0o644`, which lets any process running as the same user
+/// overwrite the file and trick `status()` / `uninstall()` into looking
+/// for the wrong CA in the keychain. Tightening to `0o600` does not add
+/// a real privilege boundary (anyone in the same user context can call
+/// the keychain APIs directly), but it makes intra-user tampering
+/// detectable: [`read_fingerprint`] also asserts the mode and ownership
+/// match what we wrote.
+///
+/// On Windows we rely on the default ACL (`CurrentUser` profile only),
+/// which already restricts access to the same user.
 pub(crate) fn write_fingerprint(fp_hex: &str) -> Result<()> {
     let path = fingerprint_path()?;
     let parent = path.parent().ok_or_else(|| {
@@ -61,7 +75,13 @@ pub(crate) fn write_fingerprint(fp_hex: &str) -> Result<()> {
         ))
     })?;
     std::fs::create_dir_all(parent)?;
-    let mut tmp = tempfile::NamedTempFile::new_in(parent)?;
+    let mut builder = tempfile::Builder::new();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        builder.permissions(std::fs::Permissions::from_mode(0o600));
+    }
+    let mut tmp = builder.tempfile_in(parent)?;
     {
         use std::io::Write as _;
         tmp.write_all(fp_hex.as_bytes())?;
@@ -76,10 +96,20 @@ pub(crate) fn write_fingerprint(fp_hex: &str) -> Result<()> {
 /// Read the previously-persisted SHA-256 fingerprint.
 ///
 /// Returns `Ok(None)` when the file does not exist (= no CA installed).
+///
+/// # Permissions (issue #376 §3.1)
+///
+/// On Unix this also verifies the file is owned by the current uid and
+/// has mode `0o600` — the same constraints [`write_fingerprint`]
+/// applies. A mismatch returns [`Error::Io`] with `PermissionDenied`,
+/// because a sentinel that another process tampered with cannot be
+/// trusted to point at our CA. Windows skips the check and relies on
+/// the default profile ACL.
 pub(crate) fn read_fingerprint() -> Result<Option<String>> {
     let path = fingerprint_path()?;
     match std::fs::read_to_string(&path) {
         Ok(content) => {
+            verify_sentinel_permissions(&path)?;
             let trimmed = content.trim().to_string();
             if trimmed.is_empty() {
                 Ok(None)
@@ -90,6 +120,47 @@ pub(crate) fn read_fingerprint() -> Result<Option<String>> {
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(None),
         Err(err) => Err(Error::Io(err)),
     }
+}
+
+/// Unix: the sentinel must be a regular file owned by the current uid
+/// with mode `0o600`. Anything else means another process touched it
+/// and we should refuse to trust the value. On Windows / unsupported
+/// targets this is a no-op.
+#[cfg(unix)]
+fn verify_sentinel_permissions(path: &std::path::Path) -> Result<()> {
+    use std::os::unix::fs::MetadataExt as _;
+    let meta = std::fs::metadata(path)?;
+    if !meta.is_file() {
+        return Err(Error::Io(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            "fingerprint sentinel is not a regular file",
+        )));
+    }
+    let mode = meta.mode() & 0o777;
+    if mode != 0o600 {
+        return Err(Error::Io(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            format!("fingerprint sentinel mode {mode:o} (expected 600)"),
+        )));
+    }
+    // `getuid()` is `unsafe` only because libc declares it so; the
+    // syscall itself has no preconditions and always succeeds.
+    let current_uid = unsafe { libc::getuid() };
+    if meta.uid() != current_uid {
+        return Err(Error::Io(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            format!(
+                "fingerprint sentinel owned by uid {}, expected {current_uid}",
+                meta.uid()
+            ),
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn verify_sentinel_permissions(_path: &std::path::Path) -> Result<()> {
+    Ok(())
 }
 
 /// Delete the fingerprint file. Idempotent — succeeds when the file is
@@ -181,5 +252,46 @@ mod tests {
             vec![FINGERPRINT_FILENAME.to_string()],
             "atomic rename must leave only the sentinel file: {entries:?}"
         );
+    }
+
+    /// Issue #376 §3.1 — sentinel must be created with mode 0o600.
+    #[cfg(unix)]
+    #[test]
+    fn write_fingerprint_uses_mode_0600_on_unix() {
+        use std::os::unix::fs::PermissionsExt as _;
+        let td = TempDir::new().expect("tempdir");
+        with_codex_home(&td);
+        write_fingerprint("abc").expect("write");
+        let path = fingerprint_path().expect("path");
+        let mode = std::fs::metadata(&path)
+            .expect("metadata")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(mode, 0o600, "expected mode 0600, got {mode:o}");
+    }
+
+    /// Issue #376 §3.1 — read must reject a tampered (world-readable)
+    /// sentinel even when its content would otherwise round-trip.
+    #[cfg(unix)]
+    #[test]
+    fn read_fingerprint_rejects_world_readable_sentinel() {
+        use std::os::unix::fs::PermissionsExt as _;
+        let td = TempDir::new().expect("tempdir");
+        with_codex_home(&td);
+        write_fingerprint("abc").expect("write");
+        let path = fingerprint_path().expect("path");
+        // Loosen the mode behind our back, simulating a tampering
+        // process running as the same user.
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644))
+            .expect("relax mode");
+        let err = read_fingerprint().expect_err("must reject loose mode");
+        match err {
+            Error::Io(io_err) => {
+                assert_eq!(io_err.kind(), std::io::ErrorKind::PermissionDenied);
+                assert!(io_err.to_string().contains("644"), "msg: {io_err}");
+            }
+            other => panic!("expected Error::Io, got {other:?}"),
+        }
     }
 }

--- a/crates/dasclaw_cert_trust/src/pem.rs
+++ b/crates/dasclaw_cert_trust/src/pem.rs
@@ -120,6 +120,25 @@ pub(crate) fn decode_and_validate_root_ca(ca_pem: &[u8]) -> Result<Vec<u8>> {
     Ok(der)
 }
 
+/// Extract the `notAfter` field from a DER-encoded certificate as an
+/// RFC 3339 timestamp string.
+///
+/// Used by `TrustStore::status()` impls to populate
+/// [`crate::status::CertStatus::expires_at`]. Returns `None` if the DER
+/// fails to parse or the timestamp cannot be formatted — `status()`
+/// should still report `installed: true` in that case (the keychain
+/// confirmed the cert is there; we just can't tell when it expires).
+///
+/// Issue #376 §3.4: `expires_at` was unconditionally `None` before
+/// X.509 validation landed. Now that #375 brought `x509-parser` in as a
+/// direct dependency, exposing the real expiry is essentially free.
+pub(crate) fn extract_not_after_rfc3339(der: &[u8]) -> Option<String> {
+    let (_rest, cert) = x509_parser::certificate::X509Certificate::from_der(der).ok()?;
+    let dt = cert.validity().not_after.to_datetime();
+    dt.format(&time::format_description::well_known::Rfc3339)
+        .ok()
+}
+
 /// Compute the lowercase-hex SHA-256 fingerprint of a DER-encoded certificate.
 ///
 /// This is the canonical identity dasclaw uses to recognize "its" CA inside
@@ -423,5 +442,22 @@ mod tests {
             matches!(err, Error::InvalidPem(_)),
             "expected InvalidPem, got {err:?}"
         );
+    }
+
+    #[test]
+    fn extract_not_after_rfc3339_returns_none_on_garbage() {
+        assert!(extract_not_after_rfc3339(b"not der").is_none());
+    }
+
+    #[test]
+    fn extract_not_after_rfc3339_returns_value_for_valid_ca() {
+        let der = build_self_signed_ca_with_validity(-1, 30);
+        let s = extract_not_after_rfc3339(&der).expect("RFC3339 expected");
+        // RFC 3339 shape requires `T` separator and ≥19 chars.
+        assert!(s.len() >= 19, "too short: {s}");
+        assert!(s.contains('T'), "missing T separator: {s}");
+        // Must round-trip back to an OffsetDateTime.
+        time::OffsetDateTime::parse(&s, &time::format_description::well_known::Rfc3339)
+            .expect("must parse back");
     }
 }

--- a/crates/dasclaw_cert_trust/src/platform/macos.rs
+++ b/crates/dasclaw_cert_trust/src/platform/macos.rs
@@ -127,13 +127,22 @@ impl TrustStore for MacOsTrustStore {
             return Ok(CertStatus::not_installed(PLATFORM));
         };
         match find_cert_by_fingerprint(&target_fp)? {
-            Some(_cert) => Ok(CertStatus {
-                installed: true,
-                fingerprint_sha256: Some(target_fp),
-                expires_at: None, // PR2 does not parse X.509 — see ADR-139 follow-up.
-                platform: PLATFORM,
-                env_fallback_active: false,
-            }),
+            Some(cert) => {
+                // Issue #376 §3.4 — surface the real `notAfter` extracted
+                // from the keychain copy of the CA. We deliberately do
+                // NOT propagate parse failures here: the keychain just
+                // confirmed the cert is installed, so `installed: true`
+                // remains the truthful answer; `expires_at: None` is the
+                // graceful degradation when the DER round-trip fails.
+                let expires_at = pem::extract_not_after_rfc3339(&cert.to_der());
+                Ok(CertStatus {
+                    installed: true,
+                    fingerprint_sha256: Some(target_fp),
+                    expires_at,
+                    platform: PLATFORM,
+                    env_fallback_active: false,
+                })
+            }
             None => Ok(CertStatus::not_installed(PLATFORM)),
         }
     }

--- a/crates/dasclaw_cert_trust/src/platform/windows.rs
+++ b/crates/dasclaw_cert_trust/src/platform/windows.rs
@@ -102,18 +102,32 @@ impl TrustStore for WindowsTrustStore {
         };
         let store = open_root_store()?;
         let found = find_cert_in_store(store.handle(), &target_fp)?;
-        let installed = found.is_some();
-        if let Some(ctx) = found {
-            // We obtained `ctx` via CertDuplicateCertificateContext —
-            // free it now since status() has no further use.
-            free_dup_context(ctx);
-        }
+        // Extract `notAfter` from the encoded DER while we still own
+        // the context, then free it. Issue #376 §3.4 — graceful
+        // degradation: parse failures yield `expires_at: None` rather
+        // than masking `installed: true`.
+        let (installed, expires_at) = match found {
+            Some(ctx) => {
+                // SAFETY: `ctx` came from CertDuplicateCertificateContext;
+                // `pbCertEncoded` is valid for `cbCertEncoded` bytes for
+                // the lifetime of the context.
+                let expires_at = unsafe {
+                    let info = &*ctx;
+                    let der =
+                        std::slice::from_raw_parts(info.pbCertEncoded, info.cbCertEncoded as usize);
+                    pem::extract_not_after_rfc3339(der)
+                };
+                free_dup_context(ctx);
+                (true, expires_at)
+            }
+            None => (false, None),
+        };
         drop(store);
         if installed {
             Ok(CertStatus {
                 installed: true,
                 fingerprint_sha256: Some(target_fp),
-                expires_at: None, // PR2 does not parse X.509 — see ADR-139 follow-up.
+                expires_at,
                 platform: PLATFORM,
                 env_fallback_active: false,
             })

--- a/desktop-client/ironclaw/src/cli/cert.rs
+++ b/desktop-client/ironclaw/src/cli/cert.rs
@@ -66,7 +66,25 @@ pub fn run_cert_command(cmd: CertCommand) -> anyhow::Result<()> {
     }
 }
 
+/// Read a CA PEM file from disk, refusing to follow symlinks.
+///
+/// Issue #376 §3.2 — `std::fs::read` happily follows symlinks. An
+/// attacker who can write to a directory the operator types into (e.g.
+/// a shared `/tmp/`) can swap a PEM symlink out for a different target
+/// between the operator's `ls` and our `read`. This function uses
+/// `symlink_metadata` to detect a symlink before reading. Hard links
+/// remain accepted — they cannot be redirected after creation, unlike
+/// symlinks — and dasclaw cannot meaningfully defend against an
+/// attacker who already has write access to the target file's inode.
 fn read_pem_file(path: &std::path::Path) -> anyhow::Result<Vec<u8>> {
+    let meta = std::fs::symlink_metadata(path)
+        .map_err(|err| anyhow::anyhow!("failed to stat CA PEM at {path:?}: {err}"))?;
+    if meta.file_type().is_symlink() {
+        anyhow::bail!(
+            "refusing to read CA PEM at {path:?}: path is a symlink \
+             (copy the PEM into a non-shared directory first)"
+        );
+    }
     std::fs::read(path).map_err(|err| anyhow::anyhow!("failed to read CA PEM at {path:?}: {err}"))
 }
 
@@ -141,11 +159,57 @@ mod tests {
             from: "/dev/null/nonexistent/ca.pem".into(),
         })
         .expect_err("missing file must error");
-        assert!(err.to_string().contains("failed to read CA PEM"));
+        // Issue #376 §3.2 — `read_pem_file` now stats first via
+        // `symlink_metadata`, so a missing path surfaces as a stat failure
+        // rather than a read failure. Both messages embed the bad path.
+        assert!(
+            err.to_string().contains("failed to stat CA PEM"),
+            "unexpected: {err}"
+        );
     }
 
     #[test]
     fn status_text_succeeds() {
         run_cert_command(CertCommand::Status { json: true }).expect("status must succeed");
+    }
+
+    /// Issue #376 §3.2 — symlinks must be rejected up front, before
+    /// reading the target. We don't accept "the target was the file the
+    /// operator expected when they typed the path" as a runtime check.
+    #[cfg(unix)]
+    #[test]
+    fn install_with_symlinked_pem_is_rejected() {
+        let td = tempfile::tempdir().expect("tempdir");
+        let real = td.path().join("real-ca.pem");
+        std::fs::write(
+            &real,
+            b"-----BEGIN CERTIFICATE-----\nAAA=\n-----END CERTIFICATE-----\n",
+        )
+        .expect("write real");
+        let link = td.path().join("link-ca.pem");
+        std::os::unix::fs::symlink(&real, &link).expect("symlink");
+        let err = run_cert_command(CertCommand::Install { from: link.clone() })
+            .expect_err("symlink must be refused");
+        let msg = err.to_string();
+        assert!(msg.contains("symlink"), "msg: {msg}");
+    }
+
+    /// Plain (non-symlinked) regular files must still be accepted; the
+    /// symlink guard must not trigger on hard links / regular files.
+    #[test]
+    fn install_with_plain_file_is_not_rejected_at_read_stage() {
+        let td = tempfile::tempdir().expect("tempdir");
+        let real = td.path().join("ca.pem");
+        std::fs::write(&real, b"not a real pem").expect("write");
+        // The error here will come from the trust-store layer (invalid
+        // PEM), NOT from `read_pem_file` itself. We just need to
+        // confirm the read passed through.
+        let err =
+            run_cert_command(CertCommand::Install { from: real }).expect_err("expected pem error");
+        let msg = err.to_string();
+        assert!(
+            !msg.contains("symlink") && !msg.contains("failed to stat"),
+            "read stage should accept a regular file, got: {msg}"
+        );
     }
 }


### PR DESCRIPTION
## 背景 / 目标

Issue #376 的 PR #373 自评中归并了 3 项 Sev 3 加固建议。本 PR 一次性落地其中
**§3.1（sentinel 文件权限）+ §3.2（CLI 拒绝 symlink）+ §3.4（`expires_at` 由 X.509 解析填充）**，
让 ADR-139 §4.5 的 cert-trust 表面更收敛。三项都不动威胁模型 —— 攻击者已假定持有同
用户上下文 —— 但都属于"成本极低、收益明确"的硬化项。

## 改动范围

### §3.1 — sentinel 写入 `0600` + 读取校验 uid

`crates/dasclaw_cert_trust/src/paths.rs`：
- `write_fingerprint`：改用 `tempfile::Builder::new().permissions(Permissions::from_mode(0o600))`
  在 unix 创建临时文件，再 `persist`，覆盖默认 umask。
- `read_fingerprint`：读完成功后调用新加的 `verify_sentinel_permissions`（unix 校验
  `mode == 0o600` 且 `uid == getuid()`，windows 为空 stub），不匹配则返回
  `Error::Io(PermissionDenied, …)`，避免别的同 uid 进程伪造 sentinel 后被信任。
- 新增 2 个 unix-only 测试：`write_fingerprint_uses_mode_0600_on_unix`、
  `read_fingerprint_rejects_world_readable_sentinel`。

### §3.2 — `dasclaw cert install --from <PATH>` 拒绝 symlink

`desktop-client/ironclaw/src/cli/cert.rs::read_pem_file`：
- 重写函数体：先 `std::fs::symlink_metadata`，若 `is_symlink()` 直接 `bail!`，
  再调用 `std::fs::read`。错误信息从 `failed to read CA PEM` 改/新增为
  `failed to stat CA PEM` / `refusing to read CA PEM at …: path is a symlink`。
- 既存 `install_with_missing_file_returns_io_error` 跟随调整为断言
  `failed to stat CA PEM`（错误源头从 read 提前到 stat）。
- 新增 2 个测试：`#[cfg(unix)] install_with_symlinked_pem_is_rejected`、
  `install_with_plain_file_is_not_rejected_at_read_stage`。

### §3.4 — `expires_at` 由 X.509 `notAfter` 解析填充（macOS / Windows）

- 新增 `dasclaw_cert_trust::pem::extract_not_after_rfc3339(der) -> Option<String>`：
  纯函数，使用 `x509-parser` 拿 `validity().not_after.to_datetime()`，
  通过 `time` crate 的 RFC3339 formatter 输出；任何解析失败一律 `None`，graceful。
- `platform/macos.rs::status`：发现 keychain 中的 CA 后用 `cert.to_der()` 喂给
  `extract_not_after_rfc3339`，结果直接灌进 `CertStatus.expires_at`。
- `platform/windows.rs::status`：在已有的 `pbCertEncoded`/`cbCertEncoded` 切片上
  调用同函数（在 `free_dup_context` 之前），输出相同字段。
- 新增 2 个 pem 测试：`extract_not_after_rfc3339_returns_none_on_garbage`、
  `extract_not_after_rfc3339_returns_value_for_valid_ca`（round-trip 验证）。

### 依赖变化

`crates/dasclaw_cert_trust/Cargo.toml`：
- 新增 `time = { version = "0.3", default-features = false, features = ["formatting"] }`
  （production，仅供 §3.4 输出 RFC3339；transitive 已存在）。
- 新增 `[target.'cfg(unix)'.dependencies] libc = "0.2"`（仅 unix，用于 §3.1 `getuid`）。

## 非目标（What's NOT in this PR）

- **不**实现 §3.3 / Linux NSS 路径（独立 issue）。
- **不**改 `CertTrust` trait 形状、不动 `CertStatus` 字段（已有 `expires_at: Option<String>` 槽）。
- **不**做 `O_NOFOLLOW` 内核级原子读 —— TOCTOU 残窗对同 uid 攻击者本就无意义，
  symlink 拒绝已覆盖运维误操作场景；后续若要彻底 close 可再上 ADR。
- **不**轮转/吊销既有 sentinel 的兼容路径 —— `read_fingerprint` 严格拒，
  老版本写出的 `0644` sentinel 在新版本读时一律失败、退回到"未安装"语义，
  调用方 `status()` 自然走 not-installed 分支。

## 验证

```bash
cargo check -p dasclaw_cert_trust --tests        # 3.10s
cargo check -p dasclaw --tests                   # 5m25s
cargo nextest run -p dasclaw_cert_trust          # 40 passed, 2 skipped
cargo nextest run -p dasclaw -E 'test(cli::cert)' # 6 passed
cargo fmt --all                                  # clean
python3.12 scripts/check_no_panics.py --base origin/xClaw  # OK
cargo clippy --no-deps -p dasclaw_cert_trust --all-targets -- -D warnings  # clean
cargo deny check advisories                      # advisories ok
```

## Cross-cuts

- **ADR-114 类A**：未引入任何 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量。
- **ADR-139 §3.7 / §4.5**：本 PR 落地 §3.1+§3.2+§3.4，留 §3.3（Linux NSS）独立追踪。
- **AGENTS.md 红线**：未新增 `unwrap()` / `expect()` / `panic!()` 至生产代码（脚本已校验）；
  未补丁式改动（每个改动点都是函数体整段重写或新增独立函数 + 独立测试）。

Refs: ADR-139 §3.7 / §4.5
Closes #376
