### PR TITLE
feat(dasclaw_sandbox): ADR-141 PR-W1+W2 — Windows/Linux enterprise fail-closed gate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3037,6 +3037,7 @@ dependencies = [
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
+ "tracing",
  "url",
  "windows-sys 0.52.0",
 ]

--- a/crates/dasclaw_exec/src/lib.rs
+++ b/crates/dasclaw_exec/src/lib.rs
@@ -225,6 +225,8 @@ pub fn policy_to_backend_config_with_env(
             // resource limits here. Callers wanting limits on FullAccess
             // tasks must override `resource_limits` explicitly.
             resource_limits: ResourceLimits::unlimited(),
+            enterprise_mode: false,
+            enterprise_allow_userspace_carveouts: false,
         },
         SandboxPolicy::ReadOnly { network_access } => SandboxBackendConfig {
             readable_roots: vec![PathBuf::from("/")],
@@ -237,6 +239,8 @@ pub fn policy_to_backend_config_with_env(
                 proxy_ports_when_restricted()
             },
             resource_limits: ResourceLimits::default(),
+            enterprise_mode: false,
+            enterprise_allow_userspace_carveouts: false,
         },
         SandboxPolicy::ExternalSandbox { network_access } => {
             let net_enabled = matches!(network_access, NetworkAccess::Enabled);
@@ -252,6 +256,8 @@ pub fn policy_to_backend_config_with_env(
                     proxy_ports_when_restricted()
                 },
                 resource_limits: ResourceLimits::default(),
+                enterprise_mode: false,
+                enterprise_allow_userspace_carveouts: false,
             }
         }
         SandboxPolicy::WorkspaceWrite { network_access, .. } => {
@@ -268,6 +274,8 @@ pub fn policy_to_backend_config_with_env(
                     proxy_ports_when_restricted()
                 },
                 resource_limits: ResourceLimits::default(),
+                enterprise_mode: false,
+                enterprise_allow_userspace_carveouts: false,
             }
         }
     }

--- a/crates/dasclaw_sandbox/Cargo.toml
+++ b/crates/dasclaw_sandbox/Cargo.toml
@@ -23,6 +23,13 @@ serde_json = "1"
 thiserror = "1"
 url = "2"
 
+# ADR-141 §6 OQ-3/OQ-4 — structured per-spawn audit events for enterprise
+# soft-mode allows. Emitted by the Windows backend when the caller has
+# opted into `enterprise_allow_userspace_carveouts = true`. Re-uses the
+# existing tracing taxonomy rather than introducing a new
+# `dasclaw_observability` event type (OQ-3 sign-off 2026-05-11).
+tracing = "0.1"
+
 # #324 sub-task 1 — Pre-main process hardening for the
 # `dasclaw-sandbox-resource-launcher` binary. Wired via `#[ctor::ctor]` at the
 # top of `src/bin/resource_launcher_win.rs`. Pattern matches codex

--- a/crates/dasclaw_sandbox/src/lib.rs
+++ b/crates/dasclaw_sandbox/src/lib.rs
@@ -72,6 +72,35 @@ pub enum SandboxError {
     #[error("windows sandbox resource launcher failed: {detail}")]
     WindowsLauncherFailed { detail: String },
 
+    /// Enterprise mode is on, but no OS-level sandbox is wired into the
+    /// spawn path on this platform. Returned by [`check_enterprise_gate`]
+    /// and surfaced by backends (currently Windows) when the platform's
+    /// kernel sandbox infrastructure is not yet available.
+    ///
+    /// **Fail-closed**: callers must not silently downgrade to direct
+    /// `exec`. See [ADR-141](../../docs/plans/architecture-refactor/adr-141-windows-enterprise-sandbox-support.md)
+    /// §3 PR-W1 / §6 OQ-2.
+    #[error("windows enterprise mode requires an OS sandbox but none is wired: {detail}")]
+    WindowsSandboxNotAvailable { detail: String },
+
+    /// Enterprise mode is on and the spawn carries workspace-write carve-outs
+    /// (e.g. `.git`, `.codex`, `.dasclaw`), but this platform's kernel-layer
+    /// `read_only_subpaths` enforcement has not been ported yet (macOS is
+    /// done via Wave-C1a; Windows waits on PR-W3/W4; Linux waits on
+    /// Wave-C1c).
+    ///
+    /// **Fail-closed by default**. Callers may downgrade to user-space-only
+    /// enforcement by setting
+    /// [`SandboxBackendConfig::enterprise_allow_userspace_carveouts`] to
+    /// `true` and emitting a structured per-spawn audit event. See
+    /// [ADR-141](../../docs/plans/architecture-refactor/adr-141-windows-enterprise-sandbox-support.md)
+    /// §3 PR-W2 / §6 OQ-1 / OQ-4.
+    #[error(
+        "enterprise mode requires kernel-layer read_only_subpaths enforcement, \
+         which is not yet ported on this platform: {detail}"
+    )]
+    ReadOnlySubpathsKernelEnforcementMissing { detail: String },
+
     #[error("io error: {0}")]
     Io(#[from] std::io::Error),
 }
