### PR TITLE
feat(dasclaw_utils_string): ADR-136 §3 amendment 2 PR-C1.prep-2 — verbatim port (~436 LOC)

### DIFF
--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -283,12 +283,26 @@ jobs:
     - name: Verify ported files match codex-cli-main snapshot byte-for-byte
       run: python3.12 scripts/check_codex_async_utils_drift.py
 
+  codex-utils-string-drift:
+    name: ADR-136 verbatim drift (dasclaw_utils_string)
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v6
+      with:
+        submodules: recursive
+    - uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+    - name: Verify ported files match codex-cli-main snapshot byte-for-byte
+      run: python3.12 scripts/check_codex_utils_string_drift.py
+
   # Roll-up job for branch protection
   code-style:
     name: Code Style (fmt + clippy + deny)
     runs-on: ubuntu-latest
     if: always()
-    needs: [format, clippy, clippy-windows, deny-check, no-panics, claw-code-readonly, no-new-ironclaw-literal, codex-execpolicy-drift, codex-process-hardening-drift, codex-shell-command-drift, codex-protocol-drift, codex-utils-home-dir-drift, codex-utils-rustls-provider-drift, codex-net-proxy-drift, codex-async-utils-drift]
+    needs: [format, clippy, clippy-windows, deny-check, no-panics, claw-code-readonly, no-new-ironclaw-literal, codex-execpolicy-drift, codex-process-hardening-drift, codex-shell-command-drift, codex-protocol-drift, codex-utils-home-dir-drift, codex-utils-rustls-provider-drift, codex-net-proxy-drift, codex-async-utils-drift, codex-utils-string-drift]
     steps:
       - run: |
           if [[ "${{ needs.format.result }}" != "success" || "${{ needs.clippy.result }}" != "success" || "${{ needs.deny-check.result }}" != "success" || "${{ needs.no-panics.result }}" != "success" || "${{ needs.claw-code-readonly.result }}" != "success" || "${{ needs.codex-execpolicy-drift.result }}" != "success" ]]; then
@@ -326,6 +340,10 @@ jobs:
           fi
           if [[ "${{ needs.codex-async-utils-drift.result }}" != "success" ]]; then
             echo "ADR-136 amendment 2 async-utils verbatim drift guard failed: ${{ needs.codex-async-utils-drift.result }}"
