### PR TITLE
feat(sandbox): [B4-2] expose cross-platform sandbox_setup_status() + ic_sandbox_status IPC

### DIFF
--- a/crates/dasclaw_sandbox/src/lib.rs
+++ b/crates/dasclaw_sandbox/src/lib.rs
@@ -463,6 +463,70 @@ pub trait Sandbox {
     fn execute(&self, req: SandboxExecRequest) -> Result<std::process::Output, SandboxError>;
 }
 
+/// Status of the platform sandbox infrastructure as observed at startup.
+///
+/// On macOS/Linux the kernel sandbox (Seatbelt / Landlock + seccomp) is
+/// always available without operator action, so the status is
+/// [`SandboxSetupStatus::Ready`].
+///
+/// On Windows the sandbox requires a one-time elevated setup
+/// (`dasclaw-sandbox-setup.exe` — see ADR-145 and
+/// `desktop-client/docs/windows-sandbox-setup-guide.md`) that materialises
+/// per-user accounts, a marker file and DPAPI state under `dasclaw_home`.
+/// Until that runs, [`SandboxSetupStatus::SetupRequired`] is returned and
+/// callers (notably the desktop-client startup hook, epic #380 / issue
+/// #464) should surface a UX prompt directing the operator to run setup.
+///
+/// `#[non_exhaustive]` so future platforms can add variants without
+/// breaking out-of-crate `match` sites.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum SandboxSetupStatus {
+    /// Platform sandbox infrastructure is ready or does not require setup.
+    Ready { kind: SandboxType },
+    /// Platform sandbox requires a one-time elevated setup before use.
+    SetupRequired {
+        kind: SandboxType,
+        /// Path inspected for setup state (so the UI can show
+        /// "expected setup root: …").
+        dasclaw_home: PathBuf,
+        /// Translation-friendly English hint describing the operator
+        /// action required to clear the `SetupRequired` state. The
+        /// front-end may localise / reword it; the Rust layer keeps it
+        /// stable as a fallback.
+        action_hint: String,
+    },
+    /// No OS-level sandbox is wired on this platform / configuration; a
+    /// spawn with `SandboxablePreference::Auto` falls back to
+    /// `NoopSandbox`. Returned on Windows when `windows_sandbox_enabled`
+    /// is `false`, and on any unsupported target OS.
+    Unavailable,
+}
+
+/// Inspect platform sandbox infrastructure readiness.
+///
+/// Pure read-only check: never blocks, never spawns a child, never mutates
+/// filesystem state. Safe to call from a process-startup hook (desktop-client
+/// uses this in `ic_sandbox_status` per epic #380 / issue #464).
+///
+/// `windows_sandbox_enabled` mirrors [`get_platform_sandbox`]: on Windows,
+/// passing `false` short-circuits to [`SandboxSetupStatus::Unavailable`]
+/// (the OS sandbox is opt-in there). For a startup readiness check the
+/// caller typically passes `true` so an un-setup install is surfaced even
+/// before the user opts in.
+pub fn sandbox_setup_status(windows_sandbox_enabled: bool) -> SandboxSetupStatus {
+    let Some(kind) = get_platform_sandbox(windows_sandbox_enabled) else {
+        return SandboxSetupStatus::Unavailable;
+    };
+
+    #[cfg(target_os = "windows")]
+    if matches!(kind, SandboxType::WindowsRestrictedToken) {
+        return windows::sandbox_setup_status_windows(kind);
+    }
+
+    SandboxSetupStatus::Ready { kind }
+}
+
 /// Resolve `pref` + platform → concrete backend.
 pub fn select_backend(
     pref: SandboxablePreference,
@@ -576,6 +640,54 @@ mod tests {
             let r = select_backend(SandboxablePreference::Require, false);
             assert!(matches!(r, Err(SandboxError::PlatformUnavailable)));
         }
+    }
+
+    #[test]
+    fn setup_status_is_pure_and_does_not_panic() {
+        // Pure read-only inspection; must be safe at startup regardless
+        // of host state. We only assert the call does not panic and
+        // returns a valid variant — host-specific assertions follow.
+        let _ = sandbox_setup_status(true);
+        let _ = sandbox_setup_status(false);
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn setup_status_macos_is_ready() {
+        let s = sandbox_setup_status(true);
+        assert!(
+            matches!(
+                s,
+                SandboxSetupStatus::Ready {
+                    kind: SandboxType::MacosSeatbelt
+                }
+            ),
+            "macOS Seatbelt is kernel-provided; expected Ready"
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn setup_status_linux_is_ready() {
+        let s = sandbox_setup_status(true);
+        assert!(
+            matches!(
+                s,
+                SandboxSetupStatus::Ready {
+                    kind: SandboxType::LinuxSeccomp
+                }
+            ),
+            "Linux Landlock+seccomp is kernel-provided; expected Ready"
+        );
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn setup_status_windows_disabled_is_unavailable() {
+        // windows_sandbox_enabled=false → get_platform_sandbox returns
+        // None on Windows → Unavailable, no FS inspection.
+        let s = sandbox_setup_status(false);
+        assert_eq!(s, SandboxSetupStatus::Unavailable);
     }
 
     #[test]

--- a/crates/dasclaw_sandbox/src/windows/mod.rs
+++ b/crates/dasclaw_sandbox/src/windows/mod.rs
@@ -308,6 +308,38 @@ fn resolve_dasclaw_home() -> Result<PathBuf, SandboxError> {
     Ok(base.join("dasclaw"))
 }
 
+/// Backend for [`crate::sandbox_setup_status`] on Windows. Read-only
+/// inspection of `dasclaw_home` + `sandbox_setup_is_complete()`. Does **not**
+/// spawn the launcher or mutate any state — safe to call at process
+/// startup (epic #380 / issue #464).
+pub(crate) fn sandbox_setup_status_windows(kind: crate::SandboxType) -> crate::SandboxSetupStatus {
+    use crate::SandboxSetupStatus;
+
+    match resolve_dasclaw_home() {
+        Ok(dasclaw_home) => {
+            if sandbox_setup_is_complete(&dasclaw_home) {
+                SandboxSetupStatus::Ready { kind }
+            } else {
+                SandboxSetupStatus::SetupRequired {
+                    kind,
+                    dasclaw_home,
+                    action_hint: "Run dasclaw-sandbox-setup.exe (elevated). See \
+                         desktop-client/docs/windows-sandbox-setup-guide.md."
+                        .into(),
+                }
+            }
+        }
+        Err(e) => SandboxSetupStatus::SetupRequired {
+            kind,
+            dasclaw_home: PathBuf::from("<unresolved>"),
+            action_hint: format!(
+                "Cannot resolve dasclaw_home ({e}); set DASCLAW_HOME, then run \
+                 dasclaw-sandbox-setup.exe (elevated)."
+            ),
+        },
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/desktop-client/src/ipc/sandbox.rs
+++ b/desktop-client/src/ipc/sandbox.rs
@@ -10,7 +10,8 @@
 //! `Command::output()`.
 
 use dasclaw_sandbox::{
-    select_backend, SandboxExecRequest, SandboxPolicy, SandboxType, SandboxablePreference,
+    sandbox_setup_status, select_backend, SandboxExecRequest, SandboxPolicy, SandboxSetupStatus,
+    SandboxType, SandboxablePreference,
 };
 use serde::Serialize;
 use std::process::Command;
@@ -110,6 +111,86 @@ fn backend_label(t: SandboxType) -> &'static str {
     }
 }
 
+/// Report shape returned by [`ic_sandbox_status`].
+///
+/// The front-end calls this at startup (epic #380 / issue #464) to detect
+/// whether the platform sandbox infrastructure is ready. On Windows, a
+/// `ready: false` response means `dasclaw-sandbox-setup.exe` has not been
+/// run yet — the UI should prompt the operator (and surface
+/// `action_hint` / `dasclaw_home` in the dialog).
+///
+/// On macOS / Linux this always returns `ready: true` because the kernel
+/// sandbox (Seatbelt / Landlock + seccomp) needs no operator setup.
+#[derive(Debug, Serialize)]
+pub struct SandboxStatusReport {
+    /// Same string namespace as [`SandboxSmokeReport::backend`].
+    pub backend: String,
+    pub ready: bool,
+    /// Inspected `dasclaw_home` (Windows only; `None` otherwise).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dasclaw_home: Option<String>,
+    /// Operator action hint when `ready == false`. Stable English; the
+    /// front-end is free to localise.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub action_hint: Option<String>,
+}
+
+/// Inspect platform sandbox infrastructure readiness.
+///
+/// Frontend should call this once at startup; on `ready == false` it shows
+/// a friendly dialog directing the operator (or IT admin) to run
+/// `dasclaw-sandbox-setup.exe` (Windows). See epic #380 / issue #464 and
+/// `dasclaw_sandbox::sandbox_setup_status` for the underlying contract.
+///
+/// `windows_sandbox_enabled = true`: we want to surface "setup pending"
+/// even before the user opts into sandbox-required mode, so the IT-admin
+/// fix path is visible immediately at first launch.
+#[tauri::command]
+pub async fn ic_sandbox_status() -> Result<SandboxStatusReport, String> {
+    // Pure read-only check (no FS writes, no spawn) — safe on the tokio
+    // worker without `spawn_blocking`.
+    Ok(map_status(sandbox_setup_status(true)))
+}
+
+fn map_status(status: SandboxSetupStatus) -> SandboxStatusReport {
+    match status {
+        SandboxSetupStatus::Ready { kind } => SandboxStatusReport {
+            backend: backend_label(kind).to_string(),
+            ready: true,
+            dasclaw_home: None,
+            action_hint: None,
+        },
+        SandboxSetupStatus::SetupRequired {
+            kind,
+            dasclaw_home,
+            action_hint,
+        } => SandboxStatusReport {
+            backend: backend_label(kind).to_string(),
+            ready: false,
+            dasclaw_home: Some(dasclaw_home.display().to_string()),
+            action_hint: Some(action_hint),
+        },
+        SandboxSetupStatus::Unavailable => SandboxStatusReport {
+            backend: "none".to_string(),
+            ready: false,
+            dasclaw_home: None,
+            action_hint: Some(
+                "No OS sandbox is wired on this platform; spawns run unsandboxed.".to_string(),
+            ),
+        },
+        // `SandboxSetupStatus` is `#[non_exhaustive]`; future variants
+        // land here until this matcher is updated.
+        _ => SandboxStatusReport {
+            backend: "unknown".to_string(),
+            ready: false,
+            dasclaw_home: None,
+            action_hint: Some(
+                "Unknown sandbox status variant; please update desktop-client.".to_string(),
+            ),
+        },
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -137,5 +218,33 @@ mod tests {
         assert_eq!(report.backend, "macos_seatbelt");
         assert!(report.success);
         assert_eq!(report.stdout, "dasclaw");
+    }
+
+    #[tokio::test]
+    async fn status_returns_valid_backend_label() {
+        let r = ic_sandbox_status().await.expect("status must not error");
+        assert!(
+            [
+                "none",
+                "macos_seatbelt",
+                "linux_seccomp",
+                "windows_restricted_token",
+                "unknown",
+            ]
+            .contains(&r.backend.as_str()),
+            "unexpected backend label: {}",
+            r.backend
+        );
+        // Contract: ready=true ↔ action_hint=None.
+        assert_eq!(r.ready, r.action_hint.is_none());
+    }
+
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
+    #[tokio::test]
+    async fn status_is_ready_on_kernel_sandbox_platforms() {
+        let r = ic_sandbox_status().await.expect("status");
+        assert!(r.ready, "macOS/Linux kernel sandbox needs no setup");
+        assert!(r.dasclaw_home.is_none());
+        assert!(r.action_hint.is_none());
     }
 }

--- a/desktop-client/src/lib.rs
+++ b/desktop-client/src/lib.rs
@@ -184,6 +184,11 @@ macro_rules! all_tauri_commands {
             desktop_client::ipc::ic_fork_thread,
             // ── Sandbox（W2 ADR-110 接线，dasclaw_sandbox）─────
             desktop_client::ipc::ic_sandbox_smoke_test,
+            // B4-2 (issue #464): startup readiness check for the
+            // platform sandbox. On Windows surfaces "setup pending" so
+            // the UI can prompt the operator to run
+            // dasclaw-sandbox-setup.exe.
+            desktop_client::ipc::ic_sandbox_status,
         ]
     };
 }

--- a/desktop-client/tests/tauri_command_contract_tests.rs
+++ b/desktop-client/tests/tauri_command_contract_tests.rs
@@ -111,6 +111,7 @@ const FRONTEND_INVOKED_COMMANDS: &[&str] = &[
     "ic_open_file_at_line",
     // ── Sandbox（W2 ADR-110 接线）──────────────────────────────
     "ic_sandbox_smoke_test",
+    "ic_sandbox_status",
 ];
 
 /// `all_tauri_commands!()` 宏中注册的所有命令名（必须与 lib.rs 保持同步）。
@@ -202,6 +203,7 @@ const REGISTERED_COMMANDS: &[&str] = &[
     "ic_open_file_at_line",
     // ── Sandbox（W2 ADR-110 接线）──────────────────────────────
     "ic_sandbox_smoke_test",
+    "ic_sandbox_status",
 ];
 
 #[test]


### PR DESCRIPTION
## 背景 / 目标

Epic #380 B4-2：desktop-client 启动时检测 Windows sandbox 是否已完成 setup，
未 setup 则弹友好对话框引导 IT 跑 `dasclaw-sandbox-setup.exe`。

本 PR 只交付 **Rust 后端层**：跨平台只读探测 API + Tauri IPC 命令 + 单元 / 契约测试。
**前端对话框 UX 不在本 PR 范围**（见下），将由后续 PR 消费这里的 IPC。

Closes #464
Refs #380

## Sources read

- `AGENTS.md` § Skills 强制使用规范 / § 反补丁原则
- `docs/plans/architecture-refactor/adr-145-windows-sandbox-extraction.md` § 6 / § 7（Windows setup 流程、`sandbox_setup_is_complete` 契约）
- `crates/dasclaw_sandbox/src/lib.rs`（既有 `SandboxType` / `get_platform_sandbox` / `Sandbox` trait 公共面）
- `crates/dasclaw_sandbox/src/windows/mod.rs`（既有 `WindowsRestrictedTokenSandbox::execute` 已经在运行期调用 `sandbox_setup_is_complete`；本 PR 把同一检查再向前推到启动期）
- `crates/dasclaw_sandbox_windows/src/identity.rs::sandbox_setup_is_complete`（leaf 原语）
- `desktop-client/src/ipc/sandbox.rs`（既有 `ic_sandbox_smoke_test` / `backend_label` 工具）
- `desktop-client/src/lib.rs` `all_tauri_commands!` 宏 + `desktop-client/tests/tauri_command_contract_tests.rs`（双数组契约）

## 改动范围

### 新增公共面
- `dasclaw_sandbox::SandboxSetupStatus`（`#[non_exhaustive]` 枚举）
  - `Ready { kind: SandboxType }`
  - `SetupRequired { kind, dasclaw_home: PathBuf, action_hint: String }`
  - `Unavailable`
- `dasclaw_sandbox::sandbox_setup_status(windows_sandbox_enabled: bool) -> SandboxSetupStatus`
  - macOS / Linux：内核 sandbox 无须 setup，直接 `Ready`
  - Windows：委派给 `windows::sandbox_setup_status_windows`，包装既有 `sandbox_setup_is_complete()` leaf 原语
  - 不再可用 → `Unavailable`
- `crates/dasclaw_sandbox/src/windows/mod.rs::sandbox_setup_status_windows`（`pub(crate)`）
- `desktop_client::ipc::ic_sandbox_status` Tauri 命令，返回
  `SandboxStatusReport { backend, ready, dasclaw_home?, action_hint? }`

### 行为属性
- **Fail-closed**：Windows 下 `resolve_dasclaw_home` 失败 → `SetupRequired`（绝不 `Ready`）；`get_platform_sandbox` 返回 `None` → `Unavailable`
- **纯只读**：无 FS 写入、无 spawn，可安全在启动钩子中调用
- **不补丁式**：不在既有 `WindowsRestrictedTokenSandbox::execute` 里追加 if 分支；新增独立的 public 函数 + windows 后端函数；既有 runtime 检查保持不动
- **前向兼容**：`#[non_exhaustive]` + `desktop-client` 端 `map_status` 兜底 `_` 臂

## 非目标（What's NOT in this PR）

- 前端启动钩子调用 `ic_sandbox_status` 的逻辑（React/TypeScript）
- "未 setup" 友好对话框 UI / 文案 i18n
- 一键启动 `dasclaw-sandbox-setup.exe` 的 IPC（后续 PR；本 PR 只回汇 `action_hint` 字符串）
- 真机 Windows smoke（B4-4 / B4-5）

## 验证

```bash
cargo check -p dasclaw_sandbox --tests                    # ✓ clean
cargo check -p desktop-client --tests                     # ✓ clean
cargo nextest run -p dasclaw_sandbox                      # 63/63 PASS（含 2 新 setup_status_*）
cargo nextest run -p desktop-client \
    --test tauri_command_contract_tests                   # 2/2 PASS（ic_sandbox_status 注册校验）
cargo nextest run -p desktop-client --lib ipc::sandbox::tests
                                                          # 4/4 PASS（含 status_returns_valid_backend_label
                                                          #  / status_is_ready_on_kernel_sandbox_platforms）
cargo clippy --no-deps -p dasclaw_sandbox --all-targets -- -D warnings   # ✓ clean
cargo fmt --all                                           # ✓ clean
python3.12 scripts/check_no_panics.py --base origin/xClaw # ✓ clean
python3   scripts/check_no_new_ironclaw_literal.py --base origin/xClaw   # ✓ clean
```

## Code-review 自审

- **P0 安全**：纯只读，无 spawn，无 FS 写；Windows resolve_dasclaw_home 错误路径 fail-closed → `SetupRequired`
- **P1 正确性**：`#[non_exhaustive]` + `map_status` 的 `_` 臂保证未来新增 variant 不破坏 desktop-client
- **SOLID**：单一职责（启动期只读探测），开放/封闭（新 API 不动既有 `execute()` runtime 检查），分层完整（leaf → facade → 跨平台 API → IPC）
- **反补丁**：新增独立 public 函数，没有在既有函数尾追加 `if` 分支，没有 flag 切换大块代码
