### PR TITLE
feat(dasclaw_sandbox): ADR-141 PR-W3 — wire read_only_subpaths to Windows kernel ACL DENY

### DIFF
--- a/crates/dasclaw_exec/src/lib.rs
+++ b/crates/dasclaw_exec/src/lib.rs
@@ -218,6 +218,8 @@ pub fn policy_to_backend_config_with_env(
         SandboxPolicy::DangerFullAccess => SandboxBackendConfig {
             readable_roots: vec![PathBuf::from("/")],
             writable_roots: vec![PathBuf::from("/")],
+            // FullAccess: no holes — full root is writable.
+            read_only_subpaths: vec![],
             allow_network: true,
             allow_spawn: true,
             proxy_loopback_ports: vec![],
@@ -231,6 +233,8 @@ pub fn policy_to_backend_config_with_env(
         SandboxPolicy::ReadOnly { network_access } => SandboxBackendConfig {
             readable_roots: vec![PathBuf::from("/")],
             writable_roots: vec![],
+            // ReadOnly: no writable roots ⇒ no carve-outs needed.
+            read_only_subpaths: vec![],
             allow_network: *network_access,
             allow_spawn: true,
             proxy_loopback_ports: if *network_access {
@@ -248,6 +252,8 @@ pub fn policy_to_backend_config_with_env(
                 // 进程内被外层容器隔离，本地视为只读。
                 readable_roots: vec![PathBuf::from("/")],
                 writable_roots: vec![],
+                // ExternalSandbox：内层视为只读，无 carve-outs。
+                read_only_subpaths: vec![],
                 allow_network: net_enabled,
                 allow_spawn: true,
                 proxy_loopback_ports: if net_enabled {
@@ -263,9 +269,22 @@ pub fn policy_to_backend_config_with_env(
         SandboxPolicy::WorkspaceWrite { network_access, .. } => {
             let roots = policy.get_writable_roots_with_cwd(cwd);
             let writable_roots: Vec<PathBuf> = roots.iter().map(|r| r.root.clone()).collect();
+            // ADR-141 §3 PR-W3 / OQ-W3-2 (sign-off 2026-05-11)：flatten
+            // 每个 WritableRoot 的 `read_only_subpaths` (例如 `.git/`,
+            // `.codex/`, `.dasclaw/`) 到 backend config 顶层 —— 下游 Windows
+            // adapter 会把它们 wire 给 launcher，再透传给上游
+            // `run_windows_sandbox_capture_with_extra_deny_write_paths` 下发
+            // Win32 DACL DENY ACE，达成 kernel-enforced 洞中洞。macOS sbpl
+            // 由 ADR-135 PR-C1 在 `dasclaw_sandboxing::seatbelt` 处理，
+            // Linux Landlock 是 PR-W4 / Wave-C1c 的工作。
+            let read_only_subpaths: Vec<PathBuf> = roots
+                .iter()
+                .flat_map(|r| r.read_only_subpaths.iter().cloned())
+                .collect();
             SandboxBackendConfig {
                 readable_roots: vec![PathBuf::from("/")],
                 writable_roots,
+                read_only_subpaths,
                 allow_network: *network_access,
                 allow_spawn: true,
                 proxy_loopback_ports: if *network_access {
@@ -378,6 +397,50 @@ mod tests {
             "writable_roots 必须包含 cwd: {:?}",
             cfg.writable_roots
         );
+    }
+
+    #[test]
+    fn req_policy_to_backend_config_flattens_read_only_subpaths() {
+        // ADR-141 §3 PR-W3 / OQ-W3-2 (sign-off 2026-05-11):
+        // SandboxPolicy::WorkspaceWrite 在 `get_writable_roots_with_cwd`
+        // 里默认会给 cwd 加 `.git` / `.codex` / `.dasclaw` 等 read-only
+        // subpaths（见 `default_read_only_subpaths_for_writable_root`）。
+        // 本测试锁定: backend config 的 `read_only_subpaths` 必须把所有
+        // root 的 holes flatten 到顶层 —— 否则 Windows adapter 无法把
+        // 它们 wire 到 launcher IPC，最终 Win32 DACL DENY 会漏 ACE。
+        let tmp = tempfile::tempdir().unwrap();
+        let git_dir = tmp.path().join(".git");
+        std::fs::create_dir_all(&git_dir).unwrap();
+        let cfg =
+            policy_to_backend_config(&SandboxPolicy::new_workspace_write_policy(), tmp.path());
+        assert!(
+            cfg.read_only_subpaths.iter().any(|p| p == &git_dir),
+            "flatten 必须包含 cwd/.git，实际: {:?}",
+            cfg.read_only_subpaths,
+        );
+    }
+
+    #[test]
+    fn req_read_only_policies_have_empty_read_only_subpaths() {
+        // ReadOnly / ExternalSandbox / DangerFullAccess 没有 writable
+        // carve-outs，read_only_subpaths 必须空。否则 ADR-141 gate
+        // (Step 2) 误判为 needs-kernel-enforcement。
+        for p in [
+            SandboxPolicy::ReadOnly {
+                network_access: false,
+            },
+            SandboxPolicy::ExternalSandbox {
+                network_access: NetworkAccess::Restricted,
+            },
+            SandboxPolicy::DangerFullAccess,
+        ] {
+            let cfg = policy_to_backend_config(&p, Path::new("/tmp"));
+            assert!(
+                cfg.read_only_subpaths.is_empty(),
+                "{p:?} 不应产生 read_only_subpaths，实际: {:?}",
+                cfg.read_only_subpaths,
+            );
+        }
     }
 
     #[test]

--- a/crates/dasclaw_sandbox/src/bin/resource_launcher_win.rs
+++ b/crates/dasclaw_sandbox/src/bin/resource_launcher_win.rs
@@ -44,7 +44,7 @@ fn main() -> std::process::ExitCode {
 
     use dasclaw_sandbox::launcher_ipc::{LauncherRequest, LauncherResponse, PROTOCOL_VERSION};
     use dasclaw_sandbox::windows::job_object::{JobObject, OuterJobLimits};
-    use dasclaw_sandbox_windows::run_windows_sandbox_capture;
+    use dasclaw_sandbox_windows::run_windows_sandbox_capture_with_extra_deny_write_paths;
 
     fn write_response(resp: &LauncherResponse) -> std::io::Result<()> {
         let json = serde_json::to_vec(resp)
@@ -99,7 +99,7 @@ fn main() -> std::process::ExitCode {
         }
     };
 
-    let capture = match run_windows_sandbox_capture(
+    let capture = match run_windows_sandbox_capture_with_extra_deny_write_paths(
         &req.policy_json,
         &req.cwd,
         &req.dasclaw_home,
@@ -107,6 +107,12 @@ fn main() -> std::process::ExitCode {
         &req.cwd,
         req.env,
         None, // timeout — adapter 上层（OsExecutor）用 tokio timeout 包裹
+        // ADR-141 §3 PR-W3 / OQ-W3-2 (sign-off 2026-05-11): forward
+        // `SandboxBackendConfig::read_only_subpaths` as upstream
+        // `additional_deny_write_paths`, so upstream's `acl::add_deny_write_ace`
+        // installs Win32 DACL DENY ACEs on every carve-out path. Empty slice
+        // preserves Slice B1 behaviour bit-for-bit.
+        &req.additional_deny_write_paths,
         req.use_private_desktop,
     ) {
         Ok(c) => c,

--- a/crates/dasclaw_sandbox/src/launcher_ipc.rs
+++ b/crates/dasclaw_sandbox/src/launcher_ipc.rs
@@ -65,6 +65,20 @@ pub struct LauncherRequest {
 
     /// 是否使用 Alternate Desktop（透传上游 API）。
     pub use_private_desktop: bool,
+
+    /// 额外的 deny-write 路径列表 — 即 [`crate::SandboxBackendConfig::read_only_subpaths`]
+    /// 的 wire 形式（ADR-141 §3 PR-W3 / OQ-W3-2 sign-off 2026-05-11）。
+    ///
+    /// launcher 收到非空列表时改调
+    /// `dasclaw_sandbox_windows::run_windows_sandbox_capture_with_extra_deny_write_paths`，
+    /// 把这些路径作为 `additional_deny_write_paths` 透传给 upstream，upstream
+    /// 再通过 `acl::add_deny_write_ace` 下发 Win32 DACL DENY entries。
+    ///
+    /// 空 Vec = 维持 Slice B1 的旧行为（调 `run_windows_sandbox_capture`），
+    /// 协议向后兼容：旧 launcher 反序列化新 request 时 serde 的 `#[serde(default)]`
+    /// 兜底为空 Vec。
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub additional_deny_write_paths: Vec<PathBuf>,
 }
 
 /// `OuterJobLimits` 的 wire 形式。
@@ -142,6 +156,7 @@ mod tests {
                 max_active_processes: Some(64),
             }),
             use_private_desktop: false,
+            additional_deny_write_paths: vec![],
         }
     }
 
@@ -160,6 +175,57 @@ mod tests {
         let json = serde_json::to_string(&req).expect("serialize");
         let back: LauncherRequest = serde_json::from_str(&json).expect("deserialize");
         assert_eq!(req, back);
+    }
+
+    #[test]
+    fn request_with_additional_deny_write_paths_round_trips() {
+        // ADR-141 §3 PR-W3 / OQ-W3-2 contract: deny paths must survive the
+        // adapter ↔ launcher IPC boundary intact so that upstream
+        // `run_windows_sandbox_capture_with_extra_deny_write_paths` can DENY
+        // them at the Win32 DACL layer.
+        let mut req = sample_request();
+        req.additional_deny_write_paths = vec![
+            PathBuf::from(r"C:\Users\u\workspace\.git"),
+            PathBuf::from(r"C:\Users\u\workspace\.dasclaw"),
+            PathBuf::from(r"C:\Users\u\workspace\.codex"),
+        ];
+        let json = serde_json::to_string(&req).expect("serialize");
+        let back: LauncherRequest = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(req, back);
+        assert_eq!(back.additional_deny_write_paths.len(), 3);
+    }
+
+    #[test]
+    fn request_omits_additional_deny_write_paths_when_empty() {
+        // skip_serializing_if keeps the wire payload backwards-compatible
+        // with launchers that predate ADR-141 PR-W3.
+        let req = sample_request();
+        assert!(req.additional_deny_write_paths.is_empty());
+        let json = serde_json::to_string(&req).expect("serialize");
+        assert!(
+            !json.contains("additional_deny_write_paths"),
+            "empty list must be omitted from wire payload, got: {json}",
+        );
+    }
+
+    #[test]
+    fn request_legacy_json_without_deny_paths_field_deserializes() {
+        // Forward-compat: an older adapter that does not yet emit the
+        // `additional_deny_write_paths` field must still be parseable.
+        let legacy_json = serde_json::json!({
+            "protocol_version": PROTOCOL_VERSION,
+            "argv": ["cmd.exe"],
+            "cwd": "C:\\workspace",
+            "env": {},
+            "dasclaw_home": "C:\\Users\\u\\.dasclaw",
+            "policy_json": "{\"ReadOnly\":{\"network_access\":false}}",
+            "outer_limits": null,
+            "use_private_desktop": false,
+        })
+        .to_string();
+        let parsed: LauncherRequest =
+            serde_json::from_str(&legacy_json).expect("legacy json must deserialize");
+        assert!(parsed.additional_deny_write_paths.is_empty());
     }
 
     #[test]

--- a/crates/dasclaw_sandbox/src/lib.rs
+++ b/crates/dasclaw_sandbox/src/lib.rs
@@ -229,6 +229,30 @@ impl ResourceLimits {
 pub struct SandboxBackendConfig {
     pub readable_roots: Vec<PathBuf>,
     pub writable_roots: Vec<PathBuf>,
+    /// Subpaths that must remain **read-only** even when contained inside a
+    /// [`Self::writable_roots`] entry — the so-called *洞中洞* / "holes within
+    /// holes" carve-outs (`.git/`, `.dasclaw/`, `.codex/`, etc.).
+    ///
+    /// Populated by `dasclaw_exec::policy_to_backend_config_with_env` from
+    /// [`ironclaw_workspace_cap::policy::WritableRoot::read_only_subpaths`]
+    /// for every writable root.
+    ///
+    /// **Per-backend semantics** (ADR-141 §3 PR-W3, OQ-W3-1/W3-4 sign-off
+    /// 2026-05-11):
+    /// - **Windows** (`crates/dasclaw_sandbox/src/windows/`) — kernel-enforced
+    ///   via Win32 DACL DENY ACEs. The list is forwarded into the launcher
+    ///   IPC ([`crate::launcher_ipc::LauncherRequest::additional_deny_write_paths`])
+    ///   and consumed by upstream
+    ///   `dasclaw_sandbox_windows::run_windows_sandbox_capture_with_extra_deny_write_paths`.
+    /// - **macOS** (`crates/dasclaw_sandbox/src/macos/`) — **ignored** at this
+    ///   layer; sbpl-level enforcement is wired through ADR-135 §3 PR-C1
+    ///   (`dasclaw_sandboxing::seatbelt`) using the higher-level
+    ///   `WritableRoot { root, read_only_subpaths }` shape directly. Keeping
+    ///   the field on `SandboxBackendConfig` lets [`check_enterprise_gate`]
+    ///   reason about the *presence* of carve-outs uniformly across hosts.
+    /// - **Linux** — ignored until Wave-C1c lands kernel-layer Landlock
+    ///   enforcement (ADR-135 PR-C3); behaviour mirrors macOS for now.
+    pub read_only_subpaths: Vec<PathBuf>,
     pub allow_network: bool,
     pub allow_spawn: bool,
     /// Loopback ports that the sandbox should allow outbound connect to,
@@ -391,10 +415,17 @@ pub fn check_enterprise_gate(
         return EnterpriseGateOutcome::DenyNoKernelSandbox;
     }
 
-    // Step 2: if the spawn carries no writable roots, there are no
-    // workspace-write carve-outs to worry about — read-only is enforced
-    // wholesale by the platform sandbox regardless.
-    if config.writable_roots.is_empty() {
+    // Step 2: if the spawn carries no `read_only_subpaths` carve-outs,
+    // there is nothing for the kernel layer to extra-deny — the base
+    // sandbox kind alone is sufficient regardless of how many writable
+    // roots are present (a workspace-write without any holes is the
+    // common case for non-enterprise tasks).
+    //
+    // OQ-W3-3 (sign-off 2026-05-11) corrected the original PR-W1+W2
+    // approximation `writable_roots.is_empty()`: a `WorkspaceWrite` policy
+    // *always* has writable roots, so the old signal misclassified the
+    // hole-free case as "needs kernel enforcement".
+    if config.read_only_subpaths.is_empty() {
         return EnterpriseGateOutcome::Allow;
     }
 
@@ -627,11 +658,17 @@ mod tests {
     // They are cross-platform pure-function tests (no `cfg(target_os = ...)`)
     // so the same matrix is verified on every CI host.
 
-    fn gate_cfg(enterprise: bool, soft: bool, writable: &[&str]) -> SandboxBackendConfig {
+    fn gate_cfg(
+        enterprise: bool,
+        soft: bool,
+        writable: &[&str],
+        read_only_subpaths: &[&str],
+    ) -> SandboxBackendConfig {
         SandboxBackendConfig {
             enterprise_mode: enterprise,
             enterprise_allow_userspace_carveouts: soft,
             writable_roots: writable.iter().map(PathBuf::from).collect(),
+            read_only_subpaths: read_only_subpaths.iter().map(PathBuf::from).collect(),
             ..SandboxBackendConfig::default()
         }
     }
@@ -644,7 +681,7 @@ mod tests {
             SandboxType::LinuxSeccomp,
             SandboxType::WindowsRestrictedToken,
         ] {
-            let cfg = gate_cfg(false, false, &["/tmp/work"]);
+            let cfg = gate_cfg(false, false, &["/tmp/work"], &["/tmp/work/.git"]);
             assert_eq!(
                 check_enterprise_gate(&cfg, sb, false),
                 EnterpriseGateOutcome::Allow,
@@ -655,7 +692,7 @@ mod tests {
 
     #[test]
     fn req_enterprise_gate_denies_when_no_kernel_sandbox() {
-        let cfg = gate_cfg(true, false, &["/tmp/work"]);
+        let cfg = gate_cfg(true, false, &["/tmp/work"], &["/tmp/work/.git"]);
         assert_eq!(
             check_enterprise_gate(&cfg, SandboxType::None, true),
             EnterpriseGateOutcome::DenyNoKernelSandbox,
@@ -664,7 +701,7 @@ mod tests {
 
     #[test]
     fn req_enterprise_gate_denies_when_windows_setup_pending() {
-        let cfg = gate_cfg(true, false, &["/tmp/work"]);
+        let cfg = gate_cfg(true, false, &["/tmp/work"], &["/tmp/work/.git"]);
         assert_eq!(
             check_enterprise_gate(&cfg, SandboxType::WindowsRestrictedToken, false),
             EnterpriseGateOutcome::DenyNoKernelSandbox,
@@ -674,7 +711,7 @@ mod tests {
 
     #[test]
     fn req_enterprise_gate_macos_allows_with_workspace_write() {
-        let cfg = gate_cfg(true, false, &["/tmp/work"]);
+        let cfg = gate_cfg(true, false, &["/tmp/work"], &["/tmp/work/.git"]);
         assert_eq!(
             check_enterprise_gate(&cfg, SandboxType::MacosSeatbelt, true),
             EnterpriseGateOutcome::Allow,
@@ -684,7 +721,7 @@ mod tests {
 
     #[test]
     fn req_enterprise_gate_windows_denies_carveouts_without_soft_flag() {
-        let cfg = gate_cfg(true, false, &["/tmp/work"]);
+        let cfg = gate_cfg(true, false, &["/tmp/work"], &["/tmp/work/.git"]);
         assert_eq!(
             check_enterprise_gate(&cfg, SandboxType::WindowsRestrictedToken, true),
             EnterpriseGateOutcome::DenyNoReadOnlySubpathsKernelEnforcement,
@@ -693,7 +730,7 @@ mod tests {
 
     #[test]
     fn req_enterprise_gate_windows_softmode_allows_with_reason() {
-        let cfg = gate_cfg(true, true, &["/tmp/work"]);
+        let cfg = gate_cfg(true, true, &["/tmp/work"], &["/tmp/work/.git"]);
         assert_eq!(
             check_enterprise_gate(&cfg, SandboxType::WindowsRestrictedToken, true),
             EnterpriseGateOutcome::AllowWithUserspaceSoftMode {
@@ -704,7 +741,7 @@ mod tests {
 
     #[test]
     fn req_enterprise_gate_linux_denies_carveouts_without_soft_flag() {
-        let cfg = gate_cfg(true, false, &["/tmp/work"]);
+        let cfg = gate_cfg(true, false, &["/tmp/work"], &["/tmp/work/.git"]);
         assert_eq!(
             check_enterprise_gate(&cfg, SandboxType::LinuxSeccomp, true),
             EnterpriseGateOutcome::DenyNoReadOnlySubpathsKernelEnforcement,
@@ -713,7 +750,7 @@ mod tests {
 
     #[test]
     fn req_enterprise_gate_linux_softmode_allows_with_reason() {
-        let cfg = gate_cfg(true, true, &["/tmp/work"]);
+        let cfg = gate_cfg(true, true, &["/tmp/work"], &["/tmp/work/.git"]);
         assert_eq!(
             check_enterprise_gate(&cfg, SandboxType::LinuxSeccomp, true),
             EnterpriseGateOutcome::AllowWithUserspaceSoftMode {
@@ -723,21 +760,42 @@ mod tests {
     }
 
     #[test]
-    fn req_enterprise_gate_no_writable_roots_allows_everywhere() {
-        // Without WorkspaceWrite carve-outs, the gate should not block on
-        // missing `read_only_subpaths` enforcement.
+    fn req_enterprise_gate_no_read_only_subpaths_allows_everywhere() {
+        // ADR-141 §3 PR-W3 / OQ-W3-3 (sign-off 2026-05-11): without any
+        // `read_only_subpaths` carve-outs, the gate must not block on
+        // missing kernel-layer hole enforcement — the base sandbox kind
+        // already covers the request. This holds even when WorkspaceWrite
+        // grants writable roots (the common non-enterprise hole-free case).
         for &sb in &[
             SandboxType::MacosSeatbelt,
             SandboxType::LinuxSeccomp,
             SandboxType::WindowsRestrictedToken,
         ] {
-            let cfg = gate_cfg(true, false, &[]);
+            let cfg = gate_cfg(true, false, &["/tmp/work"], &[]);
             assert_eq!(
                 check_enterprise_gate(&cfg, sb, true),
                 EnterpriseGateOutcome::Allow,
-                "no writable_roots ⇒ no carve-outs ⇒ Allow on {sb:?}",
+                "no read_only_subpaths ⇒ no carve-outs ⇒ Allow on {sb:?}",
             );
         }
+    }
+
+    #[test]
+    fn req_enterprise_gate_signal_is_subpaths_not_writable_roots() {
+        // OQ-W3-3 regression test: previously the gate short-circuited on
+        // `writable_roots.is_empty()`, which misclassified the common
+        // WorkspaceWrite hole-free case as "needs kernel enforcement".
+        // After the OQ-W3-3 fix, the signal is `read_only_subpaths.is_empty()`.
+        let cfg_holes_no_roots = gate_cfg(true, false, &[], &["/tmp/work/.git"]);
+        assert_eq!(
+            check_enterprise_gate(
+                &cfg_holes_no_roots,
+                SandboxType::WindowsRestrictedToken,
+                true
+            ),
+            EnterpriseGateOutcome::DenyNoReadOnlySubpathsKernelEnforcement,
+            "holes without writable_roots still demand kernel enforcement",
+        );
     }
 
     #[test]

--- a/crates/dasclaw_sandbox/src/macos/policy_bridge.rs
+++ b/crates/dasclaw_sandbox/src/macos/policy_bridge.rs
@@ -95,6 +95,7 @@ mod tests {
         let backend = SandboxBackendConfig {
             readable_roots: vec![PathBuf::from("/")],
             writable_roots: vec![],
+            read_only_subpaths: vec![],
             allow_network: false,
             allow_spawn: true,
             proxy_loopback_ports: vec![],
@@ -117,6 +118,7 @@ mod tests {
         let backend = SandboxBackendConfig {
             readable_roots: vec![PathBuf::from("/")],
             writable_roots: vec![PathBuf::from("/tmp/work")],
+            read_only_subpaths: vec![],
             allow_network: true,
             allow_spawn: true,
             proxy_loopback_ports: vec![],
@@ -147,6 +149,7 @@ mod tests {
         let backend = SandboxBackendConfig {
             readable_roots: vec![PathBuf::from("/")],
             writable_roots: vec![PathBuf::from("relative/path")],
+            read_only_subpaths: vec![],
             allow_network: false,
             allow_spawn: true,
             proxy_loopback_ports: vec![],

--- a/crates/dasclaw_sandbox/src/windows/mod.rs
+++ b/crates/dasclaw_sandbox/src/windows/mod.rs
@@ -158,6 +158,13 @@ impl Sandbox for WindowsRestrictedTokenSandbox {
             outer_limits,
             // use_private_desktop=false：维持 first-use UX 简单；Phase 1.3 / hardening 时再切换。
             use_private_desktop: false,
+            // ADR-141 §3 PR-W3 / OQ-W3-2 (sign-off 2026-05-11)：把
+            // `SandboxBackendConfig::read_only_subpaths` 透传给 launcher，
+            // launcher 改调 upstream
+            // `run_windows_sandbox_capture_with_extra_deny_write_paths`
+            // 来下发 Win32 DACL DENY ACE（kernel-enforced read-only holes
+            // inside writable workspaces）。空 Vec 时维持 Slice B1 行为。
+            additional_deny_write_paths: req.policy.read_only_subpaths.clone(),
         };
 
         launcher_client::spawn_and_capture(request)

--- a/crates/dasclaw_sandbox/tests/req_kernel_enforces_read_only_subpaths_macos.rs
+++ b/crates/dasclaw_sandbox/tests/req_kernel_enforces_read_only_subpaths_macos.rs
@@ -42,6 +42,7 @@ fn req_dasclaw_sandbox_kernel_blocks_git_hooks_under_workspace_write_macos() {
     let policy = SandboxBackendConfig {
         readable_roots: vec![PathBuf::from("/")],
         writable_roots: vec![workspace_root.clone()],
+        read_only_subpaths: vec![],
         allow_network: false,
         allow_spawn: true,
         proxy_loopback_ports: vec![],
@@ -101,6 +102,7 @@ fn req_dasclaw_sandbox_kernel_allows_write_to_non_hole_path_macos() {
     let policy = SandboxBackendConfig {
         readable_roots: vec![PathBuf::from("/")],
         writable_roots: vec![workspace_root.clone()],
+        read_only_subpaths: vec![],
         allow_network: false,
         allow_spawn: true,
         proxy_loopback_ports: vec![],

--- a/docs/plans/architecture-refactor/adr-141-windows-enterprise-sandbox-support.md
+++ b/docs/plans/architecture-refactor/adr-141-windows-enterprise-sandbox-support.md
@@ -88,12 +88,17 @@ Adopt **2A**. Concretely, sequence as five small PRs, each gated behind its own 
 - In `dasclaw_exec` Windows branch: when carve-outs are present and the codex `sandboxing` crate has not yet been ported, return the new variant unless the soft flag is set; log a structured audit event when the flag is honoured.
 - Contract test: both fail-closed and soft-flag paths.
 
-### PR-W3 — Wire `dasclaw_sandbox_windows::setup_main` / `command_runner` into the `dasclaw_exec` spawn path (effort: M, risk: med)
+### PR-W3 — Wire `read_only_subpaths` carve-outs through launcher IPC to Win32 DACL DENY (effort: M, risk: med) ✅ **landed 2026-05-11+**
 
-- Depends on `#241` unblocking and on ADR-129 §1.3 verbatim red line — wiring lives in **xClaw-only** glue code outside the verbatim crate.
-- Out of scope for this ADR; tracked under `#241`.
+- xClaw-only glue (no `crates/dasclaw_sandbox_windows/` changes — ADR-129 §1.3 red line intact).
+- Adds `SandboxBackendConfig::read_only_subpaths: Vec<PathBuf>` and flattens it from `WritableRoot::read_only_subpaths` inside `dasclaw_exec::policy_to_backend_config_with_env`.
+- Extends `LauncherRequest` (cross-platform wire struct, JSON IPC) with `additional_deny_write_paths: Vec<PathBuf>` carrying `#[serde(default, skip_serializing_if = "Vec::is_empty")]` for forward/backward compatibility with older launchers.
+- `dasclaw-sandbox-resource-launcher` (Slice B3 binary) switches its single call site from upstream `run_windows_sandbox_capture` → `run_windows_sandbox_capture_with_extra_deny_write_paths` (already-published public symbol in `dasclaw_sandbox_windows`'s verbatim port; no upstream modification needed).
+- Corrects ADR-141 §3 PR-W1+W2 fail-closed gate signal from `writable_roots.is_empty()` → `read_only_subpaths.is_empty()` (OQ-W3-3): a `WorkspaceWrite` policy *always* has writable roots, so the original approximation misclassified the hole-free case as "needs kernel enforcement". Empty-holes WorkspaceWrite now correctly returns `Allow`.
+- Out of scope: `#241` Phase 4 UAC docs; `setup_main` / `command_runner` reuse (those live in PR-W4 / Wave-C1c with Landlock).
+- Contract tests: launcher_ipc round-trip including deny paths, legacy JSON forward-compat, `policy_to_backend_config` flatten, gate signal regression.
 
-### PR-W4 — Port codex `sandboxing` crate per ADR-135 Wave-B PR-B1 (effort: XL, risk: high)
+### PR-W4 — Port codex `sandboxing` crate per ADR-135 Wave-B PR-B1 + Linux Landlock (effort: XL, risk: high)
 
 - Provides kernel-layer `additional_deny_write_paths` / Windows ACL DENY entries for `read_only_subpaths`.
 - Out of scope for this ADR; tracked under `#324` sub-task 2.
@@ -141,9 +146,17 @@ No `cargo check` / `clippy` / `nextest` runs — no code changes.
 3. **OQ-3 — Windows audit-event channel** ✅ **Re-use existing `dasclaw_observability` event taxonomy**. Avoids triggering an ADR-138 schema evolution; the soft-mode reason string is sufficient context inside an existing `sandbox.degraded` / equivalent envelope. New event types may be added in a follow-up ADR if forensic dashboards need them.
 4. **OQ-4 — Telemetry for "Windows enterprise mode activated without OS sandbox"** ✅ **Structured event (per-spawn)**. Forensic value of per-invocation context (user / cwd / command) outweighs the storage cost; metric-only would lose the audit trail required by enterprise customers.
 
+### PR-W3 follow-up open questions — RESOLVED (2026-05-11+ sign-off)
+
+5. **OQ-W3-1 — Carrier for `read_only_subpaths` on the cross-crate boundary** ✅ **A: add `read_only_subpaths: Vec<PathBuf>` to `SandboxBackendConfig`**. Keeps the field next to `writable_roots` (its semantic peer) and matches the codex upstream pattern of pairing `writable_roots` + `additional_deny_write_paths` on the same call site. Alternative B (recompute from upstream `SandboxPolicy` inside the Windows backend) was rejected: forces the adapter to re-derive holes already computed by `policy_to_backend_config_with_env`, increasing drift surface.
+6. **OQ-W3-2 — Call site for upstream Win32 DACL DENY** ✅ **A: re-use the already-public `run_windows_sandbox_capture_with_extra_deny_write_paths`** (`dasclaw_sandbox_windows::lib.rs:455`). The upstream API takes `additional_deny_write_paths: &[PathBuf]` as its 8th argument; we wire the new `LauncherRequest.additional_deny_write_paths` field straight through. ADR-129 §1.3 verbatim red line preserved: no edits to `crates/dasclaw_sandbox_windows/`. Alternative B (call private `identity::deny_write_paths_override`) was rejected for breaching the verbatim contract.
+7. **OQ-W3-3 — Gate signal correction** ✅ **A: change `check_enterprise_gate` Step 2 from `writable_roots.is_empty()` to `read_only_subpaths.is_empty()`**. The PR-W1+W2 approximation misclassified the common case "WorkspaceWrite policy with no holes" as "needs kernel enforcement" (since WorkspaceWrite *always* has writable_roots). The corrected signal makes hole-free spawns short-circuit to `Allow` while preserving the deny path for any spawn that actually demands DACL DENY.
+8. **OQ-W3-4 — macOS / Linux semantics of the new field** ✅ **B: Windows-only consumer; macOS / Linux ignore it for this PR**. macOS sbpl carve-outs are already wired by ADR-135 PR-C1 inside `dasclaw_sandboxing::seatbelt` (verified via `req_kernel_enforces_read_only_subpaths_macos.rs`); Linux Landlock support is PR-W4 / Wave-C1c. Documented per-backend semantics on the field's doc comment so future ports know the contract.
+
 ---
 
 ## 7. Decision log
 
 - 2026-05-09 — Draft created from `#91` scope; recommends 2A (fail-closed default + opt-in soft flag) over 2B (full unsupported) and 2C (silent status quo). Awaits nally sign-off.
 - 2026-05-11 — **nally signed off (Wave-C1b authorization)**. All four OQ resolved per §6; option 2A accepted. PR-W1 + PR-W2 merged into one implementation slice (the fail-closed gate; no kernel ACL DENY work yet — that stays under PR-W3/W4). The gate adds two new `SandboxError` variants, two new `SandboxBackendConfig` fields (`enterprise_mode`, `enterprise_allow_userspace_carveouts`), and a cross-platform pure decision function `check_enterprise_gate` so the same matrix is testable on macOS/Linux CI hosts even though the Windows backend is the only enforcement site today.
+- 2026-05-11+ — **nally signed off (PR-W3 authorization)**. All four PR-W3 follow-up OQ resolved per §6 (A / A / A / B). Wiring layer landed: `SandboxBackendConfig.read_only_subpaths` field, `LauncherRequest.additional_deny_write_paths` field with backwards-compatible serde, `dasclaw_exec::policy_to_backend_config_with_env` flatten, `dasclaw-sandbox-resource-launcher` switched to upstream `run_windows_sandbox_capture_with_extra_deny_write_paths`, gate signal corrected. ADR-129 §1.3 verbatim red line preserved (zero edits to `crates/dasclaw_sandbox_windows/`). PR-W4 (codex `sandboxing` crate port + Linux Landlock) remains the next blocker.


### PR DESCRIPTION
Closes #425

## 背景 / 目标

ADR-141 §3 PR-W3：把 `WritableRoot::read_only_subpaths`（即 `.git/` / `.codex/` / `.dasclaw/` 等洞中洞）端到端 wire 到 Windows kernel-enforced Win32 DACL DENY，关闭 PR-W1+W2（#424）fail-closed gate 标记的 `ReadOnlySubpathsKernelEnforcementMissing` 缺口。

ADR-129 §1.3 verbatim 红线全程保持：`crates/dasclaw_sandbox_windows/` 零修改，PR 全部 wiring 走 xClaw-only 胶水层；上游 `run_windows_sandbox_capture_with_extra_deny_write_paths`（lib.rs:455 已 public）直接复用。

## 改动范围

| 文件 | 改动 |
|---|---|
| `crates/dasclaw_sandbox/src/lib.rs` | 加 `SandboxBackendConfig.read_only_subpaths` 字段；修正 `check_enterprise_gate` Step 2 信号（OQ-W3-3）；测试 helper 扩 4-arg；rename + 1 新增矩阵测试 |
| `crates/dasclaw_sandbox/src/launcher_ipc.rs` | 加 `LauncherRequest.additional_deny_write_paths`（serde default + skip_if_empty 双向兼容）；3 个新 round-trip 测试（含 legacy JSON forward-compat） |
| `crates/dasclaw_sandbox/src/bin/resource_launcher_win.rs` | 切换上游 API：`run_windows_sandbox_capture` → `run_windows_sandbox_capture_with_extra_deny_write_paths` |
| `crates/dasclaw_sandbox/src/windows/mod.rs` | adapter execute() 把 `req.policy.read_only_subpaths.clone()` 注入 LauncherRequest |
| `crates/dasclaw_sandbox/src/macos/policy_bridge.rs` | 3 处 SandboxBackendConfig literal 补字段（macOS 不消费） |
| `crates/dasclaw_sandbox/tests/req_kernel_enforces_read_only_subpaths_macos.rs` | 2 处 literal 补字段 |
| `crates/dasclaw_exec/src/lib.rs` | `policy_to_backend_config_with_env` 4 个 arm 补字段；WorkspaceWrite arm flatten `roots[].read_only_subpaths`；2 个新 contract 测试 |
| `docs/plans/architecture-refactor/adr-141-windows-enterprise-sandbox-support.md` | §3 PR-W3 由 "Out of scope" 改为 landed；§6 加 OQ-W3-1~4 RESOLVED；§7 加 2026-05-11+ 决策日志 |

## 非目标 (What's NOT in this PR)

- ❌ Linux Landlock — PR-W4 / Wave-C1c
- ❌ macOS sbpl 变更 — 已由 ADR-135 PR-C1 在 `dasclaw_sandboxing::seatbelt` 处理；本 PR 只为字段补占位
- ❌ `#241` Phase 4 UAC docs — 独立 issue
- ❌ `crates/dasclaw_sandbox_windows/` 任何修改（ADR-129 §1.3 红线）
- ❌ codex `sandboxing` crate full port — PR-W4

## 验证

```bash
cargo check -p dasclaw_sandbox --tests          # ✅
cargo check -p dasclaw_exec --tests             # ✅
cargo nextest run -p dasclaw_sandbox -p dasclaw_exec  # ✅ 81 passed (含 4 new tests)
cargo fmt --all                                 # ✅
python3.12 scripts/check_no_panics.py --base origin/xClaw          # ✅ OK
python3   scripts/check_no_new_ironclaw_literal.py --base origin/xClaw  # ✅ OK
cargo clippy --no-deps -p dasclaw_sandbox -p dasclaw_exec --all-targets -- -D warnings  # ✅
```

新增 / 重命名的 req_* 测试：

- `req_enterprise_gate_no_read_only_subpaths_allows_everywhere`（重命名 + 重写断言）
- `req_enterprise_gate_signal_is_subpaths_not_writable_roots`（OQ-W3-3 回归保护）
- `req_policy_to_backend_config_flattens_read_only_subpaths`（dasclaw_exec flatten 契约）
- `req_read_only_policies_have_empty_read_only_subpaths`（非 WorkspaceWrite 不产生洞）
- `request_with_additional_deny_write_paths_round_trips` / `request_omits_additional_deny_write_paths_when_empty` / `request_legacy_json_without_deny_paths_field_deserializes`（launcher IPC wire 兼容性）

## Sources read

- `AGENTS.md` § Skills 强制使用规范, § 三层验证, § 测试纪律
- `docs/plans/architecture-refactor/adr-141-windows-enterprise-sandbox-support.md` § 3 PR-W3 / § 6 OQ-W3 / § 7
- `docs/plans/architecture-refactor/adr-129-windows-sandbox-port.md` § 1.3（verbatim 红线）
- `docs/plans/architecture-refactor/adr-131-windows-job-object-resource-limits-wrapper.md` § launcher IPC 协议
- `crates/dasclaw_sandbox_windows/src/lib.rs:333,335,455`（上游 `_with_extra_deny_write_paths` 签名）
- `crates/ironclaw_workspace_cap/src/policy.rs:116-232`（WritableRoot 与 default_read_only_subpaths_for_writable_root）

## Skills 自审摘要

**adr-compliance-check**：
- ADR-129 §1.3：✅ `git diff --stat origin/xClaw...HEAD -- crates/dasclaw_sandbox_windows/` 空（红线无破）
- ADR-141 §3 PR-W3：✅ 本 PR 范围 = ADR 列出的 wiring 工作，无超额
- ADR-131：✅ LauncherRequest 扩展走 `#[serde(default, skip_serializing_if)]`，兼容旧 launcher

**code-quality-audit**：
- 无新 `unwrap()` / `expect()` / `panic!()` 在生产代码（panic gate 已过）
- 无新 `.ironclaw` literal（literal gate 已过）
- 无 patch-style：所有改动是结构性新增字段 + 信号修正 + 端到端 wire，不是在已有函数追加 `if` 分支
- 命名遵循 req_<module>_<id>_<desc>

**code-review-expert**：
- 失败路径覆盖：launcher IPC legacy JSON forward-compat 测试 + gate signal 回归测试
- Fail-Safe：默认值 `vec![]` → 等价于 PR-W3 前行为；只有显式配置 holes 才触发新代码路径
- 跨平台一致性：read_only_subpaths 字段语义在字段 doc 上明确声明（Windows 消费 / macOS 已由 PR-C1 处理 / Linux 待 PR-W4）
