### PR TITLE
feat(dasclaw_protocol): ADR-136 §3 Step C1.3 — Layer 2 verbatim port (config_types + openai_models cycle)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2942,6 +2942,7 @@ name = "dasclaw_protocol"
 version = "0.0.0-w6"
 dependencies = [
  "chardetng",
+ "dasclaw_absolute_path",
  "encoding_rs",
  "icu_decimal",
  "icu_locale_core",
@@ -2950,8 +2951,11 @@ dependencies = [
  "schemars 0.8.22",
  "serde",
  "serde_json",
+ "strum",
+ "strum_macros",
  "sys-locale",
  "thiserror 2.0.18",
+ "tracing",
  "ts-rs",
  "uuid",
 ]
@@ -10821,6 +10825,24 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "152a0b65a590ff6c3da95cabe2353ee04e6167c896b28e3b14478c2636c922fc"
 dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",

--- a/crates/dasclaw_protocol/Cargo.toml
+++ b/crates/dasclaw_protocol/Cargo.toml
@@ -1,15 +1,14 @@
 [package]
 # Verbatim file-level slice of codex-cli-main/codex-rs/protocol/.
-# Layer 1 (C1.2): vendors parse_command + 14 zero-crate-deps leaf modules.
-# Will expand per ADR-136 §3 Step C1.3 ~ C1.5 (config_types/openai_models cycle,
-# protocol/permissions/models hub, error.rs).
+# Layers 1+2 (C1.2+C1.3): parse_command + 14 leaves + config_types/openai_models cycle.
+# Will expand per ADR-136 §3 Step C1.4 ~ C1.5 (Layer 3 hub, error.rs).
 # Mechanical edits per ADR-129 §1.3; rationale in ADR-136 §3.
 # DO NOT hand-edit any vendored *.rs file — drift guard
 # scripts/check_codex_protocol_drift.py verifies hash equality with upstream.
 name = "dasclaw_protocol"
 version = "0.0.0-w6"
 edition = "2024"
-description = "Verbatim file-level slice of codex-protocol (Layer 1 leaves; will expand per ADR-136)."
+description = "Verbatim file-level slice of codex-protocol (Layers 1+2; will expand per ADR-136)."
 license = "Apache-2.0 OR MIT"
 publish = false
 
@@ -18,6 +17,7 @@ path = "src/lib.rs"
 
 [dependencies]
 chardetng = "0.1.17"
+dasclaw_absolute_path = { path = "../dasclaw_absolute_path" }
 encoding_rs = "0.8.35"
 icu_decimal = "2.1"
 icu_locale_core = "2.1"
@@ -25,8 +25,11 @@ icu_provider = { version = "2.1", features = ["sync"] }
 schemars = "0.8.22"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+strum = "0.27.2"
+strum_macros = "0.28.0"
 sys-locale = "0.3.2"
 thiserror = "2"
+tracing = "0.1.44"
 ts-rs = { version = "11", features = ["serde-json-impl", "no-serde-warnings"] }
 uuid = { version = "1", features = ["serde", "v4", "v7"] }
 
@@ -36,4 +39,5 @@ pretty_assertions = "1"
 [package.metadata.cargo-shear]
 # `icu_provider` is required for its `sync` feature on `icu_decimal`'s
 # `DecimalFormatter` (otherwise `OnceLock<DecimalFormatter>` rejects `Sync`).
-ignored = ["icu_provider"]
+# `strum` is re-exported by `strum_macros` in non-nightly builds (matches upstream).
+ignored = ["icu_provider", "strum"]

--- a/crates/dasclaw_protocol/src/config_types.rs
+++ b/crates/dasclaw_protocol/src/config_types.rs
@@ -1,0 +1,702 @@
+use dasclaw_absolute_path::AbsolutePathBuf;
+use schemars::JsonSchema;
+use schemars::r#gen::SchemaGenerator;
+use schemars::schema::InstanceType;
+use schemars::schema::Metadata;
+use schemars::schema::Schema;
+use schemars::schema::SchemaObject;
+use serde::Deserialize;
+use serde::Serialize;
+use serde_json::Value;
+use std::num::NonZeroU64;
+use std::time::Duration;
+use strum_macros::Display;
+use strum_macros::EnumIter;
+use ts_rs::TS;
+
+use crate::openai_models::ReasoningEffort;
+
+/// A summary of the reasoning performed by the model. This can be useful for
+/// debugging and understanding the model's reasoning process.
+/// See https://platform.openai.com/docs/guides/reasoning?api-mode=responses#reasoning-summaries
+#[derive(
+    Debug, Serialize, Deserialize, Default, Clone, Copy, PartialEq, Eq, Display, JsonSchema, TS,
+)]
+#[serde(rename_all = "lowercase")]
+#[strum(serialize_all = "lowercase")]
+pub enum ReasoningSummary {
+    #[default]
+    Auto,
+    Concise,
+    Detailed,
+    /// Option to disable reasoning summaries.
+    None,
+}
+
+/// Controls output length/detail on GPT-5 models via the Responses API.
+/// Serialized with lowercase values to match the OpenAI API.
+#[derive(
+    Hash,
+    Debug,
+    Serialize,
+    Deserialize,
+    Default,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Display,
+    JsonSchema,
+    TS,
+)]
+#[serde(rename_all = "lowercase")]
+#[strum(serialize_all = "lowercase")]
+pub enum Verbosity {
+    Low,
+    #[default]
+    Medium,
+    High,
+}
+
+#[derive(
+    Deserialize, Debug, Clone, Copy, PartialEq, Default, Serialize, Display, JsonSchema, TS,
+)]
+#[serde(rename_all = "kebab-case")]
+#[strum(serialize_all = "kebab-case")]
+pub enum SandboxMode {
+    #[serde(rename = "read-only")]
+    #[default]
+    ReadOnly,
+
+    #[serde(rename = "workspace-write")]
+    WorkspaceWrite,
+
+    #[serde(rename = "danger-full-access")]
+    DangerFullAccess,
+}
+
+#[derive(Deserialize, Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Display, TS)]
+#[strum(serialize_all = "snake_case")]
+#[ts(type = r#""user" | "auto_review" | "guardian_subagent""#)]
+/// Configures who approval requests are routed to for review. Examples
+/// include sandbox escapes, blocked network access, MCP approval prompts, and
+/// ARC escalations. Defaults to `user`. `auto_review` uses a carefully
+/// prompted subagent to gather relevant context and apply a risk-based
+/// decision framework before approving or denying the request.
+pub enum ApprovalsReviewer {
+    #[default]
+    #[serde(rename = "user")]
+    User,
+    #[serde(rename = "guardian_subagent", alias = "auto_review")]
+    #[strum(serialize = "guardian_subagent")]
+    AutoReview,
+}
+
+impl JsonSchema for ApprovalsReviewer {
+    fn schema_name() -> String {
+        "ApprovalsReviewer".to_string()
+    }
+
+    fn json_schema(_generator: &mut SchemaGenerator) -> Schema {
+        string_enum_schema_with_description(
+            &["user", "auto_review", "guardian_subagent"],
+            "Configures who approval requests are routed to for review. Examples include sandbox escapes, blocked network access, MCP approval prompts, and ARC escalations. Defaults to `user`. `auto_review` uses a carefully prompted subagent to gather relevant context and apply a risk-based decision framework before approving or denying the request. The legacy value `guardian_subagent` is accepted for compatibility.",
+        )
+    }
+}
+
+fn string_enum_schema_with_description(values: &[&str], description: &str) -> Schema {
+    let mut schema = SchemaObject {
+        instance_type: Some(InstanceType::String.into()),
+        metadata: Some(Box::new(Metadata {
+            description: Some(description.to_string()),
+            ..Default::default()
+        })),
+        ..Default::default()
+    };
+    schema.enum_values = Some(
+        values
+            .iter()
+            .map(|value| Value::String((*value).to_string()))
+            .collect(),
+    );
+    Schema::Object(schema)
+}
+
+#[derive(
+    Deserialize, Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Display, JsonSchema, TS,
+)]
+#[serde(rename_all = "kebab-case")]
+#[strum(serialize_all = "kebab-case")]
+pub enum WindowsSandboxLevel {
+    #[default]
+    Disabled,
+    RestrictedToken,
+    Elevated,
+}
+
+#[derive(
+    Debug,
+    Serialize,
+    Deserialize,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Display,
+    JsonSchema,
+    TS,
+    PartialOrd,
+    Ord,
+    EnumIter,
+)]
+#[serde(rename_all = "lowercase")]
+#[strum(serialize_all = "lowercase")]
+pub enum Personality {
+    None,
+    Friendly,
+    Pragmatic,
+}
+
+#[derive(
+    Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Display, JsonSchema, TS, Default,
+)]
+#[serde(rename_all = "lowercase")]
+#[strum(serialize_all = "lowercase")]
+pub enum WebSearchMode {
+    Disabled,
+    #[default]
+    Cached,
+    Live,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Display, JsonSchema, TS)]
+#[serde(rename_all = "lowercase")]
+#[strum(serialize_all = "lowercase")]
+pub enum WebSearchContextSize {
+    Low,
+    Medium,
+    High,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq, Eq, JsonSchema, TS)]
+#[schemars(deny_unknown_fields)]
+pub struct WebSearchLocation {
+    pub country: Option<String>,
+    pub region: Option<String>,
+    pub city: Option<String>,
+    pub timezone: Option<String>,
+}
+
+impl WebSearchLocation {
+    pub fn merge(&self, other: &Self) -> Self {
+        Self {
+            country: other.country.clone().or_else(|| self.country.clone()),
+            region: other.region.clone().or_else(|| self.region.clone()),
+            city: other.city.clone().or_else(|| self.city.clone()),
+            timezone: other.timezone.clone().or_else(|| self.timezone.clone()),
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq, Eq, JsonSchema, TS)]
+#[schemars(deny_unknown_fields)]
+pub struct WebSearchToolConfig {
+    pub context_size: Option<WebSearchContextSize>,
+    pub allowed_domains: Option<Vec<String>>,
+    pub location: Option<WebSearchLocation>,
+}
+
+impl WebSearchToolConfig {
+    pub fn merge(&self, other: &Self) -> Self {
+        Self {
+            context_size: other.context_size.or(self.context_size),
+            allowed_domains: other
+                .allowed_domains
+                .clone()
+                .or_else(|| self.allowed_domains.clone()),
+            location: match (&self.location, &other.location) {
+                (Some(location), Some(other_location)) => Some(location.merge(other_location)),
+                (Some(location), None) => Some(location.clone()),
+                (None, Some(other_location)) => Some(other_location.clone()),
+                (None, None) => None,
+            },
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq, Eq, JsonSchema, TS)]
+#[schemars(deny_unknown_fields)]
+pub struct WebSearchFilters {
+    pub allowed_domains: Option<Vec<String>>,
+}
+
+#[derive(
+    Debug, Serialize, Deserialize, Clone, Copy, Default, PartialEq, Eq, Display, JsonSchema, TS,
+)]
+#[serde(rename_all = "lowercase")]
+#[strum(serialize_all = "lowercase")]
+pub enum WebSearchUserLocationType {
+    #[default]
+    Approximate,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq, Eq, JsonSchema, TS)]
+#[schemars(deny_unknown_fields)]
+pub struct WebSearchUserLocation {
+    #[serde(default)]
+    pub r#type: WebSearchUserLocationType,
+    pub country: Option<String>,
+    pub region: Option<String>,
+    pub city: Option<String>,
+    pub timezone: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq, Eq, JsonSchema, TS)]
+#[schemars(deny_unknown_fields)]
+pub struct WebSearchConfig {
+    pub filters: Option<WebSearchFilters>,
+    pub user_location: Option<WebSearchUserLocation>,
+    pub search_context_size: Option<WebSearchContextSize>,
+}
+
+impl From<WebSearchLocation> for WebSearchUserLocation {
+    fn from(location: WebSearchLocation) -> Self {
+        Self {
+            r#type: WebSearchUserLocationType::Approximate,
+            country: location.country,
+            region: location.region,
+            city: location.city,
+            timezone: location.timezone,
+        }
+    }
+}
+
+impl From<WebSearchToolConfig> for WebSearchConfig {
+    fn from(config: WebSearchToolConfig) -> Self {
+        Self {
+            filters: config
+                .allowed_domains
+                .map(|allowed_domains| WebSearchFilters {
+                    allowed_domains: Some(allowed_domains),
+                }),
+            user_location: config.location.map(Into::into),
+            search_context_size: config.context_size,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Display, JsonSchema, TS)]
+#[serde(rename_all = "lowercase")]
+#[strum(serialize_all = "lowercase")]
+pub enum ServiceTier {
+    Fast,
+    Flex,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Display, JsonSchema, TS)]
+#[serde(rename_all = "lowercase")]
+#[strum(serialize_all = "lowercase")]
+pub enum ForcedLoginMethod {
+    Chatgpt,
+    Api,
+}
+
+const DEFAULT_PROVIDER_AUTH_TIMEOUT_MS: u64 = 5_000;
+const DEFAULT_PROVIDER_AUTH_REFRESH_INTERVAL_MS: u64 = 300_000;
+
+/// Configuration for obtaining a provider bearer token from a command.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, JsonSchema)]
+#[schemars(deny_unknown_fields)]
+pub struct ModelProviderAuthInfo {
+    /// Command to execute. Bare names are resolved via `PATH`; paths are resolved against `cwd`.
+    pub command: String,
+
+    /// Command arguments.
+    #[serde(default)]
+    pub args: Vec<String>,
+
+    /// Maximum time to wait for the token command to exit successfully.
+    #[serde(default = "default_provider_auth_timeout_ms")]
+    pub timeout_ms: NonZeroU64,
+
+    /// Maximum age for the cached token before rerunning the command.
+    /// Set to `0` to disable proactive refresh and only rerun after a 401 retry path.
+    #[serde(default = "default_provider_auth_refresh_interval_ms")]
+    pub refresh_interval_ms: u64,
+
+    /// Working directory used when running the token command.
+    #[serde(default = "default_provider_auth_cwd")]
+    #[schemars(skip_serializing_if = "is_default_provider_auth_cwd")]
+    pub cwd: AbsolutePathBuf,
+}
+
+impl ModelProviderAuthInfo {
+    pub fn timeout(&self) -> Duration {
+        Duration::from_millis(self.timeout_ms.get())
+    }
+
+    pub fn refresh_interval(&self) -> Option<Duration> {
+        NonZeroU64::new(self.refresh_interval_ms).map(|value| Duration::from_millis(value.get()))
+    }
+}
+
+fn default_provider_auth_timeout_ms() -> NonZeroU64 {
+    non_zero_u64(
+        DEFAULT_PROVIDER_AUTH_TIMEOUT_MS,
+        "model_providers.<id>.auth.timeout_ms",
+    )
+}
+
+fn default_provider_auth_refresh_interval_ms() -> u64 {
+    DEFAULT_PROVIDER_AUTH_REFRESH_INTERVAL_MS
+}
+
+fn non_zero_u64(value: u64, field_name: &str) -> NonZeroU64 {
+    match NonZeroU64::new(value) {
+        Some(value) => value,
+        None => panic!("{field_name} must be non-zero"),
+    }
+}
+
+fn default_provider_auth_cwd() -> AbsolutePathBuf {
+    let deserializer = serde::de::value::StrDeserializer::<serde::de::value::Error>::new(".");
+    if let Ok(cwd) = AbsolutePathBuf::deserialize(deserializer) {
+        return cwd;
+    }
+
+    match AbsolutePathBuf::current_dir() {
+        Ok(cwd) => cwd,
+        Err(err) => panic!("provider auth cwd must resolve: {err}"),
+    }
+}
+
+fn is_default_provider_auth_cwd(path: &AbsolutePathBuf) -> bool {
+    path == &default_provider_auth_cwd()
+}
+
+/// Represents the trust level for a project directory.
+/// This determines the approval policy and sandbox mode applied.
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Display, JsonSchema, TS)]
+#[serde(rename_all = "lowercase")]
+#[strum(serialize_all = "lowercase")]
+pub enum TrustLevel {
+    Trusted,
+    Untrusted,
+}
+
+/// Controls whether the TUI uses the terminal's alternate screen buffer.
+///
+/// **Background:** The alternate screen buffer provides a cleaner fullscreen experience
+/// without polluting the terminal's scrollback history. However, it conflicts with terminal
+/// multiplexers like Zellij that strictly follow the xterm specification, which defines
+/// that alternate screen buffers should not have scrollback.
+///
+/// **Zellij's behavior:** Zellij intentionally disables scrollback in alternate screen mode
+/// (see https://github.com/zellij-org/zellij/pull/1032) to comply with the xterm spec. This
+/// is by design and not configurable in Zellij—there is no option to enable scrollback in
+/// alternate screen mode.
+///
+/// **Solution:** This setting provides a pragmatic workaround:
+/// - `auto` (default): Automatically detect the terminal multiplexer. If running in Zellij,
+///   disable alternate screen to preserve scrollback. Enable it everywhere else.
+/// - `always`: Always use alternate screen mode (original behavior before this fix).
+/// - `never`: Never use alternate screen mode. Runs in inline mode, preserving scrollback
+///   in all multiplexers.
+///
+/// The CLI flag `--no-alt-screen` can override this setting at runtime.
+#[derive(
+    Debug, Serialize, Deserialize, Default, Clone, Copy, PartialEq, Eq, Display, JsonSchema, TS,
+)]
+#[serde(rename_all = "lowercase")]
+#[strum(serialize_all = "lowercase")]
+pub enum AltScreenMode {
+    /// Auto-detect: disable alternate screen in Zellij, enable elsewhere.
+    #[default]
+    Auto,
+    /// Always use alternate screen (original behavior).
+    Always,
+    /// Never use alternate screen (inline mode only).
+    Never,
+}
+
+/// Initial collaboration mode to use when the TUI starts.
+#[derive(
+    Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, Hash, JsonSchema, TS, Default,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum ModeKind {
+    Plan,
+    #[default]
+    #[serde(
+        alias = "code",
+        alias = "pair_programming",
+        alias = "execute",
+        alias = "custom"
+    )]
+    Default,
+    #[doc(hidden)]
+    #[serde(skip_serializing, skip_deserializing)]
+    #[schemars(skip)]
+    #[ts(skip)]
+    PairProgramming,
+    #[doc(hidden)]
+    #[serde(skip_serializing, skip_deserializing)]
+    #[schemars(skip)]
+    #[ts(skip)]
+    Execute,
+}
+
+pub const TUI_VISIBLE_COLLABORATION_MODES: [ModeKind; 2] = [ModeKind::Default, ModeKind::Plan];
+
+impl ModeKind {
+    pub const fn display_name(self) -> &'static str {
+        match self {
+            Self::Plan => "Plan",
+            Self::Default => "Default",
+            Self::PairProgramming => "Pair Programming",
+            Self::Execute => "Execute",
+        }
+    }
+
+    pub const fn is_tui_visible(self) -> bool {
+        matches!(self, Self::Plan | Self::Default)
+    }
+
+    pub const fn allows_request_user_input(self) -> bool {
+        matches!(self, Self::Plan)
+    }
+}
+
+/// Collaboration mode for a Codex session.
+#[derive(Clone, PartialEq, Eq, Hash, Debug, Serialize, Deserialize, JsonSchema, TS)]
+#[serde(rename_all = "lowercase")]
+pub struct CollaborationMode {
+    pub mode: ModeKind,
+    pub settings: Settings,
+}
+
+impl CollaborationMode {
+    /// Returns a reference to the settings.
+    fn settings_ref(&self) -> &Settings {
+        &self.settings
+    }
+
+    pub fn model(&self) -> &str {
+        self.settings_ref().model.as_str()
+    }
+
+    pub fn reasoning_effort(&self) -> Option<ReasoningEffort> {
+        self.settings_ref().reasoning_effort
+    }
+
+    /// Updates the collaboration mode with new model and/or effort values.
+    ///
+    /// - `model`: `Some(s)` to update the model, `None` to keep the current model
+    /// - `effort`: `Some(Some(e))` to set effort to `e`, `Some(None)` to clear effort, `None` to keep current effort
+    /// - `developer_instructions`: `Some(Some(s))` to set instructions, `Some(None)` to clear them, `None` to keep current
+    ///
+    /// Returns a new `CollaborationMode` with updated values, preserving the mode.
+    pub fn with_updates(
+        &self,
+        model: Option<String>,
+        effort: Option<Option<ReasoningEffort>>,
+        developer_instructions: Option<Option<String>>,
+    ) -> Self {
+        let settings = self.settings_ref();
+        let updated_settings = Settings {
+            model: model.unwrap_or_else(|| settings.model.clone()),
+            reasoning_effort: effort.unwrap_or(settings.reasoning_effort),
+            developer_instructions: developer_instructions
+                .unwrap_or_else(|| settings.developer_instructions.clone()),
+        };
+
+        CollaborationMode {
+            mode: self.mode,
+            settings: updated_settings,
+        }
+    }
+
+    /// Applies a mask to this collaboration mode, returning a new collaboration mode
+    /// with the mask values applied. Fields in the mask that are `Some` will override
+    /// the corresponding fields, while `None` values will preserve the original values.
+    ///
+    /// The `name` field in the mask is ignored as it's metadata for the mask itself.
+    pub fn apply_mask(&self, mask: &CollaborationModeMask) -> Self {
+        let settings = self.settings_ref();
+        CollaborationMode {
+            mode: mask.mode.unwrap_or(self.mode),
+            settings: Settings {
+                model: mask.model.clone().unwrap_or_else(|| settings.model.clone()),
+                reasoning_effort: mask.reasoning_effort.unwrap_or(settings.reasoning_effort),
+                developer_instructions: mask
+                    .developer_instructions
+                    .clone()
+                    .unwrap_or_else(|| settings.developer_instructions.clone()),
+            },
+        }
+    }
+}
+
+/// Settings for a collaboration mode.
+#[derive(Clone, PartialEq, Eq, Hash, Debug, Serialize, Deserialize, JsonSchema, TS)]
+pub struct Settings {
+    pub model: String,
+    pub reasoning_effort: Option<ReasoningEffort>,
+    pub developer_instructions: Option<String>,
+}
+
+/// A mask for collaboration mode settings, allowing partial updates.
+/// All fields except `name` are optional, enabling selective updates.
+#[derive(Clone, PartialEq, Eq, Hash, Debug, Serialize, Deserialize, JsonSchema, TS)]
+pub struct CollaborationModeMask {
+    pub name: String,
+    pub mode: Option<ModeKind>,
+    pub model: Option<String>,
+    pub reasoning_effort: Option<Option<ReasoningEffort>>,
+    pub developer_instructions: Option<Option<String>>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn apply_mask_can_clear_optional_fields() {
+        let mode = CollaborationMode {
+            mode: ModeKind::Default,
+            settings: Settings {
+                model: "gpt-5.2-codex".to_string(),
+                reasoning_effort: Some(ReasoningEffort::High),
+                developer_instructions: Some("stay focused".to_string()),
+            },
+        };
+        let mask = CollaborationModeMask {
+            name: "Clear".to_string(),
+            mode: None,
+            model: None,
+            reasoning_effort: Some(None),
+            developer_instructions: Some(None),
+        };
+
+        let expected = CollaborationMode {
+            mode: ModeKind::Default,
+            settings: Settings {
+                model: "gpt-5.2-codex".to_string(),
+                reasoning_effort: None,
+                developer_instructions: None,
+            },
+        };
+        assert_eq!(expected, mode.apply_mask(&mask));
+    }
+
+    #[test]
+    fn mode_kind_deserializes_alias_values_to_default() {
+        for alias in ["code", "pair_programming", "execute", "custom"] {
+            let json = format!("\"{alias}\"");
+            let mode: ModeKind = serde_json::from_str(&json).expect("deserialize mode");
+            assert_eq!(ModeKind::Default, mode);
+        }
+    }
+
+    #[test]
+    fn approvals_reviewer_serializes_auto_review_and_accepts_legacy_guardian_subagent() {
+        assert_eq!(ApprovalsReviewer::User.to_string(), "user");
+        assert_eq!(
+            serde_json::to_string(&ApprovalsReviewer::User).expect("serialize reviewer"),
+            "\"user\""
+        );
+        assert_eq!(
+            serde_json::to_string(&ApprovalsReviewer::AutoReview).expect("serialize reviewer"),
+            "\"guardian_subagent\""
+        );
+
+        for value in ["user", "auto_review", "guardian_subagent"] {
+            let json = format!("\"{value}\"");
+            let reviewer: ApprovalsReviewer =
+                serde_json::from_str(&json).expect("deserialize reviewer");
+            let expected = if value == "user" {
+                ApprovalsReviewer::User
+            } else {
+                ApprovalsReviewer::AutoReview
+            };
+            assert_eq!(expected, reviewer);
+        }
+    }
+
+    #[test]
+    fn tui_visible_collaboration_modes_match_mode_kind_visibility() {
+        let expected = [ModeKind::Default, ModeKind::Plan];
+        assert_eq!(expected, TUI_VISIBLE_COLLABORATION_MODES);
+
+        for mode in TUI_VISIBLE_COLLABORATION_MODES {
+            assert!(mode.is_tui_visible());
+        }
+
+        assert!(!ModeKind::PairProgramming.is_tui_visible());
+        assert!(!ModeKind::Execute.is_tui_visible());
+    }
+
+    #[test]
+    fn web_search_location_merge_prefers_overlay_values() {
+        let base = WebSearchLocation {
+            country: Some("US".to_string()),
+            region: Some("CA".to_string()),
+            city: None,
+            timezone: Some("America/Los_Angeles".to_string()),
+        };
+        let overlay = WebSearchLocation {
+            country: None,
+            region: Some("WA".to_string()),
+            city: Some("Seattle".to_string()),
+            timezone: None,
+        };
+
+        let expected = WebSearchLocation {
+            country: Some("US".to_string()),
+            region: Some("WA".to_string()),
+            city: Some("Seattle".to_string()),
+            timezone: Some("America/Los_Angeles".to_string()),
+        };
+
+        assert_eq!(expected, base.merge(&overlay));
+    }
+
+    #[test]
+    fn web_search_tool_config_merge_prefers_overlay_values() {
+        let base = WebSearchToolConfig {
+            context_size: Some(WebSearchContextSize::Low),
+            allowed_domains: Some(vec!["openai.com".to_string()]),
+            location: Some(WebSearchLocation {
+                country: Some("US".to_string()),
+                region: Some("CA".to_string()),
+                city: None,
+                timezone: Some("America/Los_Angeles".to_string()),
+            }),
+        };
+        let overlay = WebSearchToolConfig {
+            context_size: Some(WebSearchContextSize::High),
+            allowed_domains: None,
+            location: Some(WebSearchLocation {
+                country: None,
+                region: Some("WA".to_string()),
+                city: Some("Seattle".to_string()),
+                timezone: None,
+            }),
+        };
+
+        let expected = WebSearchToolConfig {
+            context_size: Some(WebSearchContextSize::High),
+            allowed_domains: Some(vec!["openai.com".to_string()]),
+            location: Some(WebSearchLocation {
+                country: Some("US".to_string()),
+                region: Some("WA".to_string()),
+                city: Some("Seattle".to_string()),
+                timezone: Some("America/Los_Angeles".to_string()),
+            }),
+        };
+
+        assert_eq!(expected, base.merge(&overlay));
+    }
+}

