### PR TITLE
feat(sandbox): Wave-B1 vendor codex-sandboxing as dasclaw_sandboxing (ADR-135 PR-B1, ~5,251 LOC)

### DIFF
--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -325,12 +325,26 @@ jobs:
     - name: Verify ported files match codex-cli-main snapshot byte-for-byte
       run: python3.12 scripts/check_codex_utils_image_drift.py
 
+  codex-sandboxing-drift:
+    name: ADR-135 verbatim drift (dasclaw_sandboxing)
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v6
+      with:
+        submodules: recursive
+    - uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+    - name: Verify ported files match codex-cli-main snapshot byte-for-byte
+      run: python3.12 scripts/check_codex_sandboxing_drift.py
+
   # Roll-up job for branch protection
   code-style:
     name: Code Style (fmt + clippy + deny)
     runs-on: ubuntu-latest
     if: always()
-    needs: [format, clippy, clippy-windows, deny-check, no-panics, claw-code-readonly, no-new-ironclaw-literal, codex-execpolicy-drift, codex-process-hardening-drift, codex-shell-command-drift, codex-protocol-drift, codex-utils-home-dir-drift, codex-utils-rustls-provider-drift, codex-net-proxy-drift, codex-async-utils-drift, codex-utils-string-drift, codex-utils-cache-drift, codex-utils-image-drift]
+    needs: [format, clippy, clippy-windows, deny-check, no-panics, claw-code-readonly, no-new-ironclaw-literal, codex-execpolicy-drift, codex-process-hardening-drift, codex-shell-command-drift, codex-protocol-drift, codex-utils-home-dir-drift, codex-utils-rustls-provider-drift, codex-net-proxy-drift, codex-async-utils-drift, codex-utils-string-drift, codex-utils-cache-drift, codex-utils-image-drift, codex-sandboxing-drift]
     steps:
       - run: |
           if [[ "${{ needs.format.result }}" != "success" || "${{ needs.clippy.result }}" != "success" || "${{ needs.deny-check.result }}" != "success" || "${{ needs.no-panics.result }}" != "success" || "${{ needs.claw-code-readonly.result }}" != "success" || "${{ needs.codex-execpolicy-drift.result }}" != "success" ]]; then
@@ -380,6 +394,10 @@ jobs:
           fi
           if [[ "${{ needs.codex-utils-image-drift.result }}" != "success" ]]; then
             echo "ADR-136 amendment 2 utils-image verbatim drift guard failed: ${{ needs.codex-utils-image-drift.result }}"
