### PR TITLE
docs(adr-136): revise §3 PR ordering to layered bottom-up

### DIFF
--- a/docs/plans/architecture-refactor/adr-136-protocol-expansion-plan.md
+++ b/docs/plans/architecture-refactor/adr-136-protocol-expansion-plan.md
@@ -160,16 +160,59 @@ codex-protocol
 - 选项 Y — 在 step C1 的"verbatim 文件级 slice"边界用 PR 引言记录的"upstream-pinned-types-only" placeholder（拒绝，违反 verbatim）
 - **选项 Z（推荐）** — 把那个 utils crate **小规模 file-level slice** 进 dasclaw_protocol（同样 verbatim 文件级），不新建 crate；step C2 时再分离
 
-### Step C1 PR 拆分
+### Step C1 PR 拆分（2026-05-XX 修订 — 基于实测依赖闭包）
 
-不一次开 5 个文件的 PR；分为：
-- **PR-C1.1**: rename `dasclaw_parsed_command` → `dasclaw_protocol`，drift guard 重命名（小 PR，机械改动）
-- **PR-C1.2**: 加 `error.rs` + `error_tests.rs`（中等 PR）
-- **PR-C1.3**: 加 `config_types.rs`（小 PR）
-- **PR-C1.4**: 加 `permissions.rs`（大 PR，2,548 LOC + 可能引入 transitive utils slice）
-- **PR-C1.5**: 加 `models.rs` + `protocol.rs` + `network_policy.rs`（最大 PR，验证完整闭包）
+> **修订原因**：原计划 PR-C1.2=`error.rs` 单独 port 不可行——`error.rs` `use crate::protocol::*` 直接依赖 5,238 LOC `protocol.rs`（原计划 PR-C1.5 才落地），单 PR 编译失败。同样 `config_types.rs` 与 `openai_models.rs` 互相循环依赖，必须同 PR port。原 §3 顺序违反"verbatim 文件级 slice 必须独立编译"原则；保留旧文本会导致实施时被迫 stub 缺失类型 = 补丁式代码。
+>
+> 实测依赖图详见 §6 Q2 答案。本 §3 修订把 PR 顺序改为**自底向上分层**——每个 PR 内部所有文件互相 cycle-closed，且只 use 已 port 的更下层文件。
 
