### PR TITLE
feat(crates): vendor dasclaw_utils_cache verbatim from codex-utils-cache

### DIFF
--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -297,12 +297,26 @@ jobs:
     - name: Verify ported files match codex-cli-main snapshot byte-for-byte
       run: python3.12 scripts/check_codex_utils_string_drift.py
 
+  codex-utils-cache-drift:
+    name: ADR-136 amendment 2 verbatim drift (dasclaw_utils_cache)
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v6
+      with:
+        submodules: recursive
+    - uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+    - name: Verify ported files match codex-cli-main snapshot byte-for-byte
+      run: python3.12 scripts/check_codex_utils_cache_drift.py
+
   # Roll-up job for branch protection
   code-style:
     name: Code Style (fmt + clippy + deny)
     runs-on: ubuntu-latest
     if: always()
-    needs: [format, clippy, clippy-windows, deny-check, no-panics, claw-code-readonly, no-new-ironclaw-literal, codex-execpolicy-drift, codex-process-hardening-drift, codex-shell-command-drift, codex-protocol-drift, codex-utils-home-dir-drift, codex-utils-rustls-provider-drift, codex-net-proxy-drift, codex-async-utils-drift, codex-utils-string-drift]
+    needs: [format, clippy, clippy-windows, deny-check, no-panics, claw-code-readonly, no-new-ironclaw-literal, codex-execpolicy-drift, codex-process-hardening-drift, codex-shell-command-drift, codex-protocol-drift, codex-utils-home-dir-drift, codex-utils-rustls-provider-drift, codex-net-proxy-drift, codex-async-utils-drift, codex-utils-string-drift, codex-utils-cache-drift]
     steps:
       - run: |
           if [[ "${{ needs.format.result }}" != "success" || "${{ needs.clippy.result }}" != "success" || "${{ needs.deny-check.result }}" != "success" || "${{ needs.no-panics.result }}" != "success" || "${{ needs.claw-code-readonly.result }}" != "success" || "${{ needs.codex-execpolicy-drift.result }}" != "success" ]]; then
@@ -344,6 +358,10 @@ jobs:
           fi
           if [[ "${{ needs.codex-utils-string-drift.result }}" != "success" ]]; then
             echo "ADR-136 utils-string verbatim drift guard failed: ${{ needs.codex-utils-string-drift.result }}"