+            exit 1
+          fi
+          if [[ "${{ needs.codex-utils-string-drift.result }}" != "success" ]]; then
+            echo "ADR-136 utils-string verbatim drift guard failed: ${{ needs.codex-utils-string-drift.result }}"
             exit 1
           fi
           # clippy-windows only runs on main PRs, so skipped is acceptable but failure is not

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3068,6 +3068,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "dasclaw_utils_string"
+version = "0.0.0-w7"
+dependencies = [
+ "pretty_assertions",
+ "regex-lite",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,8 @@ members = [
 	"crates/dasclaw_utils_rustls_provider",
 	# W6 ADR-136 §3 amendment 2 PR-C1.prep-1 — codex-async-utils verbatim port (~86 LOC)
 	"crates/dasclaw_async_utils",
+	# W6 ADR-136 §3 amendment 2 PR-C1.prep-2 — codex-utils-string verbatim port (~436 LOC)
+	"crates/dasclaw_utils_string",
 	# W8 ADR-139 §4.5 PR1 — MITM CA trust-chain manager (dasclaw original, not verbatim)
 	"crates/dasclaw_cert_trust",
 	"desktop-client/ironclaw",

--- a/crates/dasclaw_utils_string/Cargo.toml
+++ b/crates/dasclaw_utils_string/Cargo.toml
@@ -1,0 +1,28 @@
+# =====================================================================
+# dasclaw_utils_string — verbatim port of upstream codex-utils-string
+#
+# ADR-129 §1.3 verbatim red line + ADR-136 §3 amendment 2 PR-C1.prep-2.
+# 上游真理来源：codex-cli-main/codex-rs/utils/string/
+# 仅允许的机械变化：
+#   1. package.name 由 codex-utils-string 改为 dasclaw_utils_string
+#   2. workspace 继承字段（version/edition/license/[lints]/dep workspace=true）
+#      就地展开为显式 inline pin（xClaw 无 [workspace.dependencies]）
+# 任何其它字符级变化都视为 drift —— scripts/check_codex_utils_string_drift.py
+# 在 CI 中以 SHA256 强制比对源文件与上游字节一致。
+# =====================================================================
+[package]
+name = "dasclaw_utils_string"
+version = "0.0.0-w7"
+edition = "2024"
+license = "Apache-2.0 OR MIT"
+publish = false
+
+[lib]
+name = "dasclaw_utils_string"
+path = "src/lib.rs"
+
+[dependencies]
+regex-lite = "0.1.8"
+
+[dev-dependencies]
+pretty_assertions = "1.4.1"

--- a/crates/dasclaw_utils_string/src/lib.rs
+++ b/crates/dasclaw_utils_string/src/lib.rs
@@ -1,0 +1,163 @@
+mod truncate;
+
+pub use truncate::approx_bytes_for_tokens;
+pub use truncate::approx_token_count;
+pub use truncate::approx_tokens_from_byte_count;
+pub use truncate::truncate_middle_chars;
+pub use truncate::truncate_middle_with_token_budget;
+
+// Truncate a &str to a byte budget at a char boundary (prefix)
+#[inline]
+pub fn take_bytes_at_char_boundary(s: &str, maxb: usize) -> &str {
+    if s.len() <= maxb {
+        return s;
+    }
+    let mut last_ok = 0;
+    for (i, ch) in s.char_indices() {
+        let nb = i + ch.len_utf8();
+        if nb > maxb {
+            break;
+        }
+        last_ok = nb;
+    }
+    &s[..last_ok]
+}
+
+/// Sanitize a tag value to comply with metric tag validation rules:
+/// only ASCII alphanumeric, '.', '_', '-', and '/' are allowed.
+pub fn sanitize_metric_tag_value(value: &str) -> String {
+    const MAX_LEN: usize = 256;
+    let sanitized: String = value
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || matches!(ch, '.' | '_' | '-' | '/') {
+                ch
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    let trimmed = sanitized.trim_matches('_');
+    if trimmed.is_empty() || trimmed.chars().all(|ch| !ch.is_ascii_alphanumeric()) {
+        return "unspecified".to_string();
+    }
+    if trimmed.len() <= MAX_LEN {
+        trimmed.to_string()
+    } else {
+        trimmed[..MAX_LEN].to_string()
+    }
+}
+
+/// Find all UUIDs in a string.
+#[allow(clippy::unwrap_used)]
+pub fn find_uuids(s: &str) -> Vec<String> {
+    static RE: std::sync::OnceLock<regex_lite::Regex> = std::sync::OnceLock::new();
+    let re = RE.get_or_init(|| {
+        regex_lite::Regex::new(
+            r"[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}",
+        )
+        .unwrap() // Unwrap is safe thanks to the tests.
+    });
+
+    re.find_iter(s).map(|m| m.as_str().to_string()).collect()
+}
+
+/// Convert a markdown-style `#L..` location suffix into a terminal-friendly
+/// `:line[:column][-line[:column]]` suffix.
+pub fn normalize_markdown_hash_location_suffix(suffix: &str) -> Option<String> {
+    let fragment = suffix.strip_prefix('#')?;
+    let (start, end) = match fragment.split_once('-') {
+        Some((start, end)) => (start, Some(end)),
+        None => (fragment, None),
+    };
+    let (start_line, start_column) = parse_markdown_hash_location_point(start)?;
+    let mut normalized = String::from(":");
+    normalized.push_str(start_line);
+    if let Some(column) = start_column {
+        normalized.push(':');
+        normalized.push_str(column);
+    }
+    if let Some(end) = end {
+        let (end_line, end_column) = parse_markdown_hash_location_point(end)?;
+        normalized.push('-');
+        normalized.push_str(end_line);
+        if let Some(column) = end_column {
+            normalized.push(':');
+            normalized.push_str(column);
+        }
+    }
+    Some(normalized)
+}
+
+fn parse_markdown_hash_location_point(point: &str) -> Option<(&str, Option<&str>)> {
+    let point = point.strip_prefix('L')?;
+    match point.split_once('C') {
+        Some((line, column)) => Some((line, Some(column))),
+        None => Some((point, None)),
+    }
+}
+
+#[cfg(test)]
+#[allow(warnings, clippy::all)]
+mod tests {
+    use super::find_uuids;
+    use super::normalize_markdown_hash_location_suffix;
+    use super::sanitize_metric_tag_value;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn find_uuids_finds_multiple() {
+        let input =
+            "x 00112233-4455-6677-8899-aabbccddeeff-k y 12345678-90ab-cdef-0123-456789abcdef";
+        assert_eq!(
+            find_uuids(input),
+            vec![
+                "00112233-4455-6677-8899-aabbccddeeff".to_string(),
+                "12345678-90ab-cdef-0123-456789abcdef".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn find_uuids_ignores_invalid() {
+        let input = "not-a-uuid-1234-5678-9abc-def0-123456789abc";
+        assert_eq!(find_uuids(input), Vec::<String>::new());
+    }
+
+    #[test]
+    fn find_uuids_handles_non_ascii_without_overlap() {
+        let input = "🙂 55e5d6f7-8a7f-4d2a-8d88-123456789012abc";
+        assert_eq!(
+            find_uuids(input),
+            vec!["55e5d6f7-8a7f-4d2a-8d88-123456789012".to_string()]
+        );
+    }
+
+    #[test]
+    fn sanitize_metric_tag_value_trims_and_fills_unspecified() {
+        let msg = "///";
+        assert_eq!(sanitize_metric_tag_value(msg), "unspecified");
+    }
+
+    #[test]
+    fn sanitize_metric_tag_value_replaces_invalid_chars() {
+        let msg = "bad value!";
+        assert_eq!(sanitize_metric_tag_value(msg), "bad_value");
+    }
+
+    #[test]
+    fn normalize_markdown_hash_location_suffix_converts_single_location() {
+        assert_eq!(
+            normalize_markdown_hash_location_suffix("#L74C3"),
+            Some(":74:3".to_string())
+        );
+    }
+
+    #[test]
+    fn normalize_markdown_hash_location_suffix_converts_ranges() {
+        assert_eq!(
+            normalize_markdown_hash_location_suffix("#L74C3-L76C9"),
+            Some(":74:3-76:9".to_string())
+        );
+    }
+}

--- a/crates/dasclaw_utils_string/src/truncate.rs
+++ b/crates/dasclaw_utils_string/src/truncate.rs
@@ -1,0 +1,156 @@
+//! Utilities for truncating large chunks of output while preserving a prefix
+//! and suffix on UTF-8 boundaries.
+
+const APPROX_BYTES_PER_TOKEN: usize = 4;
+
+/// Truncate a string to `max_bytes` using a character-count marker.
+pub fn truncate_middle_chars(s: &str, max_bytes: usize) -> String {
+    truncate_with_byte_estimate(s, max_bytes, /*use_tokens*/ false)
+}
+
+/// Truncate the middle of a UTF-8 string to at most `max_tokens` approximate
+/// tokens, preserving the beginning and the end. Returns the possibly
+/// truncated string and `Some(original_token_count)` if truncation occurred;
+/// otherwise returns the original string and `None`.
+pub fn truncate_middle_with_token_budget(s: &str, max_tokens: usize) -> (String, Option<u64>) {
+    if s.is_empty() {
+        return (String::new(), None);
+    }
+
+    if max_tokens > 0 && s.len() <= approx_bytes_for_tokens(max_tokens) {
+        return (s.to_string(), None);
+    }
+
+    let truncated = truncate_with_byte_estimate(
+        s,
+        approx_bytes_for_tokens(max_tokens),
+        /*use_tokens*/ true,
+    );
+    let total_tokens = u64::try_from(approx_token_count(s)).unwrap_or(u64::MAX);
+
+    if truncated == s {
+        (truncated, None)
+    } else {
+        (truncated, Some(total_tokens))
+    }
+}
+
+fn truncate_with_byte_estimate(s: &str, max_bytes: usize, use_tokens: bool) -> String {
+    if s.is_empty() {
+        return String::new();
+    }
+
+    let total_chars = s.chars().count();
+
+    if max_bytes == 0 {
+        return format_truncation_marker(
+            use_tokens,
+            removed_units(use_tokens, s.len(), total_chars),
+        );
+    }
+
+    if s.len() <= max_bytes {
+        return s.to_string();
+    }
+
+    let total_bytes = s.len();
+    let (left_budget, right_budget) = split_budget(max_bytes);
+    let (removed_chars, left, right) = split_string(s, left_budget, right_budget);
+    let marker = format_truncation_marker(
+        use_tokens,
+        removed_units(
+            use_tokens,
+            total_bytes.saturating_sub(max_bytes),
+            removed_chars,
+        ),
+    );
+
+    assemble_truncated_output(left, right, &marker)
+}
+
+pub fn approx_token_count(text: &str) -> usize {
+    let len = text.len();
+    len.saturating_add(APPROX_BYTES_PER_TOKEN.saturating_sub(1)) / APPROX_BYTES_PER_TOKEN
+}
+
+pub fn approx_bytes_for_tokens(tokens: usize) -> usize {
+    tokens.saturating_mul(APPROX_BYTES_PER_TOKEN)
+}
+
+pub fn approx_tokens_from_byte_count(bytes: usize) -> u64 {
+    let bytes_u64 = bytes as u64;
+    bytes_u64.saturating_add((APPROX_BYTES_PER_TOKEN as u64).saturating_sub(1))
+        / (APPROX_BYTES_PER_TOKEN as u64)
+}
+
+fn split_string(s: &str, beginning_bytes: usize, end_bytes: usize) -> (usize, &str, &str) {
+    if s.is_empty() {
+        return (0, "", "");
+    }
+
+    let len = s.len();
+    let tail_start_target = len.saturating_sub(end_bytes);
+    let mut prefix_end = 0usize;
+    let mut suffix_start = len;
+    let mut removed_chars = 0usize;
+    let mut suffix_started = false;
+
+    for (idx, ch) in s.char_indices() {
+        let char_end = idx + ch.len_utf8();
+        if char_end <= beginning_bytes {
+            prefix_end = char_end;
+            continue;
+        }
+
+        if idx >= tail_start_target {
+            if !suffix_started {
+                suffix_start = idx;
+                suffix_started = true;
+            }
+            continue;
+        }
+
+        removed_chars = removed_chars.saturating_add(1);
+    }
+
+    if suffix_start < prefix_end {
+        suffix_start = prefix_end;
+    }
+
+    let before = &s[..prefix_end];
+    let after = &s[suffix_start..];
+
+    (removed_chars, before, after)
+}
+
+fn split_budget(budget: usize) -> (usize, usize) {
+    let left = budget / 2;
+    (left, budget - left)
+}
+
+fn format_truncation_marker(use_tokens: bool, removed_count: u64) -> String {
+    if use_tokens {
+        format!("…{removed_count} tokens truncated…")
+    } else {
+        format!("…{removed_count} chars truncated…")
+    }
+}
+
+fn removed_units(use_tokens: bool, removed_bytes: usize, removed_chars: usize) -> u64 {
+    if use_tokens {
+        approx_tokens_from_byte_count(removed_bytes)
+    } else {
+        u64::try_from(removed_chars).unwrap_or(u64::MAX)
+    }
+}
+
+fn assemble_truncated_output(prefix: &str, suffix: &str, marker: &str) -> String {
+    let mut out = String::with_capacity(prefix.len() + marker.len() + suffix.len() + 1);
+    out.push_str(prefix);
+    out.push_str(marker);
+    out.push_str(suffix);
+    out
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/dasclaw_utils_string/src/truncate/tests.rs
+++ b/crates/dasclaw_utils_string/src/truncate/tests.rs
@@ -1,0 +1,117 @@
+use super::split_string;
+use super::truncate_middle_chars;
+use super::truncate_middle_with_token_budget;
+use pretty_assertions::assert_eq;
+
+#[test]
+fn split_string_works() {
+    assert_eq!(
+        split_string(
+            "hello world",
+            /*beginning_bytes*/ 5,
+            /*end_bytes*/ 5
+        ),
+        (1, "hello", "world")
+    );
+    assert_eq!(
+        split_string("abc", /*beginning_bytes*/ 0, /*end_bytes*/ 0),
+        (3, "", "")
+    );
+}
+
+#[test]
+fn split_string_handles_empty_string() {
+    assert_eq!(
+        split_string("", /*beginning_bytes*/ 4, /*end_bytes*/ 4),
+        (0, "", "")
+    );
+}
+
+#[test]
+fn split_string_only_keeps_prefix_when_tail_budget_is_zero() {
+    assert_eq!(
+        split_string("abcdef", /*beginning_bytes*/ 3, /*end_bytes*/ 0),
+        (3, "abc", "")
+    );
+}
+
+#[test]
+fn split_string_only_keeps_suffix_when_prefix_budget_is_zero() {
+    assert_eq!(
+        split_string("abcdef", /*beginning_bytes*/ 0, /*end_bytes*/ 3),
+        (3, "", "def")
+    );
+}
+
+#[test]
+fn split_string_handles_overlapping_budgets_without_removal() {
+    assert_eq!(
+        split_string("abcdef", /*beginning_bytes*/ 4, /*end_bytes*/ 4),
+        (0, "abcd", "ef")
+    );
+}
+
+#[test]
+fn split_string_respects_utf8_boundaries() {
+    assert_eq!(
+        split_string("😀abc😀", /*beginning_bytes*/ 5, /*end_bytes*/ 5),
+        (1, "😀a", "c😀")
+    );
+
+    assert_eq!(
+        split_string(
+            "😀😀😀😀😀",
+            /*beginning_bytes*/ 1,
+            /*end_bytes*/ 1
+        ),
+        (5, "", "")
+    );
+    assert_eq!(
+        split_string(
+            "😀😀😀😀😀",
+            /*beginning_bytes*/ 7,
+            /*end_bytes*/ 7
+        ),
+        (3, "😀", "😀")
+    );
+    assert_eq!(
+        split_string(
+            "😀😀😀😀😀",
+            /*beginning_bytes*/ 8,
+            /*end_bytes*/ 8
+        ),
+        (1, "😀😀", "😀😀")
+    );
+}
+
+#[test]
+fn truncate_with_token_budget_returns_original_when_under_limit() {
+    let s = "short output";
+    let limit = 100;
+    let (out, original) = truncate_middle_with_token_budget(s, limit);
+    assert_eq!(out, s);
+    assert_eq!(original, None);
+}
+
+#[test]
+fn truncate_with_token_budget_reports_truncation_at_zero_limit() {
+    let s = "abcdef";
+    let (out, original) = truncate_middle_with_token_budget(s, /*max_tokens*/ 0);
+    assert_eq!(out, "…2 tokens truncated…");
+    assert_eq!(original, Some(2));
+}
+
+#[test]
+fn truncate_middle_tokens_handles_utf8_content() {
+    let s = "😀😀😀😀😀😀😀😀😀😀\nsecond line with text\n";
+    let (out, tokens) = truncate_middle_with_token_budget(s, /*max_tokens*/ 8);
+    assert_eq!(out, "😀😀😀😀…8 tokens truncated… line with text\n");
+    assert_eq!(tokens, Some(16));
+}
+
+#[test]
+fn truncate_middle_bytes_handles_utf8_content() {
+    let s = "😀😀😀😀😀😀😀😀😀😀\nsecond line with text\n";
+    let out = truncate_middle_chars(s, /*max_bytes*/ 20);
+    assert_eq!(out, "😀😀…21 chars truncated…with text\n");
+}

--- a/scripts/check_codex_utils_string_drift.py
+++ b/scripts/check_codex_utils_string_drift.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3.12
+"""Drift guard: verify dasclaw_utils_string/src remains byte-identical
+to the upstream codex snapshot vendored under codex-cli-main/codex-rs/.
+
+ADR-129 §1.3 + ADR-136 §3 amendment 2 PR-C1.prep-2 mandate verbatim port.
+The only mechanical edits allowed are:
+
+  1. `Cargo.toml` package name swap (codex-utils-string -> dasclaw_utils_string).
+
+`src/lib.rs`, `src/truncate.rs` and `src/truncate/tests.rs` have zero
+`codex_*` use-paths so no normalization is needed. This script compares
+each Rust file against its upstream peer. Any diff is treated as drift
+and exits non-zero so CI / pre-commit can block patch-style edits.
+
+Run: python3.12 scripts/check_codex_utils_string_drift.py
+"""
+
+from __future__ import annotations
+
+import hashlib
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+PAIRS: list[tuple[Path, Path]] = []
+
+LOCAL = REPO_ROOT / "crates" / "dasclaw_utils_string" / "src"
+UPSTREAM = REPO_ROOT / "codex-cli-main" / "codex-rs" / "utils" / "string" / "src"
+for rel in ["lib.rs", "truncate.rs", "truncate/tests.rs"]:
+    PAIRS.append((LOCAL / rel, UPSTREAM / rel))
+
+
+def sha(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def main() -> int:
+    drift: list[str] = []
+    missing: list[str] = []
+    for local, upstream in PAIRS:
+        if not local.exists():
+            missing.append(f"local missing: {local.relative_to(REPO_ROOT)}")
+            continue
+        if not upstream.exists():
+            missing.append(f"upstream missing: {upstream.relative_to(REPO_ROOT)}")
+            continue
+        local_text = local.read_text(encoding="utf-8")
+        upstream_text = upstream.read_text(encoding="utf-8")
+        if sha(local_text) != sha(upstream_text):
+            drift.append(
+                f"DRIFT: {local.relative_to(REPO_ROOT)} != "
+                f"{upstream.relative_to(REPO_ROOT)}"
+            )
+
+    if missing:
+        for line in missing:
+            print(line, file=sys.stderr)
+        return 2
+    if drift:
+        for line in drift:
+            print(line, file=sys.stderr)
+        print(
+            "\nADR-129 §1.3 forbids hand-edits to ported files. "
+            "If upstream changed, re-vendor and update the snapshot under "
+            "codex-cli-main/codex-rs/utils/string/.\n"
+            "If a swap rule is missing, extend SWAP_PATTERNS in this script "
+            "(no swaps currently needed for utils-string).",
+            file=sys.stderr,
+        )
+        return 1
+    print(f"OK: {len(PAIRS)} file(s) match upstream verbatim.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_no_panics.py
+++ b/scripts/check_no_panics.py
@@ -26,6 +26,7 @@ VERBATIM_PORTED_PREFIXES = (
     "crates/dasclaw_protocol/",            # ADR-133 + ADR-136 — codex-protocol file-level slice
     "crates/dasclaw_sandbox_windows/",     # ADR-129 — codex sandbox-windows port
     "crates/dasclaw_shell_command/",       # ADR-133 — codex-shell-command
+    "crates/dasclaw_utils_string/",        # ADR-136 amendment 2 — codex-utils-string verbatim port
 )
 TEST_ATTR_PATTERN = re.compile(
     r"^\s*#\s*\[\s*(?:"


### PR DESCRIPTION
## 背景/目标

ADR-136 §3 amendment 2 PR-C1.prep-2：把上游 `codex-utils-string` 作为小 vendor crate 移植到 `crates/dasclaw_utils_string/`，
解锁 PR-C1.4a/C1.4b 中 `dasclaw_protocol` 对 `approx_*` / `truncate_middle_*` / `take_bytes_at_char_boundary` /
`sanitize_metric_tag_value` / `find_uuids` / `normalize_markdown_hash_location_suffix` 等 6 个公共函数的依赖。

与 PR-C1.prep-1 (#393) 同型 vendor pattern：纯 verbatim port，零业务改动，零补丁式代码。

## 改动范围

**新增 crate**（4 个文件，~436 LOC）

- `crates/dasclaw_utils_string/Cargo.toml` — 唯一允许的机械变化：包名 `codex-utils-string` → `dasclaw_utils_string`；
  workspace 继承字段就地展开为显式 inline pin (`regex-lite="0.1.8"` / dev `pretty_assertions="1.4.1"`，与 codex-cli-main/codex-rs/Cargo.toml 完全一致)
- `crates/dasclaw_utils_string/src/lib.rs` — 与上游 byte-identical (163 行)
- `crates/dasclaw_utils_string/src/truncate.rs` — 与上游 byte-identical (156 行)
- `crates/dasclaw_utils_string/src/truncate/tests.rs` — 与上游 byte-identical (117 行)

`diff -r codex-cli-main/codex-rs/utils/string/src crates/dasclaw_utils_string/src` 输出为空。零 `codex_*` use-paths，故 drift guard 无需 SWAP_PATTERNS。

**Workspace wiring**

- `Cargo.toml`: `[workspace.members]` 追加 `"crates/dasclaw_utils_string"`，紧跟 amendment-2 兄弟 crate `dasclaw_async_utils`

**Drift guard**

- `scripts/check_codex_utils_string_drift.py` (新增, 可执行) — SHA-256 比对 3 个源文件 vs `codex-cli-main/codex-rs/utils/string/`；任何 drift 都让 CI 红。

**CI wiring**

- `.github/workflows/code_style.yml`：
  - 新增 job `codex-utils-string-drift`（在 `codex-async-utils-drift` 之后、`code-style` roll-up 之前）
  - Roll-up `code-style` 的 `needs[]` 追加 `codex-utils-string-drift`
  - Roll-up step 追加专属 failure-check stanza，drift 失败时 roll-up 红

## 非目标 (What's NOT in this PR)

- ❌ 不引入 `dasclaw_utils_string` 在任何下游 crate 的实际使用 — 仅做 vendor 准备，等 PR-C1.4a/C1.4b 再消费
- ❌ 不修改上游已有的任何源文件（`codex-cli-main/codex-rs/utils/string/` 不动）
- ❌ 不引入 hand-written 测试或文档；测试是上游 byte-identical 的 17 个 unit test
- ❌ 不动 `dasclaw_async_utils` (#393 已合) 或其它 amendment-2 utils crate

## 验证

本地（rebase to xClaw HEAD `05c4991e` 后再跑一次）:

| 命令 | 结果 |
|---|---|
| `cargo check -p dasclaw_utils_string --tests` | 0 errors / 0 warnings |
| `cargo nextest run -p dasclaw_utils_string` | **17 / 17 PASS** |
| `cargo clippy --no-deps -p dasclaw_utils_string --all-targets -- -D warnings` | clean |
| `cargo fmt --all` | no diff |
| `python3.12 scripts/check_codex_utils_string_drift.py` | `OK: 3 file(s) match upstream verbatim.` |
| `python3.12 scripts/check_codex_async_utils_drift.py` | `OK: 1 file(s) match upstream verbatim.` (rebase 未破坏 prep-1) |
| `python3.12 scripts/check_no_panics.py --base origin/xClaw` | `OK` |
| `python3.12 scripts/check_no_new_ironclaw_literal.py --base origin/xClaw` | `OK` |
| `diff -r codex-cli-main/codex-rs/utils/string/src crates/dasclaw_utils_string/src` | 空 (verbatim) |

## Sources read

- [docs/plans/architecture-refactor/adr-136-protocol-expansion-plan.md](docs/plans/architecture-refactor/adr-136-protocol-expansion-plan.md) §3 amendment 2 + §3.2 修订点 1-3
- [docs/plans/architecture-refactor/adr-129-verbatim-purity-redline.md](docs/plans/architecture-refactor/adr-129-verbatim-purity-redline.md) §1.3
- [crates/dasclaw_async_utils/Cargo.toml](crates/dasclaw_async_utils/Cargo.toml) (PR #393 vendor 模板)
- [scripts/check_codex_async_utils_drift.py](scripts/check_codex_async_utils_drift.py) (drift guard 模板)
- codex-cli-main/codex-rs/utils/string/Cargo.toml + src/{lib.rs, truncate.rs, truncate/tests.rs}
- codex-cli-main/codex-rs/Cargo.toml (workspace dep version source: regex-lite / pretty_assertions)

Cross-cuts: 类A

Closes #395
