### PR TITLE
docs(arch): sync sandbox docs post-Wave-C1c (5 drift fixes)

### DIFF
--- a/crates/dasclaw_exec/src/lib.rs
+++ b/crates/dasclaw_exec/src/lib.rs
@@ -16,8 +16,10 @@
 //!   二次拒绝。Windows 上自 ADR-141 §3 PR-W3（Wave-C1b，PR #426）起由
 //!   `dasclaw_sandbox_windows::run_windows_sandbox_capture_with_extra_deny_write_paths`
 //!   把 `read_only_subpaths` 翻译为 Win32 DACL DENY entries，Windows 沙箱内核层
-//!   强制相同语义。Linux landlock 洞中洞 deferred to Wave-C1c（需要
-//!   `dasclaw-linux-sandbox` binary 落地）。
+//!   强制相同语义。Linux 自 ADR-144（Wave-C1c，PR #444+#445+#448+#451+#453）起由
+//!   `dasclaw_sandbox_linux` setuid binary + `dasclaw_sandboxing::landlock` 把
+//!   `read_only_subpaths` 翻译为 bubblewrap `--ro-bind` 嵌套 + Landlock V5
+//!   `path_beneath_rules`，Linux 沙箱内核层强制相同语义。
 //! - **PTY 终端**：走 [`dasclaw_pty`] 独立路径，不在 `ProcessExecutor` 范围；
 //!   终端会话的 sandbox 包裹由调用方在 `spawn` 时显式组合。
 //!