+            exit 1
+          fi
+          if [[ "${{ needs.codex-sandboxing-drift.result }}" != "success" ]]; then
+            echo "ADR-135 sandboxing verbatim drift guard failed: ${{ needs.codex-sandboxing-drift.result }}"
             exit 1
           fi
           # clippy-windows only runs on main PRs, so skipped is acceptable but failure is not

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3059,6 +3059,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dasclaw_sandboxing"
+version = "0.0.0-w7"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "dasclaw_absolute_path",
+ "dasclaw_net_proxy",
+ "dasclaw_protocol",
+ "dunce",
+ "libc",
+ "pretty_assertions",
+ "regex-lite",
+ "serde_json",
+ "tempfile",
+ "tokio",
+ "tracing",
+ "url",
+ "which 8.0.2",
+]
+
+[[package]]
 name = "dasclaw_shell_command"
 version = "0.0.0-w5"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,9 @@ members = [
 	"crates/dasclaw_utils_cache",
 	# W6 ADR-136 §3 amendment 2 PR-C1.prep-4 — codex-utils-image verbatim port (~404 LOC)
 	"crates/dasclaw_utils_image",
+	# W7 ADR-135 §3 PR-B1 / #380 Wave-B1 — codex-sandboxing verbatim port
+	# (kernel-layer landlock/seatbelt primitives, ~4,895 LOC + 3 sbpl)
+	"crates/dasclaw_sandboxing",
 	# W8 ADR-139 §4.5 PR1 — MITM CA trust-chain manager (dasclaw original, not verbatim)
 	"crates/dasclaw_cert_trust",
 	"desktop-client/ironclaw",

--- a/crates/dasclaw_sandboxing/Cargo.toml
+++ b/crates/dasclaw_sandboxing/Cargo.toml
@@ -1,0 +1,51 @@
+[package]
+# Verbatim port of codex-sandboxing @ codex-cli-main commit 6e838a19fa
+# (upstream snapshot vendored under codex-cli-main/codex-rs/sandboxing).
+# Mechanical edits per ADR-129 §1.3 + ADR-135 §3.1:
+#   1. Cargo.toml package name swap: codex-sandboxing → dasclaw_sandboxing
+#      and lib name swap: codex_sandboxing → dasclaw_sandboxing.
+#   2. Workspace deps that don't exist in this repo are inlined with
+#      explicit versions matching upstream codex-rs/Cargo.toml.
+#   3. use-path swap in src/*.rs (mechanical, drift-guard enforced):
+#        codex_protocol            → dasclaw_protocol
+#        codex_network_proxy       → dasclaw_net_proxy
+#        codex_utils_absolute_path → dasclaw_absolute_path
+#   4. .sbpl asset files are byte-for-byte identical to upstream
+#      (they reference no codex-* symbols).
+# DO NOT hand-edit src/*.rs or src/*.sbpl — drift guard
+# scripts/check_codex_sandboxing_drift.py verifies hash equality.
+#
+# This crate provides the kernel-layer sandbox enforcement primitives:
+#   - Linux: bubblewrap + landlock V3 + seccomp helper (codex-linux-sandbox)
+#   - macOS: Apple seatbelt (sandbox-exec) with vendored .sbpl base policies
+#   - Common: SandboxPolicy → backend-specific transform via policy_transforms
+# Adapter wire-up into dasclaw_exec is Wave-C1 (separate PR, see issue #380).
+name = "dasclaw_sandboxing"
+version = "0.0.0-w7"
+edition = "2024"
+description = "Kernel-layer sandbox primitives (landlock/seatbelt) — verbatim port of codex-sandboxing."
+license = "Apache-2.0 OR MIT"
+publish = false
+
+[lib]
+name = "dasclaw_sandboxing"
+path = "src/lib.rs"
+
+[dependencies]
+dasclaw_net_proxy = { path = "../dasclaw_net_proxy" }
+dasclaw_protocol = { path = "../dasclaw_protocol" }
+dasclaw_absolute_path = { path = "../dasclaw_absolute_path" }
+dunce = "1.0.4"
+libc = "0.2.182"
+serde_json = "1"
+regex-lite = "0.1.8"
+tracing = { version = "0.1.44", features = ["log"] }
+url = "2"
+which = "8"
+
+[dev-dependencies]
+anyhow = "1"
+async-trait = "0.1.89"
+pretty_assertions = "1.4.1"
+tempfile = "3.23.0"
+tokio = { version = "1", features = ["macros", "rt"] }

--- a/crates/dasclaw_sandboxing/src/bwrap.rs
+++ b/crates/dasclaw_sandboxing/src/bwrap.rs
@@ -1,0 +1,136 @@
+use dasclaw_protocol::protocol::SandboxPolicy;
+use std::path::Path;
+use std::path::PathBuf;
+use std::process::Command;
+use std::process::Output;
+
+const SYSTEM_BWRAP_PROGRAM: &str = "bwrap";
+const MISSING_BWRAP_WARNING: &str = concat!(
+    "Codex could not find bubblewrap on PATH. ",
+    "Install bubblewrap with your OS package manager. ",
+    "See the sandbox prerequisites: ",
+    "https://developers.openai.com/codex/concepts/sandboxing#prerequisites. ",
+    "Codex will use the vendored bubblewrap in the meantime.",
+);
+const USER_NAMESPACE_WARNING: &str =
+    "Codex's Linux sandbox uses bubblewrap and needs access to create user namespaces.";
+pub(crate) const WSL1_BWRAP_WARNING: &str = concat!(
+    "Codex's Linux sandbox uses bubblewrap, which is not supported on WSL1 ",
+    "because WSL1 cannot create the required user namespaces. ",
+    "Use WSL2 for sandboxed shell commands."
+);
+const USER_NAMESPACE_FAILURES: [&str; 4] = [
+    "loopback: Failed RTM_NEWADDR",
+    "loopback: Failed RTM_NEWLINK",
+    "setting up uid map: Permission denied",
+    "No permissions to create a new namespace",
+];
+
+pub fn system_bwrap_warning(sandbox_policy: &SandboxPolicy) -> Option<String> {
+    if !should_warn_about_system_bwrap(sandbox_policy) {
+        return None;
+    }
+
+    let system_bwrap_path = find_system_bwrap_in_path();
+    system_bwrap_warning_for_path(system_bwrap_path.as_deref())
+}
+
+fn should_warn_about_system_bwrap(sandbox_policy: &SandboxPolicy) -> bool {
+    !matches!(
+        sandbox_policy,
+        SandboxPolicy::DangerFullAccess | SandboxPolicy::ExternalSandbox { .. }
+    )
+}
+
+fn system_bwrap_warning_for_path(system_bwrap_path: Option<&Path>) -> Option<String> {
+    if is_wsl1() {
+        return Some(WSL1_BWRAP_WARNING.to_string());
+    }
+
+    let Some(system_bwrap_path) = system_bwrap_path else {
+        return Some(MISSING_BWRAP_WARNING.to_string());
+    };
+
+    if !system_bwrap_has_user_namespace_access(system_bwrap_path) {
+        return Some(USER_NAMESPACE_WARNING.to_string());
+    }
+
+    None
+}
+
+fn system_bwrap_has_user_namespace_access(system_bwrap_path: &Path) -> bool {
+    let output = match Command::new(system_bwrap_path)
+        .args([
+            "--unshare-user",
+            "--unshare-net",
+            "--ro-bind",
+            "/",
+            "/",
+            "/bin/true",
+        ])
+        .output()
+    {
+        Ok(output) => output,
+        Err(_) => return true,
+    };
+
+    output.status.success() || !is_user_namespace_failure(&output)
+}
+
+pub(crate) fn is_wsl1() -> bool {
+    std::fs::read_to_string("/proc/version")
+        .is_ok_and(|proc_version| proc_version_indicates_wsl1(&proc_version))
+}
+
+fn proc_version_indicates_wsl1(proc_version: &str) -> bool {
+    let proc_version = proc_version.to_ascii_lowercase();
+    let mut remaining = proc_version.as_str();
+    while let Some(marker) = remaining.find("wsl") {
+        let version_start = marker + "wsl".len();
+        let version_digits: String = remaining[version_start..]
+            .chars()
+            .take_while(char::is_ascii_digit)
+            .collect();
+        if let Ok(version) = version_digits.parse::<u32>() {
+            return version == 1;
+        }
+        remaining = &remaining[version_start..];
+    }
+
+    proc_version.contains("microsoft") && !proc_version.contains("microsoft-standard")
+}
+
+fn is_user_namespace_failure(output: &Output) -> bool {
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    USER_NAMESPACE_FAILURES
+        .iter()
+        .any(|failure| stderr.contains(failure))
+}
+
+pub fn find_system_bwrap_in_path() -> Option<PathBuf> {
+    let search_path = std::env::var_os("PATH")?;
+    let cwd = std::env::current_dir().ok()?;
+    find_system_bwrap_in_search_paths(std::env::split_paths(&search_path), &cwd)
+}
+
+fn find_system_bwrap_in_search_paths(
+    search_paths: impl IntoIterator<Item = PathBuf>,
+    cwd: &Path,
+) -> Option<PathBuf> {
+    let search_path = std::env::join_paths(search_paths).ok()?;
+    let cwd = std::fs::canonicalize(cwd).unwrap_or_else(|_| cwd.to_path_buf());
+    which::which_in_all(SYSTEM_BWRAP_PROGRAM, Some(search_path), &cwd)
+        .ok()?
+        .find_map(|path| {
+            let path = std::fs::canonicalize(path).ok()?;
+            if path.starts_with(&cwd) {
+                None
+            } else {
+                Some(path)
+            }
+        })
+}
+
+#[cfg(test)]
+#[path = "bwrap_tests.rs"]
+mod tests;

--- a/crates/dasclaw_sandboxing/src/bwrap_tests.rs
+++ b/crates/dasclaw_sandboxing/src/bwrap_tests.rs
@@ -1,0 +1,148 @@
+use super::*;
+use pretty_assertions::assert_eq;
+use std::path::Path;
+use std::path::PathBuf;
+use tempfile::tempdir;
+
+#[test]
+fn system_bwrap_warning_reports_missing_system_bwrap() {
+    assert_eq!(
+        system_bwrap_warning_for_path(/*system_bwrap_path*/ None),
+        Some(MISSING_BWRAP_WARNING.to_string())
+    );
+}
+
+#[test]
+fn system_bwrap_warning_reports_user_namespace_failures() {
+    for failure in USER_NAMESPACE_FAILURES {
+        let fake_bwrap = write_fake_bwrap(&format!(
+            r#"#!/bin/sh
+echo '{failure}' >&2
+exit 1
+"#
+        ));
+        let fake_bwrap_path: &Path = fake_bwrap.as_ref();
+
+        assert_eq!(
+            system_bwrap_warning_for_path(Some(fake_bwrap_path)),
+            Some(USER_NAMESPACE_WARNING.to_string()),
+            "{failure}",
+        );
+    }
+}
+
+#[test]
+fn system_bwrap_warning_skips_unrelated_bwrap_failures() {
+    let fake_bwrap = write_fake_bwrap(
+        r#"#!/bin/sh
+echo 'bwrap: Unknown option --argv0' >&2
+exit 1
+"#,
+    );
+    let fake_bwrap_path: &Path = fake_bwrap.as_ref();
+
+    assert_eq!(system_bwrap_warning_for_path(Some(fake_bwrap_path)), None);
+}
+
+#[test]
+fn detects_wsl1_proc_version_formats() {
+    assert!(proc_version_indicates_wsl1(
+        "Linux version 4.4.0-22621-Microsoft"
+    ));
+    assert!(proc_version_indicates_wsl1(
+        "Linux version 5.15.0-microsoft-standard-WSL1"
+    ));
+    assert!(proc_version_indicates_wsl1(
+        "Linux version 5.15.0-wsl-microsoft-standard-WSL1"
+    ));
+}
+
+#[test]
+fn does_not_treat_wsl2_or_native_linux_as_wsl1() {
+    assert!(!proc_version_indicates_wsl1(
+        "Linux version 6.6.87.2-microsoft-standard-WSL2"
+    ));
+    assert!(!proc_version_indicates_wsl1(
+        "Linux version 6.6.87.2-wsl-microsoft-standard-WSL2"
+    ));
+    assert!(!proc_version_indicates_wsl1(
+        "Linux version 4.19.104-microsoft-standard"
+    ));
+    assert!(!proc_version_indicates_wsl1(
+        "Linux version 6.6.87.2-microsoft-standard-WSL3"
+    ));
+    assert!(!proc_version_indicates_wsl1("Linux version 6.8.0"));
+}
+
+#[test]
+fn finds_first_executable_bwrap_in_joined_search_path() {
+    let temp_dir = tempdir().expect("temp dir");
+    let cwd = temp_dir.path().join("cwd");
+    let first_dir = temp_dir.path().join("first");
+    let second_dir = temp_dir.path().join("second");
+    std::fs::create_dir_all(&cwd).expect("create cwd");
+    std::fs::create_dir_all(&first_dir).expect("create first dir");
+    std::fs::create_dir_all(&second_dir).expect("create second dir");
+    std::fs::write(first_dir.join("bwrap"), "not executable").expect("write non-executable bwrap");
+    let expected_bwrap = write_named_fake_bwrap_in(&second_dir);
+    let search_path = std::env::join_paths([first_dir, second_dir]).expect("join search path");
+
+    assert_eq!(
+        find_system_bwrap_in_search_paths(std::env::split_paths(&search_path), &cwd),
+        Some(expected_bwrap)
+    );
+}
+
+#[test]
+fn skips_workspace_local_bwrap_in_joined_search_path() {
+    let temp_dir = tempdir().expect("temp dir");
+    let cwd = temp_dir.path().join("cwd");
+    let trusted_dir = temp_dir.path().join("trusted");
+    std::fs::create_dir_all(&cwd).expect("create cwd");
+    std::fs::create_dir_all(&trusted_dir).expect("create trusted dir");
+    let _workspace_bwrap = write_named_fake_bwrap_in(&cwd);
+    let expected_bwrap = write_named_fake_bwrap_in(&trusted_dir);
+    let search_path = std::env::join_paths([cwd.clone(), trusted_dir]).expect("join search path");
+
+    assert_eq!(
+        find_system_bwrap_in_search_paths(std::env::split_paths(&search_path), &cwd),
+        Some(expected_bwrap)
+    );
+}
+
+fn write_fake_bwrap(contents: &str) -> tempfile::TempPath {
+    write_fake_bwrap_in(
+        &std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
+        contents,
+    )
+}
+
+fn write_fake_bwrap_in(dir: &Path, contents: &str) -> tempfile::TempPath {
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+    use tempfile::NamedTempFile;
+
+    // Bazel can mount the OS temp directory `noexec`, so prefer the current
+    // working directory for fake executables and fall back to the default temp
+    // dir outside that environment.
+    let temp_file = NamedTempFile::new_in(dir)
+        .ok()
+        .unwrap_or_else(|| NamedTempFile::new().expect("temp file"));
+    // Linux rejects exec-ing a file that is still open for writing.
+    let path = temp_file.into_temp_path();
+    fs::write(&path, contents).expect("write fake bwrap");
+    let permissions = fs::Permissions::from_mode(0o755);
+    fs::set_permissions(&path, permissions).expect("chmod fake bwrap");
+    path
+}
+
+fn write_named_fake_bwrap_in(dir: &Path) -> PathBuf {
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+
+    let path = dir.join("bwrap");
+    fs::write(&path, "#!/bin/sh\n").expect("write fake bwrap");
+    let permissions = fs::Permissions::from_mode(0o755);
+    fs::set_permissions(&path, permissions).expect("chmod fake bwrap");
+    fs::canonicalize(path).expect("canonicalize fake bwrap")
+}

--- a/crates/dasclaw_sandboxing/src/landlock.rs
+++ b/crates/dasclaw_sandboxing/src/landlock.rs
@@ -1,0 +1,117 @@
+use dasclaw_protocol::permissions::FileSystemSandboxPolicy;
+use dasclaw_protocol::permissions::NetworkSandboxPolicy;
+use dasclaw_protocol::protocol::SandboxPolicy;
+use std::path::Path;
+
+/// Basename used when the Codex executable self-invokes as the Linux sandbox
+/// helper.
+pub const CODEX_LINUX_SANDBOX_ARG0: &str = "codex-linux-sandbox";
+
+pub fn allow_network_for_proxy(enforce_managed_network: bool) -> bool {
+    // When managed network requirements are active, request proxy-only
+    // networking from the Linux sandbox helper. Without managed requirements,
+    // preserve existing behavior.
+    enforce_managed_network
+}
+
+/// Converts the sandbox policies into the CLI invocation for
+/// `codex-linux-sandbox`.
+///
+/// The helper performs the actual sandboxing (bubblewrap by default + seccomp) after
+/// parsing these arguments. Policy JSON flags are emitted before helper feature
+/// flags so the argv order matches the helper's CLI shape. See
+/// `docs/linux_sandbox.md` for the Linux semantics.
+#[allow(clippy::too_many_arguments)]
+pub fn create_linux_sandbox_command_args_for_policies(
+    command: Vec<String>,
+    command_cwd: &Path,
+    sandbox_policy: &SandboxPolicy,
+    file_system_sandbox_policy: &FileSystemSandboxPolicy,
+    network_sandbox_policy: NetworkSandboxPolicy,
+    sandbox_policy_cwd: &Path,
+    use_legacy_landlock: bool,
+    allow_network_for_proxy: bool,
+) -> Vec<String> {
+    let sandbox_policy_json = serde_json::to_string(sandbox_policy)
+        .unwrap_or_else(|err| panic!("failed to serialize sandbox policy: {err}"));
+    let file_system_policy_json = serde_json::to_string(file_system_sandbox_policy)
+        .unwrap_or_else(|err| panic!("failed to serialize filesystem sandbox policy: {err}"));
+    let network_policy_json = serde_json::to_string(&network_sandbox_policy)
+        .unwrap_or_else(|err| panic!("failed to serialize network sandbox policy: {err}"));
+    let sandbox_policy_cwd = sandbox_policy_cwd
+        .to_str()
+        .unwrap_or_else(|| panic!("cwd must be valid UTF-8"))
+        .to_string();
+    let command_cwd = command_cwd
+        .to_str()
+        .unwrap_or_else(|| panic!("command cwd must be valid UTF-8"))
+        .to_string();
+
+    let mut linux_cmd: Vec<String> = vec![
+        "--sandbox-policy-cwd".to_string(),
+        sandbox_policy_cwd,
+        "--command-cwd".to_string(),
+        command_cwd,
+        "--sandbox-policy".to_string(),
+        sandbox_policy_json,
+        "--file-system-sandbox-policy".to_string(),
+        file_system_policy_json,
+        "--network-sandbox-policy".to_string(),
+        network_policy_json,
+    ];
+    if use_legacy_landlock {
+        linux_cmd.push("--use-legacy-landlock".to_string());
+    }
+    if allow_network_for_proxy {
+        linux_cmd.push("--allow-network-for-proxy".to_string());
+    }
+    linux_cmd.push("--".to_string());
+    linux_cmd.extend(command);
+    linux_cmd
+}
+
+/// Converts the sandbox cwd and execution options into the CLI invocation for
+/// `codex-linux-sandbox`.
+#[cfg_attr(not(test), allow(dead_code))]
+fn create_linux_sandbox_command_args(
+    command: Vec<String>,
+    command_cwd: &Path,
+    sandbox_policy_cwd: &Path,
+    use_legacy_landlock: bool,
+    allow_network_for_proxy: bool,
+) -> Vec<String> {
+    let command_cwd = command_cwd
+        .to_str()
+        .unwrap_or_else(|| panic!("command cwd must be valid UTF-8"))
+        .to_string();
+    let sandbox_policy_cwd = sandbox_policy_cwd
+        .to_str()
+        .unwrap_or_else(|| panic!("cwd must be valid UTF-8"))
+        .to_string();
+
+    let mut linux_cmd: Vec<String> = vec![
+        "--sandbox-policy-cwd".to_string(),
+        sandbox_policy_cwd,
+        "--command-cwd".to_string(),
+        command_cwd,
+    ];
+    if use_legacy_landlock {
+        linux_cmd.push("--use-legacy-landlock".to_string());
+    }
+    if allow_network_for_proxy {
+        linux_cmd.push("--allow-network-for-proxy".to_string());
+    }
+
+    // Separator so that command arguments starting with `-` are not parsed as
+    // options of the helper itself.
+    linux_cmd.push("--".to_string());
+
+    // Append the original tool command.
+    linux_cmd.extend(command);
+
+    linux_cmd
+}
+
+#[cfg(test)]
+#[path = "landlock_tests.rs"]
+mod tests;

--- a/crates/dasclaw_sandboxing/src/landlock_tests.rs
+++ b/crates/dasclaw_sandboxing/src/landlock_tests.rs
@@ -1,0 +1,101 @@
+use super::*;
+use pretty_assertions::assert_eq;
+
+#[test]
+fn legacy_landlock_flag_is_included_when_requested() {
+    let command = vec!["/bin/true".to_string()];
+    let command_cwd = Path::new("/tmp/link");
+    let cwd = Path::new("/tmp");
+
+    let default_bwrap = create_linux_sandbox_command_args(
+        command.clone(),
+        command_cwd,
+        cwd,
+        /*use_legacy_landlock*/ false,
+        /*allow_network_for_proxy*/ false,
+    );
+    assert_eq!(
+        default_bwrap.contains(&"--use-legacy-landlock".to_string()),
+        false
+    );
+
+    let legacy_landlock = create_linux_sandbox_command_args(
+        command,
+        command_cwd,
+        cwd,
+        /*use_legacy_landlock*/ true,
+        /*allow_network_for_proxy*/ false,
+    );
+    assert_eq!(
+        legacy_landlock.contains(&"--use-legacy-landlock".to_string()),
+        true
+    );
+}
+
+#[test]
+fn proxy_flag_is_included_when_requested() {
+    let command = vec!["/bin/true".to_string()];
+    let command_cwd = Path::new("/tmp/link");
+    let cwd = Path::new("/tmp");
+
+    let args = create_linux_sandbox_command_args(
+        command,
+        command_cwd,
+        cwd,
+        /*use_legacy_landlock*/ true,
+        /*allow_network_for_proxy*/ true,
+    );
+    assert_eq!(
+        args.contains(&"--allow-network-for-proxy".to_string()),
+        true
+    );
+}
+
+#[test]
+fn split_policy_flags_are_included() {
+    let command = vec!["/bin/true".to_string()];
+    let command_cwd = Path::new("/tmp/link");
+    let cwd = Path::new("/tmp");
+    let sandbox_policy = SandboxPolicy::new_read_only_policy();
+    let file_system_sandbox_policy = FileSystemSandboxPolicy::from(&sandbox_policy);
+    let network_sandbox_policy = NetworkSandboxPolicy::from(&sandbox_policy);
+
+    let args = create_linux_sandbox_command_args_for_policies(
+        command,
+        command_cwd,
+        &sandbox_policy,
+        &file_system_sandbox_policy,
+        network_sandbox_policy,
+        cwd,
+        /*use_legacy_landlock*/ true,
+        /*allow_network_for_proxy*/ false,
+    );
+
+    assert_eq!(
+        args.windows(2)
+            .any(|window| { window[0] == "--file-system-sandbox-policy" && !window[1].is_empty() }),
+        true
+    );
+    assert_eq!(
+        args.windows(2)
+            .any(|window| window[0] == "--network-sandbox-policy" && window[1] == "\"restricted\""),
+        true
+    );
+    assert_eq!(
+        args.windows(2)
+            .any(|window| window[0] == "--command-cwd" && window[1] == "/tmp/link"),
+        true
+    );
+}
+
+#[test]
+fn proxy_network_requires_managed_requirements() {
+    assert_eq!(
+        allow_network_for_proxy(/*enforce_managed_network*/ false),
+        false
+    );
+    assert_eq!(
+        allow_network_for_proxy(/*enforce_managed_network*/ true),
+        true
+    );
+}

--- a/crates/dasclaw_sandboxing/src/lib.rs
+++ b/crates/dasclaw_sandboxing/src/lib.rs
@@ -1,0 +1,47 @@
+#[cfg(target_os = "linux")]
+mod bwrap;
+pub mod landlock;
+mod manager;
+pub mod policy_transforms;
+#[cfg(target_os = "macos")]
+pub mod seatbelt;
+
+#[cfg(target_os = "linux")]
+pub use bwrap::find_system_bwrap_in_path;
+#[cfg(target_os = "linux")]
+pub use bwrap::system_bwrap_warning;
+pub use manager::SandboxCommand;
+pub use manager::SandboxExecRequest;
+pub use manager::SandboxManager;
+pub use manager::SandboxTransformError;
+pub use manager::SandboxTransformRequest;
+pub use manager::SandboxType;
+pub use manager::SandboxablePreference;
+pub use manager::get_platform_sandbox;
+
+use dasclaw_protocol::error::CodexErr;
+
+#[cfg(not(target_os = "linux"))]
+pub fn system_bwrap_warning(
+    _sandbox_policy: &dasclaw_protocol::protocol::SandboxPolicy,
+) -> Option<String> {
+    None
+}
+
+impl From<SandboxTransformError> for CodexErr {
+    fn from(err: SandboxTransformError) -> Self {
+        match err {
+            SandboxTransformError::MissingLinuxSandboxExecutable => {
+                CodexErr::LandlockSandboxExecutableNotProvided
+            }
+            #[cfg(target_os = "linux")]
+            SandboxTransformError::Wsl1UnsupportedForBubblewrap => {
+                CodexErr::UnsupportedOperation(crate::bwrap::WSL1_BWRAP_WARNING.to_string())
+            }
+            #[cfg(not(target_os = "macos"))]
+            SandboxTransformError::SeatbeltUnavailable => CodexErr::UnsupportedOperation(
+                "seatbelt sandbox is only available on macOS".to_string(),
+            ),
+        }
+    }
+}

--- a/crates/dasclaw_sandboxing/src/manager.rs
+++ b/crates/dasclaw_sandboxing/src/manager.rs
@@ -1,0 +1,313 @@
+#[cfg(target_os = "linux")]
+use crate::bwrap::WSL1_BWRAP_WARNING;
+#[cfg(target_os = "linux")]
+use crate::bwrap::is_wsl1;
+use crate::landlock::CODEX_LINUX_SANDBOX_ARG0;
+use crate::landlock::allow_network_for_proxy;
+use crate::landlock::create_linux_sandbox_command_args_for_policies;
+use crate::policy_transforms::EffectiveSandboxPermissions;
+use crate::policy_transforms::effective_file_system_sandbox_policy;
+use crate::policy_transforms::effective_network_sandbox_policy;
+use crate::policy_transforms::should_require_platform_sandbox;
+use dasclaw_absolute_path::AbsolutePathBuf;
+use dasclaw_net_proxy::NetworkProxy;
+use dasclaw_protocol::config_types::WindowsSandboxLevel;
+use dasclaw_protocol::models::AdditionalPermissionProfile;
+use dasclaw_protocol::permissions::FileSystemSandboxPolicy;
+use dasclaw_protocol::permissions::NetworkSandboxPolicy;
+use dasclaw_protocol::protocol::SandboxPolicy;
+use std::collections::HashMap;
+use std::ffi::OsString;
+use std::path::Path;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SandboxType {
+    None,
+    MacosSeatbelt,
+    LinuxSeccomp,
+    WindowsRestrictedToken,
+}
+
+impl SandboxType {
+    pub fn as_metric_tag(self) -> &'static str {
+        match self {
+            SandboxType::None => "none",
+            SandboxType::MacosSeatbelt => "seatbelt",
+            SandboxType::LinuxSeccomp => "seccomp",
+            SandboxType::WindowsRestrictedToken => "windows_sandbox",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SandboxablePreference {
+    Auto,
+    Require,
+    Forbid,
+}
+
+pub fn get_platform_sandbox(windows_sandbox_enabled: bool) -> Option<SandboxType> {
+    if cfg!(target_os = "macos") {
+        Some(SandboxType::MacosSeatbelt)
+    } else if cfg!(target_os = "linux") {
+        Some(SandboxType::LinuxSeccomp)
+    } else if cfg!(target_os = "windows") {
+        if windows_sandbox_enabled {
+            Some(SandboxType::WindowsRestrictedToken)
+        } else {
+            None
+        }
+    } else {
+        None
+    }
+}
+
+#[derive(Debug)]
+pub struct SandboxCommand {
+    pub program: OsString,
+    pub args: Vec<String>,
+    pub cwd: AbsolutePathBuf,
+    pub env: HashMap<String, String>,
+    pub additional_permissions: Option<AdditionalPermissionProfile>,
+}
+
+#[derive(Debug)]
+pub struct SandboxExecRequest {
+    pub command: Vec<String>,
+    pub cwd: AbsolutePathBuf,
+    pub env: HashMap<String, String>,
+    pub network: Option<NetworkProxy>,
+    pub sandbox: SandboxType,
+    pub windows_sandbox_level: WindowsSandboxLevel,
+    pub windows_sandbox_private_desktop: bool,
+    pub sandbox_policy: SandboxPolicy,
+    pub file_system_sandbox_policy: FileSystemSandboxPolicy,
+    pub network_sandbox_policy: NetworkSandboxPolicy,
+    pub arg0: Option<String>,
+}
+
+/// Bundled arguments for sandbox transformation.
+///
+/// This keeps call sites self-documenting when several fields are optional.
+pub struct SandboxTransformRequest<'a> {
+    pub command: SandboxCommand,
+    pub policy: &'a SandboxPolicy,
+    pub file_system_policy: &'a FileSystemSandboxPolicy,
+    pub network_policy: NetworkSandboxPolicy,
+    pub sandbox: SandboxType,
+    pub enforce_managed_network: bool,
+    // TODO(viyatb): Evaluate switching this to Option<Arc<NetworkProxy>>
+    // to make shared ownership explicit across runtime/sandbox plumbing.
+    pub network: Option<&'a NetworkProxy>,
+    pub sandbox_policy_cwd: &'a Path,
+    pub codex_linux_sandbox_exe: Option<&'a Path>,
+    pub use_legacy_landlock: bool,
+    pub windows_sandbox_level: WindowsSandboxLevel,
+    pub windows_sandbox_private_desktop: bool,
+}
+
+#[derive(Debug)]
+pub enum SandboxTransformError {
+    MissingLinuxSandboxExecutable,
+    #[cfg(target_os = "linux")]
+    Wsl1UnsupportedForBubblewrap,
+    #[cfg(not(target_os = "macos"))]
+    SeatbeltUnavailable,
+}
+
+impl std::fmt::Display for SandboxTransformError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::MissingLinuxSandboxExecutable => {
+                write!(f, "missing codex-linux-sandbox executable path")
+            }
+            #[cfg(target_os = "linux")]
+            Self::Wsl1UnsupportedForBubblewrap => write!(f, "{WSL1_BWRAP_WARNING}"),
+            #[cfg(not(target_os = "macos"))]
+            Self::SeatbeltUnavailable => write!(f, "seatbelt sandbox is only available on macOS"),
+        }
+    }
+}
+
+impl std::error::Error for SandboxTransformError {}
+
+#[derive(Default)]
+pub struct SandboxManager;
+
+impl SandboxManager {
+    pub fn new() -> Self {
+        Self
+    }
+
+    pub fn select_initial(
+        &self,
+        file_system_policy: &FileSystemSandboxPolicy,
+        network_policy: NetworkSandboxPolicy,
+        pref: SandboxablePreference,
+        windows_sandbox_level: WindowsSandboxLevel,
+        has_managed_network_requirements: bool,
+    ) -> SandboxType {
+        match pref {
+            SandboxablePreference::Forbid => SandboxType::None,
+            SandboxablePreference::Require => {
+                get_platform_sandbox(windows_sandbox_level != WindowsSandboxLevel::Disabled)
+                    .unwrap_or(SandboxType::None)
+            }
+            SandboxablePreference::Auto => {
+                if should_require_platform_sandbox(
+                    file_system_policy,
+                    network_policy,
+                    has_managed_network_requirements,
+                ) {
+                    get_platform_sandbox(windows_sandbox_level != WindowsSandboxLevel::Disabled)
+                        .unwrap_or(SandboxType::None)
+                } else {
+                    SandboxType::None
+                }
+            }
+        }
+    }
+
+    pub fn transform(
+        &self,
+        request: SandboxTransformRequest<'_>,
+    ) -> Result<SandboxExecRequest, SandboxTransformError> {
+        let SandboxTransformRequest {
+            mut command,
+            policy,
+            file_system_policy,
+            network_policy,
+            sandbox,
+            enforce_managed_network,
+            network,
+            sandbox_policy_cwd,
+            codex_linux_sandbox_exe,
+            use_legacy_landlock,
+            windows_sandbox_level,
+            windows_sandbox_private_desktop,
+        } = request;
+        let additional_permissions = command.additional_permissions.take();
+        let EffectiveSandboxPermissions {
+            sandbox_policy: effective_policy,
+        } = EffectiveSandboxPermissions::new(policy, additional_permissions.as_ref());
+        let effective_file_system_policy = effective_file_system_sandbox_policy(
+            file_system_policy,
+            additional_permissions.as_ref(),
+        );
+        let effective_network_policy =
+            effective_network_sandbox_policy(network_policy, additional_permissions.as_ref());
+        let mut argv = Vec::with_capacity(1 + command.args.len());
+        argv.push(command.program);
+        argv.extend(command.args.into_iter().map(OsString::from));
+
+        let (argv, arg0_override) = match sandbox {
+            SandboxType::None => (os_argv_to_strings(argv), None),
+            #[cfg(target_os = "macos")]
+            SandboxType::MacosSeatbelt => {
+                use crate::seatbelt::CreateSeatbeltCommandArgsParams;
+                use crate::seatbelt::MACOS_PATH_TO_SEATBELT_EXECUTABLE;
+                use crate::seatbelt::create_seatbelt_command_args;
+
+                let mut args = create_seatbelt_command_args(CreateSeatbeltCommandArgsParams {
+                    command: os_argv_to_strings(argv),
+                    file_system_sandbox_policy: &effective_file_system_policy,
+                    network_sandbox_policy: effective_network_policy,
+                    sandbox_policy_cwd,
+                    enforce_managed_network,
+                    network,
+                    extra_allow_unix_sockets: &[],
+                });
+                let mut full_command = Vec::with_capacity(1 + args.len());
+                full_command.push(MACOS_PATH_TO_SEATBELT_EXECUTABLE.to_string());
+                full_command.append(&mut args);
+                (full_command, None)
+            }
+            #[cfg(not(target_os = "macos"))]
+            SandboxType::MacosSeatbelt => return Err(SandboxTransformError::SeatbeltUnavailable),
+            SandboxType::LinuxSeccomp => {
+                let exe = codex_linux_sandbox_exe
+                    .ok_or(SandboxTransformError::MissingLinuxSandboxExecutable)?;
+                let allow_proxy_network = allow_network_for_proxy(enforce_managed_network);
+                #[cfg(target_os = "linux")]
+                ensure_linux_bubblewrap_is_supported(
+                    &effective_file_system_policy,
+                    use_legacy_landlock,
+                    allow_proxy_network,
+                    is_wsl1(),
+                )?;
+                let mut args = create_linux_sandbox_command_args_for_policies(
+                    os_argv_to_strings(argv),
+                    command.cwd.as_path(),
+                    &effective_policy,
+                    &effective_file_system_policy,
+                    effective_network_policy,
+                    sandbox_policy_cwd,
+                    use_legacy_landlock,
+                    allow_proxy_network,
+                );
+                let mut full_command = Vec::with_capacity(1 + args.len());
+                full_command.push(os_string_to_command_component(exe.as_os_str().to_owned()));
+                full_command.append(&mut args);
+                (full_command, Some(linux_sandbox_arg0_override(exe)))
+            }
+            #[cfg(target_os = "windows")]
+            SandboxType::WindowsRestrictedToken => (os_argv_to_strings(argv), None),
+            #[cfg(not(target_os = "windows"))]
+            SandboxType::WindowsRestrictedToken => (os_argv_to_strings(argv), None),
+        };
+
+        Ok(SandboxExecRequest {
+            command: argv,
+            cwd: command.cwd,
+            env: command.env,
+            network: network.cloned(),
+            sandbox,
+            windows_sandbox_level,
+            windows_sandbox_private_desktop,
+            sandbox_policy: effective_policy,
+            file_system_sandbox_policy: effective_file_system_policy,
+            network_sandbox_policy: effective_network_policy,
+            arg0: arg0_override,
+        })
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn ensure_linux_bubblewrap_is_supported(
+    file_system_sandbox_policy: &FileSystemSandboxPolicy,
+    use_legacy_landlock: bool,
+    allow_network_for_proxy: bool,
+    is_wsl1: bool,
+) -> Result<(), SandboxTransformError> {
+    let requires_bubblewrap = !use_legacy_landlock
+        && (!file_system_sandbox_policy.has_full_disk_write_access() || allow_network_for_proxy);
+    if is_wsl1 && requires_bubblewrap {
+        return Err(SandboxTransformError::Wsl1UnsupportedForBubblewrap);
+    }
+
+    Ok(())
+}
+
+fn os_argv_to_strings(argv: Vec<OsString>) -> Vec<String> {
+    argv.into_iter()
+        .map(os_string_to_command_component)
+        .collect()
+}
+
+fn os_string_to_command_component(value: OsString) -> String {
+    value
+        .into_string()
+        .unwrap_or_else(|value| value.to_string_lossy().into_owned())
+}
+
+fn linux_sandbox_arg0_override(exe: &Path) -> String {
+    if exe.file_name().and_then(|name| name.to_str()) == Some(CODEX_LINUX_SANDBOX_ARG0) {
+        os_string_to_command_component(exe.as_os_str().to_owned())
+    } else {
+        CODEX_LINUX_SANDBOX_ARG0.to_string()
+    }
+}
+
+#[cfg(test)]
+#[path = "manager_tests.rs"]
+mod tests;

--- a/crates/dasclaw_sandboxing/src/manager_tests.rs
+++ b/crates/dasclaw_sandboxing/src/manager_tests.rs
@@ -1,0 +1,355 @@
+use super::SandboxCommand;
+use super::SandboxManager;
+use super::SandboxTransformRequest;
+use super::SandboxType;
+use super::SandboxablePreference;
+use super::get_platform_sandbox;
+use dasclaw_absolute_path::AbsolutePathBuf;
+use dasclaw_protocol::config_types::WindowsSandboxLevel;
+use dasclaw_protocol::models::AdditionalPermissionProfile as PermissionProfile;
+use dasclaw_protocol::models::FileSystemPermissions;
+use dasclaw_protocol::models::NetworkPermissions;
+use dasclaw_protocol::permissions::FileSystemAccessMode;
+use dasclaw_protocol::permissions::FileSystemPath;
+use dasclaw_protocol::permissions::FileSystemSandboxEntry;
+use dasclaw_protocol::permissions::FileSystemSandboxPolicy;
+use dasclaw_protocol::permissions::FileSystemSpecialPath;
+use dasclaw_protocol::permissions::NetworkSandboxPolicy;
+use dasclaw_protocol::protocol::NetworkAccess;
+use dasclaw_protocol::protocol::SandboxPolicy;
+use dunce::canonicalize;
+use pretty_assertions::assert_eq;
+use std::collections::HashMap;
+use tempfile::TempDir;
+
+#[test]
+fn danger_full_access_defaults_to_no_sandbox_without_network_requirements() {
+    let manager = SandboxManager::new();
+    let sandbox = manager.select_initial(
+        &FileSystemSandboxPolicy::unrestricted(),
+        NetworkSandboxPolicy::Enabled,
+        SandboxablePreference::Auto,
+        WindowsSandboxLevel::Disabled,
+        /*has_managed_network_requirements*/ false,
+    );
+    assert_eq!(sandbox, SandboxType::None);
+}
+
+#[test]
+fn danger_full_access_uses_platform_sandbox_with_network_requirements() {
+    let manager = SandboxManager::new();
+    let expected =
+        get_platform_sandbox(/*windows_sandbox_enabled*/ false).unwrap_or(SandboxType::None);
+    let sandbox = manager.select_initial(
+        &FileSystemSandboxPolicy::unrestricted(),
+        NetworkSandboxPolicy::Enabled,
+        SandboxablePreference::Auto,
+        WindowsSandboxLevel::Disabled,
+        /*has_managed_network_requirements*/ true,
+    );
+    assert_eq!(sandbox, expected);
+}
+
+#[test]
+fn restricted_file_system_uses_platform_sandbox_without_managed_network() {
+    let manager = SandboxManager::new();
+    let expected =
+        get_platform_sandbox(/*windows_sandbox_enabled*/ false).unwrap_or(SandboxType::None);
+    let sandbox = manager.select_initial(
+        &FileSystemSandboxPolicy::restricted(vec![FileSystemSandboxEntry {
+            path: FileSystemPath::Special {
+                value: FileSystemSpecialPath::Root,
+            },
+            access: FileSystemAccessMode::Read,
+        }]),
+        NetworkSandboxPolicy::Enabled,
+        SandboxablePreference::Auto,
+        WindowsSandboxLevel::Disabled,
+        /*has_managed_network_requirements*/ false,
+    );
+    assert_eq!(sandbox, expected);
+}
+
+#[test]
+fn transform_preserves_unrestricted_file_system_policy_for_restricted_network() {
+    let manager = SandboxManager::new();
+    let cwd = AbsolutePathBuf::current_dir().expect("current dir");
+    let exec_request = manager
+        .transform(SandboxTransformRequest {
+            command: SandboxCommand {
+                program: "true".into(),
+                args: Vec::new(),
+                cwd: cwd.clone(),
+                env: HashMap::new(),
+                additional_permissions: None,
+            },
+            policy: &SandboxPolicy::ExternalSandbox {
+                network_access: NetworkAccess::Restricted,
+            },
+            file_system_policy: &FileSystemSandboxPolicy::unrestricted(),
+            network_policy: NetworkSandboxPolicy::Restricted,
+            sandbox: SandboxType::None,
+            enforce_managed_network: false,
+            network: None,
+            sandbox_policy_cwd: cwd.as_path(),
+            codex_linux_sandbox_exe: None,
+            use_legacy_landlock: false,
+            windows_sandbox_level: WindowsSandboxLevel::Disabled,
+            windows_sandbox_private_desktop: false,
+        })
+        .expect("transform");
+
+    assert_eq!(
+        exec_request.file_system_sandbox_policy,
+        FileSystemSandboxPolicy::unrestricted()
+    );
+    assert_eq!(
+        exec_request.network_sandbox_policy,
+        NetworkSandboxPolicy::Restricted
+    );
+}
+
+#[test]
+fn transform_additional_permissions_enable_network_for_external_sandbox() {
+    let manager = SandboxManager::new();
+    let cwd = AbsolutePathBuf::current_dir().expect("current dir");
+    let temp_dir = TempDir::new().expect("create temp dir");
+    let path = AbsolutePathBuf::from_absolute_path(
+        canonicalize(temp_dir.path()).expect("canonicalize temp dir"),
+    )
+    .expect("absolute temp dir");
+    let exec_request = manager
+        .transform(SandboxTransformRequest {
+            command: SandboxCommand {
+                program: "true".into(),
+                args: Vec::new(),
+                cwd: cwd.clone(),
+                env: HashMap::new(),
+                additional_permissions: Some(PermissionProfile {
+                    network: Some(NetworkPermissions {
+                        enabled: Some(true),
+                    }),
+                    file_system: Some(FileSystemPermissions::from_read_write_roots(
+                        Some(vec![path]),
+                        Some(Vec::new()),
+                    )),
+                }),
+            },
+            policy: &SandboxPolicy::ExternalSandbox {
+                network_access: NetworkAccess::Restricted,
+            },
+            file_system_policy: &FileSystemSandboxPolicy::unrestricted(),
+            network_policy: NetworkSandboxPolicy::Restricted,
+            sandbox: SandboxType::None,
+            enforce_managed_network: false,
+            network: None,
+            sandbox_policy_cwd: cwd.as_path(),
+            codex_linux_sandbox_exe: None,
+            use_legacy_landlock: false,
+            windows_sandbox_level: WindowsSandboxLevel::Disabled,
+            windows_sandbox_private_desktop: false,
+        })
+        .expect("transform");
+
+    assert_eq!(
+        exec_request.sandbox_policy,
+        SandboxPolicy::ExternalSandbox {
+            network_access: NetworkAccess::Enabled,
+        }
+    );
+    assert_eq!(
+        exec_request.network_sandbox_policy,
+        NetworkSandboxPolicy::Enabled
+    );
+}
+
+#[test]
+fn transform_additional_permissions_preserves_denied_entries() {
+    let manager = SandboxManager::new();
+    let cwd = AbsolutePathBuf::current_dir().expect("current dir");
+    let temp_dir = TempDir::new().expect("create temp dir");
+    let workspace_root = AbsolutePathBuf::from_absolute_path(
+        canonicalize(temp_dir.path()).expect("canonicalize temp dir"),
+    )
+    .expect("absolute temp dir");
+    let allowed_path = workspace_root.join("allowed");
+    let denied_path = workspace_root.join("denied");
+    let exec_request = manager
+        .transform(SandboxTransformRequest {
+            command: SandboxCommand {
+                program: "true".into(),
+                args: Vec::new(),
+                cwd: cwd.clone(),
+                env: HashMap::new(),
+                additional_permissions: Some(PermissionProfile {
+                    file_system: Some(FileSystemPermissions::from_read_write_roots(
+                        /*read*/ None,
+                        Some(vec![allowed_path.clone()]),
+                    )),
+                    ..Default::default()
+                }),
+            },
+            policy: &SandboxPolicy::ReadOnly {
+                network_access: false,
+            },
+            file_system_policy: &FileSystemSandboxPolicy::restricted(vec![
+                FileSystemSandboxEntry {
+                    path: FileSystemPath::Special {
+                        value: FileSystemSpecialPath::Root,
+                    },
+                    access: FileSystemAccessMode::Read,
+                },
+                FileSystemSandboxEntry {
+                    path: FileSystemPath::Path {
+                        path: denied_path.clone(),
+                    },
+                    access: FileSystemAccessMode::None,
+                },
+            ]),
+            network_policy: NetworkSandboxPolicy::Restricted,
+            sandbox: SandboxType::None,
+            enforce_managed_network: false,
+            network: None,
+            sandbox_policy_cwd: cwd.as_path(),
+            codex_linux_sandbox_exe: None,
+            use_legacy_landlock: false,
+            windows_sandbox_level: WindowsSandboxLevel::Disabled,
+            windows_sandbox_private_desktop: false,
+        })
+        .expect("transform");
+
+    assert_eq!(
+        exec_request.file_system_sandbox_policy,
+        FileSystemSandboxPolicy::restricted(vec![
+            FileSystemSandboxEntry {
+                path: FileSystemPath::Special {
+                    value: FileSystemSpecialPath::Root,
+                },
+                access: FileSystemAccessMode::Read,
+            },
+            FileSystemSandboxEntry {
+                path: FileSystemPath::Path { path: denied_path },
+                access: FileSystemAccessMode::None,
+            },
+            FileSystemSandboxEntry {
+                path: FileSystemPath::Path { path: allowed_path },
+                access: FileSystemAccessMode::Write,
+            },
+        ])
+    );
+    assert_eq!(
+        exec_request.network_sandbox_policy,
+        NetworkSandboxPolicy::Restricted
+    );
+}
+
+#[cfg(target_os = "linux")]
+fn transform_linux_seccomp_request(
+    codex_linux_sandbox_exe: &std::path::Path,
+) -> super::SandboxExecRequest {
+    let manager = SandboxManager::new();
+    let cwd = AbsolutePathBuf::current_dir().expect("current dir");
+    manager
+        .transform(SandboxTransformRequest {
+            command: SandboxCommand {
+                program: "true".into(),
+                args: Vec::new(),
+                cwd: cwd.clone(),
+                env: HashMap::new(),
+                additional_permissions: None,
+            },
+            policy: &SandboxPolicy::DangerFullAccess,
+            file_system_policy: &FileSystemSandboxPolicy::unrestricted(),
+            network_policy: NetworkSandboxPolicy::Enabled,
+            sandbox: SandboxType::LinuxSeccomp,
+            enforce_managed_network: false,
+            network: None,
+            sandbox_policy_cwd: cwd.as_path(),
+            codex_linux_sandbox_exe: Some(codex_linux_sandbox_exe),
+            use_legacy_landlock: false,
+            windows_sandbox_level: WindowsSandboxLevel::Disabled,
+            windows_sandbox_private_desktop: false,
+        })
+        .expect("transform")
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn wsl1_rejects_linux_bubblewrap_path() {
+    let restricted_policy = FileSystemSandboxPolicy::restricted(vec![FileSystemSandboxEntry {
+        path: FileSystemPath::Special {
+            value: FileSystemSpecialPath::Root,
+        },
+        access: FileSystemAccessMode::Read,
+    }]);
+
+    assert!(matches!(
+        super::ensure_linux_bubblewrap_is_supported(
+            &restricted_policy,
+            /*use_legacy_landlock*/ false,
+            /*allow_network_for_proxy*/ false,
+            /*is_wsl1*/ true,
+        ),
+        Err(super::SandboxTransformError::Wsl1UnsupportedForBubblewrap)
+    ));
+    assert!(matches!(
+        super::ensure_linux_bubblewrap_is_supported(
+            &FileSystemSandboxPolicy::unrestricted(),
+            /*use_legacy_landlock*/ false,
+            /*allow_network_for_proxy*/ true,
+            /*is_wsl1*/ true,
+        ),
+        Err(super::SandboxTransformError::Wsl1UnsupportedForBubblewrap)
+    ));
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn wsl1_allows_non_bubblewrap_linux_paths() {
+    assert!(
+        super::ensure_linux_bubblewrap_is_supported(
+            &FileSystemSandboxPolicy::unrestricted(),
+            /*use_legacy_landlock*/ false,
+            /*allow_network_for_proxy*/ false,
+            /*is_wsl1*/ true,
+        )
+        .is_ok()
+    );
+
+    let restricted_policy = FileSystemSandboxPolicy::restricted(vec![FileSystemSandboxEntry {
+        path: FileSystemPath::Special {
+            value: FileSystemSpecialPath::Root,
+        },
+        access: FileSystemAccessMode::Read,
+    }]);
+    assert!(
+        super::ensure_linux_bubblewrap_is_supported(
+            &restricted_policy,
+            /*use_legacy_landlock*/ true,
+            /*allow_network_for_proxy*/ false,
+            /*is_wsl1*/ true,
+        )
+        .is_ok()
+    );
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn transform_linux_seccomp_preserves_helper_path_in_arg0_when_available() {
+    let codex_linux_sandbox_exe = std::path::PathBuf::from("/tmp/codex-linux-sandbox");
+    let exec_request = transform_linux_seccomp_request(&codex_linux_sandbox_exe);
+
+    assert_eq!(
+        exec_request.arg0,
+        Some(codex_linux_sandbox_exe.to_string_lossy().into_owned())
+    );
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn transform_linux_seccomp_uses_helper_alias_when_launcher_is_not_helper_path() {
+    let codex_linux_sandbox_exe = std::path::PathBuf::from("/tmp/codex");
+    let exec_request = transform_linux_seccomp_request(&codex_linux_sandbox_exe);
+
+    assert_eq!(exec_request.arg0, Some("codex-linux-sandbox".to_string()));
+}

--- a/crates/dasclaw_sandboxing/src/policy_transforms.rs
+++ b/crates/dasclaw_sandboxing/src/policy_transforms.rs
@@ -1,0 +1,655 @@
+use dasclaw_absolute_path::AbsolutePathBuf;
+use dasclaw_absolute_path::canonicalize_preserving_symlinks;
+use dasclaw_protocol::models::AdditionalPermissionProfile;
+use dasclaw_protocol::models::FileSystemPermissions;
+use dasclaw_protocol::models::NetworkPermissions;
+use dasclaw_protocol::permissions::FileSystemAccessMode;
+use dasclaw_protocol::permissions::FileSystemPath;
+use dasclaw_protocol::permissions::FileSystemSandboxEntry;
+use dasclaw_protocol::permissions::FileSystemSandboxKind;
+use dasclaw_protocol::permissions::FileSystemSandboxPolicy;
+use dasclaw_protocol::permissions::FileSystemSpecialPath;
+use dasclaw_protocol::permissions::NetworkSandboxPolicy;
+use dasclaw_protocol::permissions::ReadDenyMatcher;
+use dasclaw_protocol::protocol::NetworkAccess;
+use dasclaw_protocol::protocol::SandboxPolicy;
+use std::collections::HashSet;
+use std::num::NonZeroUsize;
+use std::path::Path;
+use std::path::PathBuf;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EffectiveSandboxPermissions {
+    pub sandbox_policy: SandboxPolicy,
+}
+
+impl EffectiveSandboxPermissions {
+    pub fn new(
+        sandbox_policy: &SandboxPolicy,
+        additional_permissions: Option<&AdditionalPermissionProfile>,
+    ) -> Self {
+        let Some(additional_permissions) = additional_permissions else {
+            return Self {
+                sandbox_policy: sandbox_policy.clone(),
+            };
+        };
+
+        Self {
+            sandbox_policy: effective_sandbox_policy(sandbox_policy, Some(additional_permissions)),
+        }
+    }
+}
+
+pub fn normalize_additional_permissions(
+    additional_permissions: AdditionalPermissionProfile,
+) -> Result<AdditionalPermissionProfile, String> {
+    let network = additional_permissions
+        .network
+        .filter(|network| !network.is_empty());
+    let file_system = match additional_permissions.file_system {
+        Some(file_system) => {
+            let mut entries = Vec::with_capacity(file_system.entries.len());
+            let glob_scan_max_depth = file_system.glob_scan_max_depth;
+            for entry in file_system.entries {
+                if matches!(&entry.path, FileSystemPath::GlobPattern { .. })
+                    && entry.access != FileSystemAccessMode::None
+                {
+                    return Err(
+                        "glob file system permissions only support deny-read entries".to_string(),
+                    );
+                }
+                let path = match entry.path {
+                    FileSystemPath::Path { path } => FileSystemPath::Path {
+                        path: canonicalize_preserving_symlinks(path.as_path())
+                            .ok()
+                            .and_then(|path| AbsolutePathBuf::from_absolute_path(path).ok())
+                            .unwrap_or(path),
+                    },
+                    FileSystemPath::GlobPattern { pattern } => {
+                        FileSystemPath::GlobPattern { pattern }
+                    }
+                    FileSystemPath::Special { value } => FileSystemPath::Special { value },
+                };
+                let normalized_entry = FileSystemSandboxEntry {
+                    path,
+                    access: entry.access,
+                };
+                if !entries.contains(&normalized_entry) {
+                    entries.push(normalized_entry);
+                }
+            }
+            let file_system = FileSystemPermissions {
+                entries,
+                glob_scan_max_depth,
+            };
+            (!file_system.is_empty()).then_some(file_system)
+        }
+        None => None,
+    };
+    Ok(AdditionalPermissionProfile {
+        network,
+        file_system,
+    })
+}
+
+pub fn merge_permission_profiles(
+    base: Option<&AdditionalPermissionProfile>,
+    permissions: Option<&AdditionalPermissionProfile>,
+) -> Option<AdditionalPermissionProfile> {
+    let Some(permissions) = permissions else {
+        return base.cloned();
+    };
+
+    match base {
+        Some(base) => {
+            let network = match (base.network.as_ref(), permissions.network.as_ref()) {
+                (
+                    Some(NetworkPermissions {
+                        enabled: Some(true),
+                    }),
+                    _,
+                )
+                | (
+                    _,
+                    Some(NetworkPermissions {
+                        enabled: Some(true),
+                    }),
+                ) => Some(NetworkPermissions {
+                    enabled: Some(true),
+                }),
+                _ => None,
+            };
+            let file_system = match (base.file_system.as_ref(), permissions.file_system.as_ref()) {
+                (Some(base), Some(permissions)) => Some(FileSystemPermissions {
+                    entries: merge_permission_entries(&base.entries, &permissions.entries),
+                    glob_scan_max_depth: merge_glob_scan_max_depth(
+                        &base.entries,
+                        base.glob_scan_max_depth.map(usize::from),
+                        &permissions.entries,
+                        permissions.glob_scan_max_depth.map(usize::from),
+                    )
+                    .and_then(NonZeroUsize::new),
+                })
+                .filter(|file_system| !file_system.is_empty()),
+                (Some(base), None) => Some(base.clone()),
+                (None, Some(permissions)) => Some(permissions.clone()),
+                (None, None) => None,
+            };
+
+            Some(AdditionalPermissionProfile {
+                network,
+                file_system,
+            })
+            .filter(|permissions| !permissions.is_empty())
+        }
+        None => Some(permissions.clone()).filter(|permissions| !permissions.is_empty()),
+    }
+}
+
+pub fn intersect_permission_profiles(
+    requested: AdditionalPermissionProfile,
+    granted: AdditionalPermissionProfile,
+    cwd: &Path,
+) -> AdditionalPermissionProfile {
+    let file_system = requested
+        .file_system
+        .map(|requested_file_system| {
+            let granted_file_system = granted.file_system.unwrap_or_default();
+            let requested_policy =
+                FileSystemSandboxPolicy::restricted(requested_file_system.entries.clone());
+            let requested_read_deny_matcher = ReadDenyMatcher::new(&requested_policy, cwd);
+            let mut accepted_entries = Vec::new();
+            for entry in granted_file_system.entries.iter().filter(|entry| {
+                granted_file_system_entry_within_request(
+                    &requested_file_system,
+                    &requested_policy,
+                    requested_read_deny_matcher.as_ref(),
+                    entry,
+                    cwd,
+                )
+            }) {
+                let entry = materialize_cwd_dependent_entry(entry, cwd);
+                if !accepted_entries.contains(&entry) {
+                    accepted_entries.push(entry);
+                }
+            }
+            let mut entries = accepted_entries.clone();
+            let requested_retained_deny_entries = retain_constraining_deny_entries(
+                &requested_file_system.entries,
+                &accepted_entries,
+                cwd,
+                &mut entries,
+            );
+            let granted_retained_deny_entries = retain_constraining_deny_entries(
+                &granted_file_system.entries,
+                &accepted_entries,
+                cwd,
+                &mut entries,
+            );
+            FileSystemPermissions {
+                glob_scan_max_depth: merge_glob_scan_max_depth(
+                    &requested_retained_deny_entries,
+                    requested_file_system.glob_scan_max_depth.map(usize::from),
+                    &granted_retained_deny_entries,
+                    granted_file_system.glob_scan_max_depth.map(usize::from),
+                )
+                .and_then(NonZeroUsize::new),
+                entries,
+            }
+        })
+        .filter(|file_system| !file_system.is_empty());
+    let network = match (requested.network, granted.network) {
+        (
+            Some(NetworkPermissions {
+                enabled: Some(true),
+            }),
+            Some(NetworkPermissions {
+                enabled: Some(true),
+            }),
+        ) => Some(NetworkPermissions {
+            enabled: Some(true),
+        }),
+        _ => None,
+    };
+
+    AdditionalPermissionProfile {
+        network,
+        file_system,
+    }
+}
+
+fn merge_glob_scan_max_depth(
+    left_entries: &[FileSystemSandboxEntry],
+    left_depth: Option<usize>,
+    right_entries: &[FileSystemSandboxEntry],
+    right_depth: Option<usize>,
+) -> Option<usize> {
+    let left_depth = effective_glob_scan_depth(left_entries, left_depth);
+    let right_depth = effective_glob_scan_depth(right_entries, right_depth);
+
+    match (left_depth, right_depth) {
+        (Some(GlobScanDepth::Unbounded), _) | (_, Some(GlobScanDepth::Unbounded)) => None,
+        (Some(GlobScanDepth::Bounded(left)), Some(GlobScanDepth::Bounded(right))) => {
+            Some(left.max(right))
+        }
+        (Some(GlobScanDepth::Bounded(depth)), None)
+        | (None, Some(GlobScanDepth::Bounded(depth))) => Some(depth),
+        (None, None) => None,
+    }
+}
+
+fn effective_glob_scan_depth(
+    entries: &[FileSystemSandboxEntry],
+    depth: Option<usize>,
+) -> Option<GlobScanDepth> {
+    entries
+        .iter()
+        .any(|entry| {
+            entry.access == FileSystemAccessMode::None
+                && matches!(&entry.path, FileSystemPath::GlobPattern { .. })
+        })
+        .then_some(match depth {
+            Some(depth) => GlobScanDepth::Bounded(depth),
+            None => GlobScanDepth::Unbounded,
+        })
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum GlobScanDepth {
+    Bounded(usize),
+    Unbounded,
+}
+
+fn granted_file_system_entry_within_request(
+    requested: &FileSystemPermissions,
+    requested_policy: &FileSystemSandboxPolicy,
+    requested_read_deny_matcher: Option<&ReadDenyMatcher>,
+    granted_entry: &FileSystemSandboxEntry,
+    cwd: &Path,
+) -> bool {
+    if !granted_entry.access.can_read() {
+        return false;
+    }
+
+    if let Some(path) = resolve_permission_path(&granted_entry.path, cwd) {
+        if requested_read_deny_matcher.is_some_and(|matcher| matcher.is_read_denied(path.as_path()))
+        {
+            return false;
+        }
+        return access_covers(
+            requested_policy.resolve_access_with_cwd(path.as_path(), cwd),
+            granted_entry.access,
+        );
+    }
+
+    requested.entries.iter().any(|requested_entry| {
+        access_covers(requested_entry.access, granted_entry.access)
+            && requested_entry.path == granted_entry.path
+    })
+}
+
+fn retain_constraining_deny_entries(
+    source_entries: &[FileSystemSandboxEntry],
+    accepted_entries: &[FileSystemSandboxEntry],
+    cwd: &Path,
+    output_entries: &mut Vec<FileSystemSandboxEntry>,
+) -> Vec<FileSystemSandboxEntry> {
+    let mut retained_entries = Vec::new();
+    for entry in source_entries
+        .iter()
+        .filter(|entry| entry.access == FileSystemAccessMode::None)
+    {
+        if !deny_entry_constrains_accepted_grant(entry, accepted_entries, cwd) {
+            continue;
+        }
+        let entry = materialize_cwd_dependent_entry(entry, cwd);
+        if !output_entries.contains(&entry) {
+            output_entries.push(entry.clone());
+        }
+        retained_entries.push(entry);
+    }
+    retained_entries
+}
+
+fn deny_entry_constrains_accepted_grant(
+    deny_entry: &FileSystemSandboxEntry,
+    accepted_entries: &[FileSystemSandboxEntry],
+    cwd: &Path,
+) -> bool {
+    accepted_entries
+        .iter()
+        .filter(|entry| entry.access.can_read())
+        .any(|entry| {
+            let Some(grant_path) = resolve_permission_path(&entry.path, cwd) else {
+                return false;
+            };
+            match &deny_entry.path {
+                FileSystemPath::GlobPattern { pattern } => glob_static_prefix_path(pattern, cwd)
+                    .is_some_and(|prefix| paths_overlap(prefix.as_path(), grant_path.as_path())),
+                FileSystemPath::Path { .. } | FileSystemPath::Special { .. } => {
+                    resolve_permission_path(&deny_entry.path, cwd).is_some_and(|deny_path| {
+                        paths_overlap(deny_path.as_path(), grant_path.as_path())
+                    })
+                }
+            }
+        })
+}
+
+fn glob_static_prefix_path(pattern: &str, cwd: &Path) -> Option<AbsolutePathBuf> {
+    let resolved_pattern = AbsolutePathBuf::resolve_path_against_base(pattern, cwd);
+    let resolved_pattern = resolved_pattern.as_path().to_string_lossy();
+    let prefix = match resolved_pattern.find(['*', '?', '[', ']']) {
+        Some(0) => return None,
+        Some(index) => {
+            let prefix = &resolved_pattern[..index];
+            if prefix.ends_with(std::path::MAIN_SEPARATOR)
+                || prefix.ends_with('/')
+                || prefix.ends_with('\\')
+            {
+                Path::new(prefix)
+            } else {
+                Path::new(prefix).parent()?
+            }
+        }
+        None => Path::new(resolved_pattern.as_ref()),
+    };
+    AbsolutePathBuf::from_absolute_path(prefix).ok()
+}
+
+fn paths_overlap(left: &Path, right: &Path) -> bool {
+    left.starts_with(right) || right.starts_with(left)
+}
+
+fn access_covers(requested: FileSystemAccessMode, granted: FileSystemAccessMode) -> bool {
+    match granted {
+        FileSystemAccessMode::Read => requested.can_read(),
+        FileSystemAccessMode::Write => requested.can_write(),
+        FileSystemAccessMode::None => false,
+    }
+}
+
+fn materialize_cwd_dependent_entry(
+    entry: &FileSystemSandboxEntry,
+    cwd: &Path,
+) -> FileSystemSandboxEntry {
+    match &entry.path {
+        FileSystemPath::Special {
+            value:
+                FileSystemSpecialPath::CurrentWorkingDirectory
+                | FileSystemSpecialPath::ProjectRoots { .. },
+        } => resolve_permission_path(&entry.path, cwd)
+            .map(|path| FileSystemSandboxEntry {
+                path: FileSystemPath::Path { path },
+                access: entry.access,
+            })
+            .unwrap_or_else(|| entry.clone()),
+        FileSystemPath::GlobPattern { pattern } => FileSystemSandboxEntry {
+            path: FileSystemPath::GlobPattern {
+                pattern: AbsolutePathBuf::resolve_path_against_base(pattern, cwd)
+                    .to_string_lossy()
+                    .into_owned(),
+            },
+            access: entry.access,
+        },
+        FileSystemPath::Path { .. } | FileSystemPath::Special { .. } => entry.clone(),
+    }
+}
+
+fn resolve_permission_path(path: &FileSystemPath, cwd: &Path) -> Option<AbsolutePathBuf> {
+    match path {
+        FileSystemPath::Path { path } => Some(path.clone()),
+        FileSystemPath::GlobPattern { .. } => None,
+        FileSystemPath::Special { value } => match value {
+            FileSystemSpecialPath::Root => {
+                let root = cwd.ancestors().last()?;
+                AbsolutePathBuf::from_absolute_path(root).ok()
+            }
+            FileSystemSpecialPath::CurrentWorkingDirectory => {
+                AbsolutePathBuf::from_absolute_path(cwd).ok()
+            }
+            FileSystemSpecialPath::ProjectRoots { subpath } => {
+                let cwd = AbsolutePathBuf::from_absolute_path(cwd).ok()?;
+                Some(match subpath {
+                    Some(subpath) => {
+                        AbsolutePathBuf::resolve_path_against_base(subpath, cwd.as_path())
+                    }
+                    None => cwd,
+                })
+            }
+            FileSystemSpecialPath::Tmpdir => {
+                let tmpdir = std::env::var_os("TMPDIR")?;
+                if tmpdir.is_empty() {
+                    None
+                } else {
+                    AbsolutePathBuf::from_absolute_path(PathBuf::from(tmpdir)).ok()
+                }
+            }
+            FileSystemSpecialPath::SlashTmp => AbsolutePathBuf::from_absolute_path("/tmp")
+                .ok()
+                .filter(|path| path.as_path().is_dir()),
+            FileSystemSpecialPath::Minimal | FileSystemSpecialPath::Unknown { .. } => None,
+        },
+    }
+}
+
+fn merge_permission_entries(
+    base: &[FileSystemSandboxEntry],
+    permissions: &[FileSystemSandboxEntry],
+) -> Vec<FileSystemSandboxEntry> {
+    let mut merged = Vec::with_capacity(base.len() + permissions.len());
+    for entry in base.iter().chain(permissions.iter()) {
+        if !merged.contains(entry) {
+            merged.push(entry.clone());
+        }
+    }
+    merged
+}
+
+fn dedup_absolute_paths(paths: Vec<AbsolutePathBuf>) -> Vec<AbsolutePathBuf> {
+    let mut out = Vec::with_capacity(paths.len());
+    let mut seen = HashSet::new();
+    for path in paths {
+        if seen.insert(path.to_path_buf()) {
+            out.push(path);
+        }
+    }
+    out
+}
+
+fn additional_permission_roots(
+    additional_permissions: &AdditionalPermissionProfile,
+) -> (Vec<AbsolutePathBuf>, Vec<AbsolutePathBuf>) {
+    (
+        dedup_absolute_paths(
+            additional_permissions
+                .file_system
+                .as_ref()
+                .map(|file_system| {
+                    file_system
+                        .explicit_path_entries()
+                        .filter_map(|(path, access)| access.can_read().then_some(path.clone()))
+                        .collect()
+                })
+                .unwrap_or_default(),
+        ),
+        dedup_absolute_paths(
+            additional_permissions
+                .file_system
+                .as_ref()
+                .map(|file_system| {
+                    file_system
+                        .explicit_path_entries()
+                        .filter_map(|(path, access)| access.can_write().then_some(path.clone()))
+                        .collect()
+                })
+                .unwrap_or_default(),
+        ),
+    )
+}
+
+fn merge_file_system_policy_with_additional_permissions(
+    file_system_policy: &FileSystemSandboxPolicy,
+    additional_permissions: &FileSystemPermissions,
+) -> FileSystemSandboxPolicy {
+    match file_system_policy.kind {
+        FileSystemSandboxKind::Restricted => {
+            let mut merged_policy = file_system_policy.clone();
+            for entry in &additional_permissions.entries {
+                if !merged_policy.entries.contains(entry) {
+                    merged_policy.entries.push(entry.clone());
+                }
+            }
+            merged_policy.glob_scan_max_depth = merge_glob_scan_max_depth(
+                &file_system_policy.entries,
+                file_system_policy.glob_scan_max_depth,
+                &additional_permissions.entries,
+                additional_permissions.glob_scan_max_depth.map(usize::from),
+            );
+            merged_policy
+        }
+        FileSystemSandboxKind::Unrestricted | FileSystemSandboxKind::ExternalSandbox => {
+            file_system_policy.clone()
+        }
+    }
+}
+
+pub fn effective_file_system_sandbox_policy(
+    file_system_policy: &FileSystemSandboxPolicy,
+    additional_permissions: Option<&AdditionalPermissionProfile>,
+) -> FileSystemSandboxPolicy {
+    let Some(additional_permissions) = additional_permissions else {
+        return file_system_policy.clone();
+    };
+
+    let Some(file_system_permissions) = additional_permissions.file_system.as_ref() else {
+        return file_system_policy.clone();
+    };
+    if file_system_permissions.is_empty() {
+        file_system_policy.clone()
+    } else {
+        merge_file_system_policy_with_additional_permissions(
+            file_system_policy,
+            file_system_permissions,
+        )
+    }
+}
+
+fn merge_network_access(
+    base_network_access: bool,
+    additional_permissions: &AdditionalPermissionProfile,
+) -> bool {
+    base_network_access
+        || additional_permissions
+            .network
+            .as_ref()
+            .and_then(|network| network.enabled)
+            .unwrap_or(false)
+}
+
+pub fn effective_network_sandbox_policy(
+    network_policy: NetworkSandboxPolicy,
+    additional_permissions: Option<&AdditionalPermissionProfile>,
+) -> NetworkSandboxPolicy {
+    if additional_permissions
+        .is_some_and(|permissions| merge_network_access(network_policy.is_enabled(), permissions))
+    {
+        NetworkSandboxPolicy::Enabled
+    } else if additional_permissions.is_some() {
+        NetworkSandboxPolicy::Restricted
+    } else {
+        network_policy
+    }
+}
+
+fn sandbox_policy_with_additional_permissions(
+    sandbox_policy: &SandboxPolicy,
+    additional_permissions: &AdditionalPermissionProfile,
+) -> SandboxPolicy {
+    if additional_permissions.is_empty() {
+        return sandbox_policy.clone();
+    }
+
+    let (_extra_reads, extra_writes) = additional_permission_roots(additional_permissions);
+
+    match sandbox_policy {
+        SandboxPolicy::DangerFullAccess => SandboxPolicy::DangerFullAccess,
+        SandboxPolicy::ExternalSandbox { network_access } => SandboxPolicy::ExternalSandbox {
+            network_access: if merge_network_access(
+                network_access.is_enabled(),
+                additional_permissions,
+            ) {
+                NetworkAccess::Enabled
+            } else {
+                NetworkAccess::Restricted
+            },
+        },
+        SandboxPolicy::WorkspaceWrite {
+            writable_roots,
+            network_access,
+            exclude_tmpdir_env_var,
+            exclude_slash_tmp,
+        } => {
+            let mut merged_writes = writable_roots.clone();
+            merged_writes.extend(extra_writes);
+            SandboxPolicy::WorkspaceWrite {
+                writable_roots: dedup_absolute_paths(merged_writes),
+                network_access: merge_network_access(*network_access, additional_permissions),
+                exclude_tmpdir_env_var: *exclude_tmpdir_env_var,
+                exclude_slash_tmp: *exclude_slash_tmp,
+            }
+        }
+        SandboxPolicy::ReadOnly { network_access } => {
+            if extra_writes.is_empty() {
+                SandboxPolicy::ReadOnly {
+                    network_access: merge_network_access(*network_access, additional_permissions),
+                }
+            } else {
+                // todo(dylan) - for now, this grants more access than the request. We should restrict this,
+                // but we should add a new SandboxPolicy variant to handle this. While the feature is still
+                // UnderDevelopment, it's a useful approximation of the desired behavior.
+                SandboxPolicy::WorkspaceWrite {
+                    writable_roots: dedup_absolute_paths(extra_writes),
+                    network_access: merge_network_access(*network_access, additional_permissions),
+                    exclude_tmpdir_env_var: false,
+                    exclude_slash_tmp: false,
+                }
+            }
+        }
+    }
+}
+
+fn effective_sandbox_policy(
+    sandbox_policy: &SandboxPolicy,
+    additional_permissions: Option<&AdditionalPermissionProfile>,
+) -> SandboxPolicy {
+    additional_permissions.map_or_else(
+        || sandbox_policy.clone(),
+        |permissions| sandbox_policy_with_additional_permissions(sandbox_policy, permissions),
+    )
+}
+
+pub fn should_require_platform_sandbox(
+    file_system_policy: &FileSystemSandboxPolicy,
+    network_policy: NetworkSandboxPolicy,
+    has_managed_network_requirements: bool,
+) -> bool {
+    if has_managed_network_requirements {
+        return true;
+    }
+
+    if !network_policy.is_enabled() {
+        return !matches!(
+            file_system_policy.kind,
+            FileSystemSandboxKind::ExternalSandbox
+        );
+    }
+
+    match file_system_policy.kind {
+        FileSystemSandboxKind::Restricted => !file_system_policy.has_full_disk_write_access(),
+        FileSystemSandboxKind::Unrestricted | FileSystemSandboxKind::ExternalSandbox => false,
+    }
+}
+
+#[cfg(test)]
+#[path = "policy_transforms_tests.rs"]
+mod tests;

--- a/crates/dasclaw_sandboxing/src/policy_transforms_tests.rs
+++ b/crates/dasclaw_sandboxing/src/policy_transforms_tests.rs
@@ -1,0 +1,977 @@
+use super::effective_file_system_sandbox_policy;
+use super::intersect_permission_profiles;
+use super::merge_file_system_policy_with_additional_permissions;
+use super::normalize_additional_permissions;
+use super::sandbox_policy_with_additional_permissions;
+use super::should_require_platform_sandbox;
+use dasclaw_absolute_path::AbsolutePathBuf;
+use dasclaw_protocol::models::AdditionalPermissionProfile as PermissionProfile;
+use dasclaw_protocol::models::FileSystemPermissions;
+use dasclaw_protocol::models::NetworkPermissions;
+use dasclaw_protocol::permissions::FileSystemAccessMode;
+use dasclaw_protocol::permissions::FileSystemPath;
+use dasclaw_protocol::permissions::FileSystemSandboxEntry;
+use dasclaw_protocol::permissions::FileSystemSandboxPolicy;
+use dasclaw_protocol::permissions::FileSystemSpecialPath;
+use dasclaw_protocol::permissions::NetworkSandboxPolicy;
+use dasclaw_protocol::protocol::NetworkAccess;
+use dasclaw_protocol::protocol::SandboxPolicy;
+use dunce::canonicalize;
+use pretty_assertions::assert_eq;
+#[cfg(unix)]
+use std::path::Path;
+use tempfile::TempDir;
+
+#[cfg(unix)]
+fn symlink_dir(original: &Path, link: &Path) -> std::io::Result<()> {
+    std::os::unix::fs::symlink(original, link)
+}
+
+#[test]
+fn full_access_restricted_policy_skips_platform_sandbox_when_network_is_enabled() {
+    let policy = FileSystemSandboxPolicy::restricted(vec![FileSystemSandboxEntry {
+        path: FileSystemPath::Special {
+            value: FileSystemSpecialPath::Root,
+        },
+        access: FileSystemAccessMode::Write,
+    }]);
+
+    assert_eq!(
+        should_require_platform_sandbox(
+            &policy,
+            NetworkSandboxPolicy::Enabled,
+            /*has_managed_network_requirements*/ false
+        ),
+        false
+    );
+}
+
+#[test]
+fn root_write_policy_with_carveouts_still_uses_platform_sandbox() {
+    let blocked = AbsolutePathBuf::resolve_path_against_base(
+        "blocked",
+        std::env::current_dir().expect("current dir"),
+    );
+    let policy = FileSystemSandboxPolicy::restricted(vec![
+        FileSystemSandboxEntry {
+            path: FileSystemPath::Special {
+                value: FileSystemSpecialPath::Root,
+            },
+            access: FileSystemAccessMode::Write,
+        },
+        FileSystemSandboxEntry {
+            path: FileSystemPath::Path { path: blocked },
+            access: FileSystemAccessMode::None,
+        },
+    ]);
+
+    assert_eq!(
+        should_require_platform_sandbox(
+            &policy,
+            NetworkSandboxPolicy::Enabled,
+            /*has_managed_network_requirements*/ false
+        ),
+        true
+    );
+}
+
+#[test]
+fn full_access_restricted_policy_still_uses_platform_sandbox_for_restricted_network() {
+    let policy = FileSystemSandboxPolicy::restricted(vec![FileSystemSandboxEntry {
+        path: FileSystemPath::Special {
+            value: FileSystemSpecialPath::Root,
+        },
+        access: FileSystemAccessMode::Write,
+    }]);
+
+    assert_eq!(
+        should_require_platform_sandbox(
+            &policy,
+            NetworkSandboxPolicy::Restricted,
+            /*has_managed_network_requirements*/ false
+        ),
+        true
+    );
+}
+
+#[test]
+fn normalize_additional_permissions_preserves_network() {
+    let temp_dir = TempDir::new().expect("create temp dir");
+    let path = AbsolutePathBuf::from_absolute_path(
+        canonicalize(temp_dir.path()).expect("canonicalize temp dir"),
+    )
+    .expect("absolute temp dir");
+    let permissions = normalize_additional_permissions(PermissionProfile {
+        network: Some(NetworkPermissions {
+            enabled: Some(true),
+        }),
+        file_system: Some(FileSystemPermissions::from_read_write_roots(
+            Some(vec![path.clone()]),
+            Some(vec![path.clone()]),
+        )),
+    })
+    .expect("permissions");
+
+    assert_eq!(
+        permissions.network,
+        Some(NetworkPermissions {
+            enabled: Some(true),
+        })
+    );
+    assert_eq!(
+        permissions.file_system,
+        Some(FileSystemPermissions::from_read_write_roots(
+            Some(vec![path.clone()]),
+            Some(vec![path]),
+        ))
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn normalize_additional_permissions_preserves_symlinked_write_paths() {
+    let temp_dir = TempDir::new().expect("create temp dir");
+    let real_root = temp_dir.path().join("real");
+    let link_root = temp_dir.path().join("link");
+    let write_dir = real_root.join("write");
+    std::fs::create_dir_all(&write_dir).expect("create write dir");
+    symlink_dir(&real_root, &link_root).expect("create symlinked root");
+
+    let link_write_dir =
+        AbsolutePathBuf::from_absolute_path(link_root.join("write")).expect("link write dir");
+    let permissions = normalize_additional_permissions(PermissionProfile {
+        file_system: Some(FileSystemPermissions::from_read_write_roots(
+            Some(vec![]),
+            Some(vec![link_write_dir]),
+        )),
+        ..Default::default()
+    })
+    .expect("permissions");
+
+    assert_eq!(
+        permissions.file_system,
+        Some(FileSystemPermissions::from_read_write_roots(
+            Some(vec![]),
+            Some(vec![
+                AbsolutePathBuf::from_absolute_path(link_root.join("write"))
+                    .expect("link write dir"),
+            ]),
+        ))
+    );
+}
+
+#[test]
+fn normalize_additional_permissions_rejects_glob_read_grants() {
+    let err = normalize_additional_permissions(PermissionProfile {
+        file_system: Some(FileSystemPermissions {
+            entries: vec![FileSystemSandboxEntry {
+                path: FileSystemPath::GlobPattern {
+                    pattern: "**/*.env".to_string(),
+                },
+                access: FileSystemAccessMode::Read,
+            }],
+            glob_scan_max_depth: None,
+        }),
+        ..Default::default()
+    })
+    .expect_err("read glob permissions are unsupported");
+
+    assert_eq!(
+        err,
+        "glob file system permissions only support deny-read entries"
+    );
+}
+
+#[test]
+fn normalize_additional_permissions_preserves_deny_globs() {
+    let permissions = normalize_additional_permissions(PermissionProfile {
+        file_system: Some(FileSystemPermissions {
+            entries: vec![FileSystemSandboxEntry {
+                path: FileSystemPath::GlobPattern {
+                    pattern: "**/*.env".to_string(),
+                },
+                access: FileSystemAccessMode::None,
+            }],
+            glob_scan_max_depth: std::num::NonZeroUsize::new(2),
+        }),
+        ..Default::default()
+    })
+    .expect("deny glob permissions are supported");
+
+    assert_eq!(
+        permissions,
+        PermissionProfile {
+            file_system: Some(FileSystemPermissions {
+                entries: vec![FileSystemSandboxEntry {
+                    path: FileSystemPath::GlobPattern {
+                        pattern: "**/*.env".to_string(),
+                    },
+                    access: FileSystemAccessMode::None,
+                }],
+                glob_scan_max_depth: std::num::NonZeroUsize::new(2),
+            }),
+            ..Default::default()
+        }
+    );
+}
+
+#[test]
+fn normalize_additional_permissions_drops_empty_nested_profiles() {
+    let permissions = normalize_additional_permissions(PermissionProfile {
+        network: Some(NetworkPermissions { enabled: None }),
+        file_system: Some(FileSystemPermissions::default()),
+    })
+    .expect("permissions");
+
+    assert_eq!(permissions, PermissionProfile::default());
+}
+
+#[test]
+fn intersect_permission_profiles_preserves_explicit_empty_requested_reads() {
+    let temp_dir = TempDir::new().expect("create temp dir");
+    let path = AbsolutePathBuf::from_absolute_path(
+        canonicalize(temp_dir.path()).expect("canonicalize temp dir"),
+    )
+    .expect("absolute temp dir");
+    let requested = PermissionProfile {
+        file_system: Some(FileSystemPermissions::from_read_write_roots(
+            Some(vec![]),
+            Some(vec![path]),
+        )),
+        ..Default::default()
+    };
+    let granted = requested.clone();
+
+    assert_eq!(
+        intersect_permission_profiles(requested.clone(), granted, temp_dir.path()),
+        requested
+    );
+}
+
+#[test]
+fn intersect_permission_profiles_drops_ungranted_nonempty_path_requests() {
+    let temp_dir = TempDir::new().expect("create temp dir");
+    let path = AbsolutePathBuf::from_absolute_path(
+        canonicalize(temp_dir.path()).expect("canonicalize temp dir"),
+    )
+    .expect("absolute temp dir");
+    let requested = PermissionProfile {
+        file_system: Some(FileSystemPermissions::from_read_write_roots(
+            Some(vec![path]),
+            /*write*/ None,
+        )),
+        ..Default::default()
+    };
+
+    assert_eq!(
+        intersect_permission_profiles(requested, PermissionProfile::default(), temp_dir.path()),
+        PermissionProfile::default()
+    );
+}
+
+#[test]
+fn intersect_permission_profiles_drops_explicit_empty_reads_without_grant() {
+    let temp_dir = TempDir::new().expect("create temp dir");
+    let path = AbsolutePathBuf::from_absolute_path(
+        canonicalize(temp_dir.path()).expect("canonicalize temp dir"),
+    )
+    .expect("absolute temp dir");
+    let requested = PermissionProfile {
+        file_system: Some(FileSystemPermissions::from_read_write_roots(
+            Some(vec![]),
+            Some(vec![path]),
+        )),
+        ..Default::default()
+    };
+
+    assert_eq!(
+        intersect_permission_profiles(requested, PermissionProfile::default(), temp_dir.path()),
+        PermissionProfile::default()
+    );
+}
+
+#[test]
+fn intersect_permission_profiles_accepts_child_path_granted_for_requested_cwd() {
+    let temp_dir = TempDir::new().expect("create temp dir");
+    let cwd = AbsolutePathBuf::from_absolute_path(
+        canonicalize(temp_dir.path()).expect("canonicalize temp dir"),
+    )
+    .expect("absolute temp dir");
+    let child = cwd.join("child");
+    let requested = PermissionProfile {
+        file_system: Some(FileSystemPermissions {
+            entries: vec![FileSystemSandboxEntry {
+                path: FileSystemPath::Special {
+                    value: FileSystemSpecialPath::CurrentWorkingDirectory,
+                },
+                access: FileSystemAccessMode::Write,
+            }],
+            glob_scan_max_depth: None,
+        }),
+        ..Default::default()
+    };
+    let granted = PermissionProfile {
+        file_system: Some(FileSystemPermissions::from_read_write_roots(
+            /*read*/ None,
+            Some(vec![child]),
+        )),
+        ..Default::default()
+    };
+
+    assert_eq!(
+        intersect_permission_profiles(requested, granted.clone(), cwd.as_path()),
+        granted
+    );
+}
+
+#[test]
+fn intersect_permission_profiles_materializes_cwd_grant_for_reuse() {
+    let temp_dir = TempDir::new().expect("create temp dir");
+    let request_cwd = AbsolutePathBuf::from_absolute_path(temp_dir.path().join("request-cwd"))
+        .expect("absolute request cwd");
+    let later_cwd = AbsolutePathBuf::from_absolute_path(temp_dir.path().join("later-cwd"))
+        .expect("absolute later cwd");
+    let cwd_write_permissions = PermissionProfile {
+        file_system: Some(FileSystemPermissions {
+            entries: vec![FileSystemSandboxEntry {
+                path: FileSystemPath::Special {
+                    value: FileSystemSpecialPath::CurrentWorkingDirectory,
+                },
+                access: FileSystemAccessMode::Write,
+            }],
+            glob_scan_max_depth: None,
+        }),
+        ..Default::default()
+    };
+
+    let intersected = intersect_permission_profiles(
+        cwd_write_permissions.clone(),
+        cwd_write_permissions,
+        request_cwd.as_path(),
+    );
+
+    assert_eq!(
+        intersected,
+        PermissionProfile {
+            file_system: Some(FileSystemPermissions::from_read_write_roots(
+                /*read*/ None,
+                Some(vec![request_cwd]),
+            )),
+            ..Default::default()
+        }
+    );
+    assert_eq!(
+        intersect_permission_profiles(
+            PermissionProfile {
+                file_system: Some(FileSystemPermissions::from_read_write_roots(
+                    /*read*/ None,
+                    Some(vec![later_cwd.join("child")]),
+                )),
+                ..Default::default()
+            },
+            intersected,
+            later_cwd.as_path(),
+        ),
+        PermissionProfile::default()
+    );
+}
+
+#[test]
+fn intersect_permission_profiles_deduplicates_materialized_grants() {
+    let temp_dir = TempDir::new().expect("create temp dir");
+    let cwd =
+        AbsolutePathBuf::from_absolute_path(temp_dir.path().join("cwd")).expect("absolute cwd");
+    let permissions = PermissionProfile {
+        file_system: Some(FileSystemPermissions {
+            entries: vec![
+                FileSystemSandboxEntry {
+                    path: FileSystemPath::Special {
+                        value: FileSystemSpecialPath::CurrentWorkingDirectory,
+                    },
+                    access: FileSystemAccessMode::Write,
+                },
+                FileSystemSandboxEntry {
+                    path: FileSystemPath::Path { path: cwd.clone() },
+                    access: FileSystemAccessMode::Write,
+                },
+            ],
+            glob_scan_max_depth: None,
+        }),
+        ..Default::default()
+    };
+
+    assert_eq!(
+        intersect_permission_profiles(permissions.clone(), permissions, cwd.as_path()),
+        PermissionProfile {
+            file_system: Some(FileSystemPermissions::from_read_write_roots(
+                /*read*/ None,
+                Some(vec![cwd]),
+            )),
+            ..Default::default()
+        }
+    );
+}
+
+#[test]
+fn intersect_permission_profiles_materializes_cwd_deny_entries() {
+    let temp_dir = TempDir::new().expect("create temp dir");
+    let request_cwd = AbsolutePathBuf::from_absolute_path(temp_dir.path().join("request-cwd"))
+        .expect("absolute request cwd");
+    let permissions = PermissionProfile {
+        file_system: Some(FileSystemPermissions {
+            entries: vec![
+                FileSystemSandboxEntry {
+                    path: FileSystemPath::Special {
+                        value: FileSystemSpecialPath::Root,
+                    },
+                    access: FileSystemAccessMode::Write,
+                },
+                FileSystemSandboxEntry {
+                    path: FileSystemPath::Special {
+                        value: FileSystemSpecialPath::CurrentWorkingDirectory,
+                    },
+                    access: FileSystemAccessMode::None,
+                },
+            ],
+            glob_scan_max_depth: None,
+        }),
+        ..Default::default()
+    };
+
+    assert_eq!(
+        intersect_permission_profiles(permissions.clone(), permissions, request_cwd.as_path()),
+        PermissionProfile {
+            file_system: Some(FileSystemPermissions {
+                entries: vec![
+                    FileSystemSandboxEntry {
+                        path: FileSystemPath::Special {
+                            value: FileSystemSpecialPath::Root,
+                        },
+                        access: FileSystemAccessMode::Write,
+                    },
+                    FileSystemSandboxEntry {
+                        path: FileSystemPath::Path { path: request_cwd },
+                        access: FileSystemAccessMode::None,
+                    },
+                ],
+                glob_scan_max_depth: None,
+            }),
+            ..Default::default()
+        }
+    );
+}
+
+#[test]
+fn intersect_permission_profiles_drops_deny_entries_without_filesystem_grants() {
+    let temp_dir = TempDir::new().expect("create temp dir");
+    let cwd = AbsolutePathBuf::from_absolute_path(
+        canonicalize(temp_dir.path()).expect("canonicalize temp dir"),
+    )
+    .expect("absolute temp dir");
+    let secret = cwd.join("secret");
+    let requested = PermissionProfile {
+        network: Some(NetworkPermissions {
+            enabled: Some(true),
+        }),
+        file_system: Some(FileSystemPermissions {
+            entries: vec![
+                FileSystemSandboxEntry {
+                    path: FileSystemPath::Special {
+                        value: FileSystemSpecialPath::CurrentWorkingDirectory,
+                    },
+                    access: FileSystemAccessMode::Write,
+                },
+                FileSystemSandboxEntry {
+                    path: FileSystemPath::Path { path: secret },
+                    access: FileSystemAccessMode::None,
+                },
+            ],
+            glob_scan_max_depth: None,
+        }),
+    };
+    let granted = PermissionProfile {
+        network: Some(NetworkPermissions {
+            enabled: Some(true),
+        }),
+        ..Default::default()
+    };
+
+    assert_eq!(
+        intersect_permission_profiles(requested, granted.clone(), cwd.as_path()),
+        granted
+    );
+}
+
+#[test]
+fn intersect_permission_profiles_rejects_concrete_grants_matched_by_requested_deny_globs() {
+    let temp_dir = TempDir::new().expect("create temp dir");
+    let cwd = AbsolutePathBuf::from_absolute_path(
+        canonicalize(temp_dir.path()).expect("canonicalize temp dir"),
+    )
+    .expect("absolute temp dir");
+    let env_file = cwd.join(".env");
+    let requested = PermissionProfile {
+        file_system: Some(FileSystemPermissions {
+            entries: vec![
+                FileSystemSandboxEntry {
+                    path: FileSystemPath::Special {
+                        value: FileSystemSpecialPath::CurrentWorkingDirectory,
+                    },
+                    access: FileSystemAccessMode::Write,
+                },
+                FileSystemSandboxEntry {
+                    path: FileSystemPath::GlobPattern {
+                        pattern: "**/*.env".to_string(),
+                    },
+                    access: FileSystemAccessMode::None,
+                },
+            ],
+            glob_scan_max_depth: std::num::NonZeroUsize::new(2),
+        }),
+        ..Default::default()
+    };
+    let granted = PermissionProfile {
+        file_system: Some(FileSystemPermissions::from_read_write_roots(
+            /*read*/ None,
+            Some(vec![env_file]),
+        )),
+        ..Default::default()
+    };
+
+    assert_eq!(
+        intersect_permission_profiles(requested, granted, cwd.as_path()),
+        PermissionProfile::default()
+    );
+}
+
+#[test]
+fn intersect_permission_profiles_materializes_relative_deny_globs_for_reuse() {
+    let temp_dir = TempDir::new().expect("create temp dir");
+    let request_cwd = AbsolutePathBuf::from_absolute_path(temp_dir.path().join("request-cwd"))
+        .expect("absolute request cwd");
+    let later_cwd = AbsolutePathBuf::from_absolute_path(temp_dir.path().join("later-cwd"))
+        .expect("absolute later cwd");
+    let cwd_write = FileSystemSandboxEntry {
+        path: FileSystemPath::Special {
+            value: FileSystemSpecialPath::CurrentWorkingDirectory,
+        },
+        access: FileSystemAccessMode::Write,
+    };
+    let deny_env_files = FileSystemSandboxEntry {
+        path: FileSystemPath::GlobPattern {
+            pattern: "**/*.env".to_string(),
+        },
+        access: FileSystemAccessMode::None,
+    };
+    let permissions = PermissionProfile {
+        file_system: Some(FileSystemPermissions {
+            entries: vec![cwd_write, deny_env_files],
+            glob_scan_max_depth: std::num::NonZeroUsize::new(2),
+        }),
+        ..Default::default()
+    };
+
+    let intersected =
+        intersect_permission_profiles(permissions.clone(), permissions, request_cwd.as_path());
+
+    assert_eq!(
+        intersected,
+        PermissionProfile {
+            file_system: Some(FileSystemPermissions {
+                entries: vec![
+                    FileSystemSandboxEntry {
+                        path: FileSystemPath::Path {
+                            path: request_cwd.clone(),
+                        },
+                        access: FileSystemAccessMode::Write,
+                    },
+                    FileSystemSandboxEntry {
+                        path: FileSystemPath::GlobPattern {
+                            pattern: request_cwd.join("**/*.env").to_string_lossy().into_owned(),
+                        },
+                        access: FileSystemAccessMode::None,
+                    },
+                ],
+                glob_scan_max_depth: std::num::NonZeroUsize::new(2),
+            }),
+            ..Default::default()
+        }
+    );
+    assert_eq!(
+        intersect_permission_profiles(
+            PermissionProfile {
+                file_system: Some(FileSystemPermissions::from_read_write_roots(
+                    /*read*/ None,
+                    Some(vec![later_cwd.join("token.env")]),
+                )),
+                ..Default::default()
+            },
+            intersected,
+            later_cwd.as_path(),
+        ),
+        PermissionProfile::default()
+    );
+}
+
+#[test]
+fn intersect_permission_profiles_drops_broader_cwd_grant_for_requested_child_path() {
+    let temp_dir = TempDir::new().expect("create temp dir");
+    let cwd = AbsolutePathBuf::from_absolute_path(
+        canonicalize(temp_dir.path()).expect("canonicalize temp dir"),
+    )
+    .expect("absolute temp dir");
+    let child = cwd.join("child");
+    let requested = PermissionProfile {
+        file_system: Some(FileSystemPermissions::from_read_write_roots(
+            /*read*/ None,
+            Some(vec![child]),
+        )),
+        ..Default::default()
+    };
+    let granted = PermissionProfile {
+        file_system: Some(FileSystemPermissions {
+            entries: vec![FileSystemSandboxEntry {
+                path: FileSystemPath::Special {
+                    value: FileSystemSpecialPath::CurrentWorkingDirectory,
+                },
+                access: FileSystemAccessMode::Write,
+            }],
+            glob_scan_max_depth: None,
+        }),
+        ..Default::default()
+    };
+
+    assert_eq!(
+        intersect_permission_profiles(requested, granted, cwd.as_path()),
+        PermissionProfile::default()
+    );
+}
+
+#[test]
+fn intersect_permission_profiles_uses_granted_bounded_glob_scan_depth() {
+    let cwd = std::env::current_dir().expect("current dir");
+    let root_write = FileSystemSandboxEntry {
+        path: FileSystemPath::Special {
+            value: FileSystemSpecialPath::Root,
+        },
+        access: FileSystemAccessMode::Write,
+    };
+    let deny_env_files = FileSystemSandboxEntry {
+        path: FileSystemPath::GlobPattern {
+            pattern: "**/*.env".to_string(),
+        },
+        access: FileSystemAccessMode::None,
+    };
+    let requested = PermissionProfile {
+        file_system: Some(FileSystemPermissions {
+            entries: vec![root_write.clone(), deny_env_files.clone()],
+            glob_scan_max_depth: std::num::NonZeroUsize::new(2),
+        }),
+        ..Default::default()
+    };
+    let granted = PermissionProfile {
+        file_system: Some(FileSystemPermissions {
+            entries: vec![root_write.clone(), deny_env_files],
+            glob_scan_max_depth: std::num::NonZeroUsize::new(4),
+        }),
+        ..Default::default()
+    };
+
+    assert_eq!(
+        intersect_permission_profiles(requested, granted, cwd.as_path()),
+        PermissionProfile {
+            file_system: Some(FileSystemPermissions {
+                entries: vec![
+                    root_write,
+                    FileSystemSandboxEntry {
+                        path: FileSystemPath::GlobPattern {
+                            pattern: AbsolutePathBuf::resolve_path_against_base(
+                                "**/*.env",
+                                cwd.as_path()
+                            )
+                            .to_string_lossy()
+                            .into_owned(),
+                        },
+                        access: FileSystemAccessMode::None,
+                    },
+                ],
+                glob_scan_max_depth: std::num::NonZeroUsize::new(4),
+            }),
+            ..Default::default()
+        }
+    );
+}
+
+#[test]
+fn intersect_permission_profiles_uses_granted_unbounded_glob_scan_depth() {
+    let cwd = std::env::current_dir().expect("current dir");
+    let root_write = FileSystemSandboxEntry {
+        path: FileSystemPath::Special {
+            value: FileSystemSpecialPath::Root,
+        },
+        access: FileSystemAccessMode::Write,
+    };
+    let deny_env_files = FileSystemSandboxEntry {
+        path: FileSystemPath::GlobPattern {
+            pattern: "**/*.env".to_string(),
+        },
+        access: FileSystemAccessMode::None,
+    };
+    let requested = PermissionProfile {
+        file_system: Some(FileSystemPermissions {
+            entries: vec![root_write.clone(), deny_env_files.clone()],
+            glob_scan_max_depth: std::num::NonZeroUsize::new(2),
+        }),
+        ..Default::default()
+    };
+    let granted = PermissionProfile {
+        file_system: Some(FileSystemPermissions {
+            entries: vec![root_write.clone(), deny_env_files],
+            glob_scan_max_depth: None,
+        }),
+        ..Default::default()
+    };
+
+    assert_eq!(
+        intersect_permission_profiles(requested, granted, cwd.as_path()),
+        PermissionProfile {
+            file_system: Some(FileSystemPermissions {
+                entries: vec![
+                    root_write,
+                    FileSystemSandboxEntry {
+                        path: FileSystemPath::GlobPattern {
+                            pattern: AbsolutePathBuf::resolve_path_against_base(
+                                "**/*.env",
+                                cwd.as_path()
+                            )
+                            .to_string_lossy()
+                            .into_owned(),
+                        },
+                        access: FileSystemAccessMode::None,
+                    },
+                ],
+                glob_scan_max_depth: None,
+            }),
+            ..Default::default()
+        }
+    );
+}
+
+#[test]
+fn read_only_additional_permissions_can_enable_network_without_writes() {
+    let temp_dir = TempDir::new().expect("create temp dir");
+    let path = AbsolutePathBuf::from_absolute_path(
+        canonicalize(temp_dir.path()).expect("canonicalize temp dir"),
+    )
+    .expect("absolute temp dir");
+    let policy = sandbox_policy_with_additional_permissions(
+        &SandboxPolicy::ReadOnly {
+            network_access: false,
+        },
+        &PermissionProfile {
+            network: Some(NetworkPermissions {
+                enabled: Some(true),
+            }),
+            file_system: Some(FileSystemPermissions::from_read_write_roots(
+                Some(vec![path]),
+                Some(Vec::new()),
+            )),
+        },
+    );
+
+    assert_eq!(
+        policy,
+        SandboxPolicy::ReadOnly {
+            network_access: true,
+        }
+    );
+}
+
+#[test]
+fn external_sandbox_additional_permissions_can_enable_network() {
+    let temp_dir = TempDir::new().expect("create temp dir");
+    let path = AbsolutePathBuf::from_absolute_path(
+        canonicalize(temp_dir.path()).expect("canonicalize temp dir"),
+    )
+    .expect("absolute temp dir");
+    let policy = sandbox_policy_with_additional_permissions(
+        &SandboxPolicy::ExternalSandbox {
+            network_access: NetworkAccess::Restricted,
+        },
+        &PermissionProfile {
+            network: Some(NetworkPermissions {
+                enabled: Some(true),
+            }),
+            file_system: Some(FileSystemPermissions::from_read_write_roots(
+                Some(vec![path]),
+                Some(Vec::new()),
+            )),
+        },
+    );
+
+    assert_eq!(
+        policy,
+        SandboxPolicy::ExternalSandbox {
+            network_access: NetworkAccess::Enabled,
+        }
+    );
+}
+
+#[test]
+fn merge_file_system_policy_with_additional_permissions_preserves_unreadable_roots() {
+    let temp_dir = TempDir::new().expect("create temp dir");
+    let cwd = AbsolutePathBuf::from_absolute_path(
+        canonicalize(temp_dir.path()).expect("canonicalize temp dir"),
+    )
+    .expect("absolute temp dir");
+    let allowed_path = cwd.join("allowed");
+    let denied_path = cwd.join("denied");
+    let merged_policy = merge_file_system_policy_with_additional_permissions(
+        &FileSystemSandboxPolicy::restricted(vec![
+            FileSystemSandboxEntry {
+                path: FileSystemPath::Special {
+                    value: FileSystemSpecialPath::Root,
+                },
+                access: FileSystemAccessMode::Read,
+            },
+            FileSystemSandboxEntry {
+                path: FileSystemPath::Path {
+                    path: denied_path.clone(),
+                },
+                access: FileSystemAccessMode::None,
+            },
+        ]),
+        &FileSystemPermissions::from_read_write_roots(
+            Some(vec![allowed_path.clone()]),
+            Some(Vec::new()),
+        ),
+    );
+
+    assert_eq!(
+        merged_policy.entries.contains(&FileSystemSandboxEntry {
+            path: FileSystemPath::Path { path: denied_path },
+            access: FileSystemAccessMode::None,
+        }),
+        true
+    );
+    assert_eq!(
+        merged_policy.entries.contains(&FileSystemSandboxEntry {
+            path: FileSystemPath::Path { path: allowed_path },
+            access: FileSystemAccessMode::Read,
+        }),
+        true
+    );
+}
+
+#[test]
+fn merge_file_system_policy_with_additional_permissions_carries_bounded_glob_scan_depth() {
+    let deny_env_files = FileSystemSandboxEntry {
+        path: FileSystemPath::GlobPattern {
+            pattern: "**/*.env".to_string(),
+        },
+        access: FileSystemAccessMode::None,
+    };
+    let merged_policy = merge_file_system_policy_with_additional_permissions(
+        &FileSystemSandboxPolicy::restricted(vec![FileSystemSandboxEntry {
+            path: FileSystemPath::Special {
+                value: FileSystemSpecialPath::Root,
+            },
+            access: FileSystemAccessMode::Write,
+        }]),
+        &FileSystemPermissions {
+            entries: vec![deny_env_files.clone()],
+            glob_scan_max_depth: std::num::NonZeroUsize::new(2),
+        },
+    );
+
+    assert_eq!(merged_policy, {
+        let mut policy = FileSystemSandboxPolicy::restricted(vec![
+            FileSystemSandboxEntry {
+                path: FileSystemPath::Special {
+                    value: FileSystemSpecialPath::Root,
+                },
+                access: FileSystemAccessMode::Write,
+            },
+            deny_env_files,
+        ]);
+        policy.glob_scan_max_depth = Some(2);
+        policy
+    });
+}
+
+#[test]
+fn effective_file_system_sandbox_policy_returns_base_policy_without_additional_permissions() {
+    let temp_dir = TempDir::new().expect("create temp dir");
+    let cwd = AbsolutePathBuf::from_absolute_path(
+        canonicalize(temp_dir.path()).expect("canonicalize temp dir"),
+    )
+    .expect("absolute temp dir");
+    let denied_path = cwd.join("denied");
+    let base_policy = FileSystemSandboxPolicy::restricted(vec![
+        FileSystemSandboxEntry {
+            path: FileSystemPath::Special {
+                value: FileSystemSpecialPath::Root,
+            },
+            access: FileSystemAccessMode::Read,
+        },
+        FileSystemSandboxEntry {
+            path: FileSystemPath::Path { path: denied_path },
+            access: FileSystemAccessMode::None,
+        },
+    ]);
+
+    let effective_policy =
+        effective_file_system_sandbox_policy(&base_policy, /*additional_permissions*/ None);
+
+    assert_eq!(effective_policy, base_policy);
+}
+
+#[test]
+fn effective_file_system_sandbox_policy_merges_additional_write_roots() {
+    let temp_dir = TempDir::new().expect("create temp dir");
+    let cwd = AbsolutePathBuf::from_absolute_path(
+        canonicalize(temp_dir.path()).expect("canonicalize temp dir"),
+    )
+    .expect("absolute temp dir");
+    let allowed_path = cwd.join("allowed");
+    let denied_path = cwd.join("denied");
+    let base_policy = FileSystemSandboxPolicy::restricted(vec![
+        FileSystemSandboxEntry {
+            path: FileSystemPath::Special {
+                value: FileSystemSpecialPath::Root,
+            },
+            access: FileSystemAccessMode::Read,
+        },
+        FileSystemSandboxEntry {
+            path: FileSystemPath::Path {
+                path: denied_path.clone(),
+            },
+            access: FileSystemAccessMode::None,
+        },
+    ]);
+    let additional_permissions = PermissionProfile {
+        file_system: Some(FileSystemPermissions::from_read_write_roots(
+            Some(vec![]),
+            Some(vec![allowed_path.clone()]),
+        )),
+        ..Default::default()
+    };
+
+    let effective_policy =
+        effective_file_system_sandbox_policy(&base_policy, Some(&additional_permissions));
+
+    assert_eq!(
+        effective_policy.entries.contains(&FileSystemSandboxEntry {
+            path: FileSystemPath::Path { path: denied_path },
+            access: FileSystemAccessMode::None,
+        }),
+        true
+    );
+    assert_eq!(
+        effective_policy.entries.contains(&FileSystemSandboxEntry {
+            path: FileSystemPath::Path { path: allowed_path },
+            access: FileSystemAccessMode::Write,
+        }),
+        true
+    );
+}

--- a/crates/dasclaw_sandboxing/src/restricted_read_only_platform_defaults.sbpl
+++ b/crates/dasclaw_sandboxing/src/restricted_read_only_platform_defaults.sbpl
@@ -1,0 +1,199 @@
+; macOS platform defaults included when a split filesystem policy requests `:minimal`.
+
+; Read access to standard system paths
+(allow file-read* file-test-existence
+  (subpath "/Library/Apple")
+  (subpath "/Library/Filesystems/NetFSPlugins")
+  (subpath "/Library/Preferences/Logging")
+  (subpath "/private/var/db/DarwinDirectory/local/recordStore.data")
+  (subpath "/private/var/db/timezone")
+  (subpath "/usr/lib")
+  (subpath "/usr/share")
+  (subpath "/Library/Preferences")
+  (subpath "/var/db")
+  (subpath "/private/var/db"))
+
+; Map system frameworks + dylibs for loader.
+(allow file-map-executable
+  (subpath "/Library/Apple/System/Library/Frameworks")
+  (subpath "/Library/Apple/System/Library/PrivateFrameworks")
+  (subpath "/Library/Apple/usr/lib")
+  (subpath "/System/Library/Extensions")
+  (subpath "/System/Library/Frameworks")
+  (subpath "/System/Library/PrivateFrameworks")
+  (subpath "/System/Library/SubFrameworks")
+  (subpath "/System/iOSSupport/System/Library/Frameworks")
+  (subpath "/System/iOSSupport/System/Library/PrivateFrameworks")
+  (subpath "/System/iOSSupport/System/Library/SubFrameworks")
+  (subpath "/usr/lib"))
+
+; System Framework and AppKit resources
+(allow file-read* file-test-existence
+  (subpath "/Library/Apple/System/Library/Frameworks")
+  (subpath "/Library/Apple/System/Library/PrivateFrameworks")
+  (subpath "/Library/Apple/usr/lib")
+  (subpath "/System/Library/Frameworks")
+  (subpath "/System/Library/PrivateFrameworks")
+  (subpath "/System/Library/SubFrameworks")
+  (subpath "/System/iOSSupport/System/Library/Frameworks")
+  (subpath "/System/iOSSupport/System/Library/PrivateFrameworks")
+  (subpath "/System/iOSSupport/System/Library/SubFrameworks")
+  (subpath "/usr/lib"))
+
+; Allow guarded vnodes.
+(allow system-mac-syscall (mac-policy-name "vnguard"))
+
+; Determine whether a container is expected.
+(allow system-mac-syscall
+  (require-all
+    (mac-policy-name "Sandbox")
+    (mac-syscall-number 67)))
+
+; Allow resolution of standard system symlinks.
+(allow file-read-metadata file-test-existence
+  (literal "/etc")
+  (literal "/tmp")
+  (literal "/var")
+  (literal "/private/etc/localtime"))
+
+; Allow stat'ing of firmlink parent path components.
+(allow file-read-metadata file-test-existence
+  (path-ancestors "/System/Volumes/Data/private"))
+
+; Allow processes to get their current working directory.
+(allow file-read* file-test-existence
+  (literal "/"))
+
+; Allow FSIOC_CAS_BSDFLAGS as alternate chflags.
+(allow system-fsctl (fsctl-command FSIOC_CAS_BSDFLAGS))
+
+; Allow access to standard special files.
+(allow file-read* file-test-existence
+  (literal "/dev/autofs_nowait")
+  (literal "/dev/random")
+  (literal "/dev/urandom")
+  (literal "/private/etc/master.passwd")
+  (literal "/private/etc/passwd")
+  (literal "/private/etc/protocols")
+  (literal "/private/etc/services"))
+
+; Allow null/zero read/write.
+(allow file-read* file-test-existence file-write-data
+  (literal "/dev/null")
+  (literal "/dev/zero"))
+
+; Allow read/write access to the file descriptors.
+(allow file-read-data file-test-existence file-write-data
+  (subpath "/dev/fd"))
+
+; Provide access to debugger helpers.
+(allow file-read* file-test-existence file-write-data file-ioctl
+  (literal "/dev/dtracehelper"))
+
+; Scratch space so tools can create temp files.
+(allow file-read* file-test-existence file-write* (subpath "/tmp"))
+(allow file-read* file-write* (subpath "/private/tmp"))
+(allow file-read* file-write* (subpath "/var/tmp"))
+(allow file-read* file-write* (subpath "/private/var/tmp"))
+
+; Allow reading standard config directories.
+(allow file-read* (subpath "/etc"))
+(allow file-read* (subpath "/private/etc"))
+
+(allow file-read* file-test-existence
+  (literal "/System/Library/CoreServices")
+  (literal "/System/Library/CoreServices/.SystemVersionPlatform.plist")
+  (literal "/System/Library/CoreServices/SystemVersion.plist"))
+
+; Some processes read /var metadata during startup.
+(allow file-read-metadata (subpath "/var"))
+(allow file-read-metadata (subpath "/private/var"))
+
+; IOKit access for root domain services.
+(allow iokit-open
+  (iokit-registry-entry-class "RootDomainUserClient"))
+
+; macOS Standard library queries opendirectoryd at startup
+(allow mach-lookup (global-name "com.apple.system.opendirectoryd.libinfo"))
+
+; Allow IPC to analytics, logging, trust, and other system agents.
+(allow mach-lookup
+  (global-name "com.apple.analyticsd")
+  (global-name "com.apple.analyticsd.messagetracer")
+  (global-name "com.apple.appsleep")
+  (global-name "com.apple.bsd.dirhelper")
+  (global-name "com.apple.cfprefsd.agent")
+  (global-name "com.apple.cfprefsd.daemon")
+  (global-name "com.apple.diagnosticd")
+  (global-name "com.apple.dt.automationmode.reader")
+  (global-name "com.apple.espd")
+  (global-name "com.apple.logd")
+  (global-name "com.apple.logd.events")
+  (global-name "com.apple.runningboard")
+  (global-name "com.apple.secinitd")
+  (global-name "com.apple.system.DirectoryService.libinfo_v1")
+  (global-name "com.apple.system.logger")
+  (global-name "com.apple.system.notification_center")
+  (global-name "com.apple.system.opendirectoryd.membership")
+  (global-name "com.apple.trustd")
+  (global-name "com.apple.trustd.agent")
+  (global-name "com.apple.xpc.activity.unmanaged")
+  (local-name "com.apple.cfprefsd.agent"))
+
+; Allow IPC to the syslog socket for logging.
+(allow network-outbound (literal "/private/var/run/syslog"))
+
+; macOS Notifications
+(allow ipc-posix-shm-read*
+  (ipc-posix-name "apple.shm.notification_center"))
+
+; Regulatory domain support.
+(allow file-read*
+  (literal "/private/var/db/eligibilityd/eligibility.plist"))
+
+; Audio and power management services.
+(allow mach-lookup (global-name "com.apple.audio.audiohald"))
+(allow mach-lookup (global-name "com.apple.audio.AudioComponentRegistrar"))
+(allow mach-lookup (global-name "com.apple.PowerManagement.control"))
+
+; Allow reading the minimum system runtime so exec works.
+(allow file-read-data (subpath "/bin"))
+(allow file-read-metadata (subpath "/bin"))
+(allow file-read-data (subpath "/sbin"))
+(allow file-read-metadata (subpath "/sbin"))
+(allow file-read-data (subpath "/usr/bin"))
+(allow file-read-metadata (subpath "/usr/bin"))
+(allow file-read-data (subpath "/usr/sbin"))
+(allow file-read-metadata (subpath "/usr/sbin"))
+(allow file-read-data (subpath "/usr/libexec"))
+(allow file-read-metadata (subpath "/usr/libexec"))
+
+(allow file-read* (subpath "/Library/Preferences"))
+(allow file-read* (subpath "/opt/homebrew/lib"))
+(allow file-read* (subpath "/usr/local/lib"))
+(allow file-read* (subpath "/Applications"))
+
+; Terminal basics and device handles.
+(allow file-read* (regex "^/dev/fd/(0|1|2)$"))
+(allow file-write* (regex "^/dev/fd/(1|2)$"))
+(allow file-read* file-write* (literal "/dev/null"))
+(allow file-read* file-write* (literal "/dev/tty"))
+(allow file-read-metadata (literal "/dev"))
+(allow file-read-metadata (regex "^/dev/.*$"))
+(allow file-read-metadata (literal "/dev/stdin"))
+(allow file-read-metadata (literal "/dev/stdout"))
+(allow file-read-metadata (literal "/dev/stderr"))
+(allow file-read-metadata (regex "^/dev/tty[^/]*$"))
+(allow file-read-metadata (regex "^/dev/pty[^/]*$"))
+(allow file-read* file-write* (regex "^/dev/ttys[0-9]+$"))
+(allow file-read* file-write* (literal "/dev/ptmx"))
+(allow file-ioctl (regex "^/dev/ttys[0-9]+$"))
+
+; Allow metadata traversal for firmlink parents.
+(allow file-read-metadata (literal "/System/Volumes") (vnode-type DIRECTORY))
+(allow file-read-metadata (literal "/System/Volumes/Data") (vnode-type DIRECTORY))
+(allow file-read-metadata (literal "/System/Volumes/Data/Users") (vnode-type DIRECTORY))
+
+; App sandbox extensions
+(allow file-read* (extension "com.apple.app-sandbox.read"))
+(allow file-read* file-write* (extension "com.apple.app-sandbox.read-write"))

--- a/crates/dasclaw_sandboxing/src/seatbelt.rs
+++ b/crates/dasclaw_sandboxing/src/seatbelt.rs
@@ -1,0 +1,723 @@
+use dasclaw_absolute_path::AbsolutePathBuf;
+use dasclaw_net_proxy::NetworkProxy;
+use dasclaw_net_proxy::PROXY_URL_ENV_KEYS;
+use dasclaw_net_proxy::has_proxy_url_env_vars;
+use dasclaw_net_proxy::proxy_url_env_value;
+use dasclaw_protocol::permissions::FileSystemSandboxPolicy;
+use dasclaw_protocol::permissions::NetworkSandboxPolicy;
+use dasclaw_protocol::protocol::SandboxPolicy;
+use std::collections::BTreeMap;
+use std::collections::BTreeSet;
+use std::collections::HashMap;
+use std::collections::VecDeque;
+use std::ffi::CStr;
+use std::path::Path;
+use std::path::PathBuf;
+use tracing::warn;
+use url::Url;
+
+const MACOS_SEATBELT_BASE_POLICY: &str = include_str!("seatbelt_base_policy.sbpl");
+const MACOS_SEATBELT_NETWORK_POLICY: &str = include_str!("seatbelt_network_policy.sbpl");
+const MACOS_RESTRICTED_READ_ONLY_PLATFORM_DEFAULTS: &str =
+    include_str!("restricted_read_only_platform_defaults.sbpl");
+
+/// When working with `sandbox-exec`, only consider `sandbox-exec` in `/usr/bin`
+/// to defend against an attacker trying to inject a malicious version on the
+/// PATH. If /usr/bin/sandbox-exec has been tampered with, then the attacker
+/// already has root access.
+pub const MACOS_PATH_TO_SEATBELT_EXECUTABLE: &str = "/usr/bin/sandbox-exec";
+
+fn is_loopback_host(host: &str) -> bool {
+    host.eq_ignore_ascii_case("localhost") || host == "127.0.0.1" || host == "::1"
+}
+
+fn proxy_scheme_default_port(scheme: &str) -> u16 {
+    match scheme {
+        "https" => 443,
+        "socks5" | "socks5h" | "socks4" | "socks4a" => 1080,
+        _ => 80,
+    }
+}
+
+fn proxy_loopback_ports_from_env(env: &HashMap<String, String>) -> Vec<u16> {
+    let mut ports = BTreeSet::new();
+    for key in PROXY_URL_ENV_KEYS {
+        let Some(proxy_url) = proxy_url_env_value(env, key) else {
+            continue;
+        };
+        let trimmed = proxy_url.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        let candidate = if trimmed.contains("://") {
+            trimmed.to_string()
+        } else {
+            format!("http://{trimmed}")
+        };
+        let Ok(parsed) = Url::parse(&candidate) else {
+            continue;
+        };
+        let Some(host) = parsed.host_str() else {
+            continue;
+        };
+        if !is_loopback_host(host) {
+            continue;
+        }
+
+        let scheme = parsed.scheme().to_ascii_lowercase();
+        let port = parsed
+            .port()
+            .unwrap_or_else(|| proxy_scheme_default_port(scheme.as_str()));
+        ports.insert(port);
+    }
+    ports.into_iter().collect()
+}
+
+#[derive(Debug, Default)]
+struct ProxyPolicyInputs {
+    ports: Vec<u16>,
+    has_proxy_config: bool,
+    allow_local_binding: bool,
+    unix_domain_socket_policy: UnixDomainSocketPolicy,
+}
+
+#[derive(Debug, Clone)]
+// Keep allow-all and allowlist modes disjoint so we don't carry ignored state.
+enum UnixDomainSocketPolicy {
+    AllowAll,
+    Restricted { allowed: Vec<AbsolutePathBuf> },
+}
+
+impl Default for UnixDomainSocketPolicy {
+    fn default() -> Self {
+        Self::Restricted { allowed: vec![] }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct UnixSocketPathParam {
+    index: usize,
+    path: AbsolutePathBuf,
+}
+
+fn proxy_policy_inputs(
+    network: Option<&NetworkProxy>,
+    extra_allow_unix_sockets: &[AbsolutePathBuf],
+) -> ProxyPolicyInputs {
+    let extra_allowed = extra_allow_unix_sockets
+        .iter()
+        .filter_map(|socket_path| normalize_path_for_sandbox(socket_path.as_path()))
+        .collect::<Vec<_>>();
+
+    match network {
+        Some(network) => {
+            let mut env = HashMap::new();
+            network.apply_to_env(&mut env);
+            let unix_domain_socket_policy = if network.dangerously_allow_all_unix_sockets() {
+                UnixDomainSocketPolicy::AllowAll
+            } else {
+                let mut allowed = network
+                    .allow_unix_sockets()
+                    .iter()
+                    .filter_map(|socket_path| {
+                        match normalize_path_for_sandbox(Path::new(socket_path)) {
+                            Some(path) => Some(path),
+                            None => {
+                                warn!(
+                                    "ignoring network.allow_unix_sockets entry because it could not be normalized: {socket_path}"
+                                );
+                                None
+                            }
+                        }
+                    })
+                    .collect::<Vec<_>>();
+                allowed.extend(extra_allowed);
+                UnixDomainSocketPolicy::Restricted { allowed }
+            };
+            ProxyPolicyInputs {
+                ports: proxy_loopback_ports_from_env(&env),
+                has_proxy_config: has_proxy_url_env_vars(&env),
+                allow_local_binding: network.allow_local_binding(),
+                unix_domain_socket_policy,
+            }
+        }
+        None => ProxyPolicyInputs {
+            unix_domain_socket_policy: UnixDomainSocketPolicy::Restricted {
+                allowed: extra_allowed,
+            },
+            ..Default::default()
+        },
+    }
+}
+
+fn normalize_path_for_sandbox(path: &Path) -> Option<AbsolutePathBuf> {
+    // `AbsolutePathBuf::from_absolute_path()` normalizes relative paths against the current
+    // working directory, so keep the explicit check to avoid silently accepting relative entries.
+    if !path.is_absolute() {
+        return None;
+    }
+
+    let absolute_path = AbsolutePathBuf::from_absolute_path(path).ok()?;
+    let normalized_path = absolute_path
+        .as_path()
+        .canonicalize()
+        .ok()
+        .and_then(|canonical_path| AbsolutePathBuf::from_absolute_path(canonical_path).ok());
+    normalized_path.or(Some(absolute_path))
+}
+
+fn unix_socket_path_params(proxy: &ProxyPolicyInputs) -> Vec<UnixSocketPathParam> {
+    let mut deduped_paths: BTreeMap<String, AbsolutePathBuf> = BTreeMap::new();
+    let UnixDomainSocketPolicy::Restricted { allowed } = &proxy.unix_domain_socket_policy else {
+        return vec![];
+    };
+    for path in allowed {
+        deduped_paths
+            .entry(path.to_string_lossy().to_string())
+            .or_insert_with(|| path.clone());
+    }
+
+    deduped_paths
+        .into_values()
+        .enumerate()
+        .map(|(index, path)| UnixSocketPathParam { index, path })
+        .collect()
+}
+
+fn unix_socket_path_param_key(index: usize) -> String {
+    format!("UNIX_SOCKET_PATH_{index}")
+}
+
+fn unix_socket_dir_params(proxy: &ProxyPolicyInputs) -> Vec<(String, PathBuf)> {
+    unix_socket_path_params(proxy)
+        .into_iter()
+        .map(|param| {
+            (
+                unix_socket_path_param_key(param.index),
+                param.path.into_path_buf(),
+            )
+        })
+        .collect()
+}
+
+/// Returns zero or more complete Seatbelt policy lines for unix socket rules.
+/// When non-empty, the returned string is newline-terminated so callers can
+/// append it directly to larger policy blocks.
+fn unix_socket_policy(proxy: &ProxyPolicyInputs) -> String {
+    let socket_params = unix_socket_path_params(proxy);
+    let has_unix_socket_access = matches!(
+        proxy.unix_domain_socket_policy,
+        UnixDomainSocketPolicy::AllowAll
+    ) || !socket_params.is_empty();
+    if !has_unix_socket_access {
+        return String::new();
+    }
+
+    let mut policy = String::new();
+    policy.push_str("(allow system-socket (socket-domain AF_UNIX))\n");
+    if matches!(
+        proxy.unix_domain_socket_policy,
+        UnixDomainSocketPolicy::AllowAll
+    ) {
+        // Keep AllowAll genuinely broad here; path qualifiers look narrower
+        // without a clear macOS behavioral benefit.
+        policy.push_str("(allow network-bind (local unix-socket))\n");
+        policy.push_str("(allow network-outbound (remote unix-socket))\n");
+        return policy;
+    }
+
+    for param in socket_params {
+        let key = unix_socket_path_param_key(param.index);
+        // Use subpath so allowlists cover sockets created beneath approved directories.
+        policy.push_str(&format!(
+            "(allow network-bind (local unix-socket (subpath (param \"{key}\"))))\n"
+        ));
+        policy.push_str(&format!(
+            "(allow network-outbound (remote unix-socket (subpath (param \"{key}\"))))\n"
+        ));
+    }
+    policy
+}
+
+#[cfg_attr(not(test), allow(dead_code))]
+fn dynamic_network_policy(
+    sandbox_policy: &SandboxPolicy,
+    enforce_managed_network: bool,
+    proxy: &ProxyPolicyInputs,
+) -> String {
+    dynamic_network_policy_for_network(
+        NetworkSandboxPolicy::from(sandbox_policy),
+        enforce_managed_network,
+        proxy,
+    )
+}
+
+fn dynamic_network_policy_for_network(
+    network_policy: NetworkSandboxPolicy,
+    enforce_managed_network: bool,
+    proxy: &ProxyPolicyInputs,
+) -> String {
+    let has_some_unix_socket_access = match &proxy.unix_domain_socket_policy {
+        UnixDomainSocketPolicy::AllowAll => true,
+        UnixDomainSocketPolicy::Restricted { allowed } => !allowed.is_empty(),
+    };
+    let should_use_restricted_network_policy = !proxy.ports.is_empty()
+        || proxy.has_proxy_config
+        || enforce_managed_network
+        || (!network_policy.is_enabled() && has_some_unix_socket_access);
+    if should_use_restricted_network_policy {
+        let mut policy = String::new();
+        if proxy.allow_local_binding {
+            policy.push_str("; allow local binding and loopback traffic\n");
+            policy.push_str("(allow network-bind (local ip \"*:*\"))\n");
+            policy.push_str("(allow network-inbound (local ip \"localhost:*\"))\n");
+            policy.push_str("(allow network-outbound (remote ip \"localhost:*\"))\n");
+        }
+        if proxy.allow_local_binding && !proxy.ports.is_empty() {
+            policy.push_str("; allow DNS lookups while application traffic remains proxy-routed\n");
+            policy.push_str("(allow network-outbound (remote ip \"*:53\"))\n");
+        }
+        for port in &proxy.ports {
+            policy.push_str(&format!(
+                "(allow network-outbound (remote ip \"localhost:{port}\"))\n"
+            ));
+        }
+        let unix_socket_policy = unix_socket_policy(proxy);
+        if !unix_socket_policy.is_empty() {
+            policy.push_str("; allow unix domain sockets for local IPC\n");
+            policy.push_str(&unix_socket_policy);
+        }
+        return format!("{policy}{MACOS_SEATBELT_NETWORK_POLICY}");
+    }
+
+    if proxy.has_proxy_config {
+        // Proxy configuration is present but we could not infer any valid loopback endpoints.
+        // Fail closed to avoid silently widening network access in proxy-enforced sessions.
+        return String::new();
+    }
+
+    if enforce_managed_network {
+        // Managed network requirements are active but no usable proxy endpoints
+        // are available. Fail closed for network access.
+        return String::new();
+    }
+
+    if network_policy.is_enabled() {
+        // No proxy env is configured: retain the existing full-network behavior.
+        let mut policy = String::from("(allow network-outbound)\n(allow network-inbound)\n");
+        let unix_socket_policy = unix_socket_policy(proxy);
+        if !unix_socket_policy.is_empty() {
+            policy.push_str("; allow unix domain sockets for local IPC\n");
+            policy.push_str(&unix_socket_policy);
+        }
+        format!("{policy}{MACOS_SEATBELT_NETWORK_POLICY}")
+    } else {
+        String::new()
+    }
+}
+
+fn root_absolute_path() -> AbsolutePathBuf {
+    match AbsolutePathBuf::from_absolute_path(Path::new("/")) {
+        Ok(path) => path,
+        Err(err) => panic!("root path must be absolute: {err}"),
+    }
+}
+
+#[derive(Debug, Clone)]
+struct SeatbeltAccessRoot {
+    root: AbsolutePathBuf,
+    excluded_subpaths: Vec<AbsolutePathBuf>,
+}
+
+fn build_seatbelt_access_policy(
+    action: &str,
+    param_prefix: &str,
+    roots: Vec<SeatbeltAccessRoot>,
+) -> (String, Vec<(String, PathBuf)>) {
+    let mut policy_components = Vec::new();
+    let mut params = Vec::new();
+
+    for (index, access_root) in roots.into_iter().enumerate() {
+        let root =
+            normalize_path_for_sandbox(access_root.root.as_path()).unwrap_or(access_root.root);
+        let root_param = format!("{param_prefix}_{index}");
+        params.push((root_param.clone(), root.into_path_buf()));
+
+        if access_root.excluded_subpaths.is_empty() {
+            policy_components.push(format!("(subpath (param \"{root_param}\"))"));
+            continue;
+        }
+
+        let mut require_parts = vec![format!("(subpath (param \"{root_param}\"))")];
+        for (excluded_index, excluded_subpath) in
+            access_root.excluded_subpaths.into_iter().enumerate()
+        {
+            let excluded_subpath =
+                normalize_path_for_sandbox(excluded_subpath.as_path()).unwrap_or(excluded_subpath);
+            let excluded_param = format!("{param_prefix}_{index}_EXCLUDED_{excluded_index}");
+            params.push((excluded_param.clone(), excluded_subpath.into_path_buf()));
+            // Exclude both the exact protected path and anything beneath it.
+            // `subpath` alone leaves a gap for first-time creation of the
+            // protected directory itself, such as `mkdir .codex`.
+            require_parts.push(format!(
+                "(require-not (literal (param \"{excluded_param}\")))"
+            ));
+            require_parts.push(format!(
+                "(require-not (subpath (param \"{excluded_param}\")))"
+            ));
+        }
+        policy_components.push(format!("(require-all {} )", require_parts.join(" ")));
+    }
+
+    if policy_components.is_empty() {
+        (String::new(), Vec::new())
+    } else {
+        (
+            format!("(allow {action}\n{}\n)", policy_components.join(" ")),
+            params,
+        )
+    }
+}
+
+fn build_seatbelt_unreadable_glob_policy(
+    file_system_sandbox_policy: &FileSystemSandboxPolicy,
+    cwd: &Path,
+) -> String {
+    // Seatbelt does not understand the filesystem policy's glob syntax directly.
+    // Convert each unreadable pattern into an anchored regex deny rule and apply
+    // it to both reads and unlink-style writes so a denied path cannot be probed
+    // through destructive filesystem operations.
+    let unreadable_globs = file_system_sandbox_policy.get_unreadable_globs_with_cwd(cwd);
+    if unreadable_globs.is_empty() {
+        return String::new();
+    }
+
+    let mut policy_components = Vec::new();
+    for pattern in unreadable_globs {
+        let mut regexes = BTreeSet::new();
+        if let Some(regex) = seatbelt_regex_for_unreadable_glob(&pattern) {
+            regexes.insert(regex);
+        }
+        if let Some(pattern) = canonicalize_glob_static_prefix_for_sandbox(&pattern)
+            && let Some(regex) = seatbelt_regex_for_unreadable_glob(&pattern)
+        {
+            regexes.insert(regex);
+        }
+        for regex in regexes {
+            let regex = regex.replace('"', "\\\"");
+            policy_components.push(format!(r#"(deny file-read* (regex #"{regex}"))"#));
+            policy_components.push(format!(r#"(deny file-write-unlink (regex #"{regex}"))"#));
+        }
+    }
+
+    policy_components.join("\n")
+}
+
+fn canonicalize_glob_static_prefix_for_sandbox(pattern: &str) -> Option<String> {
+    let first_glob_index = pattern
+        .char_indices()
+        .find_map(|(index, ch)| matches!(ch, '*' | '?' | '[' | ']').then_some(index));
+    let Some(first_glob_index) = first_glob_index else {
+        return normalize_path_for_sandbox(Path::new(pattern))
+            .map(|path| path.to_string_lossy().to_string());
+    };
+
+    let static_prefix = &pattern[..first_glob_index];
+    let prefix_end = if static_prefix.ends_with('/') {
+        static_prefix.len() - 1
+    } else {
+        static_prefix.rfind('/').unwrap_or(0)
+    };
+    if prefix_end == 0 {
+        return None;
+    }
+
+    let root = normalize_path_for_sandbox(Path::new(&pattern[..prefix_end]))?;
+    let root = root.to_string_lossy();
+    let suffix = &pattern[prefix_end..];
+    let normalized_pattern = format!("{root}{suffix}");
+    (normalized_pattern != pattern).then_some(normalized_pattern)
+}
+
+fn seatbelt_regex_for_unreadable_glob(pattern: &str) -> Option<String> {
+    if pattern.is_empty() {
+        return None;
+    }
+
+    // Translate the supported git-style glob subset into a Seatbelt regex:
+    // `*` and `?` stay within one path component, `**/` can consume zero or
+    // more components, and closed character classes remain character classes.
+    // A pattern with no glob metacharacters is treated as exact path plus subtree.
+    let mut regex = String::from("^");
+    let mut chars = pattern.chars().collect::<VecDeque<_>>();
+    let mut saw_glob = false;
+
+    while let Some(ch) = chars.pop_front() {
+        match ch {
+            '*' => {
+                saw_glob = true;
+                if chars.front() == Some(&'*') {
+                    chars.pop_front();
+                    if chars.front() == Some(&'/') {
+                        chars.pop_front();
+                        regex.push_str("(.*/)?");
+                    } else {
+                        regex.push_str(".*");
+                    }
+                } else {
+                    regex.push_str("[^/]*");
+                }
+            }
+            '?' => {
+                saw_glob = true;
+                regex.push_str("[^/]");
+            }
+            '[' => {
+                saw_glob = true;
+                let mut class = Vec::new();
+                let mut closed = false;
+                while let Some(class_ch) = chars.pop_front() {
+                    if class_ch == ']' {
+                        closed = true;
+                        break;
+                    }
+                    class.push(class_ch);
+                }
+                if !closed {
+                    regex.push_str("\\[");
+                    for class_ch in class.into_iter().rev() {
+                        chars.push_front(class_ch);
+                    }
+                    continue;
+                }
+
+                regex.push('[');
+                let mut class_chars = class.into_iter();
+                if let Some(first) = class_chars.next() {
+                    match first {
+                        '!' => regex.push('^'),
+                        '^' => regex.push_str("\\^"),
+                        _ => regex.push(first),
+                    }
+                }
+                for class_ch in class_chars {
+                    match class_ch {
+                        '\\' => regex.push_str("\\\\"),
+                        _ => regex.push(class_ch),
+                    }
+                }
+                regex.push(']');
+            }
+            ']' => {
+                saw_glob = true;
+                regex.push_str("\\]");
+            }
+            _ => regex.push_str(&regex_lite::escape(&ch.to_string())),
+        }
+    }
+
+    if !saw_glob {
+        regex.push_str("(/.*)?");
+    }
+    regex.push('$');
+    Some(regex)
+}
+
+#[cfg_attr(not(test), allow(dead_code))]
+fn create_seatbelt_command_args_for_legacy_policy(
+    command: Vec<String>,
+    sandbox_policy: &SandboxPolicy,
+    sandbox_policy_cwd: &Path,
+    enforce_managed_network: bool,
+    network: Option<&NetworkProxy>,
+) -> Vec<String> {
+    let file_system_sandbox_policy = FileSystemSandboxPolicy::from_legacy_sandbox_policy_for_cwd(
+        sandbox_policy,
+        sandbox_policy_cwd,
+    );
+    create_seatbelt_command_args(CreateSeatbeltCommandArgsParams {
+        command,
+        file_system_sandbox_policy: &file_system_sandbox_policy,
+        network_sandbox_policy: NetworkSandboxPolicy::from(sandbox_policy),
+        sandbox_policy_cwd,
+        enforce_managed_network,
+        network,
+        extra_allow_unix_sockets: &[],
+    })
+}
+
+#[derive(Debug)]
+pub struct CreateSeatbeltCommandArgsParams<'a> {
+    pub command: Vec<String>,
+    pub file_system_sandbox_policy: &'a FileSystemSandboxPolicy,
+    pub network_sandbox_policy: NetworkSandboxPolicy,
+    pub sandbox_policy_cwd: &'a Path,
+    pub enforce_managed_network: bool,
+    pub network: Option<&'a NetworkProxy>,
+    pub extra_allow_unix_sockets: &'a [AbsolutePathBuf],
+}
+
+pub fn create_seatbelt_command_args(args: CreateSeatbeltCommandArgsParams<'_>) -> Vec<String> {
+    let CreateSeatbeltCommandArgsParams {
+        command,
+        file_system_sandbox_policy,
+        network_sandbox_policy,
+        sandbox_policy_cwd,
+        enforce_managed_network,
+        network,
+        extra_allow_unix_sockets,
+    } = args;
+
+    let unreadable_roots =
+        file_system_sandbox_policy.get_unreadable_roots_with_cwd(sandbox_policy_cwd);
+    let (file_write_policy, file_write_dir_params) =
+        if file_system_sandbox_policy.has_full_disk_write_access() {
+            if unreadable_roots.is_empty() {
+                // Allegedly, this is more permissive than `(allow file-write*)`.
+                (
+                    r#"(allow file-write* (regex #"^/"))"#.to_string(),
+                    Vec::new(),
+                )
+            } else {
+                build_seatbelt_access_policy(
+                    "file-write*",
+                    "WRITABLE_ROOT",
+                    vec![SeatbeltAccessRoot {
+                        root: root_absolute_path(),
+                        excluded_subpaths: unreadable_roots.clone(),
+                    }],
+                )
+            }
+        } else {
+            build_seatbelt_access_policy(
+                "file-write*",
+                "WRITABLE_ROOT",
+                file_system_sandbox_policy
+                    .get_writable_roots_with_cwd(sandbox_policy_cwd)
+                    .into_iter()
+                    .map(|root| SeatbeltAccessRoot {
+                        root: root.root,
+                        excluded_subpaths: root.read_only_subpaths,
+                    })
+                    .collect(),
+            )
+        };
+
+    let (file_read_policy, file_read_dir_params) =
+        if file_system_sandbox_policy.has_full_disk_read_access() {
+            if unreadable_roots.is_empty() {
+                (
+                    "; allow read-only file operations\n(allow file-read*)".to_string(),
+                    Vec::new(),
+                )
+            } else {
+                let (policy, params) = build_seatbelt_access_policy(
+                    "file-read*",
+                    "READABLE_ROOT",
+                    vec![SeatbeltAccessRoot {
+                        root: root_absolute_path(),
+                        excluded_subpaths: unreadable_roots,
+                    }],
+                );
+                (
+                    format!("; allow read-only file operations\n{policy}"),
+                    params,
+                )
+            }
+        } else {
+            let (policy, params) = build_seatbelt_access_policy(
+                "file-read*",
+                "READABLE_ROOT",
+                file_system_sandbox_policy
+                    .get_readable_roots_with_cwd(sandbox_policy_cwd)
+                    .into_iter()
+                    .map(|root| SeatbeltAccessRoot {
+                        excluded_subpaths: unreadable_roots
+                            .iter()
+                            .filter(|path| path.as_path().starts_with(root.as_path()))
+                            .cloned()
+                            .collect(),
+                        root,
+                    })
+                    .collect(),
+            );
+            if policy.is_empty() {
+                (String::new(), params)
+            } else {
+                (
+                    format!("; allow read-only file operations\n{policy}"),
+                    params,
+                )
+            }
+        };
+
+    let proxy = proxy_policy_inputs(network, extra_allow_unix_sockets);
+    let network_policy =
+        dynamic_network_policy_for_network(network_sandbox_policy, enforce_managed_network, &proxy);
+
+    let include_platform_defaults = file_system_sandbox_policy.include_platform_defaults();
+    let deny_read_policy =
+        build_seatbelt_unreadable_glob_policy(file_system_sandbox_policy, sandbox_policy_cwd);
+    let mut policy_sections = vec![
+        MACOS_SEATBELT_BASE_POLICY.to_string(),
+        file_read_policy,
+        file_write_policy,
+        deny_read_policy,
+        network_policy,
+    ];
+    if include_platform_defaults {
+        policy_sections.push(MACOS_RESTRICTED_READ_ONLY_PLATFORM_DEFAULTS.to_string());
+    }
+
+    let full_policy = policy_sections.join("\n");
+
+    let dir_params = [
+        file_read_dir_params,
+        file_write_dir_params,
+        macos_dir_params(),
+        unix_socket_dir_params(&proxy),
+    ]
+    .concat();
+
+    let mut seatbelt_args: Vec<String> = vec!["-p".to_string(), full_policy];
+    let definition_args = dir_params
+        .into_iter()
+        .map(|(key, value): (String, PathBuf)| {
+            format!("-D{key}={value}", value = value.to_string_lossy())
+        });
+    seatbelt_args.extend(definition_args);
+    seatbelt_args.push("--".to_string());
+    seatbelt_args.extend(command);
+    seatbelt_args
+}
+
+/// Wraps libc::confstr to return a String.
+fn confstr(name: libc::c_int) -> Option<String> {
+    let mut buf = vec![0_i8; (libc::PATH_MAX as usize) + 1];
+    let len = unsafe { libc::confstr(name, buf.as_mut_ptr(), buf.len()) };
+    if len == 0 {
+        return None;
+    }
+    // confstr guarantees NUL-termination when len > 0.
+    let cstr = unsafe { CStr::from_ptr(buf.as_ptr()) };
+    cstr.to_str().ok().map(ToString::to_string)
+}
+
+/// Wraps confstr to return a canonicalized PathBuf.
+fn confstr_path(name: libc::c_int) -> Option<PathBuf> {
+    let s = confstr(name)?;
+    let path = PathBuf::from(s);
+    path.canonicalize().ok().or(Some(path))
+}
+
+fn macos_dir_params() -> Vec<(String, PathBuf)> {
+    if let Some(p) = confstr_path(libc::_CS_DARWIN_USER_CACHE_DIR) {
+        return vec![("DARWIN_USER_CACHE_DIR".to_string(), p)];
+    }
+    vec![]
+}
+
+#[cfg(test)]
+#[path = "seatbelt_tests.rs"]
+mod tests;

--- a/crates/dasclaw_sandboxing/src/seatbelt_base_policy.sbpl
+++ b/crates/dasclaw_sandboxing/src/seatbelt_base_policy.sbpl
@@ -1,0 +1,122 @@
+(version 1)
+
+; inspired by Chrome's sandbox policy:
+; https://source.chromium.org/chromium/chromium/src/+/main:sandbox/policy/mac/common.sb;l=273-319;drc=7b3962fe2e5fc9e2ee58000dc8fbf3429d84d3bd
+; https://source.chromium.org/chromium/chromium/src/+/main:sandbox/policy/mac/renderer.sb;l=64;drc=7b3962fe2e5fc9e2ee58000dc8fbf3429d84d3bd
+
+; start with closed-by-default
+(deny default)
+
+; child processes inherit the policy of their parent
+(allow process-exec)
+(allow process-fork)
+(allow signal (target same-sandbox))
+
+; process-info
+(allow process-info* (target same-sandbox))
+
+(allow file-write-data
+  (require-all
+    (path "/dev/null")
+    (vnode-type CHARACTER-DEVICE)))
+
+; sysctls permitted.
+(allow sysctl-read
+  (sysctl-name "hw.activecpu")
+  (sysctl-name "hw.busfrequency_compat")
+  (sysctl-name "hw.byteorder")
+  (sysctl-name "hw.cacheconfig")
+  (sysctl-name "hw.cachelinesize_compat")
+  (sysctl-name "hw.cpufamily")
+  (sysctl-name "hw.cpufrequency_compat")
+  (sysctl-name "hw.cputype")
+  (sysctl-name "hw.l1dcachesize_compat")
+  (sysctl-name "hw.l1icachesize_compat")
+  (sysctl-name "hw.l2cachesize_compat")
+  (sysctl-name "hw.l3cachesize_compat")
+  (sysctl-name "hw.logicalcpu_max")
+  (sysctl-name "hw.machine")
+  (sysctl-name "hw.model")
+  (sysctl-name "hw.memsize")
+  (sysctl-name "hw.ncpu")
+  (sysctl-name "hw.nperflevels")
+  ; Chrome locks these CPU feature detection down a bit more tightly,
+  ; but mostly for fingerprinting concerns which isn't an issue for codex.
+  (sysctl-name-prefix "hw.optional.arm.")
+  (sysctl-name-prefix "hw.optional.armv8_")
+  (sysctl-name "hw.packages")
+  (sysctl-name "hw.pagesize_compat")
+  (sysctl-name "hw.pagesize")
+  (sysctl-name "hw.physicalcpu")
+  (sysctl-name "hw.physicalcpu_max")
+  (sysctl-name "hw.logicalcpu")
+  (sysctl-name "hw.cpufrequency")
+  (sysctl-name "hw.tbfrequency_compat")
+  (sysctl-name "hw.vectorunit")
+  (sysctl-name "machdep.cpu.brand_string")
+  (sysctl-name "kern.argmax")
+  (sysctl-name "kern.hostname")
+  (sysctl-name "kern.maxfilesperproc")
+  (sysctl-name "kern.maxproc")
+  (sysctl-name "kern.osproductversion")
+  (sysctl-name "kern.osrelease")
+  (sysctl-name "kern.ostype")
+  (sysctl-name "kern.osvariant_status")
+  (sysctl-name "kern.osversion")
+  (sysctl-name "kern.secure_kernel")
+  (sysctl-name "kern.usrstack64")
+  (sysctl-name "kern.version")
+  (sysctl-name "sysctl.proc_cputype")
+  (sysctl-name "vm.loadavg")
+  (sysctl-name-prefix "hw.perflevel")
+  (sysctl-name-prefix "kern.proc.pgrp.")
+  (sysctl-name-prefix "kern.proc.pid.")
+  (sysctl-name-prefix "net.routetable.")
+)
+
+; Allow Java to read some CPU info. This is misclassified as a "write" because
+; userspace passes a memory buffer to the sysctl, but conceptually it is a read.
+(allow sysctl-write
+  (sysctl-name "kern.grade_cputype"))
+
+; IOKit
+(allow iokit-open
+  (iokit-registry-entry-class "RootDomainUserClient")
+)
+
+; needed to look up user info, see https://crbug.com/792228
+(allow mach-lookup
+  (global-name "com.apple.system.opendirectoryd.libinfo")
+)
+
+; Needed for python multiprocessing on MacOS for the SemLock
+(allow ipc-posix-sem)
+
+; Needed for PyTorch/libomp on macOS to register OpenMP runtimes.
+(allow ipc-posix-shm-read-data
+  ipc-posix-shm-write-create
+  ipc-posix-shm-write-unlink
+  (ipc-posix-name-regex #"^/__KMP_REGISTERED_LIB_[0-9]+$"))
+
+(allow mach-lookup
+  (global-name "com.apple.PowerManagement.control")
+)
+
+; allow openpty()
+(allow pseudo-tty)
+(allow file-read* file-write* file-ioctl (literal "/dev/ptmx"))
+(allow file-read* file-write*
+  (require-all
+    (regex #"^/dev/ttys[0-9]+")
+    (extension "com.apple.sandbox.pty")))
+; PTYs created before entering seatbelt may lack the extension; allow ioctl
+; on those slave ttys so interactive shells detect a TTY and remain functional.
+(allow file-ioctl (regex #"^/dev/ttys[0-9]+"))
+
+; allow readonly user preferences
+(allow ipc-posix-shm-read* (ipc-posix-name-prefix "apple.cfprefs."))
+(allow mach-lookup
+  (global-name "com.apple.cfprefsd.daemon")
+  (global-name "com.apple.cfprefsd.agent")
+  (local-name "com.apple.cfprefsd.agent"))
+(allow user-preference-read)

--- a/crates/dasclaw_sandboxing/src/seatbelt_network_policy.sbpl
+++ b/crates/dasclaw_sandboxing/src/seatbelt_network_policy.sbpl
@@ -1,0 +1,35 @@
+; when network access is enabled, these policies are added after those in seatbelt_base_policy.sbpl
+; proxy-specific allow rules are injected by codex-core based on environment.
+; Ref https://source.chromium.org/chromium/chromium/src/+/main:sandbox/policy/mac/network.sb;drc=f8f264d5e4e7509c913f4c60c2639d15905a07e4
+
+; allow only safe AF_SYSTEM sockets used for local platform services.
+(allow system-socket
+  (require-all
+    (socket-domain AF_SYSTEM)
+    (socket-protocol 2)
+  )
+)
+
+(allow mach-lookup
+    ; Used to look up the _CS_DARWIN_USER_CACHE_DIR in the sandbox.
+    (global-name "com.apple.bsd.dirhelper")
+    (global-name "com.apple.system.opendirectoryd.membership")
+
+    ; Communicate with the security server for TLS certificate information.
+    (global-name "com.apple.SecurityServer")
+    (global-name "com.apple.networkd")
+    (global-name "com.apple.ocspd")
+    (global-name "com.apple.trustd.agent")
+
+    ; Read network configuration.
+    (global-name "com.apple.SystemConfiguration.DNSConfiguration")
+    (global-name "com.apple.SystemConfiguration.configd")
+)
+
+(allow sysctl-read
+  (sysctl-name-regex #"^net.routetable")
+)
+
+(allow file-write*
+  (subpath (param "DARWIN_USER_CACHE_DIR"))
+)

--- a/crates/dasclaw_sandboxing/src/seatbelt_tests.rs
+++ b/crates/dasclaw_sandboxing/src/seatbelt_tests.rs
@@ -1,0 +1,1323 @@
+use super::CreateSeatbeltCommandArgsParams;
+use super::MACOS_PATH_TO_SEATBELT_EXECUTABLE;
+use super::MACOS_SEATBELT_BASE_POLICY;
+use super::ProxyPolicyInputs;
+use super::UnixDomainSocketPolicy;
+use super::build_seatbelt_unreadable_glob_policy;
+use super::create_seatbelt_command_args;
+use super::create_seatbelt_command_args_for_legacy_policy;
+use super::dynamic_network_policy;
+use super::macos_dir_params;
+use super::normalize_path_for_sandbox;
+use super::seatbelt_regex_for_unreadable_glob;
+use super::unix_socket_dir_params;
+use super::unix_socket_policy;
+use dasclaw_absolute_path::AbsolutePathBuf;
+use dasclaw_net_proxy::ConfigReloader;
+use dasclaw_net_proxy::ConfigState;
+use dasclaw_net_proxy::NetworkMode;
+use dasclaw_net_proxy::NetworkProxy;
+use dasclaw_net_proxy::NetworkProxyConfig;
+use dasclaw_net_proxy::NetworkProxyConstraints;
+use dasclaw_net_proxy::NetworkProxyState;
+use dasclaw_net_proxy::build_config_state;
+use dasclaw_protocol::permissions::FileSystemAccessMode;
+use dasclaw_protocol::permissions::FileSystemPath;
+use dasclaw_protocol::permissions::FileSystemSandboxEntry;
+use dasclaw_protocol::permissions::FileSystemSandboxPolicy;
+use dasclaw_protocol::permissions::FileSystemSpecialPath;
+use dasclaw_protocol::permissions::NetworkSandboxPolicy;
+use dasclaw_protocol::protocol::SandboxPolicy;
+use pretty_assertions::assert_eq;
+use std::fs;
+use std::path::Path;
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::Arc;
+use tempfile::TempDir;
+
+fn assert_seatbelt_denied(stderr: &[u8], path: &Path) {
+    let stderr = String::from_utf8_lossy(stderr);
+    let expected = format!("bash: {}: Operation not permitted\n", path.display());
+    assert!(
+        stderr == expected
+            || stderr.contains("sandbox-exec: sandbox_apply: Operation not permitted"),
+        "unexpected stderr: {stderr}"
+    );
+}
+
+fn absolute_path(path: &str) -> AbsolutePathBuf {
+    AbsolutePathBuf::from_absolute_path(Path::new(path)).expect("absolute path")
+}
+
+fn seatbelt_policy_arg(args: &[String]) -> &str {
+    let policy_index = args
+        .iter()
+        .position(|arg| arg == "-p")
+        .expect("seatbelt args should include -p");
+    args.get(policy_index + 1)
+        .expect("seatbelt args should include policy text")
+}
+
+struct TestConfigReloader;
+
+#[async_trait::async_trait]
+impl ConfigReloader for TestConfigReloader {
+    fn source_label(&self) -> String {
+        "seatbelt test config".to_string()
+    }
+
+    async fn maybe_reload(&self) -> anyhow::Result<Option<ConfigState>> {
+        Ok(None)
+    }
+
+    async fn reload_now(&self) -> anyhow::Result<ConfigState> {
+        Err(anyhow::anyhow!("seatbelt test config cannot reload"))
+    }
+}
+
+#[test]
+fn base_policy_allows_node_cpu_sysctls() {
+    assert!(
+        MACOS_SEATBELT_BASE_POLICY.contains("(sysctl-name \"machdep.cpu.brand_string\")"),
+        "base policy must allow CPU brand lookup for os.cpus()"
+    );
+    assert!(
+        MACOS_SEATBELT_BASE_POLICY.contains("(sysctl-name \"hw.model\")"),
+        "base policy must allow hardware model lookup for os.cpus()"
+    );
+}
+
+#[test]
+fn base_policy_allows_kmp_registration_shm_read_create_and_unlink() {
+    let expected = r##"(allow ipc-posix-shm-read-data
+  ipc-posix-shm-write-create
+  ipc-posix-shm-write-unlink
+  (ipc-posix-name-regex #"^/__KMP_REGISTERED_LIB_[0-9]+$"))"##;
+
+    assert!(
+        MACOS_SEATBELT_BASE_POLICY.contains(expected),
+        "base policy must allow only KMP registration shm read/create/unlink:\n{MACOS_SEATBELT_BASE_POLICY}"
+    );
+}
+
+#[test]
+fn create_seatbelt_args_routes_network_through_proxy_ports() {
+    let policy = dynamic_network_policy(
+        &SandboxPolicy::new_read_only_policy(),
+        /*enforce_managed_network*/ false,
+        &ProxyPolicyInputs {
+            ports: vec![43128, 48081],
+            has_proxy_config: true,
+            allow_local_binding: false,
+            ..ProxyPolicyInputs::default()
+        },
+    );
+
+    assert!(
+        policy.contains("(allow network-outbound (remote ip \"localhost:43128\"))"),
+        "expected HTTP proxy port allow rule in policy:\n{policy}"
+    );
+    assert!(
+        policy.contains("(allow network-outbound (remote ip \"localhost:48081\"))"),
+        "expected SOCKS proxy port allow rule in policy:\n{policy}"
+    );
+    assert!(
+        !policy.contains("\n(allow network-outbound)\n"),
+        "policy should not include blanket outbound allowance when proxy ports are present:\n{policy}"
+    );
+    assert!(
+        !policy.contains("(allow network-bind (local ip \"*:*\"))"),
+        "policy should not allow local binding unless explicitly enabled:\n{policy}"
+    );
+    assert!(
+        !policy.contains("(allow network-inbound (local ip \"localhost:*\"))"),
+        "policy should not allow loopback inbound unless explicitly enabled:\n{policy}"
+    );
+    assert!(
+        !policy.contains("(allow network-outbound (remote ip \"*:53\"))"),
+        "policy should not allow raw DNS unless local binding is explicitly enabled:\n{policy}"
+    );
+}
+
+#[test]
+fn explicit_unreadable_paths_are_excluded_from_full_disk_read_and_write_access() {
+    let unreadable = absolute_path("/tmp/codex-unreadable");
+    let file_system_policy = FileSystemSandboxPolicy::restricted(vec![
+        FileSystemSandboxEntry {
+            path: FileSystemPath::Special {
+                value: FileSystemSpecialPath::Root,
+            },
+            access: FileSystemAccessMode::Write,
+        },
+        FileSystemSandboxEntry {
+            path: FileSystemPath::Path { path: unreadable },
+            access: FileSystemAccessMode::None,
+        },
+    ]);
+
+    let args = create_seatbelt_command_args(CreateSeatbeltCommandArgsParams {
+        command: vec!["/bin/true".to_string()],
+        file_system_sandbox_policy: &file_system_policy,
+        network_sandbox_policy: NetworkSandboxPolicy::Restricted,
+        sandbox_policy_cwd: Path::new("/"),
+        enforce_managed_network: false,
+        network: None,
+        extra_allow_unix_sockets: &[],
+    });
+
+    let policy = seatbelt_policy_arg(&args);
+    let unreadable_roots = file_system_policy.get_unreadable_roots_with_cwd(Path::new("/"));
+    let unreadable_root = unreadable_roots.first().expect("expected unreadable root");
+    assert!(
+        policy.contains("(require-not (literal (param \"READABLE_ROOT_0_EXCLUDED_0\")))"),
+        "expected exact read carveout in policy:\n{policy}"
+    );
+    assert!(
+        policy.contains("(require-not (subpath (param \"READABLE_ROOT_0_EXCLUDED_0\")))"),
+        "expected read carveout in policy:\n{policy}"
+    );
+    assert!(
+        policy.contains("(require-not (literal (param \"WRITABLE_ROOT_0_EXCLUDED_0\")))"),
+        "expected exact write carveout in policy:\n{policy}"
+    );
+    assert!(
+        policy.contains("(require-not (subpath (param \"WRITABLE_ROOT_0_EXCLUDED_0\")))"),
+        "expected write carveout in policy:\n{policy}"
+    );
+    assert!(
+        args.iter().any(
+            |arg| arg == &format!("-DREADABLE_ROOT_0_EXCLUDED_0={}", unreadable_root.display())
+        ),
+        "expected read carveout parameter in args: {args:#?}"
+    );
+    let writable_definitions: Vec<String> = args
+        .iter()
+        .filter(|arg| arg.starts_with("-DWRITABLE_ROOT_"))
+        .cloned()
+        .collect();
+    assert_eq!(
+        writable_definitions,
+        vec![
+            "-DWRITABLE_ROOT_0=/".to_string(),
+            "-DWRITABLE_ROOT_0_EXCLUDED_0=/.codex".to_string(),
+            format!("-DWRITABLE_ROOT_0_EXCLUDED_1={}", unreadable_root.display()),
+        ],
+        "unexpected write carveout parameters in args: {args:#?}"
+    );
+}
+
+#[test]
+fn explicit_unreadable_paths_are_excluded_from_readable_roots() {
+    let root = absolute_path("/tmp/codex-readable");
+    let unreadable = absolute_path("/tmp/codex-readable/private");
+    let file_system_policy = FileSystemSandboxPolicy::restricted(vec![
+        FileSystemSandboxEntry {
+            path: FileSystemPath::Path { path: root },
+            access: FileSystemAccessMode::Read,
+        },
+        FileSystemSandboxEntry {
+            path: FileSystemPath::Path { path: unreadable },
+            access: FileSystemAccessMode::None,
+        },
+    ]);
+
+    let args = create_seatbelt_command_args(CreateSeatbeltCommandArgsParams {
+        command: vec!["/bin/true".to_string()],
+        file_system_sandbox_policy: &file_system_policy,
+        network_sandbox_policy: NetworkSandboxPolicy::Restricted,
+        sandbox_policy_cwd: Path::new("/"),
+        enforce_managed_network: false,
+        network: None,
+        extra_allow_unix_sockets: &[],
+    });
+
+    let policy = seatbelt_policy_arg(&args);
+    let readable_roots = file_system_policy.get_readable_roots_with_cwd(Path::new("/"));
+    let readable_root = readable_roots.first().expect("expected readable root");
+    let unreadable_roots = file_system_policy.get_unreadable_roots_with_cwd(Path::new("/"));
+    let unreadable_root = unreadable_roots.first().expect("expected unreadable root");
+    assert!(
+        policy.contains("(require-not (literal (param \"READABLE_ROOT_0_EXCLUDED_0\")))"),
+        "expected exact read carveout in policy:\n{policy}"
+    );
+    assert!(
+        policy.contains("(require-not (subpath (param \"READABLE_ROOT_0_EXCLUDED_0\")))"),
+        "expected read carveout in policy:\n{policy}"
+    );
+    assert!(
+        args.iter()
+            .any(|arg| arg == &format!("-DREADABLE_ROOT_0={}", readable_root.display())),
+        "expected readable root parameter in args: {args:#?}"
+    );
+    assert!(
+        args.iter().any(
+            |arg| arg == &format!("-DREADABLE_ROOT_0_EXCLUDED_0={}", unreadable_root.display())
+        ),
+        "expected read carveout parameter in args: {args:#?}"
+    );
+}
+
+#[test]
+fn unreadable_globstar_slash_matches_zero_or_more_directories() {
+    let regex = seatbelt_regex_for_unreadable_glob("/tmp/repo/**/*.env");
+    assert_eq!(regex.as_deref(), Some(r"^/tmp/repo/(.*/)?[^/]*\.env$"));
+    let regex = regex_lite::Regex::new(regex.as_deref().expect("glob should compile"))
+        .expect("regex should compile");
+
+    assert!(regex.is_match("/tmp/repo/.env"));
+    assert!(regex.is_match("/tmp/repo/app/.env"));
+    assert!(regex.is_match("/tmp/repo/app/config.env"));
+    assert!(!regex.is_match("/tmp/repo/app/config.toml"));
+}
+
+#[test]
+fn unreadable_globs_use_git_style_component_matching() {
+    let regex = seatbelt_regex_for_unreadable_glob("/tmp/repo/*/file[0-9]?.txt");
+    assert_eq!(
+        regex.as_deref(),
+        Some(r"^/tmp/repo/[^/]*/file[0-9][^/]\.txt$")
+    );
+    let regex = regex_lite::Regex::new(regex.as_deref().expect("glob should compile"))
+        .expect("regex should compile");
+
+    assert!(regex.is_match("/tmp/repo/app/file42.txt"));
+    assert!(!regex.is_match("/tmp/repo/app/nested/file42.txt"));
+    assert!(!regex.is_match("/tmp/repo/app/file4.txt"));
+    assert!(!regex.is_match("/tmp/repo/app/fileab.txt"));
+}
+
+#[test]
+fn unreadable_globs_treat_unclosed_character_classes_as_literals() {
+    let regex = seatbelt_regex_for_unreadable_glob("/tmp/repo/[*.env");
+    assert_eq!(regex.as_deref(), Some(r"^/tmp/repo/\[[^/]*\.env$"));
+    let regex = regex_lite::Regex::new(regex.as_deref().expect("glob should compile"))
+        .expect("regex should compile");
+
+    assert!(regex.is_match("/tmp/repo/[local.env"));
+    assert!(regex.is_match("/tmp/repo/[.env"));
+    assert!(!regex.is_match("/tmp/repo/local.env"));
+}
+
+#[cfg(unix)]
+#[test]
+fn unreadable_glob_policy_includes_canonicalized_static_prefix() {
+    use std::os::unix::fs::symlink;
+
+    let temp_dir = TempDir::new().expect("temp dir");
+    let real_root = temp_dir.path().join("real-root");
+    let link_root = temp_dir.path().join("link-root");
+    fs::create_dir(&real_root).expect("create real root");
+    symlink(&real_root, &link_root).expect("create symlinked root");
+
+    let pattern = format!("{}/**/*.env", link_root.display());
+    let canonical_pattern = format!(
+        "{}/**/*.env",
+        real_root
+            .canonicalize()
+            .expect("canonicalize real root")
+            .display()
+    );
+    let expected_regex = seatbelt_regex_for_unreadable_glob(&canonical_pattern)
+        .expect("canonical glob should compile");
+    let mut policy = FileSystemSandboxPolicy::default();
+    policy.entries.push(FileSystemSandboxEntry {
+        path: FileSystemPath::GlobPattern { pattern },
+        access: FileSystemAccessMode::None,
+    });
+
+    let seatbelt_policy = build_seatbelt_unreadable_glob_policy(&policy, temp_dir.path());
+
+    assert!(
+        seatbelt_policy.contains(&format!(r#"(deny file-read* (regex #"{expected_regex}"))"#)),
+        "expected canonicalized glob regex in policy:\n{seatbelt_policy}"
+    );
+}
+
+#[test]
+fn seatbelt_args_without_extension_profile_keep_legacy_preferences_read_access() {
+    let cwd = std::env::temp_dir();
+    let args = create_seatbelt_command_args_for_legacy_policy(
+        vec!["echo".to_string(), "ok".to_string()],
+        &SandboxPolicy::new_read_only_policy(),
+        cwd.as_path(),
+        /*enforce_managed_network*/ false,
+        /*network*/ None,
+    );
+    let policy = &args[1];
+    assert!(policy.contains("(allow user-preference-read)"));
+    assert!(!policy.contains("(allow user-preference-write)"));
+}
+
+#[test]
+fn create_seatbelt_args_allows_local_binding_when_explicitly_enabled() {
+    let policy = dynamic_network_policy(
+        &SandboxPolicy::new_read_only_policy(),
+        /*enforce_managed_network*/ false,
+        &ProxyPolicyInputs {
+            ports: vec![43128],
+            has_proxy_config: true,
+            allow_local_binding: true,
+            ..ProxyPolicyInputs::default()
+        },
+    );
+
+    assert!(
+        policy.contains("(allow network-bind (local ip \"*:*\"))"),
+        "policy should allow loopback local binding when explicitly enabled:\n{policy}"
+    );
+    assert!(
+        policy.contains("(allow network-inbound (local ip \"localhost:*\"))"),
+        "policy should allow loopback inbound when explicitly enabled:\n{policy}"
+    );
+    assert!(
+        policy.contains("(allow network-outbound (remote ip \"localhost:*\"))"),
+        "policy should allow loopback outbound when explicitly enabled:\n{policy}"
+    );
+    assert!(
+        policy.contains("(allow network-outbound (remote ip \"*:53\"))"),
+        "policy should allow DNS egress when local binding is explicitly enabled:\n{policy}"
+    );
+    assert!(
+        !policy.contains("\n(allow network-outbound)\n"),
+        "policy should keep proxy-routed behavior without blanket outbound allowance:\n{policy}"
+    );
+}
+
+#[test]
+fn dynamic_network_policy_preserves_restricted_policy_when_proxy_config_without_ports() {
+    let policy = dynamic_network_policy(
+        &SandboxPolicy::WorkspaceWrite {
+            writable_roots: vec![],
+            network_access: true,
+            exclude_tmpdir_env_var: false,
+            exclude_slash_tmp: false,
+        },
+        /*enforce_managed_network*/ false,
+        &ProxyPolicyInputs {
+            ports: vec![],
+            has_proxy_config: true,
+            allow_local_binding: false,
+            ..ProxyPolicyInputs::default()
+        },
+    );
+
+    assert!(
+        policy.contains("(socket-domain AF_SYSTEM)"),
+        "policy should keep the restricted network profile when proxy config is present without ports:\n{policy}"
+    );
+    assert!(
+        !policy.contains("\n(allow network-outbound)\n"),
+        "policy should not include blanket outbound allowance when proxy config is present without ports:\n{policy}"
+    );
+    assert!(
+        !policy.contains("(allow network-outbound (remote ip \"localhost:"),
+        "policy should not include proxy port allowance when proxy config is present without ports:\n{policy}"
+    );
+    assert!(
+        !policy.contains("(allow network-outbound (remote ip \"*:53\"))"),
+        "policy should stay fail-closed for DNS when no proxy ports are available:\n{policy}"
+    );
+}
+
+#[test]
+fn dynamic_network_policy_blocks_dns_when_local_binding_has_no_proxy_ports() {
+    let policy = dynamic_network_policy(
+        &SandboxPolicy::WorkspaceWrite {
+            writable_roots: vec![],
+            network_access: true,
+            exclude_tmpdir_env_var: false,
+            exclude_slash_tmp: false,
+        },
+        /*enforce_managed_network*/ false,
+        &ProxyPolicyInputs {
+            ports: vec![],
+            has_proxy_config: true,
+            allow_local_binding: true,
+            ..ProxyPolicyInputs::default()
+        },
+    );
+
+    assert!(
+        policy.contains("(allow network-bind (local ip \"*:*\"))"),
+        "policy should still allow explicitly configured local binding:\n{policy}"
+    );
+    assert!(
+        !policy.contains("(allow network-outbound (remote ip \"*:53\"))"),
+        "policy should not allow DNS egress when no proxy ports are available:\n{policy}"
+    );
+}
+
+#[test]
+fn dynamic_network_policy_preserves_restricted_policy_for_managed_network_without_proxy_config() {
+    let policy = dynamic_network_policy(
+        &SandboxPolicy::WorkspaceWrite {
+            writable_roots: vec![],
+            network_access: true,
+            exclude_tmpdir_env_var: false,
+            exclude_slash_tmp: false,
+        },
+        /*enforce_managed_network*/ true,
+        &ProxyPolicyInputs {
+            ports: vec![],
+            has_proxy_config: false,
+            allow_local_binding: false,
+            ..ProxyPolicyInputs::default()
+        },
+    );
+
+    assert!(
+        policy.contains("(socket-domain AF_SYSTEM)"),
+        "policy should keep the restricted network profile when managed network is active without proxy endpoints:\n{policy}"
+    );
+    assert!(
+        !policy.contains("\n(allow network-outbound)\n"),
+        "policy should not include blanket outbound allowance when managed network is active without proxy endpoints:\n{policy}"
+    );
+    assert!(
+        !policy.contains("(allow network-outbound (remote ip \"*:53\"))"),
+        "policy should stay fail-closed for DNS when no proxy endpoints are available:\n{policy}"
+    );
+}
+
+#[test]
+fn create_seatbelt_args_allowlists_unix_socket_paths() {
+    let policy = dynamic_network_policy(
+        &SandboxPolicy::new_read_only_policy(),
+        /*enforce_managed_network*/ false,
+        &ProxyPolicyInputs {
+            ports: vec![43128],
+            has_proxy_config: true,
+            allow_local_binding: false,
+            unix_domain_socket_policy: UnixDomainSocketPolicy::Restricted {
+                allowed: vec![absolute_path("/tmp/example.sock")],
+            },
+        },
+    );
+
+    assert!(
+        policy.contains("(allow system-socket (socket-domain AF_UNIX))"),
+        "policy should allow AF_UNIX socket creation for configured unix sockets:\n{policy}"
+    );
+    assert!(
+        policy.contains(
+            "(allow network-bind (local unix-socket (subpath (param \"UNIX_SOCKET_PATH_0\"))))"
+        ),
+        "policy should allow binding explicitly configured unix sockets:\n{policy}"
+    );
+    assert!(
+        policy.contains(
+            "(allow network-outbound (remote unix-socket (subpath (param \"UNIX_SOCKET_PATH_0\"))))"
+        ),
+        "policy should allow connecting to explicitly configured unix sockets:\n{policy}"
+    );
+    assert!(
+        !policy.contains("(allow network* (subpath"),
+        "policy should no longer use the generic subpath unix-socket rules:\n{policy}"
+    );
+}
+
+#[test]
+fn create_seatbelt_args_allowlists_explicit_unix_socket_paths_without_proxy() {
+    let cwd = TempDir::new().expect("temp cwd");
+    let file_system_policy = FileSystemSandboxPolicy::from_legacy_sandbox_policy_for_cwd(
+        &SandboxPolicy::new_read_only_policy(),
+        cwd.path(),
+    );
+    let extra_allow_unix_sockets = vec![absolute_path("/tmp/codex-browser-use")];
+    let args = create_seatbelt_command_args(CreateSeatbeltCommandArgsParams {
+        command: vec!["/usr/bin/true".to_string()],
+        file_system_sandbox_policy: &file_system_policy,
+        network_sandbox_policy: NetworkSandboxPolicy::Restricted,
+        sandbox_policy_cwd: cwd.path(),
+        enforce_managed_network: false,
+        network: None,
+        extra_allow_unix_sockets: &extra_allow_unix_sockets,
+    });
+    let policy = seatbelt_policy_arg(&args);
+
+    assert!(
+        policy.contains("(allow system-socket (socket-domain AF_UNIX))"),
+        "policy should allow AF_UNIX when explicit socket paths are requested:\n{policy}"
+    );
+    assert!(
+        policy.contains(
+            "(allow network-outbound (remote unix-socket (subpath (param \"UNIX_SOCKET_PATH_0\"))))"
+        ),
+        "policy should allow outbound AF_UNIX traffic for explicit socket paths:\n{policy}"
+    );
+    let expected_socket_root = normalize_path_for_sandbox(Path::new("/tmp/codex-browser-use"))
+        .expect("socket root should normalize")
+        .to_string_lossy()
+        .into_owned();
+    assert!(
+        args.iter()
+            .any(|arg| arg == &format!("-DUNIX_SOCKET_PATH_0={expected_socket_root}")),
+        "seatbelt args should pass the configured socket root as a sandbox param: {args:?}"
+    );
+}
+
+#[tokio::test]
+async fn create_seatbelt_args_merges_proxy_and_explicit_unix_socket_paths() -> anyhow::Result<()> {
+    let cwd = TempDir::new().expect("temp cwd");
+    let file_system_policy = FileSystemSandboxPolicy::from_legacy_sandbox_policy_for_cwd(
+        &SandboxPolicy::new_read_only_policy(),
+        cwd.path(),
+    );
+    let network_socket = "/tmp/codex-proxy-use";
+    let explicit_socket = "/tmp/codex-browser-use";
+    let mut network_config = NetworkProxyConfig::default();
+    network_config.network.enabled = true;
+    network_config.network.mode = NetworkMode::Full;
+    network_config
+        .network
+        .set_allow_unix_sockets(vec![network_socket.to_string()]);
+    let state = build_config_state(network_config, NetworkProxyConstraints::default())?;
+    let network_proxy = NetworkProxy::builder()
+        .state(Arc::new(NetworkProxyState::with_reloader(
+            state,
+            Arc::new(TestConfigReloader),
+        )))
+        .managed_by_codex(/*managed_by_codex*/ false)
+        .build()
+        .await?;
+    let extra_allow_unix_sockets = vec![absolute_path(explicit_socket)];
+
+    let args = create_seatbelt_command_args(CreateSeatbeltCommandArgsParams {
+        command: vec!["/usr/bin/true".to_string()],
+        file_system_sandbox_policy: &file_system_policy,
+        network_sandbox_policy: NetworkSandboxPolicy::Restricted,
+        sandbox_policy_cwd: cwd.path(),
+        enforce_managed_network: false,
+        network: Some(&network_proxy),
+        extra_allow_unix_sockets: &extra_allow_unix_sockets,
+    });
+
+    let expected_explicit_socket = normalize_path_for_sandbox(Path::new(explicit_socket))
+        .expect("explicit socket root should normalize");
+    let expected_network_socket = normalize_path_for_sandbox(Path::new(network_socket))
+        .expect("network socket root should normalize");
+    let unix_socket_definitions = args
+        .iter()
+        .filter(|arg| arg.starts_with("-DUNIX_SOCKET_PATH_"))
+        .cloned()
+        .collect::<Vec<_>>();
+    assert_eq!(
+        unix_socket_definitions,
+        vec![
+            format!(
+                "-DUNIX_SOCKET_PATH_0={}",
+                expected_explicit_socket.display()
+            ),
+            format!("-DUNIX_SOCKET_PATH_1={}", expected_network_socket.display()),
+        ],
+        "seatbelt args should include both explicit and network proxy socket roots: {args:?}"
+    );
+    Ok(())
+}
+
+#[test]
+fn create_seatbelt_args_preserves_full_network_with_explicit_unix_socket_paths() {
+    let cwd = TempDir::new().expect("temp cwd");
+    let file_system_policy = FileSystemSandboxPolicy::from_legacy_sandbox_policy_for_cwd(
+        &SandboxPolicy::new_read_only_policy(),
+        cwd.path(),
+    );
+    let extra_allow_unix_sockets = vec![absolute_path("/tmp/codex-browser-use")];
+    let args = create_seatbelt_command_args(CreateSeatbeltCommandArgsParams {
+        command: vec!["/usr/bin/true".to_string()],
+        file_system_sandbox_policy: &file_system_policy,
+        network_sandbox_policy: NetworkSandboxPolicy::Enabled,
+        sandbox_policy_cwd: cwd.path(),
+        enforce_managed_network: false,
+        network: None,
+        extra_allow_unix_sockets: &extra_allow_unix_sockets,
+    });
+    let policy = seatbelt_policy_arg(&args);
+
+    assert!(
+        policy.contains("(allow network-outbound)\n"),
+        "policy should preserve full outbound network access:\n{policy}"
+    );
+    assert!(
+        policy.contains("(allow network-inbound)\n"),
+        "policy should preserve full inbound network access:\n{policy}"
+    );
+    assert!(
+        policy.contains(
+            "(allow network-outbound (remote unix-socket (subpath (param \"UNIX_SOCKET_PATH_0\"))))"
+        ),
+        "policy should still allow outbound AF_UNIX traffic for explicit socket paths:\n{policy}"
+    );
+}
+
+#[test]
+fn unix_socket_policy_non_empty_output_is_newline_terminated() {
+    let allowlist_policy = unix_socket_policy(&ProxyPolicyInputs {
+        unix_domain_socket_policy: UnixDomainSocketPolicy::Restricted {
+            allowed: vec![absolute_path("/tmp/example.sock")],
+        },
+        ..ProxyPolicyInputs::default()
+    });
+    assert!(
+        allowlist_policy.ends_with('\n'),
+        "allowlist unix socket policy should end with a newline:\n{allowlist_policy}"
+    );
+
+    let allow_all_policy = unix_socket_policy(&ProxyPolicyInputs {
+        unix_domain_socket_policy: UnixDomainSocketPolicy::AllowAll,
+        ..ProxyPolicyInputs::default()
+    });
+    assert!(
+        allow_all_policy.ends_with('\n'),
+        "allow-all unix socket policy should end with a newline:\n{allow_all_policy}"
+    );
+}
+
+#[test]
+fn unix_socket_dir_params_use_stable_param_names() {
+    let params = unix_socket_dir_params(&ProxyPolicyInputs {
+        unix_domain_socket_policy: UnixDomainSocketPolicy::Restricted {
+            allowed: vec![
+                absolute_path("/tmp/b.sock"),
+                absolute_path("/tmp/a.sock"),
+                absolute_path("/tmp/a.sock"),
+            ],
+        },
+        ..ProxyPolicyInputs::default()
+    });
+
+    assert_eq!(
+        params,
+        vec![
+            (
+                "UNIX_SOCKET_PATH_0".to_string(),
+                PathBuf::from("/tmp/a.sock")
+            ),
+            (
+                "UNIX_SOCKET_PATH_1".to_string(),
+                PathBuf::from("/tmp/b.sock")
+            ),
+        ]
+    );
+}
+
+#[test]
+fn normalize_path_for_sandbox_rejects_relative_paths() {
+    assert_eq!(normalize_path_for_sandbox(Path::new("relative.sock")), None);
+}
+
+#[test]
+fn create_seatbelt_args_allows_all_unix_sockets_when_enabled() {
+    let policy = dynamic_network_policy(
+        &SandboxPolicy::new_read_only_policy(),
+        /*enforce_managed_network*/ false,
+        &ProxyPolicyInputs {
+            ports: vec![43128],
+            has_proxy_config: true,
+            allow_local_binding: false,
+            unix_domain_socket_policy: UnixDomainSocketPolicy::AllowAll,
+        },
+    );
+
+    assert!(
+        policy.contains("(allow system-socket (socket-domain AF_UNIX))"),
+        "policy should allow AF_UNIX socket creation when unix sockets are enabled:\n{policy}"
+    );
+    assert!(
+        policy.contains("(allow network-bind (local unix-socket))"),
+        "policy should allow binding unix sockets when enabled:\n{policy}"
+    );
+    assert!(
+        policy.contains("(allow network-outbound (remote unix-socket))"),
+        "policy should allow connecting to unix sockets when enabled:\n{policy}"
+    );
+    assert!(
+        !policy.contains("(allow network* (subpath"),
+        "policy should no longer use the generic subpath unix-socket rules:\n{policy}"
+    );
+}
+
+#[test]
+fn create_seatbelt_args_full_network_with_proxy_is_still_proxy_only() {
+    let policy = dynamic_network_policy(
+        &SandboxPolicy::WorkspaceWrite {
+            writable_roots: vec![],
+            network_access: true,
+            exclude_tmpdir_env_var: false,
+            exclude_slash_tmp: false,
+        },
+        /*enforce_managed_network*/ false,
+        &ProxyPolicyInputs {
+            ports: vec![43128],
+            has_proxy_config: true,
+            allow_local_binding: false,
+            ..ProxyPolicyInputs::default()
+        },
+    );
+
+    assert!(
+        policy.contains("(allow network-outbound (remote ip \"localhost:43128\"))"),
+        "expected proxy endpoint allow rule in policy:\n{policy}"
+    );
+    assert!(
+        !policy.contains("\n(allow network-outbound)\n"),
+        "policy should not include blanket outbound allowance when proxy is configured:\n{policy}"
+    );
+    assert!(
+        !policy.contains("\n(allow network-inbound)\n"),
+        "policy should not include blanket inbound allowance when proxy is configured:\n{policy}"
+    );
+}
+
+#[test]
+fn create_seatbelt_args_with_read_only_git_and_codex_subpaths() {
+    // Create a temporary workspace with two writable roots: one containing
+    // top-level .git and .codex directories and one without them.
+    let tmp = TempDir::new().expect("tempdir");
+    let PopulatedTmp {
+        vulnerable_root,
+        vulnerable_root_canonical,
+        dot_git_canonical,
+        dot_codex_canonical,
+        empty_root,
+        empty_root_canonical,
+    } = populate_tmpdir(tmp.path());
+    let cwd = tmp.path().join("cwd");
+    fs::create_dir_all(&cwd).expect("create cwd");
+
+    // Build a policy that only includes the two test roots as writable and
+    // does not automatically include defaults TMPDIR or /tmp.
+    let policy = SandboxPolicy::WorkspaceWrite {
+        writable_roots: vec![vulnerable_root, empty_root]
+            .into_iter()
+            .map(|p| p.try_into().unwrap())
+            .collect(),
+        network_access: false,
+        exclude_tmpdir_env_var: true,
+        exclude_slash_tmp: true,
+    };
+
+    // Create the Seatbelt command to wrap a shell command that tries to
+    // write to .codex/config.toml in the vulnerable root.
+    let shell_command: Vec<String> = [
+        "bash",
+        "-c",
+        "echo 'sandbox_mode = \"danger-full-access\"' > \"$1\"",
+        "bash",
+        dot_codex_canonical
+            .join("config.toml")
+            .to_string_lossy()
+            .as_ref(),
+    ]
+    .iter()
+    .map(std::string::ToString::to_string)
+    .collect();
+    let args = create_seatbelt_command_args_for_legacy_policy(
+        shell_command.clone(),
+        &policy,
+        &cwd,
+        /*enforce_managed_network*/ false,
+        /*network*/ None,
+    );
+
+    let policy_text = seatbelt_policy_arg(&args);
+    assert!(
+        policy_text.contains("(require-all (subpath (param \"WRITABLE_ROOT_0\"))"),
+        "expected cwd writable root to carry protected carveouts:\n{policy_text}",
+    );
+    assert!(
+        policy_text.contains("WRITABLE_ROOT_0_EXCLUDED_0"),
+        "expected cwd .codex carveout in policy:\n{policy_text}",
+    );
+    assert!(
+        policy_text.contains("WRITABLE_ROOT_1_EXCLUDED_0")
+            && policy_text.contains("WRITABLE_ROOT_1_EXCLUDED_1"),
+        "expected explicit writable root .git/.codex carveouts in policy:\n{policy_text}",
+    );
+    assert!(
+        policy_text.contains("(subpath (param \"WRITABLE_ROOT_2\"))"),
+        "expected second explicit writable root grant in policy:\n{policy_text}",
+    );
+
+    let expected_definitions = [
+        format!(
+            "-DWRITABLE_ROOT_0={}",
+            cwd.canonicalize()
+                .expect("canonicalize cwd")
+                .to_string_lossy()
+        ),
+        format!(
+            "-DWRITABLE_ROOT_0_EXCLUDED_0={}",
+            cwd.canonicalize()
+                .expect("canonicalize cwd")
+                .join(".codex")
+                .display()
+        ),
+        format!(
+            "-DWRITABLE_ROOT_1={}",
+            vulnerable_root_canonical.to_string_lossy()
+        ),
+        format!(
+            "-DWRITABLE_ROOT_1_EXCLUDED_0={}",
+            dot_git_canonical.to_string_lossy()
+        ),
+        format!(
+            "-DWRITABLE_ROOT_1_EXCLUDED_1={}",
+            dot_codex_canonical.to_string_lossy()
+        ),
+        format!(
+            "-DWRITABLE_ROOT_2={}",
+            empty_root_canonical.to_string_lossy()
+        ),
+    ];
+    let writable_definitions: Vec<String> = args
+        .iter()
+        .filter(|arg| arg.starts_with("-DWRITABLE_ROOT_"))
+        .cloned()
+        .collect();
+    assert_eq!(
+        writable_definitions, expected_definitions,
+        "unexpected writable-root parameter definitions in {args:#?}"
+    );
+    for (key, value) in macos_dir_params() {
+        let expected_definition = format!("-D{key}={}", value.to_string_lossy());
+        assert!(
+            args.contains(&expected_definition),
+            "expected definition arg `{expected_definition}` in {args:#?}"
+        );
+    }
+
+    let command_index = args
+        .iter()
+        .position(|arg| arg == "--")
+        .expect("seatbelt args should include command separator");
+    assert_eq!(args[command_index + 1..], shell_command);
+
+    // Verify that .codex/config.toml cannot be modified under the generated
+    // Seatbelt policy.
+    let config_toml = dot_codex_canonical.join("config.toml");
+    let output = Command::new(MACOS_PATH_TO_SEATBELT_EXECUTABLE)
+        .args(&args)
+        .current_dir(&cwd)
+        .output()
+        .expect("execute seatbelt command");
+    assert_eq!(
+        "sandbox_mode = \"read-only\"\n",
+        String::from_utf8_lossy(&fs::read(&config_toml).expect("read config.toml")),
+        "config.toml should contain its original contents because it should not have been modified"
+    );
+    assert!(
+        !output.status.success(),
+        "command to write {} should fail under seatbelt",
+        &config_toml.display()
+    );
+    assert_seatbelt_denied(&output.stderr, &config_toml);
+
+    // Create a similar Seatbelt command that tries to write to a file in
+    // the .git folder, which should also be blocked.
+    let pre_commit_hook = dot_git_canonical.join("hooks").join("pre-commit");
+    let shell_command_git: Vec<String> = [
+        "bash",
+        "-c",
+        "echo 'pwned!' > \"$1\"",
+        "bash",
+        pre_commit_hook.to_string_lossy().as_ref(),
+    ]
+    .iter()
+    .map(std::string::ToString::to_string)
+    .collect();
+    let write_hooks_file_args = create_seatbelt_command_args_for_legacy_policy(
+        shell_command_git,
+        &policy,
+        &cwd,
+        /*enforce_managed_network*/ false,
+        /*network*/ None,
+    );
+    let output = Command::new(MACOS_PATH_TO_SEATBELT_EXECUTABLE)
+        .args(&write_hooks_file_args)
+        .current_dir(&cwd)
+        .output()
+        .expect("execute seatbelt command");
+    assert!(
+        !fs::exists(&pre_commit_hook).expect("exists pre-commit hook"),
+        "{} should not exist because it should not have been created",
+        pre_commit_hook.display()
+    );
+    assert!(
+        !output.status.success(),
+        "command to write {} should fail under seatbelt",
+        &pre_commit_hook.display()
+    );
+    assert_seatbelt_denied(&output.stderr, &pre_commit_hook);
+
+    // Verify that writing a file to the folder containing .git and .codex is allowed.
+    let allowed_file = vulnerable_root_canonical.join("allowed.txt");
+    let shell_command_allowed: Vec<String> = [
+        "bash",
+        "-c",
+        "echo 'this is allowed' > \"$1\"",
+        "bash",
+        allowed_file.to_string_lossy().as_ref(),
+    ]
+    .iter()
+    .map(std::string::ToString::to_string)
+    .collect();
+    let write_allowed_file_args = create_seatbelt_command_args_for_legacy_policy(
+        shell_command_allowed,
+        &policy,
+        &cwd,
+        /*enforce_managed_network*/ false,
+        /*network*/ None,
+    );
+    let output = Command::new(MACOS_PATH_TO_SEATBELT_EXECUTABLE)
+        .args(&write_allowed_file_args)
+        .current_dir(&cwd)
+        .output()
+        .expect("execute seatbelt command");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    if !output.status.success()
+        && stderr.contains("sandbox-exec: sandbox_apply: Operation not permitted")
+    {
+        return;
+    }
+    assert!(
+        output.status.success(),
+        "command to write {} should succeed under seatbelt",
+        &allowed_file.display()
+    );
+    assert_eq!(
+        "this is allowed\n",
+        String::from_utf8_lossy(&fs::read(&allowed_file).expect("read allowed.txt")),
+        "{} should contain the written text",
+        allowed_file.display()
+    );
+}
+
+#[test]
+fn create_seatbelt_args_block_first_time_dot_codex_creation_with_exact_and_descendant_carveouts() {
+    let tmp = TempDir::new().expect("tempdir");
+    let repo_root = tmp.path().join("repo");
+    fs::create_dir_all(&repo_root).expect("create repo root");
+
+    Command::new("git")
+        .arg("init")
+        .arg(".")
+        .current_dir(&repo_root)
+        .output()
+        .expect("git init .");
+
+    let dot_codex = repo_root.join(".codex");
+    let config_toml = dot_codex.join("config.toml");
+    let policy = SandboxPolicy::WorkspaceWrite {
+        writable_roots: vec![repo_root.as_path().try_into().expect("absolute repo root")],
+        network_access: false,
+        exclude_tmpdir_env_var: true,
+        exclude_slash_tmp: true,
+    };
+
+    let shell_command: Vec<String> = [
+        "bash",
+        "-c",
+        "mkdir -p \"$1\" && echo 'sandbox_mode = \"danger-full-access\"' > \"$2\"",
+        "bash",
+        dot_codex.to_string_lossy().as_ref(),
+        config_toml.to_string_lossy().as_ref(),
+    ]
+    .iter()
+    .map(std::string::ToString::to_string)
+    .collect();
+    let args = create_seatbelt_command_args_for_legacy_policy(
+        shell_command,
+        &policy,
+        repo_root.as_path(),
+        /*enforce_managed_network*/ false,
+        /*network*/ None,
+    );
+
+    let policy_text = seatbelt_policy_arg(&args);
+    assert!(
+        policy_text.contains("(require-not (literal (param \"WRITABLE_ROOT_0_EXCLUDED_1\")))"),
+        "expected exact .codex carveout in policy:\n{policy_text}"
+    );
+    assert!(
+        policy_text.contains("(require-not (subpath (param \"WRITABLE_ROOT_0_EXCLUDED_1\")))"),
+        "expected descendant .codex carveout in policy:\n{policy_text}"
+    );
+}
+
+#[test]
+fn create_seatbelt_args_with_read_only_git_pointer_file() {
+    let tmp = TempDir::new().expect("tempdir");
+    let worktree_root = tmp.path().join("worktree_root");
+    fs::create_dir_all(&worktree_root).expect("create worktree_root");
+    let gitdir = worktree_root.join("actual-gitdir");
+    fs::create_dir_all(&gitdir).expect("create gitdir");
+    let gitdir_config = gitdir.join("config");
+    let gitdir_config_contents = "[core]\n";
+    fs::write(&gitdir_config, gitdir_config_contents).expect("write gitdir config");
+
+    let dot_git = worktree_root.join(".git");
+    let dot_git_contents = format!("gitdir: {}\n", gitdir.to_string_lossy());
+    fs::write(&dot_git, &dot_git_contents).expect("write .git pointer");
+
+    let cwd = tmp.path().join("cwd");
+    fs::create_dir_all(&cwd).expect("create cwd");
+
+    let policy = SandboxPolicy::WorkspaceWrite {
+        writable_roots: vec![worktree_root.try_into().expect("worktree_root is absolute")],
+        network_access: false,
+        exclude_tmpdir_env_var: true,
+        exclude_slash_tmp: true,
+    };
+
+    let shell_command: Vec<String> = [
+        "bash",
+        "-c",
+        "echo 'pwned!' > \"$1\"",
+        "bash",
+        dot_git.to_string_lossy().as_ref(),
+    ]
+    .iter()
+    .map(std::string::ToString::to_string)
+    .collect();
+    let args = create_seatbelt_command_args_for_legacy_policy(
+        shell_command,
+        &policy,
+        &cwd,
+        /*enforce_managed_network*/ false,
+        /*network*/ None,
+    );
+
+    let output = Command::new(MACOS_PATH_TO_SEATBELT_EXECUTABLE)
+        .args(&args)
+        .current_dir(&cwd)
+        .output()
+        .expect("execute seatbelt command");
+
+    assert_eq!(
+        dot_git_contents,
+        String::from_utf8_lossy(&fs::read(&dot_git).expect("read .git pointer")),
+        ".git pointer file should not be modified under seatbelt"
+    );
+    assert!(
+        !output.status.success(),
+        "command to write {} should fail under seatbelt",
+        dot_git.display()
+    );
+    assert_seatbelt_denied(&output.stderr, &dot_git);
+
+    let shell_command_gitdir: Vec<String> = [
+        "bash",
+        "-c",
+        "echo 'pwned!' > \"$1\"",
+        "bash",
+        gitdir_config.to_string_lossy().as_ref(),
+    ]
+    .iter()
+    .map(std::string::ToString::to_string)
+    .collect();
+    let gitdir_args = create_seatbelt_command_args_for_legacy_policy(
+        shell_command_gitdir,
+        &policy,
+        &cwd,
+        /*enforce_managed_network*/ false,
+        /*network*/ None,
+    );
+    let output = Command::new(MACOS_PATH_TO_SEATBELT_EXECUTABLE)
+        .args(&gitdir_args)
+        .current_dir(&cwd)
+        .output()
+        .expect("execute seatbelt command");
+
+    assert_eq!(
+        gitdir_config_contents,
+        String::from_utf8_lossy(&fs::read(&gitdir_config).expect("read gitdir config")),
+        "gitdir config should contain its original contents because it should not have been modified"
+    );
+    assert!(
+        !output.status.success(),
+        "command to write {} should fail under seatbelt",
+        gitdir_config.display()
+    );
+    assert_seatbelt_denied(&output.stderr, &gitdir_config);
+}
+
+#[test]
+fn create_seatbelt_args_for_cwd_as_git_repo() {
+    // Create a temporary workspace with two writable roots: one containing
+    // top-level .git and .codex directories and one without them.
+    let tmp = TempDir::new().expect("tempdir");
+    let PopulatedTmp {
+        vulnerable_root,
+        vulnerable_root_canonical,
+        dot_git_canonical,
+        dot_codex_canonical,
+        ..
+    } = populate_tmpdir(tmp.path());
+
+    // Build a policy that does not specify any writable_roots, but does
+    // use the default ones (cwd and TMPDIR) and verifies the `.git` and
+    // `.codex` checks are done properly for cwd.
+    let policy = SandboxPolicy::WorkspaceWrite {
+        writable_roots: vec![],
+        network_access: false,
+        exclude_tmpdir_env_var: false,
+        exclude_slash_tmp: false,
+    };
+
+    let shell_command: Vec<String> = [
+        "bash",
+        "-c",
+        "echo 'sandbox_mode = \"danger-full-access\"' > \"$1\"",
+        "bash",
+        dot_codex_canonical
+            .join("config.toml")
+            .to_string_lossy()
+            .as_ref(),
+    ]
+    .iter()
+    .map(std::string::ToString::to_string)
+    .collect();
+    let args = create_seatbelt_command_args_for_legacy_policy(
+        shell_command.clone(),
+        &policy,
+        vulnerable_root.as_path(),
+        /*enforce_managed_network*/ false,
+        /*network*/ None,
+    );
+
+    let tmpdir_env_var = std::env::var("TMPDIR")
+        .ok()
+        .map(PathBuf::from)
+        .and_then(|p| p.canonicalize().ok())
+        .map(|p| p.to_string_lossy().to_string());
+
+    let tempdir_policy_entry = if tmpdir_env_var.is_some() {
+        r#" (require-all (subpath (param "WRITABLE_ROOT_2")) (require-not (literal (param "WRITABLE_ROOT_2_EXCLUDED_0"))) (require-not (subpath (param "WRITABLE_ROOT_2_EXCLUDED_0"))) (require-not (literal (param "WRITABLE_ROOT_2_EXCLUDED_1"))) (require-not (subpath (param "WRITABLE_ROOT_2_EXCLUDED_1"))) )"#
+    } else {
+        ""
+    };
+
+    // Build the expected policy text using a raw string for readability.
+    // Note that the policy includes:
+    // - the base policy,
+    // - read-only access to the filesystem,
+    // - write access to WRITABLE_ROOT_0 (but not its .git or .codex), WRITABLE_ROOT_1, and cwd as WRITABLE_ROOT_2.
+    let expected_policy = format!(
+        r#"{MACOS_SEATBELT_BASE_POLICY}
+; allow read-only file operations
+(allow file-read*)
+(allow file-write*
+(require-all (subpath (param "WRITABLE_ROOT_0")) (require-not (literal (param "WRITABLE_ROOT_0_EXCLUDED_0"))) (require-not (subpath (param "WRITABLE_ROOT_0_EXCLUDED_0"))) (require-not (literal (param "WRITABLE_ROOT_0_EXCLUDED_1"))) (require-not (subpath (param "WRITABLE_ROOT_0_EXCLUDED_1"))) ) (subpath (param "WRITABLE_ROOT_1")){tempdir_policy_entry}
+)
+
+"#,
+    );
+
+    let mut expected_args = vec![
+        "-p".to_string(),
+        expected_policy,
+        format!(
+            "-DWRITABLE_ROOT_0={}",
+            vulnerable_root_canonical.to_string_lossy()
+        ),
+        format!(
+            "-DWRITABLE_ROOT_0_EXCLUDED_0={}",
+            dot_git_canonical.to_string_lossy()
+        ),
+        format!(
+            "-DWRITABLE_ROOT_0_EXCLUDED_1={}",
+            dot_codex_canonical.to_string_lossy()
+        ),
+        format!(
+            "-DWRITABLE_ROOT_1={}",
+            PathBuf::from("/tmp")
+                .canonicalize()
+                .expect("canonicalize /tmp")
+                .to_string_lossy()
+        ),
+    ];
+
+    if let Some(p) = tmpdir_env_var {
+        expected_args.push(format!("-DWRITABLE_ROOT_2={p}"));
+        expected_args.push(format!(
+            "-DWRITABLE_ROOT_2_EXCLUDED_0={}",
+            dot_git_canonical.to_string_lossy()
+        ));
+        expected_args.push(format!(
+            "-DWRITABLE_ROOT_2_EXCLUDED_1={}",
+            dot_codex_canonical.to_string_lossy()
+        ));
+    }
+
+    expected_args.extend(
+        macos_dir_params()
+            .into_iter()
+            .map(|(key, value)| format!("-D{key}={value}", value = value.to_string_lossy())),
+    );
+
+    expected_args.push("--".to_string());
+    expected_args.extend(shell_command);
+
+    assert_eq!(expected_args, args);
+}
+
+struct PopulatedTmp {
+    /// Path containing a .git and .codex subfolder.
+    /// For the purposes of this test, we consider this a "vulnerable" root
+    /// because a bad actor could write to .git/hooks/pre-commit so an
+    /// unsuspecting user would run code as privileged the next time they
+    /// ran `git commit` themselves, or modified .codex/config.toml to
+    /// contain `sandbox_mode = "danger-full-access"` so the agent would
+    /// have full privileges the next time it ran in that repo.
+    vulnerable_root: PathBuf,
+    vulnerable_root_canonical: PathBuf,
+    dot_git_canonical: PathBuf,
+    dot_codex_canonical: PathBuf,
+
+    /// Path without .git or .codex subfolders.
+    empty_root: PathBuf,
+    /// Canonicalized version of `empty_root`.
+    empty_root_canonical: PathBuf,
+}
+
+fn populate_tmpdir(tmp: &Path) -> PopulatedTmp {
+    let vulnerable_root = tmp.join("vulnerable_root");
+    fs::create_dir_all(&vulnerable_root).expect("create vulnerable_root");
+
+    // TODO(mbolin): Should also support the case where `.git` is a file
+    // with a gitdir: ... line.
+    Command::new("git")
+        .arg("init")
+        .arg(".")
+        .current_dir(&vulnerable_root)
+        .output()
+        .expect("git init .");
+
+    fs::create_dir_all(vulnerable_root.join(".codex")).expect("create .codex");
+    fs::write(
+        vulnerable_root.join(".codex").join("config.toml"),
+        "sandbox_mode = \"read-only\"\n",
+    )
+    .expect("write .codex/config.toml");
+
+    let empty_root = tmp.join("empty_root");
+    fs::create_dir_all(&empty_root).expect("create empty_root");
+
+    // Ensure we have canonical paths for -D parameter matching.
+    let vulnerable_root_canonical = vulnerable_root
+        .canonicalize()
+        .expect("canonicalize vulnerable_root");
+    let dot_git_canonical = vulnerable_root_canonical.join(".git");
+    let dot_codex_canonical = vulnerable_root_canonical.join(".codex");
+    let empty_root_canonical = empty_root.canonicalize().expect("canonicalize empty_root");
+    PopulatedTmp {
+        vulnerable_root,
+        vulnerable_root_canonical,
+        dot_git_canonical,
+        dot_codex_canonical,
+        empty_root,
+        empty_root_canonical,
+    }
+}

--- a/scripts/check_codex_sandboxing_drift.py
+++ b/scripts/check_codex_sandboxing_drift.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3.12
+"""Drift guard: verify dasclaw_sandboxing src/*.rs + *.sbpl remain
+byte-identical to the upstream codex-sandboxing snapshot vendored under
+codex-cli-main/codex-rs/sandboxing/.
+
+ADR-129 §1.3 + ADR-135 §3.1 mandate verbatim port. The only mechanical
+edits allowed in src/*.rs are:
+
+  1. `use codex_protocol::X`            → `use dasclaw_protocol::X`
+  2. `use codex_network_proxy::X`       → `use dasclaw_net_proxy::X`
+  3. `use codex_utils_absolute_path::X` → `use dasclaw_absolute_path::X`
+
+(The same crate names also appear inside type paths and macro args; the
+swap is purely textual, scoped to the three known crate identifiers.)
+
+This script normalizes (1)-(3) before hashing, then compares each Rust
+file against its upstream peer. Any other diff is treated as drift and
+exits non-zero so CI / pre-commit can block patch-style edits.
+
+.sbpl asset files reference no codex-* symbols and are compared
+byte-for-byte without normalization.
+
+Cargo.toml is intentionally NOT compared (package/lib name + dep wiring
+diverge by design — see crates/dasclaw_sandboxing/Cargo.toml header).
+
+Run: python3.12 scripts/check_codex_sandboxing_drift.py
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+LOCAL = REPO_ROOT / "crates" / "dasclaw_sandboxing" / "src"
+UPSTREAM = REPO_ROOT / "codex-cli-main" / "codex-rs" / "sandboxing" / "src"
+
+FILES = [
+    "bwrap.rs",
+    "bwrap_tests.rs",
+    "landlock.rs",
+    "landlock_tests.rs",
+    "lib.rs",
+    "manager.rs",
+    "manager_tests.rs",
+    "policy_transforms.rs",
+    "policy_transforms_tests.rs",
+    "seatbelt.rs",
+    "seatbelt_tests.rs",
+]
+
+# .sbpl files contain no codex-* identifiers — compared byte-for-byte.
+ASSETS = [
+    "restricted_read_only_platform_defaults.sbpl",
+    "seatbelt_base_policy.sbpl",
+    "seatbelt_network_policy.sbpl",
+]
+
+# Reverse the use-path swap so we compare against upstream verbatim.
+SWAP_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    (re.compile(r"\bdasclaw_protocol\b"), "codex_protocol"),
+    (re.compile(r"\bdasclaw_net_proxy\b"), "codex_network_proxy"),
+    (re.compile(r"\bdasclaw_absolute_path\b"), "codex_utils_absolute_path"),
+]
+
+
+_USE_RE = re.compile(r"^use\s+")
+
+
+def _sort_use_blocks(text: str) -> str:
+    """Sort consecutive `use ...;` lines alphabetically.
+
+    rustfmt orders `use` blocks alphabetically, but the rename shifts items
+    into a new alphabetical position. To keep the verbatim guarantee
+    semantically equivalent across that mechanical swap, we canonicalize
+    use-block ordering on both sides before hashing.
+    """
+    lines = text.split("\n")
+    out: list[str] = []
+    i = 0
+    while i < len(lines):
+        if _USE_RE.match(lines[i]):
+            j = i
+            block: list[str] = []
+            while j < len(lines) and _USE_RE.match(lines[j]):
+                block.append(lines[j])
+                j += 1
+            out.extend(sorted(block))
+            i = j
+        else:
+            out.append(lines[i])
+            i += 1
+    return "\n".join(out)
+
+
+def normalize_local(text: str) -> str:
+    for pat, repl in SWAP_PATTERNS:
+        text = pat.sub(repl, text)
+    return _sort_use_blocks(text)
+
+
+def normalize_upstream(text: str) -> str:
+    return _sort_use_blocks(text)
+
+
+def sha(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def main() -> int:
+    drift: list[str] = []
+    missing: list[str] = []
+    for fname in FILES:
+        local = LOCAL / fname
+        upstream = UPSTREAM / fname
+        if not local.exists():
+            missing.append(f"local missing: {local.relative_to(REPO_ROOT)}")
+            continue
+        if not upstream.exists():
+            missing.append(f"upstream missing: {upstream.relative_to(REPO_ROOT)}")
+            continue
+        local_norm = normalize_local(local.read_text(encoding="utf-8"))
+        upstream_norm = normalize_upstream(upstream.read_text(encoding="utf-8"))
+        if sha(local_norm) != sha(upstream_norm):
+            drift.append(
+                f"DRIFT: {local.relative_to(REPO_ROOT)} != "
+                f"{upstream.relative_to(REPO_ROOT)} "
+                f"(after use-path normalization + use-block sort)"
+            )
+
+    for fname in ASSETS:
+        local = LOCAL / fname
+        upstream = UPSTREAM / fname
+        if not local.exists():
+            missing.append(f"local missing: {local.relative_to(REPO_ROOT)}")
+            continue
+        if not upstream.exists():
+            missing.append(f"upstream missing: {upstream.relative_to(REPO_ROOT)}")
+            continue
+        if local.read_bytes() != upstream.read_bytes():
+            drift.append(
+                f"DRIFT: {local.relative_to(REPO_ROOT)} != "
+                f"{upstream.relative_to(REPO_ROOT)} (asset byte-mismatch)"
+            )
+
+    # Guard against new upstream files we didn't pick up.
+    known = set(FILES) | set(ASSETS)
+    upstream_extras = sorted(
+        p.name for p in UPSTREAM.iterdir()
+        if p.is_file() and p.name not in known
+    )
+    if upstream_extras:
+        for name in upstream_extras:
+            missing.append(
+                f"upstream has extra file not in drift list: {name} "
+                "(re-vendor required: add to FILES/ASSETS + copy to "
+                "crates/dasclaw_sandboxing/src/)"
+            )
+
+    if missing:
+        for line in missing:
+            print(line, file=sys.stderr)
+        return 2
+    if drift:
+        for line in drift:
+            print(line, file=sys.stderr)
+        print(
+            "\nADR-129 §1.3 + ADR-135 §3.1 forbid hand-edits to ported files. "
+            "If upstream needs to change, re-vendor codex-cli-main first.",
+            file=sys.stderr,
+        )
+        return 1
+    print(f"OK: {len(FILES)} files + {len(ASSETS)} assets match upstream verbatim.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_no_panics.py
+++ b/scripts/check_no_panics.py
@@ -238,11 +238,43 @@ def added_lines_for_file(base: str, head: str, path: pathlib.Path) -> set[int]:
     return added
 
 
+def is_test_only_file(path: pathlib.Path) -> bool:
+    """Recognise file naming conventions that mark a file as test-only.
+
+    1. Codex upstream convention (vendored verbatim into several crates)
+       splits large test suites into a sibling `*_tests.rs` file that is
+       included from the production module via:
+
+           #[cfg(test)]
+           #[path = "<name>_tests.rs"]
+           mod tests;
+
+       The lexer in `line_test_contexts` only sees the included file in
+       isolation, so the parent's `#[cfg(test)]` gate is invisible. Treat
+       any `*_tests.rs` or `tests.rs` filename as test-only.
+    2. Cargo integration test convention: anything under a `tests/` or
+       `benches/` directory inside a crate is a separate test/bench target,
+       always compiled with `cfg(test)`.
+    """
+
+    name = path.name
+    if name == "tests.rs":
+        return True
+    if name.endswith("_tests.rs"):
+        return True
+    parts = path.parts
+    if "tests" in parts or "benches" in parts:
+        return True
+    return False
+
+
 def collect_violations(base: str, head: str) -> list[tuple[str, int, str]]:
     violations: list[tuple[str, int, str]] = []
 
     for path in changed_rust_files(base, head):
         if not path.exists():
+            continue
+        if is_test_only_file(path):
             continue
         added_lines = added_lines_for_file(base, head, path)
         if not added_lines:
@@ -373,6 +405,20 @@ class CheckNoPanicsTests(unittest.TestCase):
         contexts = line_test_contexts(lines)
 
         self.assertTrue(all(contexts))
+
+    def test_is_test_only_file_recognises_codex_convention(self) -> None:
+        self.assertTrue(is_test_only_file(pathlib.Path("crates/foo/src/bar_tests.rs")))
+        self.assertTrue(
+            is_test_only_file(pathlib.Path("crates/foo/src/seatbelt_tests.rs"))
+        )
+        self.assertTrue(is_test_only_file(pathlib.Path("src/tests.rs")))
+        self.assertTrue(
+            is_test_only_file(pathlib.Path("crates/foo/tests/integration.rs"))
+        )
+        self.assertTrue(is_test_only_file(pathlib.Path("crates/foo/benches/bench.rs")))
+        self.assertFalse(is_test_only_file(pathlib.Path("src/lib.rs")))
+        self.assertFalse(is_test_only_file(pathlib.Path("src/seatbelt.rs")))
+        self.assertFalse(is_test_only_file(pathlib.Path("src/notests.rs")))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 背景 / 目标

ADR-135 §3 PR-B1 / 主线 epic #380 Wave-B1 实施 — 把 `codex-cli-main/codex-rs/sandboxing/` 整 crate **verbatim port** 进 `crates/dasclaw_sandboxing/`,补 ADR-002 三层 sandbox 架构最后一层(内核层 landlock / seatbelt 原语)。

**前置依赖**(全部已完成):

| 依赖 | 状态 |
|---|---|
| `dasclaw_protocol` 文件级 slice (Wave-A1) | ✅ #382/#389/#391/#393/#396/#398/#400/#402/#404/#406 |
| `dasclaw_net_proxy` (Wave-A2, ADR-137) | ✅ |
| `dasclaw_absolute_path` (ADR-132) | ✅ |

`codex-utils-template` **不需要**(ADR-138 Option 2B 已确认 sandboxing 12 文件零依赖)。

## 改动范围(机械替换,禁止补丁式代码)

按 ADR-129 §1.3 + ADR-135 §3.1,只允许:
1. **Cargo.toml**:包名 + lib 名 swap;workspace deps 内联为显式版本(对齐 codex-rs/Cargo.toml byte-for-byte)
2. **src/*.rs use-path swap**(11 文件,drift-guard 强制):
   - `codex_protocol` → `dasclaw_protocol`
   - `codex_network_proxy` → `dasclaw_net_proxy`
   - `codex_utils_absolute_path` → `dasclaw_absolute_path`
3. **src/*.sbpl**(3 文件):零改动 byte-for-byte 拷贝
4. 新增 `scripts/check_codex_sandboxing_drift.py`(范式同 `check_codex_net_proxy_drift.py` + `check_codex_protocol_drift.py`)
5. `.github/workflows/code_style.yml`:新增 `codex-sandboxing-drift` job + 挂 roll-up `code-style.needs[]`
6. workspace `Cargo.toml` members 加入 `crates/dasclaw_sandboxing`

总计 5,251 LOC 上游源(11 *.rs + 3 *.sbpl)+ 168 LOC drift script + 17 LOC CI hook。

## 非目标(What's NOT in this PR)

- ❌ **不接入** `dasclaw_exec`(那是 Wave-C1 的事,见 #380 Wave-C1)
- ❌ **不删除** `crates/dasclaw_sandbox/{linux,macos,windows}` 重叠代码(Wave-C2)
- ❌ **不**实施 `WritableRoot.read_only_subpaths` 业务接入(等 C1 wire-up 后才能 e2e)
- ❌ **不**改动 `dasclaw_protocol` / `dasclaw_net_proxy` / `dasclaw_absolute_path` 任一文件
- ❌ **不**做任何"在已有函数尾部追加 if 分支"/"复制粘贴逻辑"/"flag 切换大块代码" — 补丁式代码红线
- ❌ **不** vendor `codex-utils-template`(ADR-138 §1.3 已排除)

## 验证(命令 + 结果)

```bash
# 1. drift guard
$ python3.12 scripts/check_codex_sandboxing_drift.py
OK: 11 files + 3 assets match upstream verbatim.

# 2. cargo check
$ cargo check -p dasclaw_sandboxing --tests
Finished `dev` profile [unoptimized + debuginfo] target(s)

# 3. nextest (macOS 本机)
$ cargo nextest run -p dasclaw_sandboxing
Summary [19.496s] 64 tests run: 64 passed (1 leaky), 0 skipped

# 4. fmt
$ cargo fmt -p dasclaw_sandboxing -- --check
(clean)

# 5. no-panics
$ python3.12 scripts/check_no_panics.py --base origin/xClaw
OK: No panic-inducing calls in changed production code.

# 6. clippy (-D warnings)
$ cargo clippy --no-deps -p dasclaw_sandboxing --all-targets -- -D warnings
Finished `dev` profile (no warnings)
```

Linux landlock/bwrap 测试由 CI ubuntu runner 兜底;Windows 不参与本 crate(`#[cfg(target_os = ...)]` 守门)。

## Sources read

- [AGENTS.md](AGENTS.md) §6 必跑本地管线 + §1 强制阅读顺序
- [docs/plans/architecture-refactor/adr-135-sandboxing-crate-adoption-eval.md](docs/plans/architecture-refactor/adr-135-sandboxing-crate-adoption-eval.md) §3 PR-B1 + §3.1 use-path swap matrix + §3.2 .sbpl 零改动 + §3.3 双层关系
- [docs/plans/architecture-refactor/adr-129-sandbox-windows-windows-crate-adoption.md](docs/plans/architecture-refactor/adr-129-sandbox-windows-windows-crate-adoption.md) §1.3 verbatim 红线
- [docs/plans/architecture-refactor/adr-137-network-proxy-verbatim-port.md](docs/plans/architecture-refactor/adr-137-network-proxy-verbatim-port.md) (drift-script 范式参考)
- [docs/plans/architecture-refactor/adr-138-protocol-step-c2-evaluation.md](docs/plans/architecture-refactor/adr-138-protocol-step-c2-evaluation.md) §1.3(确认 sandboxing 12 文件不 use `codex-utils-template`,故意不 vendor)
- [docs/plans/architecture-refactor/adr-142-writable-root-kernel-enforcement.md](docs/plans/architecture-refactor/adr-142-writable-root-kernel-enforcement.md) §2-§3 三平台证据(本 crate 提供 §3.1/§3.2 原语)
- codex-cli-main/codex-rs/sandboxing/Cargo.toml + src/lib.rs(实测公共 API 与依赖版本)
- crates/dasclaw_net_proxy/Cargo.toml + scripts/check_codex_net_proxy_drift.py(本 PR drift 脚本 + Cargo.toml 范式参考)

## 红线自检

- [x] 无 `unwrap()` / `expect()` / `panic!()` / `todo!()` 新增(check_no_panics PASS)
- [x] 无补丁式代码:零追加 if 分支 / 零复制粘贴逻辑 / 零 flag 切换大块逻辑
- [x] 不绕过编译期红线
- [x] 未 `--no-verify` 提交
- [x] PR 标题前缀 `feat(sandbox):`,body 4 块齐全
- [x] `Closes #407` + `Refs #380 (Wave-B1)`

## Effort / Risk / Wave

- effort: **L** (5,251 LOC verbatim)
- risk: **med**(verbatim 范式 9 PR 实证 + 64/64 本机测试 + Linux 由 CI 兜底)
- wave: **W7 Wave-B1**

Closes #407
Refs #380 (Wave-B1)
