### PR TITLE
feat(sandbox): Wave-C2a thread NetworkProxy through SandboxExecRequest to seatbelt (ADR-135 §3 PR-C2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3017,9 +3017,12 @@ dependencies = [
 name = "dasclaw_sandbox"
 version = "0.0.0-w1"
 dependencies = [
+ "anyhow",
+ "async-trait",
  "base64 0.22.1",
  "ctor 0.2.9",
  "dasclaw_absolute_path",
+ "dasclaw_net_proxy",
  "dasclaw_process_hardening",
  "dasclaw_protocol",
  "dasclaw_sandbox_windows",
@@ -3031,6 +3034,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror 1.0.69",
+ "tokio",
  "url",
  "windows-sys 0.52.0",
 ]

--- a/crates/dasclaw_exec/src/lib.rs
+++ b/crates/dasclaw_exec/src/lib.rs
@@ -142,6 +142,11 @@ impl ProcessExecutor for SandboxedExecutor {
             policy: backend,
             preference: self.sandbox_pref,
             windows_sandbox_enabled: self.windows_sandbox_enabled,
+            // Wave-C2a: 占位 None；调用方（agent / mcp）在 Wave-C2b
+            // 切换为传入会话级 NetworkProxy，以恢复 macOS Seatbelt 的
+            // HTTP_PROXY 端口洞穿能力。Linux 已通过 backend.proxy_loopback_ports
+            // 间接消费。
+            network: None,
         };
         sandbox.execute(exec).map_err(ExecError::from)
     }

--- a/crates/dasclaw_sandbox/Cargo.toml
+++ b/crates/dasclaw_sandbox/Cargo.toml
@@ -31,6 +31,13 @@ url = "2"
 dasclaw_process_hardening = { path = "../dasclaw_process_hardening" }
 ctor = "0.2"
 
+# ADR-135 §3 Wave-C2a — NetworkProxy 通过 SandboxExecRequest 透传给
+# seatbelt sbpl 合成器，恢复 `HTTP_PROXY=http://127.0.0.1:PORT` 的洞穿能力
+# （allow_network=false 时的本地代理出口）。Linux 路径已通过
+# `proxy_loopback_ports` Vec<u16> 间接消费；macOS 路径在 PR-C2a 接上。
+# 详见 docs/plans/architecture-refactor/adr-135-sandboxing-crate-adoption-eval.md §3 PR-C2。
+dasclaw_net_proxy = { path = "../dasclaw_net_proxy" }
+
 # W3.3 — `libc` 现需在所有 Unix 平台启用（macOS + Linux），用于 setrlimit。
 # 详见 docs/plans/architecture-refactor/45-resource-limits-adr.md。
 [target.'cfg(unix)'.dependencies]
@@ -82,6 +89,11 @@ features = [
 ]
 
 # Wave-C1 contract test for kernel 洞中洞 enforcement (tests/req_kernel_*).
+# Wave-C2a contract test for proxy_loopback_ports threading through to
+# seatbelt argv (tests/req_macos_proxy_loopback_threads_through_seatbelt.rs).
 [target.'cfg(target_os = "macos")'.dev-dependencies]
 tempfile = "3"
+tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread", "sync"] }
+async-trait = "0.1"
+anyhow = "1"
 

--- a/crates/dasclaw_sandbox/src/lib.rs
+++ b/crates/dasclaw_sandbox/src/lib.rs
@@ -251,6 +251,15 @@ pub struct SandboxExecRequest {
     pub policy: SandboxBackendConfig,
     pub preference: SandboxablePreference,
     pub windows_sandbox_enabled: bool,
+    /// Optional reference to the managed `NetworkProxy` for the calling
+    /// session. macOS Seatbelt forwards this to
+    /// `dasclaw_sandboxing::seatbelt::create_seatbelt_command_args` so the
+    /// resulting sbpl includes `(allow network-outbound (remote ip ...))`
+    /// rules for the proxy's loopback HTTP/SOCKS ports (a.k.a. "hole
+    /// punching" under `allow_network=false`). When `None`, no proxy
+    /// hole-punch rules are emitted — matches Wave-C1 behaviour and is
+    /// safe (fail-closed). See ADR-135 §3 PR-C2 / ADR-142.
+    pub network: Option<dasclaw_net_proxy::NetworkProxy>,
 }
 
 /// Primary entry trait. Replaces W1 `SkeletonError`-returning placeholder.
@@ -391,6 +400,7 @@ mod tests {
             policy: SandboxPolicy::read_only_defaults(),
             preference: SandboxablePreference::Forbid,
             windows_sandbox_enabled: false,
+            network: None,
         };
         let out = sb.execute(req).expect("kind=None should run");
         assert!(out.status.success());
@@ -406,6 +416,7 @@ mod tests {
             policy: SandboxPolicy::read_only_defaults(),
             preference: SandboxablePreference::Auto,
             windows_sandbox_enabled: false,
+            network: None,
         };
         let err = sb.execute(req).unwrap_err();
         assert!(matches!(err, SandboxError::NotImplemented { stage: 2, .. }));

--- a/crates/dasclaw_sandbox/src/macos/mod.rs
+++ b/crates/dasclaw_sandbox/src/macos/mod.rs
@@ -17,16 +17,16 @@
 //! - Post-spawn `memorystatus_control` memory cap (W3.3-3b).
 //! - `spawn` + `wait_with_output` lifecycle.
 //!
-//! ## Known regression (tracked for Wave-C2)
+//! ## Wave-C2a: proxy_loopback_ports threaded via `req.network`
 //!
-//! - `proxy_loopback_ports` hole-punching (HTTP_PROXY=http://localhost:PORT
-//!   support under `allow_network=false`) is **not** plumbed in C1.
-//!   `dasclaw_sandboxing::seatbelt::create_seatbelt_command_args` derives
-//!   loopback holes from a `NetworkProxy` instance (which inspects env).
-//!   Wave-C2 will thread the upstream `NetworkProxy` through; until then,
-//!   sessions that rely on a local HTTP proxy must use a policy with
-//!   `network_access=true` (broader access) instead of relying on the
-//!   per-port hole punch.
+//! `req.network: Option<&NetworkProxy>` is now forwarded to
+//! `create_seatbelt_command_args`. When `Some`, the sbpl includes
+//! `(allow network-outbound (remote ip "127.0.0.1:N"))` rules for the
+//! proxy's loopback HTTP/SOCKS endpoints (restores `HTTP_PROXY=http://
+//! 127.0.0.1:PORT` "hole punching" under `allow_network=false`). When
+//! `None`, no proxy holes are emitted (fail-closed, matches C1
+//! behaviour). Callers (`dasclaw_exec` etc.) start populating the field
+//! in Wave-C2b.
 
 use std::os::unix::process::CommandExt;
 use std::path::PathBuf;
@@ -80,7 +80,7 @@ impl SeatbeltSandbox {
             network_sandbox_policy: triple.network_policy,
             sandbox_policy_cwd: &cwd,
             enforce_managed_network: false,
-            network: None,
+            network: req.network.as_ref(),
             extra_allow_unix_sockets: &[],
         })
     }
