### PR TITLE
feat(sandbox): Wave-C2b — wire session NetworkProxy through SandboxedExecutor / OsExecutor (ADR-135 §3 PR-C2b)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2808,7 +2808,9 @@ dependencies = [
 name = "dasclaw_exec"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "async-trait",
+ "dasclaw_net_proxy",
  "dasclaw_sandbox",
  "ironclaw_workspace_cap",
  "tempfile",

--- a/crates/dasclaw_exec/Cargo.toml
+++ b/crates/dasclaw_exec/Cargo.toml
@@ -20,7 +20,14 @@ thiserror = "1"
 ironclaw_workspace_cap = { path = "../ironclaw_workspace_cap" }
 # 下层内核：跨平台沙箱执行
 dasclaw_sandbox = { path = "../dasclaw_sandbox" }
+# 网络代理：SandboxedExecutor 可注入会话级 NetworkProxy 以驱动 macOS Seatbelt
+# 的 HTTP_PROXY hole-punch（ADR-135 §3 PR-C2b / ADR-142）。
+dasclaw_net_proxy = { path = "../dasclaw_net_proxy" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread", "sync"] }
 tempfile = "3"
+# 集成测试 tests/network_proxy_threading.rs 需要 anyhow + async-trait 实现
+# NoopReloader（ConfigReloader trait）以构造 unmanaged NetworkProxy。
+anyhow = "1"
+async-trait = "0.1"

--- a/crates/dasclaw_exec/src/lib.rs
+++ b/crates/dasclaw_exec/src/lib.rs
@@ -28,7 +28,7 @@
 //!
 //! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! let policy = SandboxPolicy::new_workspace_write_policy();
-//! let executor = SandboxedExecutor::new(policy, SandboxablePreference::Auto, false);
+//! let executor = SandboxedExecutor::new(policy, SandboxablePreference::Auto, false, None);
 //! let mut cmd = Command::new("echo");
 //! cmd.arg("hello");
 //! let output = executor.execute(ExecRequest {
@@ -46,6 +46,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 
+use dasclaw_net_proxy::NetworkProxy;
 use dasclaw_sandbox::proxy::detect_loopback_ports;
 use dasclaw_sandbox::{
     ResourceLimits, SandboxBackendConfig, SandboxError, SandboxExecRequest, SandboxablePreference,
@@ -99,6 +100,16 @@ pub struct SandboxedExecutor {
     policy: SandboxPolicy,
     sandbox_pref: SandboxablePreference,
     windows_sandbox_enabled: bool,
+    /// 会话级 [`NetworkProxy`]，构造期注入。macOS Seatbelt 后端将其转译为
+    /// `(allow network-outbound (remote ip "localhost:<port>"))` sbpl 规则，
+    /// 让沙箱内子进程的 `HTTP_PROXY` / `HTTPS_PROXY` 环境变量真正生效
+    /// （ADR-135 §3 PR-C2b / ADR-142）。
+    ///
+    /// `None` 等价于"无 proxy 注入"——backend 不会合成任何 loopback hole；
+    /// 这是 fail-safe 的缺省值（Wave-C2a 在 dasclaw_exec 出口处使用过的
+    /// 占位语义现在由调用方显式选择）。Linux 后端继续走 `backend.proxy_loopback_ports`
+    /// 的 env-detect 路径，与 `network` 互不冲突。
+    network: Option<NetworkProxy>,
 }
 
 impl SandboxedExecutor {
@@ -106,11 +117,13 @@ impl SandboxedExecutor {
         policy: SandboxPolicy,
         sandbox_pref: SandboxablePreference,
         windows_sandbox_enabled: bool,
+        network: Option<NetworkProxy>,
     ) -> Self {
         Self {
             policy,
             sandbox_pref,
             windows_sandbox_enabled,
+            network,
         }
     }
 
@@ -118,10 +131,19 @@ impl SandboxedExecutor {
     pub fn policy(&self) -> &SandboxPolicy {
         &self.policy
     }
-}
 
-impl ProcessExecutor for SandboxedExecutor {
-    fn execute(&self, req: ExecRequest) -> Result<Output, ExecError> {
+    /// 公开会话级 [`NetworkProxy`] 引用，便于调用方 / 测试断言注入是否到位。
+    pub fn network(&self) -> Option<&NetworkProxy> {
+        self.network.as_ref()
+    }
+
+    /// 把 [`ExecRequest`] 翻译成 [`SandboxExecRequest`]，**不执行**。
+    ///
+    /// 抽出来供契约测试断言 `network` 是否被忠实透传，同时让 `execute()`
+    /// 保持单一职责（assemble → run）。语义错误（cwd 落入洞中洞等）在这里
+    /// 一票否决；通过后返回的 `SandboxExecRequest` 即喂给 backend.execute()
+    /// 的最终形态。
+    pub fn assemble_request(&self, req: ExecRequest) -> Result<SandboxExecRequest, ExecError> {
         // 1. 政策门：cwd 自身不能落在洞中洞（read_only_subpath）。
         //    `is_path_writable(cwd, cwd)` 在 WorkspaceWrite 下总是把 cwd 加为
         //    隐含 root，所以这里只在非 ReadOnly 场景下，对 cwd 是否被任何
@@ -135,19 +157,20 @@ impl ProcessExecutor for SandboxedExecutor {
         // 2. 政策 → 内核配置
         let backend = policy_to_backend_config(&self.policy, &req.cwd);
 
-        // 3. 选后端 + 执行
-        let sandbox = select_backend(self.sandbox_pref, self.windows_sandbox_enabled)?;
-        let exec = SandboxExecRequest {
+        Ok(SandboxExecRequest {
             command: req.command,
             policy: backend,
             preference: self.sandbox_pref,
             windows_sandbox_enabled: self.windows_sandbox_enabled,
-            // Wave-C2a: 占位 None；调用方（agent / mcp）在 Wave-C2b
-            // 切换为传入会话级 NetworkProxy，以恢复 macOS Seatbelt 的
-            // HTTP_PROXY 端口洞穿能力。Linux 已通过 backend.proxy_loopback_ports
-            // 间接消费。
-            network: None,
-        };
+            network: self.network.clone(),
+        })
+    }
+}
+
+impl ProcessExecutor for SandboxedExecutor {
+    fn execute(&self, req: ExecRequest) -> Result<Output, ExecError> {
+        let exec = self.assemble_request(req)?;
+        let sandbox = select_backend(self.sandbox_pref, self.windows_sandbox_enabled)?;
         sandbox.execute(exec).map_err(ExecError::from)
     }
 }
@@ -474,6 +497,7 @@ mod tests {
             },
             SandboxablePreference::Forbid,
             false,
+            None,
         );
         let result = executor.execute(ExecRequest {
             command: Command::new("echo"),
@@ -495,6 +519,7 @@ mod tests {
             },
             SandboxablePreference::Forbid,
             false,
+            None,
         );
         let mut cmd = Command::new("true");
         cmd.arg("");
@@ -515,6 +540,7 @@ mod tests {
             SandboxPolicy::new_workspace_write_policy(),
             SandboxablePreference::Forbid,
             false,
+            None,
         );
         let mut cmd = Command::new("echo");
         cmd.arg("hello-from-exec");
@@ -528,4 +554,9 @@ mod tests {
         let stdout = String::from_utf8_lossy(&out.stdout);
         assert!(stdout.contains("hello-from-exec"));
     }
+
+    // NetworkProxy 透传契约 (ADR-135 §3 PR-C2b) 由集成测试覆盖：
+    // crates/dasclaw_exec/tests/network_proxy_threading.rs
+    // 该测试需要 dasclaw_net_proxy 公共 API 构造 unmanaged NetworkProxy，
+    // 故走 tests/ 目录而非 #[cfg(test)] mod。
 }

--- a/crates/dasclaw_exec/tests/network_proxy_threading.rs
+++ b/crates/dasclaw_exec/tests/network_proxy_threading.rs
@@ -1,0 +1,117 @@
+//! W3.2-C2b 端到端契约：SandboxedExecutor::assemble_request 必须把构造期
+//! 注入的 NetworkProxy 忠实透传到 SandboxExecRequest.network，下游
+//! seatbelt/landlock 才能拿到 proxy 地址在 sandbox profile 里打洞。
+//!
+//! 此测试无法放在 `dasclaw_exec/src/lib.rs#tests` 内，因为 NetworkProxy 的
+//! cfg(test) 构造 helper (`network_proxy_state_for_policy`) 被 codex 上游
+//! drift guard 锁定为 `pub(crate) #[cfg(test)]`（见
+//! crates/dasclaw_net_proxy/Cargo.toml 顶部 `DO NOT hand-edit src/*.rs`），
+//! 所以这里改用 dasclaw_net_proxy 的全公开 API 自己拼一个 unmanaged
+//! NetworkProxy（`managed_by_codex(false)` ⇒ 不绑 socket，纯地址壳子，
+//! 满足 `assemble_request` 仅 clone 不调用的契约）。
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::Arc;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use dasclaw_exec::{ExecRequest, SandboxedExecutor};
+use dasclaw_net_proxy::{
+    ConfigReloader, ConfigState, NetworkMode, NetworkProxy, NetworkProxyConfig,
+    NetworkProxyConstraints, NetworkProxyState, build_config_state,
+};
+use dasclaw_sandbox::SandboxablePreference;
+use ironclaw_workspace_cap::SandboxPolicy;
+
+struct NoopReloader;
+
+#[async_trait]
+impl ConfigReloader for NoopReloader {
+    fn source_label(&self) -> String {
+        "dasclaw_exec::tests::network_proxy_threading".to_string()
+    }
+
+    async fn maybe_reload(&self) -> Result<Option<ConfigState>> {
+        Ok(None)
+    }
+
+    async fn reload_now(&self) -> Result<ConfigState> {
+        Err(anyhow::anyhow!(
+            "force reload is not supported in this contract test"
+        ))
+    }
+}
+
+async fn build_unmanaged_proxy() -> NetworkProxy {
+    let mut cfg = NetworkProxyConfig::default();
+    cfg.network.enabled = true;
+    cfg.network.mode = NetworkMode::Full;
+    let state =
+        build_config_state(cfg, NetworkProxyConstraints::default()).expect("build_config_state");
+    let state = Arc::new(NetworkProxyState::with_reloader(
+        state,
+        Arc::new(NoopReloader),
+    ));
+    NetworkProxy::builder()
+        .state(state)
+        .managed_by_codex(false)
+        .build()
+        .await
+        .expect("build unmanaged proxy")
+}
+
+#[tokio::test]
+async fn req_executor_assemble_threads_network_into_request() {
+    let proxy = build_unmanaged_proxy().await;
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let executor = SandboxedExecutor::new(
+        SandboxPolicy::new_workspace_write_policy(),
+        SandboxablePreference::Forbid,
+        false,
+        Some(proxy.clone()),
+    );
+    assert!(
+        executor.network().is_some(),
+        "constructor must retain injected proxy"
+    );
+
+    let assembled = executor
+        .assemble_request(ExecRequest {
+            command: Command::new("true"),
+            cwd: tmp.path().to_path_buf(),
+        })
+        .expect("policy gate should pass under workspace-write + writable cwd");
+
+    assert_eq!(
+        assembled.network.as_ref(),
+        Some(&proxy),
+        "NetworkProxy 必须忠实透传到 SandboxExecRequest.network（W3.2-C2b 契约）"
+    );
+}
+
+#[tokio::test]
+async fn req_executor_assemble_omits_network_when_constructed_without_proxy() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let executor = SandboxedExecutor::new(
+        SandboxPolicy::new_workspace_write_policy(),
+        SandboxablePreference::Forbid,
+        false,
+        None,
+    );
+
+    let assembled = executor
+        .assemble_request(ExecRequest {
+            command: Command::new("true"),
+            cwd: tmp.path().to_path_buf(),
+        })
+        .expect("policy gate should pass");
+    assert!(
+        assembled.network.is_none(),
+        "fail-safe: 缺省构造下不允许凭空合成 proxy"
+    );
+
+    // 抑制 unused warnings for PathBuf import
+    let _ = PathBuf::new();
+}

--- a/desktop-client/ironclaw/src/app.rs
+++ b/desktop-client/ironclaw/src/app.rs
@@ -544,17 +544,17 @@ impl AppBuilder {
                     policy = crate::sandbox::SandboxPolicy::WorkspaceWrite;
                 }
 
-                let executor = Arc::new(crate::sandbox::OsExecutor::new(
-                    Duration::from_secs(sb.timeout_secs),
-                    sb.allow_full_access,
-                ));
-
                 // Network proxy no longer requires a secrets store: the
                 // codex-network-proxy port (W7 / ADR-137 PR-N23) enforces
                 // domain allowlist + optional MITM TLS audit only.
                 // Credential injection lives in tools/builtin/http.rs
                 // (host-side reqwest layer) where it actually works for
                 // HTTPS, see crate::sandbox::net_proxy module docs.
+                //
+                // W3.2-C2b（ADR-135 §3 PR-C2b）：先启代理拿到句柄，再用
+                // 句柄构造 OsExecutor。OsExecutor 持有的 NetworkProxy 会
+                // 被 SandboxedExecutor → dasclaw_sandbox → seatbelt profile
+                // 透传，从而在 sandbox 内自动 hole-punch 出代理地址。
                 let mut sandbox_cfg = sb.to_sandbox_config();
                 // Override policy with the (possibly downgraded) one.
                 sandbox_cfg.policy = policy;
@@ -583,6 +583,14 @@ impl AppBuilder {
                         None
                     }
                 };
+
+                // W3.2-C2b: 把代理句柄注入 OsExecutor。proxy=None 时退化为
+                // 沙箱内部完全禁网（fail-safe）。
+                let executor = Arc::new(crate::sandbox::OsExecutor::new(
+                    Duration::from_secs(sb.timeout_secs),
+                    sb.allow_full_access,
+                    proxy.as_ref().map(|h| h.proxy.clone()),
+                ));
 
                 ctx.sandbox_executor = Some(executor);
                 ctx.sandbox_policy = policy;

--- a/desktop-client/ironclaw/src/sandbox/os_executor.rs
+++ b/desktop-client/ironclaw/src/sandbox/os_executor.rs
@@ -26,9 +26,11 @@
 use std::collections::HashMap;
 use std::path::Path;
 use std::process::Command;
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use dasclaw_exec::{ExecRequest, ProcessExecutor, SandboxedExecutor};
+use dasclaw_net_proxy::NetworkProxy;
 use dasclaw_sandbox::SandboxablePreference;
 
 /// Output from sandbox execution.
@@ -70,10 +72,18 @@ fn legacy_policy_to_cap(policy: SandboxPolicy) -> CapPolicy {
 ///
 /// 不持有 Docker / 代理状态，每次 `execute` 独立构造 [`SandboxedExecutor`]。
 /// 这样 cwd / policy 可以按调用方期望逐次切换，不被首次 init 锁死。
+///
+/// W3.2-C2b: 会话级 [`NetworkProxy`] 通过构造期一次性注入，`execute` 时
+/// `.clone()` 进 [`SandboxedExecutor`]——下游 `dasclaw_sandboxing` 据此在
+/// Seatbelt profile 里 hole-punch HTTP/SOCKS 代理端口。`None` ⇒ 退化为旧
+/// 行为（沙箱内部完全禁网），fail-safe。
 pub struct OsExecutor {
     timeout: Duration,
     sandbox_pref: SandboxablePreference,
     allow_full_access: bool,
+    /// 会话级 NetworkProxy 句柄（`Arc` 因为 desktop-client 会话生命周期共享）。
+    /// `None` = 未启用代理，沙箱内部完全禁网。
+    network: Option<Arc<NetworkProxy>>,
 }
 
 impl OsExecutor {
@@ -82,11 +92,17 @@ impl OsExecutor {
     /// - `timeout`: 单条命令最大执行时间。
     /// - `allow_full_access`: 必须为 `true` 才允许 `FullAccess` 政策落到 host
     ///   进程（双 opt-in，与 `SANDBOX_ALLOW_FULL_ACCESS` 等价）。
-    pub fn new(timeout: Duration, allow_full_access: bool) -> Self {
+    /// - `network`: 可选会话级 [`NetworkProxy`]；`None` ⇒ 沙箱内部禁网。
+    pub fn new(
+        timeout: Duration,
+        allow_full_access: bool,
+        network: Option<Arc<NetworkProxy>>,
+    ) -> Self {
         Self {
             timeout,
             sandbox_pref: SandboxablePreference::Auto,
             allow_full_access,
+            network,
         }
     }
 
@@ -110,7 +126,10 @@ impl OsExecutor {
         }
 
         let cap_policy = legacy_policy_to_cap(policy);
-        let executor = SandboxedExecutor::new(cap_policy, self.sandbox_pref, false);
+        // W3.2-C2b: clone Arc → 拿到 owned NetworkProxy 句柄注入 SandboxedExecutor。
+        // NetworkProxy 内部已是 Arc<NetworkProxyState>，clone 廉价。
+        let network = self.network.as_deref().cloned();
+        let executor = SandboxedExecutor::new(cap_policy, self.sandbox_pref, false, network);
 
         let mut cmd = build_shell_command(command);
         cmd.envs(env);
@@ -221,7 +240,7 @@ mod tests {
 
     #[tokio::test]
     async fn full_access_without_opt_in_refuses() {
-        let executor = OsExecutor::new(Duration::from_secs(5), false);
+        let executor = OsExecutor::new(Duration::from_secs(5), false, None);
         let result = executor
             .execute(
                 "echo hi",
@@ -235,7 +254,7 @@ mod tests {
 
     #[tokio::test]
     async fn timeout_returns_timeout_error() {
-        let executor = OsExecutor::new(Duration::from_millis(100), true);
+        let executor = OsExecutor::new(Duration::from_millis(100), true, None);
         // sleep 远超 100ms,在 macOS / Linux 上都可用
         let result = executor
             .execute(

--- a/docs/plans/architecture-refactor/adr-135-sandboxing-crate-adoption-eval.md
+++ b/docs/plans/architecture-refactor/adr-135-sandboxing-crate-adoption-eval.md
@@ -165,7 +165,11 @@ ADR-132 (execpolicy) 解决了"应用层 policy"语言；ADR-133 (shell-command)
 
 ### Wave-C（接入 dasclaw 主流水）
 4. **PR-C1**: 在 `dasclaw_sandbox::launcher_ipc` 接入 `dasclaw_sandboxing::SandboxManager` —— 把现行进程内 cap-std 调用改为"先调内核 backend，再用 cap-std 兜底"。这是**真正的"内核层强制"接入点**。
-5. **PR-C2**: 退役 `dasclaw_sandbox/{linux,macos,windows}/` 中与 sandboxing crate 重叠的部分（保留 `windows/job_object`、`rlimit`、`launcher_ipc`，移除冗余 `sandbox-exec` 调用）。
+5. **PR-C2a** *(merged via #414)*: 在 `dasclaw_sandbox::SandboxExecRequest` 上挂载 `network: Option<NetworkProxy>` 字段并透传到 `dasclaw_sandboxing::seatbelt::create_seatbelt_command_args`，让 macOS Seatbelt profile 可以在运行时 hole-punch 出代理回环端口。这一步只动 sandbox 内部 struct，不接入调用方。
+6. **PR-C2b** *(this PR)*: 把会话级 `NetworkProxy` 顺着 `OsExecutor` → `SandboxedExecutor` → `SandboxExecRequest` 一路往下游传。`SandboxedExecutor::new` 强制要求显式的 `Option<NetworkProxy>` 参数，构造期不注入 ⇒ 沙箱内部完全禁网（fail-safe）。`app.rs` 在 boot 时先启 proxy 再构造 executor，把句柄注入。
+7. **PR-C3** *(deferred)*: 退役 `dasclaw_sandbox/{linux,macos,windows}/` 中与 sandboxing crate 重叠的部分（保留 `windows/job_object`、`rlimit`、`launcher_ipc`，移除冗余 `sandbox-exec` 调用）。
+
+> **PR-C2 拆分的记录性说明**：原 ADR 写的 PR-C2 是"退役重叠部分"，落地时发现 W7 net-proxy 验收要求"代理地址必须能在沙箱内被访问"必须先走完，遂把"代理透传"从 W7 拉到本 ADR 的 W3.2 范围内，拆为 C2a（数据结构）+ C2b（调用方接线），原 C2 顺延为 C3。这是 ADR-137 单层口径下的合理加速，不破坏 ADR-002 三层架构。
 
 每个 PR 单独 review，单 issue 一目标，不跨阶段。
 


### PR DESCRIPTION
## 背景/目标

ADR-135 §3 PR-C2b。Wave-C2a (#414) 已经把 `network: Option<NetworkProxy>` 字段挂到 `dasclaw_sandbox::SandboxExecRequest` 上，并让 `dasclaw_sandboxing::seatbelt` 在 profile 里 hole-punch 代理回环端口；但是 `crates/dasclaw_exec/src/lib.rs` 里调用方仍然在传 `network: None`——意味着即便 boot 时启了 `NetworkProxy`，真正落到 sandbox profile 的还是"完全禁网"，session 启动的代理形同虚设。

本 PR 把会话级 `NetworkProxy` 沿着 `app.rs → OsExecutor → SandboxedExecutor → SandboxExecRequest` 这条调用链全程透传，闭合 W3.2 sandbox 链路的最后一公里。

## 改动范围

1. **`crates/dasclaw_exec/`**
   - `SandboxedExecutor` 新增 `network: Option<NetworkProxy>` 字段。
   - `new(policy, sandbox_pref, windows_sandbox_enabled, network)` 4 参签名（不给 default：强制每个调用方显式表态，避免补丁式加 flag）。
   - 抽出 `pub fn assemble_request(&self, req) -> Result<SandboxExecRequest, _>`，把 cwd 写权校验 + policy → backend 翻译 + 装配 `SandboxExecRequest` 集中到一处。`ProcessExecutor::execute()` 变成 `assemble_request → select_backend → run`（SRP 整理）。
   - 公开 `network()` getter 方便上游集成测试。
   - 新增集成测试 `tests/network_proxy_threading.rs`：
     - `req_executor_assemble_threads_network_into_request`：构造期 `Some(proxy)` ⇒ assemble 后 `network == Some(proxy)`。
     - `req_executor_assemble_omits_network_when_constructed_without_proxy`：`None` ⇒ assemble 后 `.network.is_none()`（**fail-safe**）。

2. **`desktop-client/ironclaw/src/sandbox/os_executor.rs`**
   - 新增 `network: Option<Arc<NetworkProxy>>` 字段。
   - `OsExecutor::new(timeout, allow_full_access, network)` 3 参签名。
   - `execute()` 里 `self.network.as_deref().cloned()` 把 Arc 内的 `NetworkProxy` 克隆出来（内部已是 Arc 包，clone 廉价）注入 `SandboxedExecutor`。
   - 测试 callsite 跟进。

3. **`desktop-client/ironclaw/src/app.rs`**
   - 重排顺序：先 `start_network_proxy(&sandbox_cfg).await` 拿到 `NetworkProxyHandle { proxy: Arc<NetworkProxy>, .. }`，再用 `proxy.as_ref().map(|h| h.proxy.clone())` 构造 `OsExecutor`。
   - proxy 启动失败时 fail-safe 退化为 `None` ⇒ 沙箱内部完全禁网。

4. **`docs/plans/architecture-refactor/adr-135-sandboxing-crate-adoption-eval.md`**
   - §3 把原 PR-C2 拆为 C2a (#414 已并) + C2b (本 PR) + C3 (deferred decommission)。
   - 附记录性 note：解释为什么 W7 代理透传被拉到 W3.2 范围（ADR-137 单层口径下的合理加速）。

## 非目标（What's NOT in this PR）

- ❌ ADR-135 §3 原 PR-C2 "退役 dasclaw_sandbox/{linux,macos,windows} 与 sandboxing crate 重叠的部分"——重新编号为 **PR-C3**，后续单独 PR。
- ❌ Linux landlock 洞中洞 sub-task 2（#324）。
- ❌ Windows ACL DENY 内核层 enforcement。
- ❌ `x_claw_agent::hooks::SandboxExecRequest` 的代理注入——那是不同 struct，不在 W3.2 范围内。

## 关联 ADR

- [adr-135 §3](docs/plans/architecture-refactor/adr-135-sandboxing-crate-adoption-eval.md) — adoption plan（本 PR 内有改动）
- adr-137 — net-proxy 单层口径
- adr-142 — sandbox-exec proxy hole-punch

## 验证

```bash
cargo check -p dasclaw_exec --tests                                            # OK
cargo check -p dasclaw --tests                                                 # OK
cargo nextest run -p dasclaw_exec -p dasclaw_sandbox                           # OK 84/0
cargo fmt --all                                                                # OK
python3.12 scripts/check_no_panics.py --base origin/xClaw                      # OK
cargo clippy --no-deps -p dasclaw_exec -p dasclaw_sandbox --all-targets -- -D warnings  # OK
cargo clippy --no-deps -p dasclaw --lib -- -D warnings                         # OK
```

## Sources read

- `AGENTS.md` §"Skills 强制使用规范"、§"复用优先于新建"、§"PR 必填项"
- `docs/plans/architecture-refactor/adr-135-sandboxing-crate-adoption-eval.md` §3 (Wave-C, 3.3 与现有 dasclaw_sandbox 的关系)
- `docs/plans/architecture-refactor/31-target-architecture.md` §4 (proxy 单层口径)
- `docs/plans/architecture-refactor/32-execution-plan.md` W3.2 / W7
- `crates/dasclaw_net_proxy/src/{lib,proxy,runtime,config,state}.rs` 公开 API
- `crates/dasclaw_exec/src/lib.rs` 已有 SandboxedExecutor 接线
- `desktop-client/ironclaw/src/{app,sandbox/{os_executor,net_proxy}}.rs` 现状

## Self-Review (code-review-expert 自查)

- **SRP**: `assemble_request` 从 `execute` 抽出，单一职责。✅
- **Fail-Safe**: 缺省构造下 sandbox 内部完全禁网，从不凭空合成 proxy；契约测试覆盖。✅
- **No patch-style**: 4 参构造函数无 default，所有调用方编译期被迫显式声明 network。✅
- **Sec**: `NetworkProxy::clone()` 仅克隆内部 Arc，无 socket 复用风险。✅
- **No new panics**: `scripts/check_no_panics.py` 通过。✅
- **Backwards compat**: 构造签名变化，所有 callsite 在本 PR 内统一更新（dasclaw_exec 测试 / OsExecutor 测试 / app.rs 主流）。✅

Closes #415
