### PR TITLE
feat(crates): vendor dasclaw_utils_image verbatim from codex-utils-image

### DIFF
--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -311,12 +311,26 @@ jobs:
     - name: Verify ported files match codex-cli-main snapshot byte-for-byte
       run: python3.12 scripts/check_codex_utils_cache_drift.py
 
+  codex-utils-image-drift:
+    name: ADR-136 amendment 2 verbatim drift (dasclaw_utils_image)
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v6
+      with:
+        submodules: recursive
+    - uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+    - name: Verify ported files match codex-cli-main snapshot byte-for-byte
+      run: python3.12 scripts/check_codex_utils_image_drift.py
+
   # Roll-up job for branch protection
   code-style:
     name: Code Style (fmt + clippy + deny)
     runs-on: ubuntu-latest
     if: always()
-    needs: [format, clippy, clippy-windows, deny-check, no-panics, claw-code-readonly, no-new-ironclaw-literal, codex-execpolicy-drift, codex-process-hardening-drift, codex-shell-command-drift, codex-protocol-drift, codex-utils-home-dir-drift, codex-utils-rustls-provider-drift, codex-net-proxy-drift, codex-async-utils-drift, codex-utils-string-drift, codex-utils-cache-drift]
+    needs: [format, clippy, clippy-windows, deny-check, no-panics, claw-code-readonly, no-new-ironclaw-literal, codex-execpolicy-drift, codex-process-hardening-drift, codex-shell-command-drift, codex-protocol-drift, codex-utils-home-dir-drift, codex-utils-rustls-provider-drift, codex-net-proxy-drift, codex-async-utils-drift, codex-utils-string-drift, codex-utils-cache-drift, codex-utils-image-drift]
     steps:
       - run: |
           if [[ "${{ needs.format.result }}" != "success" || "${{ needs.clippy.result }}" != "success" || "${{ needs.deny-check.result }}" != "success" || "${{ needs.no-panics.result }}" != "success" || "${{ needs.claw-code-readonly.result }}" != "success" || "${{ needs.codex-execpolicy-drift.result }}" != "success" ]]; then
@@ -362,6 +376,10 @@ jobs:
           fi
           if [[ "${{ needs.codex-utils-cache-drift.result }}" != "success" ]]; then
             echo "ADR-136 amendment 2 utils-cache verbatim drift guard failed: ${{ needs.codex-utils-cache-drift.result }}"
+            exit 1
+          fi
+          if [[ "${{ needs.codex-utils-image-drift.result }}" != "success" ]]; then
+            echo "ADR-136 amendment 2 utils-image verbatim drift guard failed: ${{ needs.codex-utils-image-drift.result }}"
             exit 1
           fi
           # clippy-windows only runs on main PRs, so skipped is acceptable but failure is not

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1473,6 +1473,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1911,6 +1917,12 @@ checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
 dependencies = [
  "thiserror 2.0.18",
 ]