@@ -161,6 +161,7 @@ mod tests {
             policy: SandboxPolicy::read_only_defaults(),
             preference: SandboxablePreference::Auto,
             windows_sandbox_enabled: false,
+            network: None,
         };
         let args = sb.build_seatbelt_args(&req);
         // sandbox-exec args always start with `-p <policy>` and end with
@@ -185,6 +186,7 @@ mod tests {
             policy: SandboxPolicy::read_only_defaults().with_writable("/tmp/work"),
             preference: SandboxablePreference::Auto,
             windows_sandbox_enabled: false,
+            network: None,
         };
         let args = sb.build_seatbelt_args(&req);
         // dasclaw_sandboxing materialises writable roots as `-D
@@ -225,6 +227,7 @@ mod tests {
             policy: SandboxPolicy::read_only_defaults(),
             preference: SandboxablePreference::Require,
             windows_sandbox_enabled: false,
+            network: None,
         };
         let out = sb.execute(req).expect("seatbelt should run sh");
         assert!(out.status.success());
@@ -245,6 +248,7 @@ mod tests {
             policy: SandboxPolicy::read_only_defaults(),
             preference: SandboxablePreference::Require,
             windows_sandbox_enabled: false,
+            network: None,
         };
         let out = sb.execute(req).expect("seatbelt should run echo");
         assert!(out.status.success(), "exit={:?}", out.status);
