### PR TITLE
feat(sandbox): B4-7 dispatch Windows elevated vs restricted-token backend (#462)

### DIFF
--- a/crates/dasclaw_exec/src/lib.rs
+++ b/crates/dasclaw_exec/src/lib.rs
@@ -105,6 +105,13 @@ pub struct SandboxedExecutor {
     policy: SandboxPolicy,
     sandbox_pref: SandboxablePreference,
     windows_sandbox_enabled: bool,
+    /// Windows sandbox isolation tier (issue #462 / B4-7). Forwarded as
+    /// [`dasclaw_sandbox::SandboxExecRequest::windows_sandbox_level`] so the
+    /// Windows backend can pick between the restricted-token entry point
+    /// (default) and the elevated entry point. Default = `Disabled` keeps
+    /// the pre-#462 restricted-token behaviour for callers that haven't
+    /// migrated to the new builder API yet.
+    windows_sandbox_level: dasclaw_sandbox::WindowsSandboxLevel,
     /// 会话级 [`NetworkProxy`]，构造期注入。macOS Seatbelt 后端将其转译为
     /// `(allow network-outbound (remote ip "localhost:<port>"))` sbpl 规则，
     /// 让沙箱内子进程的 `HTTP_PROXY` / `HTTPS_PROXY` 环境变量真正生效
@@ -137,9 +144,23 @@ impl SandboxedExecutor {
             policy,
             sandbox_pref,
             windows_sandbox_enabled,
+            windows_sandbox_level: dasclaw_sandbox::WindowsSandboxLevel::Disabled,
             network,
             linux_sandbox_exe: None,
         }
+    }
+
+    /// Configure the Windows sandbox isolation tier (issue #462 / B4-7).
+    ///
+    /// Enterprise deployments pin this at build time or push it through
+    /// the admin backend; the desktop client itself does **not** expose a
+    /// UI dropdown for it. Ignored on macOS / Linux backends.
+    pub fn with_windows_sandbox_level(
+        mut self,
+        level: dasclaw_sandbox::WindowsSandboxLevel,
+    ) -> Self {
+        self.windows_sandbox_level = level;
+        self
     }
 
     /// 配置 `dasclaw-sandbox-linux` helper 二进制路径（ADR-144 §5.3 P1.2a）。
@@ -188,6 +209,7 @@ impl SandboxedExecutor {
             policy: backend,
             preference: self.sandbox_pref,
             windows_sandbox_enabled: self.windows_sandbox_enabled,
+            windows_sandbox_level: self.windows_sandbox_level,
             network: self.network.clone(),
         })
     }

