### PR TITLE
feat(dasclaw_protocol): ADR-136 §3 Step C1.2 — Layer 1 leaves verbatim port (14 modules)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1748,6 +1748,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chardetng"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14b8f0b65b7b08ae3c8187e8d77174de20cb6777864c6b832d8ad365999cf1ea"
+dependencies = [
+ "cfg-if",
+ "encoding_rs",
+ "memchr",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2930,9 +2941,19 @@ dependencies = [
 name = "dasclaw_protocol"
 version = "0.0.0-w6"
 dependencies = [
+ "chardetng",
+ "encoding_rs",
+ "icu_decimal",
+ "icu_locale_core",
+ "icu_provider",
+ "pretty_assertions",
  "schemars 0.8.22",
  "serde",
+ "serde_json",
+ "sys-locale",
+ "thiserror 2.0.18",
  "ts-rs",
+ "uuid",
 ]
 
 [[package]]
@@ -3912,6 +3933,17 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fixed_decimal"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79c3c892f121fff406e5dd6b28c1b30096b95111c30701a899d4f2b18da6d1bd"
+dependencies = [
+ "displaydoc",
+ "smallvec",
+ "writeable",
+]
 
 [[package]]
 name = "fixedbitset"
@@ -5196,35 +5228,81 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
 ]
 
 [[package]]
-name = "icu_locale_core"
-version = "2.1.1"
+name = "icu_decimal"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "288247df2e32aa776ac54fdd64de552149ac43cb840f2761811f0e8d09719dd4"
+dependencies = [
+ "displaydoc",
+ "fixed_decimal",
+ "icu_decimal_data",
+ "icu_locale",
+ "icu_locale_core",
+ "icu_plurals",
+ "icu_provider",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_decimal_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f14a5ca9e8af29eef62064f269078424283d90dbaffeac5225addf62aaabc22"
+
+[[package]]
+name = "icu_locale"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5a396343c7208121dc86e35623d3dfe19814a7613cfd14964994cdc9c9a2e26"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_locale_data",
+ "icu_provider",
+ "potential_utf",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
+ "serde",
  "tinystr",
  "writeable",
  "zerovec",
 ]
 
 [[package]]
-name = "icu_normalizer"
-version = "2.1.1"
+name = "icu_locale_data"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "d5fdcc9ac77c6d74ff5cf6e65ef3181d6af32003b16fce3a77fb451d2f695993"
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -5236,15 +5314,34 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_plurals"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a50023f1d49ad5c4333380328a0d4a19e4b9d6d842ec06639affd5ba47c8103"
+dependencies = [
+ "fixed_decimal",
+ "icu_locale",
+ "icu_plurals_data",
+ "icu_provider",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_plurals_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8485497155dc865f901decb93ecc20d3e467df67bfeceb91e3ba34e2b11e8e1d"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -5256,18 +5353,20 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
+ "serde",
+ "stable_deref_trait",
  "writeable",
  "yoke",
  "zerofrom",
@@ -7847,6 +7946,8 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
+ "serde_core",
+ "writeable",
  "zerovec",
 ]
 
@@ -10791,6 +10892,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sys-locale"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eab9a99a024a169fe8a903cf9d4a3b3601109bcc13bd9e3c6fff259138626c4"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "system-configuration"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11433,11 +11543,12 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
+ "serde_core",
  "zerovec",
 ]
 
@@ -14246,9 +14357,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -14257,9 +14368,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -14414,21 +14525,23 @@ dependencies = [
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
  "zerofrom",
+ "zerovec",
 ]
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
+ "serde",
  "yoke",
  "zerofrom",
  "zerovec-derive",
@@ -14436,9 +14549,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/dasclaw_protocol/Cargo.toml
+++ b/crates/dasclaw_protocol/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 # Verbatim file-level slice of codex-cli-main/codex-rs/protocol/.
-# Currently vendors only `parse_command.rs` (31 LOC, ParsedCommand enum).
-# Will expand per ADR-136 Step C1.2 ~ C1.5 (error.rs, config_types.rs,
-# permissions.rs, models.rs, protocol.rs, network_policy.rs).
+# Layer 1 (C1.2): vendors parse_command + 14 zero-crate-deps leaf modules.
+# Will expand per ADR-136 §3 Step C1.3 ~ C1.5 (config_types/openai_models cycle,
+# protocol/permissions/models hub, error.rs).
 # Mechanical edits per ADR-129 §1.3; rationale in ADR-136 §3.
 # DO NOT hand-edit any vendored *.rs file — drift guard
 # scripts/check_codex_protocol_drift.py verifies hash equality with upstream.
 name = "dasclaw_protocol"
 version = "0.0.0-w6"
 edition = "2024"
-description = "Verbatim file-level slice of codex-protocol (currently ParsedCommand only; will expand per ADR-136)."
+description = "Verbatim file-level slice of codex-protocol (Layer 1 leaves; will expand per ADR-136)."
 license = "Apache-2.0 OR MIT"
 publish = false
 
@@ -17,6 +17,23 @@ publish = false
 path = "src/lib.rs"
 
 [dependencies]
+chardetng = "0.1.17"
+encoding_rs = "0.8.35"
+icu_decimal = "2.1"
+icu_locale_core = "2.1"
+icu_provider = { version = "2.1", features = ["sync"] }
 schemars = "0.8.22"
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+sys-locale = "0.3.2"
+thiserror = "2"
 ts-rs = { version = "11", features = ["serde-json-impl", "no-serde-warnings"] }
+uuid = { version = "1", features = ["serde", "v4", "v7"] }
+
+[dev-dependencies]
+pretty_assertions = "1"
+
+[package.metadata.cargo-shear]
+# `icu_provider` is required for its `sync` feature on `icu_decimal`'s
+# `DecimalFormatter` (otherwise `OnceLock<DecimalFormatter>` rejects `Sync`).
+ignored = ["icu_provider"]

