### PR TITLE
feat(sandbox): ADR-141 §6 enterprise gate contract tests + Batch 3 doc sync

### DIFF
--- a/crates/dasclaw_sandbox/tests/req_check_enterprise_gate.rs
+++ b/crates/dasclaw_sandbox/tests/req_check_enterprise_gate.rs
@@ -1,0 +1,150 @@
+//! ADR-141 §6 enterprise fail-closed gate — pure-function 决策矩阵契约测试。
+//!
+//! `check_enterprise_gate` 是 ADR-141 PR-W1 引入的跨平台 pure decision
+//! function：所有三个 OS sandbox 后端（Windows / macOS / Linux）在 `execute`
+//! 入口先跑它，把 enterprise 模式下"kernel 层 carve-out enforcement 缺失"
+//! 这一类风险**统一拒绝**在 IPC / 进程派发之前。
+//!
+//! 本契约测试覆盖 ADR-141 §6 OQ-1（default `false` / fail-closed）+
+//! OQ-W3-3（gate signal 用 `read_only_subpaths.is_empty()` 而不是
+//! `writable_roots.is_empty()`）+ Wave-C1c P1.2b sign-off（删 soft-mode
+//! 后只剩 `Allow` / `DenyNoKernelSandbox` 两个 outcome）。
+//!
+//! ## 为什么是 host-agnostic 而不是 `#[cfg(windows)]`
+//!
+//! `check_enterprise_gate` 故意设计为 **side-effect-free pure function**，
+//! 全决策矩阵在 macOS / Linux CI runner 上即可完整测——不需要 Windows
+//! VM 也能守 ADR-141 §6 fail-closed 契约。这就是 epic #380 Batch 3 B3-3
+//! 列三个测试名带 `windows_enterprise` 但实际跨平台跑的原因：测的是 OQ
+//! 决策，不是 Windows IPC。
+
+use std::path::PathBuf;
+
+use dasclaw_sandbox::{
+    check_enterprise_gate, EnterpriseGateOutcome, SandboxBackendConfig, SandboxType,
+};
+
+/// 构造一个 enterprise=on + Windows + setup_complete=true 的基础 config，
+/// 各测试通过 mutator 改单一字段以隔离决策分支。
+fn enterprise_windows_config() -> SandboxBackendConfig {
+    SandboxBackendConfig {
+        enterprise_mode: true,
+        ..SandboxBackendConfig::default()
+    }
+}
+
+#[test]
+fn req_dasclaw_exec_windows_enterprise_allow_when_enterprise_off() {
+    // 兜底：enterprise_mode=false 时无论 sandbox_type / setup_complete 取何值，
+    // gate 必须 Allow（默认非企业场景行为不变）。
+    let config = SandboxBackendConfig {
+        enterprise_mode: false,
+        read_only_subpaths: vec![PathBuf::from(".git/hooks")],
+        ..SandboxBackendConfig::default()
+    };
+
+    let outcome = check_enterprise_gate(
+        &config,
+        SandboxType::None, // 即使 sandbox 不存在
+        false,             // 即使 setup 未完成
+    );
+
+    assert_eq!(
+        outcome,
+        EnterpriseGateOutcome::Allow,
+        "non-enterprise spawn must short-circuit to Allow regardless of \
+         sandbox availability — see ADR-141 §6 OQ-1 default `false`"
+    );
+}
+
+#[test]
+fn req_dasclaw_exec_windows_enterprise_fail_closed_when_no_sandbox() {
+    // ADR-141 §6 OQ-1：enterprise_mode=true 但 sandbox_type=None
+    // （平台无 kernel sandbox 后端可用）必须 fail-closed，
+    // 调用方据此返回 SandboxError::WindowsSandboxNotAvailable。
+    let config = enterprise_windows_config();
+
+    let outcome = check_enterprise_gate(
+        &config,
+        SandboxType::None,
+        true, // setup_complete 不影响 Step 1 的 None 判定
+    );
+
+    assert_eq!(
+        outcome,
+        EnterpriseGateOutcome::DenyNoKernelSandbox,
+        "enterprise spawn must be denied when no kernel sandbox backend \
+         exists on host — caller surfaces SandboxError::WindowsSandboxNotAvailable"
+    );
+}
+
+#[test]
+fn req_dasclaw_exec_windows_enterprise_fail_closed_when_kernel_setup_incomplete() {
+    // ADR-141 §3 PR-W1：sandbox 后端类型已选定（WindowsRestrictedToken），
+    // 但平台 setup 尚未完成（sandbox_setup_is_complete = false）→ 必须
+    // fail-closed。守 "首次部署未跑 dasclaw-sandbox-setup.exe 就被静默
+    // 降级" 这条 OWASP A05 安全配置失误。
+    let config = enterprise_windows_config();
+
+    let outcome = check_enterprise_gate(
+        &config,
+        SandboxType::WindowsRestrictedToken,
+        false, // kernel_setup_complete=false（Windows: IT 还没跑 elevated setup）
+    );
+
+    assert_eq!(
+        outcome,
+        EnterpriseGateOutcome::DenyNoKernelSandbox,
+        "enterprise spawn must be denied when sandbox infra is selected \
+         but setup is incomplete — fail-closed audit trail per ADR-141 §3 PR-W1"
+    );
+}
+
+#[test]
+fn req_dasclaw_exec_windows_enterprise_allow_when_no_carveouts() {
+    // OQ-W3-3 sign-off 2026-05-11+：原 PR-W1+W2 用
+    // `writable_roots.is_empty()` 做 gate signal 是错的——WorkspaceWrite
+    // policy 总是带 writable_roots，会把"无洞中洞的常见任务"误判为
+    // "需要 kernel enforcement"。修正后用 `read_only_subpaths.is_empty()`：
+    // 没有 carve-out 时 kernel 层根本无须额外 deny，base sandbox 就够了。
+    let mut config = enterprise_windows_config();
+    config.writable_roots.push(PathBuf::from("/workspace"));
+    // 注意：故意保持 read_only_subpaths 为空。
+
+    let outcome = check_enterprise_gate(&config, SandboxType::WindowsRestrictedToken, true);
+
+    assert_eq!(
+        outcome,
+        EnterpriseGateOutcome::Allow,
+        "WorkspaceWrite without holes must short-circuit to Allow — \
+         OQ-W3-3 fix prevents misclassifying the common case as \
+         'needs kernel carve-out enforcement'"
+    );
+}
+
+#[test]
+fn req_dasclaw_exec_windows_enterprise_allow_when_kernel_carveouts_wired() {
+    // Wave-C1c P1.2b sign-off：三平台 OS sandbox 后端（macOS Seatbelt /
+    // Windows RestrictedToken / Linux Seccomp）的 kernel 层 carve-out
+    // enforcement 都已落地（分别由 Wave-C1a / Wave-C1b PR #426 / Wave-C1c
+    // PR #444+#445+#448 闭环），所以 enterprise + carve-outs + 完整 setup
+    // → 仍是 Allow（让具体后端去落实 DACL/sbpl/landlock）。
+    let mut config = enterprise_windows_config();
+    config
+        .read_only_subpaths
+        .push(PathBuf::from("/workspace/.git/hooks"));
+
+    for kind in [
+        SandboxType::WindowsRestrictedToken,
+        SandboxType::MacosSeatbelt,
+        SandboxType::LinuxSeccomp,
+    ] {
+        let outcome = check_enterprise_gate(&config, kind, true);
+        assert_eq!(
+            outcome,
+            EnterpriseGateOutcome::Allow,
+            "enterprise + carve-outs + kernel ready → Allow for {kind:?}; \
+             see ADR-141 §1.1 matrix + ADR-144 §5.3 (Linux Wave-C1c)"
+        );
+    }
+}

