### PR TITLE
feat(dasclaw_async_utils): ADR-136 §3 amendment 2 PR-C1.prep-1 — verbatim port (~86 LOC)

### DIFF
--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -269,12 +269,26 @@ jobs:
     - name: Verify ported files match codex-cli-main snapshot byte-for-byte
       run: python3.12 scripts/check_codex_net_proxy_drift.py
 
+  codex-async-utils-drift:
+    name: ADR-136 amendment 2 verbatim drift (dasclaw_async_utils)
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v6
+      with:
+        submodules: recursive
+    - uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+    - name: Verify ported files match codex-cli-main snapshot byte-for-byte
+      run: python3.12 scripts/check_codex_async_utils_drift.py
+
   # Roll-up job for branch protection
   code-style:
     name: Code Style (fmt + clippy + deny)
     runs-on: ubuntu-latest
     if: always()
-    needs: [format, clippy, clippy-windows, deny-check, no-panics, claw-code-readonly, no-new-ironclaw-literal, codex-execpolicy-drift, codex-process-hardening-drift, codex-shell-command-drift, codex-protocol-drift, codex-utils-home-dir-drift, codex-utils-rustls-provider-drift, codex-net-proxy-drift]
+    needs: [format, clippy, clippy-windows, deny-check, no-panics, claw-code-readonly, no-new-ironclaw-literal, codex-execpolicy-drift, codex-process-hardening-drift, codex-shell-command-drift, codex-protocol-drift, codex-utils-home-dir-drift, codex-utils-rustls-provider-drift, codex-net-proxy-drift, codex-async-utils-drift]
     steps:
       - run: |
           if [[ "${{ needs.format.result }}" != "success" || "${{ needs.clippy.result }}" != "success" || "${{ needs.deny-check.result }}" != "success" || "${{ needs.no-panics.result }}" != "success" || "${{ needs.claw-code-readonly.result }}" != "success" || "${{ needs.codex-execpolicy-drift.result }}" != "success" ]]; then
@@ -308,6 +322,10 @@ jobs:
           fi
           if [[ "${{ needs.codex-net-proxy-drift.result }}" != "success" ]]; then
             echo "ADR-137 net-proxy verbatim drift guard failed: ${{ needs.codex-net-proxy-drift.result }}"
