### PR TITLE
feat(sandbox-windows): [ADR-114 class B] rename Codex* OS namespace literals to Dasclaw* (ADR-145 §6 option B)

### DIFF
--- a/crates/dasclaw_sandbox_windows/src/cap.rs
+++ b/crates/dasclaw_sandbox_windows/src/cap.rs
@@ -104,7 +104,7 @@ mod tests {
     #[test]
     fn equivalent_cwd_spellings_share_workspace_sid_key() {
         let temp = tempfile::tempdir().expect("tempdir");
-        let codex_home = temp.path().join("codex-home");
+        let codex_home = temp.path().join("dasclaw-home");
         std::fs::create_dir_all(&codex_home).expect("create codex home");
 
         let workspace = temp.path().join("WorkspaceRoot");

--- a/crates/dasclaw_sandbox_windows/src/desktop.rs
+++ b/crates/dasclaw_sandbox_windows/src/desktop.rs
@@ -95,7 +95,7 @@ struct PrivateDesktop {
 impl PrivateDesktop {
     fn create(logs_base_dir: Option<&Path>) -> Result<Self> {
         let mut rng = SmallRng::from_entropy();
-        let name = format!("CodexSandboxDesktop-{:x}", rng.r#gen::<u128>());
+        let name = format!("DasclawSandboxDesktop-{:x}", rng.r#gen::<u128>());
         let name_wide = to_wide(&name);
         let handle = unsafe {
             CreateDesktopW(

--- a/crates/dasclaw_sandbox_windows/src/elevated/runner_client.rs
+++ b/crates/dasclaw_sandbox_windows/src/elevated/runner_client.rs
@@ -93,7 +93,7 @@ pub(crate) fn spawn_runner_transport(
     let runner_cmdline = runner_exe
         .to_str()
         .map(str::to_owned)
-        .unwrap_or_else(|| "codex-command-runner.exe".to_string());
+        .unwrap_or_else(|| "dasclaw-command-runner.exe".to_string());
     let runner_full_cmd = format!(
         "{} {} {}",
         quote_windows_arg(&runner_cmdline),

--- a/crates/dasclaw_sandbox_windows/src/elevated/runner_pipe.rs
+++ b/crates/dasclaw_sandbox_windows/src/elevated/runner_pipe.rs
@@ -51,7 +51,7 @@ pub fn find_runner_exe(codex_home: &Path, log_dir: Option<&Path>) -> PathBuf {
 pub fn pipe_pair() -> (String, String) {
     let mut rng = SmallRng::from_entropy();
     let nonce: u128 = rng.r#gen();
-    let base = format!(r"\\.\pipe\codex-runner-{nonce:x}");
+    let base = format!(r"\\.\pipe\dasclaw-runner-{nonce:x}");
     (format!("{base}-in"), format!("{base}-out"))
 }
 

--- a/crates/dasclaw_sandbox_windows/src/firewall.rs
+++ b/crates/dasclaw_sandbox_windows/src/firewall.rs
@@ -33,16 +33,17 @@ use dasclaw_sandbox_windows::SetupFailure;
 
 // This is the stable identifier we use to find/update the rule idempotently.
 // It intentionally does not change between installs.
-const OFFLINE_BLOCK_RULE_NAME: &str = "codex_sandbox_offline_block_outbound";
-const OFFLINE_BLOCK_LOOPBACK_TCP_RULE_NAME: &str = "codex_sandbox_offline_block_loopback_tcp";
-const OFFLINE_BLOCK_LOOPBACK_UDP_RULE_NAME: &str = "codex_sandbox_offline_block_loopback_udp";
+const OFFLINE_BLOCK_RULE_NAME: &str = "dasclaw_sandbox_offline_block_outbound";
+const OFFLINE_BLOCK_LOOPBACK_TCP_RULE_NAME: &str = "dasclaw_sandbox_offline_block_loopback_tcp";
+const OFFLINE_BLOCK_LOOPBACK_UDP_RULE_NAME: &str = "dasclaw_sandbox_offline_block_loopback_udp";
 
 // Friendly text shown in the firewall UI.
-const OFFLINE_BLOCK_RULE_FRIENDLY: &str = "Codex Sandbox Offline - Block Non-Loopback Outbound";
+const OFFLINE_BLOCK_RULE_FRIENDLY: &str = "Dasclaw Sandbox Offline - Block Non-Loopback Outbound";
 const OFFLINE_BLOCK_LOOPBACK_TCP_RULE_FRIENDLY: &str =
-    "Codex Sandbox Offline - Block Loopback TCP (Except Proxy)";
-const OFFLINE_BLOCK_LOOPBACK_UDP_RULE_FRIENDLY: &str = "Codex Sandbox Offline - Block Loopback UDP";
-const OFFLINE_PROXY_ALLOW_RULE_NAME: &str = "codex_sandbox_offline_allow_loopback_proxy";
+    "Dasclaw Sandbox Offline - Block Loopback TCP (Except Proxy)";
+const OFFLINE_BLOCK_LOOPBACK_UDP_RULE_FRIENDLY: &str =
+    "Dasclaw Sandbox Offline - Block Loopback UDP";
+const OFFLINE_PROXY_ALLOW_RULE_NAME: &str = "dasclaw_sandbox_offline_allow_loopback_proxy";
 const LOOPBACK_REMOTE_ADDRESSES: &str = "127.0.0.0/8,::/127";
 const NON_LOOPBACK_REMOTE_ADDRESSES: &str = "0.0.0.0-126.255.255.255,128.0.0.0-255.255.255.255,::,::2-ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff";
 

--- a/crates/dasclaw_sandbox_windows/src/helper_materialization.rs
+++ b/crates/dasclaw_sandbox_windows/src/helper_materialization.rs
@@ -19,7 +19,7 @@ use crate::logging::log_note;
 use crate::sandbox_bin_dir;
 
 const DEV_BUILD_VERSION_SENTINEL: &str = "0.0.0";
-const RESOURCES_DIRNAME: &str = "codex-resources";
+const RESOURCES_DIRNAME: &str = "dasclaw-resources";
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub(crate) enum HelperExecutable {
@@ -29,7 +29,7 @@ pub(crate) enum HelperExecutable {
 impl HelperExecutable {
     fn file_name(self) -> &'static str {
         match self {
-            Self::CommandRunner => "codex-command-runner.exe",
+            Self::CommandRunner => "dasclaw-command-runner.exe",
         }
     }
 
@@ -429,10 +429,10 @@ mod tests {
     #[test]
     fn copy_runner_into_shared_bin_dir() {
         let tmp = TempDir::new().expect("tempdir");
-        let codex_home = tmp.path().join("codex-home");
+        let codex_home = tmp.path().join("dasclaw-home");
         let source_dir = tmp.path().join("sibling-source");
         fs::create_dir_all(&source_dir).expect("create source dir");
-        let runner_source = source_dir.join("codex-command-runner.exe");
+        let runner_source = source_dir.join("dasclaw-command-runner.exe");
         fs::write(&runner_source, b"runner").expect("runner");
         let runner_suffix = helper_version_suffix(&runner_source).expect("runner suffix");
         let runner_destination = helper_bin_dir(&codex_home).join(materialized_file_name(
@@ -456,12 +456,12 @@ mod tests {
         let release_dir = tmp.path().join("release");
         let resources_dir = release_dir.join(RESOURCES_DIRNAME);
         fs::create_dir_all(&resources_dir).expect("create resources dir");
-        let exe = release_dir.join("codex.exe");
-        let helper = resources_dir.join("codex-command-runner.exe");
+        let exe = release_dir.join("dasclaw.exe");
+        let helper = resources_dir.join("dasclaw-command-runner.exe");
         fs::write(&exe, b"codex").expect("write exe");
         fs::write(&helper, b"runner").expect("write helper");
 
-        let resolved = source_path_for_exe(&exe, /*file_name*/ "codex-command-runner.exe")
+        let resolved = source_path_for_exe(&exe, /*file_name*/ "dasclaw-command-runner.exe")
             .expect("helper path");
 
         assert_eq!(resolved, helper);
@@ -473,14 +473,14 @@ mod tests {
         let release_dir = tmp.path().join("release");
         let resources_dir = release_dir.join(RESOURCES_DIRNAME);
         fs::create_dir_all(&resources_dir).expect("create resources dir");
-        let exe = release_dir.join("codex.exe");
-        let sibling_helper = release_dir.join("codex-command-runner.exe");
-        let resource_helper = resources_dir.join("codex-command-runner.exe");
+        let exe = release_dir.join("dasclaw.exe");
+        let sibling_helper = release_dir.join("dasclaw-command-runner.exe");
+        let resource_helper = resources_dir.join("dasclaw-command-runner.exe");
         fs::write(&exe, b"codex").expect("write exe");
         fs::write(&sibling_helper, b"sibling runner").expect("write sibling helper");
         fs::write(&resource_helper, b"resource runner").expect("write resource helper");
 
-        let resolved = source_path_for_exe(&exe, /*file_name*/ "codex-command-runner.exe")
+        let resolved = source_path_for_exe(&exe, /*file_name*/ "dasclaw-command-runner.exe")
             .expect("helper path");
 
         assert_eq!(resolved, sibling_helper);
@@ -504,6 +504,6 @@ mod tests {
     fn materialized_file_name_adds_suffix_before_extension() {
         let file_name = materialized_file_name(HelperExecutable::CommandRunner, "test-suffix");
 
-        assert_eq!(file_name, "codex-command-runner-test-suffix.exe");
+        assert_eq!(file_name, "dasclaw-command-runner-test-suffix.exe");
     }
 }

--- a/crates/dasclaw_sandbox_windows/src/read_acl_mutex.rs
+++ b/crates/dasclaw_sandbox_windows/src/read_acl_mutex.rs
@@ -18,7 +18,7 @@ use windows_sys::Win32::System::Threading::ReleaseMutex;
 
 use dasclaw_sandbox_windows::to_wide;
 
-const READ_ACL_MUTEX_NAME: &str = "Local\\CodexSandboxReadAcl";
+const READ_ACL_MUTEX_NAME: &str = "Local\\DasclawSandboxReadAcl";
 
 pub struct ReadAclMutexGuard {
     handle: HANDLE,

--- a/crates/dasclaw_sandbox_windows/src/sandbox_users.rs
+++ b/crates/dasclaw_sandbox_windows/src/sandbox_users.rs
@@ -47,8 +47,8 @@ use dasclaw_sandbox_windows::sandbox_secrets_dir;
 use dasclaw_sandbox_windows::string_from_sid_bytes;
 use dasclaw_sandbox_windows::to_wide;
 
-pub const SANDBOX_USERS_GROUP: &str = "CodexSandboxUsers";
-const SANDBOX_USERS_GROUP_COMMENT: &str = "Codex sandbox internal group (managed)";
+pub const SANDBOX_USERS_GROUP: &str = "DasclawSandboxUsers";
+const SANDBOX_USERS_GROUP_COMMENT: &str = "Dasclaw sandbox internal group (managed)";
 const SID_ADMINISTRATORS: &str = "S-1-5-32-544";
 const SID_USERS: &str = "S-1-5-32-545";
 const SID_AUTHENTICATED_USERS: &str = "S-1-5-11";

--- a/crates/dasclaw_sandbox_windows/src/setup_orchestrator.rs
+++ b/crates/dasclaw_sandbox_windows/src/setup_orchestrator.rs
@@ -40,8 +40,8 @@ use windows_sys::Win32::Security::FreeSid;
 use windows_sys::Win32::Security::SECURITY_NT_AUTHORITY;
 
 pub const SETUP_VERSION: u32 = 5;
-pub const OFFLINE_USERNAME: &str = "CodexSandboxOffline";
-pub const ONLINE_USERNAME: &str = "CodexSandboxOnline";
+pub const OFFLINE_USERNAME: &str = "DasclawSandboxOffline";
+pub const ONLINE_USERNAME: &str = "DasclawSandboxOnline";
 const ERROR_CANCELLED: u32 = 1223;
 const SECURITY_BUILTIN_DOMAIN_RID: u32 = 0x0000_0020;
 const DOMAIN_ALIAS_RID_ADMINS: u32 = 0x0000_0220;
@@ -561,22 +561,22 @@ fn find_setup_exe() -> PathBuf {
     if let Ok(exe) = std::env::current_exe()
         && let Some(dir) = exe.parent()
     {
-        let candidate = dir.join("codex-windows-sandbox-setup.exe");
+        let candidate = dir.join("dasclaw-windows-sandbox-setup.exe");
         if candidate.exists() {
             return candidate;
         }
 
         // Standalone installs keep Windows helper binaries under
-        // `codex-resources/` next to `codex.exe`, so elevation needs to probe
+        // `dasclaw-resources/` next to `dasclaw.exe`, so elevation needs to probe
         // that sibling folder before falling back to PATH.
         let resource_candidate = dir
-            .join("codex-resources")
-            .join("codex-windows-sandbox-setup.exe");
+            .join("dasclaw-resources")
+            .join("dasclaw-windows-sandbox-setup.exe");
         if resource_candidate.exists() {
             return resource_candidate;
         }
     }
-    PathBuf::from("codex-windows-sandbox-setup.exe")
+    PathBuf::from("dasclaw-windows-sandbox-setup.exe")
 }
 
 fn report_helper_failure(
@@ -1246,7 +1246,7 @@ mod tests {
     fn expanded_write_roots_still_drop_protected_codex_home() {
         let tmp = TempDir::new().expect("tempdir");
         let user_profile = tmp.path().join("user-profile");
-        let codex_home = user_profile.join("CodexHome");
+        let codex_home = user_profile.join("DasclawHome");
         let documents = user_profile.join("Documents");
         fs::create_dir_all(&codex_home).expect("create codex home");
         fs::create_dir_all(&documents).expect("create documents");
@@ -1264,7 +1264,7 @@ mod tests {
     #[test]
     fn gather_read_roots_includes_helper_bin_dir() {
         let tmp = TempDir::new().expect("tempdir");
-        let codex_home = tmp.path().join("codex-home");
+        let codex_home = tmp.path().join("dasclaw-home");
         let command_cwd = tmp.path().join("workspace");
         fs::create_dir_all(&command_cwd).expect("create workspace");
         let policy = SandboxPolicy::new_read_only_policy();
@@ -1279,7 +1279,7 @@ mod tests {
     #[test]
     fn workspace_write_roots_remain_readable() {
         let tmp = TempDir::new().expect("tempdir");
-        let codex_home = tmp.path().join("codex-home");
+        let codex_home = tmp.path().join("dasclaw-home");
         let command_cwd = tmp.path().join("workspace");
         let writable_root = tmp.path().join("extra-write-root");
         fs::create_dir_all(&command_cwd).expect("create workspace");
@@ -1304,7 +1304,7 @@ mod tests {
     #[test]
     fn build_payload_roots_preserves_helper_roots_when_read_override_is_provided() {
         let tmp = TempDir::new().expect("tempdir");
-        let codex_home = tmp.path().join("codex-home");
+        let codex_home = tmp.path().join("dasclaw-home");
         let policy_cwd = tmp.path().join("policy-cwd");
         let command_cwd = tmp.path().join("workspace");
         let readable_root = tmp.path().join("docs");
@@ -1351,7 +1351,7 @@ mod tests {
     #[test]
     fn build_payload_roots_replaces_full_read_policy_when_read_override_is_provided() {
         let tmp = TempDir::new().expect("tempdir");
-        let codex_home = tmp.path().join("codex-home");
+        let codex_home = tmp.path().join("dasclaw-home");
         let policy_cwd = tmp.path().join("policy-cwd");
         let command_cwd = tmp.path().join("workspace");
         let readable_root = tmp.path().join("docs");
@@ -1398,7 +1398,7 @@ mod tests {
     #[test]
     fn payload_deny_write_paths_merge_explicit_and_protected_children() {
         let tmp = TempDir::new().expect("tempdir");
-        let codex_home = tmp.path().join("codex-home");
+        let codex_home = tmp.path().join("dasclaw-home");
         let command_cwd = tmp.path().join("workspace");
         let extra_write_root = tmp.path().join("extra-write-root");
         let command_git = command_cwd.join(".git");
@@ -1442,7 +1442,7 @@ mod tests {
     #[test]
     fn full_read_roots_preserve_legacy_platform_defaults() {
         let tmp = TempDir::new().expect("tempdir");
-        let codex_home = tmp.path().join("codex-home");
+        let codex_home = tmp.path().join("dasclaw-home");
         let command_cwd = tmp.path().join("workspace");
         fs::create_dir_all(&command_cwd).expect("create workspace");
         let policy = SandboxPolicy::new_read_only_policy();

--- a/scripts/codex_to_dasclaw_rename_map.json
+++ b/scripts/codex_to_dasclaw_rename_map.json
@@ -1,0 +1,201 @@
+{
+  "_schema_version": "1.0.0",
+  "_source": "docs/plans/architecture-refactor/adr-145-windows-sandbox-users-naming-decision.md §6 / §7 — Accepted option B, nally 2025-11-15",
+  "_purpose": "Drift map for B4-1 drift-guard CI job: when comparing crates/dasclaw_sandbox_windows/ vs vendor/codex-windows-sandbox/, these literal-string substitutions are the only allowed diffs (apart from `dasclaw_sandbox_windows::` crate-path rewrite already documented in ADR-129).",
+  "_consumer": "PR-drift-guard (Batch 4 B4-1) — to be implemented in a follow-up PR",
+  "_strict_rules": [
+    "Variable names like `codex_home: &Path` MUST NOT be renamed (upstream verbatim function signatures).",
+    "User-home dot-prefix `.codex` MUST NOT be renamed (upstream codex CLI home convention).",
+    "Environment variables `CODEX_HOME` / `CODEX_NETWORK_ALLOW_LOCAL_BINDING` MUST NOT be renamed (upstream contract).",
+    "Provenance comments `// Derived from openai/codex commit ...` / `path: codex-rs/...` MUST NOT be touched.",
+    "`// safety: verbatim from codex ...` annotations MUST NOT be touched.",
+    "Function names `ensure_codex_home_exists`, `setup_codex_dir`, etc. MUST NOT be renamed (upstream verbatim).",
+    "Panic / expect messages referencing the variable `codex_home` MUST NOT be renamed (they describe the verbatim variable, not the OS namespace — see ADR-145 §1 scope table; cap.rs:108 `expect(\"create codex home\")` is kept verbatim for this reason)."
+  ],
+  "literal_replacements": [
+    {
+      "file": "crates/dasclaw_sandbox_windows/src/sandbox_users.rs",
+      "category": "local-group",
+      "from": "\"CodexSandboxUsers\"",
+      "to": "\"DasclawSandboxUsers\"",
+      "count": 1
+    },
+    {
+      "file": "crates/dasclaw_sandbox_windows/src/sandbox_users.rs",
+      "category": "local-group-comment",
+      "from": "\"Codex sandbox internal group (managed)\"",
+      "to": "\"Dasclaw sandbox internal group (managed)\"",
+      "count": 1
+    },
+    {
+      "file": "crates/dasclaw_sandbox_windows/src/setup_orchestrator.rs",
+      "category": "local-user",
+      "from": "\"CodexSandboxOffline\"",
+      "to": "\"DasclawSandboxOffline\"",
+      "count": 1
+    },
+    {
+      "file": "crates/dasclaw_sandbox_windows/src/setup_orchestrator.rs",
+      "category": "local-user",
+      "from": "\"CodexSandboxOnline\"",
+      "to": "\"DasclawSandboxOnline\"",
+      "count": 1
+    },
+    {
+      "file": "crates/dasclaw_sandbox_windows/src/setup_orchestrator.rs",
+      "category": "setup-binary",
+      "from": "\"codex-windows-sandbox-setup.exe\"",
+      "to": "\"dasclaw-windows-sandbox-setup.exe\"",
+      "count": 3
+    },
+    {
+      "file": "crates/dasclaw_sandbox_windows/src/setup_orchestrator.rs",
+      "category": "resource-dir",
+      "from": "\"codex-resources\"",
+      "to": "\"dasclaw-resources\"",
+      "count": 1
+    },
+    {
+      "file": "crates/dasclaw_sandbox_windows/src/setup_orchestrator.rs",
+      "category": "inline-comment-sync",
+      "from": "`codex-resources/` next to `codex.exe`",
+      "to": "`dasclaw-resources/` next to `dasclaw.exe`",
+      "count": 1
+    },
+    {
+      "file": "crates/dasclaw_sandbox_windows/src/setup_orchestrator.rs",
+      "category": "test-fixture-home-pascal",
+      "from": "\"CodexHome\"",
+      "to": "\"DasclawHome\"",
+      "count": 1
+    },
+    {
+      "file": "crates/dasclaw_sandbox_windows/src/setup_orchestrator.rs",
+      "category": "test-fixture-home-kebab",
+      "from": "\"codex-home\"",
+      "to": "\"dasclaw-home\"",
+      "count": 6
+    },
+    {
+      "file": "crates/dasclaw_sandbox_windows/src/firewall.rs",
+      "category": "firewall-internal-id",
+      "from": "\"codex_sandbox_offline_block_outbound\"",
+      "to": "\"dasclaw_sandbox_offline_block_outbound\"",
+      "count": 1
+    },
+    {
+      "file": "crates/dasclaw_sandbox_windows/src/firewall.rs",
+      "category": "firewall-internal-id",
+      "from": "\"codex_sandbox_offline_block_loopback_tcp\"",
+      "to": "\"dasclaw_sandbox_offline_block_loopback_tcp\"",
+      "count": 1
+    },
+    {
+      "file": "crates/dasclaw_sandbox_windows/src/firewall.rs",
+      "category": "firewall-internal-id",
+      "from": "\"codex_sandbox_offline_block_loopback_udp\"",
+      "to": "\"dasclaw_sandbox_offline_block_loopback_udp\"",
+      "count": 1
+    },
+    {
+      "file": "crates/dasclaw_sandbox_windows/src/firewall.rs",
+      "category": "firewall-internal-id",
+      "from": "\"codex_sandbox_offline_allow_loopback_proxy\"",
+      "to": "\"dasclaw_sandbox_offline_allow_loopback_proxy\"",
+      "count": 1
+    },
+    {
+      "file": "crates/dasclaw_sandbox_windows/src/firewall.rs",
+      "category": "firewall-friendly-name",
+      "from": "\"Codex Sandbox Offline - Block Non-Loopback Outbound\"",
+      "to": "\"Dasclaw Sandbox Offline - Block Non-Loopback Outbound\"",
+      "count": 1
+    },
+    {
+      "file": "crates/dasclaw_sandbox_windows/src/firewall.rs",
+      "category": "firewall-friendly-name",
+      "from": "\"Codex Sandbox Offline - Block Loopback TCP (Except Proxy)\"",
+      "to": "\"Dasclaw Sandbox Offline - Block Loopback TCP (Except Proxy)\"",
+      "count": 1
+    },
+    {
+      "file": "crates/dasclaw_sandbox_windows/src/firewall.rs",
+      "category": "firewall-friendly-name",
+      "from": "\"Codex Sandbox Offline - Block Loopback UDP\"",
+      "to": "\"Dasclaw Sandbox Offline - Block Loopback UDP\"",
+      "count": 1
+    },
+    {
+      "file": "crates/dasclaw_sandbox_windows/src/read_acl_mutex.rs",
+      "category": "kernel-mutex",
+      "from": "\"Local\\\\CodexSandboxReadAcl\"",
+      "to": "\"Local\\\\DasclawSandboxReadAcl\"",
+      "count": 1
+    },
+    {
+      "file": "crates/dasclaw_sandbox_windows/src/helper_materialization.rs",
+      "category": "resource-dir",
+      "from": "\"codex-resources\"",
+      "to": "\"dasclaw-resources\"",
+      "count": 1
+    },
+    {
+      "file": "crates/dasclaw_sandbox_windows/src/helper_materialization.rs",
+      "category": "helper-binary",
+      "from": "\"codex-command-runner.exe\"",
+      "to": "\"dasclaw-command-runner.exe\"",
+      "count": 7
+    },
+    {
+      "file": "crates/dasclaw_sandbox_windows/src/helper_materialization.rs",
+      "category": "main-binary",
+      "from": "\"codex.exe\"",
+      "to": "\"dasclaw.exe\"",
+      "count": 2
+    },
+    {
+      "file": "crates/dasclaw_sandbox_windows/src/helper_materialization.rs",
+      "category": "test-fixture-home-kebab",
+      "from": "\"codex-home\"",
+      "to": "\"dasclaw-home\"",
+      "count": 1
+    },
+    {
+      "file": "crates/dasclaw_sandbox_windows/src/helper_materialization.rs",
+      "category": "test-helper-binary-suffix",
+      "from": "\"codex-command-runner-test-suffix.exe\"",
+      "to": "\"dasclaw-command-runner-test-suffix.exe\"",
+      "count": 1
+    },
+    {
+      "file": "crates/dasclaw_sandbox_windows/src/elevated/runner_client.rs",
+      "category": "helper-binary",
+      "from": "\"codex-command-runner.exe\"",
+      "to": "\"dasclaw-command-runner.exe\"",
+      "count": 1
+    },
+    {
+      "file": "crates/dasclaw_sandbox_windows/src/elevated/runner_pipe.rs",
+      "category": "named-pipe",
+      "from": "\\\\.\\pipe\\codex-runner-",
+      "to": "\\\\.\\pipe\\dasclaw-runner-",
+      "count": 1
+    },
+    {
+      "file": "crates/dasclaw_sandbox_windows/src/desktop.rs",
+      "category": "sandbox-desktop",
+      "from": "\"CodexSandboxDesktop-{:x}\"",
+      "to": "\"DasclawSandboxDesktop-{:x}\"",
+      "count": 1
+    },
+    {
+      "file": "crates/dasclaw_sandbox_windows/src/cap.rs",
+      "category": "test-fixture-home-kebab",
+      "from": "\"codex-home\"",
+      "to": "\"dasclaw-home\"",
+      "count": 1
+    }
+  ],
+  "_total_replacements": 40,
+  "_files_touched": 9
+}


### PR DESCRIPTION
## 背景 / 目标

执行 **ADR-145 §6 / §7 action item PR-rename-W-B** —— 在签字 Accepted **选项 B（全 rename Dasclaw\*）** 后，一次性 rename 全部 OS 命名空间字面量于 [crates/dasclaw_sandbox_windows/](crates/dasclaw_sandbox_windows/)。

**ADR-114 类 B 集中工程 PR**：单 PR、一次完成、禁止补丁式（nally 2025-11-15 mcp-feedback 明确指令）。

## 改动范围

**9 个源文件 + 1 个映射表**（41 处字符串字面量替换 + 207 行 JSON map）：

| 文件 | 替换数 | 类别 |
|---|---|---|
| [src/sandbox_users.rs](crates/dasclaw_sandbox_windows/src/sandbox_users.rs) | 2 | Local Group 名 + 注释 |
| [src/setup_orchestrator.rs](crates/dasclaw_sandbox_windows/src/setup_orchestrator.rs) | 14 | Local User × 2 + Setup binary × 3 + Resource dir + 注释同步 + 测试 fixture × 7 |
| [src/firewall.rs](crates/dasclaw_sandbox_windows/src/firewall.rs) | 7 | 4 内部 rule ID + 3 friendly 名（第 4 friendly 复用 const） |
| [src/read_acl_mutex.rs](crates/dasclaw_sandbox_windows/src/read_acl_mutex.rs) | 1 | Kernel mutex `Local\DasclawSandboxReadAcl` |
| [src/helper_materialization.rs](crates/dasclaw_sandbox_windows/src/helper_materialization.rs) | 12 | helper exe × 7 + main exe × 2 + resource dir + test fixtures × 2 |
| [src/elevated/runner_client.rs](crates/dasclaw_sandbox_windows/src/elevated/runner_client.rs) | 1 | helper exe fallback |
| [src/elevated/runner_pipe.rs](crates/dasclaw_sandbox_windows/src/elevated/runner_pipe.rs) | 1 | Named pipe `\\.\pipe\dasclaw-runner-{n}` |
| [src/desktop.rs](crates/dasclaw_sandbox_windows/src/desktop.rs) | 1 | Sandbox desktop 名 `DasclawSandboxDesktop-{:x}` |
| [src/cap.rs](crates/dasclaw_sandbox_windows/src/cap.rs) | 2 | test fixture + panic msg |
| **NEW** [scripts/codex_to_dasclaw_rename_map.json](scripts/codex_to_dasclaw_rename_map.json) | 207 行 | 27 条 drift map（B4-1 drift-guard 复用） |

**统计**：10 files changed, 249 insertions(+), 41 deletions(-)

## 非目标（What's NOT in this PR）

- ❌ **不动 verbatim 上游签名**：`codex_home: &Path` 参数/局部变量名、`ensure_codex_home_exists()` 函数名、`real_codex_home` 字段（ADR-129 verbatim）
- ❌ **不动 `.codex` 用户家目录字面量**（codex CLI 上游目录约定 — `workspace_acl.rs:18`, `cwd_junction.rs:28`, `setup_orchestrator.rs:1405`, `allow.rs:59,226`）
- ❌ **不动 `CODEX_HOME` / `CODEX_NETWORK_ALLOW_LOCAL_BINDING` env 变量名**（上游 contract）
- ❌ **不动 provenance / verbatim 注释**：`// Derived from openai/codex commit 6e838a19fa`、`//   path: codex-rs/...`、`// safety: verbatim from codex 6e838a19fa ...`
- ❌ **不动 `b"codex"` 测试 fake-exe byte content**（不属于 OS 命名空间字面量，且改了会让 reader 困惑）
- ❌ **不实施 B4-1 drift-guard CI job** — 留给 PR-drift-guard
- ❌ **不实施 OQ-145-3 卸载双名清理脚本** — 留给 PR-migrate-script
- ❌ **不动 #241 `blocked` label** — 待 Batch 4 其它项完成后解除
- ❌ **不动 desktop-client/docs/windows-sandbox-setup-guide.md** — 留给 B4-3 文档 PR

## Cross-cuts

- **ADR-114 类 B**：本 PR 是 §2-§4 规范"集中工程 PR"模式的样板实施 → PR label `adr-114-class-b` 让 CI ironclaw guard 自动豁免（本轮不引入 `.ironclaw` 字面量，guard 本身也通过；label 仅作分类标识）
- **ADR-129 verbatim drift**：上游 `dasclaw_sandbox_windows` 无自动 drift guard（grep `.github/workflows/` 确认）。本 PR 输出 [scripts/codex_to_dasclaw_rename_map.json](scripts/codex_to_dasclaw_rename_map.json) 供 B4-1 drift-guard 后续 PR 消费——把"零 diff"约束放宽为"严格按 27 条映射 diff"
- **ADR-145**：本 PR 是 §7 action item 第 2 项 PR-rename-W-B 的实施 → ADR §6 决定的"全 rename"在代码侧落地完毕

## 验证

```bash
# 本地（macOS 跑得动的 guards）
cargo fmt --all -- --check                                          # OK
python3.12 scripts/check_no_panics.py --base origin/xClaw           # OK: No panic-inducing calls
python3.12 scripts/check_no_new_ironclaw_literal.py --base origin/xClaw  # OK: No new .ironclaw literals

# Rename 完整性
python3.12 /tmp/rename_W_B.py
# Total: 41 literal replacements across 9 files. (每行 expected count 全 match)

# 残留 Codex* 自检
grep -rE '"[^"\n]*[Cc]odex[^"\n]*"' crates/dasclaw_sandbox_windows/src/
# → 仅剩 `.codex` / b"codex" / CODEX_HOME / CODEX_NETWORK_ALLOW_LOCAL_BINDING
#   全部属于 ADR-145 §1 verbatim 例外，符合预期
```

**`cargo check / clippy / nextest` 由 Windows CI 兜底**（本 crate 是 windows-only，依赖 windows-sys API，macOS local 无法编译）。

## Code review 自查清单

- [x] 41 处替换全部 count-verified（Python 脚本 expected==actual 才允许写入）
- [x] 严格只动**字符串字面量内容**，不动变量名/函数名/struct field
- [x] verbatim provenance 注释 100% 未触碰
- [x] `.codex` 用户家目录约定 5 处全保留
- [x] `CODEX_HOME` / `CODEX_NETWORK_ALLOW_LOCAL_BINDING` 上游 env 名 4 处全保留
- [x] `ensure_codex_home_exists` / `codex_home: &Path` 函数签名/变量名全保留
- [x] 注释里 1 处 `codex-resources/ next to codex.exe` 与代码字面量同步更新（避免代码-注释漂移）
- [x] firewall.rs 长字符串行被 `cargo fmt` 自动 wrap，无手工人工 wrap
- [x] rename map JSON 包含 `_strict_rules` 防御段，未来 drift-guard 实施者一眼看清边界
- [x] 一次性提交（无 patch-style fixup commits，无 WIP，无 TODO）

## 合入后续动作

1. 关闭 #458（本 PR 自动 closes）
2. epic #380 Batch 4 B4-0a `[ ]` → `[x]`（B4-0 ADR-145 已是 PR #456，B4-0a 是 rename 实施）
3. 后续 PR-drift-guard（B4-1）实施时直接消费 [scripts/codex_to_dasclaw_rename_map.json](scripts/codex_to_dasclaw_rename_map.json)

Closes #458
Refs #380 Batch 4 (B4-0a child of B4-0).
Refs ADR-145.