@@ -277,6 +281,7 @@ mod tests {
             policy,
             preference: SandboxablePreference::Require,
             windows_sandbox_enabled: false,
+            network: None,
         };
         let out = sb.execute(req).expect("seatbelt should run sh");
         assert!(out.status.success(), "exit={:?}", out.status);
@@ -285,6 +290,127 @@ mod tests {
             stdout.trim(),
             "64",
             "child should see RLIMIT_NOFILE=64, got {stdout:?}"
+        );
+    }
+
+    // ---------------------------------------------------------------------
+    // ADR-135 §3 Wave-C2a — `proxy_loopback_ports` 透传契约测试。
+    //
+    // 验证 `SandboxExecRequest.network` 是否被 `build_seatbelt_args` 正确
+    // 转发给 `dasclaw_sandboxing::seatbelt::create_seatbelt_command_args`。
+    // PR-C1 的回归在于硬编码 `network: None`；C2a 改为 `req.network.as_ref()`，
+    // 在 sbpl 中恢复 `(allow network-outbound (remote ip "localhost:<port>"))`
+    // hole-punch 规则。端到端的真实子进程穿透测试留给 PR-C2b（届时
+    // `dasclaw_exec` 才会真正下传 `NetworkProxy`）。
+    // ---------------------------------------------------------------------
+
+    use async_trait::async_trait;
+    use dasclaw_net_proxy::{
+        build_config_state, ConfigReloader, ConfigState, NetworkProxy, NetworkProxyConfig,
+        NetworkProxyConstraints, NetworkProxyState,
+    };
+    use std::net::Ipv4Addr;
+    use std::net::SocketAddr;
+    use std::sync::Arc;
+
+    #[derive(Clone)]
+    struct StaticReloader {
+        state: ConfigState,
+    }
+
+    #[async_trait]
+    impl ConfigReloader for StaticReloader {
+        async fn maybe_reload(&self) -> anyhow::Result<Option<ConfigState>> {
+            Ok(None)
+        }
+
+        async fn reload_now(&self) -> anyhow::Result<ConfigState> {
+            Ok(self.state.clone())
+        }
+
+        fn source_label(&self) -> String {
+            "PR-C2a contract test reloader".to_string()
+        }
+    }
+
+    /// Build a `NetworkProxy` pointing at a fixed loopback HTTP port without
+    /// reserving real listeners. `managed_by_codex(false)` keeps the builder
+    /// from allocating an ephemeral port so the test stays deterministic.
+    async fn make_proxy(http_port: u16) -> NetworkProxy {
+        let mut cfg = NetworkProxyConfig::default();
+        cfg.network.enabled = true;
+        cfg.network.enable_socks5 = false;
+        cfg.network.proxy_url = format!("http://127.0.0.1:{http_port}");
+
+        let state = build_config_state(cfg, NetworkProxyConstraints::default())
+            .expect("build_config_state");
+        let reloader = Arc::new(StaticReloader {
+            state: state.clone(),
+        });
+        let proxy_state = Arc::new(NetworkProxyState::with_reloader(state, reloader));
+        NetworkProxy::builder()
+            .state(proxy_state)
+            .managed_by_codex(false)
+            .http_addr(SocketAddr::from((Ipv4Addr::LOCALHOST, http_port)))
+            .build()
+            .await
+            .expect("NetworkProxy::build")
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn req_macos_seatbelt_threads_proxy_loopback_port_into_sbpl() {
+        const HTTP_PORT: u16 = 18887;
+        let proxy = make_proxy(HTTP_PORT).await;
+
+        let mut cmd = Command::new("/bin/true");
+        cmd.current_dir("/tmp");
+        let req = SandboxExecRequest {
+            command: cmd,
+            policy: SandboxPolicy::read_only_defaults(),
+            preference: SandboxablePreference::Require,
+            windows_sandbox_enabled: false,
+            network: Some(proxy),
+        };
+
+        let args = SeatbeltSandbox::new().build_seatbelt_args(&req);
+        let policy = args
+            .iter()
+            .skip_while(|a| a.as_str() != "-p")
+            .nth(1)
+            .expect("sbpl policy follows -p");
+
+        let expected_rule =
+            format!("(allow network-outbound (remote ip \"localhost:{HTTP_PORT}\"))");
+        assert!(
+            policy.contains(&expected_rule),
+            "expected sbpl to hole-punch HTTP_PROXY loopback port via {expected_rule}; got policy:\n{policy}"
+        );
+    }
+
+    #[test]
+    fn req_macos_seatbelt_omits_loopback_holes_when_network_is_none() {
+        // Fail-safe negative test — defends against a future regression
+        // where a default proxy / env sniff would silently inject a hole.
+        let mut cmd = Command::new("/bin/true");
+        cmd.current_dir("/tmp");
+        let req = SandboxExecRequest {
+            command: cmd,
+            policy: SandboxPolicy::read_only_defaults(),
+            preference: SandboxablePreference::Require,
+            windows_sandbox_enabled: false,
+            network: None,
+        };
+
+        let args = SeatbeltSandbox::new().build_seatbelt_args(&req);
+        let policy = args
+            .iter()
+            .skip_while(|a| a.as_str() != "-p")
+            .nth(1)
+            .expect("sbpl policy follows -p");
+
+        assert!(
+            !policy.contains("(allow network-outbound (remote ip \"localhost:"),
+            "with network=None the sbpl must not emit any localhost:<port> hole; got:\n{policy}"
         );
     }
 }