@@ -211,6 +240,30 @@ pub struct SandboxBackendConfig {
     /// / 1024 FDs / 1024 procs). Pass [`ResourceLimits::unlimited`] to opt
     /// out completely. See W3.3 ADR.
     pub resource_limits: ResourceLimits,
+
+    /// Whether the calling session is governed by **enterprise mode**
+    /// (i.e. an organization-managed fail-closed policy applies).
+    ///
+    /// When `false` (default), backends behave as before; the gate in
+    /// [`check_enterprise_gate`] short-circuits to
+    /// [`EnterpriseGateOutcome::Allow`].
+    ///
+    /// When `true`, backends must run the gate at the top of `execute` and
+    /// reject spawns whose required kernel-layer enforcement is not yet
+    /// ported on the host platform. See
+    /// [ADR-141](../../docs/plans/architecture-refactor/adr-141-windows-enterprise-sandbox-support.md)
+    /// §3 PR-W1 / §6 OQ-1.
+    pub enterprise_mode: bool,
+
+    /// **Soft-mode opt-in** for enterprise mode. When `enterprise_mode = true`
+    /// **and** the host platform lacks kernel-layer `read_only_subpaths`
+    /// enforcement, this flag lets the caller proceed with user-space-only
+    /// carve-outs (via [`ironclaw_workspace_cap::WorkspaceCap`] cap-std
+    /// interception + `is_path_writable`) **provided that** a structured
+    /// per-spawn audit event is emitted by the caller.
+    ///
+    /// Defaults to `false` (fail-closed) per ADR-141 §6 OQ-1.
+    pub enterprise_allow_userspace_carveouts: bool,
 }
 
 impl SandboxBackendConfig {
@@ -232,6 +285,143 @@ impl SandboxBackendConfig {
     pub fn with_resource_limits(mut self, limits: ResourceLimits) -> Self {
         self.resource_limits = limits;
         self
+    }
+
+    /// Enable enterprise mode (fail-closed gate). See [ADR-141][adr-141].
+    ///
+    /// [adr-141]: ../../docs/plans/architecture-refactor/adr-141-windows-enterprise-sandbox-support.md
+    pub fn with_enterprise_mode(mut self, enabled: bool) -> Self {
+        self.enterprise_mode = enabled;
+        self
+    }
+
+    /// Opt into user-space-only carve-out enforcement when the host
+    /// platform's kernel does not yet enforce `read_only_subpaths`. Must be
+    /// paired with a structured per-spawn audit event by the caller. See
+    /// [ADR-141][adr-141] §6 OQ-1 / OQ-4.
+    ///
+    /// [adr-141]: ../../docs/plans/architecture-refactor/adr-141-windows-enterprise-sandbox-support.md
+    pub fn with_enterprise_allow_userspace_carveouts(mut self, allow: bool) -> Self {
+        self.enterprise_allow_userspace_carveouts = allow;
+        self
+    }
+}
+
+/// Reason a soft-mode allow was granted by [`check_enterprise_gate`].
+///
+/// Carried in [`EnterpriseGateOutcome::AllowWithUserspaceSoftMode`] so callers
+/// can emit a structured per-spawn audit event (ADR-141 §6 OQ-4).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum SoftModeReason {
+    /// Windows lacks kernel-layer `read_only_subpaths` enforcement until
+    /// ADR-141 PR-W3/W4 lands (codex `sandboxing` crate Windows port).
+    WindowsNoKernelReadOnlySubpaths,
+    /// Linux lacks kernel-layer `read_only_subpaths` enforcement until
+    /// Wave-C1c (`dasclaw-linux-sandbox` setuid binary) lands.
+    LinuxNoKernelReadOnlySubpaths,
+}
+
+impl SoftModeReason {
+    /// Stable, dot-namespaced tag suitable for log fields / metric labels.
+    pub fn as_audit_tag(self) -> &'static str {
+        match self {
+            Self::WindowsNoKernelReadOnlySubpaths => "windows.no_kernel_read_only_subpaths",
+            Self::LinuxNoKernelReadOnlySubpaths => "linux.no_kernel_read_only_subpaths",
+        }
+    }
+}
+
+/// Outcome of the ADR-141 enterprise fail-closed gate.
+///
+/// Encodes the four-way decision matrix from ADR-141 §3 PR-W1+W2 as a closed
+/// enum so callers `match` exhaustively — there is no silent fall-through.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum EnterpriseGateOutcome {
+    /// Either enterprise mode is off, or every required kernel-layer
+    /// enforcement is already in place. Caller may proceed with the spawn.
+    Allow,
+    /// Enterprise mode is on, kernel-layer `read_only_subpaths` is not yet
+    /// ported on this platform, **and** the caller opted into soft mode via
+    /// [`SandboxBackendConfig::enterprise_allow_userspace_carveouts`].
+    ///
+    /// Caller **must** emit a structured per-spawn audit event before
+    /// continuing (ADR-141 §6 OQ-3 / OQ-4). The `reason` is the audit tag.
+    AllowWithUserspaceSoftMode { reason: SoftModeReason },
+    /// Enterprise mode is on and the OS sandbox infrastructure is missing
+    /// (Windows setup not run, or no sandbox backend at all). Caller must
+    /// refuse to spawn with
+    /// [`SandboxError::WindowsSandboxNotAvailable`].
+    DenyNoKernelSandbox,
+    /// Enterprise mode is on, kernel-layer carve-outs are not ported on this
+    /// platform, and the soft flag is **not** set. Caller must refuse with
+    /// [`SandboxError::ReadOnlySubpathsKernelEnforcementMissing`].
+    DenyNoReadOnlySubpathsKernelEnforcement,
+}
+
+/// Cross-platform pure decision function for the ADR-141 enterprise
+/// fail-closed gate.
+///
+/// **No side effects** — designed so the full decision matrix can be unit
+/// tested on any host (macOS / Linux CI runners do not need a Windows VM).
+///
+/// Inputs:
+/// - `config`: the resolved [`SandboxBackendConfig`]; only the two
+///   `enterprise_*` fields and `writable_roots` affect the decision.
+/// - `sandbox_type`: the platform backend that will actually run the spawn.
+/// - `kernel_setup_complete`: the platform-specific "sandbox infra ready"
+///   signal. On Windows this is `sandbox_setup_is_complete(dasclaw_home)`;
+///   on macOS/Linux it should be passed as `true` (the kernel is always
+///   available — there is no per-machine setup step).
+///
+/// See [ADR-141](../../docs/plans/architecture-refactor/adr-141-windows-enterprise-sandbox-support.md)
+/// §1.1 for the platform-by-platform support matrix that drives this logic.
+pub fn check_enterprise_gate(
+    config: &SandboxBackendConfig,
+    sandbox_type: SandboxType,
+    kernel_setup_complete: bool,
+) -> EnterpriseGateOutcome {
+    if !config.enterprise_mode {
+        return EnterpriseGateOutcome::Allow;
+    }
+
+    // Step 1: a kernel sandbox must exist and be set up on this platform.
+    if sandbox_type == SandboxType::None || !kernel_setup_complete {
+        return EnterpriseGateOutcome::DenyNoKernelSandbox;
+    }
+
+    // Step 2: if the spawn carries no writable roots, there are no
+    // workspace-write carve-outs to worry about — read-only is enforced
+    // wholesale by the platform sandbox regardless.
+    if config.writable_roots.is_empty() {
+        return EnterpriseGateOutcome::Allow;
+    }
+
+    // Step 3: kernel-layer `read_only_subpaths` enforcement matrix
+    // (ADR-141 §1.1). macOS is wired in Wave-C1a via
+    // `dasclaw_sandboxing::seatbelt`; Windows waits on PR-W3/W4; Linux
+    // waits on Wave-C1c.
+    match sandbox_type {
+        SandboxType::MacosSeatbelt => EnterpriseGateOutcome::Allow,
+        SandboxType::WindowsRestrictedToken => {
+            decide_carveout_outcome(config, SoftModeReason::WindowsNoKernelReadOnlySubpaths)
+        }
+        SandboxType::LinuxSeccomp => {
+            decide_carveout_outcome(config, SoftModeReason::LinuxNoKernelReadOnlySubpaths)
+        }
+        SandboxType::None => EnterpriseGateOutcome::DenyNoKernelSandbox,
+    }
+}
+
+fn decide_carveout_outcome(
+    config: &SandboxBackendConfig,
+    reason: SoftModeReason,
+) -> EnterpriseGateOutcome {
+    if config.enterprise_allow_userspace_carveouts {
+        EnterpriseGateOutcome::AllowWithUserspaceSoftMode { reason }
+    } else {
+        EnterpriseGateOutcome::DenyNoReadOnlySubpathsKernelEnforcement
     }
 }
 
