### PR TITLE
ci(sandbox): wire ADR-144 §5.4 Linux CI — enable userns sysctl + pre-build dasclaw_sandbox_linux helper

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,6 +66,19 @@ jobs:
             mold \
             pkg-config \
             libcap-dev
+      # ADR-144 §5.4 — enable unprivileged user namespaces on the GHA runner
+      # so that the `dasclaw_sandbox_linux` helper (vendored bwrap) can
+      # `unshare(CLONE_NEWUSER)` without setuid. Mirrors codex's CI snippet
+      # verbatim ([`codex-rs/.github/workflows/rust-ci-full.yml:644-655`]).
+      # `apparmor_restrict_unprivileged_userns` only exists on Ubuntu 24.04+;
+      # the conditional `grep` keeps the step compatible with older runners.
+      - name: Enable unprivileged user namespaces (Linux)
+        run: |
+          set -euo pipefail
+          sudo sysctl -w kernel.unprivileged_userns_clone=1
+          if sudo sysctl -a 2>/dev/null | grep -q '^kernel.apparmor_restrict_unprivileged_userns'; then
+            sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+          fi
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
@@ -118,6 +131,31 @@ jobs:
             echo "scope=$args" >> "$GITHUB_OUTPUT"
             echo "Using scoped: $args"
           fi
+      # ADR-144 §5.3 P1.2a + §5.4 — produce the `dasclaw-sandbox-linux`
+      # helper binary that
+      # `crates/dasclaw_sandbox/tests/req_kernel_enforces_read_only_subpaths_linux.rs`
+      # auto-detects under `target/debug/`. Without this step the test
+      # self-skips (helper missing) and we lose Linux kernel-enforcement
+      # regression coverage. Built only when the scope actually exercises
+      # the test surface (touches `dasclaw_sandbox` / `dasclaw_sandbox_linux`,
+      # or uses the workspace fallback).
+      - name: Build dasclaw_sandbox_linux helper (Wave-C1c P1.2a regression coverage)
+        if: |
+          contains(steps.scope.outputs.scope, 'dasclaw_sandbox') ||
+          steps.scope.outputs.scope == '--workspace' ||
+          steps.scope.outputs.scope == '' ||
+          matrix.name != 'default'
+        run: |
+          set -euo pipefail
+          # sccache fail-soft (mirrors the strategy used by `Run Tests` below):
+          # GHA Cache backend has occasional outages; probe before use, fall
+          # back to plain rustc if unavailable rather than failing the job.
+          if ! sccache --start-server >/dev/null 2>&1; then
+            echo "::warning::sccache unavailable; building helper without RUSTC_WRAPPER"
+            unset RUSTC_WRAPPER
+            unset SCCACHE_GHA_ENABLED
+          fi
+          cargo build -p dasclaw_sandbox_linux --bin dasclaw-sandbox-linux
       - name: Run Tests
         run: |
           set -euo pipefail


### PR DESCRIPTION
## 背景 / 目标

Wave-C1c Phase 1 最终一层（stacked 在 PR #448 上）。

