### PR TITLE
feat(x_claw_agent): thread SandboxNetworkHint through hook SandboxExecRequest

### DIFF
--- a/crates/dasclaw_hooks/src/lib.rs
+++ b/crates/dasclaw_hooks/src/lib.rs
@@ -37,7 +37,7 @@ pub use x_claw_agent::{
     ApprovalError, ApprovalGate, ApprovalOutcome, ApprovalRequest, AutoApproveGate, DenyAllGate,
     HookBundle, InMemorySecrets, NoopSafetyHook, NoopSandboxExecutor, NoopSessionHooks,
     SafetyDecision, SafetyError, SafetyHook, SandboxError, SandboxExecOutput, SandboxExecRequest,
-    SandboxExecutor, SecretError, SecretProvider, SecretString, SessionHooks,
+    SandboxExecutor, SandboxNetworkHint, SecretError, SecretProvider, SecretString, SessionHooks,
 };
 
 /// Bridge [`HookRegistry`] into the `x_claw_agent::SessionHooks` trait so

--- a/crates/x_claw_agent/src/hooks.rs
+++ b/crates/x_claw_agent/src/hooks.rs
@@ -109,6 +109,23 @@ impl SafetyHook for NoopSafetyHook {
 // SandboxExecutor
 // ---------------------------------------------------------------------------
 
+/// Pluggable network-proxy hint passed through to the sandbox runtime.
+///
+/// Mirrors `dasclaw_net_proxy::NetworkProxy`'s relevant surface for the IPC
+/// boundary but stays dependency-free so `x_claw_agent` can continue to
+/// serialize sandbox requests over NDJSON without pulling the proxy crate
+/// (see this module's design constraint "No ironclaw / claw-code
+/// dependency").
+///
+/// The hosting runtime is responsible for hole-punching the corresponding
+/// loopback port in kernel-level sandbox profiles (ADR-137 / ADR-142).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SandboxNetworkHint {
+    /// Loopback URL (e.g. `http://127.0.0.1:48273`) that sandboxed
+    /// processes should treat as their HTTP/HTTPS proxy.
+    pub proxy_url: String,
+}
+
 /// Request describing one command to run inside the sandbox.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SandboxExecRequest {
@@ -118,6 +135,16 @@ pub struct SandboxExecRequest {
     pub cwd: PathBuf,
     /// Environment variables passed into the sandbox.
     pub env: HashMap<String, String>,
+    /// Optional network-proxy hint. `None` ⇒ the sandbox runs without
+    /// network egress (Fail-Safe). When `Some`, implementations MUST
+    /// hole-punch the loopback port at the kernel sandbox layer; otherwise
+    /// the proxy is unreachable from inside the sandbox.
+    ///
+    /// Backwards-compat: `#[serde(default)]` so existing NDJSON peers that
+    /// were emitting requests without this field continue to deserialize
+    /// into `None`.
+    #[serde(default)]
+    pub network: Option<SandboxNetworkHint>,
 }
 
 /// Result of a sandbox command execution.