--- a/crates/dasclaw_protocol/src/account.rs
+++ b/crates/dasclaw_protocol/src/account.rs
@@ -1,0 +1,124 @@
+use schemars::JsonSchema;
+use serde::Deserialize;
+use serde::Serialize;
+use ts_rs::TS;
+
+#[derive(Serialize, Deserialize, Copy, Clone, Debug, PartialEq, Eq, JsonSchema, TS, Default)]
+#[serde(rename_all = "lowercase")]
+#[ts(rename_all = "lowercase")]
+pub enum PlanType {
+    #[default]
+    Free,
+    Go,
+    Plus,
+    Pro,
+    ProLite,
+    Team,
+    #[serde(rename = "self_serve_business_usage_based")]
+    #[ts(rename = "self_serve_business_usage_based")]
+    SelfServeBusinessUsageBased,
+    Business,
+    #[serde(rename = "enterprise_cbp_usage_based")]
+    #[ts(rename = "enterprise_cbp_usage_based")]
+    EnterpriseCbpUsageBased,
+    Enterprise,
+    Edu,
+    #[serde(other)]
+    Unknown,
+}
+
+/// Account state returned by a model provider before it is adapted to an app-facing wire type.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProviderAccount {
+    ApiKey,
+    Chatgpt { email: String, plan_type: PlanType },
+    AmazonBedrock,
+}
+
+impl PlanType {
+    pub fn is_team_like(self) -> bool {
+        matches!(self, Self::Team | Self::SelfServeBusinessUsageBased)
+    }
+
+    pub fn is_business_like(self) -> bool {
+        matches!(self, Self::Business | Self::EnterpriseCbpUsageBased)
+    }
+
+    pub fn is_workspace_account(self) -> bool {
+        matches!(
+            self,
+            Self::Team
+                | Self::SelfServeBusinessUsageBased
+                | Self::Business
+                | Self::EnterpriseCbpUsageBased
+                | Self::Enterprise
+                | Self::Edu
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::PlanType;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn usage_based_plan_types_use_expected_wire_names() {
+        assert_eq!(
+            serde_json::to_string(&PlanType::SelfServeBusinessUsageBased)
+                .expect("self-serve business usage based should serialize"),
+            "\"self_serve_business_usage_based\""
+        );
+        assert_eq!(
+            serde_json::to_string(&PlanType::EnterpriseCbpUsageBased)
+                .expect("enterprise cbp usage based should serialize"),
+            "\"enterprise_cbp_usage_based\""
+        );
+        assert_eq!(
+            serde_json::to_string(&PlanType::ProLite).expect("prolite should serialize"),
+            "\"prolite\""
+        );
+        assert_eq!(
+            serde_json::from_str::<PlanType>("\"self_serve_business_usage_based\"")
+                .expect("self-serve business usage based should deserialize"),
+            PlanType::SelfServeBusinessUsageBased
+        );
+        assert_eq!(
+            serde_json::from_str::<PlanType>("\"prolite\"").expect("prolite should deserialize"),
+            PlanType::ProLite
+        );
+        assert_eq!(
+            serde_json::from_str::<PlanType>("\"enterprise_cbp_usage_based\"")
+                .expect("enterprise cbp usage based should deserialize"),
+            PlanType::EnterpriseCbpUsageBased
+        );
+    }
+
+    #[test]
+    fn plan_family_helpers_group_usage_based_variants_with_existing_plans() {
+        assert_eq!(PlanType::Team.is_team_like(), true);
+        assert_eq!(PlanType::SelfServeBusinessUsageBased.is_team_like(), true);
+        assert_eq!(PlanType::Business.is_team_like(), false);
+
+        assert_eq!(PlanType::Business.is_business_like(), true);
+        assert_eq!(PlanType::EnterpriseCbpUsageBased.is_business_like(), true);
+        assert_eq!(PlanType::Team.is_business_like(), false);
+    }
+
+    #[test]
+    fn workspace_account_helper_includes_usage_based_workspace_plans() {
+        assert_eq!(PlanType::Team.is_workspace_account(), true);
+        assert_eq!(
+            PlanType::SelfServeBusinessUsageBased.is_workspace_account(),
+            true
+        );
+        assert_eq!(PlanType::Business.is_workspace_account(), true);
+        assert_eq!(
+            PlanType::EnterpriseCbpUsageBased.is_workspace_account(),
+            true
+        );
+        assert_eq!(PlanType::Enterprise.is_workspace_account(), true);
+        assert_eq!(PlanType::Edu.is_workspace_account(), true);
+        assert_eq!(PlanType::Pro.is_workspace_account(), false);
+    }
+}

--- a/crates/dasclaw_protocol/src/agent_path.rs
+++ b/crates/dasclaw_protocol/src/agent_path.rs
@@ -1,0 +1,240 @@
+use schemars::JsonSchema;
+use serde::Deserialize;
+use serde::Serialize;
+use std::fmt;
+use std::ops::Deref;
+use std::str::FromStr;
+use ts_rs::TS;
+
+#[derive(
+    Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, JsonSchema, TS,
+)]
+#[serde(try_from = "String", into = "String")]
+#[schemars(with = "String")]
+#[ts(type = "string")]
+pub struct AgentPath(String);
+
+impl AgentPath {
+    pub const ROOT: &str = "/root";
+    pub const MORPHEUS: &str = "/morpheus";
+    const ROOT_SEGMENT: &str = "root";
+
+    pub fn root() -> Self {
+        Self(Self::ROOT.to_string())
+    }
+
+    pub fn morpheus() -> Self {
+        Self(Self::MORPHEUS.to_string())
+    }
+
+    pub fn from_string(path: String) -> Result<Self, String> {
+        validate_absolute_path(path.as_str())?;
+        Ok(Self(path))
+    }
+
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+
+    pub fn is_root(&self) -> bool {
+        self.as_str() == Self::ROOT
+    }
+
+    pub fn name(&self) -> &str {
+        if self.is_root() {
+            return Self::ROOT_SEGMENT;
+        }
+        self.as_str()
+            .rsplit('/')
+            .next()
+            .filter(|segment| !segment.is_empty())
+            .unwrap_or(Self::ROOT_SEGMENT)
+    }
+
+    pub fn join(&self, agent_name: &str) -> Result<Self, String> {
+        validate_agent_name(agent_name)?;
+        Self::from_string(format!("{self}/{agent_name}"))
+    }
+
+    pub fn resolve(&self, reference: &str) -> Result<Self, String> {
+        if reference.is_empty() {
+            return Err("agent path must not be empty".to_string());
+        }
+        if reference == Self::ROOT {
+            return Ok(Self::root());
+        }
+        if reference.starts_with('/') {
+            return Self::try_from(reference);
+        }
+
+        validate_relative_reference(reference)?;
+        Self::from_string(format!("{self}/{reference}"))
+    }
+}
+
+impl TryFrom<String> for AgentPath {
+    type Error = String;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::from_string(value)
+    }
+}
+
+impl TryFrom<&str> for AgentPath {
+    type Error = String;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        Self::from_string(value.to_string())
+    }
+}
+
+impl From<AgentPath> for String {
+    fn from(value: AgentPath) -> Self {
+        value.0
+    }
+}
+
+impl FromStr for AgentPath {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::try_from(s)
+    }
+}
+
+impl AsRef<str> for AgentPath {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl Deref for AgentPath {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        self.as_str()
+    }
+}
+
+impl fmt::Display for AgentPath {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+fn validate_agent_name(agent_name: &str) -> Result<(), String> {
+    if agent_name.is_empty() {
+        return Err("agent_name must not be empty".to_string());
+    }
+    if agent_name == AgentPath::ROOT_SEGMENT {
+        return Err("agent_name `root` is reserved".to_string());
+    }
+    if agent_name == "." || agent_name == ".." {
+        return Err(format!("agent_name `{agent_name}` is reserved"));
+    }
+    if agent_name.contains('/') {
+        return Err("agent_name must not contain `/`".to_string());
+    }
+    if !agent_name
+        .chars()
+        .all(|ch| ch.is_ascii_lowercase() || ch.is_ascii_digit() || ch == '_')
+    {
+        return Err(
+            "agent_name must use only lowercase letters, digits, and underscores".to_string(),
+        );
+    }
+    Ok(())
+}
+
+fn validate_absolute_path(path: &str) -> Result<(), String> {
+    if path == AgentPath::MORPHEUS {
+        return Ok(());
+    }
+
+    let Some(stripped) = path.strip_prefix('/') else {
+        return Err("absolute agent paths must start with `/root` or be `/morpheus`".to_string());
+    };
+    let mut segments = stripped.split('/');
+    let Some(root) = segments.next() else {
+        return Err("absolute agent path must not be empty".to_string());
+    };
+    if root != AgentPath::ROOT_SEGMENT {
+        return Err("absolute agent paths must start with `/root` or be `/morpheus`".to_string());
+    }
+    if stripped.ends_with('/') {
+        return Err("absolute agent path must not end with `/`".to_string());
+    }
+    for segment in segments {
+        validate_agent_name(segment)?;
+    }
+    Ok(())
+}
+
+fn validate_relative_reference(reference: &str) -> Result<(), String> {
+    if reference.ends_with('/') {
+        return Err("relative agent path must not end with `/`".to_string());
+    }
+    for segment in reference.split('/') {
+        validate_agent_name(segment)?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::AgentPath;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn root_has_expected_name() {
+        let root = AgentPath::root();
+        assert_eq!(root.as_str(), AgentPath::ROOT);
+        assert_eq!(root.name(), "root");
+        assert!(root.is_root());
+    }
+
+    #[test]
+    fn morpheus_has_expected_name() {
+        let morpheus = AgentPath::morpheus();
+        assert_eq!(morpheus.as_str(), AgentPath::MORPHEUS);
+        assert_eq!(morpheus.name(), "morpheus");
+        assert!(!morpheus.is_root());
+    }
+
+    #[test]
+    fn join_builds_child_paths() {
+        let root = AgentPath::root();
+        let child = root.join("researcher").expect("child path");
+        assert_eq!(child.as_str(), "/root/researcher");
+        assert_eq!(child.name(), "researcher");
+    }
+
+    #[test]
+    fn resolve_supports_relative_and_absolute_references() {
+        let current = AgentPath::try_from("/root/researcher").expect("path");
+        assert_eq!(
+            current.resolve("worker").expect("relative path"),
+            AgentPath::try_from("/root/researcher/worker").expect("path")
+        );
+        assert_eq!(
+            current.resolve("/root/other").expect("absolute path"),
+            AgentPath::try_from("/root/other").expect("path")
+        );
+    }
+
+    #[test]
+    fn invalid_names_and_paths_are_rejected() {
+        assert_eq!(
+            AgentPath::root().join("BadName"),
+            Err("agent_name must use only lowercase letters, digits, and underscores".to_string())
+        );
+        assert_eq!(
+            AgentPath::try_from("/not-root"),
+            Err("absolute agent paths must start with `/root` or be `/morpheus`".to_string())
+        );
+        assert_eq!(
+            AgentPath::root().resolve("../sibling"),
+            Err("agent_name `..` is reserved".to_string())
+        );
+    }
+}

--- a/crates/dasclaw_protocol/src/auth.rs
+++ b/crates/dasclaw_protocol/src/auth.rs
@@ -1,0 +1,120 @@
+use serde::Deserialize;
+use serde::Serialize;
+use thiserror::Error;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum PlanType {
+    Known(KnownPlan),
+    Unknown(String),
+}
+
+impl PlanType {
+    pub fn from_raw_value(raw: &str) -> Self {
+        match raw.to_ascii_lowercase().as_str() {
+            "free" => Self::Known(KnownPlan::Free),
+            "go" => Self::Known(KnownPlan::Go),
+            "plus" => Self::Known(KnownPlan::Plus),
+            "pro" => Self::Known(KnownPlan::Pro),
+            "prolite" => Self::Known(KnownPlan::ProLite),
+            "team" => Self::Known(KnownPlan::Team),
+            "self_serve_business_usage_based" => {
+                Self::Known(KnownPlan::SelfServeBusinessUsageBased)
+            }
+            "business" => Self::Known(KnownPlan::Business),
+            "enterprise_cbp_usage_based" => Self::Known(KnownPlan::EnterpriseCbpUsageBased),
+            "enterprise" | "hc" => Self::Known(KnownPlan::Enterprise),
+            "education" | "edu" => Self::Known(KnownPlan::Edu),
+            _ => Self::Unknown(raw.to_string()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum KnownPlan {
+    Free,
+    Go,
+    Plus,
+    Pro,
+    ProLite,
+    Team,
+    #[serde(rename = "self_serve_business_usage_based")]
+    SelfServeBusinessUsageBased,
+    Business,
+    #[serde(rename = "enterprise_cbp_usage_based")]
+    EnterpriseCbpUsageBased,
+    #[serde(alias = "hc")]
+    Enterprise,
+    Edu,
+}
+
+impl KnownPlan {
+    pub fn display_name(self) -> &'static str {
+        match self {
+            Self::Free => "Free",
+            Self::Go => "Go",
+            Self::Plus => "Plus",
+            Self::Pro => "Pro",
+            Self::ProLite => "Pro Lite",
+            Self::Team => "Team",
+            Self::SelfServeBusinessUsageBased => "Self Serve Business Usage Based",
+            Self::Business => "Business",
+            Self::EnterpriseCbpUsageBased => "Enterprise CBP Usage Based",
+            Self::Enterprise => "Enterprise",
+            Self::Edu => "Edu",
+        }
+    }
+
+    pub fn raw_value(self) -> &'static str {
+        match self {
+            Self::Free => "free",
+            Self::Go => "go",
+            Self::Plus => "plus",
+            Self::Pro => "pro",
+            Self::ProLite => "prolite",
+            Self::Team => "team",
+            Self::SelfServeBusinessUsageBased => "self_serve_business_usage_based",
+            Self::Business => "business",
+            Self::EnterpriseCbpUsageBased => "enterprise_cbp_usage_based",
+            Self::Enterprise => "enterprise",
+            Self::Edu => "edu",
+        }
+    }
+
+    pub fn is_workspace_account(self) -> bool {
+        matches!(
+            self,
+            Self::Team
+                | Self::SelfServeBusinessUsageBased
+                | Self::Business
+                | Self::EnterpriseCbpUsageBased
+                | Self::Enterprise
+                | Self::Edu
+        )
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[error("{message}")]
+pub struct RefreshTokenFailedError {
+    pub reason: RefreshTokenFailedReason,
+    pub message: String,
+}
+
+impl RefreshTokenFailedError {
+    pub fn new(reason: RefreshTokenFailedReason, message: impl Into<String>) -> Self {
+        Self {
+            reason,
+            message: message.into(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RefreshTokenFailedReason {
+    Expired,
+    Exhausted,
+    Revoked,
+    Other,
+}

--- a/crates/dasclaw_protocol/src/dynamic_tools.rs
+++ b/crates/dasclaw_protocol/src/dynamic_tools.rs
@@ -1,0 +1,139 @@
+use schemars::JsonSchema;
+use serde::Deserialize;
+use serde::Deserializer;
+use serde::Serialize;
+use serde_json::Value as JsonValue;
+use ts_rs::TS;
+
+#[derive(Debug, Clone, Serialize, PartialEq, JsonSchema, TS)]
+#[serde(rename_all = "camelCase")]
+pub struct DynamicToolSpec {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub namespace: Option<String>,
+    pub name: String,
+    pub description: String,
+    pub input_schema: JsonValue,
+    #[serde(default)]
+    pub defer_loading: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, JsonSchema, TS)]
+#[serde(rename_all = "camelCase")]
+pub struct DynamicToolCallRequest {
+    pub call_id: String,
+    pub turn_id: String,
+    #[serde(default)]
+    pub namespace: Option<String>,
+    pub tool: String,
+    pub arguments: JsonValue,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, JsonSchema, TS)]
+#[serde(rename_all = "camelCase")]
+pub struct DynamicToolResponse {
+    pub content_items: Vec<DynamicToolCallOutputContentItem>,
+    pub success: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, JsonSchema, TS)]
+#[serde(tag = "type", rename_all = "camelCase")]
+#[ts(tag = "type")]
+pub enum DynamicToolCallOutputContentItem {
+    #[serde(rename_all = "camelCase")]
+    InputText { text: String },
+    #[serde(rename_all = "camelCase")]
+    InputImage { image_url: String },
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct DynamicToolSpecDe {
+    namespace: Option<String>,
+    name: String,
+    description: String,
+    input_schema: JsonValue,
+    defer_loading: Option<bool>,
+    expose_to_context: Option<bool>,
+}
+
+impl<'de> Deserialize<'de> for DynamicToolSpec {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let DynamicToolSpecDe {
+            namespace,
+            name,
+            description,
+            input_schema,
+            defer_loading,
+            expose_to_context,
+        } = DynamicToolSpecDe::deserialize(deserializer)?;
+
+        Ok(Self {
+            namespace,
+            name,
+            description,
+            input_schema,
+            defer_loading: defer_loading
+                .unwrap_or_else(|| expose_to_context.map(|visible| !visible).unwrap_or(false)),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::DynamicToolSpec;
+    use pretty_assertions::assert_eq;
+    use serde_json::json;
+
+    #[test]
+    fn dynamic_tool_spec_deserializes_defer_loading() {
+        let value = json!({
+            "name": "lookup_ticket",
+            "description": "Fetch a ticket",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "id": { "type": "string" }
+                }
+            },
+            "deferLoading": true,
+        });
+
+        let actual: DynamicToolSpec = serde_json::from_value(value).expect("deserialize");
+
+        assert_eq!(
+            actual,
+            DynamicToolSpec {
+                namespace: None,
+                name: "lookup_ticket".to_string(),
+                description: "Fetch a ticket".to_string(),
+                input_schema: json!({
+                    "type": "object",
+                    "properties": {
+                        "id": { "type": "string" }
+                    }
+                }),
+                defer_loading: true,
+            }
+        );
+    }
+
+    #[test]
+    fn dynamic_tool_spec_legacy_expose_to_context_inverts_to_defer_loading() {
+        let value = json!({
+            "name": "lookup_ticket",
+            "description": "Fetch a ticket",
+            "inputSchema": {
+                "type": "object",
+                "properties": {}
+            },
+            "exposeToContext": false,
+        });
+
+        let actual: DynamicToolSpec = serde_json::from_value(value).expect("deserialize");
+
+        assert!(actual.defer_loading);
+    }
+}

--- a/crates/dasclaw_protocol/src/exec_output.rs
+++ b/crates/dasclaw_protocol/src/exec_output.rs
@@ -1,0 +1,169 @@
+//! Text encoding detection and conversion utilities for shell output.
+//!
+//! Windows users frequently run into code pages such as CP1251 or CP866 when invoking commands
+//! through VS Code. Those bytes show up as invalid UTF-8 and used to be replaced with the standard
+//! Unicode replacement character. We now lean on `chardetng` and `encoding_rs` so we can
+//! automatically detect and decode the vast majority of legacy encodings before falling back to
+//! lossy UTF-8 decoding.
+
+use chardetng::EncodingDetector;
+use encoding_rs::Encoding;
+use encoding_rs::IBM866;
+use encoding_rs::WINDOWS_1252;
+use std::time::Duration;
+
+#[derive(Debug, Clone)]
+pub struct StreamOutput<T: Clone> {
+    pub text: T,
+    pub truncated_after_lines: Option<u32>,
+}
+
+impl StreamOutput<String> {
+    pub fn new(text: String) -> Self {
+        Self {
+            text,
+            truncated_after_lines: None,
+        }
+    }
+}
+
+impl StreamOutput<Vec<u8>> {
+    pub fn from_utf8_lossy(&self) -> StreamOutput<String> {
+        StreamOutput {
+            text: bytes_to_string_smart(&self.text),
+            truncated_after_lines: self.truncated_after_lines,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ExecToolCallOutput {
+    pub exit_code: i32,
+    pub stdout: StreamOutput<String>,
+    pub stderr: StreamOutput<String>,
+    pub aggregated_output: StreamOutput<String>,
+    pub duration: Duration,
+    pub timed_out: bool,
+}
+
+impl Default for ExecToolCallOutput {
+    fn default() -> Self {
+        Self {
+            exit_code: 0,
+            stdout: StreamOutput::new(String::new()),
+            stderr: StreamOutput::new(String::new()),
+            aggregated_output: StreamOutput::new(String::new()),
+            duration: Duration::ZERO,
+            timed_out: false,
+        }
+    }
+}
+
+/// Attempts to convert arbitrary bytes to UTF-8 with best-effort encoding detection.
+pub fn bytes_to_string_smart(bytes: &[u8]) -> String {
+    if bytes.is_empty() {
+        return String::new();
+    }
+
+    if let Ok(utf8_str) = std::str::from_utf8(bytes) {
+        return utf8_str.to_owned();
+    }
+
+    let encoding = detect_encoding(bytes);
+    decode_bytes(bytes, encoding)
+}
+
+// Windows-1252 reassigns a handful of 0x80-0x9F slots to smart punctuation (curly quotes, dashes,
+// ™). CP866 uses those *same byte values* for uppercase Cyrillic letters. When chardetng sees shell
+// snippets that mix these bytes with ASCII it sometimes guesses IBM866, so “smart quotes” render as
+// Cyrillic garbage (“УФЦ”) in VS Code. However, CP866 uppercase tokens are perfectly valid output
+// (e.g., `ПРИ test`) so we cannot flip every 0x80-0x9F byte to Windows-1252 either. The compromise
+// is to only coerce IBM866 to Windows-1252 when (a) the high bytes are exclusively the punctuation
+// values listed below and (b) we spot adjacent ASCII. This targets the real failure case without
+// clobbering legitimate Cyrillic text. If another code page has a similar collision, introduce a
+// dedicated allowlist (like this one) plus unit tests that capture the actual shell output we want
+// to preserve. Windows-1252 byte values for smart punctuation.
+const WINDOWS_1252_PUNCT_BYTES: [u8; 8] = [
+    0x91, // ‘ (left single quotation mark)
+    0x92, // ’ (right single quotation mark)
+    0x93, // “ (left double quotation mark)
+    0x94, // ” (right double quotation mark)
+    0x95, // • (bullet)
+    0x96, // – (en dash)
+    0x97, // — (em dash)
+    0x99, // ™ (trade mark sign)
+];
+
+fn detect_encoding(bytes: &[u8]) -> &'static Encoding {
+    let mut detector = EncodingDetector::new();
+    detector.feed(bytes, true);
+    let (encoding, _is_confident) = detector.guess_assess(None, true);
+
+    // chardetng occasionally reports IBM866 for short strings that only contain Windows-1252 “smart
+    // punctuation” bytes (0x80-0x9F) because that range maps to Cyrillic letters in IBM866. When
+    // those bytes show up alongside an ASCII word (typical shell output: `"“`test), we know the
+    // intent was likely CP1252 quotes/dashes. Prefer WINDOWS_1252 in that specific situation so we
+    // render the characters users expect instead of Cyrillic junk. References:
+    // - Windows-1252 reserving 0x80-0x9F for curly quotes/dashes:
+    //   https://en.wikipedia.org/wiki/Windows-1252
+    // - CP866 mapping 0x93/0x94/0x96 to Cyrillic letters, so the same bytes show up as “УФЦ” when
+    //   mis-decoded: https://www.unicode.org/Public/MAPPINGS/VENDORS/MICSFT/PC/CP866.TXT
+    if encoding == IBM866 && looks_like_windows_1252_punctuation(bytes) {
+        return WINDOWS_1252;
+    }
+
+    encoding
+}
+
+fn decode_bytes(bytes: &[u8], encoding: &'static Encoding) -> String {
+    let (decoded, _, had_errors) = encoding.decode(bytes);
+
+    if had_errors {
+        return String::from_utf8_lossy(bytes).into_owned();
+    }
+
+    decoded.into_owned()
+}
+
+/// Detect whether the byte stream looks like Windows-1252 “smart punctuation” wrapped around
+/// otherwise-ASCII text.
+///
+/// Context: IBM866 and Windows-1252 share the 0x80-0x9F slot range. In IBM866 these bytes decode to
+/// Cyrillic letters, whereas Windows-1252 maps them to curly quotes and dashes. chardetng can guess
+/// IBM866 for short snippets that only contain those bytes, which turns shell output such as
+/// `“test”` into unreadable Cyrillic. To avoid that, we treat inputs comprising a handful of bytes
+/// from the problematic range plus ASCII letters as CP1252 punctuation. We deliberately do *not*
+/// cap how many of those punctuation bytes we accept: VS Code frequently prints several quoted
+/// phrases (e.g., `"foo" - "bar"`), and truncating the count would once again mis-decode those as
+/// Cyrillic. If we discover additional encodings with overlapping byte ranges, prefer adding
+/// encoding-specific byte allowlists like `WINDOWS_1252_PUNCT` and tests that exercise real-world
+/// shell snippets.
+fn looks_like_windows_1252_punctuation(bytes: &[u8]) -> bool {
+    let mut saw_extended_punctuation = false;
+    let mut saw_ascii_word = false;
+
+    for &byte in bytes {
+        if byte >= 0xA0 {
+            return false;
+        }
+        if (0x80..=0x9F).contains(&byte) {
+            if !is_windows_1252_punct(byte) {
+                return false;
+            }
+            saw_extended_punctuation = true;
+        }
+        if byte.is_ascii_alphabetic() {
+            saw_ascii_word = true;
+        }
+    }
+
+    saw_extended_punctuation && saw_ascii_word
+}
+
+fn is_windows_1252_punct(byte: u8) -> bool {
+    WINDOWS_1252_PUNCT_BYTES.contains(&byte)
+}
+
+#[cfg(test)]
+#[path = "exec_output_tests.rs"]
+mod tests;

--- a/crates/dasclaw_protocol/src/exec_output_tests.rs
+++ b/crates/dasclaw_protocol/src/exec_output_tests.rs
@@ -1,0 +1,77 @@
+//! Integration test for the text encoding fix for issue #6178.
+//!
+//! These tests simulate VSCode's shell preview on Windows/WSL where the output
+//! may be encoded with a legacy code page before it reaches Codex.
+
+use super::StreamOutput;
+use pretty_assertions::assert_eq;
+
+#[test]
+fn test_utf8_shell_output() {
+    // Baseline: UTF-8 output should bypass the detector and remain unchanged.
+    assert_eq!(decode_shell_output("пример".as_bytes()), "пример");
+}
+
+#[test]
+fn test_cp1251_shell_output() {
+    // VS Code shells on Windows frequently surface CP1251 bytes for Cyrillic text.
+    assert_eq!(decode_shell_output(b"\xEF\xF0\xE8\xEC\xE5\xF0"), "пример");
+}
+
+#[test]
+fn test_cp866_shell_output() {
+    // Native cmd.exe still defaults to CP866; make sure we recognize that too.
+    assert_eq!(decode_shell_output(b"\xAF\xE0\xA8\xAC\xA5\xE0"), "пример");
+}
+
+#[test]
+fn test_windows_1252_smart_decoding() {
+    // Smart detection should turn fancy quotes/dashes into the proper Unicode glyphs.
+    assert_eq!(
+        decode_shell_output(b"\x93\x94 test \x96 dash"),
+        "\u{201C}\u{201D} test \u{2013} dash"
+    );
+}
+
+#[test]
+fn test_smart_decoding_improves_over_lossy_utf8() {
+    // Regression guard: String::from_utf8_lossy() alone used to emit replacement chars here.
+    let bytes = b"\x93\x94 test \x96 dash";
+    assert!(
+        String::from_utf8_lossy(bytes).contains('\u{FFFD}'),
+        "lossy UTF-8 should inject replacement chars"
+    );
+    assert_eq!(
+        decode_shell_output(bytes),
+        "\u{201C}\u{201D} test \u{2013} dash",
+        "smart decoding should keep curly quotes intact"
+    );
+}
+
+#[test]
+fn test_mixed_ascii_and_legacy_encoding() {
+    // Commands tend to mix ASCII status text with Latin-1 bytes (e.g. café).
+    assert_eq!(decode_shell_output(b"Output: caf\xE9"), "Output: café"); // codespell:ignore caf
+}
+
+#[test]
+fn test_pure_latin1_shell_output() {
+    // Latin-1 by itself should still decode correctly (regression coverage for the older tests).
+    assert_eq!(decode_shell_output(b"caf\xE9"), "café"); // codespell:ignore caf
+}
+
+#[test]
+fn test_invalid_bytes_still_fall_back_to_lossy() {
+    // If detection fails, we still want the user to see replacement characters.
+    let bytes = b"\xFF\xFE\xFD";
+    assert_eq!(decode_shell_output(bytes), String::from_utf8_lossy(bytes));
+}
+
+fn decode_shell_output(bytes: &[u8]) -> String {
+    StreamOutput {
+        text: bytes.to_vec(),
+        truncated_after_lines: None,
+    }
+    .from_utf8_lossy()
+    .text
+}

--- a/crates/dasclaw_protocol/src/lib.rs
+++ b/crates/dasclaw_protocol/src/lib.rs
@@ -1,16 +1,32 @@
 //! Verbatim file-level slice of `codex-cli-main/codex-rs/protocol/`.
 //!
-//! **Current scope** (Step C1.1, ADR-136): `parse_command.rs` only — the
-//! 31-LOC `ParsedCommand` enum needed by `dasclaw_shell_command`.
+//! **Current scope** (Step C1.2, ADR-136 §3 layered plan):
+//! Layer 1 zero-`crate::`-deps leaves (14 modules) + `parse_command` from C1.1.
 //!
-//! **Planned expansion** (ADR-136 §3 Step C1.2 ~ C1.5): `error.rs`,
-//! `config_types.rs`, `permissions.rs`, `models.rs`, `protocol.rs`,
-//! `network_policy.rs` (≈12,547 LOC, 70% of codex-protocol).
-//! Step C1.5 verifies whether `protocol.rs` independently compiles or
-//! requires further `codex_utils_*` slices (ADR-136 §6 Q2).
+//! **Planned expansion** (ADR-136 §3 Step C1.3 ~ C1.5):
+//! Layer 2 — `config_types` + `openai_models` (mutual cycle, ~1.5 KLOC);
+//! Layer 3 — `protocol`, `permissions`, `models`, `approvals`, `network_policy`,
+//! `items`, `request_permissions` (~12 KLOC, hub crate);
+//! Layer 4 — `error` + `error_tests` (~1.2 KLOC).
 //!
 //! Verbatim red line per [ADR-129 §1.3](../../docs/plans/architecture-refactor/adr-129-sandbox-windows-windows-crate-adoption.md);
-//! file-level slicing rationale per [ADR-136 §3.1](../../docs/plans/architecture-refactor/adr-136-protocol-expansion-plan.md)
-//! (predecessor: ADR-133 §2.5 single-file slice).
+//! file-level slicing rationale per [ADR-136 §3.1](../../docs/plans/architecture-refactor/adr-136-protocol-expansion-plan.md).
 
+pub mod account;
+mod agent_path;
+pub mod auth;
+mod thread_id;
+mod tool_name;
+pub use agent_path::AgentPath;
+pub use thread_id::ThreadId;
+pub use tool_name::ToolName;
+pub mod dynamic_tools;
+pub mod exec_output;
+pub mod mcp;
+pub mod memory_citation;
+pub mod message_history;
+pub mod num_format;
 pub mod parse_command;
+pub mod plan_tool;
+pub mod request_user_input;
+pub mod user_input;

--- a/crates/dasclaw_protocol/src/mcp.rs
+++ b/crates/dasclaw_protocol/src/mcp.rs
@@ -1,0 +1,360 @@
+//! Types used when representing Model Context Protocol (MCP) values inside the
+//! Codex protocol.
+//!
+//! We intentionally keep these types TS/JSON-schema friendly (via `ts-rs` and
+//! `schemars`) so they can be embedded in Codex's own protocol structures.
+use schemars::JsonSchema;
+use serde::Deserialize;
+use serde::Serialize;
+use ts_rs::TS;
+
+/// ID of a request, which can be either a string or an integer.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema, TS)]
+#[serde(untagged)]
+pub enum RequestId {
+    String(String),
+    #[ts(type = "number")]
+    Integer(i64),
+}
+
+impl std::fmt::Display for RequestId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RequestId::String(s) => f.write_str(s),
+            RequestId::Integer(i) => i.fmt(f),
+        }
+    }
+}
+
+/// Definition for a tool the client can call.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema, TS)]
+#[serde(rename_all = "camelCase")]
+pub struct Tool {
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub title: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub description: Option<String>,
+    pub input_schema: serde_json::Value,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub output_schema: Option<serde_json::Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub annotations: Option<serde_json::Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub icons: Option<Vec<serde_json::Value>>,
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub meta: Option<serde_json::Value>,
+}
+
+/// A known resource that the server is capable of reading.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema, TS)]
+#[serde(rename_all = "camelCase")]
+pub struct Resource {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub annotations: Option<serde_json::Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub description: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub mime_type: Option<String>,
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    #[ts(type = "number")]
+    pub size: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub title: Option<String>,
+    pub uri: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub icons: Option<Vec<serde_json::Value>>,
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub meta: Option<serde_json::Value>,
+}
+
+/// Contents returned when reading a resource from an MCP server.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema, TS)]
+#[serde(untagged)]
+pub enum ResourceContent {
+    #[serde(rename_all = "camelCase")]
+    #[ts(rename_all = "camelCase")]
+    Text {
+        /// The URI of this resource.
+        uri: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        #[ts(optional)]
+        mime_type: Option<String>,
+        text: String,
+        #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+        #[ts(optional)]
+        meta: Option<serde_json::Value>,
+    },
+    #[serde(rename_all = "camelCase")]
+    #[ts(rename_all = "camelCase")]
+    Blob {
+        /// The URI of this resource.
+        uri: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        #[ts(optional)]
+        mime_type: Option<String>,
+        blob: String,
+        #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+        #[ts(optional)]
+        meta: Option<serde_json::Value>,
+    },
+}
+
+/// A template description for resources available on the server.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema, TS)]
+#[serde(rename_all = "camelCase")]
+pub struct ResourceTemplate {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub annotations: Option<serde_json::Value>,
+    pub uri_template: String,
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub title: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub description: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub mime_type: Option<String>,
+}
+
+/// The server's response to a tool call.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema, TS)]
+#[serde(rename_all = "camelCase")]
+pub struct CallToolResult {
+    pub content: Vec<serde_json::Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub structured_content: Option<serde_json::Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub is_error: Option<bool>,
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub meta: Option<serde_json::Value>,
+}
+
+// === Adapter helpers ===
+//
+// These types and conversions intentionally live in `codex-protocol` so other crates can convert
+// “wire-shaped” MCP JSON (typically coming from rmcp model structs serialized with serde) into our
+// TS/JsonSchema-friendly protocol types without depending on `mcp-types`.
+
+fn deserialize_lossy_opt_i64<'de, D>(deserializer: D) -> Result<Option<i64>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    match Option::<serde_json::Number>::deserialize(deserializer)? {
+        Some(number) => {
+            if let Some(v) = number.as_i64() {
+                Ok(Some(v))
+            } else if let Some(v) = number.as_u64() {
+                Ok(i64::try_from(v).ok())
+            } else {
+                Ok(None)
+            }
+        }
+        None => Ok(None),
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ToolSerde {
+    name: String,
+    #[serde(default)]
+    title: Option<String>,
+    #[serde(default)]
+    description: Option<String>,
+    #[serde(default, rename = "inputSchema", alias = "input_schema")]
+    input_schema: serde_json::Value,
+    #[serde(default, rename = "outputSchema", alias = "output_schema")]
+    output_schema: Option<serde_json::Value>,
+    #[serde(default)]
+    annotations: Option<serde_json::Value>,
+    #[serde(default)]
+    icons: Option<Vec<serde_json::Value>>,
+    #[serde(rename = "_meta", default)]
+    meta: Option<serde_json::Value>,
+}
+
+impl From<ToolSerde> for Tool {
+    fn from(value: ToolSerde) -> Self {
+        let ToolSerde {
+            name,
+            title,
+            description,
+            input_schema,
+            output_schema,
+            annotations,
+            icons,
+            meta,
+        } = value;
+        Self {
+            name,
+            title,
+            description,
+            input_schema,
+            output_schema,
+            annotations,
+            icons,
+            meta,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ResourceSerde {
+    #[serde(default)]
+    annotations: Option<serde_json::Value>,
+    #[serde(default)]
+    description: Option<String>,
+    #[serde(rename = "mimeType", alias = "mime_type", default)]
+    mime_type: Option<String>,
+    name: String,
+    #[serde(default, deserialize_with = "deserialize_lossy_opt_i64")]
+    size: Option<i64>,
+    #[serde(default)]
+    title: Option<String>,
+    uri: String,
+    #[serde(default)]
+    icons: Option<Vec<serde_json::Value>>,
+    #[serde(rename = "_meta", default)]
+    meta: Option<serde_json::Value>,
+}
+
+impl From<ResourceSerde> for Resource {
+    fn from(value: ResourceSerde) -> Self {
+        let ResourceSerde {
+            annotations,
+            description,
+            mime_type,
+            name,
+            size,
+            title,
+            uri,
+            icons,
+            meta,
+        } = value;
+        Self {
+            annotations,
+            description,
+            mime_type,
+            name,
+            size,
+            title,
+            uri,
+            icons,
+            meta,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ResourceTemplateSerde {
+    #[serde(default)]
+    annotations: Option<serde_json::Value>,
+    #[serde(rename = "uriTemplate", alias = "uri_template")]
+    uri_template: String,
+    name: String,
+    #[serde(default)]
+    title: Option<String>,
+    #[serde(default)]
+    description: Option<String>,
+    #[serde(rename = "mimeType", alias = "mime_type", default)]
+    mime_type: Option<String>,
+}
+
+impl From<ResourceTemplateSerde> for ResourceTemplate {
+    fn from(value: ResourceTemplateSerde) -> Self {
+        let ResourceTemplateSerde {
+            annotations,
+            uri_template,
+            name,
+            title,
+            description,
+            mime_type,
+        } = value;
+        Self {
+            annotations,
+            uri_template,
+            name,
+            title,
+            description,
+            mime_type,
+        }
+    }
+}
+
+impl Tool {
+    pub fn from_mcp_value(value: serde_json::Value) -> Result<Self, serde_json::Error> {
+        Ok(serde_json::from_value::<ToolSerde>(value)?.into())
+    }
+}
+
+impl Resource {
+    pub fn from_mcp_value(value: serde_json::Value) -> Result<Self, serde_json::Error> {
+        Ok(serde_json::from_value::<ResourceSerde>(value)?.into())
+    }
+}
+
+impl ResourceTemplate {
+    pub fn from_mcp_value(value: serde_json::Value) -> Result<Self, serde_json::Error> {
+        Ok(serde_json::from_value::<ResourceTemplateSerde>(value)?.into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use pretty_assertions::assert_eq;
+
+    use super::*;
+
+    #[test]
+    fn resource_size_deserializes_without_narrowing() {
+        let resource = serde_json::json!({
+            "name": "big",
+            "uri": "file:///tmp/big",
+            "size": 5_000_000_000u64,
+        });
+
+        let parsed = Resource::from_mcp_value(resource).expect("should deserialize");
+        assert_eq!(parsed.size, Some(5_000_000_000));
+
+        let resource = serde_json::json!({
+            "name": "negative",
+            "uri": "file:///tmp/negative",
+            "size": -1,
+        });
+
+        let parsed = Resource::from_mcp_value(resource).expect("should deserialize");
+        assert_eq!(parsed.size, Some(-1));
+
+        let resource = serde_json::json!({
+            "name": "too_big_for_i64",
+            "uri": "file:///tmp/too_big_for_i64",
+            "size": 18446744073709551615u64,
+        });
+
+        let parsed = Resource::from_mcp_value(resource).expect("should deserialize");
+        assert_eq!(parsed.size, None);
+    }
+}

--- a/crates/dasclaw_protocol/src/memory_citation.rs
+++ b/crates/dasclaw_protocol/src/memory_citation.rs
@@ -1,0 +1,20 @@
+use schemars::JsonSchema;
+use serde::Deserialize;
+use serde::Serialize;
+use ts_rs::TS;
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq, JsonSchema, TS)]
+#[serde(rename_all = "camelCase")]
+pub struct MemoryCitation {
+    pub entries: Vec<MemoryCitationEntry>,
+    pub rollout_ids: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, JsonSchema, TS)]
+#[serde(rename_all = "camelCase")]
+pub struct MemoryCitationEntry {
+    pub path: String,
+    pub line_start: u32,
+    pub line_end: u32,
+    pub note: String,
+}

--- a/crates/dasclaw_protocol/src/message_history.rs
+++ b/crates/dasclaw_protocol/src/message_history.rs
@@ -1,0 +1,11 @@
+use schemars::JsonSchema;
+use serde::Deserialize;
+use serde::Serialize;
+use ts_rs::TS;
+
+#[derive(Serialize, Deserialize, Debug, Clone, JsonSchema, TS)]
+pub struct HistoryEntry {
+    pub conversation_id: String,
+    pub ts: u64,
+    pub text: String,
+}

--- a/crates/dasclaw_protocol/src/num_format.rs
+++ b/crates/dasclaw_protocol/src/num_format.rs
@@ -1,0 +1,103 @@
+use std::sync::OnceLock;
+
+use icu_decimal::DecimalFormatter;
+use icu_decimal::input::Decimal;
+use icu_decimal::options::DecimalFormatterOptions;
+use icu_locale_core::Locale;
+
+fn make_local_formatter() -> Option<DecimalFormatter> {
+    let loc: Locale = sys_locale::get_locale()?.parse().ok()?;
+    DecimalFormatter::try_new(loc.into(), DecimalFormatterOptions::default()).ok()
+}
+
+fn make_en_us_formatter() -> DecimalFormatter {
+    #![allow(clippy::expect_used)]
+    let loc: Locale = "en-US".parse().expect("en-US wasn't a valid locale");
+    DecimalFormatter::try_new(loc.into(), DecimalFormatterOptions::default())
+        .expect("en-US wasn't a valid locale")
+}
+
+fn formatter() -> &'static DecimalFormatter {
+    static FORMATTER: OnceLock<DecimalFormatter> = OnceLock::new();
+    FORMATTER.get_or_init(|| make_local_formatter().unwrap_or_else(make_en_us_formatter))
+}
+
+/// Format an i64 with locale-aware digit separators (e.g. "12345" -> "12,345"
+/// for en-US).
+pub fn format_with_separators(n: i64) -> String {
+    formatter().format(&Decimal::from(n)).to_string()
+}
+
+fn format_with_separators_with_formatter(n: i64, formatter: &DecimalFormatter) -> String {
+    formatter.format(&Decimal::from(n)).to_string()
+}
+
+fn format_si_suffix_with_formatter(n: i64, formatter: &DecimalFormatter) -> String {
+    let n = n.max(0);
+    if n < 1000 {
+        return formatter.format(&Decimal::from(n)).to_string();
+    }
+
+    // Format `n / scale` with the requested number of fractional digits.
+    let format_scaled = |n: i64, scale: i64, frac_digits: u32| -> String {
+        let value = n as f64 / scale as f64;
+        let scaled: i64 = (value * 10f64.powi(frac_digits as i32)).round() as i64;
+        let mut dec = Decimal::from(scaled);
+        dec.multiply_pow10(-(frac_digits as i16));
+        formatter.format(&dec).to_string()
+    };
+
+    const UNITS: [(i64, &str); 3] = [(1_000, "K"), (1_000_000, "M"), (1_000_000_000, "G")];
+    let f = n as f64;
+    for &(scale, suffix) in &UNITS {
+        if (100.0 * f / scale as f64).round() < 1000.0 {
+            return format!("{}{}", format_scaled(n, scale, 2), suffix);
+        } else if (10.0 * f / scale as f64).round() < 1000.0 {
+            return format!("{}{}", format_scaled(n, scale, 1), suffix);
+        } else if (f / scale as f64).round() < 1000.0 {
+            return format!("{}{}", format_scaled(n, scale, 0), suffix);
+        }
+    }
+
+    // Above 1000G, keep whole‑G precision.
+    format!(
+        "{}G",
+        format_with_separators_with_formatter(((n as f64) / 1e9).round() as i64, formatter)
+    )
+}
+
+/// Format token counts to 3 significant figures, using base-10 SI suffixes.
+///
+/// Examples (en-US):
+///   - 999 -> "999"
+///   - 1200 -> "1.20K"
+///   - 123456789 -> "123M"
+pub fn format_si_suffix(n: i64) -> String {
+    format_si_suffix_with_formatter(n, formatter())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn kmg() {
+        let formatter = make_en_us_formatter();
+        let fmt = |n: i64| format_si_suffix_with_formatter(n, &formatter);
+        assert_eq!(fmt(0), "0");
+        assert_eq!(fmt(999), "999");
+        assert_eq!(fmt(1_000), "1.00K");
+        assert_eq!(fmt(1_200), "1.20K");
+        assert_eq!(fmt(10_000), "10.0K");
+        assert_eq!(fmt(100_000), "100K");
+        assert_eq!(fmt(999_500), "1.00M");
+        assert_eq!(fmt(1_000_000), "1.00M");
+        assert_eq!(fmt(1_234_000), "1.23M");
+        assert_eq!(fmt(12_345_678), "12.3M");
+        assert_eq!(fmt(999_950_000), "1.00G");
+        assert_eq!(fmt(1_000_000_000), "1.00G");
+        assert_eq!(fmt(1_234_000_000), "1.23G");
+        // Above 1000G we keep whole‑G precision (no higher unit supported here).
+        assert_eq!(fmt(1_234_000_000_000), "1,234G");
+    }
+}

--- a/crates/dasclaw_protocol/src/plan_tool.rs
+++ b/crates/dasclaw_protocol/src/plan_tool.rs
@@ -1,0 +1,29 @@
+use schemars::JsonSchema;
+use serde::Deserialize;
+use serde::Serialize;
+use ts_rs::TS;
+
+// Types for the TODO tool arguments matching codex-vscode/todo-mcp/src/main.rs
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, TS)]
+#[serde(rename_all = "snake_case")]
+pub enum StepStatus {
+    Pending,
+    InProgress,
+    Completed,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, TS)]
+#[serde(deny_unknown_fields)]
+pub struct PlanItemArg {
+    pub step: String,
+    pub status: StepStatus,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, TS)]
+#[serde(deny_unknown_fields)]
+pub struct UpdatePlanArgs {
+    /// Arguments for the `update_plan` todo/checklist tool (not plan mode).
+    #[serde(default)]
+    pub explanation: Option<String>,
+    pub plan: Vec<PlanItemArg>,
+}

--- a/crates/dasclaw_protocol/src/request_user_input.rs
+++ b/crates/dasclaw_protocol/src/request_user_input.rs
@@ -1,0 +1,55 @@
+use std::collections::HashMap;
+
+use schemars::JsonSchema;
+use serde::Deserialize;
+use serde::Serialize;
+use ts_rs::TS;
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, JsonSchema, TS)]
+pub struct RequestUserInputQuestionOption {
+    pub label: String,
+    pub description: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, JsonSchema, TS)]
+pub struct RequestUserInputQuestion {
+    pub id: String,
+    pub header: String,
+    pub question: String,
+    #[serde(rename = "isOther", default)]
+    #[schemars(rename = "isOther")]
+    #[ts(rename = "isOther")]
+    pub is_other: bool,
+    #[serde(rename = "isSecret", default)]
+    #[schemars(rename = "isSecret")]
+    #[ts(rename = "isSecret")]
+    pub is_secret: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub options: Option<Vec<RequestUserInputQuestionOption>>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, JsonSchema, TS)]
+pub struct RequestUserInputArgs {
+    pub questions: Vec<RequestUserInputQuestion>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, JsonSchema, TS)]
+pub struct RequestUserInputAnswer {
+    pub answers: Vec<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, JsonSchema, TS)]
+pub struct RequestUserInputResponse {
+    pub answers: HashMap<String, RequestUserInputAnswer>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, JsonSchema, TS)]
+pub struct RequestUserInputEvent {
+    /// Responses API call id for the associated tool call, if available.
+    pub call_id: String,
+    /// Turn ID that this request belongs to.
+    /// Uses `#[serde(default)]` for backwards compatibility.
+    #[serde(default)]
+    pub turn_id: String,
+    pub questions: Vec<RequestUserInputQuestion>,
+}

