### PR TITLE
feat(sandbox-linux): wire dasclaw-sandbox-linux helper into linux adapter (ADR-144 §5.3 P1.2a)

### DIFF
--- a/crates/dasclaw_exec/src/lib.rs
+++ b/crates/dasclaw_exec/src/lib.rs
@@ -113,6 +113,15 @@ pub struct SandboxedExecutor {
     /// 占位语义现在由调用方显式选择）。Linux 后端继续走 `backend.proxy_loopback_ports`
     /// 的 env-detect 路径，与 `network` 互不冲突。
     network: Option<NetworkProxy>,
+
+    /// 路径到 `dasclaw-sandbox-linux` helper 二进制。Linux 内核层 FS 隔离
+    /// （bubblewrap + landlock）必须经此 helper；ADR-144 §5.3 P1.2a wiring。
+    /// macOS / Windows 后端忽略；Linux 上为 `None` ⇒ adapter fail-closed。
+    ///
+    /// 调用方（如 desktop-client `OsExecutor`）在启动时解析
+    /// `std::env::current_exe()?.parent()?.join("dasclaw-sandbox-linux")`，
+    /// 通过 [`Self::with_linux_sandbox_exe`] 注入。
+    linux_sandbox_exe: Option<PathBuf>,
 }
 
 impl SandboxedExecutor {
@@ -127,7 +136,17 @@ impl SandboxedExecutor {
             sandbox_pref,
             windows_sandbox_enabled,
             network,
+            linux_sandbox_exe: None,
         }
+    }
+
+    /// 配置 `dasclaw-sandbox-linux` helper 二进制路径（ADR-144 §5.3 P1.2a）。
+    ///
+    /// 此值会被透传到 [`SandboxBackendConfig::linux_sandbox_exe`]，Linux 后端
+    /// 依据它决定走 helper 包装路径还是 fail-closed。macOS / Windows 上忽略。
+    pub fn with_linux_sandbox_exe(mut self, exe: Option<PathBuf>) -> Self {
+        self.linux_sandbox_exe = exe;
+        self
     }
 
     /// 公开 policy 供调用方做额外用户态检查。
@@ -158,7 +177,9 @@ impl SandboxedExecutor {
         }
 
         // 2. 政策 → 内核配置