@@ -464,6 +491,7 @@ mod tests {
             command: "ls".to_string(),
             cwd: PathBuf::from("/"),
             env: HashMap::new(),
+            network: None,
         };
         assert!(matches!(
             sb.run_bash(req).await,

--- a/crates/x_claw_agent/src/lib.rs
+++ b/crates/x_claw_agent/src/lib.rs
@@ -39,8 +39,8 @@ pub use bash_validation::{
 pub use hooks::{
     ApprovalError, ApprovalGate, ApprovalOutcome, ApprovalRequest, AutoApproveGate, DenyAllGate,
     HookBundle, InMemorySecrets, NoopSafetyHook, NoopSandboxExecutor, SafetyDecision, SafetyError,
-    SafetyHook, SandboxError, SandboxExecOutput, SandboxExecRequest, SandboxExecutor, SecretError,
-    SecretProvider, SecretString,
+    SafetyHook, SandboxError, SandboxExecOutput, SandboxExecRequest, SandboxExecutor,
+    SandboxNetworkHint, SecretError, SecretProvider, SecretString,
 };
 pub use messages::{
     ChatMessage, CompletionRequest, CompletionResponse, ContentPart, FinishReason, ImageUrl,

--- a/crates/x_claw_agent/tests/sandbox_network_hint.rs
+++ b/crates/x_claw_agent/tests/sandbox_network_hint.rs
@@ -1,0 +1,59 @@
+//! Contract tests for `SandboxExecRequest.network`.
+//!
+//! These tests pin the IPC-shape guarantees the `x_claw_agent` hook
+//! contract makes for sandbox runtime integrations (Wave-C2b sibling of
+//! `dasclaw_sandbox::SandboxExecRequest.network`, but on the
+//! dependency-free hook seam):
+//!
+//! 1. **Fail-Safe default** — Constructing a request without an explicit
+//!    `network` value (via Serde, mimicking an NDJSON peer that predates
+//!    this field) yields `network == None`, i.e. no egress.
+//! 2. **Round-trip stability** — `Some(SandboxNetworkHint { .. })`
+//!    serializes & deserializes losslessly, so future-runtime daemons can
+//!    safely thread proxy endpoints across the JSON boundary.
+//!
+//! These tests deliberately live as an integration test (not a unit
+//! test) so they exercise only the public `x_claw_agent` API surface and
+//! catch any accidental visibility regressions on `SandboxNetworkHint`.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use x_claw_agent::{SandboxExecRequest, SandboxNetworkHint};
+
+#[test]
+fn req_sandbox_exec_request_defaults_network_to_none_on_legacy_payload() {
+    // Legacy NDJSON peer: no `network` key present.
+    let legacy = r#"{
+        "command": "ls",
+        "cwd": "/",
+        "env": {}
+    }"#;
+    let req: SandboxExecRequest =
+        serde_json::from_str(legacy).expect("legacy payload must deserialize");
+    assert!(
+        req.network.is_none(),
+        "Fail-Safe: missing `network` key must decode to None (no egress)"
+    );
+}
+
+#[test]
+fn req_sandbox_exec_request_network_round_trip_preserves_proxy_url() {
+    let original = SandboxExecRequest {
+        command: "curl https://example.test".to_string(),
+        cwd: PathBuf::from("/workspace"),
+        env: HashMap::new(),
+        network: Some(SandboxNetworkHint {
+            proxy_url: "http://127.0.0.1:48273".to_string(),
+        }),
+    };
+
+    let wire = serde_json::to_string(&original).expect("serialize");
+    let decoded: SandboxExecRequest = serde_json::from_str(&wire).expect("deserialize");
+
+    let hint = decoded
+        .network
+        .as_ref()
+        .expect("network must survive round-trip");
+    assert_eq!(hint.proxy_url, "http://127.0.0.1:48273");
+}


### PR DESCRIPTION
## 背景 / 目标

Wave-C2a/C2b（#414 / #416）已经把 `network: Option<NetworkProxy>` 字段加到了 kernel/adapter 路径的 `dasclaw_sandbox::SandboxExecRequest`，本 PR 在 hook 契约侧（`x_claw_agent::hooks::SandboxExecRequest`）补齐对称字段，避免两条 IPC 形状继续漂移。

`x_claw_agent` 的硬约束（`crates/x_claw_agent/src/hooks.rs:6-11`）禁止引入 `dasclaw_net_proxy` / `ironclaw` / `claw-code` 依赖，因此本 PR 走 dep-free serde POJO 路线，不是补丁式 hack。

## 改动范围

- `crates/x_claw_agent/src/hooks.rs`
  - 新增 `SandboxNetworkHint { proxy_url: String }` —— dep-free serde POJO，文档注明它是 `dasclaw_net_proxy::NetworkProxy` 的 IPC 投影
  - `SandboxExecRequest` 新增 `pub network: Option<SandboxNetworkHint>`，标注 `#[serde(default)]` —— 旧 NDJSON 对端解码为 `None`（Fail-Safe = 无 egress）
  - 同步更新唯一构造点（`noop_sandbox_executor_refuses` 测试）
- `crates/x_claw_agent/src/lib.rs` —— re-export `SandboxNetworkHint`
- `crates/dasclaw_hooks/src/lib.rs` —— 同步把 `SandboxNetworkHint` 加入 `pub use x_claw_agent::{...}` 列表
- `crates/x_claw_agent/tests/sandbox_network_hint.rs` —— 新增契约测试：
  - `req_sandbox_exec_request_defaults_network_to_none_on_legacy_payload`
  - `req_sandbox_exec_request_network_round_trip_preserves_proxy_url`

## 非目标（What's NOT in this PR）

- 不修改 `NoopSandboxExecutor` 的行为（仍是 Fail-Safe 拒绝一切）
- 不接入任何生产代码路径 —— `x_claw_agent::SandboxExecutor` trait 目前在 Phase-3 中没有被 ironclaw runtime 调用（见 `hooks.rs:146-167` 的 Phase-3 状态注释），本 PR 只是把契约形状对齐
- 不在 `x_claw_agent` 添加 `dasclaw_net_proxy` 依赖（被 crate 文档硬约束禁止）
- 不修改 `dasclaw_sandbox::SandboxExecRequest`（已在 #414 完成）
- 不动 `desktop-client/src/ipc/sandbox.rs`（它用的是 `dasclaw_sandbox::SandboxExecRequest`，不是本 PR 触及的类型）

## 验证（命令 + 结果）

```bash
$ cargo check -p x_claw_agent --tests
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 26.17s

$ cargo nextest run -p x_claw_agent
     Summary [  79.479s] 240 tests run: 240 passed, 0 skipped
     # 含新增 2 个 contract tests:
     #   sandbox_network_hint::req_sandbox_exec_request_defaults_network_to_none_on_legacy_payload
     #   sandbox_network_hint::req_sandbox_exec_request_network_round_trip_preserves_proxy_url

$ cargo check -p dasclaw_hooks --tests   # re-export 兼容
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 33.84s

$ cargo fmt --all                        # 无 diff

$ python3.12 scripts/check_no_panics.py --base origin/xClaw
OK: No panic-inducing calls in changed production code.

$ cargo clippy --no-deps -p x_claw_agent --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 7.43s   # 无 warning
```

## Sources read

- `AGENTS.md` § Skills 强制使用规范 / 红线
- `crates/x_claw_agent/src/hooks.rs` § 模块头部 dep-free 约束（lines 1-50）
- `crates/x_claw_agent/src/hooks.rs` § SandboxExecRequest 与 Phase-3 状态注释（lines 108-200）
- `crates/x_claw_agent/src/hooks.rs` § `noop_sandbox_executor_refuses` 测试（lines 485-510）
- `crates/dasclaw_hooks/src/lib.rs` § `pub use x_claw_agent::{...}` re-export 列表
- `crates/dasclaw_sandbox/src/lib.rs` § SandboxExecRequest（对照参考）
- `desktop-client/src/ipc/sandbox.rs` § smoke-test（确认 `network: None` 沿用 dasclaw_sandbox 侧，不受本 PR 影响）
- `docs/plans/architecture-refactor/adr-137-network-proxy.md` / `adr-142-sandbox-tiers.md`（间接，via 现有代码注释）

## Self-Review

- [x] **不是补丁式代码**：通过新增独立 POJO + `#[serde(default)]` 的契约演进方式，而不是在已有结构体尾部叠 flag 或在调用方搞分支
- [x] **没有引入红线依赖**：`x_claw_agent` 的 dep-free 约束保持完整（无 `dasclaw_net_proxy` / `ironclaw` / `claw-code`）
- [x] **Fail-Safe**：新字段缺省 `None` ⇒ 无 egress；契约测试显式 pin 住这条不变量
- [x] **测试先行**：契约测试覆盖 ① legacy NDJSON 解码 ② Some round-trip，确保后续 sandbox_daemon 接线时不会破坏 wire format
- [x] **无 unwrap/expect/panic 生产代码**：`check_no_panics.py` 通过；测试文件里的 `.expect("...")` 仅出现在 `tests/` 路径
- [x] **没有改 `--no-verify` / 没有 `git push --force`**

Closes #419