--- a/crates/dasclaw_sandbox/tests/req_kernel_enforces_read_only_subpaths_macos.rs
+++ b/crates/dasclaw_sandbox/tests/req_kernel_enforces_read_only_subpaths_macos.rs
@@ -64,6 +64,7 @@ fn req_dasclaw_sandbox_kernel_blocks_git_hooks_under_workspace_write_macos() {
         policy,
         preference: SandboxablePreference::Require,
         windows_sandbox_enabled: false,
+        network: None,
     };
     let out = SeatbeltSandbox::new()
         .execute(req)
@@ -114,6 +115,7 @@ fn req_dasclaw_sandbox_kernel_allows_write_to_non_hole_path_macos() {
         policy,
         preference: SandboxablePreference::Require,
         windows_sandbox_enabled: false,
+        network: None,
     };
     let out = SeatbeltSandbox::new()
         .execute(req)

--- a/desktop-client/src/ipc/sandbox.rs
+++ b/desktop-client/src/ipc/sandbox.rs
@@ -82,6 +82,8 @@ fn run_smoke_blocking() -> Result<SandboxSmokeReport, String> {
         policy: SandboxPolicy::read_only_defaults(),
         preference: SandboxablePreference::Auto,
         windows_sandbox_enabled: false,
+        // Wave-C2a: smoke-test 路径不需要本地代理洞穿；保持 None。
+        network: None,
     };
 
     let out = sb


### PR DESCRIPTION
> **Note**: 本 PR 是 #412 的 rebase 重开版本。原 #412 因 base 分支（C1 旧 PR #410 → 重开为 #413）被合并删除而被 GitHub 自动 closed。已 rebase 到最新 `xClaw`（B1 #408 + C1 #413 已合入）。Commit 内容、改动范围、验证结果与 #412 完全相同。

Closes #411