--- a/crates/dasclaw_protocol/src/lib.rs
+++ b/crates/dasclaw_protocol/src/lib.rs
@@ -1,10 +1,10 @@
 //! Verbatim file-level slice of `codex-cli-main/codex-rs/protocol/`.
 //!
-//! **Current scope** (Step C1.2, ADR-136 §3 layered plan):
-//! Layer 1 zero-`crate::`-deps leaves (14 modules) + `parse_command` from C1.1.
+//! **Current scope** (Step C1.3, ADR-136 §3 layered plan):
+//! Layer 1 zero-`crate::`-deps leaves (14 modules) + parse_command (C1.1) +
+//! Layer 2 mutual-cycle pair `config_types` ↔ `openai_models` (C1.3).
 //!
-//! **Planned expansion** (ADR-136 §3 Step C1.3 ~ C1.5):
-//! Layer 2 — `config_types` + `openai_models` (mutual cycle, ~1.5 KLOC);
+//! **Planned expansion** (ADR-136 §3 Step C1.4 ~ C1.5):
 //! Layer 3 — `protocol`, `permissions`, `models`, `approvals`, `network_policy`,
 //! `items`, `request_permissions` (~12 KLOC, hub crate);
 //! Layer 4 — `error` + `error_tests` (~1.2 KLOC).
