### PR TITLE
feat(sandbox): B6-2 process sandbox startup latency baseline

### DIFF
--- a/docs/plans/architecture-refactor/sandbox-perf-baseline.md
+++ b/docs/plans/architecture-refactor/sandbox-perf-baseline.md
@@ -1,0 +1,114 @@
+# Sandbox 进程启动延迟基线（W2 验收 / B6-2）
+
+> Issue: [#380](https://github.com/Linnanli/xClaw/issues/380) Batch 6 B6-2  
+> Plan reference: [`32-execution-plan.md`](32-execution-plan.md) · "性能基准：进程沙箱启动 < 50ms (对比 codex baseline)"
+
+## 目的
+
+固化"进程沙箱启动到一个 noop 子进程退出"的端到端 wall-clock 延迟基线，
+为后续 W2.2/W2.3/W2.4 的真实 backend（macOS Seatbelt / Linux landlock+bubblewrap /
+Windows RestrictedToken）提供可比较的参照数据，并给 CI 一条可执行的 gate（默认 p50 ≤ 50 ms）。
+
+## 方法论
+
+直接调用 host 提供的进程沙箱 CLI 包装一个最便宜的 noop（`/usr/bin/true`），
+**测的是"沙箱前置成本 + fork/exec + ld.so + true 退出"端到端 wall-clock**，不是
+沙箱内部子模块（policy parsing、profile compile）单独的耗时。
+
+| 后端 | 命令 | 备注 |
+|------|------|------|
+| `sandbox-exec` (macOS) | `/usr/bin/sandbox-exec -p '(version 1)(allow default)' /usr/bin/true` | `(allow default)` 是最小 profile，不阻断任何系统调用，测的是 `sandbox-exec` 本身的 fork+ profile install 成本 |
+| `bwrap` (Linux) | `bwrap --dev-bind / / --proc /proc /bin/true` | 以最少 mount 的容器执行 noop |
+| `baseline` (对照) | `/usr/bin/true` | 不带任何沙箱，作 fork+exec 基线，用于隔离纯 OS 进程创建成本 |
+
+执行样本：默认 100 次（`--runs 100`），10 次 warmup（`--warmup 10`）丢弃。
+统计：`min / mean / p50 / p95 / p99 / max`，p50 作为阈值判定指标。
+
+> **不对 codex 自身跑分**：codex 上游的 sandbox 调用最终也是壳到 `sandbox-exec` /
+> `bwrap`，host 同后端的延迟即是 codex baseline；如未来需要 codex 端到端对比，
+> 单独发起 follow-up，本基线提供横切对照所需的 host backend 数字。
+
+## 用法
+
+```bash
+# auto-detect backend（macOS→sandbox-exec, Linux→bwrap, 其他→baseline）
+python3.12 scripts/sandbox_perf_baseline.py --append-doc
+
+# 显式 backend 与样本数
+python3.12 scripts/sandbox_perf_baseline.py --backend sandbox-exec --runs 200 --warmup 20
+
+# 仅作对照（裸 spawn）
+python3.12 scripts/sandbox_perf_baseline.py --backend baseline --runs 100
+
+# CI gate（p50 > 50 ms 时返回 exit code 2）
+python3.12 scripts/sandbox_perf_baseline.py --backend auto --threshold-ms 50
+```
+
+脚本：[`scripts/sandbox_perf_baseline.py`](../../../scripts/sandbox_perf_baseline.py)
+
+## 阈值
+
+- **W2 验收红线**：p50 ≤ **50 ms**（来源：`32-execution-plan.md`）
+- 超阈值：脚本以 exit code 2 退出，CI 应判失败
+- 同 host 同后端的两轮跑分波动若 > 30 % p50，建议用 `--runs 300` 重测以收敛
+
+## Runs
+
+> 每次跑分追加在下方。脚本 `--append-doc` 自动维护，不要手改格式。
+
+### 2026-05-13T05:22:01Z · Darwin 23.6.0 · backend=baseline
+
+```json
+{
+  "backend": "baseline",
+  "command": [
+    "/usr/bin/true"
+  ],
+  "runs": 100,
+  "warmup": 10,
+  "host": {
+    "system": "Darwin",
+    "release": "23.6.0",
+    "machine": "x86_64"
+  },
+  "stats_ms": {
+    "min": 3.217,
+    "p50": 4.078,
+    "p95": 6.138,
+    "p99": 6.883,
+    "max": 6.991,
+    "mean": 4.354
+  },
+  "iso_ts": "2026-05-13T05:22:01Z"
+}
+```
+
+### 2026-05-13T05:23:09Z · Darwin 23.6.0 · backend=sandbox-exec
+
+```json
+{
+  "backend": "sandbox-exec",
+  "command": [
+    "/usr/bin/sandbox-exec",
+    "-p",
+    "(version 1)(allow default)",
+    "/usr/bin/true"
+  ],
+  "runs": 100,
+  "warmup": 10,
+  "host": {
+    "system": "Darwin",
+    "release": "23.6.0",
+    "machine": "x86_64"
+  },
+  "stats_ms": {
+    "min": 15.446,
+    "p50": 16.598,
+    "p95": 18.474,
+    "p99": 21.446,
+    "max": 158.14,
+    "mean": 18.179
+  },
+  "iso_ts": "2026-05-13T05:23:09Z"
+}
+```

--- a/scripts/sandbox_perf_baseline.py
+++ b/scripts/sandbox_perf_baseline.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3.12
+"""B6-2 sandbox startup latency baseline.
+
+跨平台测进程沙箱"启动到 noop 退出"的端到端 wall-clock 延迟。
+W2 验收阈值：p50 < 50 ms。
+
+支持后端：
+- macOS  → /usr/bin/sandbox-exec  + 最小 (allow default) profile + /usr/bin/true
+- Linux  → bwrap --dev-bind / / --proc /proc /bin/true
+- 也可通过 --baseline-only 跳过沙箱、只测裸 spawn /usr/bin/true 作对照
+
+输出：
+- stdout: JSON 一行（host 元数据 + p50/p95/p99/min/max/n + samples_ms）
+- 同时把同一份 JSON 追加到 docs/plans/architecture-refactor/sandbox-perf-baseline.md
+  下方 "## Runs" 段（如果 --append-doc 启用）。
+
+非目标：
+- 不对 codex 自身跑分；codex baseline 数据按 W2 决定（人工跑或后续 CI 任务）
+- 不测 dasclaw_exec → dasclaw_sandboxing 完整 pipeline；W2.1 的 backend 还是 stub
+- 不做并发吞吐基准；本脚本只测启动延迟
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import platform
+import shutil
+import statistics
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DOC_PATH = (
+    REPO_ROOT
+    / "docs"
+    / "plans"
+    / "architecture-refactor"
+    / "sandbox-perf-baseline.md"
+)
+
+MACOS_PROFILE = "(version 1)(allow default)"
+
+
+def build_command(backend: str) -> list[str]:
+    if backend == "baseline":
+        return ["/usr/bin/true"] if Path("/usr/bin/true").exists() else ["true"]
+    if backend == "sandbox-exec":
+        return ["/usr/bin/sandbox-exec", "-p", MACOS_PROFILE, "/usr/bin/true"]
+    if backend == "bwrap":
+        return [
+            "bwrap",
+            "--dev-bind",
+            "/",
+            "/",
+            "--proc",
+            "/proc",
+            "/bin/true",
+        ]
+    raise ValueError(f"unknown backend: {backend}")
+
+
+def detect_default_backend() -> str:
+    system = platform.system()
+    if system == "Darwin" and shutil.which("sandbox-exec"):
+        return "sandbox-exec"
+    if system == "Linux" and shutil.which("bwrap"):
+        return "bwrap"
+    return "baseline"
+
+
+def run_one(cmd: list[str]) -> float:
+    start = time.perf_counter()
+    proc = subprocess.run(cmd, capture_output=True)
+    elapsed_ms = (time.perf_counter() - start) * 1000.0
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"{cmd[0]} returned {proc.returncode}: stderr={proc.stderr!r}"
+        )
+    return elapsed_ms
+
+
+def percentile(samples: list[float], p: float) -> float:
+    """linear-interpolation percentile（statistics.quantiles 在 n<2 时会抛）。"""
+    if not samples:
+        raise ValueError("empty samples")
+    if len(samples) == 1:
+        return samples[0]
+    ordered = sorted(samples)
+    rank = p / 100.0 * (len(ordered) - 1)
+    low = int(rank)
+    high = min(low + 1, len(ordered) - 1)
+    weight = rank - low
+    return ordered[low] * (1 - weight) + ordered[high] * weight
+
+
+def gather(backend: str, runs: int, warmup: int) -> dict:
+    cmd = build_command(backend)
+    # warmup（吃 fork/exec/page cache 冷启动），不计入统计
+    for _ in range(warmup):
+        run_one(cmd)
+    samples = [run_one(cmd) for _ in range(runs)]
+    return {
+        "backend": backend,
+        "command": cmd,
+        "runs": runs,
+        "warmup": warmup,
+        "host": {
+            "system": platform.system(),
+            "release": platform.release(),
+            "machine": platform.machine(),
+        },
+        "stats_ms": {
+            "min": round(min(samples), 3),
+            "p50": round(percentile(samples, 50), 3),
+            "p95": round(percentile(samples, 95), 3),
+            "p99": round(percentile(samples, 99), 3),
+            "max": round(max(samples), 3),
+            "mean": round(statistics.fmean(samples), 3),
+        },
+        "samples_ms": [round(s, 3) for s in samples],
+        "iso_ts": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+    }
+
+
+def append_to_doc(payload: dict) -> None:
+    if not DOC_PATH.exists():
+        raise FileNotFoundError(
+            f"{DOC_PATH} 不存在；先创建文档骨架再用 --append-doc。"
+        )
+    text = DOC_PATH.read_text(encoding="utf-8")
+    marker = "## Runs"
+    if marker not in text:
+        raise RuntimeError(
+            f"{DOC_PATH} 没找到 `## Runs` 段；检查文档结构。"
+        )
+    snippet = (
+        f"\n### {payload['iso_ts']} · {payload['host']['system']} "
+        f"{payload['host']['release']} · backend={payload['backend']}\n\n"
+        "```json\n"
+        f"{json.dumps({k: v for k, v in payload.items() if k != 'samples_ms'}, indent=2)}\n"
+        "```\n"
+    )
+    DOC_PATH.write_text(text.rstrip() + "\n" + snippet, encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--backend",
+        choices=["auto", "sandbox-exec", "bwrap", "baseline"],
+        default="auto",
+        help="auto = host 自动选；baseline = 不带沙箱裸 spawn 作对照",
+    )
+    parser.add_argument("--runs", type=int, default=100)
+    parser.add_argument("--warmup", type=int, default=10)
+    parser.add_argument(
+        "--append-doc",
+        action="store_true",
+        help="追加结果到 docs/plans/architecture-refactor/sandbox-perf-baseline.md",
+    )
+    parser.add_argument(
+        "--threshold-ms",
+        type=float,
+        default=50.0,
+        help="p50 阈值；超过非 0 退出（用于 CI gate；默认 50ms）",
+    )
+    args = parser.parse_args()
+
+    backend = detect_default_backend() if args.backend == "auto" else args.backend
+    payload = gather(backend, args.runs, args.warmup)
+    print(json.dumps(payload, indent=2))
+
+    if args.append_doc:
+        append_to_doc(payload)
+
+    p50 = payload["stats_ms"]["p50"]
+    if p50 > args.threshold_ms:
+        print(
+            f"\n[FAIL] p50={p50} ms 超过阈值 {args.threshold_ms} ms",
+            file=sys.stderr,
+        )
+        return 2
+    print(
+        f"\n[OK] p50={p50} ms <= 阈值 {args.threshold_ms} ms",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
# feat(sandbox): B6-2 process sandbox startup latency baseline

Closes #478
Refs #380 (Sandbox mainline finalization epic, Batch 6 B6-2)
Parallel to #476 (B6-1a)

## 背景 / 目标

[`32-execution-plan.md`](https://github.com/Linnanli/xClaw/blob/xClaw/docs/plans/architecture-refactor/32-execution-plan.md) Batch 6 B6-2：
> 性能基准：进程沙箱启动 < 50 ms（对比 codex baseline）

W2 验收要求把"进程沙箱启动到 noop 退出"的端到端延迟固化成可重复跑的基线，
并给出阈值守门，方便后续 W2.2/W2.3/W2.4 真实 backend（macOS Seatbelt /
Linux landlock+bubblewrap / Windows RestrictedToken）落地时回归对照。

## 改动范围

新增 2 个文件，0 个修改：

1. `scripts/sandbox_perf_baseline.py`（170 行）
   - 跨平台：`auto` 自动选 host backend（Darwin→`sandbox-exec`、Linux→`bwrap`、其他→`baseline`）
   - 三后端：`sandbox-exec` / `bwrap` / `baseline`（裸 spawn 作对照）
   - 输出：JSON（host 元数据 + min/mean/p50/p95/p99/max + samples_ms）
   - `--append-doc` 自动追加结果到下方文档的 `## Runs` 段
   - `--threshold-ms` p50 超阈值时 exit code 2（CI gate ready）
2. `docs/plans/architecture-refactor/sandbox-perf-baseline.md`（138 行）
   - 方法论、命令矩阵、阈值（50 ms）、用法、Runs 段（首批两条）

零修改任何 `crates/dasclaw_*` 源码。

## 首批基线数据（macOS 14.6.1 x86_64）

| 后端 | min | p50 | p95 | p99 | max | 阈值 |
|------|-----|-----|-----|-----|-----|------|
| `baseline`（裸 `/usr/bin/true`） | 3.22 | **4.08** | 6.14 | 6.88 | 6.99 | — |
| `sandbox-exec` (allow default) | 15.45 | **16.60** | 18.47 | 21.45 | 158.14 | 50 ms ✅ |

沙箱前置成本 ≈ 12.5 ms（p50 差值），p99 21.45 ms 仍远低于 50 ms 阈值。

> p50 max 158 ms 是 100 次样本里的 1 次离群（推测调度抖动 / cgroup 节流），
> p95/p99 不受影响。后续在 self-hosted runner 上重测会更稳。

## 非目标（What's NOT in this PR）

- ❌ 不对 codex 自身跑分：codex 上游同样壳到 `sandbox-exec` / `bwrap`，host
  同后端的延迟即是 codex baseline；如未来需要 codex 端到端对比，单独发起
  follow-up
- ❌ 不接入 CI 自动跑分：脚本已就绪可被 CI 调用，但 W2 还没到强制 gate 阶段
- ❌ 不实现 dasclaw_exec → dasclaw_sandboxing 的完整端到端测试：W2.1 backend
  仍是 stub，要到 W2.2/W2.3/W2.4 backend 落地才有意义
- ❌ 不测并发吞吐：本基线只测启动延迟单点

## 验证

```bash
# 语法
python3.12 -m py_compile scripts/sandbox_perf_baseline.py   # ok

# 实际跑分（macOS 14.6.1 x86_64）
python3.12 scripts/sandbox_perf_baseline.py --backend baseline    --runs 100 --warmup 10
# → p50=4.078 ms, [OK] p50 <= 50 ms

python3.12 scripts/sandbox_perf_baseline.py --backend sandbox-exec --runs 100 --warmup 10
# → p50=16.598 ms, [OK] p50 <= 50 ms

# 守卫
python3.12 scripts/check_no_new_ironclaw_literal.py --base origin/xClaw   # OK
```

`fmt`/`clippy`/`check_no_panics` 不适用（纯 Python + Markdown）；drift guards
不适用（未触及 `crates/dasclaw_*/src/`）。

## Cross-cuts

- ADR-114（`.ironclaw` → `.dasclaw` 迁移）：**类 A**，不引入任何
  `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量
- ADR-112 / 113 / 129 / 132 / 136 / 137：不涉及（未触及 verbatim port crate）

## 后续步骤

- Linux host 上重跑 `--backend bwrap` 把首条 Linux 数据补进文档（self-hosted
  runner 或开发者本地）
- W2.2 macOS Seatbelt backend 落地后，把脚本扩展到调真实 dasclaw backend
  spawn 而非裸 `sandbox-exec` CLI（覆盖 backend 内部 profile compile 成本）
- 把 `--threshold-ms 50` 接入 CI 作回归 gate（待 backend 真实化后）
