### PR TITLE
ci(sandbox-windows): [B4-5a] hosted windows-latest sandbox e2e workflow (capability smoke + release tests)

### DIFF
--- a/.github/workflows/windows-sandbox-e2e.yml
+++ b/.github/workflows/windows-sandbox-e2e.yml
@@ -1,0 +1,144 @@
+name: Windows Sandbox E2E
+
+# B4-5a (Issue #468): hosted GitHub Actions windows-latest 上跑 Windows OS
+# sandbox 的"能力 smoke + release 模式单测"，先验证 B4-5 评估文档
+# (docs/plans/architecture-refactor/b4-5-windows-runner-evaluation.md) 附录 A
+# 列出的未联网项：
+#   1. runner 是否 admin?
+#   2. 能否 `net user` 创建 / 删除本地账号?
+#   3. 能否 `netsh advfirewall` 增 / 删规则?
+#
+# 设计取舍：
+#   - 触发只接 workflow_dispatch + 每周日 schedule，**不接 PR**，确保非阻断
+#     （PR 流水线由现有 windows-ci.yml 兜底）
+#   - 不直接调用 `dasclaw-sandbox-setup.exe`：该 bin 是 privileged helper，
+#     需 orchestrator 构造 base64 payload；后续 PR 实现 orchestrator 端调用
+#   - cleanup step 用 `if: always()` 兜底，避免 smoke 中途失败留下残余账号 / 规则
+
+on:
+  workflow_dispatch:
+  schedule:
+    # 每周日 04:00 UTC ≈ 北京时间周日 12:00（与 windows-ci.yml 错开 1 小时）
+    - cron: '0 4 * * 0'
+
+permissions:
+  contents: read
+
+# 资源命名集中常量，避免 cleanup 时漏字符
+env:
+  SMOKE_USER: dasclaw_b4_5a_smoke
+  SMOKE_FW_RULE: DasclawB45aSmoke
+
+jobs:
+  capability-smoke-and-release-tests:
+    name: Windows Sandbox E2E (capability smoke + release tests)
+    runs-on: windows-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: windows-sandbox-e2e
+
+      # ---------- 能力 smoke：验证 B4-5 评估文档 §附录 A ----------
+
+      - name: Assert runner runs as Administrator
+        shell: pwsh
+        run: |
+          $groups = whoami /groups
+          if (-not ($groups -match 'BUILTIN\\Administrators')) {
+            Write-Error 'runner does not have BUILTIN\Administrators group; B4-5 evaluation §附录 A item #1 FAILED'
+            exit 1
+          }
+          Write-Host '[OK] runner is Administrator (B4-5 §附录 A item #1)'
+
+      - name: Smoke create + delete local user
+        shell: pwsh
+        run: |
+          $u = "${env:SMOKE_USER}"
+          net user $u /add /active:no /comment:"B4-5a CI smoke ephemeral" 2>&1 | Out-Host
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "net user /add FAILED for $u; B4-5 evaluation §附录 A item #2 FAILED"
+            exit 1
+          }
+          net user $u /delete 2>&1 | Out-Host
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "net user /delete FAILED for $u"
+            exit 1
+          }
+          Write-Host "[OK] net user add/delete works (B4-5 §附录 A item #2)"
+
+      - name: Smoke add + delete firewall rule
+        shell: pwsh
+        run: |
+          $r = "${env:SMOKE_FW_RULE}"
+          $bogus = Join-Path $env:TEMP 'dasclaw_b4_5a_nonexistent.exe'
+          netsh advfirewall firewall add rule name="$r" dir=out action=block program="$bogus" 2>&1 | Out-Host
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "netsh advfirewall add rule FAILED; B4-5 evaluation §附录 A item #3 FAILED"
+            exit 1
+          }
+          netsh advfirewall firewall delete rule name="$r" 2>&1 | Out-Host
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "netsh advfirewall delete rule FAILED"
+            exit 1
+          }
+          Write-Host "[OK] netsh advfirewall add/delete rule works (B4-5 §附录 A item #3)"
+
+      # ---------- 资源清理（即使 smoke 失败也跑） ----------
+
+      - name: Cleanup leftover smoke resources
+        if: always()
+        shell: pwsh
+        run: |
+          $u = "${env:SMOKE_USER}"
+          $r = "${env:SMOKE_FW_RULE}"
+          net user $u /delete 2>$null | Out-Null
+          netsh advfirewall firewall delete rule name="$r" 2>$null | Out-Null
+          Write-Host '[OK] cleanup pass complete (idempotent; ignores not-found)'
+
+      # ---------- release 模式 build + 全套单测 ----------
+
+      - name: Build dasclaw-sandbox-setup.exe (release)
+        shell: pwsh
+        run: |
+          cargo build --release -p dasclaw_sandbox_windows --bin dasclaw-sandbox-setup
+          $exe = 'target\release\dasclaw-sandbox-setup.exe'
+          if (-not (Test-Path $exe)) {
+            Write-Error "Expected $exe not found"
+            exit 1
+          }
+          Write-Host "[OK] $exe built ($(Get-Item $exe).Length bytes)"
+
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: nextest
+
+      - name: Run release-mode nextest for dasclaw_sandbox_windows
+        shell: pwsh
+        run: cargo nextest run --release -p dasclaw_sandbox_windows --no-fail-fast
+
+  # 聚合 job：为未来分支保护规则保留单一入口
+  windows-sandbox-e2e-success:
+    name: Windows Sandbox E2E Success
+    runs-on: ubuntu-latest
+    if: always()
+    needs: [capability-smoke-and-release-tests]
+    steps:
+      - name: Aggregate result
+        run: |
+          result="${{ needs.capability-smoke-and-release-tests.result }}"
+          if [[ "$result" == "failure" || "$result" == "cancelled" ]]; then
+            echo "Windows Sandbox E2E failed"
+            exit 1
+          fi
+          echo "Windows Sandbox E2E OK (or skipped)"