@@ -20,12 +20,14 @@ mod tool_name;
 pub use agent_path::AgentPath;
 pub use thread_id::ThreadId;
 pub use tool_name::ToolName;
+pub mod config_types;
 pub mod dynamic_tools;
 pub mod exec_output;
 pub mod mcp;
 pub mod memory_citation;
 pub mod message_history;
 pub mod num_format;
+pub mod openai_models;
 pub mod parse_command;
 pub mod plan_tool;
 pub mod request_user_input;

--- a/crates/dasclaw_protocol/src/openai_models.rs
+++ b/crates/dasclaw_protocol/src/openai_models.rs
@@ -1,0 +1,832 @@
+//! Shared model metadata types exchanged between Codex services and clients.
+//!
+//! These types are serialized across core, TUI, app-server, and SDK boundaries, so field defaults
+//! are used to preserve compatibility when older payloads omit newly introduced attributes.
+
+use std::collections::HashMap;
+use std::str::FromStr;
+
+use schemars::JsonSchema;
+use serde::Deserialize;
+use serde::Serialize;
+use strum::IntoEnumIterator;
+use strum_macros::Display;
+use strum_macros::EnumIter;
+use tracing::warn;
+use ts_rs::TS;
+
+use crate::config_types::Personality;
+use crate::config_types::ReasoningSummary;
+use crate::config_types::Verbosity;
+
+const PERSONALITY_PLACEHOLDER: &str = "{{ personality }}";
+pub const SPEED_TIER_FAST: &str = "fast";
+
+/// See https://platform.openai.com/docs/guides/reasoning?api-mode=responses#get-started-with-reasoning
+#[derive(
+    Debug,
+    Serialize,
+    Deserialize,
+    Default,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Display,
+    JsonSchema,
+    TS,
+    EnumIter,
+    Hash,
+)]
+#[serde(rename_all = "lowercase")]
+#[strum(serialize_all = "lowercase")]
+pub enum ReasoningEffort {
+    None,
+    Minimal,
+    Low,
+    #[default]
+    Medium,
+    High,
+    XHigh,
+}
+
+impl FromStr for ReasoningEffort {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        serde_json::from_value(serde_json::Value::String(s.to_string()))
+            .map_err(|_| format!("invalid reasoning_effort: {s}"))
+    }
+}
+
+/// Canonical user-input modality tags advertised by a model.
+#[derive(
+    Debug,
+    Serialize,
+    Deserialize,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Display,
+    JsonSchema,
+    TS,
+    EnumIter,
+    Hash,
+)]
+#[serde(rename_all = "lowercase")]
+#[strum(serialize_all = "lowercase")]
+pub enum InputModality {
+    /// Plain text turns and tool payloads.
+    Text,
+    /// Image attachments included in user turns.
+    Image,
+}
+
+/// Backward-compatible default when `input_modalities` is omitted on the wire.
+///
+/// Legacy payloads predate modality metadata, so we conservatively assume both text and images are
+/// accepted unless a preset explicitly narrows support.
+pub fn default_input_modalities() -> Vec<InputModality> {
+    vec![InputModality::Text, InputModality::Image]
+}
+
+/// A reasoning effort option that can be surfaced for a model.
+#[derive(Debug, Clone, Deserialize, Serialize, TS, JsonSchema, PartialEq, Eq)]
+pub struct ReasoningEffortPreset {
+    /// Effort level that the model supports.
+    pub effort: ReasoningEffort,
+    /// Short human description shown next to the effort in UIs.
+    pub description: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, TS, JsonSchema, PartialEq)]
+pub struct ModelUpgrade {
+    pub id: String,
+    pub reasoning_effort_mapping: Option<HashMap<ReasoningEffort, ReasoningEffort>>,
+    pub migration_config_key: String,
+    pub model_link: Option<String>,
+    pub upgrade_copy: Option<String>,
+    pub migration_markdown: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, TS, JsonSchema, PartialEq, Eq)]
+pub struct ModelAvailabilityNux {
+    pub message: String,
+}
+
+/// Metadata describing a Codex-supported model.
+#[derive(Debug, Clone, Deserialize, Serialize, TS, JsonSchema, PartialEq)]
+pub struct ModelPreset {
+    /// Stable identifier for the preset.
+    pub id: String,
+    /// Model slug (e.g., "gpt-5").
+    pub model: String,
+    /// Display name shown in UIs.
+    pub display_name: String,
+    /// Short human description shown in UIs.
+    pub description: String,
+    /// Reasoning effort applied when none is explicitly chosen.
+    pub default_reasoning_effort: ReasoningEffort,
+    /// Supported reasoning effort options.
+    pub supported_reasoning_efforts: Vec<ReasoningEffortPreset>,
+    /// Whether this model supports personality-specific instructions.
+    #[serde(default)]
+    pub supports_personality: bool,
+    /// Additional speed tiers this model can run with beyond the standard path.
+    #[serde(default)]
+    pub additional_speed_tiers: Vec<String>,
+    /// Whether this is the default model for new users.
+    pub is_default: bool,
+    /// recommended upgrade model
+    pub upgrade: Option<ModelUpgrade>,
+    /// Whether this preset should appear in the picker UI.
+    pub show_in_picker: bool,
+    /// Availability NUX shown when this preset becomes accessible to the user.
+    pub availability_nux: Option<ModelAvailabilityNux>,
+    /// whether this model is supported in the api
+    pub supported_in_api: bool,
+    /// Input modalities accepted when composing user turns for this preset.
+    #[serde(default = "default_input_modalities")]
+    pub input_modalities: Vec<InputModality>,
+}
+
+/// Visibility of a model in the picker or APIs.
+#[derive(
+    Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq, TS, JsonSchema, EnumIter, Display,
+)]
+#[serde(rename_all = "lowercase")]
+#[strum(serialize_all = "lowercase")]
+pub enum ModelVisibility {
+    List,
+    Hide,
+    None,
+}
+
+/// Shell execution capability for a model.
+#[derive(
+    Debug,
+    Serialize,
+    Deserialize,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    TS,
+    JsonSchema,
+    EnumIter,
+    Display,
+    Hash,
+)]
+#[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
+pub enum ConfigShellToolType {
+    Default,
+    Local,
+    UnifiedExec,
+    Disabled,
+    ShellCommand,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash, TS, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ApplyPatchToolType {
+    Freeform,
+    Function,
+}
+
+#[derive(
+    Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash, TS, JsonSchema, Default,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum WebSearchToolType {
+    #[default]
+    Text,
+    TextAndImage,
+}
+
+/// Server-provided truncation policy metadata for a model.
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq, TS, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum TruncationMode {
+    Bytes,
+    Tokens,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq, TS, JsonSchema)]
+pub struct TruncationPolicyConfig {
+    pub mode: TruncationMode,
+    pub limit: i64,
+}
+
+impl TruncationPolicyConfig {
+    pub const fn bytes(limit: i64) -> Self {
+        Self {
+            mode: TruncationMode::Bytes,
+            limit,
+        }
+    }
+
+    pub const fn tokens(limit: i64) -> Self {
+        Self {
+            mode: TruncationMode::Tokens,
+            limit,
+        }
+    }
+}
+
+/// Semantic version triple encoded as an array in JSON (e.g. [0, 62, 0]).
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq, TS, JsonSchema)]
+pub struct ClientVersion(pub i32, pub i32, pub i32);
+
+const fn default_effective_context_window_percent() -> i64 {
+    95
+}
+
+/// Model metadata returned by the Codex backend `/models` endpoint.
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, TS, JsonSchema)]
+pub struct ModelInfo {
+    pub slug: String,
+    pub display_name: String,
+    pub description: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default_reasoning_level: Option<ReasoningEffort>,
+    pub supported_reasoning_levels: Vec<ReasoningEffortPreset>,
+    pub shell_type: ConfigShellToolType,
+    pub visibility: ModelVisibility,
+    pub supported_in_api: bool,
+    pub priority: i32,
+    #[serde(default)]
+    pub additional_speed_tiers: Vec<String>,
+    pub availability_nux: Option<ModelAvailabilityNux>,
+    pub upgrade: Option<ModelInfoUpgrade>,
+    pub base_instructions: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model_messages: Option<ModelMessages>,
+    pub supports_reasoning_summaries: bool,
+    #[serde(default)]
+    pub default_reasoning_summary: ReasoningSummary,
+    pub support_verbosity: bool,
+    pub default_verbosity: Option<Verbosity>,
+    pub apply_patch_tool_type: Option<ApplyPatchToolType>,
+    #[serde(default)]
+    pub web_search_tool_type: WebSearchToolType,
+    pub truncation_policy: TruncationPolicyConfig,
+    pub supports_parallel_tool_calls: bool,
+    #[serde(default)]
+    pub supports_image_detail_original: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context_window: Option<i64>,
+    /// Maximum context window allowed for config overrides.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_context_window: Option<i64>,
+    /// Token threshold for automatic compaction. When omitted, core derives it
+    /// from `context_window` (90%). When provided, core clamps it to 90% of the
+    /// context window when available.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub auto_compact_token_limit: Option<i64>,
+    /// Percentage of the context window considered usable for inputs, after
+    /// reserving headroom for system prompts, tool overhead, and model output.
+    #[serde(default = "default_effective_context_window_percent")]
+    pub effective_context_window_percent: i64,
+    pub experimental_supported_tools: Vec<String>,
+    /// Input modalities accepted by the backend for this model.
+    #[serde(default = "default_input_modalities")]
+    pub input_modalities: Vec<InputModality>,
+    /// Internal-only marker set by core when a model slug resolved to fallback metadata.
+    #[serde(default, skip_serializing, skip_deserializing)]
+    #[schemars(skip)]
+    #[ts(skip)]
+    pub used_fallback_model_metadata: bool,
+    #[serde(default)]
+    pub supports_search_tool: bool,
+}
+
+impl ModelInfo {
+    pub fn resolved_context_window(&self) -> Option<i64> {
+        self.context_window.or(self.max_context_window)
+    }
+
+    pub fn auto_compact_token_limit(&self) -> Option<i64> {
+        let context_limit = self
+            .resolved_context_window()
+            .map(|context_window| (context_window * 9) / 10);
+        let config_limit = self.auto_compact_token_limit;
+        if let Some(context_limit) = context_limit {
+            return Some(
+                config_limit.map_or(context_limit, |limit| std::cmp::min(limit, context_limit)),
+            );
+        }
+        config_limit
+    }
+
+    pub fn supports_personality(&self) -> bool {
+        self.model_messages
+            .as_ref()
+            .is_some_and(ModelMessages::supports_personality)
+    }
+
+    pub fn get_model_instructions(&self, personality: Option<Personality>) -> String {
+        if let Some(model_messages) = &self.model_messages
+            && let Some(template) = &model_messages.instructions_template
+        {
+            // if we have a template, always use it
+            let personality_message = model_messages
+                .get_personality_message(personality)
+                .unwrap_or_default();
+            template.replace(PERSONALITY_PLACEHOLDER, personality_message.as_str())
+        } else if let Some(personality) = personality {
+            warn!(
+                model = %self.slug,
+                %personality,
+                "Model personality requested but model_messages is missing, falling back to base instructions."
+            );
+            self.base_instructions.clone()
+        } else {
+            self.base_instructions.clone()
+        }
+    }
+}
+
+/// A strongly-typed template for assembling model instructions and developer messages. If
+/// instructions_* is populated and valid, it will override base_instructions.
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, TS, JsonSchema)]
+pub struct ModelMessages {
+    pub instructions_template: Option<String>,
+    pub instructions_variables: Option<ModelInstructionsVariables>,
+}
+
+impl ModelMessages {
+    fn has_personality_placeholder(&self) -> bool {
+        self.instructions_template
+            .as_ref()
+            .map(|spec| spec.contains(PERSONALITY_PLACEHOLDER))
+            .unwrap_or(false)
+    }
+
+    fn supports_personality(&self) -> bool {
+        self.has_personality_placeholder()
+            && self
+                .instructions_variables
+                .as_ref()
+                .is_some_and(ModelInstructionsVariables::is_complete)
+    }
+
+    pub fn get_personality_message(&self, personality: Option<Personality>) -> Option<String> {
+        self.instructions_variables
+            .as_ref()
+            .and_then(|variables| variables.get_personality_message(personality))
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, TS, JsonSchema)]
+pub struct ModelInstructionsVariables {
+    pub personality_default: Option<String>,
+    pub personality_friendly: Option<String>,
+    pub personality_pragmatic: Option<String>,
+}
+
+impl ModelInstructionsVariables {
+    pub fn is_complete(&self) -> bool {
+        self.personality_default.is_some()
+            && self.personality_friendly.is_some()
+            && self.personality_pragmatic.is_some()
+    }
+
+    pub fn get_personality_message(&self, personality: Option<Personality>) -> Option<String> {
+        if let Some(personality) = personality {
+            match personality {
+                Personality::None => Some(String::new()),
+                Personality::Friendly => self.personality_friendly.clone(),
+                Personality::Pragmatic => self.personality_pragmatic.clone(),
+            }
+        } else {
+            self.personality_default.clone()
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, TS, JsonSchema)]
+pub struct ModelInfoUpgrade {
+    pub model: String,
+    pub migration_markdown: String,
+}
+
+impl From<&ModelUpgrade> for ModelInfoUpgrade {
+    fn from(upgrade: &ModelUpgrade) -> Self {
+        ModelInfoUpgrade {
+            model: upgrade.id.clone(),
+            migration_markdown: upgrade.migration_markdown.clone().unwrap_or_default(),
+        }
+    }
+}
+
+/// Response wrapper for `/models`.
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, TS, JsonSchema, Default)]
+pub struct ModelsResponse {
+    pub models: Vec<ModelInfo>,
+}
+
+// convert ModelInfo to ModelPreset
+impl From<ModelInfo> for ModelPreset {
+    fn from(info: ModelInfo) -> Self {
+        let supports_personality = info.supports_personality();
+        ModelPreset {
+            id: info.slug.clone(),
+            model: info.slug.clone(),
+            display_name: info.display_name,
+            description: info.description.unwrap_or_default(),
+            default_reasoning_effort: info
+                .default_reasoning_level
+                .unwrap_or(ReasoningEffort::None),
+            supported_reasoning_efforts: info.supported_reasoning_levels.clone(),
+            supports_personality,
+            additional_speed_tiers: info.additional_speed_tiers,
+            is_default: false, // default is the highest priority available model
+            upgrade: info.upgrade.as_ref().map(|upgrade| ModelUpgrade {
+                id: upgrade.model.clone(),
+                reasoning_effort_mapping: reasoning_effort_mapping_from_presets(
+                    &info.supported_reasoning_levels,
+                ),
+                migration_config_key: info.slug.clone(),
+                // todo(aibrahim): add the model link here.
+                model_link: None,
+                upgrade_copy: None,
+                migration_markdown: Some(upgrade.migration_markdown.clone()),
+            }),
+            show_in_picker: info.visibility == ModelVisibility::List,
+            availability_nux: info.availability_nux,
+            supported_in_api: info.supported_in_api,
+            input_modalities: info.input_modalities,
+        }
+    }
+}
+
+impl ModelPreset {
+    pub fn supports_fast_mode(&self) -> bool {
+        self.additional_speed_tiers
+            .iter()
+            .any(|tier| tier == SPEED_TIER_FAST)
+    }
+
+    /// Filter models based on authentication mode.
+    ///
+    /// In ChatGPT mode, all models are visible. Otherwise, only API-supported models are shown.
+    pub fn filter_by_auth(models: Vec<ModelPreset>, chatgpt_mode: bool) -> Vec<ModelPreset> {
+        models
+            .into_iter()
+            .filter(|model| chatgpt_mode || model.supported_in_api)
+            .collect()
+    }
+
+    /// Recompute the single default preset using picker visibility.
+    ///
+    /// The first picker-visible model wins; if none are picker-visible, the first model wins.
+    pub fn mark_default_by_picker_visibility(models: &mut [ModelPreset]) {
+        for preset in models.iter_mut() {
+            preset.is_default = false;
+        }
+        if let Some(default) = models.iter_mut().find(|preset| preset.show_in_picker) {
+            default.is_default = true;
+        } else if let Some(default) = models.first_mut() {
+            default.is_default = true;
+        }
+    }
+}
+
+fn reasoning_effort_mapping_from_presets(
+    presets: &[ReasoningEffortPreset],
+) -> Option<HashMap<ReasoningEffort, ReasoningEffort>> {
+    if presets.is_empty() {
+        return None;
+    }
+
+    // Map every canonical effort to the closest supported effort for the new model.
+    let supported: Vec<ReasoningEffort> = presets.iter().map(|p| p.effort).collect();
+    let mut map = HashMap::new();
+    for effort in ReasoningEffort::iter() {
+        let nearest = nearest_effort(effort, &supported);
+        map.insert(effort, nearest);
+    }
+    Some(map)
+}
+
+fn effort_rank(effort: ReasoningEffort) -> i32 {
+    match effort {
+        ReasoningEffort::None => 0,
+        ReasoningEffort::Minimal => 1,
+        ReasoningEffort::Low => 2,
+        ReasoningEffort::Medium => 3,
+        ReasoningEffort::High => 4,
+        ReasoningEffort::XHigh => 5,
+    }
+}
+
+fn nearest_effort(target: ReasoningEffort, supported: &[ReasoningEffort]) -> ReasoningEffort {
+    let target_rank = effort_rank(target);
+    supported
+        .iter()
+        .copied()
+        .min_by_key(|candidate| (effort_rank(*candidate) - target_rank).abs())
+        .unwrap_or(target)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    fn test_model(spec: Option<ModelMessages>) -> ModelInfo {
+        ModelInfo {
+            slug: "test-model".to_string(),
+            display_name: "Test Model".to_string(),
+            description: None,
+            default_reasoning_level: None,
+            supported_reasoning_levels: vec![],
+            shell_type: ConfigShellToolType::ShellCommand,
+            visibility: ModelVisibility::List,
+            supported_in_api: true,
+            priority: 1,
+            additional_speed_tiers: Vec::new(),
+            availability_nux: None,
+            upgrade: None,
+            base_instructions: "base".to_string(),
+            model_messages: spec,
+            supports_reasoning_summaries: false,
+            default_reasoning_summary: ReasoningSummary::Auto,
+            support_verbosity: false,
+            default_verbosity: None,
+            apply_patch_tool_type: None,
+            web_search_tool_type: WebSearchToolType::Text,
+            truncation_policy: TruncationPolicyConfig::bytes(/*limit*/ 10_000),
+            supports_parallel_tool_calls: false,
+            supports_image_detail_original: false,
+            context_window: None,
+            max_context_window: None,
+            auto_compact_token_limit: None,
+            effective_context_window_percent: 95,
+            experimental_supported_tools: vec![],
+            input_modalities: default_input_modalities(),
+            used_fallback_model_metadata: false,
+            supports_search_tool: false,
+        }
+    }
+
+    fn personality_variables() -> ModelInstructionsVariables {
+        ModelInstructionsVariables {
+            personality_default: Some("default".to_string()),
+            personality_friendly: Some("friendly".to_string()),
+            personality_pragmatic: Some("pragmatic".to_string()),
+        }
+    }
+
+    #[test]
+    fn reasoning_effort_from_str_accepts_known_values() {
+        assert_eq!("high".parse(), Ok(ReasoningEffort::High));
+        assert_eq!("minimal".parse(), Ok(ReasoningEffort::Minimal));
+    }
+
+    #[test]
+    fn reasoning_effort_from_str_rejects_unknown_values() {
+        assert_eq!(
+            "unsupported".parse::<ReasoningEffort>(),
+            Err("invalid reasoning_effort: unsupported".to_string())
+        );
+    }
+
+    #[test]
+    fn get_model_instructions_uses_template_when_placeholder_present() {
+        let model = test_model(Some(ModelMessages {
+            instructions_template: Some("Hello {{ personality }}".to_string()),
+            instructions_variables: Some(personality_variables()),
+        }));
+
+        let instructions = model.get_model_instructions(Some(Personality::Friendly));
+
+        assert_eq!(instructions, "Hello friendly");
+    }
+
+    #[test]
+    fn get_model_instructions_always_strips_placeholder() {
+        let model = test_model(Some(ModelMessages {
+            instructions_template: Some("Hello\n{{ personality }}".to_string()),
+            instructions_variables: Some(ModelInstructionsVariables {
+                personality_default: None,
+                personality_friendly: Some("friendly".to_string()),
+                personality_pragmatic: None,
+            }),
+        }));
+        assert_eq!(
+            model.get_model_instructions(Some(Personality::Friendly)),
+            "Hello\nfriendly"
+        );
+        assert_eq!(
+            model.get_model_instructions(Some(Personality::Pragmatic)),
+            "Hello\n"
+        );
+        assert_eq!(
+            model.get_model_instructions(Some(Personality::None)),
+            "Hello\n"
+        );
+        assert_eq!(
+            model.get_model_instructions(/*personality*/ None),
+            "Hello\n"
+        );
+
+        let model_no_personality = test_model(Some(ModelMessages {
+            instructions_template: Some("Hello\n{{ personality }}".to_string()),
+            instructions_variables: Some(ModelInstructionsVariables {
+                personality_default: None,
+                personality_friendly: None,
+                personality_pragmatic: None,
+            }),
+        }));
+        assert_eq!(
+            model_no_personality.get_model_instructions(Some(Personality::Friendly)),
+            "Hello\n"
+        );
+        assert_eq!(
+            model_no_personality.get_model_instructions(Some(Personality::Pragmatic)),
+            "Hello\n"
+        );
+        assert_eq!(
+            model_no_personality.get_model_instructions(Some(Personality::None)),
+            "Hello\n"
+        );
+        assert_eq!(
+            model_no_personality.get_model_instructions(/*personality*/ None),
+            "Hello\n"
+        );
+    }
+
+    #[test]
+    fn get_model_instructions_falls_back_when_template_is_missing() {
+        let model = test_model(Some(ModelMessages {
+            instructions_template: None,
+            instructions_variables: Some(ModelInstructionsVariables {
+                personality_default: None,
+                personality_friendly: None,
+                personality_pragmatic: None,
+            }),
+        }));
+
+        let instructions = model.get_model_instructions(Some(Personality::Friendly));
+
+        assert_eq!(instructions, "base");
+    }
+
+    #[test]
+    fn get_personality_message_returns_default_when_personality_is_none() {
+        let personality_template = personality_variables();
+        assert_eq!(
+            personality_template.get_personality_message(/*personality*/ None),
+            Some("default".to_string())
+        );
+    }
+
+    #[test]
+    fn get_personality_message() {
+        let personality_variables = personality_variables();
+        assert_eq!(
+            personality_variables.get_personality_message(Some(Personality::Friendly)),
+            Some("friendly".to_string())
+        );
+        assert_eq!(
+            personality_variables.get_personality_message(Some(Personality::Pragmatic)),
+            Some("pragmatic".to_string())
+        );
+        assert_eq!(
+            personality_variables.get_personality_message(Some(Personality::None)),
+            Some(String::new())
+        );
+        assert_eq!(
+            personality_variables.get_personality_message(/*personality*/ None),
+            Some("default".to_string())
+        );
+
+        let personality_variables = ModelInstructionsVariables {
+            personality_default: Some("default".to_string()),
+            personality_friendly: None,
+            personality_pragmatic: None,
+        };
+        assert_eq!(
+            personality_variables.get_personality_message(Some(Personality::Friendly)),
+            None
+        );
+        assert_eq!(
+            personality_variables.get_personality_message(Some(Personality::Pragmatic)),
+            None
+        );
+        assert_eq!(
+            personality_variables.get_personality_message(Some(Personality::None)),
+            Some(String::new())
+        );
+        assert_eq!(
+            personality_variables.get_personality_message(/*personality*/ None),
+            Some("default".to_string())
+        );
+
+        let personality_variables = ModelInstructionsVariables {
+            personality_default: None,
+            personality_friendly: Some("friendly".to_string()),
+            personality_pragmatic: Some("pragmatic".to_string()),
+        };
+        assert_eq!(
+            personality_variables.get_personality_message(Some(Personality::Friendly)),
+            Some("friendly".to_string())
+        );
+        assert_eq!(
+            personality_variables.get_personality_message(Some(Personality::Pragmatic)),
+            Some("pragmatic".to_string())
+        );
+        assert_eq!(
+            personality_variables.get_personality_message(Some(Personality::None)),
+            Some(String::new())
+        );
+        assert_eq!(
+            personality_variables.get_personality_message(/*personality*/ None),
+            None
+        );
+    }
+
+    #[test]
+    fn model_info_defaults_availability_nux_to_none_when_omitted() {
+        let model: ModelInfo = serde_json::from_value(serde_json::json!({
+            "slug": "test-model",
+            "display_name": "Test Model",
+            "description": null,
+            "supported_reasoning_levels": [],
+            "shell_type": "shell_command",
+            "visibility": "list",
+            "supported_in_api": true,
+            "priority": 1,
+            "upgrade": null,
+            "base_instructions": "base",
+            "model_messages": null,
+            "supports_reasoning_summaries": false,
+            "default_reasoning_summary": "auto",
+            "support_verbosity": false,
+            "default_verbosity": null,
+            "apply_patch_tool_type": null,
+            "truncation_policy": {
+                "mode": "bytes",
+                "limit": 10000
+            },
+            "supports_parallel_tool_calls": false,
+            "supports_image_detail_original": false,
+            "context_window": null,
+            "auto_compact_token_limit": null,
+            "effective_context_window_percent": 95,
+            "experimental_supported_tools": [],
+            "input_modalities": ["text", "image"]
+        }))
+        .expect("deserialize model info");
+
+        assert_eq!(model.availability_nux, None);
+        assert!(!model.supports_image_detail_original);
+        assert_eq!(model.web_search_tool_type, WebSearchToolType::Text);
+        assert!(!model.supports_search_tool);
+    }
+
+    #[test]
+    fn resolved_context_window_prefers_context_window() {
+        let model = ModelInfo {
+            context_window: Some(273_000),
+            max_context_window: Some(400_000),
+            ..test_model(/*spec*/ None)
+        };
+
+        assert_eq!(model.resolved_context_window(), Some(273_000));
+    }
+
+    #[test]
+    fn resolved_context_window_falls_back_to_max_context_window() {
+        let model = ModelInfo {
+            context_window: None,
+            max_context_window: Some(400_000),
+            ..test_model(/*spec*/ None)
+        };
+
+        assert_eq!(model.resolved_context_window(), Some(400_000));
+        assert_eq!(model.auto_compact_token_limit(), Some(360_000));
+    }
+
+    #[test]
+    fn model_preset_preserves_availability_nux() {
+        let preset = ModelPreset::from(ModelInfo {
+            availability_nux: Some(ModelAvailabilityNux {
+                message: "Try Spark.".to_string(),
+            }),
+            additional_speed_tiers: vec![SPEED_TIER_FAST.to_string()],
+            ..test_model(/*spec*/ None)
+        });
+
+        assert_eq!(
+            preset.availability_nux,
+            Some(ModelAvailabilityNux {
+                message: "Try Spark.".to_string(),
+            })
+        );
+        assert!(preset.supports_fast_mode());
+    }
+}