--- a/crates/dasclaw_protocol/src/thread_id.rs
+++ b/crates/dasclaw_protocol/src/thread_id.rs
@@ -1,0 +1,103 @@
+use std::fmt::Display;
+
+use schemars::JsonSchema;
+use schemars::r#gen::SchemaGenerator;
+use schemars::schema::Schema;
+use serde::Deserialize;
+use serde::Serialize;
+use ts_rs::TS;
+use uuid::Uuid;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, TS, Hash)]
+#[ts(type = "string")]
+pub struct ThreadId {
+    uuid: Uuid,
+}
+
+impl ThreadId {
+    pub fn new() -> Self {
+        Self {
+            uuid: Uuid::now_v7(),
+        }
+    }
+
+    pub fn from_string(s: &str) -> Result<Self, uuid::Error> {
+        Ok(Self {
+            uuid: Uuid::parse_str(s)?,
+        })
+    }
+}
+
+impl TryFrom<&str> for ThreadId {
+    type Error = uuid::Error;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        Self::from_string(value)
+    }
+}
+
+impl TryFrom<String> for ThreadId {
+    type Error = uuid::Error;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::from_string(value.as_str())
+    }
+}
+
+impl From<ThreadId> for String {
+    fn from(value: ThreadId) -> Self {
+        value.to_string()
+    }
+}
+
+impl Default for ThreadId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Display for ThreadId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Display::fmt(&self.uuid, f)
+    }
+}
+
+impl Serialize for ThreadId {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.collect_str(&self.uuid)
+    }
+}
+
+impl<'de> Deserialize<'de> for ThreadId {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        let uuid = Uuid::parse_str(&value).map_err(serde::de::Error::custom)?;
+        Ok(Self { uuid })
+    }
+}
+
+impl JsonSchema for ThreadId {
+    fn schema_name() -> String {
+        "ThreadId".to_string()
+    }
+
+    fn json_schema(generator: &mut SchemaGenerator) -> Schema {
+        <String>::json_schema(generator)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn test_thread_id_default_is_not_zeroes() {
+        let id = ThreadId::default();
+        assert_ne!(id.uuid, Uuid::nil());
+    }
+}

--- a/crates/dasclaw_protocol/src/tool_name.rs
+++ b/crates/dasclaw_protocol/src/tool_name.rs
@@ -1,0 +1,62 @@
+use serde::Deserialize;
+use serde::Serialize;
+use std::fmt;
+
+/// Identifies a callable tool, preserving the namespace split when the model
+/// provides one.
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+pub struct ToolName {
+    pub name: String,
+    pub namespace: Option<String>,
+}
+
+impl ToolName {
+    pub fn new(namespace: Option<String>, name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            namespace,
+        }
+    }
+
+    pub fn plain(name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            namespace: None,
+        }
+    }
+
+    pub fn namespaced(namespace: impl Into<String>, name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            namespace: Some(namespace.into()),
+        }
+    }
+
+    pub fn display(&self) -> String {
+        match &self.namespace {
+            Some(namespace) => format!("{namespace}{}", self.name),
+            None => self.name.clone(),
+        }
+    }
+}
+
+impl fmt::Display for ToolName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.namespace {
+            Some(namespace) => write!(f, "{namespace}{}", self.name),
+            None => f.write_str(&self.name),
+        }
+    }
+}
+
+impl From<String> for ToolName {
+    fn from(name: String) -> Self {
+        Self::plain(name)
+    }
+}
+
+impl From<&str> for ToolName {
+    fn from(name: &str) -> Self {
+        Self::plain(name)
+    }
+}