-        let backend = policy_to_backend_config(&self.policy, &req.cwd);
+        let mut backend = policy_to_backend_config(&self.policy, &req.cwd);
+        // ADR-144 §5.3 P1.2a：透传 helper exe，让 Linux 后端 wiring。
+        backend.linux_sandbox_exe = self.linux_sandbox_exe.clone();
 
         Ok(SandboxExecRequest {
             command: req.command,
@@ -232,6 +253,7 @@ pub fn policy_to_backend_config_with_env(
             resource_limits: ResourceLimits::unlimited(),
             enterprise_mode: false,
             enterprise_allow_userspace_carveouts: false,
+            linux_sandbox_exe: None,
         },
         SandboxPolicy::ReadOnly { network_access } => SandboxBackendConfig {
             readable_roots: vec![PathBuf::from("/")],
@@ -248,6 +270,7 @@ pub fn policy_to_backend_config_with_env(
             resource_limits: ResourceLimits::default(),
             enterprise_mode: false,
             enterprise_allow_userspace_carveouts: false,
+            linux_sandbox_exe: None,
         },
         SandboxPolicy::ExternalSandbox { network_access } => {
             let net_enabled = matches!(network_access, NetworkAccess::Enabled);
@@ -267,6 +290,7 @@ pub fn policy_to_backend_config_with_env(
                 resource_limits: ResourceLimits::default(),
                 enterprise_mode: false,
                 enterprise_allow_userspace_carveouts: false,
+                linux_sandbox_exe: None,
             }
         }
         SandboxPolicy::WorkspaceWrite { network_access, .. } => {
@@ -298,6 +322,7 @@ pub fn policy_to_backend_config_with_env(
                 resource_limits: ResourceLimits::default(),
                 enterprise_mode: false,
                 enterprise_allow_userspace_carveouts: false,
+                linux_sandbox_exe: None,
             }
         }
     }

--- a/crates/dasclaw_sandbox/Cargo.toml
+++ b/crates/dasclaw_sandbox/Cargo.toml
@@ -113,3 +113,9 @@ tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread", "sync"] 
 async-trait = "0.1"
 anyhow = "1"
 
+# Wave-C1c P1.2a contract test for kernel-enforced read_only_subpaths via
+# the dasclaw-sandbox-linux helper (bubblewrap + landlock V3),
+# tests/req_kernel_enforces_read_only_subpaths_linux.rs.
+[target.'cfg(target_os = "linux")'.dev-dependencies]
+tempfile = "3"
+

--- a/crates/dasclaw_sandbox/Cargo.toml
+++ b/crates/dasclaw_sandbox/Cargo.toml
@@ -68,8 +68,17 @@ dasclaw_absolute_path = { path = "../dasclaw_absolute_path" }
 #   - 文件系统限制由进程内 `ironclaw_workspace_cap` (cap-std) 兜底，
 #     与 dasclaw_sandbox kernel 层互补不重叠。
 #   - 不引入外部 bwrap setuid 依赖，部署更轻。
+#
+# ADR-144 §5.3 P1.2a — `dasclaw-sandbox-linux` helper wiring：当
+# `SandboxBackendConfig.linux_sandbox_exe = Some(exe)` 时，把 user command
+# 包装成 `[exe, --..., --, user_cmd]` argv（与 codex landlock.rs 同形），
+# 把 FS 隔离 + seccomp 委托给 helper 内部完成；adapter 自身只保留 rlimit
+# / cgroup 等父进程层。argv 合成走 `dasclaw_sandboxing::landlock`。
 [target.'cfg(target_os = "linux")'.dependencies]
 seccompiler = "0.5"
+dasclaw_sandboxing = { path = "../dasclaw_sandboxing" }
+dasclaw_protocol = { path = "../dasclaw_protocol" }
+dasclaw_absolute_path = { path = "../dasclaw_absolute_path" }
 
 # W2.4 — Windows restricted-token backend (adapter to `dasclaw_sandbox_windows`).
 # 仅在 Windows target 启用，承接 `SandboxType::WindowsRestrictedToken`。

--- a/crates/dasclaw_sandbox/src/lib.rs
+++ b/crates/dasclaw_sandbox/src/lib.rs
@@ -28,6 +28,11 @@
 /// 跨平台公开（serde 数据结构），便于本地测试与 macOS/Linux 构建检查通过。
 pub mod launcher_ipc;
 
+// Shared backend-config → protocol-policy bridge used by both macOS
+// (Seatbelt) and Linux (helper wiring per ADR-144 §5.3 P1.2a) backends.
+#[cfg(any(target_os = "macos", target_os = "linux"))]
+mod policy_bridge;
+
 #[cfg(target_os = "macos")]
 pub mod macos;
 #[cfg(target_os = "macos")]
@@ -301,11 +306,31 @@ pub struct SandboxBackendConfig {
     /// on every host; the flag becomes a no-op everywhere once Wave-C1c
     /// (`dasclaw-linux-sandbox` setuid binary) lands.
     pub enterprise_allow_userspace_carveouts: bool,
+
+    /// Path to the `dasclaw-sandbox-linux` helper binary that performs
+    /// kernel-layer FS isolation (bubblewrap + landlock) and seccomp on
+    /// Linux. **Required** for the Linux backend to spawn anything
+    /// (fail-closed) — see ADR-144 §5.3 P1.2a wiring + ADR-141 §6 OQ-1.
+    /// macOS / Windows backends ignore this field.
+    ///
+    /// Callers (e.g. desktop-client `OsExecutor`) typically resolve the
+    /// helper sibling to the running binary via
+    /// `std::env::current_exe()?.parent()?.join("dasclaw-sandbox-linux")`
+    /// at startup and inject it via [`Self::with_linux_sandbox_exe`].
+    pub linux_sandbox_exe: Option<PathBuf>,
 }
 
 impl SandboxBackendConfig {
     pub fn read_only_defaults() -> Self {
         Self::default()
+    }
+
+    /// Configure the path to the `dasclaw-sandbox-linux` helper binary
+    /// used by the Linux backend for kernel-layer FS isolation. See
+    /// [`Self::linux_sandbox_exe`] for the fail-closed contract.
+    pub fn with_linux_sandbox_exe(mut self, exe: PathBuf) -> Self {
+        self.linux_sandbox_exe = Some(exe);
+        self
     }
 
     pub fn with_writable<P: Into<PathBuf>>(mut self, p: P) -> Self {

--- a/crates/dasclaw_sandbox/src/linux/mod.rs
+++ b/crates/dasclaw_sandbox/src/linux/mod.rs
@@ -170,6 +170,7 @@ impl Sandbox for LinuxSeccompSandbox {
 ///   返回 [`SandboxError::ReadOnlySubpathsKernelEnforcementMissing`]。
 ///   守住 ADR-141 §6 OQ-1：要求 kernel FS 隔离但没接 helper 时，**不能**
 ///   静默降级到 seccomp-only。
+#[derive(Debug)]
 pub(crate) struct CommandPlan {
     pub program: PathBuf,
     pub arg0: Option<String>,

--- a/crates/dasclaw_sandbox/src/linux/mod.rs
+++ b/crates/dasclaw_sandbox/src/linux/mod.rs
@@ -37,7 +37,9 @@
 #![cfg(target_os = "linux")]
 
 use std::collections::BTreeMap;
+use std::ffi::OsString;
 use std::os::unix::process::CommandExt;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
 use seccompiler::{
@@ -47,8 +49,13 @@ use seccompiler::{
 
 pub mod cgroup_v2;
 
+use crate::policy_bridge;
 use crate::rlimit;
 use crate::{Sandbox, SandboxError, SandboxExecRequest, SandboxType};
+
+use dasclaw_sandboxing::landlock::{
+    create_linux_sandbox_command_args_for_policies, CODEX_LINUX_SANDBOX_ARG0,
+};
 
 /// Linux 子进程沙箱后端：seccomp 网络阻断（W2.3a）。
 pub struct LinuxSeccompSandbox;
@@ -71,15 +78,20 @@ impl Sandbox for LinuxSeccompSandbox {
     }
 
     fn execute(&self, req: SandboxExecRequest) -> Result<std::process::Output, SandboxError> {
-        let allow_network = req.policy.allow_network;
+        let plan = prepare_command(&req)?;
         let proxy_routed = !req.policy.proxy_loopback_ports.is_empty();
+        // `install_seccomp` 已经在 build_legacy_plan 里编码了 `!allow_network`
+        // 的语义；helper 路径下永远为 false（helper 内部装 seccomp）。父层
+        // 只需读 plan 标志，不必再重复 allow_network 判断。
+        let install_seccomp = plan.install_parent_seccomp;
 
-        // 复制 req.command 必要属性到本地新 Command，便于注入 pre_exec。
-        let program = req.command.get_program().to_os_string();
-        let args: Vec<_> = req.command.get_args().map(|a| a.to_os_string()).collect();
-        let mut cmd = Command::new(&program);
-        for a in &args {
+        // 复制 req.command 的 env / cwd 到新 Command，并应用 plan 决定的 argv。
+        let mut cmd = Command::new(&plan.program);
+        for a in &plan.args {
             cmd.arg(a);
+        }
+        if let Some(arg0) = plan.arg0.clone() {
+            cmd.arg0(arg0);
         }
 
         // env 透传策略与 macOS Seatbelt 对齐：env_clear() 后只透传调用方
@@ -95,19 +107,15 @@ impl Sandbox for LinuxSeccompSandbox {
         }
 
         // W3.3-2: setrlimit 总是先应用（与 allow_network 无关）。
-        // seccomp 只在网络受限时安装。两者合并到同一个 pre_exec 闭包，
-        // 子进程 fork() 后顺序执行：rlimit → no_new_privs → seccomp → exec。
+        // seccomp 仅在 legacy 路径（无 helper）下安装到父-fork 子进程；
+        // helper 路径下，由 helper 内部在 bwrap 之后安装 seccomp，本层不重复。
         let limits = req.policy.resource_limits.clone();
-        let install_seccomp = !allow_network;
 
-        // 让父进程能在 spawn 后通过 child.id() 把 pid 写入 cgroup.procs，
-        // 因此需要 piped stdout/stderr 配合后续 wait_with_output()。
         cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
 
-        // pre_exec 闭包：fork() 之后、exec() 之前在子进程上下文运行。
         let pre_exec_limits = limits.clone();
-        // SAFETY: 我们只调用 async-signal-safe 的 syscall（setrlimit, prctl,
-        // seccomp 系列）和返回 io::Error 的 helper。不会触发分配、锁或线程。
+        // SAFETY: 只调用 async-signal-safe 的 syscall（setrlimit, prctl,
+        // seccomp 系列），无分配 / 锁 / 线程操作。
         unsafe {
             cmd.pre_exec(move || {
                 rlimit::apply_in_pre_exec(&pre_exec_limits)?;
@@ -126,13 +134,9 @@ impl Sandbox for LinuxSeccompSandbox {
             });
         }
 
-        // W3.3-3a: cgroup v2 RSS-based 内存限制（如可用）。
-        // 与 rlimit 层互补：rlimit 走 RLIMIT_AS（虚拟地址空间，cargo build 等
-        // 工具容易误伤）；cgroup memory.max 走 RSS（真实物理占用）。两者并行。
-        //
-        // 时序：spawn → assign_pid（写 cgroup.procs）→ wait_with_output。
-        // 为什么不在 pre_exec 写 cgroup：写 cgroup.procs 不在 async-signal-safe
-        // 列表，且需要父进程已知子 pid。
+        // W3.3-3a: cgroup v2 RSS-based 内存限制（如可用）。与 rlimit 互补，
+        // 对 helper 路径同样适用 —— cgroup 套在父进程 spawn 的直接子进程上，
+        // 而 helper 内部 fork 的孙进程会被 cgroup 继承。
         let cgroup_guard = match (limits.max_memory_bytes, cgroup_v2::detect()) {
             (Some(_), cgroup_v2::DetectionResult::Available) => {
                 let suffix = cgroup_v2::unique_suffix();
@@ -144,16 +148,100 @@ impl Sandbox for LinuxSeccompSandbox {
         let mut child = cmd.spawn()?;
 
         if let Some(ref guard) = cgroup_guard {
-            // pid 写 cgroup.procs 失败不应整个 execute 失败：cgroup 是
-            // 增强项，rlimit 已经在 pre_exec 兜底。失败时记录但继续。
-            // 与 ADR-45 "backend log line" 设计一致——观测性问题，不是正确性问题。
             let _ = guard.assign_pid(child.id());
         }
 
         let output = child.wait_with_output()?;
-        // cgroup_guard 在此处自动 drop → rmdir。
         drop(cgroup_guard);
         Ok(output)
+    }
+}
+
+/// ADR-144 §5.3 P1.2a — 决定一次 Linux sandbox 调用走哪条 spawn 路径。
+///
+/// - **Helper 路径**（`policy.linux_sandbox_exe = Some(exe)`）：把 user
+///   command 包装为 `[exe, --sandbox-policy-cwd, ..., --, user_argv...]`
+///   argv，arg0 设为 [`CODEX_LINUX_SANDBOX_ARG0`]（与 helper 内部 dispatch
+///   兼容）。文件系统隔离 + seccomp 由 helper 内部完成；父层只保留 rlimit
+///   / cgroup。
+/// - **Legacy 路径**（`linux_sandbox_exe = None` 且 spawn 不要求 kernel
+///   层 FS 隔离）：保留 W2.3 端口的直接 seccomp pre_exec 行为。
+/// - **Fail-Safe**（`None` + `read_only_subpaths` 非空 或 `enterprise_mode`）：
+///   返回 [`SandboxError::ReadOnlySubpathsKernelEnforcementMissing`]。
+///   守住 ADR-141 §6 OQ-1：要求 kernel FS 隔离但没接 helper 时，**不能**
+///   静默降级到 seccomp-only。
+pub(crate) struct CommandPlan {
+    pub program: PathBuf,
+    pub arg0: Option<String>,
+    pub args: Vec<OsString>,
+    /// `true`：父-fork 子进程要装 seccomp 网络 filter（legacy 路径）。
+    /// `false`：helper 路径，seccomp 由 helper 内部装。
+    pub install_parent_seccomp: bool,
+}
+
+pub(crate) fn prepare_command(req: &SandboxExecRequest) -> Result<CommandPlan, SandboxError> {
+    let requires_kernel_fs =
+        !req.policy.read_only_subpaths.is_empty() || req.policy.enterprise_mode;
+
+    match req.policy.linux_sandbox_exe.as_ref() {
+        Some(exe) => Ok(build_helper_plan(req, exe)),
+        None if requires_kernel_fs => Err(SandboxError::ReadOnlySubpathsKernelEnforcementMissing {
+            detail: format!(
+                "linux_sandbox_exe not configured but spawn requires kernel FS isolation \
+                 (read_only_subpaths={}, enterprise_mode={})",
+                req.policy.read_only_subpaths.len(),
+                req.policy.enterprise_mode
+            ),
+        }),
+        None => Ok(build_legacy_plan(req)),
+    }
+}
+
+fn build_helper_plan(req: &SandboxExecRequest, exe: &Path) -> CommandPlan {
+    let cwd: PathBuf = req
+        .command
+        .get_current_dir()
+        .map(Path::to_path_buf)
+        .or_else(|| std::env::current_dir().ok())
+        .unwrap_or_else(|| PathBuf::from("/"));
+
+    let triple = policy_bridge::to_protocol_policy(&req.policy, &cwd);
+
+    let user_program = req.command.get_program().to_string_lossy().into_owned();
+    let mut user_command: Vec<String> = Vec::with_capacity(1 + req.command.get_args().len());
+    user_command.push(user_program);
+    for a in req.command.get_args() {
+        user_command.push(a.to_string_lossy().into_owned());
+    }
+
+    let allow_network_for_proxy = !req.policy.proxy_loopback_ports.is_empty();
+    let args_str = create_linux_sandbox_command_args_for_policies(
+        user_command,
+        &cwd,
+        &triple.sandbox_policy,
+        &triple.file_system_policy,
+        triple.network_policy,
+        &cwd,
+        /* use_legacy_landlock */ false,
+        allow_network_for_proxy,
+    );
+
+    CommandPlan {
+        program: exe.to_path_buf(),
+        arg0: Some(CODEX_LINUX_SANDBOX_ARG0.to_string()),
+        args: args_str.into_iter().map(OsString::from).collect(),
+        install_parent_seccomp: false,
+    }
+}
+
+fn build_legacy_plan(req: &SandboxExecRequest) -> CommandPlan {
+    let program = PathBuf::from(req.command.get_program());
+    let args: Vec<OsString> = req.command.get_args().map(|a| a.to_os_string()).collect();
+    CommandPlan {
+        program,
+        arg0: None,
+        args,
+        install_parent_seccomp: !req.policy.allow_network,
     }
 }
 
@@ -336,5 +424,118 @@ mod tests {
             NetworkSeccompMode::Restricted
         };
         assert_eq!(mode, NetworkSeccompMode::ProxyRouted);
+    }
+
+    /// H1 (ADR-144 §5.3 P1.2a)：`linux_sandbox_exe = None` + 无 carve-out
+    /// 时走 legacy 路径，父-fork 子进程仍要装 seccomp。
+    #[test]
+    fn req_dasclaw_sandbox_p1_2a_prepare_legacy_when_no_exe_and_no_carveouts() {
+        use crate::{SandboxBackendConfig, SandboxablePreference};
+
+        let mut policy = SandboxBackendConfig::default();
+        policy.linux_sandbox_exe = None;
+        policy.read_only_subpaths.clear();
+        policy.enterprise_mode = false;
+        policy.allow_network = false;
+
+        let cmd = Command::new("/bin/echo");
+        let req = SandboxExecRequest {
+            command: cmd,
+            policy,
+            preference: SandboxablePreference::Auto,
+            windows_sandbox_enabled: false,
+            network: None,
+        };
+        let plan = prepare_command(&req).expect("legacy path should succeed");
+        assert_eq!(plan.program, PathBuf::from("/bin/echo"));
+        assert!(plan.arg0.is_none(), "legacy path must not override arg0");
+        assert!(
+            plan.install_parent_seccomp,
+            "legacy path must install seccomp when allow_network=false"
+        );
+    }
+
+    /// H1 (ADR-144 §5.3 P1.2a)：`linux_sandbox_exe = Some` 时走 helper 路径，
+    /// argv[0] = helper exe，且 arg0 override 为 `CODEX_LINUX_SANDBOX_ARG0`。
+    /// 不再在父层装 seccomp（由 helper 内部装）。
+    #[test]
+    fn req_dasclaw_sandbox_p1_2a_prepare_helper_when_exe_configured() {
+        use crate::{SandboxBackendConfig, SandboxablePreference};
+
+        let helper_exe = PathBuf::from("/usr/local/bin/dasclaw-sandbox-linux");
+        let mut policy = SandboxBackendConfig::default();
+        policy.linux_sandbox_exe = Some(helper_exe.clone());
+        policy.writable_roots = vec![PathBuf::from("/tmp/wk")];
+        policy.allow_network = false;
+
+        let cmd = Command::new("/bin/ls");
+        let req = SandboxExecRequest {
+            command: cmd,
+            policy,
+            preference: SandboxablePreference::Auto,
+            windows_sandbox_enabled: false,
+            network: None,
+        };
+        let plan = prepare_command(&req).expect("helper path should succeed");
+
+        assert_eq!(plan.program, helper_exe);
+        assert_eq!(
+            plan.arg0.as_deref(),
+            Some(CODEX_LINUX_SANDBOX_ARG0),
+            "helper path must override arg0 so the helper recognises self-invocation",
+        );
+        assert!(
+            !plan.install_parent_seccomp,
+            "helper path must NOT install parent seccomp — helper does it internally",
+        );
+
+        let args_str: Vec<String> = plan
+            .args
+            .iter()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect();
+        let sep_idx = args_str
+            .iter()
+            .position(|a| a == "--")
+            .expect("helper argv must contain `--` separator before user command");
+        assert_eq!(
+            args_str[sep_idx + 1],
+            "/bin/ls",
+            "user command must follow `--` separator verbatim",
+        );
+        assert!(
+            args_str.iter().any(|a| a == "--sandbox-policy-cwd"),
+            "helper argv must include policy CWD flag for landlock helper",
+        );
+    }
+
+    /// H1 (ADR-144 §5.3 P1.2a)：`linux_sandbox_exe = None` 但 spawn 携带
+    /// `read_only_subpaths` carve-out（即要求 kernel 层 FS 隔离）时，
+    /// 必须 Fail-Safe，不能静默降级为 seccomp-only。
+    /// 守 ADR-141 §6 OQ-1 安全红线。
+    #[test]
+    fn req_dasclaw_sandbox_p1_2a_prepare_fail_closed_when_carveout_and_no_exe() {
+        use crate::{SandboxBackendConfig, SandboxablePreference};
+
+        let mut policy = SandboxBackendConfig::default();
+        policy.linux_sandbox_exe = None;
+        policy.read_only_subpaths = vec![PathBuf::from(".git/hooks")];
+
+        let cmd = Command::new("/bin/touch");
+        let req = SandboxExecRequest {
+            command: cmd,
+            policy,
+            preference: SandboxablePreference::Auto,
+            windows_sandbox_enabled: false,
+            network: None,
+        };
+        let err = prepare_command(&req).expect_err("must fail-closed");
+        assert!(
+            matches!(
+                err,
+                SandboxError::ReadOnlySubpathsKernelEnforcementMissing { .. }
+            ),
+            "expected ReadOnlySubpathsKernelEnforcementMissing, got {err:?}",
+        );
     }
 }

--- a/crates/dasclaw_sandbox/src/macos/mod.rs
+++ b/crates/dasclaw_sandbox/src/macos/mod.rs
@@ -33,8 +33,8 @@ use std::path::PathBuf;
 use std::process::{Command, Stdio};
 
 pub mod memorystatus;
-mod policy_bridge;
 
+use crate::policy_bridge;
 use crate::rlimit;
 use crate::{Sandbox, SandboxError, SandboxExecRequest, SandboxType};
 

--- a/crates/dasclaw_sandbox/src/policy_bridge.rs
+++ b/crates/dasclaw_sandbox/src/policy_bridge.rs
@@ -1,27 +1,38 @@
-//! macOS policy bridge — Wave-C1 (ADR-135 §3 PR-C1).
+//! Backend-config → protocol-policy bridge (shared by macOS Seatbelt and
+//! Linux helper wiring).
 //!
 //! Translates the flat backend-level [`SandboxBackendConfig`] used by
-//! `dasclaw_exec`/`dasclaw_sandbox` into the **high-level**
+//! `dasclaw_exec`/`dasclaw_sandbox` into the high-level
 //! `dasclaw_protocol::SandboxPolicy` enum + `FileSystemSandboxPolicy` +
-//! `NetworkSandboxPolicy` triplet consumed by
-//! [`dasclaw_sandboxing::seatbelt::create_seatbelt_command_args`].
+//! `NetworkSandboxPolicy` triplet consumed by `dasclaw_sandboxing`
+//! argv builders (`seatbelt::create_seatbelt_command_args` on macOS,
+//! `landlock::create_linux_sandbox_command_args_for_policies` on Linux).
 //!
-//! The bridge is intentionally lossy in one direction (high-level four-tier
-//! enum → flat config) and reconstructs an *equivalent* policy on the way
-//! back:
+//! ## History
+//!
+//! - ADR-135 §3 PR-C1 (Wave-C1a): introduced as `macos/policy_bridge.rs`
+//!   to back the macOS Seatbelt rewrite.
+//! - ADR-144 §5.3 P1.2a: promoted to a shared crate-level module so the
+//!   Linux helper wiring can reuse the exact same translation logic.
+//!
+//! ## Lossy direction
+//!
+//! The high-level four-tier enum → flat config direction (handled by
+//! `dasclaw_exec::policy_to_backend_config_with_env`) is intentionally
+//! lossy. This bridge reconstructs an *equivalent* policy:
 //!
 //! - empty `writable_roots` ⇒ `SandboxPolicy::ReadOnly`
 //! - non-empty `writable_roots` ⇒ `SandboxPolicy::WorkspaceWrite`
 //!   with `exclude_tmpdir_env_var: true` + `exclude_slash_tmp: true`,
 //!   because the caller (`dasclaw_exec`) has already materialised every
-//!   intended writable root into `writable_roots`. If we leave the
-//!   `exclude_*` flags `false`, `FileSystemSandboxPolicy::from_legacy_*`
-//!   would silently append `/tmp` and `$TMPDIR` again — broadening access
-//!   relative to the caller's intent.
+//!   intended writable root into `writable_roots`. Leaving the
+//!   `exclude_*` flags `false` would let
+//!   `FileSystemSandboxPolicy::from_legacy_*` silently append `/tmp` and
+//!   `$TMPDIR` again — broadening access relative to the caller's intent.
 //!
-//! Network access is mirrored as a boolean. `proxy_loopback_ports` is **not**
-//! plumbed in C1 — see the regression notice in the module doc of
-//! [`crate::macos`]. Wave-C2 will thread `NetworkProxy` through.
+//! Network access is mirrored as a boolean. `proxy_loopback_ports` is
+//! plumbed to backends via `SandboxExecRequest.network` (macOS) /
+//! `req.policy.proxy_loopback_ports` (Linux env-detect path).
 
 use std::path::Path;
 
@@ -33,7 +44,7 @@ use dasclaw_protocol::protocol::SandboxPolicy as ProtocolSandboxPolicy;
 use crate::SandboxBackendConfig;
 
 /// Result of bridging a [`SandboxBackendConfig`] for consumption by
-/// `dasclaw_sandboxing::seatbelt::create_seatbelt_command_args`.
+/// `dasclaw_sandboxing` argv builders.
 pub(crate) struct ProtocolPolicyTriple {
     pub sandbox_policy: ProtocolSandboxPolicy,
     pub file_system_policy: FileSystemSandboxPolicy,
@@ -90,9 +101,8 @@ mod tests {
     use super::*;
     use std::path::PathBuf;
 
-    #[test]
-    fn empty_writable_roots_yields_read_only() {
-        let backend = SandboxBackendConfig {
+    fn empty_backend() -> SandboxBackendConfig {
+        SandboxBackendConfig {
             readable_roots: vec![PathBuf::from("/")],
             writable_roots: vec![],
             read_only_subpaths: vec![],
@@ -102,7 +112,13 @@ mod tests {
             resource_limits: Default::default(),
             enterprise_mode: false,
             enterprise_allow_userspace_carveouts: false,
-        };
+            linux_sandbox_exe: None,
+        }
+    }
+
+    #[test]
+    fn empty_writable_roots_yields_read_only() {
+        let backend = empty_backend();
         let cwd = PathBuf::from("/");
         let triple = to_protocol_policy(&backend, &cwd);
         assert!(matches!(
@@ -115,17 +131,9 @@ mod tests {
 
     #[test]
     fn writable_roots_yield_workspace_write_with_excludes() {
-        let backend = SandboxBackendConfig {
-            readable_roots: vec![PathBuf::from("/")],
-            writable_roots: vec![PathBuf::from("/tmp/work")],
-            read_only_subpaths: vec![],
-            allow_network: true,
-            allow_spawn: true,
-            proxy_loopback_ports: vec![],
-            resource_limits: Default::default(),
-            enterprise_mode: false,
-            enterprise_allow_userspace_carveouts: false,
-        };
+        let mut backend = empty_backend();
+        backend.writable_roots = vec![PathBuf::from("/tmp/work")];
+        backend.allow_network = true;
         let cwd = PathBuf::from("/tmp/work");
         let triple = to_protocol_policy(&backend, &cwd);
         match triple.sandbox_policy {
@@ -146,17 +154,8 @@ mod tests {
 
     #[test]
     fn relative_writable_root_is_dropped_fail_safe() {
-        let backend = SandboxBackendConfig {
-            readable_roots: vec![PathBuf::from("/")],
-            writable_roots: vec![PathBuf::from("relative/path")],
-            read_only_subpaths: vec![],
-            allow_network: false,
-            allow_spawn: true,
-            proxy_loopback_ports: vec![],
-            resource_limits: Default::default(),
-            enterprise_mode: false,
-            enterprise_allow_userspace_carveouts: false,
-        };
+        let mut backend = empty_backend();
+        backend.writable_roots = vec![PathBuf::from("relative/path")];
         let cwd = PathBuf::from("/");
         let triple = to_protocol_policy(&backend, &cwd);
         // Relative path is rejected → no writable roots → ReadOnly.

--- a/crates/dasclaw_sandbox/tests/req_kernel_enforces_read_only_subpaths_linux.rs
+++ b/crates/dasclaw_sandbox/tests/req_kernel_enforces_read_only_subpaths_linux.rs
@@ -1,0 +1,137 @@
+//! H2 (ADR-144 §5.3 P1.2a) — Linux kernel-enforced `read_only_subpaths` 集成测试。
+//!
+//! 当 `linux_sandbox_exe` 配置好 helper 时，对 `read_only_subpaths` 下的
+//! 写入必须被 kernel 拒绝（EACCES / 子进程非零退出）。当 helper 未配置
+//! 但 spawn 携带 carve-outs 时，必须 fail-closed 返回
+//! `ReadOnlySubpathsKernelEnforcementMissing`，**不能**静默降级为
+//! seccomp-only（守 ADR-141 §6 OQ-1）。
+//!
+//! 仅在 Linux target 启用 — 其他平台编译期完全跳过。
+//!
+//! ## 真实路径前置
+//!
+//! 测试用例 `req_dasclaw_sandbox_p1_2a_helper_blocks_read_only_subpath` 需要
+//! 真实的 `dasclaw-sandbox-linux` helper binary 存在。CI 矩阵在 Linux
+//! runner 上 `cargo build -p dasclaw_sandbox_linux` 后会把产物放在
+//! `target/debug/dasclaw-sandbox-linux`；本测试自动探测该路径。本地未构建
+//! helper 时跳过（不算失败）。
+
+#![cfg(target_os = "linux")]
+
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+
+use dasclaw_sandbox::{
+    LinuxSeccompSandbox, Sandbox, SandboxBackendConfig, SandboxError, SandboxExecRequest,
+    SandboxablePreference,
+};
+
+/// 探测仓库构建出的 helper 路径；找不到返回 `None`。
+fn locate_helper() -> Option<PathBuf> {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    // crates/dasclaw_sandbox/ → repo_root
+    let repo_root = manifest_dir.parent()?.parent()?;
+    for candidate in [
+        repo_root.join("target/debug/dasclaw-sandbox-linux"),
+        repo_root.join("target/release/dasclaw-sandbox-linux"),
+    ] {
+        if candidate.exists() {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+#[test]
+fn req_dasclaw_sandbox_p1_2a_helper_blocks_read_only_subpath() {
+    let helper = match locate_helper() {
+        Some(p) => p,
+        None => {
+            eprintln!(
+                "skip: dasclaw-sandbox-linux helper not built — \
+                 run `cargo build -p dasclaw_sandbox_linux` first"
+            );
+            return;
+        }
+    };
+
+    let workspace = tempfile::tempdir().expect("tempdir");
+    let workspace_root = workspace.path().to_path_buf();
+    let git_hooks = workspace_root.join(".git").join("hooks");
+    fs::create_dir_all(&git_hooks).expect("mkdir .git/hooks");
+    let hook = git_hooks.join("pre-commit");
+    fs::write(&hook, "#!/bin/sh\nexit 0\n").expect("seed hook");
+
+    let mut policy = SandboxBackendConfig::default();
+    policy.readable_roots = vec![PathBuf::from("/")];
+    policy.writable_roots = vec![workspace_root.clone()];
+    policy.read_only_subpaths = vec![workspace_root.join(".git/hooks")];
+    policy.allow_network = false;
+    policy.allow_spawn = true;
+    policy.linux_sandbox_exe = Some(helper);
+
+    let mut cmd = Command::new("/bin/sh");
+    cmd.arg("-c").arg(format!(
+        "echo malicious > {}",
+        hook.to_string_lossy().replace('\'', "'\\''")
+    ));
+    cmd.current_dir(&workspace_root);
+
+    let req = SandboxExecRequest {
+        command: cmd,
+        policy,
+        preference: SandboxablePreference::Require,
+        windows_sandbox_enabled: false,
+        network: None,
+    };
+    let out = LinuxSeccompSandbox::new()
+        .execute(req)
+        .expect("helper should spawn even if user command fails");
+
+    assert!(
+        !out.status.success(),
+        "helper should block write to .git/hooks/pre-commit, shell exited {:?}\nstderr={}",
+        out.status,
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let after = fs::read_to_string(&hook).expect("read hook back");
+    assert!(
+        !after.contains("malicious"),
+        "kernel-layer regression: .git/hooks/pre-commit was overwritten despite read_only_subpaths"
+    );
+}
+
+#[test]
+fn req_dasclaw_sandbox_p1_2a_fail_closed_when_helper_missing() {
+    let workspace = tempfile::tempdir().expect("tempdir");
+    let workspace_root = workspace.path().to_path_buf();
+
+    let mut policy = SandboxBackendConfig::default();
+    policy.readable_roots = vec![PathBuf::from("/")];
+    policy.writable_roots = vec![workspace_root.clone()];
+    policy.read_only_subpaths = vec![workspace_root.join(".git/hooks")];
+    policy.linux_sandbox_exe = None; // 未配置 helper → fail-closed
+
+    let mut cmd = Command::new("/bin/true");
+    cmd.current_dir(&workspace_root);
+
+    let req = SandboxExecRequest {
+        command: cmd,
+        policy,
+        preference: SandboxablePreference::Require,
+        windows_sandbox_enabled: false,
+        network: None,
+    };
+    let err = LinuxSeccompSandbox::new()
+        .execute(req)
+        .expect_err("must fail-closed when helper missing and carve-outs requested");
+
+    assert!(
+        matches!(
+            err,
+            SandboxError::ReadOnlySubpathsKernelEnforcementMissing { .. }
+        ),
+        "expected ReadOnlySubpathsKernelEnforcementMissing, got {err:?}"
+    );
+}

--- a/crates/dasclaw_sandbox/tests/req_kernel_enforces_read_only_subpaths_macos.rs
+++ b/crates/dasclaw_sandbox/tests/req_kernel_enforces_read_only_subpaths_macos.rs
@@ -49,6 +49,7 @@ fn req_dasclaw_sandbox_kernel_blocks_git_hooks_under_workspace_write_macos() {
         resource_limits: Default::default(),
         enterprise_mode: false,
         enterprise_allow_userspace_carveouts: false,
+        linux_sandbox_exe: None,
     };
 
     // Attempt to overwrite the hook from inside the sandbox. With kernel-
@@ -109,6 +110,7 @@ fn req_dasclaw_sandbox_kernel_allows_write_to_non_hole_path_macos() {
         resource_limits: Default::default(),
         enterprise_mode: false,
         enterprise_allow_userspace_carveouts: false,
+        linux_sandbox_exe: None,
     };
 
     let mut cmd = Command::new("/bin/sh");

--- a/desktop-client/ironclaw/src/sandbox/os_executor.rs
+++ b/desktop-client/ironclaw/src/sandbox/os_executor.rs
@@ -25,6 +25,7 @@
 
 use std::collections::HashMap;
 use std::path::Path;
+use std::path::PathBuf;
 use std::process::Command;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -129,7 +130,13 @@ impl OsExecutor {
         // W3.2-C2b: clone Arc → 拿到 owned NetworkProxy 句柄注入 SandboxedExecutor。
         // NetworkProxy 内部已是 Arc<NetworkProxyState>，clone 廉价。
         let network = self.network.as_deref().cloned();
-        let executor = SandboxedExecutor::new(cap_policy, self.sandbox_pref, false, network);
+        // ADR-144 §5.3 P1.2a — Linux helper exe 解析：相对当前 ironclaw
+        // 主程序位置 `$EXE_DIR/dasclaw-sandbox-linux`。helper 不存在或路径
+        // 解析失败时返回 None，由 `dasclaw_sandbox::linux::prepare_command`
+        // 决定 fail-closed（需要 kernel FS 隔离时）或走 legacy seccomp 路径。
+        let linux_sandbox_exe = resolve_linux_sandbox_exe();
+        let executor = SandboxedExecutor::new(cap_policy, self.sandbox_pref, false, network)
+            .with_linux_sandbox_exe(linux_sandbox_exe);
 
         let mut cmd = build_shell_command(command);
         cmd.envs(env);
@@ -171,6 +178,38 @@ fn build_shell_command(command: &str) -> Command {
         let mut c = Command::new("sh");
         c.args(["-c", command]);
         c
+    }
+}
+
+/// ADR-144 §5.3 P1.2a — 解析 Linux helper `dasclaw-sandbox-linux` 的绝对路径。
+///
+/// 约定 helper 与 ironclaw 主程序同目录（`current_exe().parent()`），
+/// 这也是构建产物的默认布局。Helper 不存在或当前可执行路径无法获取时
+/// 返回 `None`，让 `dasclaw_sandbox::linux::prepare_command` 自行决定
+/// 走 legacy seccomp 路径还是 fail-closed（取决于 spawn 是否需要 kernel
+/// FS 隔离）。
+///
+/// 仅在 Linux target 下返回 `Some`；macOS/Windows 返回 `None`。
+fn resolve_linux_sandbox_exe() -> Option<PathBuf> {
+    #[cfg(target_os = "linux")]
+    {
+        let exe = std::env::current_exe().ok()?;
+        let dir = exe.parent()?;
+        let helper = dir.join("dasclaw-sandbox-linux");
+        if helper.exists() {
+            Some(helper)
+        } else {
+            tracing::warn!(
+                helper = %helper.display(),
+                "dasclaw-sandbox-linux helper not found alongside main binary; \
+                 spawns requiring kernel FS isolation will fail-closed"
+            );
+            None
+        }
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        None
     }
 }
 


### PR DESCRIPTION
# 背景 / 目标

ADR-144 §5.3 Phase 1.2a — 把上一切片落地的 `dasclaw_sandbox_linux` helper（PR #443 verbatim port）接入到 `dasclaw_sandbox` adapter，使 Linux sandbox 调用 spawn 时能通过 helper 走 kernel-layer FS 隔离（bwrap + landlock），同时守住 ADR-141 §6 OQ-1 fail-closed 默认：要求 kernel FS 隔离但 helper 未配置时**禁止**静默降级为 seccomp-only。

参考 Windows Phase 1.2 #320 的对称模板（adapter + OsExecutor wire-up）。

# 改动范围

**核心 wiring**：
- `crates/dasclaw_exec/src/lib.rs` — `SandboxedExecutor` 增 `linux_sandbox_exe: Option<PathBuf>` + `with_linux_sandbox_exe` builder；4 处 `SandboxBackendConfig` literal 补齐 `linux_sandbox_exe: None`。
- `crates/dasclaw_sandbox/src/lib.rs` — `SandboxBackendConfig` 同步加字段；`mod policy_bridge` 提升到 crate 顶层（cfg = macos|linux）。
- `crates/dasclaw_sandbox/src/policy_bridge.rs` (新文件) — 原 `macos/policy_bridge.rs` 提升共享。
- `crates/dasclaw_sandbox/src/macos/mod.rs` — 改为 `use crate::policy_bridge`。
- `crates/dasclaw_sandbox/src/macos/policy_bridge.rs` — 删除（renamed 到 crate root）。
- `crates/dasclaw_sandbox/src/linux/mod.rs` — 新增 `prepare_command()` 三分支调度器（helper / fail-closed / legacy seccomp），`CommandPlan` 结构体，`build_helper_plan` + `build_legacy_plan`；`execute()` 重写为消费 plan，单点读取 `plan.install_parent_seccomp`。
- `crates/dasclaw_sandbox/Cargo.toml` — Linux target deps 增 `dasclaw_sandboxing` / `dasclaw_protocol` / `dasclaw_absolute_path`。
- `desktop-client/ironclaw/src/sandbox/os_executor.rs` — 新 `resolve_linux_sandbox_exe()`（Linux only：`current_exe().parent().join("dasclaw-sandbox-linux") + .exists()`，缺失时 tracing::warn），通过 `.with_linux_sandbox_exe()` 注入。

**测试**：
- H1 单元测试（`crates/dasclaw_sandbox/src/linux/mod.rs` inline，cfg=linux）×3：
  - `req_dasclaw_sandbox_p1_2a_prepare_legacy_when_no_exe_and_no_carveouts`
  - `req_dasclaw_sandbox_p1_2a_prepare_helper_when_exe_configured` — 校验 arg0 = `CODEX_LINUX_SANDBOX_ARG0` + `--` 分隔符 + `--sandbox-policy-cwd` flag
  - `req_dasclaw_sandbox_p1_2a_prepare_fail_closed_when_carveout_and_no_exe`
- H2 集成测试（`crates/dasclaw_sandbox/tests/req_kernel_enforces_read_only_subpaths_linux.rs`，cfg=linux）×2：
  - `req_dasclaw_sandbox_p1_2a_helper_blocks_read_only_subpath`（helper 未构建时自动 skip）
  - `req_dasclaw_sandbox_p1_2a_fail_closed_when_helper_missing`
- `crates/dasclaw_sandbox/tests/req_kernel_enforces_read_only_subpaths_macos.rs` — 2 处 struct literal 补 `linux_sandbox_exe: None`。

# 非目标（What's NOT in this PR）

- ❌ **不删 `SoftModeReason::LinuxNoKernelReadOnlySubpaths`** — 该 flip 属于 ADR-144 §5.2 P1.2 完整切片的收尾步骤，待 Linux runner 上 E2E 跑通后单独 PR 处理（模板 = PR #437 删 `WindowsNoKernelReadOnlySubpaths`）。
- ❌ **不替换 W2.3 seccomp ProxyRouted 临时实现**（ADR-144 §6 OQ-C1c-2）— 现 legacy 路径仍跑自有 seccomp ProxyRouted；codex `proxy_routing.rs` (797 LOC) 的 verbatim 端口留待 Phase 1.2b 单独切片。
- ❌ **不接 Linux CI sysctl/apt 步骤**（ADR-144 §5.4）— 由 Phase 1.3 drift guard + workflow PR 完成。
- ❌ **不做 GHA `ubuntu-latest` 真机集成测试**（ADR-144 §5.3 Phase 2 范围）。
- ❌ **不改本地 PR 模板的 4 部分** — 仍按 AGENTS.md 节奏走。
- ❌ **不动 `dasclaw_sandbox_linux` crate 本身**（verbatim port 纯度由 PR #443 保证）。

# 验证（macOS host）

```bash
cargo check -p dasclaw_sandbox --tests        # ✅
cargo check -p dasclaw_exec --tests            # ✅
cargo check -p desktop-client --lib            # ✅ (2m49s)
cargo nextest run -p dasclaw_sandbox           # ✅ 59/59 passed
cargo clippy --no-deps -p dasclaw_sandbox --all-targets -- -D warnings  # ✅
cargo clippy --no-deps -p dasclaw_exec --all-targets -- -D warnings      # ✅
cargo fmt --all                                # ✅
python3.12 scripts/check_no_panics.py --base origin/xClaw                # ✅
python3 scripts/check_no_new_ironclaw_literal.py --base origin/xClaw     # ✅
```

Linux target 交叉编译 + H2 真机集成测试 + 完整 workspace build 由 CI 兜底（本地无 `x86_64-unknown-linux-gnu` toolchain）。

**Skills 管线**：
- ✅ `code-quality-audit` — 5 项全过（补丁式 / 函数规模 / 重复 / unwrap-clone / 重复造轮子）
- ✅ `code-simplifier` — N/A（实现已最简，无可简化点；policy_bridge 是 mv 不是 rewrite）
- ✅ `adr-compliance-check`（手动核对，skill 文件未提供）— ADR-144 §5.3 P1.2a / ADR-141 §6 OQ-1 / ADR-129 §1.3 / ADR-114 grep guard 全合规
- ✅ `code-review-expert` — 0 P0 / 0 P1；P2 #1（冗余条件）已修，P2 #2（OsString→String→OsString lossy）记为已知上游接口限制；P3 不阻断

# Cross-cuts

**ADR-114**: 类 A（无新增 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量；`check_no_new_ironclaw_literal.py` 已绿）

# 后续 / 下一步

1. CI 完整 build + Tests + Clippy 跑通后等 review。
2. Linux runner 上验证 H2 集成测试真实 EACCES（需要 helper 已 `cargo build -p dasclaw_sandbox_linux`）。
3. 后续 PR 处理 `SoftModeReason::LinuxNoKernelReadOnlySubpaths` flip（参 PR #437）+ W2.3 ProxyRouted 替换（OQ-C1c-2）+ Linux CI workflow 注入（§5.4）。

# Sources read

- [`docs/plans/architecture-refactor/adr-144-linux-writable-root-kernel-enforcement.md`](docs/plans/architecture-refactor/adr-144-linux-writable-root-kernel-enforcement.md) §5.2/§5.3/§6 OQ-C1c-2
- [`docs/plans/architecture-refactor/adr-141-windows-writable-root-kernel-enforcement.md`](docs/plans/architecture-refactor/adr-141-windows-writable-root-kernel-enforcement.md) §6 OQ-1（fail-closed 默认）
- [`crates/dasclaw_sandboxing/src/landlock.rs`](crates/dasclaw_sandboxing/src/landlock.rs) — `CODEX_LINUX_SANDBOX_ARG0` 常量 + `create_linux_sandbox_command_args_for_policies()` argv 构造
- [`crates/dasclaw_sandbox/src/macos/policy_bridge.rs`](crates/dasclaw_sandbox/src/policy_bridge.rs) — 提升前 baseline
- [`crates/dasclaw_sandbox/src/linux/mod.rs`](crates/dasclaw_sandbox/src/linux/mod.rs) — W2.3 baseline（seccomp 网络阻断 + ProxyRouted）
- [PR #320](https://github.com/Linnanli/xClaw/pull/320) — Windows Phase 1.2 对称模板

Closes #446
Refs #380 (epic)