+
+[[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
 name = "colorchoice"
@@ -3067,6 +3079,18 @@ dependencies = [
  "dirs 6.0.0",
  "pretty_assertions",
  "tempfile",
+]
+
+[[package]]
+name = "dasclaw_utils_image"
+version = "0.0.0-w7"
+dependencies = [
+ "base64 0.22.1",
+ "dasclaw_utils_cache",
+ "image",
+ "mime_guess",
+ "thiserror 2.0.18",
+ "tokio",
 ]
 
 [[package]]
@@ -4472,6 +4496,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gif"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
+dependencies = [
+ "color_quant",
+ "weezl",
+]
+
+[[package]]
 name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5436,6 +5470,34 @@ checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "color_quant",
+ "gif",
+ "image-webp",
+ "moxcms",
+ "num-traits",
+ "png 0.18.1",
+ "zune-core",
+ "zune-jpeg",
+]
+
+[[package]]
+name = "image-webp"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
+dependencies = [
+ "byteorder-lite",
+ "quick-error 2.0.1",
 ]
 
 [[package]]
@@ -6607,6 +6669,16 @@ dependencies = [
  "smallvec",
  "tagptr",
  "uuid",
+]
+
+[[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
 ]
 
 [[package]]
@@ -8208,10 +8280,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "pxfm"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
@@ -9463,7 +9547,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
 dependencies = [
  "fnv",
- "quick-error",
+ "quick-error 1.2.3",
  "tempfile",
  "wait-timeout",
 ]
@@ -14668,6 +14752,21 @@ checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
 dependencies = [
  "cc",
  "pkg-config",
+]
+
+[[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,8 @@ members = [
 	"crates/dasclaw_utils_string",
 	# W6 ADR-136 §3 amendment 2 PR-C1.prep-3 — codex-utils-cache verbatim port (~193 LOC)
 	"crates/dasclaw_utils_cache",
+	# W6 ADR-136 §3 amendment 2 PR-C1.prep-4 — codex-utils-image verbatim port (~404 LOC)
+	"crates/dasclaw_utils_image",
 	# W8 ADR-139 §4.5 PR1 — MITM CA trust-chain manager (dasclaw original, not verbatim)
 	"crates/dasclaw_cert_trust",
 	"desktop-client/ironclaw",

--- a/crates/dasclaw_utils_image/Cargo.toml
+++ b/crates/dasclaw_utils_image/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "dasclaw_utils_image"
+version = "0.0.0-w7"
+edition = "2024"
+license = "Apache-2.0 OR MIT"
+publish = false
+
+# ADR-136 §3 amendment 2 PR-C1.prep-4 — verbatim port of codex-cli-main
+# `codex-utils-image` (~404 LOC). Per ADR-129 §1.3 the only edits permitted
+# in this Cargo.toml are mechanical package name swaps:
+#   codex-utils-image -> dasclaw_utils_image
+#   codex-utils-cache -> dasclaw_utils_cache (path dep, see below)
+# All dep version pins are taken verbatim from
+# codex-cli-main/codex-rs/Cargo.toml workspace.dependencies (xClaw does not
+# use a [workspace.dependencies] table — versions are inlined per crate to
+# match prep-1 / prep-2 / prep-3 precedent).
+
+[dependencies]
+base64 = "0.22.1"
+image = { version = "^0.25.9", default-features = false, features = ["jpeg", "png", "gif", "webp"] }
+dasclaw_utils_cache = { path = "../dasclaw_utils_cache" }
+mime_guess = "2.0.5"
+thiserror = "2.0.17"
+tokio = { version = "1", features = ["fs", "rt", "rt-multi-thread", "macros"] }
+
+[dev-dependencies]
+image = { version = "^0.25.9", default-features = false, features = ["jpeg", "png", "gif", "webp"] }

--- a/crates/dasclaw_utils_image/src/error.rs
+++ b/crates/dasclaw_utils_image/src/error.rs
@@ -1,0 +1,55 @@
+use image::ImageError;
+use image::ImageFormat;
+use std::path::PathBuf;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum ImageProcessingError {
+    #[error("failed to read image at {path}: {source}")]
+    Read {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("failed to decode image at {path}: {source}")]
+    Decode {
+        path: PathBuf,
+        #[source]
+        source: image::ImageError,
+    },
+    #[error("failed to encode image as {format:?}: {source}")]
+    Encode {
+        format: ImageFormat,
+        #[source]
+        source: image::ImageError,
+    },
+    #[error("unsupported image `{mime}`")]
+    UnsupportedImageFormat { mime: String },
+}
+
+impl ImageProcessingError {
+    pub fn decode_error(path: &std::path::Path, source: image::ImageError) -> Self {
+        if matches!(source, ImageError::Decoding(_)) {
+            return ImageProcessingError::Decode {
+                path: path.to_path_buf(),
+                source,
+            };
+        }
+
+        let mime = mime_guess::from_path(path)
+            .first()
+            .map(|mime_guess| mime_guess.essence_str().to_owned())
+            .unwrap_or_else(|| "unknown".to_string());
+        ImageProcessingError::UnsupportedImageFormat { mime }
+    }
+
+    pub fn is_invalid_image(&self) -> bool {
+        matches!(
+            self,
+            ImageProcessingError::Decode {
+                source: ImageError::Decoding(_),
+                ..
+            }
+        )
+    }
+}

--- a/crates/dasclaw_utils_image/src/lib.rs
+++ b/crates/dasclaw_utils_image/src/lib.rs
@@ -1,0 +1,349 @@
+use std::num::NonZeroUsize;
+use std::path::Path;
+use std::sync::LazyLock;
+
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
+use dasclaw_utils_cache::BlockingLruCache;
+use dasclaw_utils_cache::sha1_digest;
+use image::ColorType;
+use image::DynamicImage;
+use image::GenericImageView;
+use image::ImageEncoder;
+use image::ImageFormat;
+use image::codecs::jpeg::JpegEncoder;
+use image::codecs::png::PngEncoder;
+use image::codecs::webp::WebPEncoder;
+use image::imageops::FilterType;
+/// Maximum width or height used when resizing images before uploading.
+pub const MAX_DIMENSION: u32 = 2048;
+
+pub mod error;
+
+pub use crate::error::ImageProcessingError;
+
+#[derive(Debug, Clone)]
+pub struct EncodedImage {
+    pub bytes: Vec<u8>,
+    pub mime: String,
+    pub width: u32,
+    pub height: u32,
+}
+
+impl EncodedImage {
+    pub fn into_data_url(self) -> String {
+        let encoded = BASE64_STANDARD.encode(&self.bytes);
+        format!("data:{};base64,{encoded}", self.mime)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum PromptImageMode {
+    ResizeToFit,
+    Original,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+struct ImageCacheKey {
+    digest: [u8; 20],
+    mode: PromptImageMode,
+}
+
+static IMAGE_CACHE: LazyLock<BlockingLruCache<ImageCacheKey, EncodedImage>> =
+    LazyLock::new(|| BlockingLruCache::new(NonZeroUsize::new(32).unwrap_or(NonZeroUsize::MIN)));
+
+pub fn load_for_prompt_bytes(
+    path: &Path,
+    file_bytes: Vec<u8>,
+    mode: PromptImageMode,
+) -> Result<EncodedImage, ImageProcessingError> {
+    let path_buf = path.to_path_buf();
+
+    let key = ImageCacheKey {
+        digest: sha1_digest(&file_bytes),
+        mode,
+    };
+
+    IMAGE_CACHE.get_or_try_insert_with(key, move || {
+        let format = match image::guess_format(&file_bytes) {
+            Ok(ImageFormat::Png) => Some(ImageFormat::Png),
+            Ok(ImageFormat::Jpeg) => Some(ImageFormat::Jpeg),
+            Ok(ImageFormat::Gif) => Some(ImageFormat::Gif),
+            Ok(ImageFormat::WebP) => Some(ImageFormat::WebP),
+            _ => None,
+        };
+
+        let dynamic = image::load_from_memory(&file_bytes)
+            .map_err(|source| ImageProcessingError::decode_error(&path_buf, source))?;
+
+        let (width, height) = dynamic.dimensions();
+
+        let encoded = if mode == PromptImageMode::Original
+            || (width <= MAX_DIMENSION && height <= MAX_DIMENSION)
+        {
+            if let Some(format) = format.filter(|format| can_preserve_source_bytes(*format)) {
+                let mime = format_to_mime(format);
+                EncodedImage {
+                    bytes: file_bytes,
+                    mime,
+                    width,
+                    height,
+                }
+            } else {
+                let (bytes, output_format) = encode_image(&dynamic, ImageFormat::Png)?;
+                let mime = format_to_mime(output_format);
+                EncodedImage {
+                    bytes,
+                    mime,
+                    width,
+                    height,
+                }
+            }
+        } else {
+            let resized = dynamic.resize(MAX_DIMENSION, MAX_DIMENSION, FilterType::Triangle);
+            let target_format = format
+                .filter(|format| can_preserve_source_bytes(*format))
+                .unwrap_or(ImageFormat::Png);
+            let (bytes, output_format) = encode_image(&resized, target_format)?;
+            let mime = format_to_mime(output_format);
+            EncodedImage {
+                bytes,
+                mime,
+                width: resized.width(),
+                height: resized.height(),
+            }
+        };
+
+        Ok(encoded)
+    })
+}
+
+fn can_preserve_source_bytes(format: ImageFormat) -> bool {
+    // Public API docs explicitly call out non-animated GIF support only.
+    // Preserve byte-for-byte only for formats we can safely pass through.
+    matches!(
+        format,
+        ImageFormat::Png | ImageFormat::Jpeg | ImageFormat::WebP
+    )
+}
+
+fn encode_image(
+    image: &DynamicImage,
+    preferred_format: ImageFormat,
+) -> Result<(Vec<u8>, ImageFormat), ImageProcessingError> {
+    let target_format = match preferred_format {
+        ImageFormat::Jpeg => ImageFormat::Jpeg,
+        ImageFormat::WebP => ImageFormat::WebP,
+        _ => ImageFormat::Png,
+    };
+
+    let mut buffer = Vec::new();
+
+    match target_format {
+        ImageFormat::Png => {
+            let rgba = image.to_rgba8();
+            let encoder = PngEncoder::new(&mut buffer);
+            encoder
+                .write_image(
+                    rgba.as_raw(),
+                    image.width(),
+                    image.height(),
+                    ColorType::Rgba8.into(),
+                )
+                .map_err(|source| ImageProcessingError::Encode {
+                    format: target_format,
+                    source,
+                })?;
+        }
+        ImageFormat::Jpeg => {
+            let mut encoder = JpegEncoder::new_with_quality(&mut buffer, 85);
+            encoder
+                .encode_image(image)
+                .map_err(|source| ImageProcessingError::Encode {
+                    format: target_format,
+                    source,
+                })?;
+        }
+        ImageFormat::WebP => {
+            let rgba = image.to_rgba8();
+            let encoder = WebPEncoder::new_lossless(&mut buffer);
+            encoder
+                .write_image(
+                    rgba.as_raw(),
+                    image.width(),
+                    image.height(),
+                    ColorType::Rgba8.into(),
+                )
+                .map_err(|source| ImageProcessingError::Encode {
+                    format: target_format,
+                    source,
+                })?;
+        }
+        _ => unreachable!("unsupported target_format should have been handled earlier"),
+    }
+
+    Ok((buffer, target_format))
+}
+
+fn format_to_mime(format: ImageFormat) -> String {
+    match format {
+        ImageFormat::Jpeg => "image/jpeg".to_string(),
+        ImageFormat::Gif => "image/gif".to_string(),
+        ImageFormat::WebP => "image/webp".to_string(),
+        _ => "image/png".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Cursor;
+
+    use super::*;
+    use image::GenericImageView;
+    use image::ImageBuffer;
+    use image::Rgba;
+
+    fn image_bytes(image: &ImageBuffer<Rgba<u8>, Vec<u8>>, format: ImageFormat) -> Vec<u8> {
+        let mut encoded = Cursor::new(Vec::new());
+        DynamicImage::ImageRgba8(image.clone())
+            .write_to(&mut encoded, format)
+            .expect("encode image to bytes");
+        encoded.into_inner()
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn returns_original_image_when_within_bounds() {
+        for (format, mime) in [
+            (ImageFormat::Png, "image/png"),
+            (ImageFormat::WebP, "image/webp"),
+        ] {
+            let image = ImageBuffer::from_pixel(64, 32, Rgba([10u8, 20, 30, 255]));
+            let original_bytes = image_bytes(&image, format);
+
+            let encoded = load_for_prompt_bytes(
+                Path::new("in-memory-image"),
+                original_bytes.clone(),
+                PromptImageMode::ResizeToFit,
+            )
+            .expect("process image");
+
+            assert_eq!(encoded.width, 64);
+            assert_eq!(encoded.height, 32);
+            assert_eq!(encoded.mime, mime);
+            assert_eq!(encoded.bytes, original_bytes);
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn downscales_large_image() {
+        for (format, mime) in [
+            (ImageFormat::Png, "image/png"),
+            (ImageFormat::WebP, "image/webp"),
+        ] {
+            let image = ImageBuffer::from_pixel(4096, 2048, Rgba([200u8, 10, 10, 255]));
+            let original_bytes = image_bytes(&image, format);
+
+            let processed = load_for_prompt_bytes(
+                Path::new("in-memory-image"),
+                original_bytes,
+                PromptImageMode::ResizeToFit,
+            )
+            .expect("process image");
+
+            assert!(processed.width <= MAX_DIMENSION);
+            assert!(processed.height <= MAX_DIMENSION);
+            assert_eq!(processed.mime, mime);
+
+            let detected_format =
+                image::guess_format(&processed.bytes).expect("detect resized output format");
+            assert_eq!(detected_format, format);
+
+            let loaded = image::load_from_memory(&processed.bytes)
+                .expect("read resized bytes back into image");
+            assert_eq!(loaded.dimensions(), (processed.width, processed.height));
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn downscales_tall_image_to_fit_square_bounds() {
+        let image = ImageBuffer::from_pixel(1024, 4096, Rgba([200u8, 10, 10, 255]));
+        let original_bytes = image_bytes(&image, ImageFormat::Png);
+
+        let processed = load_for_prompt_bytes(
+            Path::new("in-memory-image"),
+            original_bytes,
+            PromptImageMode::ResizeToFit,
+        )
+        .expect("process image");
+
+        assert_eq!(processed.width, 512);
+        assert_eq!(processed.height, MAX_DIMENSION);
+        assert_eq!(processed.mime, "image/png");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn preserves_large_image_in_original_mode() {
+        let image = ImageBuffer::from_pixel(4096, 2048, Rgba([180u8, 30, 30, 255]));
+        let original_bytes = image_bytes(&image, ImageFormat::Png);
+
+        let processed = load_for_prompt_bytes(
+            Path::new("in-memory-image"),
+            original_bytes.clone(),
+            PromptImageMode::Original,
+        )
+        .expect("process image");
+
+        assert_eq!(processed.width, 4096);
+        assert_eq!(processed.height, 2048);
+        assert_eq!(processed.mime, "image/png");
+        assert_eq!(processed.bytes, original_bytes);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn fails_cleanly_for_invalid_images() {
+        let err = load_for_prompt_bytes(
+            Path::new("in-memory-image"),
+            b"not an image".to_vec(),
+            PromptImageMode::ResizeToFit,
+        )
+        .expect_err("invalid image should fail");
+        assert!(matches!(
+            err,
+            ImageProcessingError::Decode { .. }
+                | ImageProcessingError::UnsupportedImageFormat { .. }
+        ));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn reprocesses_updated_file_contents() {
+        {
+            IMAGE_CACHE.clear();
+        }
+
+        let first_image = ImageBuffer::from_pixel(32, 16, Rgba([20u8, 120, 220, 255]));
+        let first_bytes = image_bytes(&first_image, ImageFormat::Png);
+
+        let first = load_for_prompt_bytes(
+            Path::new("in-memory-image"),
+            first_bytes,
+            PromptImageMode::ResizeToFit,
+        )
+        .expect("process first image");
+
+        let second_image = ImageBuffer::from_pixel(96, 48, Rgba([50u8, 60, 70, 255]));
+        let second_bytes = image_bytes(&second_image, ImageFormat::Png);
+
+        let second = load_for_prompt_bytes(
+            Path::new("in-memory-image"),
+            second_bytes,
+            PromptImageMode::ResizeToFit,
+        )
+        .expect("process updated image");
+
+        assert_eq!(first.width, 32);
+        assert_eq!(first.height, 16);
+        assert_eq!(second.width, 96);
+        assert_eq!(second.height, 48);
+        assert_ne!(second.bytes, first.bytes);
+    }
+}

--- a/scripts/check_codex_utils_image_drift.py
+++ b/scripts/check_codex_utils_image_drift.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3.12
+"""Drift guard: verify dasclaw_utils_image src/*.rs remains byte-identical
+to the upstream codex-utils-image snapshot vendored under
+codex-cli-main/codex-rs/utils/image/.
+
+ADR-129 §1.3 + ADR-136 §3 amendment 2 (PR-C1.prep-4) mandate verbatim port.
+The only mechanical edits allowed in src/*.rs are:
+
+  1. `codex_utils_cache` → `dasclaw_utils_cache`  (consequence of prep-3)
+
+This script normalizes (1) before hashing, then compares each Rust file
+against its upstream peer. Any other diff is treated as drift and exits
+non-zero so CI / pre-commit can block patch-style edits.
+
+Cargo.toml is intentionally NOT compared (package name + dep wiring
+diverge by design — see crates/dasclaw_utils_image/Cargo.toml header).
+
+Run: python3.12 scripts/check_codex_utils_image_drift.py
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+LOCAL = REPO_ROOT / "crates" / "dasclaw_utils_image" / "src"
+UPSTREAM = REPO_ROOT / "codex-cli-main" / "codex-rs" / "utils" / "image" / "src"
+
+FILES = [
+    "error.rs",
+    "lib.rs",
+]
+
+# Reverse the use-path swap so we compare against upstream verbatim.
+SWAP_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    (re.compile(r"\bdasclaw_utils_cache\b"), "codex_utils_cache"),
+]
+
+
+_USE_RE = re.compile(r"^use\s+")
+
+
+def _sort_use_blocks(text: str) -> str:
+    """Sort consecutive `use ...;` lines alphabetically.
+
+    rustfmt orders `use` blocks alphabetically, but the rename shifts items
+    into a new alphabetical position. To keep the verbatim guarantee
+    semantically equivalent across that mechanical swap, we canonicalize
+    use-block ordering on both sides before hashing.
+    """
+    lines = text.split("\n")
+    out: list[str] = []
+    i = 0
+    while i < len(lines):
+        if _USE_RE.match(lines[i]):
+            j = i
+            block: list[str] = []
+            while j < len(lines) and _USE_RE.match(lines[j]):
+                block.append(lines[j])
+                j += 1
+            out.extend(sorted(block))
+            i = j
+        else:
+            out.append(lines[i])
+            i += 1
+    return "\n".join(out)
+
+
+def normalize_local(text: str) -> str:
+    for pat, repl in SWAP_PATTERNS:
+        text = pat.sub(repl, text)
+    return _sort_use_blocks(text)
+
+
+def normalize_upstream(text: str) -> str:
+    return _sort_use_blocks(text)
+
+
+def sha(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def main() -> int:
+    drift: list[str] = []
+    missing: list[str] = []
+    for fname in FILES:
+        local = LOCAL / fname
+        upstream = UPSTREAM / fname
+        if not local.exists():
+            missing.append(f"local missing: {local.relative_to(REPO_ROOT)}")
+            continue
+        if not upstream.exists():
+            missing.append(f"upstream missing: {upstream.relative_to(REPO_ROOT)}")
+            continue
+        local_norm = normalize_local(local.read_text(encoding="utf-8"))
+        upstream_norm = normalize_upstream(upstream.read_text(encoding="utf-8"))
+        if sha(local_norm) != sha(upstream_norm):
+            drift.append(
+                f"DRIFT: {local.relative_to(REPO_ROOT)} != "
+                f"{upstream.relative_to(REPO_ROOT)} "
+                f"(after use-path normalization + use-block sort)"
+            )
+
+    # Guard against new upstream files we didn't pick up.
+    upstream_extras = sorted(
+        p.name for p in UPSTREAM.glob("*.rs") if p.name not in FILES
+    )
+    if upstream_extras:
+        for name in upstream_extras:
+            missing.append(
+                f"upstream has extra file not in drift list: {name} "
+                "(re-vendor required: add to FILES + copy to crates/dasclaw_utils_image/src/)"
+            )
+
+    if missing:
+        for line in missing:
+            print(line, file=sys.stderr)
+        return 2
+    if drift:
+        for line in drift:
+            print(line, file=sys.stderr)
+        print(
+            "\nADR-129 §1.3 + ADR-136 amendment 2 forbid hand-edits to ported files. "
+            "If upstream needs to change, re-vendor codex-cli-main first.",
+            file=sys.stderr,
+        )
+        return 1
+    print(f"OK: {len(FILES)} files match upstream verbatim.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #399

## 背景/目标
ADR-136 §3 amendment 2 **PR-C1.prep-4**（4 个 utils 预备 crate 的最后一个）。把上游 `codex-utils-image` (~404 LOC：`src/lib.rs` 349 + `src/error.rs` 55) 按 byte-identical verbatim 规范（ADR-129 §1.3）vendor 进 `crates/dasclaw_utils_image/`。本 PR 完成后，C1.4a / 4b / 5 即可在新工作区中直接 `use dasclaw_utils_image::...`。

## 改动范围
- `crates/dasclaw_utils_image/Cargo.toml` — package.name 机械替换；`codex-utils-cache = { workspace = true }` → `dasclaw_utils_cache = { path = "../dasclaw_utils_cache" }`；其余 deps 全部内联固定版本（`base64=0.22.1` / `image=^0.25.9` 含 jpeg+png+gif+webp / `mime_guess=2.0.5` / `thiserror=2.0.17` / `tokio=1` 含 fs+rt+rt-multi-thread+macros），与 prep-1 / 2 / 3 保持"无 [workspace.dependencies]"约定。
- `crates/dasclaw_utils_image/src/error.rs` — byte-identical（55 行，`ImageProcessingError` enum）。
- `crates/dasclaw_utils_image/src/lib.rs` — 仅 2 处 use-path 机械替换 `codex_utils_cache::` → `dasclaw_utils_cache::`，其余 byte-identical（349 行）。
- `scripts/check_codex_utils_image_drift.py` — SHA-256 drift guard，`PAIRS=2`，`SWAP_PATTERNS=[(dasclaw_utils_cache → codex_utils_cache)]`，含 `_sort_use_blocks` 归一（rustfmt 字母重排兼容，与 net_proxy / protocol 同模板）。
- `.github/workflows/code_style.yml` — 新增 `codex-utils-image-drift` job + 接入 `code-style` roll-up `needs[]` + 对应失败信息分支。
- 根 `Cargo.toml` `workspace.members` — 紧随 `dasclaw_utils_cache` 后追加一条注释 + 成员条目。

## 非目标 (What's NOT in this PR)
- **不**在任何消费者 crate（dasclaw_exec / agent / mcp / ...）中 `use dasclaw_utils_image`。布线推迟到 C1.4a/4b/5。
- **不**调整任何逻辑、API、特性（verbatim 红线）。
- **不**扩展 `scripts/check_no_panics.py` 的 `VERBATIM_PORTED_PREFIXES`：上游 lib.rs 全部 `.expect(...)` 都在 `#[cfg(test)] mod tests`（line 197+），生产代码无 panic 调用，按"只在确实需要时声明"原则不做提前声明。
- **不**引入 `[workspace.dependencies]` 表（沿袭 prep-1/2/3 内联钉死约定）。

## 验证（命令 + 结果）
```bash
cargo check -p dasclaw_utils_image --tests              # PASS
cargo nextest run -p dasclaw_utils_image                # 6 PASS / 0 FAIL
cargo fmt --all                                         # no diff
cargo clippy --no-deps -p dasclaw_utils_image --all-targets -- -D warnings   # clean
python3.12 scripts/check_codex_utils_image_drift.py     # OK: 2 files match upstream verbatim.
python3.12 scripts/check_no_panics.py --base origin/xClaw   # OK
```

## Sources read
- AGENTS.md §（Sources read 强制声明 / verbatim port 规范 / 禁止补丁式代码）
- docs/plans/architecture-refactor/adr-136-protocol-expansion-plan.md §3 amendment 2 修订点 1（4 个 utils prep crate）
- docs/plans/architecture-refactor/adr-129-... §1.3（verbatim 红线 + 机械替换 allowlist）
- codex-cli-main/codex-rs/utils/image/{Cargo.toml, src/error.rs, src/lib.rs}（上游源）
- 已合并先例：#393 (prep-1) / #396 (prep-2) / #398 (prep-3) — 同一 4 块 PR 模板
- scripts/check_codex_net_proxy_drift.py（SWAP_PATTERNS + use-block sort 模板）

## 与 prep-1/2/3 的差异提醒
- **首个含 `SWAP_PATTERNS` 的 utils prep**：prep-3 (cache) 因零 codex_* use-path 不需要；prep-4 因 `dasclaw_utils_cache` 改名需要 1 条规则。
- **首个内部 path 依赖**：prep-3 出现后才让 prep-4 能在 workspace 内 `path = "../dasclaw_utils_cache"`。审核请确认顺序约定（prep-3 必须先 land，#398 已合并 `f1cc333d`）。
- 6 个 nextest 测试比 prep-3 的 3 个、prep-2 的 17 个差距合理：image 处理本身是 IO + 像素操作，覆盖 6 个具代表性场景（downscale / preserve / reprocess / fail-clean）。