--- a/crates/dasclaw_protocol/src/user_input.rs
+++ b/crates/dasclaw_protocol/src/user_input.rs
@@ -1,0 +1,109 @@
+use schemars::JsonSchema;
+use serde::Deserialize;
+use serde::Serialize;
+use ts_rs::TS;
+
+/// Conservative cap so one user message cannot monopolize a large context window.
+pub const MAX_USER_INPUT_TEXT_CHARS: usize = 1 << 20;
+
+/// User input
+#[non_exhaustive]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, TS, JsonSchema)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum UserInput {
+    Text {
+        text: String,
+        /// UI-defined spans within `text` that should be treated as special elements.
+        /// These are byte ranges into the UTF-8 `text` buffer and are used to render
+        /// or persist rich input markers (e.g., image placeholders) across history
+        /// and resume without mutating the literal text.
+        #[serde(default)]
+        text_elements: Vec<TextElement>,
+    },
+    /// Pre‑encoded data: URI image.
+    Image { image_url: String },
+
+    /// Local image path provided by the user.  This will be converted to an
+    /// `Image` variant (base64 data URL) during request serialization.
+    LocalImage { path: std::path::PathBuf },
+
+    /// Skill selected by the user (name + path to SKILL.md).
+    Skill {
+        name: String,
+        path: std::path::PathBuf,
+    },
+    /// Explicit structured mention selected by the user.
+    ///
+    /// `path` identifies the exact mention target, for example
+    /// `app://<connector-id>` or `plugin://<plugin-name>@<marketplace-name>`.
+    Mention { name: String, path: String },
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, TS, JsonSchema)]
+pub struct TextElement {
+    /// Byte range in the parent `text` buffer that this element occupies.
+    pub byte_range: ByteRange,
+    /// Optional human-readable placeholder for the element, displayed in the UI.
+    placeholder: Option<String>,
+}
+
+impl TextElement {
+    pub fn new(byte_range: ByteRange, placeholder: Option<String>) -> Self {
+        Self {
+            byte_range,
+            placeholder,
+        }
+    }
+
+    /// Returns a copy of this element with a remapped byte range.
+    ///
+    /// The placeholder is preserved as-is; callers must ensure the new range
+    /// still refers to the same logical element (and same placeholder)
+    /// within the new text.
+    pub fn map_range<F>(&self, map: F) -> Self
+    where
+        F: FnOnce(ByteRange) -> ByteRange,
+    {
+        Self {
+            byte_range: map(self.byte_range),
+            placeholder: self.placeholder.clone(),
+        }
+    }
+
+    pub fn set_placeholder(&mut self, placeholder: Option<String>) {
+        self.placeholder = placeholder;
+    }
+
+    /// Returns the stored placeholder without falling back to the text buffer.
+    ///
+    /// This must only be used inside `From<TextElement>` implementations on equivalent
+    /// protocol types where the source text is unavailable. Prefer `placeholder(text)`
+    /// everywhere else.
+    #[doc(hidden)]
+    pub fn _placeholder_for_conversion_only(&self) -> Option<&str> {
+        self.placeholder.as_deref()
+    }
+
+    pub fn placeholder<'a>(&'a self, text: &'a str) -> Option<&'a str> {
+        self.placeholder
+            .as_deref()
+            .or_else(|| text.get(self.byte_range.start..self.byte_range.end))
+    }
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq, TS, JsonSchema)]
+pub struct ByteRange {
+    /// Start byte offset (inclusive) within the UTF-8 text buffer.
+    pub start: usize,
+    /// End byte offset (exclusive) within the UTF-8 text buffer.
+    pub end: usize,
+}
+
+impl From<std::ops::Range<usize>> for ByteRange {
+    fn from(range: std::ops::Range<usize>) -> Self {
+        Self {
+            start: range.start,
+            end: range.end,
+        }
+    }
+}

