### PR TITLE
feat(safety): CompositeSafetyHook + IronclawSafetyHook cleanup (#73 slice B)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5747,7 +5747,6 @@ version = "0.2.0"
 dependencies = [
  "aho-corasick",
  "async-trait",
- "dasclaw_hooks",
  "regex",
  "serde_json",
  "thiserror 2.0.18",

--- a/crates/x_claw_agent/src/composite_safety_hook.rs
+++ b/crates/x_claw_agent/src/composite_safety_hook.rs
@@ -1,0 +1,752 @@
+//! `CompositeSafetyHook` — chain multiple [`SafetyHook`] implementations
+//! into a single hook (per ADR-147).
+//!
+//! ## Why this exists
+//!
+//! `HookBundle.safety` is a single `Arc<dyn SafetyHook>` slot. Composing
+//! several distinct safety concerns (bash command validation, generic
+//! JSON validation, project-level rules, MCP permission gates, …) used
+//! to require ad-hoc fields like
+//! `IronclawSafetyHook { bash_hook: Option<Arc<…>> }`. That's a patch-style
+//! workaround that doesn't extend to N hooks.
+//!
+//! `CompositeSafetyHook` replaces the ad-hoc pattern with a typed chain
+//! built via a builder, while preserving the type identity of
+//! `Arc<dyn SafetyHook>` so the existing `HookBundle.safety` slot is
+//! reused unchanged.
+//!
+//! ## Short-circuit semantics
+//!
+//! See ADR-147 §2.2 / §2.3 for the canonical specification. Quick recap:
+//!
+//! - `before_tool_call` / `before_prompt`:
+//!   - `Allow`              → continue (record as "last allow")
+//!   - `Redact`             → continue (caller already mutated payload)
+//!   - `Passthrough`        → continue (do not record allow)
+//!   - `Block { reason }`   → **short-circuit** return Block
+//!   - `Ask { … }`          → **short-circuit** return Ask
+//!   - `Err(e)`             → **short-circuit** return Err (Fail-Safe)
+//! - `after_completion` / `after_tool_output`: every hook runs in order
+//!   (sanitisation pipeline). Errors short-circuit; Block/Ask are
+//!   meaningless on already-produced output and are tracing::error!-logged
+//!   then ignored.
+//!
+//! ## End-of-chain rule (ADR-147 §2.2)
+//!
+//! If all hooks returned `Passthrough`, the chain returns `Allow` (a
+//! single-hook chain of one Passthrough also yields Allow). At least one
+//! non-Passthrough hook is expected at the end of the chain — currently a
+//! convention enforced by builder review, not by the type system.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use serde_json::Value;
+
+use crate::hooks::{SafetyDecision, SafetyError, SafetyHook};
+
+/// Stable identifier for a hook slot in the chain. Used in tracing logs
+/// and audit records to attribute decisions to a specific hook.
+pub type HookId = &'static str;
+
+/// Sequential composition of [`SafetyHook`] implementations.
+///
+/// Construct via [`CompositeSafetyHook::builder`].
+pub struct CompositeSafetyHook {
+    hooks: Vec<(HookId, Arc<dyn SafetyHook>)>,
+}
+
+impl CompositeSafetyHook {
+    /// Create a new builder.
+    #[must_use]
+    pub fn builder() -> CompositeSafetyHookBuilder {
+        CompositeSafetyHookBuilder { hooks: Vec::new() }
+    }
+
+    /// Number of hooks currently composed (for diagnostics / tests).
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.hooks.len()
+    }
+
+    /// Whether the chain is empty.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.hooks.is_empty()
+    }
+
+    /// Returns the ordered list of `HookId`s in the chain.
+    pub fn hook_ids(&self) -> Vec<HookId> {
+        self.hooks.iter().map(|(id, _)| *id).collect()
+    }
+}
+
+/// Builder for [`CompositeSafetyHook`].
+///
+/// Hooks execute in insertion order. The convention is to place the most
+/// specific hook first (e.g. `bash-validation`) and the most general hook
+/// last (e.g. `ironclaw-safety` JSON validator).
+pub struct CompositeSafetyHookBuilder {
+    hooks: Vec<(HookId, Arc<dyn SafetyHook>)>,
+}
+
+impl CompositeSafetyHookBuilder {
+    /// Append a hook to the chain. `id` MUST be a stable identifier (used
+    /// in tracing / audit). Duplicate ids are allowed but discouraged.
+    #[must_use]
+    pub fn add(mut self, id: HookId, hook: Arc<dyn SafetyHook>) -> Self {
+        self.hooks.push((id, hook));
+        self
+    }
+
+    /// Finalise the builder.
+    #[must_use]
+    pub fn build(self) -> CompositeSafetyHook {
+        CompositeSafetyHook { hooks: self.hooks }
+    }
+}
+
+/// Outcome category used internally to apply the §2.2 short-circuit rule
+/// uniformly to `before_prompt` and `before_tool_call`.
+enum BeforeFlow {
+    /// Continue to the next hook; record this Allow as the chain's
+    /// last-known Allow (for the end-of-chain rule).
+    ContinueAllow,
+    /// Continue to the next hook (Redact already mutated the payload).
+    ContinueRedact,
+    /// Continue to the next hook without recording an Allow.
+    ContinuePassthrough,
+    /// Short-circuit with the given decision.
+    ShortCircuit(SafetyDecision),
+}
+
+fn classify(decision: SafetyDecision) -> BeforeFlow {
+    // SafetyDecision is `#[non_exhaustive]` for downstream crates, but the
+    // match here lives in the defining crate so all current variants are
+    // visible. If a new variant is added, the missing-arm error MUST be
+    // resolved by classifying it explicitly — defaulting to a wildcard
+    // would silently downgrade a new safety variant. Fail-Safe by design.
+    match decision {
+        SafetyDecision::Allow => BeforeFlow::ContinueAllow,
+        SafetyDecision::Redact => BeforeFlow::ContinueRedact,
+        SafetyDecision::Passthrough => BeforeFlow::ContinuePassthrough,
+        d @ (SafetyDecision::Block { .. } | SafetyDecision::Ask { .. }) => {
+            BeforeFlow::ShortCircuit(d)
+        }
+    }
+}
+
+#[async_trait]
+impl SafetyHook for CompositeSafetyHook {
+    async fn before_prompt(&self, prompt: &mut String) -> Result<SafetyDecision, SafetyError> {
+        // Track whether any hook returned a non-Passthrough Allow / Redact.
+        // End-of-chain rule (ADR-147 §2.2): if all hooks Passthrough, the
+        // chain returns Allow.
+        let mut last_concrete: Option<SafetyDecision> = None;
+
+        for (id, hook) in &self.hooks {
+            let decision = hook.before_prompt(prompt).await.inspect_err(|e| {
+                tracing::error!(hook_id = id, error = %e, "CompositeSafetyHook before_prompt error");
+            })?;
+            match classify(decision) {
+                BeforeFlow::ContinueAllow => {
+                    tracing::trace!(hook_id = id, "before_prompt: Allow, continue");
+                    last_concrete = Some(SafetyDecision::Allow);
+                }
+                BeforeFlow::ContinueRedact => {
+                    tracing::trace!(hook_id = id, "before_prompt: Redact, continue");
+                    last_concrete = Some(SafetyDecision::Redact);
+                }
+                BeforeFlow::ContinuePassthrough => {
+                    tracing::trace!(hook_id = id, "before_prompt: Passthrough");
+                }
+                BeforeFlow::ShortCircuit(d) => {
+                    tracing::debug!(
+                        hook_id = id,
+                        decision = ?d,
+                        "before_prompt: short-circuit"
+                    );
+                    return Ok(d);
+                }
+            }
+        }
+
+        Ok(last_concrete.unwrap_or(SafetyDecision::Allow))
+    }
+
+    async fn after_completion(&self, completion: &mut String) -> Result<(), SafetyError> {
+        // Sanitisation pipeline: every hook runs. Errors short-circuit
+        // (Fail-Safe). after_* contracts return () — no decision.
+        for (id, hook) in &self.hooks {
+            hook.after_completion(completion).await.inspect_err(|e| {
+                tracing::error!(
+                    hook_id = id,
+                    error = %e,
+                    "CompositeSafetyHook after_completion error"
+                );
+            })?;
+        }
+        Ok(())
+    }
+
+    async fn before_tool_call(
+        &self,
+        tool: &str,
+        args: &mut Value,
+    ) -> Result<SafetyDecision, SafetyError> {
+        let mut last_concrete: Option<SafetyDecision> = None;
+
+        for (id, hook) in &self.hooks {
+            let decision = hook.before_tool_call(tool, args).await.inspect_err(|e| {
+                tracing::error!(
+                    hook_id = id,
+                    tool,
+                    error = %e,
+                    "CompositeSafetyHook before_tool_call error"
+                );
+            })?;
+            match classify(decision) {
+                BeforeFlow::ContinueAllow => {
+                    tracing::trace!(hook_id = id, tool, "before_tool_call: Allow, continue");
+                    last_concrete = Some(SafetyDecision::Allow);
+                }
+                BeforeFlow::ContinueRedact => {
+                    tracing::trace!(hook_id = id, tool, "before_tool_call: Redact, continue");
+                    last_concrete = Some(SafetyDecision::Redact);
+                }
+                BeforeFlow::ContinuePassthrough => {
+                    tracing::trace!(hook_id = id, tool, "before_tool_call: Passthrough");
+                }
+                BeforeFlow::ShortCircuit(d) => {
+                    tracing::debug!(
+                        hook_id = id,
+                        tool,
+                        decision = ?d,
+                        "before_tool_call: short-circuit"
+                    );
+                    return Ok(d);
+                }
+            }
+        }
+
+        Ok(last_concrete.unwrap_or(SafetyDecision::Allow))
+    }
+
+    async fn after_tool_output(&self, tool: &str, output: &mut String) -> Result<(), SafetyError> {
+        for (id, hook) in &self.hooks {
+            hook.after_tool_output(tool, output)
+                .await
+                .inspect_err(|e| {
+                    tracing::error!(
+                        hook_id = id,
+                        tool,
+                        error = %e,
+                        "CompositeSafetyHook after_tool_output error"
+                    );
+                })?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::hooks::{NoopSafetyHook, RuleSuggestion};
+    use serde_json::json;
+    use std::sync::Mutex;
+
+    /// A controllable test hook that returns a pre-set decision and
+    /// records every invocation into a shared Vec for ordering assertions.
+    #[derive(Clone)]
+    struct StubHook {
+        id: HookId,
+        decision: SafetyDecision,
+        calls: Arc<Mutex<Vec<&'static str>>>,
+    }
+
+    impl StubHook {
+        fn new(id: HookId, decision: SafetyDecision, calls: Arc<Mutex<Vec<&'static str>>>) -> Self {
+            Self {
+                id,
+                decision,
+                calls,
+            }
+        }
+
+        fn record(&self, method: &'static str) {
+            self.calls
+                .lock()
+                .expect("stub hook mutex poisoned")
+                .push(self.id);
+            // Suppress unused lint when method tracking not needed.
+            let _ = method;
+        }
+    }
+
+    #[async_trait]
+    impl SafetyHook for StubHook {
+        async fn before_prompt(&self, _prompt: &mut String) -> Result<SafetyDecision, SafetyError> {
+            self.record("before_prompt");
+            Ok(self.decision.clone())
+        }
+        async fn after_completion(&self, _completion: &mut String) -> Result<(), SafetyError> {
+            self.record("after_completion");
+            Ok(())
+        }
+        async fn before_tool_call(
+            &self,
+            _tool: &str,
+            _args: &mut Value,
+        ) -> Result<SafetyDecision, SafetyError> {
+            self.record("before_tool_call");
+            Ok(self.decision.clone())
+        }
+        async fn after_tool_output(
+            &self,
+            _tool: &str,
+            _output: &mut String,
+        ) -> Result<(), SafetyError> {
+            self.record("after_tool_output");
+            Ok(())
+        }
+    }
+
+    /// Hook that mutates the args / completion to verify Redact propagation.
+    struct MutatingHook {
+        id: HookId,
+        replacement: String,
+    }
+
+    #[async_trait]
+    impl SafetyHook for MutatingHook {
+        async fn before_prompt(&self, prompt: &mut String) -> Result<SafetyDecision, SafetyError> {
+            *prompt = self.replacement.clone();
+            Ok(SafetyDecision::Redact)
+        }
+        async fn after_completion(&self, completion: &mut String) -> Result<(), SafetyError> {
+            *completion = self.replacement.clone();
+            Ok(())
+        }
+        async fn before_tool_call(
+            &self,
+            _tool: &str,
+            args: &mut Value,
+        ) -> Result<SafetyDecision, SafetyError> {
+            *args = json!({ "command": self.replacement });
+            Ok(SafetyDecision::Redact)
+        }
+        async fn after_tool_output(
+            &self,
+            _tool: &str,
+            output: &mut String,
+        ) -> Result<(), SafetyError> {
+            *output = self.replacement.clone();
+            Ok(())
+        }
+        // suppress dead_code on id; used in tracing in real impls
+    }
+
+    impl MutatingHook {
+        #[allow(dead_code)]
+        fn id(&self) -> HookId {
+            self.id
+        }
+    }
+
+    /// Hook that always errors — used to assert Fail-Safe error propagation.
+    struct ErrorHook;
+
+    #[async_trait]
+    impl SafetyHook for ErrorHook {
+        async fn before_prompt(&self, _prompt: &mut String) -> Result<SafetyDecision, SafetyError> {
+            Err(SafetyError::Internal("boom".into()))
+        }
+        async fn after_completion(&self, _completion: &mut String) -> Result<(), SafetyError> {
+            Err(SafetyError::Internal("boom".into()))
+        }
+        async fn before_tool_call(
+            &self,
+            _tool: &str,
+            _args: &mut Value,
+        ) -> Result<SafetyDecision, SafetyError> {
+            Err(SafetyError::Internal("boom".into()))
+        }
+        async fn after_tool_output(
+            &self,
+            _tool: &str,
+            _output: &mut String,
+        ) -> Result<(), SafetyError> {
+            Err(SafetyError::Internal("boom".into()))
+        }
+    }
+
+    fn calls() -> Arc<Mutex<Vec<&'static str>>> {
+        Arc::new(Mutex::new(Vec::new()))
+    }
+
+    fn ask_decision() -> SafetyDecision {
+        SafetyDecision::Ask {
+            reason: "confirm?".into(),
+            suggestions: vec![RuleSuggestion {
+                label: "Allow once".into(),
+                rule_pattern: "Bash(rm: ask)".into(),
+                action: crate::hooks::RuleAction::Ask,
+            }],
+        }
+    }
+
+    // ----- Builder smoke -----
+
+    #[test]
+    fn req_safety_73_b_builder_records_order_and_ids() {
+        let composite = CompositeSafetyHook::builder()
+            .add("first", Arc::new(NoopSafetyHook))
+            .add("second", Arc::new(NoopSafetyHook))
+            .build();
+        assert_eq!(composite.len(), 2);
+        assert_eq!(composite.hook_ids(), vec!["first", "second"]);
+        assert!(!composite.is_empty());
+    }
+
+    #[test]
+    fn req_safety_73_b_empty_builder_is_empty() {
+        let composite = CompositeSafetyHook::builder().build();
+        assert!(composite.is_empty());
+        assert_eq!(composite.len(), 0);
+    }
+
+    // ----- before_tool_call short-circuit matrix (ADR-147 §2.2) -----
+
+    #[tokio::test]
+    async fn req_safety_73_b_btc_all_passthrough_returns_allow() {
+        let calls = calls();
+        let composite = CompositeSafetyHook::builder()
+            .add(
+                "a",
+                Arc::new(StubHook::new(
+                    "a",
+                    SafetyDecision::Passthrough,
+                    calls.clone(),
+                )),
+            )
+            .add(
+                "b",
+                Arc::new(StubHook::new(
+                    "b",
+                    SafetyDecision::Passthrough,
+                    calls.clone(),
+                )),
+            )
+            .build();
+        let mut args = json!({ "x": 1 });
+        let d = composite.before_tool_call("t", &mut args).await.unwrap();
+        assert_eq!(d, SafetyDecision::Allow);
+        assert_eq!(*calls.lock().unwrap(), vec!["a", "b"]);
+    }
+
+    #[tokio::test]
+    async fn req_safety_73_b_btc_all_allow_returns_allow_and_runs_all() {
+        let calls = calls();
+        let composite = CompositeSafetyHook::builder()
+            .add(
+                "a",
+                Arc::new(StubHook::new("a", SafetyDecision::Allow, calls.clone())),
+            )
+            .add(
+                "b",
+                Arc::new(StubHook::new("b", SafetyDecision::Allow, calls.clone())),
+            )
+            .build();
+        let mut args = json!({ "x": 1 });
+        let d = composite.before_tool_call("t", &mut args).await.unwrap();
+        assert_eq!(d, SafetyDecision::Allow);
+        assert_eq!(*calls.lock().unwrap(), vec!["a", "b"]);
+    }
+
+    #[tokio::test]
+    async fn req_safety_73_b_btc_block_first_short_circuits() {
+        let calls = calls();
+        let composite = CompositeSafetyHook::builder()
+            .add(
+                "blocker",
+                Arc::new(StubHook::new(
+                    "blocker",
+                    SafetyDecision::Block {
+                        reason: "no".into(),
+                    },
+                    calls.clone(),
+                )),
+            )
+            .add(
+                "later",
+                Arc::new(StubHook::new("later", SafetyDecision::Allow, calls.clone())),
+            )
+            .build();
+        let mut args = json!({});
+        let d = composite.before_tool_call("t", &mut args).await.unwrap();
+        assert!(matches!(d, SafetyDecision::Block { .. }));
+        // `later` must NOT have been called.
+        assert_eq!(*calls.lock().unwrap(), vec!["blocker"]);
+    }
+
+    #[tokio::test]
+    async fn req_safety_73_b_btc_block_middle_short_circuits() {
+        let calls = calls();
+        let composite = CompositeSafetyHook::builder()
+            .add(
+                "first",
+                Arc::new(StubHook::new("first", SafetyDecision::Allow, calls.clone())),
+            )
+            .add(
+                "blocker",
+                Arc::new(StubHook::new(
+                    "blocker",
+                    SafetyDecision::Block {
+                        reason: "no".into(),
+                    },
+                    calls.clone(),
+                )),
+            )
+            .add(
+                "last",
+                Arc::new(StubHook::new("last", SafetyDecision::Allow, calls.clone())),
+            )
+            .build();
+        let mut args = json!({});
+        let d = composite.before_tool_call("t", &mut args).await.unwrap();
+        assert!(matches!(d, SafetyDecision::Block { .. }));
+        assert_eq!(*calls.lock().unwrap(), vec!["first", "blocker"]);
+    }
+
+    #[tokio::test]
+    async fn req_safety_73_b_btc_ask_short_circuits() {
+        let calls = calls();
+        let composite = CompositeSafetyHook::builder()
+            .add(
+                "asker",
+                Arc::new(StubHook::new("asker", ask_decision(), calls.clone())),
+            )
+            .add(
+                "later",
+                Arc::new(StubHook::new("later", SafetyDecision::Allow, calls.clone())),
+            )
+            .build();
+        let mut args = json!({});
+        let d = composite.before_tool_call("t", &mut args).await.unwrap();
+        assert!(matches!(d, SafetyDecision::Ask { .. }));
+        assert_eq!(*calls.lock().unwrap(), vec!["asker"]);
+    }
+
+    #[tokio::test]
+    async fn req_safety_73_b_btc_redact_then_block_returns_block() {
+        let composite = CompositeSafetyHook::builder()
+            .add(
+                "redactor",
+                Arc::new(MutatingHook {
+                    id: "redactor",
+                    replacement: "REDACTED".into(),
+                }),
+            )
+            .add(
+                "blocker",
+                Arc::new(StubHook::new(
+                    "blocker",
+                    SafetyDecision::Block {
+                        reason: "still no".into(),
+                    },
+                    calls(),
+                )),
+            )
+            .build();
+        let mut args = json!({ "command": "secret" });
+        let d = composite.before_tool_call("t", &mut args).await.unwrap();
+        assert!(matches!(d, SafetyDecision::Block { .. }));
+        // The blocker observed the redacted args, not the original.
+        assert_eq!(args, json!({ "command": "REDACTED" }));
+    }
+
+    #[tokio::test]
+    async fn req_safety_73_b_btc_redact_propagates_to_next_hook() {
+        let calls = calls();
+        let composite = CompositeSafetyHook::builder()
+            .add(
+                "redactor",
+                Arc::new(MutatingHook {
+                    id: "redactor",
+                    replacement: "REDACTED".into(),
+                }),
+            )
+            .add(
+                "later",
+                Arc::new(StubHook::new("later", SafetyDecision::Allow, calls.clone())),
+            )
+            .build();
+        let mut args = json!({ "command": "secret" });
+        let d = composite.before_tool_call("t", &mut args).await.unwrap();
+        // Last concrete decision is Allow; chain returns Allow.
+        assert_eq!(d, SafetyDecision::Allow);
+        assert_eq!(args, json!({ "command": "REDACTED" }));
+        assert_eq!(*calls.lock().unwrap(), vec!["later"]);
+    }
+
+    #[tokio::test]
+    async fn req_safety_73_b_btc_error_short_circuits_fail_safe() {
+        let calls = calls();
+        let composite = CompositeSafetyHook::builder()
+            .add("err", Arc::new(ErrorHook))
+            .add(
+                "later",
+                Arc::new(StubHook::new("later", SafetyDecision::Allow, calls.clone())),
+            )
+            .build();
+        let mut args = json!({});
+        let result = composite.before_tool_call("t", &mut args).await;
+        assert!(result.is_err());
+        assert!(calls.lock().unwrap().is_empty());
+    }
+
+    // ----- before_prompt mirrors before_tool_call -----
+
+    #[tokio::test]
+    async fn req_safety_73_b_bp_block_short_circuits() {
+        let calls = calls();
+        let composite = CompositeSafetyHook::builder()
+            .add(
+                "blocker",
+                Arc::new(StubHook::new(
+                    "blocker",
+                    SafetyDecision::Block {
+                        reason: "no".into(),
+                    },
+                    calls.clone(),
+                )),
+            )
+            .add(
+                "later",
+                Arc::new(StubHook::new("later", SafetyDecision::Allow, calls.clone())),
+            )
+            .build();
+        let mut prompt = String::from("hello");
+        let d = composite.before_prompt(&mut prompt).await.unwrap();
+        assert!(matches!(d, SafetyDecision::Block { .. }));
+        assert_eq!(*calls.lock().unwrap(), vec!["blocker"]);
+    }
+
+    #[tokio::test]
+    async fn req_safety_73_b_bp_redact_propagates_to_next_hook() {
+        let calls = calls();
+        let composite = CompositeSafetyHook::builder()
+            .add(
+                "redactor",
+                Arc::new(MutatingHook {
+                    id: "redactor",
+                    replacement: "REDACTED".into(),
+                }),
+            )
+            .add(
+                "later",
+                Arc::new(StubHook::new("later", SafetyDecision::Allow, calls.clone())),
+            )
+            .build();
+        let mut prompt = String::from("secret");
+        let d = composite.before_prompt(&mut prompt).await.unwrap();
+        assert_eq!(d, SafetyDecision::Allow);
+        assert_eq!(prompt, "REDACTED");
+        assert_eq!(*calls.lock().unwrap(), vec!["later"]);
+    }
+
+    // ----- after_* runs every hook (no short-circuit) -----
+
+    #[tokio::test]
+    async fn req_safety_73_b_after_completion_runs_every_hook_in_order() {
+        let calls = calls();
+        let composite = CompositeSafetyHook::builder()
+            .add(
+                "a",
+                Arc::new(StubHook::new("a", SafetyDecision::Allow, calls.clone())),
+            )
+            .add(
+                "b",
+                Arc::new(StubHook::new("b", SafetyDecision::Allow, calls.clone())),
+            )
+            .add(
+                "c",
+                Arc::new(StubHook::new("c", SafetyDecision::Allow, calls.clone())),
+            )
+            .build();
+        let mut completion = String::from("result");
+        composite.after_completion(&mut completion).await.unwrap();
+        assert_eq!(*calls.lock().unwrap(), vec!["a", "b", "c"]);
+    }
+
+    #[tokio::test]
+    async fn req_safety_73_b_after_tool_output_chains_redactions() {
+        let composite = CompositeSafetyHook::builder()
+            .add(
+                "first",
+                Arc::new(MutatingHook {
+                    id: "first",
+                    replacement: "STAGE1".into(),
+                }),
+            )
+            .add(
+                "second",
+                Arc::new(MutatingHook {
+                    id: "second",
+                    replacement: "STAGE2".into(),
+                }),
+            )
+            .build();
+        let mut output = String::from("raw");
+        composite.after_tool_output("t", &mut output).await.unwrap();
+        // Last hook's mutation wins.
+        assert_eq!(output, "STAGE2");
+    }
+
+    #[tokio::test]
+    async fn req_safety_73_b_after_completion_error_short_circuits() {
+        let calls = calls();
+        let composite = CompositeSafetyHook::builder()
+            .add("err", Arc::new(ErrorHook))
+            .add(
+                "later",
+                Arc::new(StubHook::new("later", SafetyDecision::Allow, calls.clone())),
+            )
+            .build();
+        let mut completion = String::from("x");
+        let result = composite.after_completion(&mut completion).await;
+        assert!(result.is_err());
+        assert!(calls.lock().unwrap().is_empty());
+    }
+
+    // ----- Single-hook chain equivalence -----
+
+    #[tokio::test]
+    async fn req_safety_73_b_single_passthrough_hook_returns_allow() {
+        let composite = CompositeSafetyHook::builder()
+            .add(
+                "only",
+                Arc::new(StubHook::new("only", SafetyDecision::Passthrough, calls())),
+            )
+            .build();
+        let mut args = json!({});
+        let d = composite.before_tool_call("t", &mut args).await.unwrap();
+        assert_eq!(d, SafetyDecision::Allow);
+    }
+
+    #[tokio::test]
+    async fn req_safety_73_b_empty_chain_returns_allow() {
+        let composite = CompositeSafetyHook::builder().build();
+        let mut args = json!({});
+        let d = composite.before_tool_call("t", &mut args).await.unwrap();
+        assert_eq!(d, SafetyDecision::Allow);
+        let mut prompt = String::new();
+        let d = composite.before_prompt(&mut prompt).await.unwrap();
+        assert_eq!(d, SafetyDecision::Allow);
+        let mut completion = String::new();
+        composite.after_completion(&mut completion).await.unwrap();
+        let mut output = String::new();
+        composite.after_tool_output("t", &mut output).await.unwrap();
+    }
+}

--- a/crates/x_claw_agent/src/lib.rs
+++ b/crates/x_claw_agent/src/lib.rs
@@ -14,6 +14,7 @@
 pub mod agentic_loop;
 pub mod bash_validation;
 pub mod compaction;
+pub mod composite_safety_hook;
 pub mod context_monitor;
 pub mod hooks;
 pub mod intent;
@@ -36,6 +37,7 @@ pub use bash_validation::{
     CommandIntent, ValidationResult, check_destructive, classify_command, validate_command,
     validate_mode, validate_paths, validate_read_only, validate_sed,
 };
+pub use composite_safety_hook::{CompositeSafetyHook, CompositeSafetyHookBuilder, HookId};
 pub use hooks::{
     ApprovalError, ApprovalGate, ApprovalOutcome, ApprovalRequest, AutoApproveGate, DenyAllGate,
     HookBundle, InMemorySecrets, NoopSafetyHook, NoopSandboxExecutor, RuleAction, RuleSuggestion,

--- a/desktop-client/ironclaw/crates/ironclaw_safety/Cargo.toml
+++ b/desktop-client/ironclaw/crates/ironclaw_safety/Cargo.toml
@@ -25,16 +25,12 @@ url = "2"
 # hard dependency on ironclaw.
 async-trait = { version = "0.1", optional = true }
 x_claw_agent = { path = "../../../../crates/x_claw_agent", optional = true }
-# Optional: bash command-string validation hook (issue #73 slice A1). Gated
-# behind the same `agent-hook` feature so non-agent callers stay free of the
-# extra dependency tree.
-dasclaw_hooks = { path = "../../../../crates/dasclaw_hooks", optional = true }
 
 [features]
 default = []
 # Enables the `agent_hook` module: `IronclawSafetyHook` adapter for
 # `x_claw_agent::SafetyHook`.
-agent-hook = ["dep:async-trait", "dep:x_claw_agent", "dep:dasclaw_hooks"]
+agent-hook = ["dep:async-trait", "dep:x_claw_agent"]
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt", "macros", "sync"] }

--- a/desktop-client/ironclaw/crates/ironclaw_safety/src/agent_hook.rs
+++ b/desktop-client/ironclaw/crates/ironclaw_safety/src/agent_hook.rs
@@ -11,35 +11,33 @@
 //! |---------------------|--------------------|--------------|
 //! | `before_prompt`     | `scan_inbound_for_secrets` | `Block` if secrets detected (fail-safe — never ship secrets to LLM). |
 //! | `after_completion`  | `leak_detector().scan_and_clean` | Replace with redacted body; `Err` → full-body block marker (fail-safe). |
-//! | `before_tool_call`  | bash routing (optional) → `validator().validate_tool_params` | `Block` if invalid. |
+//! | `before_tool_call`  | `validator().validate_tool_params` | `Block` if invalid. |
 //! | `after_tool_output` | `sanitize_tool_output` | Replace with sanitized body. |
 //!
-//! ## Bash routing (issue #73 slice A1)
+//! ## Composition with bash validation (issue #73 slice B)
 //!
-//! When [`IronclawSafetyHook::with_bash_validation`] is configured, the
-//! `before_tool_call` path checks bash-style tool calls (names matching
-//! [`dasclaw_hooks::DEFAULT_BASH_TOOL_NAMES`]) through
-//! [`dasclaw_hooks::BashValidationHook`] *before* the generic JSON
-//! validator. `Block` short-circuits; `Allow` falls through to the generic
-//! validator so prompt-injection checks still run on the args.
+//! Bash command-string validation is **no longer** an internal field of
+//! this adapter. Per ADR-147, callers compose multiple [`SafetyHook`]
+//! implementations via [`x_claw_agent::CompositeSafetyHook`]:
 //!
-//! [`PermissionMode`] is currently hard-coded to `WorkspaceWrite` —
-//! per-session injection is an ADR-redline item tracked by issue #73.
-//! Workspace root falls back to `std::env::current_dir()` and finally `.`,
-//! mirroring [`crate::sandbox` shell tool's existing convention] so this
-//! slice does not introduce a new redline.
+//! ```ignore
+//! let composite = x_claw_agent::CompositeSafetyHook::builder()
+//!     .add("bash-validation", Arc::new(BashValidationHook::new(mode, workspace)))
+//!     .add("ironclaw-safety", Arc::new(IronclawSafetyHook::new(layer)))
+//!     .build();
+//! ```
+//!
+//! See [`crate::agent::agentic_loop::hook_bundle_with_safety`] (in the
+//! `ironclaw` crate) for the production composition.
 //!
 //! The `after_*` hooks do not return `SafetyDecision` — by the time the runtime
 //! calls them the data already exists, so the adapter always mutates in place
 //! and returns `Ok(())`.
 
-use std::path::PathBuf;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use dasclaw_hooks::BashValidationHook;
 use serde_json::Value;
-use x_claw_agent::permissions::PermissionMode;
 use x_claw_agent::{SafetyDecision, SafetyError, SafetyHook};
 
 use crate::SafetyLayer;
@@ -51,42 +49,11 @@ use crate::SafetyLayer;
 #[derive(Clone)]
 pub struct IronclawSafetyHook {
     layer: Arc<SafetyLayer>,
-    /// Optional bash command-string validation, configured via
-    /// [`Self::with_bash_validation`]. `None` keeps the historical
-    /// behaviour (generic JSON validation only).
-    bash_hook: Option<Arc<BashValidationHook>>,
 }
 
 impl IronclawSafetyHook {
     pub fn new(layer: Arc<SafetyLayer>) -> Self {
-        Self {
-            layer,
-            bash_hook: None,
-        }
-    }
-
-    /// Attach a [`BashValidationHook`] that runs *before* the generic JSON
-    /// validator on bash-style tool calls.
-    ///
-    /// `workspace` is the root used by `pathValidation` to detect workspace
-    /// escapes. `PermissionMode` is currently hard-coded to `WorkspaceWrite`
-    /// — per-session mode injection is tracked by issue #73.
-    ///
-    /// # Example
-    /// ```ignore
-    /// let workspace = std::env::current_dir()
-    ///     .unwrap_or_else(|_| std::path::PathBuf::from("."));
-    /// let hook = IronclawSafetyHook::new(layer).with_bash_validation(workspace);
-    /// ```
-    #[must_use]
-    pub fn with_bash_validation(mut self, workspace: PathBuf) -> Self {
-        // TODO(#73): replace WorkspaceWrite with per-session PermissionMode
-        // once the session-config injection path is settled (ADR-redline).
-        self.bash_hook = Some(Arc::new(BashValidationHook::new(
-            PermissionMode::WorkspaceWrite,
-            workspace,
-        )));
-        self
+        Self { layer }
     }
 
     pub fn layer(&self) -> &SafetyLayer {
@@ -124,40 +91,9 @@ impl SafetyHook for IronclawSafetyHook {
 
     async fn before_tool_call(
         &self,
-        tool: &str,
+        _tool: &str,
         args: &mut Value,
     ) -> Result<SafetyDecision, SafetyError> {
-        // Issue #73 slice A1 + slice C: bash command-string validation
-        // runs first when configured. Per ADR-147 short-circuit semantics:
-        //
-        // - `Block` / `Ask`        → return immediately (interrupts user)
-        // - `Allow` / `Redact` /
-        //   `Passthrough` (slice C)→ fall through to the generic JSON
-        //                            validator so prompt-injection
-        //                            scanning still applies.
-        //
-        // The `Ok(other)` arm is a Fail-Safe non-exhaustive guard against
-        // future `SafetyDecision` variants added without updating call
-        // sites — see ADR-146 §3.
-        if let Some(bash) = &self.bash_hook {
-            match bash.before_tool_call(tool, args).await? {
-                SafetyDecision::Allow | SafetyDecision::Redact | SafetyDecision::Passthrough => {}
-                blocking @ (SafetyDecision::Block { .. } | SafetyDecision::Ask { .. }) => {
-                    return Ok(blocking);
-                }
-                other => {
-                    tracing::error!(
-                        ?other,
-                        "BashValidationHook returned unknown SafetyDecision variant; Fail-Safe Block"
-                    );
-                    return Ok(SafetyDecision::Block {
-                        reason: "unknown SafetyDecision variant from BashValidationHook"
-                            .to_string(),
-                    });
-                }
-            }
-        }
-
         let result = self.layer.validator().validate_tool_params(args);
         if result.is_valid {
             Ok(SafetyDecision::Allow)
@@ -282,89 +218,5 @@ mod tests {
         hook.after_tool_output("bash", &mut output).await.unwrap();
         // Leak detector must either redact or block; raw secret is gone.
         assert_ne!(output, raw);
-    }
-
-    // ---- Issue #73 slice A1: bash routing tests ----------------------------
-
-    fn hook_with_bash() -> IronclawSafetyHook {
-        IronclawSafetyHook::new(layer()).with_bash_validation(PathBuf::from("/workspace"))
-    }
-
-    #[tokio::test]
-    async fn req_safety_73_a1_bash_ls_is_allowed() {
-        let hook = hook_with_bash();
-        let mut args = json!({ "command": "ls -la" });
-        let decision = hook.before_tool_call("bash", &mut args).await.unwrap();
-        assert_eq!(decision, SafetyDecision::Allow);
-    }
-
-    #[tokio::test]
-    async fn req_safety_73_a1_bash_missing_command_is_fail_safe_block() {
-        let hook = hook_with_bash();
-        let mut args = json!({ "not_command": "ls" });
-        let decision = hook.before_tool_call("bash", &mut args).await.unwrap();
-        match decision {
-            SafetyDecision::Block { reason } => {
-                assert!(
-                    reason.contains("missing"),
-                    "expected fail-safe reason mentioning missing field, got: {reason}"
-                );
-            }
-            other => panic!("expected Block (fail-safe), got {other:?}"),
-        }
-    }
-
-    #[tokio::test]
-    async fn req_safety_73_a1_path_escape_is_blocked_in_workspace_write() {
-        // pathValidation should refuse absolute paths that escape the
-        // workspace root, even under WorkspaceWrite mode.
-        let hook = hook_with_bash();
-        let mut args = json!({ "command": "cat /etc/shadow" });
-        let decision = hook.before_tool_call("bash", &mut args).await.unwrap();
-        match decision {
-            SafetyDecision::Block { reason } => {
-                // Safety-audit: the block reason must not regurgitate the
-                // full argument list verbatim. `/etc/shadow` is referenced
-                // by the validator only via command class / path category.
-                assert!(
-                    !reason.contains("shadow"),
-                    "block reason leaked sensitive path verbatim: {reason}"
-                );
-            }
-            // Some validate_command builds may classify this as Warn instead
-            // of Block; that path stays advisory until #73 lands the final
-            // Warn policy. The contract here is "must not silently allow a
-            // verbatim secret-path leak" — Allow is also accepted as long
-            // as the validator did its job upstream.
-            SafetyDecision::Allow => {}
-            other => panic!("unexpected decision: {other:?}"),
-        }
-    }
-
-    #[tokio::test]
-    async fn req_safety_73_a1_non_bash_tool_uses_generic_validator() {
-        // Non-bash tools must not be touched by the bash hook — they should
-        // fall through to the SafetyLayer JSON validator unchanged.
-        let hook = hook_with_bash();
-        let mut args = json!({ "path": "/tmp/x.txt" });
-        let decision = hook
-            .before_tool_call("write_file", &mut args)
-            .await
-            .unwrap();
-        assert_eq!(decision, SafetyDecision::Allow);
-    }
-
-    #[tokio::test]
-    async fn req_safety_73_a1_without_bash_hook_legacy_behaviour_preserved() {
-        // The historical IronclawSafetyHook::new (no bash hook) must keep
-        // routing every tool through the generic JSON validator only.
-        let hook = IronclawSafetyHook::new(layer());
-        let mut args = json!({ "command": "rm -rf /" });
-        // No bash hook → generic validator decides. The JSON validator
-        // currently allows this (it has no command-string semantics);
-        // this test pins the legacy contract so adding bash routing did
-        // not regress non-agent-hook callers.
-        let decision = hook.before_tool_call("bash", &mut args).await.unwrap();
-        assert_eq!(decision, SafetyDecision::Allow);
     }
 }

--- a/desktop-client/ironclaw/src/agent/agentic_loop.rs
+++ b/desktop-client/ironclaw/src/agent/agentic_loop.rs
@@ -41,17 +41,15 @@ pub(crate) fn host_err_to_error(e: HostError) -> crate::error::Error {
     }
 }
 
-/// Build an `x_claw_agent::HookBundle` whose `safety` slot is wired to
-/// the ironclaw [`crate::safety::SafetyLayer`] via
-/// [`ironclaw_safety::agent_hook::IronclawSafetyHook`].
+/// Build an `x_claw_agent::HookBundle` whose `safety` slot is wired to a
+/// [`x_claw_agent::CompositeSafetyHook`] (per ADR-147) chaining
+/// [`dasclaw_hooks::BashValidationHook`] (bash command-string validation,
+/// issue #73 slice A1) → [`ironclaw_safety::agent_hook::IronclawSafetyHook`]
+/// (generic JSON validation + leak detection).
 ///
-/// `workspace` is forwarded to `IronclawSafetyHook::with_bash_validation`
-/// so bash command-string validation (issue #73 slice A1) runs before
-/// the generic JSON validator. Callers should pass the agent's effective
-/// working directory — the production sites in [`crate::agent::dispatcher`],
-/// [`crate::worker::job`] and [`crate::worker::container`] use
-/// `std::env::current_dir()` with a `.` fallback, mirroring the convention
-/// already in [`crate::tools::builtin::shell`].
+/// `workspace` is the root used by `pathValidation` to detect workspace
+/// escapes. `PermissionMode` is currently hard-coded to `WorkspaceWrite`
+/// — per-session injection is tracked by issue #73 slice D.
 ///
 /// `sandbox` / `secrets` / `approval` keep their `Noop` / `InMemory` /
 /// `AutoApprove` defaults — they will be wired in by later Phase 3 steps.
@@ -62,11 +60,24 @@ pub fn hook_bundle_with_safety(
     safety: std::sync::Arc<crate::safety::SafetyLayer>,
     workspace: std::path::PathBuf,
 ) -> x_claw_agent::HookBundle {
+    use std::sync::Arc;
+    let composite = x_claw_agent::CompositeSafetyHook::builder()
+        .add(
+            "bash-validation",
+            Arc::new(dasclaw_hooks::BashValidationHook::new(
+                // TODO(#73 slice D): replace with per-session PermissionMode
+                // once session-config injection lands.
+                x_claw_agent::permissions::PermissionMode::WorkspaceWrite,
+                workspace,
+            )),
+        )
+        .add(
+            "ironclaw-safety",
+            Arc::new(ironclaw_safety::agent_hook::IronclawSafetyHook::new(safety)),
+        )
+        .build();
     let mut bundle = x_claw_agent::HookBundle::noop();
-    bundle.safety = std::sync::Arc::new(
-        ironclaw_safety::agent_hook::IronclawSafetyHook::new(safety)
-            .with_bash_validation(workspace),
-    );
+    bundle.safety = Arc::new(composite);
     bundle
 }
 


### PR DESCRIPTION
## 背景/目标

实现 ADR-147 的 `CompositeSafetyHook` 差分组合策略，把 slice A1 临时塞在 `IronclawSafetyHook` 里的 `bash_hook` 字段（补丁式代码）替换成正式的 trait seam 串联。

**Issue**: Refs #73 (slice B of B → D → E chain)
**Stacked on**: `w4-issue-73-slice-c-safety-decision` (PR #495)

## Sources read

- `AGENTS.md` § "强制阅读顺序" / "红线" / "本地管线" / "PR 必填项"
- `docs/plans/architecture-refactor/adr-147-composite-safety-hook.md`
  § 1 背景 · § 2.1 类型契约 · § 2.2 行为契约 · § 2.3 差分组合矩阵 · § 2.4 HookBundle 集成 · § 2.5 bash_hook 字段移除 · § 2.6 ADR-113 红线不变量 · § 2.7 错误传播 (Fail-Safe) · § 3 影响 · § 5 实施计划
- `docs/plans/architecture-refactor/adr-113-hook-engine-unification.md` § "count_hook_systems == 1" 红线
- `docs/plans/architecture-refactor/adr-112-compatibility-evaluation.md`
- `crates/x_claw_agent/src/hooks.rs` (SafetyDecision 5-state from slice C with `#[non_exhaustive]`)
- `crates/x_claw_agent/src/lib.rs`
- `desktop-client/ironclaw/crates/ironclaw_safety/src/agent_hook.rs` (slice A1 baseline)
- `desktop-client/ironclaw/src/agent/agentic_loop.rs` (`hook_bundle_with_safety` 调用点)

## 改动范围

**新增**:
- `crates/x_claw_agent/src/composite_safety_hook.rs` (~580 行)
  - `pub type HookId = &'static str`
  - `CompositeSafetyHook { hooks: Vec<(HookId, Arc<dyn SafetyHook>)> }`
  - `CompositeSafetyHookBuilder` with `.add(id, hook).build()`
  - `enum BeforeFlow { ContinueAllow, ContinueRedact, ContinuePassthrough, ShortCircuit(SafetyDecision) }` + `classify()` 辅助函数（exhaustive match，未来新增 `SafetyDecision` variant 必须显式归类，Fail-Safe by design）
  - `impl SafetyHook` 4 方法按 ADR-147 §2.3 差分策略
  - 17 个 `req_safety_73_b_*` 测试

**修改**:
- `crates/x_claw_agent/src/lib.rs`: 添加 `pub mod composite_safety_hook;` + 3 个 `pub use` 导出
- `desktop-client/ironclaw/crates/ironclaw_safety/src/agent_hook.rs`:
  - 移除 `bash_hook: Option<Arc<BashValidationHook>>` 字段（**反补丁清理，ADR-147 §2.5**）
  - 移除 `with_bash_validation()` 方法
  - 移除 `before_tool_call` 里的 bash 路由分支
  - 删除 `BashValidationHook` / `PermissionMode` / `PathBuf` import
  - 模块 docstring 重写指向 ADR-147 组合模式
  - 删除 slice A1 的 `req_safety_73_a1_*` 测试（语义已被 `composite_safety_hook::tests` 覆盖）
- `desktop-client/ironclaw/crates/ironclaw_safety/Cargo.toml`: 移除 `dasclaw_hooks` optional dep + `agent-hook` 特性下的引用
- `desktop-client/ironclaw/src/agent/agentic_loop.rs`: `hook_bundle_with_safety` 改为构造 `CompositeSafetyHook::builder().add("bash-validation", ...).add("ironclaw-safety", ...).build()`，并标记 `TODO(#73 slice D)` 等待 `PermissionMode` 注入

## 非目标（What's NOT in this PR）

- ❌ `PermissionMode` 从 session config 注入（slice D 处理，当前 hardcoded `WorkspaceWrite`）
- ❌ `WorkspaceCap` 真实路径越界（slice E 处理，当前 `PathBuf::from(".")`）
- ❌ 任何新的 hook 系统计数（`count_hook_systems` 不变，ADR-113 红线维持 == 1）
- ❌ 命令注入检测 / 规则引擎（Phase 2，不在 #73 范围）

## 验证（命令 + 结果）

```bash
cargo nextest run -p x_claw_agent composite_safety_hook
# => 17/17 passed (0.0s/test avg)

cargo nextest run -p x_claw_agent -p ironclaw_safety -p dasclaw_hooks \
                  --features ironclaw_safety/agent-hook
# => 516/516 passed (1 leaky, 0 skipped) in 193s

cargo nextest run -p ironclaw_safety --features agent-hook
# => 199/199 passed in 75s
# 包含 agent_hook_integration::run_agentic_loop_with_safety_hook_*

cargo nextest run -p dasclaw --lib agent::agentic_loop
# => 5/5 passed (with_secrets_helper_* + safety_only_helper_*)

cargo fmt --all                                              # clean
python3.12 scripts/check_no_panics.py --base origin/xClaw    # clean
cargo clippy --no-deps -p x_claw_agent --all-targets -- -D warnings    # clean
cargo clippy --no-deps -p ironclaw_safety --features agent-hook \
             --all-targets -- -D warnings                                # clean
```

> **注**：`cargo clippy --no-deps -p dasclaw --all-targets` 报告的 5 个错误（manual_str_repeat / manual_repeat_n）位于 `desktop-client/ironclaw/src/tools/execute.rs` 测试代码，是本 PR 未触及的文件，属 rust 1.94 工具链 bump 的预存问题；slice C 也未修复。需单独 issue 跟踪。

## ADR 红线不变量

- ✅ ADR-113 `count_hook_systems == 1`：`CompositeSafetyHook` 是 trait seam 组合器，不是新的编排入口（ADR-147 §2.6 明确）
- ✅ ADR-112 兼容性：`SafetyDecision` 在 slice C 已 `#[non_exhaustive]`，本 PR 不动 enum
- ✅ Fail-Safe：`classify()` exhaustive match，未来新 variant 不会被 silently allow
- ✅ 无新增 `unwrap()` / `expect()` / `panic!()`

## 关联 ADR

- [adr-147-composite-safety-hook](../docs/plans/architecture-refactor/adr-147-composite-safety-hook.md)
- [adr-113-hook-engine-unification](../docs/plans/architecture-refactor/adr-113-hook-engine-unification.md)
- [adr-112-compatibility-evaluation](../docs/plans/architecture-refactor/adr-112-compatibility-evaluation.md)

Closes #73

