### PR TITLE
ci(sandbox): re-merge ADR-144 §5.4 Linux CI onto xClaw — cherry-pick of #450 (auto-merge race rescue)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,6 +66,19 @@ jobs:
             mold \
             pkg-config \
             libcap-dev
+      # ADR-144 §5.4 — enable unprivileged user namespaces on the GHA runner
+      # so that the `dasclaw_sandbox_linux` helper (vendored bwrap) can
+      # `unshare(CLONE_NEWUSER)` without setuid. Mirrors codex's CI snippet
+      # verbatim ([`codex-rs/.github/workflows/rust-ci-full.yml:644-655`]).
+      # `apparmor_restrict_unprivileged_userns` only exists on Ubuntu 24.04+;
+      # the conditional `grep` keeps the step compatible with older runners.
+      - name: Enable unprivileged user namespaces (Linux)
+        run: |
+          set -euo pipefail
+          sudo sysctl -w kernel.unprivileged_userns_clone=1
+          if sudo sysctl -a 2>/dev/null | grep -q '^kernel.apparmor_restrict_unprivileged_userns'; then
+            sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+          fi
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
@@ -118,6 +131,31 @@ jobs:
             echo "scope=$args" >> "$GITHUB_OUTPUT"
             echo "Using scoped: $args"
           fi
+      # ADR-144 §5.3 P1.2a + §5.4 — produce the `dasclaw-sandbox-linux`
+      # helper binary that
+      # `crates/dasclaw_sandbox/tests/req_kernel_enforces_read_only_subpaths_linux.rs`
+      # auto-detects under `target/debug/`. Without this step the test
+      # self-skips (helper missing) and we lose Linux kernel-enforcement
+      # regression coverage. Built only when the scope actually exercises
+      # the test surface (touches `dasclaw_sandbox` / `dasclaw_sandbox_linux`,
+      # or uses the workspace fallback).
+      - name: Build dasclaw_sandbox_linux helper (Wave-C1c P1.2a regression coverage)
+        if: |
+          contains(steps.scope.outputs.scope, 'dasclaw_sandbox') ||
+          steps.scope.outputs.scope == '--workspace' ||
+          steps.scope.outputs.scope == '' ||
+          matrix.name != 'default'
+        run: |
+          set -euo pipefail
+          # sccache fail-soft (mirrors the strategy used by `Run Tests` below):
+          # GHA Cache backend has occasional outages; probe before use, fall
+          # back to plain rustc if unavailable rather than failing the job.
+          if ! sccache --start-server >/dev/null 2>&1; then
+            echo "::warning::sccache unavailable; building helper without RUSTC_WRAPPER"
+            unset RUSTC_WRAPPER
+            unset SCCACHE_GHA_ENABLED
+          fi
+          cargo build -p dasclaw_sandbox_linux --bin dasclaw-sandbox-linux
       - name: Run Tests
         run: |
           set -euo pipefail


### PR DESCRIPTION
## 背景

[PR #450](https://github.com/Linnanli/xClaw/pull/450) 在 stacked-PR 合并过程中触发了 auto-merge race condition——auto-merge 在我们 retarget base 到 `xClaw` 之前就 fired，结果 squash commit `76fc70e4` 落在了**陈旧的** `feat/sandbox-linux-p1-2b-softmode-flip` 分支上（该分支的内容已通过 #448 squash 合并为 `4b5c7f16`），并未进入 `xClaw`。

本 PR 把 `76fc70e4`（即 ADR-144 §5.4 CI 接线）cherry-pick 到 `xClaw`，补救漏网。

## 改动范围

零差异于 PR #450 — 仅 `.github/workflows/test.yml`，+38 行：

1. `Enable unprivileged user namespaces (Linux)` step（ADR-144 §5.4 verbatim codex snippet）
2. `Build dasclaw_sandbox_linux helper` step（让 `req_kernel_enforces_read_only_subpaths_linux` 不再 self-skip）

Cherry-pick commit `76fc70e4` 直接对应 #450 的最终内容；无人为修改。

## 非目标

- 不重做 code review（PR #450 已 APPROVE / 0 blockers，内容字节相同）
- 不改 #445 / #448 已 merge 的内容
- 不引入 self-hosted runner

## 关联

- 补救 [#450](https://github.com/Linnanli/xClaw/pull/450)（已 MERGED 至废弃分支）
- Closes #449（与 #450 同闭环）
- Refs #380（Wave-C1c）
- ADR-144 §5.4

## Sources read

- `git show 76fc70e4 -- .github/workflows/test.yml` — 确认 cherry-pick 内容字节相同
- [`.github/workflows/test.yml`](../.github/workflows/test.yml) — current main tip 缺该 38 行
- [`docs/plans/architecture-refactor/adr-144-linux-writable-root-kernel-enforcement.md` §5.4](../docs/plans/architecture-refactor/adr-144-linux-writable-root-kernel-enforcement.md)

## 验证

```bash
# 与 #450 内容一致性
git diff 76fc70e4 HEAD -- .github/workflows/test.yml
# → 空（cherry-pick 干净，无 conflict）

# YAML
python3 -c "import yaml; d=yaml.safe_load(open('.github/workflows/test.yml')); print(len(d['jobs']['tests']['steps']),'steps')"
# → 11 steps

# 红线
python3.12 scripts/check_no_panics.py --base origin/xClaw  # → OK
python3 scripts/check_no_new_ironclaw_literal.py --base origin/xClaw  # → OK
```

## Stacked PR 说明

- **base**: `xClaw`（直接合主）
- **head**: `ci/sandbox-linux-p1-5-4-rebased-onto-main`
- 本 PR **不依赖任何其他开放 PR**，无须 stacked merge order