--- a/desktop-client/README.md
+++ b/desktop-client/README.md
@@ -14,3 +14,23 @@ clean 后重编 → sccache 命中缓存，速度比无缓存快很多
 
 # 在项目根目录（不是 ironclaw 子目录）
 cargo build -p desktop-client --lib
+
+---
+
+## Enterprise sandbox 现状（三平台一致 fail-closed）
+
+桌面端在 `enterprise_mode = true` 时，三平台均走内核级 sandbox，缺失即拒绝 spawn，不再退化为 user-space 检查。
+
+| 平台 | 内核层 | 状态 | 主要依据 |
+|---|---|---|---|
+| macOS | Seatbelt (`sandbox-exec`) + `read_only_subpaths` SBPL DENY | ✅ 内核强制 | ADR-141 §1.1 |
+| Linux | Landlock V3 + seccomp + `read_only_subpaths` DENY | ✅ 内核强制（Wave-C1c） | ADR-144 |
+| Windows | Job Object + AppContainer + DACL DENY (`additional_deny_write_paths`) | ✅ 内核强制（Wave-C1b PR #426） | ADR-141 §1.1 / ADR-129 |
+
+要点：
+
+- 内核 sandbox 未就绪时，`dasclaw_exec` 直接返回 `SandboxError`，**不会**回退到直接 exec。
+- 软模式（`enterprise_allow_userspace_carveouts`）已在 Wave-C1c 移除（PR #448），无 opt-out。
+- `enterprise_mode` 是配置层字段（`dasclaw_sandbox::SandboxBackendConfig`），不暴露给终端用户切换。
+
+详细 ADR 路径：[`docs/plans/architecture-refactor/adr-141-windows-enterprise-sandbox-support.md`](../docs/plans/architecture-refactor/adr-141-windows-enterprise-sandbox-support.md) / [`adr-144-linux-writable-root-kernel-enforcement.md`](../docs/plans/architecture-refactor/adr-144-linux-writable-root-kernel-enforcement.md)。