--- a/crates/dasclaw_sandbox/src/bin/resource_launcher_win.rs
+++ b/crates/dasclaw_sandbox/src/bin/resource_launcher_win.rs
@@ -44,7 +44,9 @@ fn main() -> std::process::ExitCode {
 
     use dasclaw_sandbox::launcher_ipc::{LauncherRequest, LauncherResponse, PROTOCOL_VERSION};
     use dasclaw_sandbox::windows::job_object::{JobObject, OuterJobLimits};
+    use dasclaw_sandbox_windows::run_windows_sandbox_capture_elevated;
     use dasclaw_sandbox_windows::run_windows_sandbox_capture_with_extra_deny_write_paths;
+    use dasclaw_sandbox_windows::ElevatedSandboxCaptureRequest;
 
     fn write_response(resp: &LauncherResponse) -> std::io::Result<()> {
         let json = serde_json::to_vec(resp)
@@ -99,24 +101,53 @@ fn main() -> std::process::ExitCode {
         }
     };
 
-    let capture = match run_windows_sandbox_capture_with_extra_deny_write_paths(
-        &req.policy_json,
-        &req.cwd,
-        &req.dasclaw_home,
-        req.argv,
-        &req.cwd,
-        req.env,
-        None, // timeout — adapter 上层（OsExecutor）用 tokio timeout 包裹
-        // ADR-141 §3 PR-W3 / OQ-W3-2 (sign-off 2026-05-11): forward
-        // `SandboxBackendConfig::read_only_subpaths` as upstream
-        // `additional_deny_write_paths`, so upstream's `acl::add_deny_write_ace`
-        // installs Win32 DACL DENY ACEs on every carve-out path. Empty slice
-        // preserves Slice B1 behaviour bit-for-bit.
-        &req.additional_deny_write_paths,
-        req.use_private_desktop,
-    ) {
-        Ok(c) => c,
-        Err(e) => return fail(format!("run_windows_sandbox_capture: {e}"), 1),
+    let capture = if req.use_elevated_backend {
+        // Issue #462 (B4-7) — Elevated backend branch. v1: pass `None` for
+        // every filesystem override so upstream uses the policy_json
+        // defaults verbatim; future slices may surface real overrides
+        // through the IPC. `proxy_enforced` here mirrors the dispatch
+        // decision (helper returns `true` when either operator config or
+        // proxy demand it), so plumbing `true` keeps the elevated path's
+        // own firewall-mode logic consistent.
+        let request = ElevatedSandboxCaptureRequest {
+            policy_json_or_preset: req.policy_json.as_str(),
+            sandbox_policy_cwd: req.cwd.as_path(),
+            codex_home: req.dasclaw_home.as_path(),
+            command: req.argv,
+            cwd: req.cwd.as_path(),
+            env_map: req.env,
+            timeout_ms: None,
+            use_private_desktop: req.use_private_desktop,
+            proxy_enforced: true,
+            read_roots_override: None,
+            read_roots_include_platform_defaults: true,
+            write_roots_override: None,
+            deny_write_paths_override: req.additional_deny_write_paths.as_slice(),
+        };
+        match run_windows_sandbox_capture_elevated(request) {
+            Ok(c) => c,
+            Err(e) => return fail(format!("run_windows_sandbox_capture_elevated: {e}"), 1),
+        }
+    } else {
+        match run_windows_sandbox_capture_with_extra_deny_write_paths(
+            &req.policy_json,
+            &req.cwd,
+            &req.dasclaw_home,
+            req.argv,
+            &req.cwd,
+            req.env,
+            None, // timeout — adapter 上层（OsExecutor）用 tokio timeout 包裹
+            // ADR-141 §3 PR-W3 / OQ-W3-2 (sign-off 2026-05-11): forward
+            // `SandboxBackendConfig::read_only_subpaths` as upstream
+            // `additional_deny_write_paths`, so upstream's `acl::add_deny_write_ace`
+            // installs Win32 DACL DENY ACEs on every carve-out path. Empty slice
+            // preserves Slice B1 behaviour bit-for-bit.
+            &req.additional_deny_write_paths,
+            req.use_private_desktop,
+        ) {
+            Ok(c) => c,
+            Err(e) => return fail(format!("run_windows_sandbox_capture: {e}"), 1),
+        }
     };
 
     let resp = LauncherResponse {

--- a/crates/dasclaw_sandbox/src/launcher_ipc.rs
+++ b/crates/dasclaw_sandbox/src/launcher_ipc.rs
@@ -79,6 +79,25 @@ pub struct LauncherRequest {
     /// 兜底为空 Vec。
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub additional_deny_write_paths: Vec<PathBuf>,
+
+    /// Issue #462 (B4-7) — select elevated Windows sandbox backend.
+    ///
+    /// - `false` (default; old-launcher wire compat) → launcher calls
+    ///   `dasclaw_sandbox_windows::run_windows_sandbox_capture_with_extra_deny_write_paths`
+    ///   (restricted-token / default / weaker isolation, no admin setup
+    ///   needed at run time).
+    /// - `true` → launcher calls
+    ///   `dasclaw_sandbox_windows::run_windows_sandbox_capture_elevated`
+    ///   (full elevated isolation: per-user firewall + dedicated logon
+    ///   user; requires `dasclaw-sandbox-setup.exe` to have completed).
+    ///
+    /// Decided in the adapter by
+    /// [`crate::windows_dispatch::windows_sandbox_uses_elevated_backend`].
+    /// `#[serde(default)]` keeps the wire backward-compatible: old launcher
+    /// binaries decoding a new request just see `false`, matching the
+    /// pre-#462 behaviour.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub use_elevated_backend: bool,
 }
 
 /// `OuterJobLimits` 的 wire 形式。
@@ -157,6 +176,7 @@ mod tests {
             }),
             use_private_desktop: false,
             additional_deny_write_paths: vec![],
+            use_elevated_backend: false,
         }
     }
 

