### PR TITLE
docs(dasclaw_exec): mark Windows WritableRoot as kernel-enforced (PR #426 follow-up)

### DIFF
--- a/crates/dasclaw_exec/src/lib.rs
+++ b/crates/dasclaw_exec/src/lib.rs
@@ -13,8 +13,11 @@
 //!   sbpl 中表达，sandbox-exec 内核层强制 `.git/`、`.dasclaw/`、`.codex/` 等
 //!   敏感子路径仅读不可写；`is_path_writable` 用户态决策仍然作为第一道关，
 //!   [`ironclaw_workspace_cap::WorkspaceCap`] 的 cap-std 文件接口在策略层做
-//!   二次拒绝。Linux landlock 洞中洞 deferred to Wave-C3（需要 `dasclaw-linux-sandbox`
-//!   binary 落地），Windows ACL DENY 由 ADR-141 enterprise PR 提供。
+//!   二次拒绝。Windows 上自 ADR-141 §3 PR-W3（Wave-C1b，PR #426）起由
+//!   `dasclaw_sandbox_windows::run_windows_sandbox_capture_with_extra_deny_write_paths`
+//!   把 `read_only_subpaths` 翻译为 Win32 DACL DENY entries，Windows 沙箱内核层
+//!   强制相同语义。Linux landlock 洞中洞 deferred to Wave-C1c（需要
+//!   `dasclaw-linux-sandbox` binary 落地）。
 //! - **PTY 终端**：走 [`dasclaw_pty`] 独立路径，不在 `ProcessExecutor` 范围；
 //!   终端会话的 sandbox 包裹由调用方在 `spawn` 时显式组合。
 //!
@@ -191,13 +194,13 @@ impl ProcessExecutor for SandboxedExecutor {
 /// | 平台 | 内核层（kernel-enforced） | 用户态兜底 |
 /// |------|---------------------------|-----------|
 /// | macOS | ✅ 通过 `dasclaw_sandboxing::seatbelt` 在 sbpl 中表达 `(deny file-write* (subpath ".git/.codex/.dasclaw"))`（ADR-135 §3 PR-C1 / Wave-C1a） | [`ironclaw_workspace_cap`] cap-std + `is_path_writable` 第一道关 |
+/// | Windows | ✅ 通过 `dasclaw_sandbox_windows::run_windows_sandbox_capture_with_extra_deny_write_paths` 把 `read_only_subpaths` 翻译为 Win32 DACL DENY entries（ADR-141 §3 PR-W3 / Wave-C1b，PR #426） | 同上 |
 /// | Linux | ❌ deferred to Wave-C1c（需 `dasclaw-linux-sandbox` setuid binary 落地，对齐 codex landlock V5 + bwrap 路径） | 同上 |
-/// | Windows | ❌ deferred to Wave-C1b / ADR-141（需在 `dasclaw_sandbox/src/windows/mod.rs` 调 `dasclaw_sandbox_windows::acl` 把 `read_only_subpaths` 转 DACL DENY entries） | 同上 |
 ///
-/// Linux / Windows 上洞中洞当前仅靠 `is_path_writable` 用户态决策 +
+/// Linux 上洞中洞当前仅靠 `is_path_writable` 用户态决策 +
 /// [`ironclaw_workspace_cap::WorkspaceCap`] cap-std 文件接口拦截；子进程通过
-/// 直接 syscall 写 `.git/hooks/` 在 Linux / Windows 上**目前不会被内核拒绝**。
-/// 进度追踪：[issue #380](https://github.com/Linnanli/xClaw/issues/380) Wave-C1b / C1c。
+/// 直接 syscall 写 `.git/hooks/` 在 Linux 上**目前不会被内核拒绝**。
+/// 进度追踪：[issue #380](https://github.com/Linnanli/xClaw/issues/380) Wave-C1c。
 pub fn policy_to_backend_config(policy: &SandboxPolicy, cwd: &Path) -> SandboxBackendConfig {
     policy_to_backend_config_with_env(policy, cwd, &std::env::vars().collect())
 }


### PR DESCRIPTION
Closes #427

## 背景 / 目标

PR #426（ADR-141 PR-W3 / Wave-C1b）已把 `read_only_subpaths` 端到端接到
Windows kernel DACL DENY（通过 `run_windows_sandbox_capture_with_extra_deny_write_paths`）。
但 `crates/dasclaw_exec/src/lib.rs` 顶部模块 doc 与 `policy_to_backend_config`
函数 doc 中的"平台分层强制表"还停留在 PR #426 之前的语义，写着：

- `Windows ACL DENY 由 ADR-141 enterprise PR 提供`（未来式）
- `Windows | ❌ deferred to Wave-C1b / ADR-141`
- `Linux / Windows 上洞中洞当前仅靠 is_path_writable 用户态决策`

本 PR 把这三处 doc 同步到现实：Windows 行从 ❌ deferred 改为 ✅ kernel-enforced，
明确指向 `dasclaw_sandbox_windows::run_windows_sandbox_capture_with_extra_deny_write_paths`
与 ADR-141 §3 PR-W3 / PR #426。Linux 行保持 ❌ deferred to Wave-C1c。

## 改动范围

- `crates/dasclaw_exec/src/lib.rs`：模块级 doc 段落（L11-L20）+ `policy_to_backend_config`
  doc 表格（L194-L204）双处同步更新。`+9 / -6`，纯 doc，无代码逻辑改动。

## What's NOT in this PR

- 不做 Wave-C1c (Linux setuid binary)
- 不做 Wave-C2 (macOS 残余下沉)
- 不修任何函数实现
- 不动其它 crate

## 验证

```bash
cargo check -p dasclaw_exec --tests        # ✅ Finished in 6.48s
cargo nextest run -p dasclaw_exec          # ✅ 22 tests passed
cargo fmt --all                            # ✅ no diff
python3.12 scripts/check_no_panics.py --base origin/xClaw                  # ✅ OK
python3.12 scripts/check_no_new_ironclaw_literal.py --base origin/xClaw    # ✅ OK
cargo clippy --no-deps -p dasclaw_exec --all-targets -- -D warnings        # ✅ Finished in 14.31s
```

6 步本地管线全部 ✅。

## Sources read

- [crates/dasclaw_exec/src/lib.rs](crates/dasclaw_exec/src/lib.rs#L1-L20) §模块级 doc 设计边界（确认 PR #426 前 Windows 写法）
- [crates/dasclaw_exec/src/lib.rs](crates/dasclaw_exec/src/lib.rs#L180-L204) §`policy_to_backend_config` doc（确认平台分层表格）
- PR #426 (merged) — ADR-141 PR-W3 Windows kernel ACL wiring，commit `2d010797`
- Epic #380 ROADMAP REVISED 2026-05-15 — Wave-C1b 状态描述
- ADR-141 §3 PR-W3 / §7 decision log 2026-05-11+
- AGENTS.md — Sources read 自检规约

## Code review

doc-only / +9 -6 / 单文件，无需走完整 skills pipeline。
人眼复核：表格 Windows 行 ✅ 与 macOS 行结构一致；兜底句把 "Linux / Windows" 改为 "Linux"
正确反映现状；进度追踪链接从 "Wave-C1b / C1c" 改为 "Wave-C1c"（C1b 已完成）。