@@ -216,12 +218,10 @@ impl ProcessExecutor for SandboxedExecutor {
 /// |------|---------------------------|-----------|
 /// | macOS | ✅ 通过 `dasclaw_sandboxing::seatbelt` 在 sbpl 中表达 `(deny file-write* (subpath ".git/.codex/.dasclaw"))`（ADR-135 §3 PR-C1 / Wave-C1a） | [`ironclaw_workspace_cap`] cap-std + `is_path_writable` 第一道关 |
 /// | Windows | ✅ 通过 `dasclaw_sandbox_windows::run_windows_sandbox_capture_with_extra_deny_write_paths` 把 `read_only_subpaths` 翻译为 Win32 DACL DENY entries（ADR-141 §3 PR-W3 / Wave-C1b，PR #426） | 同上 |
-/// | Linux | ❌ deferred to Wave-C1c（需 `dasclaw-linux-sandbox` setuid binary 落地，对齐 codex landlock V5 + bwrap 路径） | 同上 |
+/// | Linux | ✅ 通过 `dasclaw_sandbox_linux` setuid binary + `dasclaw_sandboxing::landlock` 把 `read_only_subpaths` 翻译为 bubblewrap `--ro-bind` 嵌套 + Landlock V5 `path_beneath_rules`（ADR-144 / Wave-C1c，PR #444+#445+#448+#451+#453） | 同上 |
 ///
-/// Linux 上洞中洞当前仅靠 `is_path_writable` 用户态决策 +
-/// [`ironclaw_workspace_cap::WorkspaceCap`] cap-std 文件接口拦截；子进程通过
-/// 直接 syscall 写 `.git/hooks/` 在 Linux 上**目前不会被内核拒绝**。
-/// 进度追踪：[issue #380](https://github.com/Linnanli/xClaw/issues/380) Wave-C1c。
+/// 三平台均已内核层强制，子进程绕过 `is_path_writable` 用户态决策直接
+/// syscall 写 `.git/hooks/`、`.codex/*`、`.dasclaw/*` 在三平台**均会被内核拒绝**。
 pub fn policy_to_backend_config(policy: &SandboxPolicy, cwd: &Path) -> SandboxBackendConfig {
     policy_to_backend_config_with_env(policy, cwd, &std::env::vars().collect())
 }

--- a/crates/dasclaw_sandbox/tests/req_kernel_enforces_read_only_subpaths_macos.rs
+++ b/crates/dasclaw_sandbox/tests/req_kernel_enforces_read_only_subpaths_macos.rs
@@ -10,9 +10,10 @@
 //!
 //! ## 平台
 //!
-//! 仅 macOS。Linux landlock 洞中洞由 Wave-C3 落地（需要外部
-//! `dasclaw-linux-sandbox` binary），Windows ACL DENY 由 ADR-141 enterprise
-//! 路径提供。
+//! 仅 macOS。Linux landlock 洞中洞由 Wave-C1c（ADR-144 / PR
+//! #444+#445+#448+#451+#453）落地（`dasclaw_sandbox_linux` setuid binary +
+//! `dasclaw_sandboxing::landlock`），Windows ACL DENY 由 ADR-141 §3 PR-W3
+//! enterprise 路径提供（Wave-C1b / PR #426）。
 
 #![cfg(target_os = "macos")]
 

--- a/docs/plans/architecture-refactor/32-execution-plan.md
+++ b/docs/plans/architecture-refactor/32-execution-plan.md
@@ -214,13 +214,13 @@ W1 失败：恢复 desktop-client/ironclaw 子模块（git revert）。
 - ironclaw 工具调用全部经过 dasclaw_sandbox + dasclaw_workspace_cap
 
 ### 验收
-- [ ] 三平台单元测试通过（CI matrix 覆盖 ubuntu/macos/windows）
-- [ ] 失败路径测试：沙箱不可用时工具调用被拒绝，不降级为直接 exec
-- [ ] **WritableRoot 洞中洞契约测试**：sandbox 在 WorkspaceWrite 模式下写 `.git/hooks/*`、`.codex/*`、`.git/config` 必须返回 SandboxError，且无任何 fallback。**已知限制（v2.5 补充）**：当前仅在 `dasclaw_sandbox` adapter 层检查，内核层强制（Linux Landlock-based subpath deny / macOS Seatbelt subpath deny / Windows Restricted Token DACL）跟进补强由 [#324 sub-task 2](https://github.com/Linnanli/xClaw/issues/324) 追踪
-- [ ] **ExternalSandbox 嵌套测试**：在 docker 容器内启动 desktop-client，agent 工具调用走 ExternalSandbox 模式，network_access 由 NetworkAccess 枚举决定
-- [ ] 性能基准：进程沙箱启动 < 50ms（对比 codex 基线）
-- [ ] PTY resize/信号转发 在 macOS+Linux 各 1 个示例脚本过
-- [ ] dasclaw_workspace_cap 协议 enum 通过 `ts-rs` 导出 TypeScript 类型，desktop-client 前端可直接 import
+- [x] 三平台单元测试通过（CI matrix 覆盖 ubuntu/macos/windows）
+- [x] 失败路径测试：沙箱不可用时工具调用被拒绝，不降级为直接 exec
+- [x] **WritableRoot 洞中洞契约测试**：sandbox 在 WorkspaceWrite 模式下写 `.git/hooks/*`、`.codex/*`、`.git/config` 必须返回 SandboxError，且无任何 fallback。**三平台内核层强制均已完成**：macOS Seatbelt subpath deny（ADR-135 §3 PR-C1 / Wave-C1a）、Windows Restricted Token DACL DENY（ADR-141 §3 PR-W3 / Wave-C1b / PR #426）、Linux bubblewrap `--ro-bind` 嵌套 + Landlock V5 `path_beneath_rules`（ADR-144 / Wave-C1c / PR #444+#445+#448+#451+#453）
+- [ ] **ExternalSandbox 嵌套测试**：在 docker 容器内启动 desktop-client，agent 工具调用走 ExternalSandbox 模式，network_access 由 NetworkAccess 枚举决定（追踪：[#380](https://github.com/Linnanli/xClaw/issues/380) Batch 6 B6-1）
+- [ ] 性能基准：进程沙箱启动 < 50ms（对比 codex 基线）（追踪：[#380](https://github.com/Linnanli/xClaw/issues/380) Batch 6 B6-2）
+- [ ] PTY resize/信号转发 在 macOS+Linux 各 1 个示例脚本过（追踪：[#380](https://github.com/Linnanli/xClaw/issues/380) Batch 6 B6-3）
+- [ ] dasclaw_workspace_cap 协议 enum 通过 `ts-rs` 导出 TypeScript 类型，desktop-client 前端可直接 import（追踪：[#380](https://github.com/Linnanli/xClaw/issues/380) Batch 6 B6-4）
 
 ### 复用 codex 测试
 - codex-rs/linux-sandbox/tests/* 直接 port


### PR DESCRIPTION
## 背景/目标

Wave-C1c（ADR-144 Linux WritableRoot kernel enforcement）已于上轮闭环（PR #444+#445+#448+#451+#453），但应用层 doc 与计划文档 W2 验收清单未跟随 flip。本 PR 修 5 处与 Wave-C1c 现实自相矛盾的旧描述（属 PR #428 B6-7 doc drift 修复 + PR #453 closeout 漏 sync 的延后清理）。

无代码逻辑变更，纯 doc。

## 改动范围

| 文件 | 改动 |
|---|---|
| `crates/dasclaw_exec/src/lib.rs` L19 模块 doc | "Linux landlock 洞中洞 deferred to Wave-C1c" → "Linux 自 ADR-144（Wave-C1c）起由 setuid binary + landlock 内核层强制" |
| `crates/dasclaw_exec/src/lib.rs` L219-225 表格 + 段落 | "Linux ❌ deferred" → "✅ ADR-144/Wave-C1c 完成"；"目前不会被内核拒绝" → "三平台均会被内核拒绝" |
| `crates/dasclaw_sandbox/tests/req_kernel_enforces_read_only_subpaths_macos.rs` L13 test header | "Linux landlock 由 Wave-C3 落地" → "Linux 由 Wave-C1c（ADR-144）落地" |
| `docs/plans/architecture-refactor/32-execution-plan.md` L218-219 W2 验收 footnote | 删除 "**已知限制（v2.5 补充）**...由 #324 sub-task 2 追踪"；改写为 "三平台内核层强制均已完成" |
| `docs/plans/architecture-refactor/32-execution-plan.md` L215-218 W2 验收 checkbox | 三项 flip 为 `[x]`（CI matrix / 失败路径 / WritableRoot 洞中洞契约）；剩余 4 项保持 `[ ]` 并指向 #380 Batch 6 B6-1~B6-4 |

## 非目标（What's NOT in this PR）

- 不实现 W2 验收剩余 4 项（B6-1 ExternalSandbox 嵌套 / B6-2 性能基准 / B6-3 PTY resize 示例 / B6-4 ts-rs 导出）
- 不动 Batch 3 / Batch 4 / F1 / #28 / #241 等 live 任务
- 不动 ADR / 红线 / verbatim crate 本体
- 不动 `dasclaw_sandbox_linux` 实现代码

## 验证

```bash
cargo fmt --all -- --check                                              # ✅ clean
python3.12 scripts/check_no_panics.py --base origin/xClaw               # ✅ OK
cargo check -p dasclaw_exec --tests                                     # ✅ 12.57s
cargo check -p dasclaw_sandbox --tests                                  # ✅ 2.55s
cargo clippy --no-deps -p dasclaw_exec --all-targets -- -D warnings     # ✅ 16.10s
cargo clippy --no-deps -p dasclaw_sandbox --all-targets -- -D warnings  # ✅ 14.55s
```

完整 build / workspace clippy / heavy integration 由 CI 兜底（按 AGENTS.md "本地快速开发节奏"）。

## Sources read

- `AGENTS.md` §"任务启动 4 问" + §"本地快速开发节奏" + §"Skills 强制使用规范"
- `.github/copilot-instructions.md` 完整
- `docs/plans/architecture-refactor/32-execution-plan.md` §W2 (L183-231)
- `docs/plans/architecture-refactor/31-target-architecture.md` §ADR-102 (L147-152)
- `crates/dasclaw_exec/src/lib.rs` 模块 doc + `policy_to_backend_config` doc 表格
- `crates/dasclaw_sandbox/src/linux/mod.rs` L169-193, L514-523（确认 Linux backend 已 enforce `read_only_subpaths`）
- `crates/dasclaw_sandbox/tests/req_kernel_enforces_read_only_subpaths_macos.rs` 完整
- GitHub: epic #380 + #241 + #28 body 全量

## 关联

- 上接：PR #453（ADR-144 closeout，本 PR 修其漏同步的应用层 doc）
- 同性质：PR #428（B6-7 doc drift，本 PR 修其遗漏的 W2 plan checklist）
- 不 Closes 任何 issue（这是 doc drift 清理，不闭环 epic 子任务）