--- a/crates/dasclaw_sandbox/src/lib.rs
+++ b/crates/dasclaw_sandbox/src/lib.rs
@@ -28,6 +28,20 @@
 /// 跨平台公开（serde 数据结构），便于本地测试与 macOS/Linux 构建检查通过。
 pub mod launcher_ipc;
 
+/// Issue #462 (B4-7) — Windows sandbox backend dispatch helpers
+/// (`Elevated` vs `RestrictedToken` runtime selection).
+///
+/// Cross-platform module so the decision matrix can be exercised in
+/// contract tests on any host; the actual `cfg(target_os = "windows")`
+/// adapter in `windows/mod.rs` consumes the same helper.
+pub mod windows_dispatch;
+
+/// Re-export of [`dasclaw_protocol::config_types::WindowsSandboxLevel`]
+/// so direct consumers of [`SandboxExecRequest`] don't need an extra
+/// `dasclaw_protocol` dependency just to populate
+/// [`SandboxExecRequest::windows_sandbox_level`] (issue #462 / B4-7).
+pub use dasclaw_protocol::config_types::WindowsSandboxLevel;
+
 // Shared backend-config → protocol-policy bridge used by both macOS
 // (Seatbelt) and Linux (helper wiring per ADR-144 §5.3 P1.2a) backends.
 #[cfg(any(target_os = "macos", target_os = "linux"))]