+            exit 1
+          fi
+          if [[ "${{ needs.codex-utils-cache-drift.result }}" != "success" ]]; then
+            echo "ADR-136 amendment 2 utils-cache verbatim drift guard failed: ${{ needs.codex-utils-cache-drift.result }}"
             exit 1
           fi
           # clippy-windows only runs on main PRs, so skipped is acceptable but failure is not

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3051,6 +3051,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dasclaw_utils_cache"
+version = "0.0.0-w7"
+dependencies = [
+ "lru",
+ "sha1",
+ "tokio",
+]
+
+[[package]]
 name = "dasclaw_utils_home_dir"
 version = "0.0.0-w5"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,8 @@ members = [
 	"crates/dasclaw_async_utils",
 	# W6 ADR-136 §3 amendment 2 PR-C1.prep-2 — codex-utils-string verbatim port (~436 LOC)
 	"crates/dasclaw_utils_string",
+	# W6 ADR-136 §3 amendment 2 PR-C1.prep-3 — codex-utils-cache verbatim port (~193 LOC)
+	"crates/dasclaw_utils_cache",
 	# W8 ADR-139 §4.5 PR1 — MITM CA trust-chain manager (dasclaw original, not verbatim)
 	"crates/dasclaw_cert_trust",
 	"desktop-client/ironclaw",

--- a/crates/dasclaw_utils_cache/Cargo.toml
+++ b/crates/dasclaw_utils_cache/Cargo.toml
@@ -1,0 +1,30 @@
+# =====================================================================
+# dasclaw_utils_cache — verbatim port of upstream codex-utils-cache
+#
+# ADR-129 §1.3 verbatim red line + ADR-136 §3 amendment 2 PR-C1.prep-3.
+# 上游真理来源：codex-cli-main/codex-rs/utils/cache/
+# 仅允许的机械变化：
+#   1. package.name 由 codex-utils-cache 改为 dasclaw_utils_cache
+#   2. workspace 继承字段（version/edition/license/[lints]/dep workspace=true）
+#      就地展开为显式 inline pin（xClaw 无 [workspace.dependencies]）
+# 任何其它字符级变化都视为 drift —— scripts/check_codex_utils_cache_drift.py
+# 在 CI 中以 SHA256 强制比对源文件与上游字节一致。
+# =====================================================================
+[package]
+name = "dasclaw_utils_cache"
+version = "0.0.0-w7"
+edition = "2024"
+license = "Apache-2.0 OR MIT"
+publish = false
+
+[lib]
+name = "dasclaw_utils_cache"
+path = "src/lib.rs"
+
+[dependencies]
+lru = "0.16.3"
+sha1 = "0.10.6"
+tokio = { version = "1", features = ["sync", "rt", "rt-multi-thread"] }
+
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread"] }

--- a/crates/dasclaw_utils_cache/src/lib.rs
+++ b/crates/dasclaw_utils_cache/src/lib.rs
@@ -1,0 +1,193 @@
+use std::borrow::Borrow;
+use std::hash::Hash;
+use std::num::NonZeroUsize;
+
+use lru::LruCache;
+use sha1::Digest;
+use sha1::Sha1;
+use tokio::sync::Mutex;
+use tokio::sync::MutexGuard;
+
+/// A minimal LRU cache protected by a Tokio mutex.
+/// Calls outside a Tokio runtime are no-ops.
+pub struct BlockingLruCache<K, V> {
+    inner: Mutex<LruCache<K, V>>,
+}
+
+impl<K, V> BlockingLruCache<K, V>
+where
+    K: Eq + Hash,
+{
+    /// Creates a cache with the provided non-zero capacity.
+    #[must_use]
+    pub fn new(capacity: NonZeroUsize) -> Self {
+        Self {
+            inner: Mutex::new(LruCache::new(capacity)),
+        }
+    }
+
+    /// Returns a clone of the cached value for `key`, or computes and inserts it.
+    pub fn get_or_insert_with(&self, key: K, value: impl FnOnce() -> V) -> V
+    where
+        V: Clone,
+    {
+        if let Some(mut guard) = lock_if_runtime(&self.inner) {
+            if let Some(v) = guard.get(&key) {
+                return v.clone();
+            }
+            let v = value();
+            // Insert and return a clone to keep ownership in the cache.
+            guard.put(key, v.clone());
+            return v;
+        }
+        value()
+    }
+
+    /// Like `get_or_insert_with`, but the value factory may fail.
+    pub fn get_or_try_insert_with<E>(
+        &self,
+        key: K,
+        value: impl FnOnce() -> Result<V, E>,
+    ) -> Result<V, E>
+    where
+        V: Clone,
+    {
+        if let Some(mut guard) = lock_if_runtime(&self.inner) {
+            if let Some(v) = guard.get(&key) {
+                return Ok(v.clone());
+            }
+            let v = value()?;
+            guard.put(key, v.clone());
+            return Ok(v);
+        }
+        value()
+    }
+
+    /// Builds a cache if `capacity` is non-zero, returning `None` otherwise.
+    #[must_use]
+    pub fn try_with_capacity(capacity: usize) -> Option<Self> {
+        NonZeroUsize::new(capacity).map(Self::new)
+    }
+
+    /// Returns a clone of the cached value corresponding to `key`, if present.
+    pub fn get<Q>(&self, key: &Q) -> Option<V>
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq + ?Sized,
+        V: Clone,
+    {
+        let mut guard = lock_if_runtime(&self.inner)?;
+        guard.get(key).cloned()
+    }
+
+    /// Inserts `value` for `key`, returning the previous entry if it existed.
+    pub fn insert(&self, key: K, value: V) -> Option<V> {
+        let mut guard = lock_if_runtime(&self.inner)?;
+        guard.put(key, value)
+    }
+
+    /// Removes the entry for `key` if it exists, returning it.
+    pub fn remove<Q>(&self, key: &Q) -> Option<V>
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq + ?Sized,
+    {
+        let mut guard = lock_if_runtime(&self.inner)?;
+        guard.pop(key)
+    }
+
+    /// Clears all entries from the cache.
+    pub fn clear(&self) {
+        if let Some(mut guard) = lock_if_runtime(&self.inner) {
+            guard.clear();
+        }
+    }
+
+    /// Executes `callback` with a mutable reference to the underlying cache.
+    pub fn with_mut<R>(&self, callback: impl FnOnce(&mut LruCache<K, V>) -> R) -> R {
+        if let Some(mut guard) = lock_if_runtime(&self.inner) {
+            callback(&mut guard)
+        } else {
+            let mut disabled = LruCache::unbounded();
+            callback(&mut disabled)
+        }
+    }
+
+    /// Provides direct access to the cache guard when a Tokio runtime is available.
+    pub fn blocking_lock(&self) -> Option<MutexGuard<'_, LruCache<K, V>>> {
+        lock_if_runtime(&self.inner)
+    }
+}
+
+fn lock_if_runtime<K, V>(m: &Mutex<LruCache<K, V>>) -> Option<MutexGuard<'_, LruCache<K, V>>>
+where
+    K: Eq + Hash,
+{
+    tokio::runtime::Handle::try_current().ok()?;
+    Some(tokio::task::block_in_place(|| m.blocking_lock()))
+}
+
+/// Computes the SHA-1 digest of `bytes`.
+///
+/// Useful for content-based cache keys when you want to avoid staleness
+/// caused by path-only keys.
+#[must_use]
+pub fn sha1_digest(bytes: &[u8]) -> [u8; 20] {
+    let mut hasher = Sha1::new();
+    hasher.update(bytes);
+    let result = hasher.finalize();
+    let mut out = [0; 20];
+    out.copy_from_slice(&result);
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::BlockingLruCache;
+    use std::num::NonZeroUsize;
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn stores_and_retrieves_values() {
+        let cache = BlockingLruCache::new(NonZeroUsize::new(2).expect("capacity"));
+
+        assert!(cache.get(&"first").is_none());
+        cache.insert("first", /*value*/ 1);
+        assert_eq!(cache.get(&"first"), Some(1));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn evicts_least_recently_used() {
+        let cache = BlockingLruCache::new(NonZeroUsize::new(2).expect("capacity"));
+        cache.insert("a", /*value*/ 1);
+        cache.insert("b", /*value*/ 2);
+        assert_eq!(cache.get(&"a"), Some(1));
+
+        cache.insert("c", /*value*/ 3);
+
+        assert!(cache.get(&"b").is_none());
+        assert_eq!(cache.get(&"a"), Some(1));
+        assert_eq!(cache.get(&"c"), Some(3));
+    }
+
+    #[test]
+    fn disabled_without_runtime() {
+        let cache = BlockingLruCache::new(NonZeroUsize::new(2).expect("capacity"));
+        cache.insert("first", /*value*/ 1);
+        assert!(cache.get(&"first").is_none());
+
+        assert_eq!(cache.get_or_insert_with("first", || 2), 2);
+        assert!(cache.get(&"first").is_none());
+
+        assert!(cache.remove(&"first").is_none());
+        cache.clear();
+
+        let result = cache.with_mut(|inner| {
+            inner.put("tmp", 3);
+            inner.get(&"tmp").cloned()
+        });
+        assert_eq!(result, Some(3));
+        assert!(cache.get(&"tmp").is_none());
+
+        assert!(cache.blocking_lock().is_none());
+    }
+}

--- a/scripts/check_codex_utils_cache_drift.py
+++ b/scripts/check_codex_utils_cache_drift.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3.12
+"""Drift guard: verify dasclaw_utils_cache/src remains byte-identical
+to the upstream codex snapshot vendored under codex-cli-main/codex-rs/.
+
+ADR-129 §1.3 + ADR-136 §3 amendment 2 PR-C1.prep-3 mandate verbatim port.
+The only mechanical edits allowed are:
+
+  1. `Cargo.toml` package name swap (codex-utils-cache -> dasclaw_utils_cache).
+
+`src/lib.rs` has zero `codex_*` use-paths so no normalization is needed.
+This script compares each Rust file against its upstream peer. Any diff
+is treated as drift and exits non-zero so CI / pre-commit can block
+patch-style edits.
+
+Run: python3.12 scripts/check_codex_utils_cache_drift.py
+"""
+
+from __future__ import annotations
+
+import hashlib
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+PAIRS: list[tuple[Path, Path]] = []
+
+LOCAL = REPO_ROOT / "crates" / "dasclaw_utils_cache" / "src"
+UPSTREAM = REPO_ROOT / "codex-cli-main" / "codex-rs" / "utils" / "cache" / "src"
+for fname in ["lib.rs"]:
+    PAIRS.append((LOCAL / fname, UPSTREAM / fname))
+
+
+def sha(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def main() -> int:
+    drift: list[str] = []
+    missing: list[str] = []
+    for local, upstream in PAIRS:
+        if not local.exists():
+            missing.append(f"local missing: {local.relative_to(REPO_ROOT)}")
+            continue
+        if not upstream.exists():
+            missing.append(f"upstream missing: {upstream.relative_to(REPO_ROOT)}")
+            continue
+        local_text = local.read_text(encoding="utf-8")
+        upstream_text = upstream.read_text(encoding="utf-8")
+        if sha(local_text) != sha(upstream_text):
+            drift.append(
+                f"DRIFT: {local.relative_to(REPO_ROOT)} != "
+                f"{upstream.relative_to(REPO_ROOT)}"
+            )
+
+    if missing:
+        for line in missing:
+            print(line, file=sys.stderr)
+        return 2
+    if drift:
+        for line in drift:
+            print(line, file=sys.stderr)
+        print(
+            "\nADR-129 §1.3 forbids hand-edits to ported files. "
+            "If upstream changed, re-vendor and update the snapshot under "
+            "codex-cli-main/codex-rs/utils/cache/.\n"
+            "If a swap rule is missing, extend SWAP_PATTERNS in this script "
+            "(no swaps currently needed for utils-cache).",
+            file=sys.stderr,
+        )
+        return 1
+    print(f"OK: {len(PAIRS)} file(s) match upstream verbatim.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #397

## 背景/目标
ADR-136 §3 amendment 2 PR-C1.prep-3。把 codex-cli-main 上游 `codex-utils-cache` (~193 LOC) 按 byte-identical verbatim 规范（ADR-129 §1.3）vendor 进 `crates/dasclaw_utils_cache/`，为后续 C1.4a/4b/5 调用方就位。

## 改动范围
- `crates/dasclaw_utils_cache/Cargo.toml` — 仅 package.name 机械替换（codex-utils-cache → dasclaw_utils_cache），其余字段与上游 1:1 对齐；deps 内联固定版本：`lru=0.16.3` / `sha1=0.10.6` / `tokio={version="1",features=["sync","rt","rt-multi-thread"]}`；dev-deps `tokio={version="1",features=["macros","rt","rt-multi-thread"]}`。
- `crates/dasclaw_utils_cache/src/lib.rs` — byte-identical（193 LOC，3 unit tests，含 `BlockingLruCache<K,V>` + `sha1_digest` + `lock_if_runtime`）。
- `scripts/check_codex_utils_cache_drift.py` — SHA-256 drift guard（`PAIRS=1`，无 SWAP_PATTERNS，因为零 `codex_*` use-path）。
- `.github/workflows/code_style.yml` — 新增 `codex-utils-cache-drift` job + 接入 `code-style` roll-up needs[] + 失败信息分支。
- 根 `Cargo.toml` `workspace.members` — 紧随 `dasclaw_utils_string` 之后添加注释 + 成员条目。

## 非目标 (What's NOT in this PR)
- 不在任何消费者 crate（dasclaw_exec / agent / mcp / ...）中 `use dasclaw_utils_cache`。布线推迟到 C1.4a/4b/5。
- 不调整任何逻辑、API、特性。verbatim 红线。
- 不引入 `[workspace.dependencies]` 表（xClaw 沿袭"每 crate 内联版本钉死"约定，与 prep-1 / prep-2 保持一致）。
- 不预先把 `crates/dasclaw_utils_cache/` 加入 `scripts/check_no_panics.py` 的 `VERBATIM_PORTED_PREFIXES`：上游生产代码无 `.unwrap()/.expect()/panic!`（仅测试 scope 的 `.expect("capacity")`），按"只在确实需要时声明"原则不做提前声明。

## 验证（命令 + 结果）
```bash
cargo check -p dasclaw_utils_cache --tests              # PASS
cargo nextest run -p dasclaw_utils_cache                # 3 PASS / 0 FAIL
cargo fmt --all                                         # no diff
cargo clippy --no-deps -p dasclaw_utils_cache --all-targets -- -D warnings   # clean
python3.12 scripts/check_codex_utils_cache_drift.py     # OK: 1 file(s) match upstream verbatim.
python3.12 scripts/check_no_panics.py --base origin/xClaw   # OK
diff -r codex-cli-main/codex-rs/utils/cache/src/ crates/dasclaw_utils_cache/src/   # empty
```

## Sources read
- AGENTS.md §（Sources read 强制声明 / verbatim port 规范）
- docs/plans/architecture-refactor/adr-136-protocol-expansion-plan.md §3 amendment 2 修订点 1（4 个 utils prep crate）
- docs/plans/architecture-refactor/adr-129-... §1.3（verbatim 红线 + 机械替换 allowlist）
- codex-cli-main/codex-rs/utils/cache/Cargo.toml + src/lib.rs（上游源）
- 已合并先例：#393 (prep-1) / #396 (prep-2) — 用同一 4 块结构 + drift 接入模板

## 与 prep-1 / prep-2 的差异提醒
- prep-3 是 4 个 utils 中**最小且无外部 codex_* 依赖**的一个 → drift guard 没有 `SWAP_PATTERNS`，路径树极简。
- 与 prep-2 不同，本 PR 不需要扩展 `scripts/check_no_panics.py`。