--- a/scripts/check_codex_protocol_drift.py
+++ b/scripts/check_codex_protocol_drift.py
@@ -37,14 +37,14 @@ PAIRS: list[tuple[Path, Path]] = []
 PROTO_LOCAL = REPO_ROOT / "crates" / "dasclaw_protocol" / "src"
 PROTO_UPSTREAM = REPO_ROOT / "codex-cli-main" / "codex-rs" / "protocol" / "src"
 
-# ADR-136 Step C1.2 (Layer 1): parse_command + 14 zero-crate-deps leaves.
-# Step C1.3 ~ C1.5 will append: config_types, openai_models (cycle);
-# protocol, permissions, models, approvals, network_policy, items,
-# request_permissions (hub); error, error_tests.
+# ADR-136 Step C1.3 (Layers 1+2): parse_command + 14 leaves + config_types/openai_models cycle.
+# Step C1.4 ~ C1.5 will append: protocol, permissions, models, approvals,
+# network_policy, items, request_permissions (hub); error, error_tests.
 for fname in [
     "account.rs",
     "agent_path.rs",
     "auth.rs",
+    "config_types.rs",
     "dynamic_tools.rs",
     "exec_output.rs",
     "exec_output_tests.rs",
@@ -52,6 +52,7 @@ for fname in [
     "memory_citation.rs",
     "message_history.rs",
     "num_format.rs",
+    "openai_models.rs",
     "parse_command.rs",
     "plan_tool.rs",
     "request_user_input.rs",


### PR DESCRIPTION
## 背景 / 目标

ADR-136 §3 Step C1.3 —— Wave-A1 `dasclaw_protocol` verbatim slice 自底向上分层第 2 层。

`config_types.rs` 与 `openai_models.rs` 之间存在双向循环依赖（`config_types` 引用 `openai_models::ReasoningEffort`；`openai_models` 引用 `config_types::Personality/Verbosity/ReasoningSummary`），按 ADR-136 §3 amendment 必须同 PR 一起 port，避免单独移植任何一方导致编译断裂。

承接：#382 (C1.1 rename) → #387 (§3 amendment) → #389 (C1.2 Layer 1 leaves) → **本 PR (C1.3 Layer 2 cycle)**。

## 改动范围

- 新增 `crates/dasclaw_protocol/src/config_types.rs` (702 LOC)
- 新增 `crates/dasclaw_protocol/src/openai_models.rs` (832 LOC)
- `crates/dasclaw_protocol/src/lib.rs`：插入 `pub mod config_types;` + `pub mod openai_models;`（位置严格按 upstream 字母序）
- `crates/dasclaw_protocol/Cargo.toml`：补 `dasclaw_absolute_path` (path dep)、`strum = "0.27.2"`、`strum_macros = "0.28.0"`、`tracing = "0.1.44"`，全部对齐 upstream `codex-cli-main/codex-rs/Cargo.toml`
- `scripts/check_codex_protocol_drift.py`：PAIRS 列表 16 → 18，按字母序插入 `config_types.rs` 与 `openai_models.rs`

唯一机械编辑（ADR-129 §1.3 允许）：
- `config_types.rs` line 1：`use codex_utils_absolute_path::AbsolutePathBuf;` → `use dasclaw_absolute_path::AbsolutePathBuf;`

drift guard `SWAP_PATTERNS` 已经在 hash 比较前把上述 swap 反向归一，所以 `OK: 18 files match upstream verbatim.` 仍然成立。

## 非目标 (What's NOT in this PR)

- ❌ 不动 hub 层（`message_types.rs` / `protocol.rs`）—— 留给后续 C1.4
- ❌ 不动 error 层 —— 留给最终 C1.5
- ❌ 不动 upstream 的任何字节（除上面唯一的机械 use-path swap）
- ❌ 不为 verbatim 文件加注释、文档、refactor、format 调整
- ❌ 不动 desktop-client、admin-backend、其它 crate

## 验证

```bash
$ python3.12 scripts/check_codex_protocol_drift.py
OK: 18 files match upstream verbatim.

$ cargo check -p dasclaw_protocol --tests
    Finished `dev` profile [unoptimized + debuginfo] target(s)

$ cargo nextest run -p dasclaw_protocol
Summary [16.246s] 38 tests run: 38 passed (1 leaky), 0 skipped

$ cargo clippy --no-deps -p dasclaw_protocol --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s)

$ cargo fmt --all   # 无变更

$ python3.12 scripts/check_no_panics.py --base origin/xClaw
OK: No panic-inducing calls in changed production code.

$ python3 scripts/check_no_new_ironclaw_literal.py --base origin/xClaw
OK: No new .ironclaw / IRONCLAW_BASE_DIR literals introduced.
```

## Cross-cuts

类 A —— 无新增 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量。

## Sources read

- [docs/plans/architecture-refactor/adr-129-codex-rs-port-charter.md](../docs/plans/architecture-refactor/adr-129-codex-rs-port-charter.md) §1.3（verbatim red line）
- [docs/plans/architecture-refactor/adr-136-w1-staged-execution-plan.md](../docs/plans/architecture-refactor/adr-136-w1-staged-execution-plan.md) §3 amendment（4-layer bottom-up plan，Layer 2 cycle pair）
- [codex-cli-main/codex-rs/protocol/src/config_types.rs](../codex-cli-main/codex-rs/protocol/src/config_types.rs)（upstream verbatim source）
- [codex-cli-main/codex-rs/protocol/src/openai_models.rs](../codex-cli-main/codex-rs/protocol/src/openai_models.rs)（upstream verbatim source）
- [codex-cli-main/codex-rs/Cargo.toml](../codex-cli-main/codex-rs/Cargo.toml)（dep version pins）

## 后续 PR / 下一步

- C1.4：hub 层（`message_types.rs` / `protocol.rs`）
- C1.5：error 层 + 收尾

Closes #390
Related: #380, #382, #387, #389