+            exit 1
+          fi
+          if [[ "${{ needs.codex-async-utils-drift.result }}" != "success" ]]; then
+            echo "ADR-136 amendment 2 async-utils verbatim drift guard failed: ${{ needs.codex-async-utils-drift.result }}"
             exit 1
           fi
           # clippy-windows only runs on main PRs, so skipped is acceptable but failure is not

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2748,6 +2748,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dasclaw_async_utils"
+version = "0.0.0-w7"
+dependencies = [
+ "async-trait",
+ "pretty_assertions",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
 name = "dasclaw_bash_validation"
 version = "0.0.0-w1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,8 @@ members = [
 	# W5 #324 sub-task 3 / ADR-137 — codex-network-proxy transitive deps (verbatim port)
 	"crates/dasclaw_utils_home_dir",
 	"crates/dasclaw_utils_rustls_provider",
+	# W6 ADR-136 §3 amendment 2 PR-C1.prep-1 — codex-async-utils verbatim port (~86 LOC)
+	"crates/dasclaw_async_utils",
 	# W8 ADR-139 §4.5 PR1 — MITM CA trust-chain manager (dasclaw original, not verbatim)
 	"crates/dasclaw_cert_trust",
 	"desktop-client/ironclaw",

--- a/crates/dasclaw_async_utils/Cargo.toml
+++ b/crates/dasclaw_async_utils/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+# Verbatim port of codex-async-utils @ codex-cli-main
+# (upstream snapshot vendored under codex-cli-main/codex-rs/async-utils).
+#
+# ADR-129 §1.3 + ADR-136 §3 amendment 2 PR-C1.prep-1 mandate verbatim port.
+# Mechanical edits allowed:
+#   1. Cargo.toml package name swap: codex-async-utils → dasclaw_async_utils.
+#   2. Workspace deps inlined with explicit versions; no workspace.dependencies
+#      table exists in this fork.
+#
+# src/lib.rs has zero `codex_*` use-paths, so no use-path swaps needed.
+# DO NOT hand-edit src/lib.rs — drift guard
+# scripts/check_codex_async_utils_drift.py verifies hash equality with upstream.
+#
+# Consumed by: PR-C1.5 (dasclaw_protocol::error::CancelErr).
+# See ADR-136 §3 amendment 2 for the bottom-up port plan.
+name = "dasclaw_async_utils"
+version = "0.0.0-w7"
+edition = "2024"
+description = "OrCancelExt trait + CancelErr for cancellation-aware futures (verbatim port of codex-async-utils)."
+license = "Apache-2.0 OR MIT"
+publish = false
+
+[lib]
+name = "dasclaw_async_utils"
+path = "src/lib.rs"
+
+[dependencies]
+async-trait = "0.1"
+tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread", "time"] }
+tokio-util = "0.7.18"
+
+[dev-dependencies]
+pretty_assertions = "1"

--- a/crates/dasclaw_async_utils/src/lib.rs
+++ b/crates/dasclaw_async_utils/src/lib.rs
@@ -1,0 +1,86 @@
+use async_trait::async_trait;
+use std::future::Future;
+use tokio_util::sync::CancellationToken;
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum CancelErr {
+    Cancelled,
+}
+
+#[async_trait]
+pub trait OrCancelExt: Sized {
+    type Output;
+
+    async fn or_cancel(self, token: &CancellationToken) -> Result<Self::Output, CancelErr>;
+}
+
+#[async_trait]
+impl<F> OrCancelExt for F
+where
+    F: Future + Send,
+    F::Output: Send,
+{
+    type Output = F::Output;
+
+    async fn or_cancel(self, token: &CancellationToken) -> Result<Self::Output, CancelErr> {
+        tokio::select! {
+            _ = token.cancelled() => Err(CancelErr::Cancelled),
+            res = self => Ok(res),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+    use std::time::Duration;
+    use tokio::task;
+    use tokio::time::sleep;
+
+    #[tokio::test]
+    async fn returns_ok_when_future_completes_first() {
+        let token = CancellationToken::new();
+        let value = async { 42 };
+
+        let result = value.or_cancel(&token).await;
+
+        assert_eq!(Ok(42), result);
+    }
+
+    #[tokio::test]
+    async fn returns_err_when_token_cancelled_first() {
+        let token = CancellationToken::new();
+        let token_clone = token.clone();
+
+        let cancel_handle = task::spawn(async move {
+            sleep(Duration::from_millis(10)).await;
+            token_clone.cancel();
+        });
+
+        let result = async {
+            sleep(Duration::from_millis(100)).await;
+            7
+        }
+        .or_cancel(&token)
+        .await;
+
+        cancel_handle.await.expect("cancel task panicked");
+        assert_eq!(Err(CancelErr::Cancelled), result);
+    }
+
+    #[tokio::test]
+    async fn returns_err_when_token_already_cancelled() {
+        let token = CancellationToken::new();
+        token.cancel();
+
+        let result = async {
+            sleep(Duration::from_millis(50)).await;
+            5
+        }
+        .or_cancel(&token)
+        .await;
+
+        assert_eq!(Err(CancelErr::Cancelled), result);
+    }
+}

--- a/scripts/check_codex_async_utils_drift.py
+++ b/scripts/check_codex_async_utils_drift.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3.12
+"""Drift guard: verify dasclaw_async_utils/src remains byte-identical
+to the upstream codex snapshot vendored under codex-cli-main/codex-rs/.
+
+ADR-129 §1.3 + ADR-136 §3 amendment 2 PR-C1.prep-1 mandate verbatim port.
+The only mechanical edits allowed are:
+
+  1. `Cargo.toml` package name swap (codex-async-utils → dasclaw_async_utils).
+
+`src/lib.rs` has zero `codex_*` use-paths so no normalization is needed.
+This script compares each Rust file against its upstream peer. Any diff
+is treated as drift and exits non-zero so CI / pre-commit can block
+patch-style edits.
+
+Run: python3.12 scripts/check_codex_async_utils_drift.py
+"""
+
+from __future__ import annotations
+
+import hashlib
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+PAIRS: list[tuple[Path, Path]] = []
+
+LOCAL = REPO_ROOT / "crates" / "dasclaw_async_utils" / "src"
+UPSTREAM = REPO_ROOT / "codex-cli-main" / "codex-rs" / "async-utils" / "src"
+for fname in ["lib.rs"]:
+    PAIRS.append((LOCAL / fname, UPSTREAM / fname))
+
+
+def sha(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def main() -> int:
+    drift: list[str] = []
+    missing: list[str] = []
+    for local, upstream in PAIRS:
+        if not local.exists():
+            missing.append(f"local missing: {local.relative_to(REPO_ROOT)}")
+            continue
+        if not upstream.exists():
+            missing.append(f"upstream missing: {upstream.relative_to(REPO_ROOT)}")
+            continue
+        local_text = local.read_text(encoding="utf-8")
+        upstream_text = upstream.read_text(encoding="utf-8")
+        if sha(local_text) != sha(upstream_text):
+            drift.append(
+                f"DRIFT: {local.relative_to(REPO_ROOT)} != "
+                f"{upstream.relative_to(REPO_ROOT)}"
+            )
+
+    if missing:
+        for line in missing:
+            print(line, file=sys.stderr)
+        return 2
+    if drift:
+        for line in drift:
+            print(line, file=sys.stderr)
+        print(
+            "\nADR-129 §1.3 forbids hand-edits to ported files. "
+            "If upstream changed, re-vendor and update the snapshot under "
+            "codex-cli-main/codex-rs/async-utils/.\n"
+            "If a swap rule is missing, extend SWAP_PATTERNS in this script "
+            "(no swaps currently needed for async-utils).",
+            file=sys.stderr,
+        )
+        return 1
+    print(f"OK: {len(PAIRS)} file(s) match upstream verbatim.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## 背景 / 目标

ADR-136 §3 amendment 2 ([#392](https://github.com/Linnanli/xClaw/pull/392)) PR-C1.prep-1 — 把上游 `codex-async-utils` (~86 LOC, 1 file) 作为小 vendor crate 移植，以解锁后续 PR-C1.5 中 `dasclaw_protocol::error::CancelErr` 的依赖。范式与已合的 `dasclaw_net_proxy` / `dasclaw_absolute_path` / `dasclaw_features` 一致：file-level slice = 独立小 crate（amendment 2 修订点 1：正式废止 amendment 1 line 161「不新建 crate」歧义文字）。

## 改动范围

1. **新 crate `crates/dasclaw_async_utils/`**
   - `Cargo.toml`：包名 swap `codex-async-utils → dasclaw_async_utils`；workspace deps inline 为显式版本（async-trait 0.1 / tokio 1 / tokio-util 0.7.18 / pretty_assertions 1），与上游 `codex-cli-main/codex-rs/Cargo.toml` workspace pins 一致
   - `src/lib.rs`：与 `codex-cli-main/codex-rs/async-utils/src/lib.rs` 字节相同（零 `codex_*` use-paths，无需 use-path swap）
2. **`Cargo.toml`**：把 `crates/dasclaw_async_utils` 加入 workspace `members`（紧跟 `dasclaw_utils_rustls_provider` 之后）
3. **`scripts/check_codex_async_utils_drift.py`**：新 SHA256 drift guard，PAIRS = 1 文件，SWAP_PATTERNS 为空
4. **`.github/workflows/code_style.yml`**：新增 `codex-async-utils-drift` job + roll-up `code-style` 的 `needs[]` + 失败检查 stanza

## 非目标

- ❌ 不修改 `dasclaw_protocol`（PR-C1.5 阶段才会 use 此 crate）
- ❌ 不写自定义测试（沿用上游 3 个 unit test，全部通过）
- ❌ 不引入 workspace.dependencies 表（amendment 2 沿用 inline 版本范式）
- ❌ 不改任何已有 crate 的 Cargo.toml

## 验证

```bash
$ cargo check -p dasclaw_async_utils --tests
  Finished dev profile in 29.04s (0 errors, 0 warnings)

$ cargo nextest run -p dasclaw_async_utils
  3 tests run: 3 passed, 0 skipped
  - returns_ok_when_future_completes_first
  - returns_err_when_token_cancelled_first
  - returns_err_when_token_already_cancelled

$ cargo clippy --no-deps -p dasclaw_async_utils --all-targets -- -D warnings
  Finished (clean)

$ python3.12 scripts/check_codex_async_utils_drift.py
  OK: 1 file(s) match upstream verbatim.

$ python3.12 scripts/check_no_panics.py --base origin/xClaw
  OK: No panic-inducing calls in changed production code.

$ python3 scripts/check_no_new_ironclaw_literal.py --base origin/xClaw
  OK: No new .ironclaw / IRONCLAW_BASE_DIR literals introduced.

$ diff codex-cli-main/codex-rs/async-utils/src/lib.rs crates/dasclaw_async_utils/src/lib.rs
  (no diff — byte-identical)
```

## Cross-cuts

**类A** — 本 PR 无新增 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量；grep guard 自查通过（见上）。

## Sources read

- [docs/plans/architecture-refactor/adr-136-protocol-expansion-plan.md](docs/plans/architecture-refactor/adr-136-protocol-expansion-plan.md) §3 amendment 2 表格 + §3.2 修订点 1-3
- [docs/plans/architecture-refactor/adr-129-verbatim-purity-redline.md](docs/plans/architecture-refactor/adr-129-verbatim-purity-redline.md) §1.3 verbatim 红线
- [crates/dasclaw_net_proxy/Cargo.toml](crates/dasclaw_net_proxy/Cargo.toml) — small vendor crate precedent
- [scripts/check_codex_utils_home_dir_drift.py](scripts/check_codex_utils_home_dir_drift.py) — drift guard 模板
- `codex-cli-main/codex-rs/async-utils/Cargo.toml` + `src/lib.rs` — verbatim source
- `codex-cli-main/codex-rs/Cargo.toml` — workspace dep version pins (async-trait / tokio / tokio-util / pretty_assertions)

## 后续 PR

amendment 2 §3 表格剩余 9 个 PR（本 PR 是 #1）：

- **PR-C1.prep-2** `dasclaw_utils_string` (~436 LOC) — 解锁 `error.rs::truncate_middle_*`
- **PR-C1.prep-3** `dasclaw_utils_cache` (~?) — `utils_image` 的 transitive dep
- **PR-C1.prep-4** `dasclaw_utils_image` (~404 LOC) — 解锁 `models.rs` / `permissions.rs`
- **PR-C1.4a** Layer 3 inner cycle (`protocol + permissions + models + request_permissions`, ~9K LOC)
- **PR-C1.4b** Layer 3 outer (`approvals + network_policy + items`, ~3K LOC)
- **PR-C1.5** Layer 4 (`error + error_tests`, ~1.2K LOC) — C1 闭环

Closes #394