### PR TITLE
fix(tests): use struct-update syntax in parity_gate_p2 make_ctx (clippy field-reassign-with-default)

### DIFF
--- a/desktop-client/ironclaw/tests/parity_gate_p2.rs
+++ b/desktop-client/ironclaw/tests/parity_gate_p2.rs
@@ -22,9 +22,10 @@ use uuid::Uuid;
 // ═══════════════════════════════════════════════════════════════════════
 
 fn make_ctx() -> JobContext {
-    let mut ctx = JobContext::default();
-    ctx.conversation_id = Some(Uuid::new_v4());
-    ctx
+    JobContext {
+        conversation_id: Some(Uuid::new_v4()),
+        ..JobContext::default()
+    }
 }
 
 fn session_with_turns(n: usize) -> (Session, Uuid) {


### PR DESCRIPTION
## 背景/目标

`desktop-client/ironclaw/tests/parity_gate_p2.rs` 的 `make_ctx()` 触发 clippy
`field-reassign-with-default`：先 `JobContext::default()` 再单字段重赋。在 commit
`3f45d504`（"feat: internalize ironclaw as x-claw core (ADR-110)"）落入主干，
导致每次跑 `cargo clippy --no-deps -p dasclaw --all-targets -- -D warnings` 都会
被卡住，无法做完整的 crate 级 clippy 守门。

本 PR 用结构体字面量 + `..Default::default()` 重写 helper，让 clippy 干净，
不引入任何运行时行为变化。

## 改动范围

- `desktop-client/ironclaw/tests/parity_gate_p2.rs` 的 `make_ctx`：
  从"先 default 后逐字段重赋"改成结构体字面量 + struct-update 语法。

## 非目标（What's NOT in this PR）

- ❌ 修复其他 test 文件里的 clippy 告警（不同模块、不同根因）。
- ❌ 修改 `JobContext` 本身的 `Default` 实现。
- ❌ 增加/修改任何测试用例的断言。

## 关联 ADR

- 无（纯 clippy 守门修复，不触红线）。

## 验证

```bash
cargo clippy --no-deps -p dasclaw --test parity_gate_p2 -- -D warnings  # ✅ Finished
cargo nextest run -p dasclaw --test parity_gate_p2                      # ✅ 17/17
cargo fmt --all                                                          # ✅
python3.12 scripts/check_no_panics.py --base origin/xClaw               # ✅
```

## Sources read

- `AGENTS.md` §"必跑的本地管线"、§"PR 必填项"
- `desktop-client/ironclaw/tests/parity_gate_p2.rs` lines 24–28 (make_ctx)
- `rust-1.94.0` clippy 文档 §field-reassign-with-default

## Self-Review

- **SRP**：helper 单一职责，未变。✅
- **No patch-style**：不是加 `#[allow(...)]` 绕过，而是按 clippy 推荐的
  idiomatic 写法重写。✅
- **No behavior change**：返回值等价（`conversation_id = Some(Uuid::new_v4())`，
  其余字段 = `Default::default()`）。✅
- **Tests**：17/17 全部通过，包括 `fp_023b/fp_027/fp_028/fp_029/fp_030`
  全部依赖 `make_ctx()` 的用例。✅


Closes #417