[ADR-144 §5.4](../docs/plans/architecture-refactor/adr-144-linux-writable-root-kernel-enforcement.md#54-ci-可行性快速预校验) 要求 GHA Linux 任务：

1. 开启 `kernel.unprivileged_userns_clone=1`（+ Ubuntu 24.04+ 的 `kernel.apparmor_restrict_unprivileged_userns=0`），以便 `dasclaw_sandbox_linux`（vendored bwrap）可在无 setuid 的情况下 `unshare(CLONE_NEWUSER)`。
2. 在 `Run Tests` 之前预先 `cargo build` 出 `dasclaw-sandbox-linux` helper 二进制；否则 PR #445 引入的 [`req_kernel_enforces_read_only_subpaths_linux.rs`](../crates/dasclaw_sandbox/tests/req_kernel_enforces_read_only_subpaths_linux.rs) 会因 `locate_helper()` 返回 `None` 而静默自跳过，Wave-C1c P1.2a 的回归覆盖直接蒸发。

`sysctl` 片段为 ADR-144 §5.4 指定的 codex CI 同款（"Phase 1 PR 直接复用此片段"），未做改写。

## 改动范围

仅 `.github/workflows/test.yml::tests` job，新增 **两个 step**：

| Step 位置 | 名字 | 触发条件 |
|---|---|---|
| 在 apt-deps 之后、Install Rust 之前 | `Enable unprivileged user namespaces (Linux)` | 无条件（job 本就跑 `ubuntu-latest`） |
| 在 scope-compute 之后、Run Tests 之前 | `Build dasclaw_sandbox_linux helper` | `contains(scope, 'dasclaw_sandbox') \|\| --workspace \|\| 空 \|\| 非 default matrix` |

`tests` job step list 现在是 11 step，顺序：

```
Checkout → apt-deps → sysctl → Install Rust → sccache cache → sccache setup
→ install nextest → compute scope (PR) → build helper → Run Tests → sccache stats
```

## 非目标（What's NOT in this PR）

- ❌ 不新建 `linux-sandbox-ci.yml`（windows-ci.yml 之所以独立是因为 windows-latest 与主 PR 节奏解耦；Linux 无此不对称，扩展 `test.yml` 更省心）
- ❌ 不改 helper crate `dasclaw_sandbox_linux` 本身
- ❌ 不改集成测试本身
- ❌ 不动 `code_style.yml::codex-linux-sandbox-drift`（已在前序 PR wired）
- ❌ 不引入 self-hosted runner / heavy matrix

## 关联 ADR

- [adr-144-linux-writable-root-kernel-enforcement.md §5.4](../docs/plans/architecture-refactor/adr-144-linux-writable-root-kernel-enforcement.md)
- adr-112 / adr-113 红线：未触碰

## Sources read

- [`docs/plans/architecture-refactor/adr-144-linux-writable-root-kernel-enforcement.md` §5.4 — CI 可行性快速预校验](../docs/plans/architecture-refactor/adr-144-linux-writable-root-kernel-enforcement.md) — verbatim sysctl + apt 片段，确认 GHA `ubuntu-latest` 足够
- [`.github/workflows/test.yml` §`tests` job](../.github/workflows/test.yml) — 现有 step 顺序、scope 计算逻辑、sccache fail-soft 模式
- [`.github/workflows/windows-ci.yml`](../.github/workflows/windows-ci.yml) — 对照模板，确认 Linux 不需要独立 workflow（design choice 写入 commit message）
- [`crates/dasclaw_sandbox/tests/req_kernel_enforces_read_only_subpaths_linux.rs` §`locate_helper()`](../crates/dasclaw_sandbox/tests/req_kernel_enforces_read_only_subpaths_linux.rs) — 确认 helper 缺失时测试自跳过 → 必须 pre-build
- [`crates/dasclaw_sandbox_linux/Cargo.toml`](../crates/dasclaw_sandbox_linux/Cargo.toml) — 通过 `cargo metadata` 验证 `[[bin]] name = "dasclaw-sandbox-linux"` 匹配 build step target
- [`AGENTS.md` §强制阅读顺序 / §测试纪律 / §Skills 强制使用规范](../AGENTS.md)

## 验证

```bash
# YAML 语法
python3 -c "import yaml; d=yaml.safe_load(open('.github/workflows/test.yml')); print(len(d['jobs']['tests']['steps']),'steps')"
# → 11 steps

# 红线
python3.12 scripts/check_no_panics.py --base origin/xClaw
# → OK: No panic-inducing calls in changed production code.

python3 scripts/check_no_new_ironclaw_literal.py --base origin/xClaw
# → OK: No new .ironclaw / IRONCLAW_BASE_DIR literals introduced.

# Binary 名匹配
cargo metadata --no-deps --format-version=1 | python3 -c "import json,sys; d=json.load(sys.stdin); [print('binaries:',[t['name'] for t in p['targets'] if 'bin' in t['kind']]) for p in d['packages'] if p['name']=='dasclaw_sandbox_linux']"
# → binaries: ['dasclaw-sandbox-linux']
```

Cargo 本身没动，工作区编译不需要本地验证；end-to-end 验证由本 PR 自身的 CI 跑（这恰好是改动的内容）。

## Code Review

`code-review-expert` skill review verdict: **APPROVE / 0 blockers**

| 维度 | 评级 |
|---|---|
| YAML & step ordering | ✅ PASS |
| Conditional logic (`contains` 匹配 `dasclaw_sandbox` ∪ `dasclaw_sandbox_linux`) | ✅ PASS |
| 禁止补丁式代码 | ✅ PASS（sccache fail-soft 复用模式，非复制粘贴） |
| 向后兼容（无关 PR 零开销） | ✅ PASS |
| 安全（`sudo sysctl` 于 ephemeral GHA runner） | ✅ PASS（codex 同款，无新攻击面） |
| 注释质量（ADR-144 §5.4 引用） | ✅ PASS |
| Linux/Windows 不对称设计合理性 | ✅ PASS（intentional & justified） |

1 个 P3 polish 建议（为 helper build step 的 sccache fail-soft 增加 inline 注释）已在 push 前 apply。

## Stacked PR 说明

- **base**: `feat/sandbox-linux-p1-2b-softmode-flip`（PR #448），**不是** `xClaw`
- **merge 顺序**: 先 #445 → 再 #448 → 最后本 PR
- 审阅时请先看 #445 / #448 上下文，本 PR diff 只包含 `test.yml` 的 38 行新增

Closes #449
Refs #380
