### PR TITLE
feat(sandbox): B6-1b ExternalSandbox docker nested contract tests

### DIFF
--- a/.github/workflows/external-sandbox-container.yml
+++ b/.github/workflows/external-sandbox-container.yml
@@ -1,0 +1,124 @@
+# B6-1b — ExternalSandbox 嵌套契约 CI workflow
+#
+# Issue:  https://github.com/Linnanli/xClaw/issues/472
+# Source: docs/plans/architecture-refactor/32-execution-plan.md §W2 验收
+#         "ExternalSandbox 嵌套测试"
+#
+# 设计：
+#   1. ubuntu-22.04 runner（glibc 2.35，与容器内 debian:bookworm-slim 的
+#      glibc 2.36 兼容）
+#   2. cargo test --no-run 在 runner 本机编译测试 binary（命中 cache）
+#   3. 容器运行：`--network none --read-only --tmpfs /tmp`，把 binary 以
+#      只读卷挂进去——这是 ExternalSandbox 嵌套契约的真实重放环境
+#   4. 不用 docker-in-docker、不用 --privileged、不需要 host sudo
+#
+# 为什么不直接在 runner 上 `cargo test`：
+#   那只覆盖 "ExternalSandbox 类型层不变量"。本 workflow 的价值是
+#   把测试 binary 放进**真实裸容器**里跑——若 ExternalSandbox 误启
+#   内层 sandbox，缺 CAP_SYS_ADMIN 会让 bwrap/landlock 初始化失败，
+#   测试就会炸。这是非容器环境下捕不到的回归。
+#
+# 范围限定（非目标，见 issue #472）：
+#   - 不引入 docker-in-docker
+#   - 不主动管理容器作为内建沙箱
+#   - 不改 `dasclaw_sandboxing/src/*.rs`（drift guard 守护）
+
+name: external-sandbox-container
+
+on:
+  pull_request:
+    paths:
+      - 'crates/dasclaw_sandboxing/**'
+      - 'crates/dasclaw_protocol/src/permissions.rs'
+      - 'crates/dasclaw_protocol/src/protocol.rs'
+      - 'ci/external-sandbox/**'
+      - '.github/workflows/external-sandbox-container.yml'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  external-sandbox-nested:
+    name: ExternalSandbox nested contract (linux container)
+    runs-on: ubuntu-22.04
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain (stable)
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cargo cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: external-sandbox-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            external-sandbox-${{ runner.os }}-
+
+      # 单独编译测试 binary，避免 build 整个 workspace。
+      - name: Build req_external_sandbox_container test binary
+        run: |
+          cargo test --no-run \
+            -p dasclaw_sandboxing \
+            --test req_external_sandbox_container \
+            --message-format=json \
+            | tee /tmp/cargo-build.json
+
+      # 从 cargo --message-format=json 输出里精确抓出 binary 路径，
+      # 不再 `find target/debug/deps -name '...'`（避免 SHA suffix 多版本）
+      - name: Locate test binary
+        id: locate
+        run: |
+          BIN=$(python3 -c "
+          import json, sys
+          path = None
+          with open('/tmp/cargo-build.json') as f:
+              for line in f:
+                  msg = json.loads(line)
+                  if msg.get('reason') != 'compiler-artifact':
+                      continue
+                  if msg.get('profile', {}).get('test') is not True:
+                      continue
+                  target = msg.get('target', {})
+                  if target.get('name') != 'req_external_sandbox_container':
+                      continue
+                  exe = msg.get('executable')
+                  if exe:
+                      path = exe
+          if not path:
+              print('ERR: test binary not found in cargo output', file=sys.stderr)
+              sys.exit(1)
+          print(path)
+          ")
+          echo "Test binary: $BIN"
+          test -x "$BIN" || { echo "binary not executable"; exit 1; }
+          echo "bin=$BIN" >> "$GITHUB_OUTPUT"
+
+      - name: Build container image
+        run: docker build -f ci/external-sandbox/Dockerfile -t xclaw-external-sandbox-test .
+
+      # 关键步骤：--network none --read-only --tmpfs /tmp 真实复现
+      # "外层 docker 已隔离" 的运行环境。binary 通过只读 bind mount 进入。
+      - name: Run nested contract tests inside container
+        run: |
+          docker run --rm \
+            --network none \
+            --read-only \
+            --tmpfs /tmp:rw,size=64m \
+            -v "${{ steps.locate.outputs.bin }}:/test:ro" \
+            xclaw-external-sandbox-test \
+            /test --nocapture --test-threads=1
+
+      - name: Show container info on failure
+        if: failure()
+        run: |
+          echo "=== docker info ==="
+          docker info || true
+          echo "=== image labels ==="
+          docker inspect xclaw-external-sandbox-test || true

--- a/ci/external-sandbox/Dockerfile
+++ b/ci/external-sandbox/Dockerfile
@@ -1,0 +1,36 @@
+# B6-1b — ExternalSandbox 嵌套契约测试容器
+#
+# Issue: https://github.com/Linnanli/xClaw/issues/472
+# 用途：把外部宿主机预编译好的 `req_external_sandbox_container` 测试二进制
+#       拷进一个最小 debian 镜像里跑，验证 ExternalSandbox 模式下沙箱启动
+#       路径不依赖 bubblewrap / landlock / CAP_SYS_ADMIN。
+#
+# 设计要点：
+#   - 不在容器里跑 cargo（避免在 `--network none` 容器里依赖 crates.io）
+#   - 不在容器里编译 Rust（避免冷启动 3+ 分钟，cache 也复杂）
+#   - workflow 用 `actions/cache` 缓存外部宿主 target/，容器只做"运行测试"
+#   - 镜像保持最小：只装 `/bin/true` 所在的 coreutils（debian:bookworm-slim 自带）
+#   - **glibc 兼容**：runner pin 在 ubuntu-22.04（glibc 2.35），bookworm-slim
+#     glibc 2.36 向后兼容；不混 newer/older glibc 版本，避免 binary 跑不起来
+#
+# 使用：
+#   docker build -f ci/external-sandbox/Dockerfile -t xclaw-external-sandbox-test .
+#   docker run --rm --network none --read-only --tmpfs /tmp \
+#     -v "$PWD/target/debug/deps/req_external_sandbox_container-XXXX:/test:ro" \
+#     xclaw-external-sandbox-test
+#
+# 不主动 COPY 测试 binary 进 image —— workflow 用 `-v` 挂载，让单 image 重用
+FROM debian:bookworm-slim
+
+# 显式声明：本镜像不需要任何网络工具、不需要 sudo / setuid、不需要 cgroup
+# 写权限。任何引入"包管理 install 一个网络/沙箱依赖"的 patch 都违反 B6-1b
+# 的非目标声明（详见 issue #472），review 时必拒。
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /workspace
+
+# 默认入口由 workflow 显式覆盖（exec 形式 `/test --nocapture`）。
+# 此处只防呆：直接 `docker run xclaw-external-sandbox-test` 时打印用法。
+CMD ["/bin/sh", "-c", "echo 'usage: docker run --rm -v <test-bin>:/test:ro xclaw-external-sandbox-test /test [--nocapture]'; exit 64"]

--- a/crates/dasclaw_sandboxing/tests/req_external_sandbox_container.rs
+++ b/crates/dasclaw_sandboxing/tests/req_external_sandbox_container.rs
@@ -1,0 +1,201 @@
+//! B6-1b — ExternalSandbox 嵌套契约（必须在 docker 容器内跑才有意义）
+//!
+//! Issue：[xClaw#472](https://github.com/Linnanli/xClaw/issues/472)
+//! 范围：epic [#380](https://github.com/Linnanli/xClaw/issues/380) Batch 6
+//! 关联：[`docs/plans/architecture-refactor/32-execution-plan.md`](../../../../docs/plans/architecture-refactor/32-execution-plan.md)
+//! §W2 验收"ExternalSandbox 嵌套测试"
+//!
+//! ## 测什么
+//!
+//! 当用户在外层 docker / firecracker / nsjail 里跑 xClaw，并显式声明
+//! `SandboxPolicy::ExternalSandbox { network_access: ... }`，本模块验证：
+//!
+//! 1. **`SandboxManager::select_initial` 在 ExternalSandbox 的 FS policy
+//!    （unrestricted、无 managed network requirements）下返回
+//!    `SandboxType::None`**——不会去启 bubblewrap / landlock / seatbelt /
+//!    Windows Job Object，因为外层容器已是隔离边界。
+//!
+//! 2. **`transform()` 返回的 argv 是用户程序本身**，没有 `bwrap` /
+//!    `sandbox-exec` / `dasclaw-sandbox-resource-launcher` wrapper 前缀。
+//!    这是在容器里跑时不会因为缺 bubblewrap / 缺 CAP_SYS_ADMIN 而炸的关键。
+//!
+//! 3. **`network_access` 字段照常透传**：`Restricted` 不会被偷偷升级，
+//!    `Enabled` 也不会被偷偷降级——容器编排者依赖这个字段决定是否启
+//!    docker `--network none`，逻辑不能漂移。
+//!
+//! 4. **真实 spawn `/bin/true` 在 ExternalSandbox + None 模式下退出 0**：
+//!    这条断言只有在 *没有* OS sandbox 包装时才能在 `--network none
+//!    --read-only` debian 容器里成功——是嵌套契约的端到端 falsifier。
+//!
+//! ## 为什么不放 `manager_tests.rs`
+//!
+//! `crates/dasclaw_sandboxing/src/*.rs` 是 verbatim port，受
+//! `scripts/check_codex_sandboxing_drift.py` 守护，**不能加测试**。
+//! 集成测试在 `tests/` 目录，drift guard 不约束。
+//!
+//! ## 为什么 `#[cfg(target_os = "linux")]`
+//!
+//! 嵌套契约的真实落地场景是 docker（Linux 容器）。在 macOS host 上单跑
+//! 这个集成测试也能过（语义跨平台），但 CI workflow
+//! `external-sandbox-container.yml` 才是它的唯一权威触发点——把这个 cfg
+//! 守门留给 workflow，不污染 macOS 本地开发循环。
+
+#![cfg(target_os = "linux")]
+
+use std::collections::HashMap;
+use std::process::Command;
+
+use dasclaw_absolute_path::AbsolutePathBuf;
+use dasclaw_protocol::config_types::WindowsSandboxLevel;
+use dasclaw_protocol::permissions::FileSystemSandboxPolicy;
+use dasclaw_protocol::permissions::NetworkSandboxPolicy;
+use dasclaw_protocol::protocol::NetworkAccess;
+use dasclaw_protocol::protocol::SandboxPolicy;
+use dasclaw_sandboxing::SandboxCommand;
+use dasclaw_sandboxing::SandboxManager;
+use dasclaw_sandboxing::SandboxTransformRequest;
+use dasclaw_sandboxing::SandboxType;
+use dasclaw_sandboxing::SandboxablePreference;
+
+/// 契约 1：FS policy 是 `ExternalSandbox`（语义等价 unrestricted）+
+/// `SandboxablePreference::Auto` + 无 managed network 时，select_initial
+/// 不应启平台沙箱。这是 codex 把 ExternalSandbox 当"外层已隔离"信号的根。
+#[test]
+fn req_dasclaw_sandbox_b6_1b_external_sandbox_selects_no_inner_sandbox() {
+    let manager = SandboxManager::new();
+    let sandbox = manager.select_initial(
+        &FileSystemSandboxPolicy::external_sandbox(),
+        NetworkSandboxPolicy::Enabled,
+        SandboxablePreference::Auto,
+        WindowsSandboxLevel::Disabled,
+        /* has_managed_network_requirements */ false,
+    );
+    assert_eq!(
+        sandbox,
+        SandboxType::None,
+        "ExternalSandbox 的 FS policy 在 Auto + 无 managed network 下\
+         必须落到 SandboxType::None——这是嵌套场景下不再启内层平台沙箱\
+         的判定点。任何回归都会让容器里的 spawn 试图调 bubblewrap 而失败。"
+    );
+}
+
+/// 契约 2：transform 出的 argv = 用户程序本体，无任何 OS sandbox 前缀。
+/// 这条在 `--network none --read-only` 容器内跑时尤其关键：任何 wrapper
+/// 都依赖 root / CAP_SYS_ADMIN / 写入 /proc 等容器里不可得的能力。
+#[test]
+fn req_dasclaw_sandbox_b6_1b_external_sandbox_transform_yields_bare_argv() {
+    let manager = SandboxManager::new();
+    let cwd = AbsolutePathBuf::current_dir().expect("current dir");
+    let exec_request = manager
+        .transform(SandboxTransformRequest {
+            command: SandboxCommand {
+                program: "/bin/true".into(),
+                args: Vec::new(),
+                cwd: cwd.clone(),
+                env: HashMap::new(),
+                additional_permissions: None,
+            },
+            policy: &SandboxPolicy::ExternalSandbox {
+                network_access: NetworkAccess::Restricted,
+            },
+            file_system_policy: &FileSystemSandboxPolicy::external_sandbox(),
+            network_policy: NetworkSandboxPolicy::Restricted,
+            sandbox: SandboxType::None,
+            enforce_managed_network: false,
+            network: None,
+            sandbox_policy_cwd: cwd.as_path(),
+            codex_linux_sandbox_exe: None,
+            use_legacy_landlock: false,
+            windows_sandbox_level: WindowsSandboxLevel::Disabled,
+            windows_sandbox_private_desktop: false,
+        })
+        .expect("transform must succeed for ExternalSandbox + SandboxType::None");
+
+    assert_eq!(
+        exec_request.command.first().map(String::as_str),
+        Some("/bin/true"),
+        "argv[0] 必须仍是用户程序本身。任何 bwrap/sandbox-exec/launcher 前缀\
+         都意味着内层 sandbox 试图启用——会在裸容器里直接炸。"
+    );
+    assert!(
+        exec_request.arg0.is_none(),
+        "ExternalSandbox + None 不应触发 arg0 重写。"
+    );
+}
+
+/// 契约 3：network_access 字段在 ExternalSandbox 模式下不被透明改写。
+/// 容器编排（docker --network none 与否）依赖这条信号准确。
+#[test]
+fn req_dasclaw_sandbox_b6_1b_external_sandbox_preserves_network_access_signal() {
+    let restricted = SandboxPolicy::ExternalSandbox {
+        network_access: NetworkAccess::Restricted,
+    };
+    let enabled = SandboxPolicy::ExternalSandbox {
+        network_access: NetworkAccess::Enabled,
+    };
+
+    assert!(
+        !restricted.has_full_network_access(),
+        "ExternalSandbox{{Restricted}} 必须报告无全量网络访问——\
+         编排层据此选择 docker --network none。"
+    );
+    assert!(
+        enabled.has_full_network_access(),
+        "ExternalSandbox{{Enabled}} 必须报告有全量网络访问——\
+         编排层据此放开容器网络。"
+    );
+}
+
+/// 契约 4：端到端 falsifier。spawn `/bin/true` 在 ExternalSandbox 模式
+/// 走 `SandboxType::None` 路径，必须真的能在裸容器里跑出 exit 0。
+///
+/// 这条测试在 macOS host 上也能过，但价值是被
+/// `external-sandbox-container.yml` 在 `--network none --read-only`
+/// 容器里跑——那才是它真正能 falsify"内层 sandbox 不会被错误启用"
+/// 这条不变量的环境。
+#[test]
+fn req_dasclaw_sandbox_b6_1b_external_sandbox_spawn_actually_works() {
+    let manager = SandboxManager::new();
+    let cwd = AbsolutePathBuf::current_dir().expect("current dir");
+    let exec_request = manager
+        .transform(SandboxTransformRequest {
+            command: SandboxCommand {
+                program: "/bin/true".into(),
+                args: Vec::new(),
+                cwd: cwd.clone(),
+                env: HashMap::new(),
+                additional_permissions: None,
+            },
+            policy: &SandboxPolicy::ExternalSandbox {
+                network_access: NetworkAccess::Restricted,
+            },
+            file_system_policy: &FileSystemSandboxPolicy::external_sandbox(),
+            network_policy: NetworkSandboxPolicy::Restricted,
+            sandbox: SandboxType::None,
+            enforce_managed_network: false,
+            network: None,
+            sandbox_policy_cwd: cwd.as_path(),
+            codex_linux_sandbox_exe: None,
+            use_legacy_landlock: false,
+            windows_sandbox_level: WindowsSandboxLevel::Disabled,
+            windows_sandbox_private_desktop: false,
+        })
+        .expect("transform");
+
+    let argv = &exec_request.command;
+    let Some((program, args)) = argv.split_first() else {
+        panic!("transform 返回了空 argv——契约 2 应已先拦下，回归。")
+    };
+
+    let status = Command::new(program)
+        .args(args)
+        .status()
+        .expect("spawn /bin/true 失败——可能容器内 PATH/binary 缺失");
+
+    assert!(
+        status.success(),
+        "ExternalSandbox + None 路径下 /bin/true 应退出 0；\
+         实际 status = {status:?}。回归常因内层 sandbox 被错误启用、\
+         在容器里因缺 CAP_SYS_ADMIN 而初始化失败导致。"
+    );
+}


### PR DESCRIPTION
## 背景 / 目标

W2 验收清单遗留项 — 在外层 docker 已隔离时，验证 `SandboxPolicy::ExternalSandbox` 真的旁路内层 OS sandbox 而不是错误启动它（误启会因缺 `CAP_SYS_ADMIN` 而炸）。

**Source**: [docs/plans/architecture-refactor/32-execution-plan.md#L220](https://github.com/Linnanli/xClaw/blob/xClaw/docs/plans/architecture-refactor/32-execution-plan.md#L220) §W2 验收"ExternalSandbox 嵌套测试"  
**关联 ADR**: ADR-135 §3 / ADR-141 §6

Closes #472

## 改动范围

| 文件 | 类型 | 角色 |
|---|---|---|
| [crates/dasclaw_sandboxing/tests/req_external_sandbox_container.rs](crates/dasclaw_sandboxing/tests/req_external_sandbox_container.rs) | 新 | 4 个 `#[cfg(target_os = "linux")]` 契约测试 |
| [ci/external-sandbox/Dockerfile](ci/external-sandbox/Dockerfile) | 新 | `debian:bookworm-slim` 测试运行容器（不编译，纯运行） |
| [.github/workflows/external-sandbox-container.yml](.github/workflows/external-sandbox-container.yml) | 新 | CI：本机编译 → docker `--network none --read-only` 运行 |

### 4 条契约（详见测试模块文档）

1. `select_initial(external_sandbox FS policy, Auto, ...) == SandboxType::None` — 不启内层
2. `transform()` 返回的 argv = 用户程序本体，无 `bwrap` / `sandbox-exec` / launcher 前缀
3. `ExternalSandbox{Restricted}.has_full_network_access() == false`、`Enabled` 为 true — network 信号透传
4. 真实 spawn `/bin/true` 退出 0 — 端到端 falsifier

## 非目标（What's NOT in this PR）

- ❌ docker-in-docker（不需要，单层 hosted runner + `docker run` 足够）
- ❌ 主动管理容器作为内建沙箱（与 ironclaw 范式区分；codex / xClaw 走"信任外层声明"）
- ❌ 改 `crates/dasclaw_sandboxing/src/*.rs`（drift guard 守护 verbatim port，新测试在 `tests/`）
- ❌ 改 `ExternalSandbox` enum 语义
- ❌ macOS / Windows 嵌套测试（嵌套场景的权威是 Linux 容器；其他平台已被 manager_tests.rs mock 覆盖）

## 验证

### 本地（macOS）

```bash
cargo fmt --all                                                         # ✓
cargo check -p dasclaw_sandboxing --tests                                # ✓
cargo clippy --no-deps -p dasclaw_sandboxing --tests -- -D warnings      # ✓
cargo nextest run -p dasclaw_sandboxing                                  # 64 passed (new tests cfg-gated for linux)
python3.12 scripts/check_no_panics.py --base origin/xClaw                # ✓ No panic-inducing calls
python3.12 scripts/check_codex_sandboxing_drift.py                       # ✓ 11 files + 3 assets match upstream
python3.12 scripts/check_no_new_ironclaw_literal.py --base origin/xClaw  # ✓ No new literals
```

### CI（本 PR 触发）

`external-sandbox-container.yml` 会在 ubuntu-22.04 runner 上：
1. `cargo test --no-run -p dasclaw_sandboxing --test req_external_sandbox_container`
2. 从 `--message-format=json` 输出精确定位测试 binary
3. `docker build` → `docker run --rm --network none --read-only --tmpfs /tmp -v <bin>:/test:ro xclaw-external-sandbox-test /test --nocapture`

如果 ExternalSandbox 路径误启 bwrap/landlock，bwrap 在裸容器内无 `CAP_SYS_ADMIN` 会立刻失败，测试 4 必炸。

## Sources read

- [AGENTS.md](AGENTS.md) — 中文规约总入口（必读，本 PR 严守"禁止补丁式代码"）
- [docs/plans/architecture-refactor/32-execution-plan.md](docs/plans/architecture-refactor/32-execution-plan.md#L220) §W2 验收 "ExternalSandbox 嵌套测试"
- [docs/plans/architecture-refactor/adr-135-sandboxing-crate-adoption-eval.md](docs/plans/architecture-refactor/adr-135-sandboxing-crate-adoption-eval.md) §3 — Wave-C1 内核层 sandbox 接入
- [docs/plans/architecture-refactor/adr-141-closeout-handoff.md](docs/plans/architecture-refactor/adr-141-closeout-handoff.md) §6 — Windows enterprise gate 跨平台 pure-function 测试模式
- [crates/dasclaw_protocol/src/permissions.rs](crates/dasclaw_protocol/src/permissions.rs#L135) `FileSystemSandboxKind::ExternalSandbox` enum + `external_sandbox()` 构造器
- [crates/dasclaw_protocol/src/protocol.rs](crates/dasclaw_protocol/src/protocol.rs#L1050) `SandboxPolicy::ExternalSandbox { network_access }` + `has_full_network_access`
- [crates/dasclaw_sandboxing/src/manager.rs](crates/dasclaw_sandboxing/src/manager.rs#L75) `SandboxExecRequest` 公开字段 + `SandboxManager::transform` 公共 API
- [crates/dasclaw_sandboxing/src/manager_tests.rs](crates/dasclaw_sandboxing/src/manager_tests.rs#L86) 已有 ExternalSandbox mock 测试（确认未重复，本 PR 是嵌套环境补充）
- [codex-cli-main/codex-rs/core/src/sandbox_tags.rs](codex-cli-main/codex-rs/core/src/sandbox_tags.rs) — codex 上游 ExternalSandbox `"external"` tag 跳过 `get_platform_sandbox()`
- [codex-cli-main/codex-rs/core/src/exec.rs](codex-cli-main/codex-rs/core/src/exec.rs#L912) — codex `should_use_windows_restricted_token_sandbox` 对 ExternalSandbox 返回 false