--- a/docs/plans/architecture-refactor/35-codex-capability-inventory.md
+++ b/docs/plans/architecture-refactor/35-codex-capability-inventory.md
@@ -373,11 +373,11 @@ agent-identity（ED25519 assertion）+ login（OAuth PKCE）+ keyring-store。**
 | B | apply_patch | ✅ | ❌ | ⚠️ | **codex** | 移植 |
 | B | code_mode (Node VM) | ✅ | ❌ | ⚠️ | **codex** | 可选 feature |
 | B | portable-pty | ✅ | ⚠️ | ❌ | **codex** | 移植 |
-| C | Linux sandbox (Landlock+bwrap) | ✅ | ⚠️ Docker | ⚠️ | **codex** | **完整移植** |
-| C | macOS sandbox (Seatbelt) | ✅ | ⚠️ Docker | ❌ | **codex** | **完整移植** |
-| C | Windows sandbox (JobObject) | ✅ | ❌ | ❌ | **codex** | **完整移植** |
+| C | Linux sandbox (Landlock+bwrap) | ✅ | ⚠️ Docker | ⚠️ | **codex** | ✅ **已完整移植** (Wave-C1c: ADR-144 / PR #444+#445+#448+#451+#453) |
+| C | macOS sandbox (Seatbelt) | ✅ | ⚠️ Docker | ❌ | **codex** | ✅ **已完整移植** (Wave-C1a: ADR-135 §3 PR-C1) |
+| C | Windows sandbox (JobObject) | ✅ | ❌ | ❌ | **codex** | ✅ **已完整移植** (Wave-C1b: ADR-141 §3 PR-W3 / PR #426) |
 | C | SandboxPolicy enum 协议 | ✅ | ⚠️ cap-std only | ❌ | **codex** | **协议层移植** |
-| C | WritableRoot 洞中洞 | ✅ | ❌ | ❌ | **codex** | 移植 |
+| C | WritableRoot 洞中洞 | ✅ | ❌ | ❌ | **codex** | ✅ **三平台 kernel 层已强制** (Wave-C1a/b/c) |
 | C | ExternalSandbox 嵌套 | ✅ | ❌ | ❌ | **codex** | 移植 |
 | D | Hooks 三分离（schema/registry/engine）| ✅ | ⚠️ 散落 | ⚠️ | **codex** | 移植结构 |
 | E | AGENTS.md 多层 | ✅ 3 层 | ⚠️ 2 层 | ✅ 2 层 | codex/claw | 三家合并 |


### PR DESCRIPTION
## 背景/目标

接 epic #380 Batch 3 闭环。上一轮（PR #454 doc-sync）发现：B3-0~B3-5 实质均已通 过 PR #426 / #448 落地，但 epic body 仍全部 `- [ ]`、`35-codex-capability-inventory.md` 仍把三平台 sandbox 标"完整移植"含糊态、契约测试（B3-3）真实缺失。本 PR  把 (A) 契约测试 + (B) 文档同步合并为一个 PR 推完。

**关联 ADR**：[ADR-141](docs/plans/architecture-refactor/adr-141-windows-enterprise-sandbox-support.md) §3 PR-W1 / §6 OQ-1 / OQ-W3-3 / Wave-C1c P1.2b sign-off / **PR-W5 README sync**

## Sources read

- `AGENTS.md` § 本地快速开发节奏 / TDD / 复用优先
- [docs/plans/architecture-refactor/adr-141-windows-enterprise-sandbox-support.md](docs/plans/architecture-refactor/adr-141-windows-enterprise-sandbox-support.md) §3 PR-W1+W2+W3+W5 / §6 OQ-1 / OQ-W3-3 / OQ-W3-4 / §7 sign-off
- [docs/plans/architecture-refactor/adr-144-linux-writable-root-kernel-enforcement.md](docs/plans/architecture-refactor/adr-144-linux-writable-root-kernel-enforcement.md) Wave-C1c
- [crates/dasclaw_sandbox/src/lib.rs](crates/dasclaw_sandbox/src/lib.rs#L222-L390) `SandboxBackendConfig` + `EnterpriseGateOutcome` + `check_enterprise_gate`
- [crates/dasclaw_sandbox/tests/req_kernel_enforces_read_only_subpaths_linux.rs](crates/dasclaw_sandbox/tests/req_kernel_enforces_read_only_subpaths_linux.rs) 既有契约测试模板
- [docs/plans/architecture-refactor/35-codex-capability-inventory.md](docs/plans/architecture-refactor/35-codex-capability-inventory.md#L376-L380) sandbox 矩阵
- epic #380 body Batch 3 section

## 改动范围

1. **新增** [crates/dasclaw_sandbox/tests/req_check_enterprise_gate.rs](crates/dasclaw_sandbox/tests/req_check_enterprise_gate.rs)
   - 5 个 pure-function 决策矩阵契约测试（host-agnostic，macOS / Linux CI runner 即可完整跑 Windows enterprise 矩阵）
   - 覆盖 ADR-141 §6 OQ-1（兜底 + None / setup-incomplete fail-closed）+ OQ-W3-3（`read_only_subpaths.is_empty()` gate signal 修正）+ 三平台 kernel carveouts 已就绪路径
2. **修改** [docs/plans/architecture-refactor/35-codex-capability-inventory.md](docs/plans/architecture-refactor/35-codex-capability-inventory.md#L376-L380)
   - 5 行 sandbox 矩阵（Linux / macOS / Windows 三平台 + WritableRoot）从含糊"完整移植"flip 为带 PR 编号 ✅
3. **新增** [desktop-client/README.md](desktop-client/README.md) "Enterprise sandbox 现状" 章节
   - 三平台 fail-closed 矩阵 + 引用 ADR-141 / ADR-144 + 明确 soft-mode 已在 PR #448 移除（B3-4 PR-W5 README portion）
4. **epic #380 body**（已通过 `gh issue edit` 推送，非 PR 内变更）：B3-0~B3-5 + 验收 3 项全部 flip 为 `[x]`，附 PR / 演进说明

## 非目标（What's NOT in this PR）

- ❌ 不动 `crates/dasclaw_sandbox/src/`（生产代码零变更——`check_enterprise_gate` / 两个 SandboxError variant / `enterprise_mode` 字段都已由 PR #426 / #448 落地）
- ❌ 不动 #241 / Batch 4（adr-redline，需真机 + ADR sign-off）
- ❌ 不再写 `_softflag_audit_emitted` 测试（B3-2 演进：P1.2b sign-off 已删 soft-mode 路径）

## Cross-cuts

- ADR-114（`.ironclaw` → `.dasclaw` 命名迁移）：**类A**（无新增 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量）

## 验证

```bash
cargo fmt --all -- --check                                          # OK
python3.12 scripts/check_no_panics.py --base origin/xClaw           # OK
cargo check -p dasclaw_sandbox --tests                              # OK
cargo nextest run -p dasclaw_sandbox --test req_check_enterprise_gate
#   5 tests run: 5 passed, 0 skipped (1.505s)
cargo clippy --no-deps -p dasclaw_sandbox --all-targets -- -D warnings  # OK
```

epic #380 `- [ ]` 计数：25 → 16（Batch 3 全闭环）。

Closes #457
Refs #380 Batch 3 (epic remains open for Batch 4/5/6).