-每个 PR 验证 `cargo check` 通过 + drift guard 通过 + 旧 use-path 全部 swap 完毕。
+**层级图**（箭头 = "use 关系"）：
+
+```
+┌────────────────────────────────────────────────────────────┐
+│ Layer 4: error.rs / error_tests.rs                         │
+│   ↓ uses ThreadId, auth, exec_output, network_policy,      │
+│     protocol                                               │
+└────────────────────────────────────────────────────────────┘
+                    ↓
+┌────────────────────────────────────────────────────────────┐
+│ Layer 3: protocol / permissions / models / approvals /     │
+│          network_policy / items / request_permissions      │
+│   ↓ inner cycle: protocol↔permissions↔models               │
+└────────────────────────────────────────────────────────────┘
+                    ↓
+┌────────────────────────────────────────────────────────────┐
+│ Layer 2: config_types ↔ openai_models (循环依赖)           │
+└────────────────────────────────────────────────────────────┘
+                    ↓
+┌────────────────────────────────────────────────────────────┐
+│ Layer 1: 14 个叶子（zero crate:: deps）                    │
+│   account, agent_path, auth, dynamic_tools,                │
+│   exec_output(+_tests), mcp, memory_citation,              │
+│   message_history, num_format, plan_tool,                  │
+│   request_user_input, thread_id, tool_name, user_input     │
+└────────────────────────────────────────────────────────────┘
+                    ↓
+┌────────────────────────────────────────────────────────────┐
+│ Layer 0: parse_command.rs (PR #342 已落地)                 │
+└────────────────────────────────────────────────────────────┘
+```
+
+**修订后的 PR 拆分**：
+
+| PR | 内容 | 文件数 | 估算 LOC | 备注 |
+|---|---|---|---|---|
+| **PR-C1.1** | rename `dasclaw_parsed_command` → `dasclaw_protocol` + drift guard 拆分 | 14（含 rename）| +217 / -63 | ✅ 已开 [#382](https://github.com/Linnanli/xClaw/pull/382)（in-flight） |
+| **PR-C1.2** | Layer 1：14 个叶子文件 verbatim port + lib.rs 出口（`AgentPath` / `ThreadId` / `ToolName`）| 14 + lib.rs + drift guard | ~2,500-3,000 | 单 PR；全 zero `crate::` deps，机械度高 |
+| **PR-C1.3** | Layer 2：`config_types.rs` + `openai_models.rs`（互相循环依赖）| 2 + lib.rs + drift guard | ~1,534 | 必须同 PR；解锁 Layer 3 |
+| **PR-C1.4** | Layer 3：`protocol.rs` + `permissions.rs` + `models.rs` + `approvals.rs` + `network_policy.rs` + `items.rs` + `request_permissions.rs` | 7 + lib.rs + drift guard | ~12,000 | 最大 PR；inner cycle protocol↔permissions↔models 必须同 PR；**也是 §6 Q2 实测验证点**——这里发现 `codex_async_utils` / `codex_utils_string` / `codex_utils_image` / `codex_network_proxy` 的 use 真实数量并触发选项 Z（utils file-level slice）|
+| **PR-C1.5** | Layer 4：`error.rs` + `error_tests.rs` | 2 + lib.rs + drift guard | ~1,182 | 收尾；C1 闭环 |
+
+**总数**：5 个 PR（与原计划相同），但每个 PR 现在都能独立编译。
+
+**每个 PR 仍需验证**：`cargo check -p dasclaw_protocol` 通过 + drift guard 通过 + 旧 use-path 全部 swap 完毕。
+
+**Layer 3 拆分应急方案**（如 reviewer 认为 ~12K LOC 单 PR 太大）：在 PR-C1.4 启动前先评估 `{protocol, permissions, models, request_permissions}` 与 `{approvals, network_policy, items}` 是否可拆为 C1.4a + C1.4b（前者 inner cycle 闭包，后者只 use 前者）。机械可行；视 reviewer bandwidth 决定。
 
 ### Step C2 — Full protocol port（W7+）
 
@@ -214,7 +257,13 @@ cargo fmt --all -- --check   # OK (no .rs changed)
 ## 6. Open questions（留给 reviewer）
 
 1. **Q1 — ADR-129 §1.3 解读**：file-level verbatim slice 是否被 §1.3 接受？还是必须 full-crate? 倾向接受（沿用 ADR-133 §2.5 先例）。
-2. **Q2 — `protocol.rs` 5,238 LOC 真的能独立编译吗**：未实测；step C1 启动前必须先 grep `protocol.rs` 中 codex_utils_* / codex_async_utils / codex_network_proxy 的 use 数量决定切分边界。如发现 `codex_network_proxy` use → step C1 必须等 #324 sub-task 3 落地，回到 ADR-135 的 Wave-A 阻塞。
+2. **Q2 — `protocol.rs` 5,238 LOC 真的能独立编译吗**：~~未实测~~ **2026-05-XX 部分回答**：实测 `codex-cli-main/codex-rs/protocol/src/` 全 28 文件 `^use ` 行后得：
+   - **叶子层（14 文件）零 `crate::` deps**：account/agent_path/auth/dynamic_tools/exec_output/mcp/memory_citation/message_history/num_format/plan_tool/request_user_input/thread_id/tool_name/user_input — 全部仅 use stdlib + 外部 crate（`serde`/`schemars`/`ts_rs`/`uuid`/`thiserror`/`chardetng`/`encoding_rs`/`icu_decimal`/`icu_locale_core`）；其中 `auth.rs` 仅 use `serde + thiserror`。
+   - **Layer 2 互相循环**：`config_types.rs` use `crate::openai_models::ReasoningEffort`；`openai_models.rs` use `crate::config_types::{Personality, ReasoningSummary, Verbosity}` → 必须同 PR。
+   - **Layer 3 inner cycle**：`protocol.rs` use `crate::config_types::*`；`permissions.rs` use `crate::protocol::*`；`models.rs` use `crate::permissions::*` + `crate::protocol::SandboxPolicy` → 三文件互相依赖必须同 PR。
+   - **Layer 4 顶端**：`error.rs` use `crate::{ThreadId, auth, exec_output, network_policy, protocol}`，传递依赖整个 Layer 3 闭包 → 必须最后 port。
+   - **transitive utils crate use**（影响选项 Z 触发）：`error.rs` use `codex_async_utils::CancelErr` + `codex_utils_string::truncate_middle_*`；`exec_output.rs` use `chardetng + encoding_rs`（外部 crate 非 codex-utils）；`network_policy.rs` use `codex_network_proxy::*`。`protocol.rs` 5,238 LOC 全 grep 待 PR-C1.4 实施时给最终答案，但目前已知至少需 `codex_async_utils` 与 `codex_utils_string` 各 1 个 file-level slice（选项 Z）。
+   - **`codex_network_proxy` use 已确认存在**（`network_policy.rs` 仅 22 LOC）→ ADR-135 Wave-A 阻塞中"#324 sub-task 3 必须先于或同期 port `codex_network_proxy`"被实证。建议在 PR-C1.4 启动前同期开 PR vendor `dasclaw_network_proxy`（small file-level slice，不开新 ADR-138 全 crate port）。
 3. **Q3 — codex-protocol 升级节奏**：上游近 6 月 commit log 显示 protocol.rs 平均每周加 1-2 个 enum 变体。drift guard 触发频率会很高 — 是否值得更激进地选 2A full port 来抹平这个？
 4. **Q4 — Step C2 时机**：W7 / W8 / W9？建议在 step C1 5 个 PR 全绿后再决定。
 
@@ -224,3 +273,4 @@ cargo fmt --all -- --check   # OK (no .rs changed)
 
 - **2026-05-08**: 起草，提出 2C two-tier 方案。等待 nally sign-off 决定走 2A 还是 2C。如选 2C，立即起 issue track step C1.1 - C1.5 五个 PR。
 - **2026-05-15**: nally 在 epic [#380](https://github.com/Linnanli/xClaw/issues/380) 批准 option 2C two-tier file-level verbatim slice；与 ADR-135 OQ-1 合流。下一步：为 step C1.1 起专属 issue（rename `dasclaw_parsed_command` → `dasclaw_protocol` + drift guard 重命名），作为 Wave-A1 的首个实现 PR。Q2 （`protocol.rs` 是否独立编译）仍作为 step C1.5 启动前验证门，不在本 ADR 预答。
+- **2026-05-XX (本 amendment)**: PR-C1.1 实施期间（[#382](https://github.com/Linnanli/xClaw/pull/382)），实测上游 protocol crate `^use ` 行得真实依赖图，发现原 §3 PR 顺序与依赖闭包冲突——`error.rs`（原 C1.2）传递依赖 `protocol.rs`（原 C1.5），`config_types.rs`（原 C1.3）与 `openai_models.rs` 循环依赖。按原顺序硬推会强制 stub 缺失类型 = 补丁式代码。本 amendment 把 §3 PR 拆分改为自底向上 4 层（叶子 → config_types+openai_models → protocol+models+permissions+approvals+items+network_policy+request_permissions → error），每个 PR 内部 cycle-closed 且只 use 下层；§6 Q2 部分回答归档；总 PR 数仍为 5（不变）。next: 起 PR-C1.2 实现 14 个叶子合并 PR。


### PR DESCRIPTION
## 背景 / 目标

PR-C1.1 实施（#382）期间，对 `codex-cli-main/codex-rs/protocol/src/` 全 28 文件做了 `^use ` grep，得到真实依赖闭包后发现 **ADR-136 §3 原 PR 顺序不可实现**：

- 原 PR-C1.2 = `error.rs` 单独 port → 但 `error.rs` `use crate::protocol::*` 直接依赖 5,238 LOC `protocol.rs`（原 C1.5 才落地）。**单 PR 编译失败**。
- 原 PR-C1.3 = `config_types.rs` 单独 port → 与 `openai_models.rs` 互相**循环依赖**，必须同 PR port。

按原顺序硬推会被迫 stub 缺失类型 = 补丁式代码，违反 AGENTS.md anti-patch-code + ADR-129 §1.3 verbatim 红线。

## 改动范围

**Doc-only**（+59 / −9）— 只动 `docs/plans/architecture-refactor/adr-136-protocol-expansion-plan.md`：

- **§3** — 旧 5-PR 列表替换为 4 层自底向上分层 + 层级图 + PR 表格 + Layer 3 拆分应急方案
- **§6 Q2** — 实测部分回答：14 叶子零 `crate::` deps；Layer 2 cycle；Layer 3 inner cycle (protocol↔permissions↔models)；`codex_network_proxy` 在 `network_policy.rs` 已确认；`codex_async_utils` + `codex_utils_string` 在 `error.rs` 已确认
- **§7** — 2026-05-XX amendment 条目

**总 PR 数仍为 5**（不变），但每个 PR 现在独立编译。

## 非目标

- ❌ 不写 Rust 代码
- ❌ 不开 ADR-138（全 crate verbatim port 仍是未来工作）
- ❌ 不预决 Layer 3 是否拆 4a/4b
- ❌ 不开 `dasclaw_network_proxy` vendor PR（属另 PR）

## 验证

```bash
python3.12 scripts/check_no_panics.py                    OK
python3 scripts/check_no_new_ironclaw_literal.py         OK
git diff --stat HEAD                                     1 file +59 -9
```

## ⚠️ Stacked PR

- **base 不是 `xClaw`**，是 `feat/dasclaw-protocol-rename-c1-1`（PR #382 分支）
- **merge 顺序**：先 #382，再本 PR
- **请先看 #382 再看本 PR**

## Cross-cuts

- 与 ADR-114 关系：**类 A**（doc-only，无 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量新增）

## 后续

- 本 PR merge 后立即开 PR-C1.2（Layer 1 14 叶子文件 verbatim port）
- 在 PR-C1.4 启动前开 `dasclaw_network_proxy` vendor PR

Closes #385
Related: #380 (Wave-A1 epic), #382 (PR-C1.1 in-flight), #383 (PR-C1.1 tracking)