> **Stacked**: base = `feat/sandbox-wave-c1-exec-adapter` (PR #410, on top of B1 #408). 请先看 #408 → #410，再看本 PR。

## 背景/目标

Wave-C1 (#410) 把 macOS Seatbelt sbpl 合成委托给 `dasclaw_sandboxing`，但下层 API `create_seatbelt_command_args` 接收 `network: Option<&NetworkProxy>` 而 C1 硬编码 `network: None`——`HTTP_PROXY=http://127.0.0.1:PORT` 端口洞穿（`allow_network=false` 下的本地代理出口）回归。本 PR 在 `SandboxExecRequest` 上加 `network` 字段并由 macOS backend 透传，**wiring only**。

## 改动范围

- `crates/dasclaw_sandbox/Cargo.toml`：加 `dasclaw_net_proxy` 普通依赖（NetworkProxy 类型需要在 `SandboxExecRequest` 上跨平台可见）+ macOS dev-deps (`tokio`/`async-trait`/`anyhow`) 给契约测试用。
- `crates/dasclaw_sandbox/src/lib.rs`：`SandboxExecRequest` 新增 `network: Option<NetworkProxy>`。
- `crates/dasclaw_sandbox/src/macos/mod.rs`：`build_seatbelt_args` 用 `req.network.as_ref()` 代替 `None`；模块文档把 "Known regression" 改成 "Wave-C2a delivered"。
- 所有现有 `SandboxExecRequest { ... }` 构造点补 `network: None`（5 个 macOS 单测 + 2 个 `tests/req_kernel_*` 契约测试 + 2 个 `lib.rs` 单测 + 1 个 `dasclaw_exec` 生产路径，共 10 处）。
- `crates/dasclaw_sandbox/src/macos/mod.rs` 新增 2 个契约测试（见下方验证）。

## 非目标（What's NOT in this PR）

- 调用方 (`dasclaw_exec` / agent / mcp) 真实构造并下传会话级 `NetworkProxy`——留给 **Wave-C2b**。本 PR `dasclaw_exec` 仍传 `None`，**生产行为零变化**。
- 真实子进程 sandbox-exec 端到端穿透测试——依赖 C2b 把 NetworkProxy 接到 exec 层，届时把端到端测试加在 `dasclaw_exec` / agent crate。
- Linux 路径：已通过 `SandboxBackendConfig.proxy_loopback_ports: Vec<u16>` 间接消费，无回归，不在 C2a 范围。
- Windows 路径：无对应内核 backend，不涉及。

## 验证

新增契约测试 (`crates/dasclaw_sandbox/src/macos/mod.rs` `mod tests`)：
- ✅ `req_macos_seatbelt_threads_proxy_loopback_port_into_sbpl`：正向。构造一个 `NetworkProxy` (`HTTP_PROXY=http://127.0.0.1:18887`) 并通过 `SandboxExecRequest.network = Some(proxy)` 下传，断言生成的 sbpl 包含 `(allow network-outbound (remote ip "localhost:18887"))` hole-punch 规则。
- ✅ `req_macos_seatbelt_omits_loopback_holes_when_network_is_none`：失败-安全反向测试。`network: None` 时 sbpl 不得出现任何 `localhost:<port>` 规则——防御未来回归（例如 env 嗅探导致静默放宽）。

本地管线（按 AGENTS.md §3 顺序）：

```bash
cargo nextest run -p dasclaw_sandbox         # 44/44 pass (C1 时 42/42 → +2 新契约)
cargo nextest run -p dasclaw_exec            # 18/18 pass
cargo fmt --all                              # clean
python3.12 scripts/check_no_panics.py --base origin/xClaw      # clean
cargo clippy --no-deps -p dasclaw_sandbox --all-targets -- -D warnings  # clean
python3.12 scripts/check_codex_sandboxing_drift.py             # 11 files + 3 assets verbatim
python3.12 scripts/check_codex_net_proxy_drift.py              # 15 files verbatim
```

## Sources read

- [docs/plans/architecture-refactor/adr-135-sandboxing-crate-adoption-eval.md](docs/plans/architecture-refactor/adr-135-sandboxing-crate-adoption-eval.md) §3 PR-C2
- [docs/plans/architecture-refactor/adr-142-sandbox-write-permission-hardening.md](docs/plans/architecture-refactor/adr-142-sandbox-write-permission-hardening.md) (proxy hole-punch 上下文)
- [crates/dasclaw_sandboxing/src/seatbelt.rs](crates/dasclaw_sandboxing/src/seatbelt.rs) §proxy_policy_inputs + ports → `localhost:<port>` 规则合成 (line 265-285)
- [crates/dasclaw_net_proxy/src/proxy.rs](crates/dasclaw_net_proxy/src/proxy.rs) §NetworkProxy::builder + `apply_to_env` (line 558-605)
- [crates/dasclaw_net_proxy/src/network_policy.rs](crates/dasclaw_net_proxy/src/network_policy.rs) §StaticReloader 测试模式 (line 558-575)
- AGENTS.md（开 PR 前检查清单）