@@ -429,5 +619,147 @@ mod tests {
         assert_eq!(p.writable_roots[0], PathBuf::from("/tmp/work"));
         assert!(!p.allow_network);
         assert!(!p.allow_spawn);
+    }
+
+    // ---- ADR-141 fail-closed gate ---------------------------------------
+    //
+    // These tests cover the full `check_enterprise_gate` decision matrix.
+    // They are cross-platform pure-function tests (no `cfg(target_os = ...)`)
+    // so the same matrix is verified on every CI host.
+
+    fn gate_cfg(enterprise: bool, soft: bool, writable: &[&str]) -> SandboxBackendConfig {
+        SandboxBackendConfig {
+            enterprise_mode: enterprise,
+            enterprise_allow_userspace_carveouts: soft,
+            writable_roots: writable.iter().map(PathBuf::from).collect(),
+            ..SandboxBackendConfig::default()
+        }
+    }
+
+    #[test]
+    fn req_enterprise_gate_off_always_allows() {
+        for &sb in &[
+            SandboxType::None,
+            SandboxType::MacosSeatbelt,
+            SandboxType::LinuxSeccomp,
+            SandboxType::WindowsRestrictedToken,
+        ] {
+            let cfg = gate_cfg(false, false, &["/tmp/work"]);
+            assert_eq!(
+                check_enterprise_gate(&cfg, sb, false),
+                EnterpriseGateOutcome::Allow,
+                "enterprise_mode=false must short-circuit on {sb:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn req_enterprise_gate_denies_when_no_kernel_sandbox() {
+        let cfg = gate_cfg(true, false, &["/tmp/work"]);
+        assert_eq!(
+            check_enterprise_gate(&cfg, SandboxType::None, true),
+            EnterpriseGateOutcome::DenyNoKernelSandbox,
+        );
+    }
+
+    #[test]
+    fn req_enterprise_gate_denies_when_windows_setup_pending() {
+        let cfg = gate_cfg(true, false, &["/tmp/work"]);
+        assert_eq!(
+            check_enterprise_gate(&cfg, SandboxType::WindowsRestrictedToken, false),
+            EnterpriseGateOutcome::DenyNoKernelSandbox,
+            "Windows with !kernel_setup_complete must Deny",
+        );
+    }
+
+    #[test]
+    fn req_enterprise_gate_macos_allows_with_workspace_write() {
+        let cfg = gate_cfg(true, false, &["/tmp/work"]);
+        assert_eq!(
+            check_enterprise_gate(&cfg, SandboxType::MacosSeatbelt, true),
+            EnterpriseGateOutcome::Allow,
+            "Wave-C1a wired macOS kernel carve-outs",
+        );
+    }
+
+    #[test]
+    fn req_enterprise_gate_windows_denies_carveouts_without_soft_flag() {
+        let cfg = gate_cfg(true, false, &["/tmp/work"]);
+        assert_eq!(
+            check_enterprise_gate(&cfg, SandboxType::WindowsRestrictedToken, true),
+            EnterpriseGateOutcome::DenyNoReadOnlySubpathsKernelEnforcement,
+        );
+    }
+
+    #[test]
+    fn req_enterprise_gate_windows_softmode_allows_with_reason() {
+        let cfg = gate_cfg(true, true, &["/tmp/work"]);
+        assert_eq!(
+            check_enterprise_gate(&cfg, SandboxType::WindowsRestrictedToken, true),
+            EnterpriseGateOutcome::AllowWithUserspaceSoftMode {
+                reason: SoftModeReason::WindowsNoKernelReadOnlySubpaths,
+            },
+        );
+    }
+
+    #[test]
+    fn req_enterprise_gate_linux_denies_carveouts_without_soft_flag() {
+        let cfg = gate_cfg(true, false, &["/tmp/work"]);
+        assert_eq!(
+            check_enterprise_gate(&cfg, SandboxType::LinuxSeccomp, true),
+            EnterpriseGateOutcome::DenyNoReadOnlySubpathsKernelEnforcement,
+        );
+    }
+
+    #[test]
+    fn req_enterprise_gate_linux_softmode_allows_with_reason() {
+        let cfg = gate_cfg(true, true, &["/tmp/work"]);
+        assert_eq!(
+            check_enterprise_gate(&cfg, SandboxType::LinuxSeccomp, true),
+            EnterpriseGateOutcome::AllowWithUserspaceSoftMode {
+                reason: SoftModeReason::LinuxNoKernelReadOnlySubpaths,
+            },
+        );
+    }
+
+    #[test]
+    fn req_enterprise_gate_no_writable_roots_allows_everywhere() {
+        // Without WorkspaceWrite carve-outs, the gate should not block on
+        // missing `read_only_subpaths` enforcement.
+        for &sb in &[
+            SandboxType::MacosSeatbelt,
+            SandboxType::LinuxSeccomp,
+            SandboxType::WindowsRestrictedToken,
+        ] {
+            let cfg = gate_cfg(true, false, &[]);
+            assert_eq!(
+                check_enterprise_gate(&cfg, sb, true),
+                EnterpriseGateOutcome::Allow,
+                "no writable_roots ⇒ no carve-outs ⇒ Allow on {sb:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn req_softmode_reason_audit_tag_is_stable() {
+        // Tag strings are part of the audit-log contract (ADR-141 §6 OQ-4).
+        // Changing them is a downstream breaking change.
+        assert_eq!(
+            SoftModeReason::WindowsNoKernelReadOnlySubpaths.as_audit_tag(),
+            "windows.no_kernel_read_only_subpaths",
+        );
+        assert_eq!(
+            SoftModeReason::LinuxNoKernelReadOnlySubpaths.as_audit_tag(),
+            "linux.no_kernel_read_only_subpaths",
+        );
+    }
+
+    #[test]
+    fn enterprise_builders_set_fields() {
+        let cfg = SandboxBackendConfig::default()
+            .with_enterprise_mode(true)
+            .with_enterprise_allow_userspace_carveouts(true);
+        assert!(cfg.enterprise_mode);
+        assert!(cfg.enterprise_allow_userspace_carveouts);
     }
 }

--- a/crates/dasclaw_sandbox/src/macos/policy_bridge.rs
+++ b/crates/dasclaw_sandbox/src/macos/policy_bridge.rs
@@ -99,6 +99,8 @@ mod tests {
             allow_spawn: true,
             proxy_loopback_ports: vec![],
             resource_limits: Default::default(),
+            enterprise_mode: false,
+            enterprise_allow_userspace_carveouts: false,
         };
         let cwd = PathBuf::from("/");
         let triple = to_protocol_policy(&backend, &cwd);
@@ -119,6 +121,8 @@ mod tests {
             allow_spawn: true,
             proxy_loopback_ports: vec![],
             resource_limits: Default::default(),
+            enterprise_mode: false,
+            enterprise_allow_userspace_carveouts: false,
         };
         let cwd = PathBuf::from("/tmp/work");
         let triple = to_protocol_policy(&backend, &cwd);
@@ -147,6 +151,8 @@ mod tests {
             allow_spawn: true,
             proxy_loopback_ports: vec![],
             resource_limits: Default::default(),
+            enterprise_mode: false,
+            enterprise_allow_userspace_carveouts: false,
         };
         let cwd = PathBuf::from("/");
         let triple = to_protocol_policy(&backend, &cwd);

--- a/crates/dasclaw_sandbox/src/windows/mod.rs
+++ b/crates/dasclaw_sandbox/src/windows/mod.rs
@@ -62,7 +62,8 @@ use dasclaw_sandbox_windows::types::{NetworkAccess, SandboxPolicy as UpstreamPol
 
 use crate::launcher_ipc::{LauncherRequest, OuterJobLimitsWire, PROTOCOL_VERSION};
 use crate::{
-    ResourceLimits, Sandbox, SandboxBackendConfig, SandboxError, SandboxExecRequest, SandboxType,
+    check_enterprise_gate, EnterpriseGateOutcome, ResourceLimits, Sandbox, SandboxBackendConfig,
+    SandboxError, SandboxExecRequest, SandboxType, SoftModeReason,
 };
 
 /// Windows restricted-token sandbox backend.
@@ -91,8 +92,41 @@ impl Sandbox for WindowsRestrictedTokenSandbox {
 
     fn execute(&self, req: SandboxExecRequest) -> Result<std::process::Output, SandboxError> {
         let dasclaw_home = resolve_dasclaw_home()?;
+        let setup_complete = sandbox_setup_is_complete(&dasclaw_home);
 
-        if !sandbox_setup_is_complete(&dasclaw_home) {
+        // ADR-141 fail-closed gate (PR-W1 + PR-W2). Runs first so that
+        // enterprise spawns surface the correct error variant before any
+        // command decomposition / IPC work.
+        match check_enterprise_gate(
+            &req.policy,
+            SandboxType::WindowsRestrictedToken,
+            setup_complete,
+        ) {
+            EnterpriseGateOutcome::Allow => {}
+            EnterpriseGateOutcome::AllowWithUserspaceSoftMode { reason } => {
+                emit_enterprise_softmode_audit_event(reason, &req, &dasclaw_home);
+            }
+            EnterpriseGateOutcome::DenyNoKernelSandbox => {
+                return Err(SandboxError::WindowsSandboxNotAvailable {
+                    detail: format!(
+                        "Windows enterprise mode requires the OS sandbox to be set up at {} \
+                         (run dasclaw-sandbox-setup.exe elevated). See ADR-141 §3 PR-W1.",
+                        dasclaw_home.display()
+                    ),
+                });
+            }
+            EnterpriseGateOutcome::DenyNoReadOnlySubpathsKernelEnforcement => {
+                return Err(SandboxError::ReadOnlySubpathsKernelEnforcementMissing {
+                    detail: "Windows kernel-layer read_only_subpaths enforcement is not \
+                             yet ported (ADR-141 PR-W3/W4 / Wave-C1b pending). Set \
+                             enterprise_allow_userspace_carveouts = true to opt into \
+                             user-space-only enforcement with an audit event."
+                        .to_string(),
+                });
+            }
+        }
+
+        if !setup_complete {
             return Err(SandboxError::WindowsSetupPending {
                 detail: format!(
                     "Windows sandbox not initialized at {}. Run \
@@ -243,6 +277,42 @@ fn backend_config_to_upstream_policy(
             exclude_slash_tmp: false,
         })
     }
+}
+
+/// Emit a structured per-spawn audit event recording that an enterprise
+/// spawn proceeded under user-space-only carve-out enforcement (ADR-141
+/// §6 OQ-3 / OQ-4 sign-off 2026-05-11).
+///
+/// Implemented as a `tracing::warn!` event rather than a new
+/// `dasclaw_observability::ObservabilityEvent` type — OQ-3 explicitly
+/// chose "re-use existing taxonomy" to avoid an ADR-138 schema evolution.
+/// Downstream telemetry sinks subscribed to the
+/// `sandbox.enterprise.softmode` target consume this event.
+///
+/// Per OQ-4, the event is **per-spawn** (one record per call), carrying
+/// program / cwd / soft-mode reason so a forensic search can answer
+/// "who ran what when".
+fn emit_enterprise_softmode_audit_event(
+    reason: SoftModeReason,
+    req: &SandboxExecRequest,
+    dasclaw_home: &Path,
+) {
+    let program = req.command.get_program().to_string_lossy().into_owned();
+    let cwd = req
+        .command
+        .get_current_dir()
+        .map(|p| p.display().to_string())
+        .unwrap_or_else(|| "<inherit>".to_string());
+    tracing::warn!(
+        target: "sandbox.enterprise.softmode",
+        reason = reason.as_audit_tag(),
+        program = %program,
+        cwd = %cwd,
+        dasclaw_home = %dasclaw_home.display(),
+        writable_roots = req.policy.writable_roots.len(),
+        "enterprise spawn proceeded under user-space-only carve-out enforcement \
+         (kernel-layer read_only_subpaths not yet ported); see ADR-141",
+    );
 }
 
 /// 解析 dasclaw_home 路径。优先级见模块文档。

--- a/crates/dasclaw_sandbox/tests/req_kernel_enforces_read_only_subpaths_macos.rs
+++ b/crates/dasclaw_sandbox/tests/req_kernel_enforces_read_only_subpaths_macos.rs
@@ -46,6 +46,8 @@ fn req_dasclaw_sandbox_kernel_blocks_git_hooks_under_workspace_write_macos() {
         allow_spawn: true,
         proxy_loopback_ports: vec![],
         resource_limits: Default::default(),
+        enterprise_mode: false,
+        enterprise_allow_userspace_carveouts: false,
     };
 
     // Attempt to overwrite the hook from inside the sandbox. With kernel-
@@ -103,6 +105,8 @@ fn req_dasclaw_sandbox_kernel_allows_write_to_non_hole_path_macos() {
         allow_spawn: true,
         proxy_loopback_ports: vec![],
         resource_limits: Default::default(),
+        enterprise_mode: false,
+        enterprise_allow_userspace_carveouts: false,
     };
 
     let mut cmd = Command::new("/bin/sh");

--- a/docs/plans/architecture-refactor/adr-141-windows-enterprise-sandbox-support.md
+++ b/docs/plans/architecture-refactor/adr-141-windows-enterprise-sandbox-support.md
@@ -1,8 +1,8 @@
 # ADR-141: Windows enterprise sandbox / resource-limit support matrix (research-only)
 
-- **Status**: 🟡 **Draft — proposes fail-closed default until #241 unblocks** (research-only ADR; implementation is **out of scope** for this PR)
-- **Date**: 2026-05-09
-- **Approver**: pending nally sign-off
+- **Status**: ✅ **Accepted (2A: fail-closed default)** — sign-off 2026-05-11 (see §7)
+- **Date**: 2026-05-09 (drafted) / 2026-05-11 (sign-off)
+- **Approver**: nally (signed 2026-05-11; OQ-1~OQ-4 all resolved, see §6)
 - **Authors**: GitHub Copilot agent
 - **Tracker**: [#91](https://github.com/Linnanli/xClaw/issues/91) — [P1/W3] Windows sandbox/resource-limit support plan
 - **Related**:
@@ -134,15 +134,16 @@ No `cargo check` / `clippy` / `nextest` runs — no code changes.
 
 ---
 
-## 6. Open questions (for reviewer)
+## 6. Open questions — RESOLVED (2026-05-11 sign-off)
 
-1. **OQ-1 — Default for `enterprise_allow_userspace_carveouts`.** This ADR proposes `false` (fail-closed). nally to confirm; alternative is `true` with a deprecation timer until PR-W4 lands.
-2. **OQ-2 — Naming of the new `SandboxError` variants.** Proposed names mirror existing codex `core/src/exec.rs:1006-1024` strings; nally to ratify or rename before PR-W1 is opened.
-3. **OQ-3 — Windows audit-event channel.** PR-W2's structured audit log needs a sink. Re-use existing `dasclaw_observability` event taxonomy or define a new `enterprise.windows.softmode_used` event? Defer to PR-W2 ADR.
-4. **OQ-4 — Telemetry for "Windows enterprise mode activated without OS sandbox".** Should this be a metric (count) or a structured event (per-spawn)? Default to event for forensic value; OQ deferred.
+1. **OQ-1 — Default for `enterprise_allow_userspace_carveouts`** ✅ **`false` (fail-closed)**. Aligns with Linux/macOS posture, codex `core/src/exec.rs:1006-1024` pattern, and the `#28` adr-redline contract. Enterprise Windows users must explicitly opt into soft mode if they need to run before PR-W3/W4 lands; the opt-in must produce a structured audit event so the soft path leaves forensic evidence.
+2. **OQ-2 — Naming of the new `SandboxError` variants** ✅ **Accept proposed names verbatim**: `SandboxError::WindowsSandboxNotAvailable` and `SandboxError::ReadOnlySubpathsKernelEnforcementMissing`. Mirrors codex upstream string identifiers and avoids cross-platform translation surprises.
+3. **OQ-3 — Windows audit-event channel** ✅ **Re-use existing `dasclaw_observability` event taxonomy**. Avoids triggering an ADR-138 schema evolution; the soft-mode reason string is sufficient context inside an existing `sandbox.degraded` / equivalent envelope. New event types may be added in a follow-up ADR if forensic dashboards need them.
+4. **OQ-4 — Telemetry for "Windows enterprise mode activated without OS sandbox"** ✅ **Structured event (per-spawn)**. Forensic value of per-invocation context (user / cwd / command) outweighs the storage cost; metric-only would lose the audit trail required by enterprise customers.
 
 ---
 
 ## 7. Decision log
 
 - 2026-05-09 — Draft created from `#91` scope; recommends 2A (fail-closed default + opt-in soft flag) over 2B (full unsupported) and 2C (silent status quo). Awaits nally sign-off.
+- 2026-05-11 — **nally signed off (Wave-C1b authorization)**. All four OQ resolved per §6; option 2A accepted. PR-W1 + PR-W2 merged into one implementation slice (the fail-closed gate; no kernel ACL DENY work yet — that stays under PR-W3/W4). The gate adds two new `SandboxError` variants, two new `SandboxBackendConfig` fields (`enterprise_mode`, `enterprise_allow_userspace_carveouts`), and a cross-platform pure decision function `check_enterprise_gate` so the same matrix is testable on macOS/Linux CI hosts even though the Windows backend is the only enforcement site today.


### PR DESCRIPTION
Closes #423

Refs #380 Batch 6 Wave-C1b
Refs #91 Windows sandbox tracker
Refs ADR-141 (signed 2026-05-11, OQ-1~OQ-4 resolved)

## 背景 / 目标

ADR-141 Wave-C1b 落地 PR-W1+W2：在 `dasclaw_sandbox` 中加入**跨平台纯决策函数 + Windows 后端结构化集成**的企业模式 fail-closed 闸门。所有 4 个 OQ 已在 ADR §6 完成签字：

| OQ | 决策 | 落地 |
|---|---|---|
| OQ-1 默认值 | `enterprise_allow_userspace_carveouts = false`（fail-closed） | `SandboxBackendConfig::default()` |
| OQ-2 命名 | 直接采用 codex 现有命名 | `enterprise_mode` / `SoftModeReason::*` |
| OQ-3 审计 sink | 复用 `tracing` warn 事件 | `target = "sandbox.enterprise.softmode"` |
| OQ-4 事件 schema | 每 spawn 一条结构化字段 | `reason / program / cwd / dasclaw_home / writable_roots_count` |

## 改动范围

- `crates/dasclaw_sandbox/src/lib.rs`
  - 新增 `SandboxError::WindowsSandboxNotAvailable`、`ReadOnlySubpathsKernelEnforcementMissing`（thiserror, 链接 ADR-141）
  - `SandboxBackendConfig` 加 2 字段（默认 false） + 2 builder (`with_enterprise_mode` / `with_enterprise_allow_userspace_carveouts`)
  - 新 `SoftModeReason`（`#[non_exhaustive]`）+ `as_audit_tag()` 稳定字符串
  - 新 `EnterpriseGateOutcome`（`#[non_exhaustive]`, 4 枚举）
  - **纯函数** `check_enterprise_gate(config, sandbox_type, kernel_setup_complete) -> EnterpriseGateOutcome` — 无副作用、跨平台可测，实现 ADR-141 §1.1 决策矩阵全部行
- `crates/dasclaw_sandbox/src/windows/mod.rs`
  - `execute()` 把 gate 作为**结构化前置 check**（非 patch-style 追加）
  - 4 个 outcome 分支：Allow / softmode→`emit_enterprise_softmode_audit_event` / DenyNoKernelSandbox→`WindowsSandboxNotAvailable` / DenyNoReadOnlySubpathsKernelEnforcement→`ReadOnlySubpathsKernelEnforcementMissing`
  - 私有 `emit_enterprise_softmode_audit_event` 用 `tracing::warn!` 结构化字段
- `crates/dasclaw_sandbox/Cargo.toml`：加 `tracing = "0.1"`（标注 ADR-141 §6 OQ-3/OQ-4）
- 9 处 `SandboxBackendConfig` 字面量补齐新字段（保持显式枚举风格）：`macos/policy_bridge.rs` ×3 / `dasclaw_exec/src/lib.rs` ×4 / `tests/req_kernel_enforces_read_only_subpaths_macos.rs` ×2
- `docs/plans/architecture-refactor/adr-141-windows-enterprise-sandbox-support.md`：Status → ✅ Accepted，§6 OQ 全部标 RESOLVED，§7 加 2026-05-11 决策日志

## 非目标（NOT in this PR）

- **不实现** 内核 ACL DENY 执行（属 PR-W3/W4）
- **不接通** `ProcessExecutor` / 上层 CLI 入口（属 PR-W3）
- **不实现** Linux Landlock（属 PR-W4）
- **不动** `ironclaw_workspace_cap::SandboxPolicy` schema

## 验证

```bash
cargo check  -p dasclaw_sandbox --tests                                  # PASS 2.26s
cargo check  -p dasclaw_exec    --tests                                  # PASS
cargo nextest run -p dasclaw_sandbox                                     # 55 passed, 0 failed (含 11 个新 req_* 测试)
cargo fmt --all                                                          # clean
python3.12 scripts/check_no_panics.py --base origin/xClaw                # OK
python3   scripts/check_no_new_ironclaw_literal.py --base origin/xClaw   # OK
cargo clippy --no-deps -p dasclaw_sandbox --all-targets -- -D warnings   # clean
cargo clippy --no-deps -p dasclaw_exec    --all-targets -- -D warnings   # clean
```

新增 11 个测试覆盖 ADR-141 §1.1 矩阵：

- `req_enterprise_gate_off_always_allows`
- `req_enterprise_gate_denies_when_no_kernel_sandbox`
- `req_enterprise_gate_denies_when_windows_setup_pending`
- `req_enterprise_gate_macos_allows_with_workspace_write`
- `req_enterprise_gate_windows_denies_carveouts_without_soft_flag`
- `req_enterprise_gate_windows_softmode_allows_with_reason`
- `req_enterprise_gate_linux_denies_carveouts_without_soft_flag`
- `req_enterprise_gate_linux_softmode_allows_with_reason`
- `req_enterprise_gate_no_writable_roots_allows_everywhere`
- `req_softmode_reason_audit_tag_is_stable`
- `enterprise_builders_set_fields`

## Sources read

- AGENTS.md §1–§7（红线 / 6 步管线 / PR 必填项 / 三层验证）
- docs/plans/architecture-refactor/adr-141-windows-enterprise-sandbox-support.md §1.1 决策矩阵 / §3 PR-W1+W2 范围 / §6 OQ-1~OQ-4 / §7 决策日志
- docs/plans/architecture-refactor/adr-112-compatibility-evaluation.md（确认 SandboxBackendConfig 字段新增对兼容性表的影响 = 默认 false 无破坏）
- docs/plans/architecture-refactor/adr-113-hook-engine-unification.md（确认本 PR 不触及 hook engine）
- crates/dasclaw_sandbox/src/lib.rs 顶部模块文档 + `SandboxError`、`SandboxBackendConfig` 现有定义
- crates/dasclaw_sandbox/src/windows/mod.rs 现有 `sandbox_setup_is_complete` / `WindowsSetupPending` 路径

## Skills 自审摘要

- **code-quality-audit**：无 unwrap/expect/panic（脚本通过）；新错误用 thiserror 与既有变体一致；2 个新 enum 都加 `#[non_exhaustive]` 防未来扩展破 ABI；纯决策函数 100% 可单元测试，无 I/O。
- **adr-compliance-check (ADR-141)**：§1.1 矩阵全行有对应测试；§6 OQ-1~OQ-4 全部按签字落实（默认 false / 沿用 codex 名 / tracing 复用 / 5 字段结构化）；§3 PR 范围严格限定为 fail-closed gate，未越界进 PR-W3/W4。
- **code-review-expert**：命名清晰自解释（`EnterpriseGateOutcome` / `SoftModeReason` / `check_enterprise_gate`）；Windows backend 集成为**结构化前置 check**而非补丁式追加分支；audit tag 字符串由测试锁定为稳定接口；builder API 保持 ergonomics 与既有 `with_*` 一致。