--- a/scripts/check_codex_protocol_drift.py
+++ b/scripts/check_codex_protocol_drift.py
@@ -37,11 +37,27 @@ PAIRS: list[tuple[Path, Path]] = []
 PROTO_LOCAL = REPO_ROOT / "crates" / "dasclaw_protocol" / "src"
 PROTO_UPSTREAM = REPO_ROOT / "codex-cli-main" / "codex-rs" / "protocol" / "src"
 
-# ADR-136 Step C1.1: only parse_command.rs is vendored.
-# Step C1.2 ~ C1.5 will append: error.rs, config_types.rs, permissions.rs,
-# models.rs, protocol.rs, network_policy.rs.
+# ADR-136 Step C1.2 (Layer 1): parse_command + 14 zero-crate-deps leaves.
+# Step C1.3 ~ C1.5 will append: config_types, openai_models (cycle);
+# protocol, permissions, models, approvals, network_policy, items,
+# request_permissions (hub); error, error_tests.
 for fname in [
+    "account.rs",
+    "agent_path.rs",
+    "auth.rs",
+    "dynamic_tools.rs",
+    "exec_output.rs",
+    "exec_output_tests.rs",
+    "mcp.rs",
+    "memory_citation.rs",
+    "message_history.rs",
+    "num_format.rs",
     "parse_command.rs",
+    "plan_tool.rs",
+    "request_user_input.rs",
+    "thread_id.rs",
+    "tool_name.rs",
+    "user_input.rs",
 ]:
     PAIRS.append((PROTO_LOCAL / fname, PROTO_UPSTREAM / fname))
 