### PR DESCRIPTION
## 背景 / 目标

Epic #380 Batch 4 B4-5a：落地 [B4-5 评估文档](docs/plans/architecture-refactor/b4-5-windows-runner-evaluation.md) §6 PR 拆分的第一步——
在 GitHub Actions hosted `windows-latest` 上跑能力 smoke + release 模式单测。

**核心目标**：把 B4-5 评估文档 §附录 A 列出的三项**未联网验证项**（runner 是否
Admin / `net user` / `netsh advfirewall`）变成 CI 可重复验证的事实。

## Sources read

- [AGENTS.md](../AGENTS.md) §强制阅读顺序、§Skills 强制使用规范
- [docs/plans/architecture-refactor/b4-5-windows-runner-evaluation.md](docs/plans/architecture-refactor/b4-5-windows-runner-evaluation.md) §3 决策矩阵、§6 PR 拆分、§附录 A 未验证项
- [.github/workflows/windows-ci.yml](.github/workflows/windows-ci.yml) §触发策略、§聚合 job 模式（windows-ci-success）
- [crates/dasclaw_sandbox_windows/Cargo.toml](crates/dasclaw_sandbox_windows/Cargo.toml) §`[[bin]] dasclaw-sandbox-setup`、§`dasclaw-command-runner` 因 conpty 未移植而 gated
- [crates/dasclaw_sandbox_windows/src/bin/setup_main.rs](crates/dasclaw_sandbox_windows/src/bin/setup_main.rs) §bin 入口
- [crates/dasclaw_sandbox_windows/src/setup_main_win.rs](crates/dasclaw_sandbox_windows/src/setup_main_win.rs) §argv[1] 是 base64 payload（privileged helper，不能直接调用）

## 改动范围

- 新增：`.github/workflows/windows-sandbox-e2e.yml`（144 LOC）

