### PR TITLE
tech-debt(deps): migrate dasclaw_cert_trust off rustls-pemfile (#374)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2752,7 +2752,7 @@ dependencies = [
  "libc",
  "pretty_assertions",
  "rcgen",
- "rustls-pemfile 2.2.0",
+ "rustls-pki-types",
  "security-framework 3.7.0",
  "serde",
  "sha2",

--- a/crates/dasclaw_cert_trust/Cargo.toml
+++ b/crates/dasclaw_cert_trust/Cargo.toml
@@ -29,7 +29,11 @@ tracing = "0.1"
 # PR2 (ADR-139 §4.5) — PEM↔DER decoding, SHA-256 fingerprinting, and
 # base64 encoding (for `export` PEM rewrap) are cross-platform, so they
 # live in `[dependencies]` (not cfg-gated).
-rustls-pemfile = "2"
+#
+# Issue #374 — `rustls-pemfile` 2.x is unmaintained (RUSTSEC-2025-0134);
+# use `rustls-pki-types::pem::PemObject` directly instead. The `std`
+# feature is required for `from_pem_*` blanket impls.
+rustls-pki-types = { version = "1", features = ["std"] }
 sha2 = "0.10"
 base64 = "0.22"
 dirs = "6"

--- a/crates/dasclaw_cert_trust/src/pem.rs
+++ b/crates/dasclaw_cert_trust/src/pem.rs
@@ -4,6 +4,7 @@
 //! deliberately small: only the public functions actually used by the
 //! `TrustStore` impls are exposed.
 
+use rustls_pki_types::pem::{PemObject, SectionKind};
 use sha2::Digest;
 use x509_parser::prelude::FromDer as _;
 
@@ -16,17 +17,23 @@ use crate::error::Error;
 /// - the input contains no `-----BEGIN CERTIFICATE-----` header,
 /// - the base64 body is malformed,
 /// - the first item is not a `CERTIFICATE` (e.g. a private key block).
+///
+/// Issue #374 — uses `rustls-pki-types::pem::PemObject` (the tuple impl
+/// on `(SectionKind, Vec<u8>)`) so we see the kind of the first PEM
+/// section directly. `CertificateDer::from_pem_slice` would skip
+/// non-certificate blocks silently, which would weaken the
+/// "first block is not a CERTIFICATE" error and let a private key
+/// block followed by a certificate slip through unchallenged.
 pub(crate) fn decode_first_certificate(ca_pem: &[u8]) -> Result<Vec<u8>> {
-    let mut cursor = std::io::Cursor::new(ca_pem);
-    match rustls_pemfile::read_one(&mut cursor) {
-        Ok(Some(rustls_pemfile::Item::X509Certificate(der))) => Ok(der.as_ref().to_vec()),
-        Ok(Some(_)) => Err(Error::InvalidPem(
+    match <(SectionKind, Vec<u8>) as PemObject>::pem_slice_iter(ca_pem).next() {
+        Some(Ok((SectionKind::Certificate, der))) => Ok(der),
+        Some(Ok(_)) => Err(Error::InvalidPem(
             "first PEM block is not a CERTIFICATE".into(),
         )),
-        Ok(None) => Err(Error::InvalidPem(
+        None => Err(Error::InvalidPem(
             "no CERTIFICATE block found in PEM input".into(),
         )),
-        Err(err) => Err(Error::InvalidPem(format!("PEM decode failed: {err}"))),
+        Some(Err(err)) => Err(Error::InvalidPem(format!("PEM decode failed: {err}"))),
     }
 }
 

--- a/deny.toml
+++ b/deny.toml
@@ -66,14 +66,14 @@ ignore = [
 
     # rustls-pemfile 2.x is unmaintained as of 2025-10; upstream redirects
     # callers to the `PemObject` trait in `rustls-pki-types`. This crate is
-    # already pulled into the workspace transitively by bollard /
-    # rustls-native-certs / hyper-rustls (libsql), so the surface area was
-    # already present on origin/xClaw. ADR-139 §4.5 PR2 (#372 / PR #373)
-    # additionally added `rustls-pemfile = "2"` as a direct dependency in
-    # `crates/dasclaw_cert_trust` for parsing user-supplied CA PEM bytes.
-    # Migration to `rustls-pki-types::PemObject` is tracked under #374;
-    # there is no security flaw, only a maintenance signal. Remove this
-    # ignore once dasclaw_cert_trust + transitive consumers all migrate.
+    # pulled into the workspace transitively by bollard /
+    # rustls-native-certs / hyper-rustls (libsql); reqwest 0.11 also pulls
+    # the 1.x line. Issue #374 (PR landing this comment) migrated the only
+    # **direct** consumer (`crates/dasclaw_cert_trust`) to
+    # `rustls-pki-types::pem::PemObject`. The transitive paths can only be
+    # cleared once bollard / libsql / reqwest upgrade upstream, so the
+    # ignore stays until `cargo tree -i rustls-pemfile` is empty. There is
+    # no security flaw, only a maintenance signal.
     "RUSTSEC-2025-0134",  # rustls-pemfile unmaintained (no CVE)
 ]
 


### PR DESCRIPTION
## 背景 / 目标

`rustls-pemfile` 2.x 自 2025-10 起被上游标记 unmaintained
([RUSTSEC-2025-0134](https://rustsec.org/advisories/RUSTSEC-2025-0134))；
上游建议改用 `rustls-pki-types::pem::PemObject`。本仓库唯一的**直接**消费者
是 `crates/dasclaw_cert_trust`（PR #373 引入）。

本 PR 完成 `dasclaw_cert_trust` 的迁移，去掉直接依赖。Transitive 路径
（bollard / libsql → hyper-rustls → rustls-native-certs / reqwest 1.x）
按 issue #374 非目标条款留待上游升级。

## 改动范围

### `crates/dasclaw_cert_trust/Cargo.toml`
- 移除直接依赖 `rustls-pemfile = "2"`
- 新增 `rustls-pki-types = { version = "1", features = ["std"] }`（已为 transitive，不增树）

### `crates/dasclaw_cert_trust/src/pem.rs::decode_first_certificate`
- 整段重写（非补丁式）：
  ```rust
  match <(SectionKind, Vec<u8>) as PemObject>::pem_slice_iter(ca_pem).next() {
      Some(Ok((SectionKind::Certificate, der))) => Ok(der),
      Some(Ok(_))    => Err(Error::InvalidPem("first PEM block is not a CERTIFICATE".into())),
      None           => Err(Error::InvalidPem("no CERTIFICATE block found in PEM input".into())),
      Some(Err(e))   => Err(Error::InvalidPem(format!("PEM decode failed: {e}"))),
  }
  ```
- 选用 tuple `(SectionKind, Vec<u8>)` 的 `PemObject` impl 而非
  `CertificateDer::from_pem_slice`：后者会**静默跳过**非证书块，
  会让"first block is not a CERTIFICATE"语义弱化（私钥块后跟证书的情况
  不再被拒）。tuple 版本能直接拿到第一个 section 的 kind。
- 行为完全等价：现有 12 个 pem 模块单测全部不变、全部通过。

### `deny.toml`
- 仅更新 `RUSTSEC-2025-0134` 的注释，反映"直接消费者已迁移、留 ignore
  仅因 transitive 路径"的现状。**不**移除 ignore。

## 非目标（What's NOT in this PR）

- ❌ 不动 bollard / libsql / reqwest transitive 路径上的 `rustls-pemfile`
  （依赖上游升级；issue #374 非目标条款）
- ❌ 不移除 `deny.toml` 里的 `RUSTSEC-2025-0134` ignore（同上）
- ❌ 不动 cert_trust 的对外 API（`TrustStore` trait / `Error` 枚举形状不变）

## 验证

```bash
cargo check -p dasclaw_cert_trust --tests       # 1.84s
cargo nextest run -p dasclaw_cert_trust         # 40 passed, 2 skipped
cargo fmt --all                                 # clean
python3.12 scripts/check_no_panics.py --base origin/xClaw  # OK
cargo clippy --no-deps -p dasclaw_cert_trust --all-targets -- -D warnings  # clean
cargo deny check advisories                     # advisories ok
cargo tree -i 'rustls-pemfile@2.2.0'           # only transitive (bollard / libsql)
                                                # 直接消费者已不在
```

## Cross-cuts

- **ADR-114 类A**：未引入 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量。
- **ADR-139 §4.5**：cert_trust 表面 API 不变，仅替换内部 PEM 解析后端。
- **AGENTS.md 红线**：未新增 `unwrap()`/`expect()`/`panic!()`；
  `decode_first_certificate` 函数体整段重写，未追加 if 分支或 flag 切换。

Refs: RUSTSEC-2025-0134, ADR-139 §4.5
Closes #374
