### PR TITLE
docs(adr-135,adr-136): mark Accepted with nally sign-off

### DIFF
--- a/docs/plans/architecture-refactor/adr-135-sandboxing-crate-adoption-eval.md
+++ b/docs/plans/architecture-refactor/adr-135-sandboxing-crate-adoption-eval.md
@@ -1,8 +1,8 @@
 # ADR-135: codex `sandboxing` crate adoption evaluation (research-only)
 
-- **Status**: 🟡 **Decision: adopt-verbatim-but-blocked** (research-only ADR per [#324](https://github.com/Linnanli/xClaw/issues/324) sub-task 2; implementation is **out of scope** for this PR)
-- **Date**: 2026-05-08
-- **Approver**: pending nally sign-off
+- **Status**: ✅ **Accepted** (path: option 2A whole-crate verbatim port; implementation is **out of scope** for this PR — driven by per-PR ADRs in Wave-A/B/C)
+- **Date**: 2026-05-08 (drafted) / 2026-05-15 (accepted)
+- **Approver**: nally (sign-off in epic [#380](https://github.com/Linnanli/xClaw/issues/380))
 - **Authors**: GitHub Copilot agent
 - **Tracker**: [#324](https://github.com/Linnanli/xClaw/issues/324) sub-task 2 — kernel-level WritableRoot 强制（landlock V3 / sbpl / Win ACL）
 - **Related**:
@@ -238,3 +238,12 @@ cargo fmt --all -- --check   # OK (no .rs changed)
 ## 7. Decision log
 
 - **2026-05-08**: 起草，研究 codex sandboxing crate 与 dasclaw 现状对比，提出三波落地路径。等待 nally sign-off。
+- **2026-05-15**: nally 在 epic [#380](https://github.com/Linnanli/xClaw/issues/380) 沙箱主线 Batch 1 启动源追对话中批准执行。决议落点：
+  - **D1 / §3 路径**：采纳 option 2A — `codex-cli-main/codex-rs/sandboxing/` 整 crate verbatim port 到 `crates/dasclaw_sandboxing/`（5,251 LOC）+ drift guard；拒绝 2B/2C/2D。
+  - **D2 / §2C 拒绝**：禁止在 `dasclaw_sandbox` 内自家实现 landlock/sbpl/Win ACL（违反 ADR-129 §1.3 verbatim 红线 + AGENTS.md 禁止补丁式代码）。
+  - **D3 / §3 wave 归属**：接受 #324 sub-task 2 跨 W6 / W7 落地（不在 W5 闭环）；Wave-A→B→C 顺序约束。
+  - **D4 / §3 Wave 顺序**：A1 (`dasclaw_protocol` 扩，由 ADR-136 单独 govern) → A2 (`dasclaw_net_proxy` 已落地 ADR-137 + PR-N23，本路径已通) → B1 (`dasclaw_sandboxing` 整 crate verbatim) → C1+C2 (adapter 接入 + 退役 dasclaw_sandbox 重叠路径)。
+  - **OQ-1 答**：与 ADR-136 决议合流——`dasclaw_protocol` 走 option 2C two-tier 文件级 verbatim slice（12,547 LOC，70% codex-protocol），不切到类型粒度；W7+ 评估是否升级到 full crate port（ADR-138 单独提）。
+  - **OQ-2 答**：ADR-135 §3 “PR-A2 dasclaw_net_proxy verbatim port” 描述**已过时**——该工作已通过 ADR-137 + PR-N23 落地完成；§1.3 transitive 依赖图中红色 `codex-network-proxy` 标注现应视为已解锁。
+  - **OQ-3 答**：#324 sub-task 2 重 milestone 到 W6 起，跨 W7。
+  - **OQ-4 答**：[#324](https://github.com/Linnanli/xClaw/issues/324) sub-task 2 issue body 字面写“新增 `dasclaw_sandbox/src/{landlock_v3,sbpl_writable_root,win_acl_deny}.rs`” 路径**作废**——该写法早于 ADR-129/132/133/135 verbatim 纪律确立，按本 ADR 修订为“verbatim port `codex sandboxing` 整 crate 到 `crates/dasclaw_sandboxing/`”。issue body 由 epic [#380](https://github.com/Linnanli/xClaw/issues/380) 关联流程更新。

--- a/docs/plans/architecture-refactor/adr-136-protocol-expansion-plan.md
+++ b/docs/plans/architecture-refactor/adr-136-protocol-expansion-plan.md
@@ -1,8 +1,8 @@
 # ADR-136: dasclaw_protocol expansion plan (research-only)
 
-- **Status**: 🟡 **Decision: pending — proposes hybrid approach** (research-only ADR; implementation **out of scope** for this PR)
-- **Date**: 2026-05-08
-- **Approver**: pending nally sign-off
+- **Status**: ✅ **Accepted** (path: option 2C two-tier — file-level verbatim slice now, full crate port deferred to ADR-138; implementation **out of scope** for this PR — driven by per-PR sub-ADRs in Step C1.1 ~ C1.5)
+- **Date**: 2026-05-08 (drafted) / 2026-05-15 (accepted)
+- **Approver**: nally (sign-off in epic [#380](https://github.com/Linnanli/xClaw/issues/380))
 - **Authors**: GitHub Copilot agent
 - **Tracker**: ADR-135 §6 Q1 — "dasclaw_protocol 切片粒度"
 - **Related**:
@@ -223,3 +223,4 @@ cargo fmt --all -- --check   # OK (no .rs changed)
 ## 7. Decision log
 
 - **2026-05-08**: 起草，提出 2C two-tier 方案。等待 nally sign-off 决定走 2A 还是 2C。如选 2C，立即起 issue track step C1.1 - C1.5 五个 PR。
+- **2026-05-15**: nally 在 epic [#380](https://github.com/Linnanli/xClaw/issues/380) 批准 option 2C two-tier file-level verbatim slice；与 ADR-135 OQ-1 合流。下一步：为 step C1.1 起专属 issue（rename `dasclaw_parsed_command` → `dasclaw_protocol` + drift guard 重命名），作为 Wave-A1 的首个实现 PR。Q2 （`protocol.rs` 是否独立编译）仍作为 step C1.5 启动前验证门，不在本 ADR 预答。


### PR DESCRIPTION
## 背景 / 目标

`#380` 沙箱主线 epic 的 Batch 1 启动溯源对话中，nally 批准 ADR-135 + ADR-136 共同方案：
- ADR-135 走 option 2A：`codex sandboxing` 整 crate verbatim port 到 `crates/dasclaw_sandboxing/`
- ADR-136 走 option 2C：`dasclaw_protocol` 文件级 verbatim slice（70% codex-protocol，12,547 LOC），不切到类型粒度
- 两者合流回答 ADR-135 §6 Q1（OQ-1）

本 PR 是**纯文档 PR**，把两个 ADR 从 🟡 draft 翻到 ✅ Accepted，并把 nally 的 D1-D4 + OQ-1~OQ-4 答复落到 Decision log。

## 改动范围

| 文件 | 改动 |
|---|---|
| `docs/plans/architecture-refactor/adr-135-sandboxing-crate-adoption-eval.md` | Status 🟡 → ✅；Decision log 追加 2026-05-15 nally sign-off + D1-D4 + OQ-1~OQ-4 |
| `docs/plans/architecture-refactor/adr-136-protocol-expansion-plan.md` | Status 🟡 → ✅；Decision log 追加 2026-05-15 nally sign-off |

合计 +16 / −6 行。

## 非目标（What's NOT in this PR）

❌ 不写一行 Rust 代码（ADR-135 §4 + ADR-136 §4 明文 out-of-scope）
❌ 不动 `crates/dasclaw_parsed_command/` 任何文件（rename 到 `dasclaw_protocol` 由后续 step C1.1 PR 完成）
❌ 不动 `Cargo.toml` workspace members
❌ 不更新 #324 sub-task 2 issue body（由 epic #380 关联流程在本 PR merge 后更新）
❌ 不起 `dasclaw_sandboxing` PR（待 Wave-A1 step C1.1~C1.5 完成后 Wave-B1 才启动）

## Cross-cuts

**类A** — 不引入新 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量（ADR-114 grep guard 已通过）

## 验证

```
$ git diff --stat origin/xClaw...HEAD
 .../adr-135-sandboxing-crate-adoption-eval.md | 15 ++++++++++++---
 .../adr-136-protocol-expansion-plan.md        |  7 ++++---
 2 files changed, 16 insertions(+), 6 deletions(-)

$ python3.12 scripts/check_no_panics.py --base origin/xClaw
OK: No panic-inducing calls in changed production code.

$ python3 scripts/check_no_new_ironclaw_literal.py --base origin/xClaw
OK: No new .ironclaw / IRONCLAW_BASE_DIR literals introduced.
```

`cargo fmt` 不适用（无 Rust 变更）；`cargo check` 不适用（无 Rust 变更）。

## 后续 PR / 下一步

按 ADR-135 D4 的 Wave 顺序：

1. **PR-A1 Step C1.1**（下一个 PR，本 PR merge 后立即起）：rename `crates/dasclaw_parsed_command/` → `crates/dasclaw_protocol/`，drift guard 脚本同步重命名；机械级改动；预估 ~50 LOC diff（rename + drift guard renames + workspace member rename）
2. **PR-A1 Step C1.2**: 加 `error.rs` + `error_tests.rs` 文件级 verbatim
3. **PR-A1 Step C1.3**: 加 `config_types.rs` 文件级 verbatim
4. **PR-A1 Step C1.4**: 加 `permissions.rs` 文件级 verbatim（最大 PR，2,548 LOC + transitive utils slice 评估）
5. **PR-A1 Step C1.5**: 加 `models.rs` + `protocol.rs` + `network_policy.rs`，验证 ADR-136 Q2（`protocol.rs` 是否独立编译）
6. **PR-B1**: `dasclaw_sandboxing` 整 crate verbatim port（5,251 LOC + sbpl 三文件 + drift guard）
7. **PR-C1 + PR-C2**: `dasclaw_exec` adapter 接 `dasclaw_sandboxing`；`dasclaw_sandbox` 重叠路径退役

epic #380 跟踪整体进度。