@@ -446,6 +460,19 @@ pub struct SandboxExecRequest {
     pub policy: SandboxBackendConfig,
     pub preference: SandboxablePreference,
     pub windows_sandbox_enabled: bool,
+    /// Windows sandbox isolation tier (issue #462 / B4-7). Drives the
+    /// Windows backend's choice between the **restricted-token** entry
+    /// point (default, weaker isolation, no admin setup required at run
+    /// time) and the **elevated** entry point (full per-user firewall +
+    /// dedicated logon user, requires `dasclaw-sandbox-setup.exe`). See
+    /// [`crate::windows_dispatch::windows_sandbox_uses_elevated_backend`]
+    /// for the decision matrix. Ignored on macOS / Linux backends and
+    /// when `windows_sandbox_enabled == false`.
+    ///
+    /// Default = `WindowsSandboxLevel::Disabled` keeps the historical
+    /// (pre-#462) restricted-token path active even when callers haven't
+    /// migrated to setting the field explicitly.
+    pub windows_sandbox_level: dasclaw_protocol::config_types::WindowsSandboxLevel,
     /// Optional reference to the managed `NetworkProxy` for the calling
     /// session. macOS Seatbelt forwards this to
     /// `dasclaw_sandboxing::seatbelt::create_seatbelt_command_args` so the
@@ -707,6 +734,7 @@ mod tests {
             policy: SandboxPolicy::read_only_defaults(),
             preference: SandboxablePreference::Forbid,
             windows_sandbox_enabled: false,
+            windows_sandbox_level: dasclaw_protocol::config_types::WindowsSandboxLevel::Disabled,
             network: None,
         };
         let out = sb.execute(req).expect("kind=None should run");
@@ -723,6 +751,7 @@ mod tests {
             policy: SandboxPolicy::read_only_defaults(),
             preference: SandboxablePreference::Auto,
             windows_sandbox_enabled: false,
+            windows_sandbox_level: dasclaw_protocol::config_types::WindowsSandboxLevel::Disabled,
             network: None,
         };
         let err = sb.execute(req).unwrap_err();

--- a/crates/dasclaw_sandbox/src/linux/mod.rs
+++ b/crates/dasclaw_sandbox/src/linux/mod.rs
@@ -445,6 +445,7 @@ mod tests {
             policy,
             preference: SandboxablePreference::Auto,
             windows_sandbox_enabled: false,
+            windows_sandbox_level: dasclaw_protocol::config_types::WindowsSandboxLevel::Disabled,
             network: None,
         };
         let plan = prepare_command(&req).expect("legacy path should succeed");
@@ -475,6 +476,7 @@ mod tests {
             policy,
             preference: SandboxablePreference::Auto,
             windows_sandbox_enabled: false,
+            windows_sandbox_level: dasclaw_protocol::config_types::WindowsSandboxLevel::Disabled,
             network: None,
         };
         let plan = prepare_command(&req).expect("helper path should succeed");
@@ -528,6 +530,7 @@ mod tests {
             policy,
             preference: SandboxablePreference::Auto,
             windows_sandbox_enabled: false,
+            windows_sandbox_level: dasclaw_protocol::config_types::WindowsSandboxLevel::Disabled,
             network: None,
         };
         let err = prepare_command(&req).expect_err("must fail-closed");

--- a/crates/dasclaw_sandbox/src/macos/mod.rs
+++ b/crates/dasclaw_sandbox/src/macos/mod.rs
@@ -161,6 +161,7 @@ mod tests {
             policy: SandboxPolicy::read_only_defaults(),
             preference: SandboxablePreference::Auto,
             windows_sandbox_enabled: false,
+            windows_sandbox_level: dasclaw_protocol::config_types::WindowsSandboxLevel::Disabled,
             network: None,
         };
         let args = sb.build_seatbelt_args(&req);
@@ -186,6 +187,7 @@ mod tests {
             policy: SandboxPolicy::read_only_defaults().with_writable("/tmp/work"),
             preference: SandboxablePreference::Auto,
             windows_sandbox_enabled: false,
+            windows_sandbox_level: dasclaw_protocol::config_types::WindowsSandboxLevel::Disabled,
             network: None,
         };
         let args = sb.build_seatbelt_args(&req);
@@ -227,6 +229,7 @@ mod tests {
             policy: SandboxPolicy::read_only_defaults(),
             preference: SandboxablePreference::Require,
             windows_sandbox_enabled: false,
+            windows_sandbox_level: dasclaw_protocol::config_types::WindowsSandboxLevel::Disabled,
             network: None,
         };
         let out = sb.execute(req).expect("seatbelt should run sh");
@@ -248,6 +251,7 @@ mod tests {
             policy: SandboxPolicy::read_only_defaults(),
             preference: SandboxablePreference::Require,
             windows_sandbox_enabled: false,
+            windows_sandbox_level: dasclaw_protocol::config_types::WindowsSandboxLevel::Disabled,
             network: None,
         };
         let out = sb.execute(req).expect("seatbelt should run echo");
@@ -281,6 +285,7 @@ mod tests {
             policy,
             preference: SandboxablePreference::Require,
             windows_sandbox_enabled: false,
+            windows_sandbox_level: dasclaw_protocol::config_types::WindowsSandboxLevel::Disabled,
             network: None,
         };
         let out = sb.execute(req).expect("seatbelt should run sh");
@@ -369,6 +374,7 @@ mod tests {
             policy: SandboxPolicy::read_only_defaults(),
             preference: SandboxablePreference::Require,
             windows_sandbox_enabled: false,
+            windows_sandbox_level: dasclaw_protocol::config_types::WindowsSandboxLevel::Disabled,
             network: Some(proxy),
         };
 
@@ -398,6 +404,7 @@ mod tests {
             policy: SandboxPolicy::read_only_defaults(),
             preference: SandboxablePreference::Require,
             windows_sandbox_enabled: false,
+            windows_sandbox_level: dasclaw_protocol::config_types::WindowsSandboxLevel::Disabled,
             network: None,
         };
 

--- a/crates/dasclaw_sandbox/src/windows/mod.rs
+++ b/crates/dasclaw_sandbox/src/windows/mod.rs
@@ -170,6 +170,15 @@ impl Sandbox for WindowsRestrictedTokenSandbox {
             // 来下发 Win32 DACL DENY ACE（kernel-enforced read-only holes
             // inside writable workspaces）。空 Vec 时维持 Slice B1 行为。
             additional_deny_write_paths: req.policy.read_only_subpaths.clone(),
+            // Issue #462 (B4-7) — decide elevated vs restricted-token
+            // backend mirroring codex `exec.rs::windows_sandbox_uses_elevated_backend`.
+            // `proxy_enforced` = LLM/HTTP proxy in front of the sandboxed
+            // command (req.network is Some), since Windows firewall
+            // enforcement is tied to the logon-user identity.
+            use_elevated_backend: crate::windows_dispatch::windows_sandbox_uses_elevated_backend(
+                req.windows_sandbox_level,
+                req.network.is_some(),
+            ),
         };
 
         launcher_client::spawn_and_capture(request)

--- a/crates/dasclaw_sandbox/src/windows_dispatch.rs
+++ b/crates/dasclaw_sandbox/src/windows_dispatch.rs
@@ -1,0 +1,40 @@
+//! Windows sandbox backend dispatch helpers.
+//!
+//! Cross-platform pure functions used by the Windows backend adapter to
+//! decide which upstream `dasclaw_sandbox_windows` entry point to invoke.
+//! Lives outside `windows/mod.rs` (which is `#[cfg(target_os = "windows")]`
+//! only) so contract tests can exercise the decision matrix on any host.
+//!
+//! Source of truth: verbatim ported from
+//! `codex-cli-main/codex-rs/core/src/exec.rs::windows_sandbox_uses_elevated_backend`
+//! (codex upstream). Keep behaviour bit-identical so the dispatch story
+//! stays consistent with codex's Windows sandbox model.
+//!
+//! See `docs/plans/architecture-refactor/adr-141-windows-enterprise-sandbox-support.md`
+//! and issue #462 (B4-7).
+
+use dasclaw_protocol::config_types::WindowsSandboxLevel;
+
+/// Decide whether the Windows sandbox should run on the **elevated**
+/// backend (`run_windows_sandbox_capture_elevated`) versus the default
+/// **restricted-token** backend (`run_windows_sandbox_capture_with_extra_deny_write_paths`).
+///
+/// Verbatim from codex `core/src/exec.rs:113-121`:
+/// > Windows firewall enforcement is tied to the logon-user sandbox
+/// > identities, so proxy-enforced sessions must use that backend even
+/// > when the configured mode is the default restricted-token sandbox.
+///
+/// Returns `true` to use the elevated backend in either of:
+/// - `proxy_enforced == true` (an LLM/HTTP proxy is in front of the
+///   sandboxed command — needs per-user firewall ⇒ elevated backend), or
+/// - `sandbox_level == Elevated` (explicit operator/admin opt-in).
+///
+/// Otherwise returns `false`: use the restricted-token backend (default
+/// in xClaw today; weaker isolation but no admin setup required at run
+/// time).
+pub fn windows_sandbox_uses_elevated_backend(
+    sandbox_level: WindowsSandboxLevel,
+    proxy_enforced: bool,
+) -> bool {
+    proxy_enforced || matches!(sandbox_level, WindowsSandboxLevel::Elevated)
+}

--- a/crates/dasclaw_sandbox/tests/req_kernel_enforces_read_only_subpaths_linux.rs
+++ b/crates/dasclaw_sandbox/tests/req_kernel_enforces_read_only_subpaths_linux.rs
@@ -83,6 +83,7 @@ fn req_dasclaw_sandbox_p1_2a_helper_blocks_read_only_subpath() {
         policy,
         preference: SandboxablePreference::Require,
         windows_sandbox_enabled: false,
+        windows_sandbox_level: dasclaw_protocol::config_types::WindowsSandboxLevel::Disabled,
         network: None,
     };
     let out = LinuxSeccompSandbox::new()
@@ -121,6 +122,7 @@ fn req_dasclaw_sandbox_p1_2a_fail_closed_when_helper_missing() {
         policy,
         preference: SandboxablePreference::Require,
         windows_sandbox_enabled: false,
+        windows_sandbox_level: dasclaw_protocol::config_types::WindowsSandboxLevel::Disabled,
         network: None,
     };
     let err = LinuxSeccompSandbox::new()

--- a/crates/dasclaw_sandbox/tests/req_kernel_enforces_read_only_subpaths_macos.rs
+++ b/crates/dasclaw_sandbox/tests/req_kernel_enforces_read_only_subpaths_macos.rs
@@ -68,6 +68,7 @@ fn req_dasclaw_sandbox_kernel_blocks_git_hooks_under_workspace_write_macos() {
         policy,
         preference: SandboxablePreference::Require,
         windows_sandbox_enabled: false,
+        windows_sandbox_level: dasclaw_protocol::config_types::WindowsSandboxLevel::Disabled,
         network: None,
     };
     let out = SeatbeltSandbox::new()
@@ -122,6 +123,7 @@ fn req_dasclaw_sandbox_kernel_allows_write_to_non_hole_path_macos() {
         policy,
         preference: SandboxablePreference::Require,
         windows_sandbox_enabled: false,
+        windows_sandbox_level: dasclaw_protocol::config_types::WindowsSandboxLevel::Disabled,
         network: None,
     };
     let out = SeatbeltSandbox::new()

--- a/crates/dasclaw_sandbox/tests/req_sandbox_windows_b4_7_decision_matrix.rs
+++ b/crates/dasclaw_sandbox/tests/req_sandbox_windows_b4_7_decision_matrix.rs
@@ -1,0 +1,114 @@
+//! Issue #462 (B4-7) — Windows sandbox backend dispatch decision matrix.
+//!
+//! Verifies the pure helper
+//! [`dasclaw_sandbox::windows_dispatch::windows_sandbox_uses_elevated_backend`]
+//! matches codex `core/src/exec.rs::windows_sandbox_uses_elevated_backend`
+//! across the full 3×2 matrix of `(WindowsSandboxLevel × proxy_enforced)`.
+//!
+//! Also covers the [`dasclaw_sandbox::launcher_ipc::LauncherRequest::use_elevated_backend`]
+//! serde back-compat contract: `false` is omitted from the wire (kept
+//! legacy launchers happy) while `true` survives a JSON round-trip.
+
+use dasclaw_sandbox::launcher_ipc::{LauncherRequest, OuterJobLimitsWire, PROTOCOL_VERSION};
+use dasclaw_sandbox::windows_dispatch::windows_sandbox_uses_elevated_backend;
+use dasclaw_sandbox::WindowsSandboxLevel;
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+// -------------------- decision matrix (6 cases) --------------------
+
+#[test]
+fn req_sandbox_windows_b4_7_disabled_no_proxy_uses_restricted() {
+    assert!(!windows_sandbox_uses_elevated_backend(
+        WindowsSandboxLevel::Disabled,
+        false,
+    ));
+}
+
+#[test]
+fn req_sandbox_windows_b4_7_disabled_with_proxy_uses_elevated() {
+    assert!(windows_sandbox_uses_elevated_backend(
+        WindowsSandboxLevel::Disabled,
+        true,
+    ));
+}
+
+#[test]
+fn req_sandbox_windows_b4_7_restricted_no_proxy_uses_restricted() {
+    assert!(!windows_sandbox_uses_elevated_backend(
+        WindowsSandboxLevel::RestrictedToken,
+        false,
+    ));
+}
+
+#[test]
+fn req_sandbox_windows_b4_7_restricted_with_proxy_uses_elevated() {
+    assert!(windows_sandbox_uses_elevated_backend(
+        WindowsSandboxLevel::RestrictedToken,
+        true,
+    ));
+}
+
+#[test]
+fn req_sandbox_windows_b4_7_elevated_no_proxy_uses_elevated() {
+    assert!(windows_sandbox_uses_elevated_backend(
+        WindowsSandboxLevel::Elevated,
+        false,
+    ));
+}
+
+#[test]
+fn req_sandbox_windows_b4_7_elevated_with_proxy_uses_elevated() {
+    assert!(windows_sandbox_uses_elevated_backend(
+        WindowsSandboxLevel::Elevated,
+        true,
+    ));
+}
+
+// -------------------- wire back-compat round-trip --------------------
+
+fn sample_request(use_elevated: bool) -> LauncherRequest {
+    LauncherRequest {
+        protocol_version: PROTOCOL_VERSION,
+        argv: vec!["cmd.exe".into()],
+        cwd: PathBuf::from("C:/work"),
+        env: HashMap::new(),
+        dasclaw_home: PathBuf::from("C:/dasclaw"),
+        policy_json: "{}".into(),
+        outer_limits: None::<OuterJobLimitsWire>,
+        use_private_desktop: false,
+        additional_deny_write_paths: vec![],
+        use_elevated_backend: use_elevated,
+    }
+}
+
+#[test]
+fn req_sandbox_windows_b4_7_wire_default_false_is_omitted() {
+    // `#[serde(skip_serializing_if = "Not::not")]` keeps the wire clean
+    // for legacy launcher binaries that decoded request without the
+    // field.
+    let req = sample_request(false);
+    let json = serde_json::to_string(&req).expect("serialize");
+    assert!(
+        !json.contains("use_elevated_backend"),
+        "default `false` must not appear on wire: {json}"
+    );
+
+    // Forward-compat: old launcher decoding new (still-false) JSON
+    // produces `false` via `#[serde(default)]`.
+    let back: LauncherRequest = serde_json::from_str(&json).expect("deserialize");
+    assert!(!back.use_elevated_backend);
+}
+
+#[test]
+fn req_sandbox_windows_b4_7_wire_true_round_trips() {
+    let req = sample_request(true);
+    let json = serde_json::to_string(&req).expect("serialize");
+    assert!(
+        json.contains("\"use_elevated_backend\":true"),
+        "elevated request must emit field on wire: {json}"
+    );
+    let back: LauncherRequest = serde_json::from_str(&json).expect("deserialize");
+    assert!(back.use_elevated_backend);
+    assert_eq!(req, back);
+}

--- a/desktop-client/src/ipc/sandbox.rs
+++ b/desktop-client/src/ipc/sandbox.rs
@@ -11,7 +11,7 @@
 
 use dasclaw_sandbox::{
     sandbox_setup_status, select_backend, SandboxExecRequest, SandboxPolicy, SandboxSetupStatus,
-    SandboxType, SandboxablePreference,
+    SandboxType, SandboxablePreference, WindowsSandboxLevel,
 };
 use serde::Serialize;
 use std::process::Command;
@@ -83,6 +83,7 @@ fn run_smoke_blocking() -> Result<SandboxSmokeReport, String> {
         policy: SandboxPolicy::read_only_defaults(),
         preference: SandboxablePreference::Auto,
         windows_sandbox_enabled: false,
+        windows_sandbox_level: WindowsSandboxLevel::Disabled,
         // Wave-C2a: smoke-test 路径不需要本地代理洞穿；保持 None。
         network: None,
     };


### PR DESCRIPTION
# feat(sandbox): B4-7 dispatch Windows elevated vs restricted-token backend

Closes #462

## 背景 / 目标

xClaw 的 Windows sandbox adapter 目前始终走 `run_windows_sandbox_capture_with_extra_deny_write_paths`（restricted-token / 默认弱隔离）。codex 上游 `core/src/exec.rs:113-590` 早已实现 elevated / restricted-token 二分派：当运维强配 `WindowsSandboxLevel::Elevated` 或会话被 proxy 接管时，应改调 `run_windows_sandbox_capture_elevated`（per-user firewall + dedicated logon user，强隔离）。

本 PR 把 codex 这套分派逻辑 verbatim port 到 xClaw 的胶水层（`crates/dasclaw_sandbox/`），不动 `crates/dasclaw_sandboxing/`（verbatim-locked by `scripts/check_codex_sandboxing_drift.py`）。

## 改动范围

- `crates/dasclaw_sandbox/src/windows_dispatch.rs` (NEW) — 纯函数 `windows_sandbox_uses_elevated_backend(level, proxy_enforced)`，逐字移植自 codex `exec.rs:113-121`，跨平台模块以便决策矩阵在任何 host 上做契约测试。
- `crates/dasclaw_sandbox/src/lib.rs` — `SandboxExecRequest` 新增 `windows_sandbox_level`；`pub use dasclaw_protocol::config_types::WindowsSandboxLevel` 再导出避免下游消费者新加 dep。
- `crates/dasclaw_sandbox/src/launcher_ipc.rs` — `LauncherRequest` 新增 `use_elevated_backend: bool`，`#[serde(default, skip_serializing_if = "Not::not")]` 保持 wire 向后兼容。
- `crates/dasclaw_sandbox/src/windows/mod.rs` — adapter 调 `windows_dispatch` helper（`proxy_enforced = req.network.is_some()`），填入 `LauncherRequest`。
- `crates/dasclaw_sandbox/src/bin/resource_launcher_win.rs` — launcher 二分派：`true` → `run_windows_sandbox_capture_elevated(ElevatedSandboxCaptureRequest{..})`；`false` → 保持现有 call site bit-identical。v1 elevated 分支 read/write_roots override 全 None，使用 policy_json 默认值。
- `crates/dasclaw_sandbox/tests/req_sandbox_windows_b4_7_decision_matrix.rs` (NEW) — 6 个纯函数决策矩阵 case (3 levels × 2 proxy) + 2 个 wire round-trip。
- `crates/dasclaw_exec` + `linux/macos` backends + `desktop-client/src/ipc/sandbox.rs` — 机械传字段（`Disabled` 默认），全部走再导出，不引入新 dep。

## 决策矩阵

| # | level | proxy_enforced | use_elevated_backend |
|---|---|---|---|
| 1 | Disabled | false | false |
| 2 | Disabled | true | true |
| 3 | RestrictedToken | false | false |
| 4 | RestrictedToken | true | true |
| 5 | Elevated | false | true |
| 6 | Elevated | true | true |

## 非目标 / What's NOT in this PR

- **UI dropdown / admin-backend push 配置**：B4 设计上由企业部署决定，desktop-client 不暴露用户开关。
- **B4-4 真机矩阵手测 / B4-5b/c 集成测试**：迁去 #481（需 VM lab）。
- **ADR-146**：reviewer 觉得需要再补。
- **Issue body 写的"dispatch in `dasclaw_sandboxing/src/manager.rs`"**：错误，那里 verbatim-locked。本 PR 在 xClaw-owned `crates/dasclaw_sandbox/` 实现。

## ADR-114 cross-cuts

不涉及。无新增 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量。

## 验证

```
cargo fmt --all
cargo check -p dasclaw_sandbox -p dasclaw_exec -p desktop-client --tests
cargo nextest run -p dasclaw_sandbox             # 71/71 passed (含 8 个新 req_sandbox_windows_b4_7_*)
cargo clippy --no-deps -p dasclaw_sandbox -p dasclaw_exec --all-targets -- -D warnings
python3.12 scripts/check_no_panics.py --base origin/xClaw
python3 scripts/check_codex_sandboxing_drift.py
python3 scripts/check_codex_sandbox_windows_drift.py
python3 scripts/check_no_new_ironclaw_literal.py --base origin/xClaw
```

全部 green。

## Sources read

- `codex-cli-main/codex-rs/core/src/exec.rs` §113-121 (helper) + §539-590 (dispatch site)
- `crates/dasclaw_sandbox_windows/src/elevated_impl.rs` §15-29 (`ElevatedSandboxCaptureRequest` struct) + §121 (`run_windows_sandbox_capture`)
- `crates/dasclaw_sandbox_windows/src/lib.rs` §324-328 (re-exports)
- `scripts/check_codex_sandboxing_drift.py` (verified locked scope = `dasclaw_sandboxing/`, not `dasclaw_sandbox/`)
- `docs/plans/architecture-refactor/adr-141-windows-enterprise-sandbox-support.md` (Windows 沙箱 tier 决策上下文)
- `docs/plans/architecture-refactor/adr-129-codex-verbatim-port-redline.md` §1.3 (verbatim port 红线 — windows_dispatch helper 是 verbatim port)

## 后续步骤

- #462 close 后按 nally 早先批示模式（参考 #380）：把 #241 拆 close + 子 issue 推到 #481
- 真机矩阵 / 端到端验证 → #481
- 如 reviewer 觉得需要 ADR-146 单独立卷，开 follow-up
