### PR TITLE
docs(dasclaw_exec): replace stale '已知限制' note with three-platform hole-in-hole matrix (#380 B6-7)

### DIFF
--- a/crates/dasclaw_exec/src/lib.rs
+++ b/crates/dasclaw_exec/src/lib.rs
@@ -184,12 +184,20 @@ impl ProcessExecutor for SandboxedExecutor {
 /// | `DangerFullAccess` | 允许 | 全盘可写 | 仅用于 trust 极高的本地任务 |
 /// | `ReadOnly { network_access }` | 由字段决定 | 全盘只读 | spawn 仍允许（unsafe shell 工具） |
 /// | `ExternalSandbox { network_access }` | 由字段决定 | 全盘只读（本地降级） | 实际隔离由外部容器完成 |
-/// | `WorkspaceWrite { roots, .. }` | 由字段决定 | cwd + roots + /tmp + $TMPDIR | 洞中洞 `.git/.codex` 在用户态强制 |
+/// | `WorkspaceWrite { roots, .. }` | 由字段决定 | cwd + roots + /tmp + $TMPDIR | 洞中洞 `.git/.codex/.dasclaw` 按平台分层强制（见下） |
 ///
-/// **已知限制**：sandbox 内核层（seatbelt / seccomp）按 root 整体允许写，
-/// 不强制 `read_only_subpaths`（洞中洞）。洞中洞契约由
-/// [`ironclaw_workspace_cap::policy::SandboxPolicy::is_path_writable`] 用户态决策
-/// 与 [`ironclaw_workspace_cap::WorkspaceCap`] 文件接口共同强制。
+/// **WritableRoot 洞中洞强制按平台分层**（与模块级 doc 一致）：
+///
+/// | 平台 | 内核层（kernel-enforced） | 用户态兜底 |
+/// |------|---------------------------|-----------|
+/// | macOS | ✅ 通过 `dasclaw_sandboxing::seatbelt` 在 sbpl 中表达 `(deny file-write* (subpath ".git/.codex/.dasclaw"))`（ADR-135 §3 PR-C1 / Wave-C1a） | [`ironclaw_workspace_cap`] cap-std + `is_path_writable` 第一道关 |
+/// | Linux | ❌ deferred to Wave-C1c（需 `dasclaw-linux-sandbox` setuid binary 落地，对齐 codex landlock V5 + bwrap 路径） | 同上 |
+/// | Windows | ❌ deferred to Wave-C1b / ADR-141（需在 `dasclaw_sandbox/src/windows/mod.rs` 调 `dasclaw_sandbox_windows::acl` 把 `read_only_subpaths` 转 DACL DENY entries） | 同上 |
+///
+/// Linux / Windows 上洞中洞当前仅靠 `is_path_writable` 用户态决策 +
+/// [`ironclaw_workspace_cap::WorkspaceCap`] cap-std 文件接口拦截；子进程通过
+/// 直接 syscall 写 `.git/hooks/` 在 Linux / Windows 上**目前不会被内核拒绝**。
+/// 进度追踪：[issue #380](https://github.com/Linnanli/xClaw/issues/380) Wave-C1b / C1c。
 pub fn policy_to_backend_config(policy: &SandboxPolicy, cwd: &Path) -> SandboxBackendConfig {
     policy_to_backend_config_with_env(policy, cwd, &std::env::vars().collect())
 }


### PR DESCRIPTION
## 背景 / 目标

[#380](https://github.com/Linnanli/xClaw/issues/380) Batch 6 **B6-7 doc drift 清理**。

`crates/dasclaw_exec/src/lib.rs` 的 `policy_to_backend_config` doc 第 188–194 行残留旧的「已知限制」注释，声称"sandbox 内核层（seatbelt / seccomp）按 root 整体允许写，不强制 `read_only_subpaths`（洞中洞）"。该说法与同文件 **模块级 doc 第 11–19 行**（说 macOS Wave-C1a 已通过 `dasclaw_sandboxing::seatbelt` 在 sbpl 中内核强制洞中洞）**自相矛盾**。

contract test [`crates/dasclaw_sandbox/tests/req_kernel_enforces_read_only_subpaths_macos.rs`](../tree/docs/dasclaw-exec-hole-in-hole-platform-matrix/crates/dasclaw_sandbox/tests/req_kernel_enforces_read_only_subpaths_macos.rs) 实跑 sandbox-exec 验证 macOS 洞中洞内核拒写，证实模块级 doc 才是真理。

## 改动范围

**纯 doc 修改**，整段重写（非补丁式追加），1 文件 / +13 / -5：

- 表格 `WorkspaceWrite` 行尾部说明从 "洞中洞 `.git/.codex` 在用户态强制" → "洞中洞 `.git/.codex/.dasclaw` 按平台分层强制（见下）"
- 替换「已知限制」段为三平台分层表：

| 平台 | 内核层 | 状态 |
|---|---|---|
| macOS | ✅ `dasclaw_sandboxing::seatbelt` 在 sbpl 表达 `(deny file-write* (subpath ...))` | Wave-C1a 已完成 |
| Linux | ❌ deferred | Wave-C1c（需 `dasclaw-linux-sandbox` setuid binary） |
| Windows | ❌ deferred | Wave-C1b / ADR-141（需在 windows backend 调 `dasclaw_sandbox_windows::acl`） |

明确补充："Linux / Windows 上洞中洞当前仅靠 `is_path_writable` 用户态决策 + `WorkspaceCap` cap-std 文件接口拦截；子进程通过直接 syscall 写 `.git/hooks/` 在 Linux / Windows 上**目前不会被内核拒绝**"，并指向 #380 Wave-C1b / C1c 追踪。

## 非目标（What's NOT in this PR）

- ❌ 不动 Linux / Windows backend 代码（Wave-C1b / C1c 各自独立 PR）
- ❌ 不修任何业务逻辑、签名、test assertion
- ❌ 不改 `dasclaw_sandboxing` / `dasclaw_sandbox` 任一 crate 的 doc
- ❌ 不动 ADR-129/135/141/142 任何 ADR markdown

## 验证

本地 6 步管线全过：

```
$ cargo check -p dasclaw_exec --tests
  Finished `dev` profile in 22.93s

$ cargo fmt --all
  (no changes)

$ python3.12 scripts/check_no_panics.py --base origin/xClaw
  OK: No panic-inducing calls in changed production code.

$ python3 scripts/check_no_new_ironclaw_literal.py --base origin/xClaw
  OK: No new .ironclaw / IRONCLAW_BASE_DIR literals introduced.

$ cargo clippy --no-deps -p dasclaw_exec --all-targets -- -D warnings
  Finished `dev` profile in 23.70s
```

nextest skip：doc-only 改动，未触及任何代码路径。

## Cross-cuts

- 类 A（无新增 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量；grep guard 已自检通过）

## 后续 PR

- Wave-C1b（Windows ACL DENY 接线）— 等 ADR-141 OQ-1~OQ-4 人签后启动
- Wave-C1c（Linux setuid sandbox binary port）— XL 大工程，独立评估

Closes #422

Refs #380 (Batch 6 B6-7).
