### PR TITLE
docs(adr): SafetyDecision 5-state + CompositeSafetyHook design (#73)

### DIFF
--- a/docs/plans/architecture-refactor/adr-146-safety-decision-enum-extension.md
+++ b/docs/plans/architecture-refactor/adr-146-safety-decision-enum-extension.md
@@ -1,0 +1,261 @@
+# ADR-146: `SafetyDecision` 枚举扩展（4 → 5 态）
+
+- **Status**: Draft（W4 #73 slice C 前置）
+- **Date**: 2026-05-29
+- **Approver**: pending
+- **Supersedes**: 无
+- **Related**: ADR-112（兼容性矩阵）、ADR-113（HookEngine 收口）、ADR-147（CompositeSafetyHook 设计）
+- **Tracking Issue**: #73 slice C
+
+---
+
+## 1. Context — 现状盘点
+
+### 1.1 当前 `SafetyDecision` 定义
+
+`crates/x_claw_agent/src/hooks.rs:37`：
+
+```rust
+#[derive(Debug, Clone, PartialEq)]
+pub enum SafetyDecision {
+    Allow,
+    Redact { content: String, reason: String },
+    Block { reason: String },
+}
+```
+
+3 态，无 `#[non_exhaustive]`，外部 `match` 必须穷尽 3 个分支。
+
+### 1.2 上游对照（claude-code-main）
+
+`claude-code-main/src/utils/permissions/PermissionResult.ts` 是 4 态：
+
+| TS 变体 | 字段 | 等价 Rust 现状 |
+|---|---|---|
+| `{ behavior: 'allow', decisionReason?: DecisionReason }` | `decisionReason` 结构化 | `Allow` 无字段 |
+| `{ behavior: 'deny', reason: string, decisionReason?: DecisionReason }` | 同上 | `Block { reason: String }` |
+| `{ behavior: 'ask', reason: string, suggestions: RuleSuggestion[] }` | 提示用户确认 | **缺失** |
+| `{ behavior: 'redact', ... }` | 修改 args 后继续 | `Redact { ... }` |
+
+`Passthrough` 在 claude-code 不是显式 enum 变体，而是 8 步 pipeline 内部"未表态"语义。本 ADR 将其显式化为 enum 变体以支持 `CompositeSafetyHook`（ADR-147）的链式语义。
+
+### 1.3 #73 issue body 验收要求
+
+> SafetyDecision 扩展 `Ask` + `Passthrough` 接口位
+
+### 1.4 当前外部 `SafetyDecision` 使用面
+
+通过 `vscode_listCodeUsages` + grep 三层验证：
+
+| 位置 | 用途 |
+|---|---|
+| `crates/dasclaw_hooks/src/bash_validation_hook.rs` | 内部构造 `Allow / Block` |
+| `desktop-client/ironclaw/crates/ironclaw_safety/src/agent_hook.rs` | 内部构造 `Allow / Block` |
+| `crates/x_claw_agent/src/safety_noop.rs` | 实现 `NoopSafetyHook` |
+| 测试模块约 12 处 `match` / `assert_eq!(...)` | 需要随枚举改动同步 |
+
+外部 crate（含 dasclaw_governance / dasclaw_features）未使用 `SafetyDecision::*` literal。**爆炸半径有限**，可一次性升级。
+
+---
+
+## 2. Decision
+
+### 2.1 新 enum 形态
+
+```rust
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub enum SafetyDecision {
+    Allow {
+        decision_reason: Option<DecisionReason>,
+    },
+    Redact {
+        content: String,
+        reason: String,
+    },
+    Block {
+        reason: String,
+        decision_reason: Option<DecisionReason>,
+    },
+    Ask {
+        reason: String,
+        decision_reason: DecisionReason,
+        suggestions: Vec<RuleSuggestion>,
+    },
+    Passthrough,
+}
+```
+
+**关键设计**：
+- 所有变体加 `#[non_exhaustive]`（外部 `match` 必须显式 `_` 兜底，未来再加变体不破坏外部代码）
+- `Allow` / `Block` 都可携带结构化 `decision_reason`（Block 必带；Allow 选填）
+- `Ask` 必带 `decision_reason` + 至少一个 `suggestions` 候选
+
+### 2.2 `DecisionReason` 结构
+
+```rust
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub enum DecisionReason {
+    /// 命中具体的 deny/allow/ask 规则。
+    RuleMatch {
+        rule_id: String,
+        rule_pattern: String,
+    },
+    /// 由 PermissionMode 决定（如 ReadOnly mode 拒绝 write 命令）。
+    ModeEnforcement {
+        mode: PermissionMode,
+    },
+    /// 路径越界（workspace 边界）。
+    PathValidation {
+        path: String,
+        category: PathEscapeCategory,
+    },
+    /// 命中破坏性命令分类。
+    DestructiveCommand {
+        command_class: String,
+    },
+    /// sed 表达式校验失败。
+    SedValidation {
+        detail: String,
+    },
+    /// 命令注入检测（bashSecurity）。
+    CommandInjection {
+        injection_kind: String,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub enum PathEscapeCategory {
+    OutsideWorkspace,
+    HomeDirReference,
+    SystemPath,
+    Redirect,
+}
+```
+
+**为什么强类型 enum 而不是 `struct { source: &str, detail: String }`**：
+1. 后续 desktop-client `Ask` 弹窗按 `DecisionReason` 类型渲染不同 UI（规则命中 vs 路径越界 vs 命令注入 文案完全不同）
+2. 审计日志按 `DecisionReason` 类型分类统计
+3. 与 claude-code TS 的 discriminated union 同源
+
+### 2.3 `RuleSuggestion` 结构
+
+```rust
+#[derive(Debug, Clone, PartialEq)]
+pub struct RuleSuggestion {
+    /// 用户可点击的展示文本，如 "Always allow `git status`"。
+    pub label: String,
+    /// 实际规则模式，如 "Bash(git status: allow)"。
+    pub rule_pattern: String,
+    /// 该 suggestion 对应的动作（allow / deny / ask）。
+    pub action: RuleAction,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RuleAction {
+    Allow,
+    Deny,
+    Ask,
+}
+```
+
+### 2.4 `Passthrough` 语义
+
+> `Passthrough` 表示"此 hook 不表态，请 chain 继续问下一个 hook"。
+
+- 单 hook 上下文（无 CompositeSafetyHook）：`Passthrough` 等价于 `Allow { decision_reason: None }`（向后兼容）
+- `CompositeSafetyHook` 上下文：见 ADR-147
+
+### 2.5 Warn → Decision 映射（PermissionMode 依赖）
+
+`BashValidationHook` 当前的 `ValidationResult::Warn { message }` 映射：
+
+| PermissionMode | 当前（PR #493 / TODO #73）| 本 ADR 目标 |
+|---|---|---|
+| ReadOnly | Block | `Block { reason, decision_reason: Some(...) }` |
+| WorkspaceWrite | Allow + log（TODO #73）| `Allow { decision_reason: Some(...) }` + tracing log |
+| DangerFullAccess | Allow + log | 同上 |
+| Allow | Allow | `Allow { decision_reason: None }` |
+| Prompt | Allow + log | `Ask { reason, suggestions, decision_reason }` |
+
+`Ask` 变体在 Prompt mode 才触发；WorkspaceWrite/DangerFullAccess 走结构化 `Allow + reason`，**不打断用户**。
+
+---
+
+## 3. Consequences
+
+### 3.1 破坏性变更面
+
+| 影响 | 严重度 | 缓解 |
+|---|---|---|
+| 所有 `SafetyDecision::Allow` literal 必须改为 `Allow { decision_reason: None }` | 中 | 一次性迁移；项目内约 20-30 处 |
+| 所有 `match SafetyDecision { Allow => ..., Redact => ..., Block => ... }` 必须加 `_` 兜底（因为 `#[non_exhaustive]`） | 中 | 一次性迁移；测试断言用 `matches!()` 替代 |
+| `NoopSafetyHook` 默认返回值改为 `Allow { decision_reason: None }` | 低 | 行为等价 |
+
+### 3.2 与 ADR-112 兼容性矩阵的关系
+
+ADR-112 §"枚举禁止破坏性扩展"条款要求枚举变更走 major version。`x_claw_agent` 当前 `0.1.0` (path = ...) 未发布，本次变更落在 0.1.x，属内部演进。后续真正发版前再走 ADR-112 兼容性流程。
+
+### 3.3 ADR-113 红线影响
+
+不动 `count_hook_systems()` 编译期断言。枚举扩展对"系统数"无影响。
+
+### 3.4 性能
+
+`DecisionReason` enum 加入后 `SafetyDecision` size 增大（最大变体 `Ask` 含 `Vec`）。考虑用 `Box` 包装大字段：
+
+```rust
+Ask {
+    reason: String,
+    decision_reason: DecisionReason,
+    suggestions: Box<[RuleSuggestion]>,  // 而不是 Vec
+},
+```
+
+实测后决定。
+
+---
+
+## 4. Alternatives Considered
+
+### 4.1 不加 `#[non_exhaustive]`
+
+理由：减少外部 `match` 的 `_` 强制。  
+拒绝：违反 ADR-112 长期兼容性原则，每次扩展都是 breaking。
+
+### 4.2 `DecisionReason` 用 `String` 而不是 enum
+
+理由：实现简单。  
+拒绝：失去 UI / 审计的分类能力，后续无法演进。
+
+### 4.3 `Passthrough` 不进 enum，仅作为 `CompositeSafetyHook` 内部协议
+
+理由：减少 public API 表面。  
+拒绝：外部自定义 hook 也可能需要"不表态"语义；不暴露则无法表达。
+
+---
+
+## 5. Implementation Plan
+
+slice C PR 内一次性完成：
+
+1. 枚举改动 + 新增 `DecisionReason` / `RuleSuggestion` / `PathEscapeCategory` / `RuleAction` 类型
+2. 所有内部 `SafetyDecision::Allow` literal 升级
+3. 所有内部 `match` 加 `_` 兜底
+4. `NoopSafetyHook` 行为保持
+5. `BashValidationHook` Warn 映射按 §2.5 表实现（5 个 PermissionMode 分支）
+6. 测试矩阵：5 决策态 × 5 PermissionMode = 25 case + 5 `DecisionReason` 类型分类测试
+7. `IronclawSafetyHook::before_tool_call` 适配新枚举（PR #493 落地的 `if let SafetyDecision::Block` 改为 `match` 处理 5 态）
+
+---
+
+## 6. References
+
+- claude-code-main `src/utils/permissions/PermissionResult.ts`
+- claude-code-main `src/utils/permissions/DecisionReason.ts`
+- ADR-112 §"枚举兼容性"
+- ADR-113 §"trait seam 收口"
+- Issue #73 §"接口扩展"
+- PR #493（slice A1，本 ADR 前置）

--- a/docs/plans/architecture-refactor/adr-147-composite-safety-hook.md
+++ b/docs/plans/architecture-refactor/adr-147-composite-safety-hook.md
@@ -1,0 +1,218 @@
+# ADR-147: `CompositeSafetyHook` —— SafetyHook 链式串联
+
+- **Status**: Draft（W4 #73 slice B 前置）
+- **Date**: 2026-05-29
+- **Approver**: pending
+- **Supersedes**: 无
+- **Related**: ADR-112、ADR-113（HookEngine 收口）、ADR-146（SafetyDecision 5 态）
+- **Tracking Issue**: #73 slice B
+
+---
+
+## 1. Context
+
+### 1.1 现状
+
+`HookBundle.safety: Arc<dyn SafetyHook>` 是单 hook 槽位。`IronclawSafetyHook`（PR #493 落地）通过持有 `Option<Arc<BashValidationHook>>` 字段手工组合两个 hook —— 这是补丁式硬编码，无法扩展到 secrets / project rules / mcp-permission 等更多 hook。
+
+### 1.2 #73 issue body 要求
+
+> CompositeSafetyHook：可顺序组合多个 SafetyHook，Passthrough 时继续下一个。
+
+### 1.3 上游对照（claude-code-main）
+
+claude-code-main `src/utils/permissions/pipeline.ts` 实现 8 步 pipeline：
+
+```
+canUseTool → planMode → bashSecurity → permissions → bashPermissions
+  → claudeRules → mcpPermission → askPermissionResult
+```
+
+每一步返回 `PermissionResult`，behavior !== 'allow' 短路。pipeline 是固定顺序硬编码的。
+
+本 ADR 采用更通用的 `Vec<Arc<dyn SafetyHook>>` 顺序执行模型，让上层动态决定 chain。
+
+---
+
+## 2. Decision
+
+### 2.1 `CompositeSafetyHook` 定义
+
+落在 `crates/x_claw_agent/src/composite_safety_hook.rs`（与 `SafetyHook` trait 同 crate）。
+
+```rust
+pub struct CompositeSafetyHook {
+    hooks: Vec<(HookId, Arc<dyn SafetyHook>)>,
+}
+
+pub type HookId = &'static str;
+
+impl CompositeSafetyHook {
+    pub fn builder() -> CompositeSafetyHookBuilder { ... }
+}
+
+pub struct CompositeSafetyHookBuilder {
+    hooks: Vec<(HookId, Arc<dyn SafetyHook>)>,
+}
+
+impl CompositeSafetyHookBuilder {
+    pub fn add(mut self, id: HookId, hook: Arc<dyn SafetyHook>) -> Self { ... }
+    pub fn build(self) -> CompositeSafetyHook { ... }
+}
+
+#[async_trait]
+impl SafetyHook for CompositeSafetyHook {
+    async fn before_tool_call(...) -> Result<SafetyDecision> {
+        // 见 §2.2 短路语义
+    }
+    // before_prompt / after_completion / after_tool_output 见 §2.3
+}
+```
+
+`HookId` 为 `&'static str`，用于 tracing log 和审计（追踪哪条 hook 出的决策）。
+
+### 2.2 `before_tool_call` 短路语义
+
+| 当前 hook 返回 | 行为 |
+|---|---|
+| `Allow { decision_reason }` | **继续**问下一个 hook，但记录该 hook 的 Allow（用于 audit） |
+| `Redact { ... }` | **修改 args 后继续**问下一个 hook（下一个 hook 看到 redacted args） |
+| `Block { reason, decision_reason }` | **短路**返回 Block |
+| `Ask { ... }` | **短路**返回 Ask |
+| `Passthrough` | **继续**问下一个 hook（不记录 Allow，纯透传） |
+
+**末端语义**：所有 hook 都跑完后，最终决策按以下规则汇总：
+- 如果有任何 hook 返回 `Allow`：返回**最后一个** `Allow { decision_reason }`
+- 如果所有 hook 都返回 `Passthrough`：返回 `Allow { decision_reason: None }`（与上游一致）
+- Block / Ask 已经在中途短路，不会走到末端
+
+> **Fail-Safe 通过约定保证**：CompositeSafetyHook 末端必须挂"非 Passthrough"hook 作为兜底（如 `IronclawSafetyHook`）。运行时不强制；文档约束 + builder pattern review 时审查。
+
+### 2.3 4 个 SafetyHook 方法的串联差异
+
+| 方法 | 串联策略 |
+|---|---|
+| `before_prompt` | 链式 redact：第一个 hook redact 后第二个看到 redacted 版本；Block 短路；最终返回最后非 Passthrough 的 Allow |
+| `before_tool_call` | §2.2 短路语义 |
+| `after_completion` | **全部串联**（不短路）：每个 hook 顺序应用 sanitize；Block / Ask 在 after_* 无意义，遇到时降级为 Allow + 错误 log |
+| `after_tool_output` | 同 `after_completion` |
+
+`after_*` 不短路的理由：output 已经产生，目标是 sanitize，不是拦截。每个 hook 都有机会清洗。
+
+### 2.4 与 `HookBundle.safety` 的接入
+
+**B5.b 方案**（最小破坏面）：`CompositeSafetyHook: SafetyHook`，外部代码不感知。
+
+```rust
+// 现状（PR #493 后）
+let hook = IronclawSafetyHook::new(safety_layer).with_bash_validation(workspace);
+let bundle = HookBundle::default().with_safety(Arc::new(hook));
+
+// 本 ADR 后
+let composite = CompositeSafetyHook::builder()
+    .add("bash-validation", Arc::new(BashValidationHook::new(workspace, mode)))
+    .add("ironclaw-safety", Arc::new(IronclawSafetyHook::new(safety_layer)))
+    .add("project-rules", Arc::new(ProjectRulesHook::from_config(...)))
+    .build();
+let bundle = HookBundle::default().with_safety(Arc::new(composite));
+```
+
+`HookBundle.safety` 类型不变，仍是 `Arc<dyn SafetyHook>`。
+
+### 2.5 `IronclawSafetyHook` 的内部 `bash_hook` 字段下线
+
+PR #493 引入的 `bash_hook: Option<Arc<BashValidationHook>>` 字段在 slice B 落地后**移除**。BashValidationHook 直接挂在 CompositeSafetyHook chain 第一位。`IronclawSafetyHook::with_bash_validation()` builder 标记 `#[deprecated]` 一个版本后删除。
+
+### 2.6 ADR-113 红线影响
+
+ADR-113 §2.2 "1 = 编排入口数"。CompositeSafetyHook 是 trait seam 的组合器，**不是新的编排系统**——它仍然走 `HookBundle.safety` 单槽位。`count_hook_systems()` 编译期断言**不变**。
+
+需在 ADR-113 中追加一句澄清：
+> trait seam 的内部组合（如 `CompositeSafetyHook`）不计入"hook 系统数"。
+
+### 2.7 错误传播
+
+任何 hook 返回 `Err(_)` 立即短路，整个 chain 失败。**不允许"某个 hook 失败但继续问下一个"**（Fail-Safe）。
+
+---
+
+## 3. Consequences
+
+### 3.1 PR #493 的回退
+
+| PR #493 代码 | slice B 后 |
+|---|---|
+| `IronclawSafetyHook.bash_hook: Option<Arc<BashValidationHook>>` | 移除字段 |
+| `IronclawSafetyHook::with_bash_validation(workspace)` | `#[deprecated]` → 删除 |
+| `before_tool_call` 内 `if let Some(bash) = &self.bash_hook && let Block...` | 移除（chain 由 CompositeSafetyHook 负责）|
+| `hook_bundle_with_safety(safety, workspace)` | 签名改为 `hook_bundle_with_safety(safety: Arc<dyn SafetyHook>)`，workspace 走 builder |
+
+调用方需迁移到 CompositeSafetyHook builder。**PR #493 不是白做**——slice A1 验证了 hook 接线在 production 跑通，是 slice B 的可执行基础。
+
+### 3.2 与 ADR-146 的耦合
+
+CompositeSafetyHook 的短路语义依赖 `SafetyDecision::Passthrough` 和 `Ask` 变体存在。**slice B 必须在 slice C 之后**。
+
+### 3.3 测试
+
+- 单元：每种短路语义（Allow / Redact / Block / Ask / Passthrough / Err）×（first hook / middle hook / last hook）位置 = 18 case
+- 集成：3-hook chain 端到端（BashValidation + IronclawSafetyHook + ProjectRules mock）
+- 性能：100-hook chain 延迟 < 1ms（基线）
+
+### 3.4 后续扩展
+
+slice D / E 落地后，CompositeSafetyHook chain 形态：
+
+```rust
+CompositeSafetyHook::builder()
+    .add("bash-validation", Arc::new(BashValidationHook::new(workspace_cap, mode_provider)))
+    .add("ironclaw-safety", Arc::new(IronclawSafetyHook::new(safety_layer)))
+    .add("project-rules", project_rules_hook)
+    .add("mcp-permission", mcp_perm_hook)
+    .build()
+```
+
+---
+
+## 4. Alternatives Considered
+
+### 4.1 仿照 claude-code 硬编码 8 步 pipeline
+
+理由：与上游 100% 对齐。  
+拒绝：硬编码 chain 顺序无法适配 desktop-client 与 CLI 的差异；project-rules / mcp-permission 在 ironclaw 端尚未存在。
+
+### 4.2 `Vec<Box<dyn SafetyHook>>` 而不是 `Vec<(HookId, Arc<...>)>`
+
+理由：减少 boilerplate。  
+拒绝：丢失 audit / tracing 的 hook 来源标识；`Arc` 比 `Box` 适配多 chain 共享。
+
+### 4.3 `before_*` / `after_*` 全部统一短路 OR 全部串联
+
+理由：语义一致。  
+拒绝：`before_*` 拦截语义和 `after_*` sanitize 语义本质不同；强行统一会让某一端语义错误。
+
+---
+
+## 5. Implementation Plan
+
+slice B PR 内：
+
+1. 新增 `crates/x_claw_agent/src/composite_safety_hook.rs`（+ 模块导出）
+2. `CompositeSafetyHook` + Builder 实现
+3. `impl SafetyHook for CompositeSafetyHook` 实现 4 方法
+4. 单元测试：18 短路 case + 错误传播
+5. 集成测试：3-hook chain 端到端
+6. `IronclawSafetyHook` 内 `bash_hook` 字段标记 `#[deprecated(note = "use CompositeSafetyHook")]`
+7. ironclaw `hook_bundle_with_safety_*` 签名重构，调用方迁移到 builder
+8. ADR-113 文档追加 §2.2 澄清条款
+
+---
+
+## 6. References
+
+- claude-code-main `src/utils/permissions/pipeline.ts`
+- ADR-112 §"枚举 + trait 兼容"
+- ADR-113 §"1 = 编排入口数"
+- ADR-146（SafetyDecision 5 态）
+- PR #493（slice A1，本 ADR 的前置接线）
+- Issue #73 §"CompositeSafetyHook"


### PR DESCRIPTION
# docs(adr): SafetyDecision 5-state + CompositeSafetyHook design (#73)

Closes part of #73 (design phase).

## Sources read

- [AGENTS.md](../AGENTS.md) §"Skills 强制使用 / 红线流程"
- [adr-112-compatibility-evaluation.md](../docs/plans/architecture-refactor/adr-112-compatibility-evaluation.md) §"枚举兼容性"
- [adr-113-hook-engine-unification.md](../docs/plans/architecture-refactor/adr-113-hook-engine-unification.md) §2.2 "1 = 编排入口数"
- claude-code-main `src/utils/permissions/PermissionResult.ts` + `pipeline.ts`（先前 3 层验证调研）
- Issue #73 body + PR #493 (slice A1)

## 背景 / 目标

#73 验收要求 `SafetyDecision` 加 `Ask` + `Passthrough` 接口位、并落 `CompositeSafetyHook` 链式串联。这两条都触 ADR-redline（ADR-112 枚举兼容性 + ADR-113 hook 系统数）。

按 W3-A 流程，红线代码改动前先 ADR + reviewer 批准。本 PR **只交付 ADR 文档**，不动任何生产代码。

PR #493（slice A1, in-flight）已经把 `BashValidationHook` 通过 `IronclawSafetyHook` 接到 3 个生产 callsite，验证了 hook 接线在 production 跑通。本 PR 的两份 ADR 是 slice B / C 的设计前置。

## 改动范围

新增两份 ADR：

- `docs/plans/architecture-refactor/adr-146-safety-decision-enum-extension.md`
  - SafetyDecision 3 → 5 态，加 `#[non_exhaustive]`
  - Allow / Block 携带可选 `DecisionReason`（强类型 enum）
  - Ask 变体含 `RuleSuggestion` 候选列表
  - `Passthrough` 单 hook 上下文等价 Allow，CompositeSafetyHook 上下文继续 chain
  - Warn 状态映射表（5 PermissionMode × Warn → 决策），保守版：仅 Prompt mode 触发 Ask
  - 25 case 测试矩阵（5 决策 × 5 mode）在 slice C PR 内一次性落地
  - 破坏面盘点：约 20-30 处内部 literal 升级，外部 crate 未引用

- `docs/plans/architecture-refactor/adr-147-composite-safety-hook.md`
  - `Vec<(HookId, Arc<dyn SafetyHook>)>` + Builder pattern（HookId = `&'static str`）
  - `before_tool_call` 短路语义：Allow / Redact / Passthrough 继续；Block / Ask 短路；Err 传播
  - `before_*` 短路 / `after_*` 全部串联 sanitize 的差异化策略
  - 末端语义：全 Passthrough → 兜底 Allow（Fail-Safe 由 chain 末端必挂非 Passthrough hook 在文档约束）
  - PR #493 落地的 `IronclawSafetyHook::bash_hook` 字段在 slice B 后 `#[deprecated]` → 删除（不是浪费，是 slice B 的可执行基础）
  - ADR-113 §2.2 追加澄清条款（trait seam 内部组合不计入 hook 系统数）随 slice B PR 落地，**本 PR 不动 ADR-113**

## 非目标（What's NOT in this PR）

- 不动 `SafetyDecision` enum 定义（slice C PR 做）
- 不动 `CompositeSafetyHook` 实现（slice B PR 做）
- 不动 `IronclawSafetyHook.bash_hook` 字段（slice B PR 移除）
- 不动 ADR-113 文档（slice B PR 追加澄清条款）
- 不动 `count_hook_systems()` 编译期断言
- 不开 slice B / C / D / E 子 issue（等本 ADR 评审批准后再开）

## 设计要点（决策摘要）

| 决策点 | 选择 | 出处 |
|---|---|---|
| Allow 变体携带 decision_reason | Optional 字段 | ADR-146 §2.1 |
| DecisionReason 类型形态 | 强类型 enum（非 String） | ADR-146 §2.2 |
| Ask 变体字段 | reason + decision_reason + suggestions[] | ADR-146 §2.3 |
| Passthrough 末端语义 | 兜底 Allow（与 claude-code 一致） | ADR-147 §2.2 |
| `#[non_exhaustive]` 范围 | enum + Allow/Ask 结构变体 | ADR-146 §2.1 |
| Warn 状态映射 | 保守版（仅 Prompt mode 触发 Ask） | ADR-146 §2.5 |
| CompositeSafetyHook 注册位置 | `x_claw_agent`（与 SafetyHook trait 同 crate） | ADR-147 §2.1 |
| HookBundle 接入方式 | `CompositeSafetyHook: SafetyHook`，外部不感知 | ADR-147 §2.4 |
| before_*/after_* 差异 | before_* 短路；after_* 全部串联 sanitize | ADR-147 §2.3 |
| ADR-113 兼容性 | trait seam 组合不计入"系统数"；count_hook_systems 不变 | ADR-147 §2.6 |
| 实施顺序 | C → B → D → E 四 stacked PR | 决策清单 M1.a |
| 25 case 矩阵承接 | slice C 一并落地（与枚举改动强耦合） | 决策清单 M3.a |

## 验证

纯文档 PR：
- 无 cargo / clippy / test 改动
- 无新增 unwrap/expect/panic
- markdown 渲染本地预览正常
- ADR 编号 146 / 147 已确认空位（145 = windows-sandbox-users-naming-decision，146/147 未占用）

## ADR 红线自查

| 红线 | 影响 | 本 PR 状态 |
|---|---|---|
| ADR-112 枚举兼容性 | 设计阶段，无代码改动 | ✅ 仅文档 |
| ADR-113 count_hook_systems() == 1 | 未触碰编译期断言 | ✅ 不动 |
| `unwrap`/`expect`/`panic` | 无新增 | ✅ 不适用（纯文档） |

## Refs

- Closes part of #73 (design phase for slice B + slice C)
- Builds on: PR #493 (slice A1, in-flight)
- Predecessor ADRs: ADR-112, ADR-113

## 下一步

待 reviewer 批准 ADR-146 / ADR-147 内容后：
1. slice C PR：枚举改动 + 25 case 矩阵（不依赖 PR #493 合并，可并行）
2. slice B PR：CompositeSafetyHook + PR #493 字段下线 + ADR-113 §2.2 追加澄清（依赖 slice C + PR #493 合并）
3. slice D PR：PermissionMode 从 session config 注入
4. slice E PR：WorkspaceCap 注入（先调研 `dasclaw_workspace_cap` 当前 API 表面）