**workflow 结构**：
- `on`: `workflow_dispatch` + 每周日 04:00 UTC（与 `windows-ci.yml` 03:00 错开 1 小时）
- `permissions: contents: read`
- `env`: `SMOKE_USER` / `SMOKE_FW_RULE` 集中常量
- Job `capability-smoke-and-release-tests`（`windows-latest`，`timeout-minutes: 30`）
  1. Checkout + Rust stable + rust-cache
  2. Capability smoke 1：`whoami /groups` 断言 `BUILTIN\Administrators`
  3. Capability smoke 2：`net user $SMOKE_USER /add /active:no` → `net user $SMOKE_USER /delete`
  4. Capability smoke 3：`netsh advfirewall firewall add rule ...` → `delete rule ...`
  5. `Cleanup leftover smoke resources`（`if: always()`，幂等兜底）
  6. `cargo build --release --bin dasclaw-sandbox-setup` + 文件存在性断言
  7. 安装 `cargo-nextest`
  8. `cargo nextest run --release -p dasclaw_sandbox_windows --no-fail-fast`
- 聚合 job `windows-sandbox-e2e-success`（ubuntu-latest，单一 status 给未来分支保护用）

## 非目标（What's NOT in this PR）

- ❌ 不直接调用 `dasclaw-sandbox-setup.exe`（该 bin argv[1] 要 base64 payload，是
  privileged helper；orchestrator 端调用属下个 PR）
- ❌ 不接 `dasclaw-command-runner.exe`（conpty 模块未移植，bin 已 gated 在 Cargo.toml）
- ❌ 不修改现有 `.github/workflows/windows-ci.yml`
- ❌ 不接 PR 触发器，避免阻断主线
- ❌ 不部署 self-hosted runner（B4-5c）
- ❌ 不动任何 Rust / desktop-client 代码

## 验证

```bash
# YAML 语法
python3 -c "import yaml; yaml.safe_load(open('.github/workflows/windows-sandbox-e2e.yml'))"
# [OK] yaml valid

# Guards
python3.12 scripts/check_no_new_ironclaw_literal.py --base origin/xClaw
# OK: No new .ironclaw / IRONCLAW_BASE_DIR literals introduced.
```

**workflow_dispatch 验证（merge 后人工跑一次）**：
- Actions → Windows Sandbox E2E → Run workflow → 选 xClaw 分支
- 期待：3 个 `[OK]` smoke 日志 + release build + nextest 全绿

## Code-review 自审

- ✅ **复用优先**：未新建 Rust crate / 模块；workflow 独立文件，不污染 `windows-ci.yml`
- ✅ **非补丁式**：单一目的（hosted runner 能力验证 + release 单测）；未在 `windows-ci.yml` 尾部
  加 if 分支；未通过 flag 切大块逻辑
- ✅ **Fail-Safe**：`Cleanup leftover smoke resources` 用 `if: always()`，smoke 中途崩也不留
  残余账号 / 防火墙规则；cleanup 步骤本身 `2>$null` 吞 not-found 错误，幂等
- ✅ **资源命名集中**：`SMOKE_USER` / `SMOKE_FW_RULE` 走 `env`，避免拼写漂移
- ✅ **非阻断**：仅 `workflow_dispatch` + `schedule`，PR 流水线不变
- ✅ **聚合 job 设计**：复用 `windows-ci-success` 模式，给未来分支保护规则留单一 entry
- ✅ **Pinned actions**：`checkout@v6` / `dtolnay/rust-toolchain@stable` / `Swatinem/rust-cache@v2`
  / `taiki-e/install-action@v2`，与仓库其它 workflow 一致
- ✅ **timeout-minutes: 30** 避免卡死（B4-5 评估文档单 e2e ≤ 10 分钟）
- ✅ **未引入任何新 secret / 凭据**

## 关联 issue / PR

- Closes #468
- Refs #380（epic）、#466（B4-5 评估）、#241（Phase 5 CI gate）
- 与 PR #465（B4-2 status API）并行，无依赖