### PR DESCRIPTION
## 背景 / 目标

ADR-136 §3 Step C1.2（[#387](https://github.com/Linnanli/xClaw/pull/387) 修订后的 4 层自底向上计划）的 **Layer 1**：从 `codex-cli-main/codex-rs/protocol/src/` verbatim 复制 14 个零 `crate::` 依赖的叶子模块到 `crates/dasclaw_protocol/src/`。

这是 [#380](https://github.com/Linnanli/xClaw/issues/380) Wave-A1 verbatim port chain 的第 2 个 PR，紧跟 [#382](https://github.com/Linnanli/xClaw/pull/382) 的 crate rename。

## 改动范围

**14 个叶子模块**（每个文件 byte-identical 到 upstream）：

| 模块 | 用途 |
|---|---|
| account | Plan/account 类型 |
| agent_path | AgentPath（subagent 路径） |
| auth | OAuth/API key 类型 + thiserror |
| dynamic_tools | 动态工具 spec/legacy |
| exec_output (+ exec_output_tests via `#[path]`) | 命令输出智能解码（CP866/CP1251/Latin1/UTF-8/Windows-1252） |
| mcp | MCP 协议 ResourceSize 等 |
| memory_citation | Memory citation 数据 |
| message_history | 历史消息类型 |
| num_format | ICU 本地化数字格式（kmg） |
| plan_tool | Plan 工具 schema |
| request_user_input | 用户输入请求 |
| thread_id | ThreadId（UUID v7） |
| tool_name | ToolName + JsonSchema |
| user_input | 用户输入类型 |

**机械配套修改**（ADR-129 §1.3 允许范围）：

- `src/lib.rs`：14 个 `pub mod`/`mod` 声明 + 3 个 `pub use` re-exports（`AgentPath`/`ThreadId`/`ToolName`），完全镜像 upstream lib.rs ordering
- `Cargo.toml`：添加新 deps（`chardetng`/`encoding_rs`/`icu_decimal`/`icu_locale_core`/`icu_provider[sync]`/`sys-locale`/`serde_json`/`thiserror`/`uuid`/`pretty_assertions`），版本与 upstream `codex-rs/Cargo.toml` 一致
- `scripts/check_codex_protocol_drift.py`：PAIRS 列表从 1 项扩到 16 项

**禁止项（已遵守）**：

- ❌ 不修改任何 `.rs` 文件内容（drift guard 验证 byte-equality）
- ❌ 不补 stub、不加 `if` 分支、不改算法
- ❌ 不引入 `crate::` 跨文件依赖（Layer 1 定义）

## 非目标

- ❌ Layer 2 (`config_types` + `openai_models` cycle) — 留给 PR-C1.3
- ❌ Layer 3 hub (`protocol`/`permissions`/`models`/...) — 留给 PR-C1.4
- ❌ Layer 4 (`error.rs` + `error_tests.rs`) — 留给 PR-C1.5
- ❌ 接线 / 替换 ironclaw 现有 ParsedCommand 调用方 — 由后续 wave 统一收尾
- ❌ `dasclaw_network_proxy` vendor — Layer 3 启动前另开 PR

## 验证

```bash
cargo check -p dasclaw_protocol --tests          # OK, 0 warn
cargo nextest run -p dasclaw_protocol            # 21 passed
cargo clippy --no-deps -p dasclaw_protocol --all-targets -- -D warnings  # 0 warn
python3.12 scripts/check_codex_protocol_drift.py # OK: 16 files match upstream verbatim
cargo fmt --all                                  # clean
python3.12 scripts/check_no_panics.py --base origin/xClaw  # OK
python3 scripts/check_no_new_ironclaw_literal.py --base origin/xClaw  # OK
```

## Cross-cuts

- 与 ADR-114 关系：**类 A**（无 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量新增）

## 后续

- 本 PR merge 后立即开 PR-C1.3（Layer 2：`config_types` + `openai_models` 循环依赖一起 port）
- Layer 3 启动前另开 `dasclaw_network_proxy` vendor PR

Closes #388
Related: #380 (W1 epic), #382 (C1.1 merged), #387 (ADR-136 §3 amendment merged)
