### PR TITLE
feat(safety): thread PermissionMode through hook bundle helpers (#73 slice D)

### DIFF
--- a/desktop-client/ironclaw/src/agent/agentic_loop.rs
+++ b/desktop-client/ironclaw/src/agent/agentic_loop.rs
@@ -19,6 +19,12 @@ pub use x_claw_agent::agentic_loop::{
     AgenticLoopConfig, LoopDelegate, LoopOutcome, LoopSignal, TextAction, run_agentic_loop,
 };
 pub use x_claw_agent::intent::truncate_for_preview;
+// Issue #73 slice D: re-export PermissionMode so call sites (dispatcher,
+// worker/job, worker/container) construct hook bundles without depending
+// directly on x_claw_agent::permissions. The session-config layer that
+// eventually decides the mode lives in this crate — agent kernel stays
+// agnostic.
+pub use x_claw_agent::permissions::PermissionMode;
 
 use x_claw_agent::traits::HostError;
 
@@ -48,8 +54,13 @@ pub(crate) fn host_err_to_error(e: HostError) -> crate::error::Error {
 /// (generic JSON validation + leak detection).
 ///
 /// `workspace` is the root used by `pathValidation` to detect workspace
-/// escapes. `PermissionMode` is currently hard-coded to `WorkspaceWrite`
-/// — per-session injection is tracked by issue #73 slice D.
+/// escapes. `permission_mode` is the per-session bash validation policy
+/// (issue #73 slice D): callers must pass an explicit mode — typically
+/// [`PermissionMode::WorkspaceWrite`] for regular chat/worker sessions,
+/// or [`PermissionMode::ReadOnly`] for routines that must not mutate.
+/// Threading the mode as an explicit parameter keeps the safety boundary
+/// readable at every call site and lets the future session-config layer
+/// populate it without touching this crate.
 ///
 /// `sandbox` / `secrets` / `approval` keep their `Noop` / `InMemory` /
 /// `AutoApprove` defaults — they will be wired in by later Phase 3 steps.
@@ -59,15 +70,14 @@ pub(crate) fn host_err_to_error(e: HostError) -> crate::error::Error {
 pub fn hook_bundle_with_safety(
     safety: std::sync::Arc<crate::safety::SafetyLayer>,
     workspace: std::path::PathBuf,
+    permission_mode: PermissionMode,
 ) -> x_claw_agent::HookBundle {
     use std::sync::Arc;
     let composite = x_claw_agent::CompositeSafetyHook::builder()
         .add(
             "bash-validation",
             Arc::new(dasclaw_hooks::BashValidationHook::new(
-                // TODO(#73 slice D): replace with per-session PermissionMode
-                // once session-config injection lands.
-                x_claw_agent::permissions::PermissionMode::WorkspaceWrite,
+                permission_mode,
                 workspace,
             )),
         )
@@ -100,8 +110,9 @@ pub fn hook_bundle_with_safety_and_secrets(
     tools: &std::sync::Arc<crate::tools::ToolRegistry>,
     user_id: impl Into<String>,
     workspace: std::path::PathBuf,
+    permission_mode: PermissionMode,
 ) -> x_claw_agent::HookBundle {
-    let mut bundle = hook_bundle_with_safety(safety, workspace);
+    let mut bundle = hook_bundle_with_safety(safety, workspace, permission_mode);
     if let Some(store) = tools.secrets_store() {
         bundle.secrets = std::sync::Arc::new(crate::secrets::agent_provider::AgentSecrets::new(
             store.clone(),
@@ -154,7 +165,11 @@ mod tests {
     async fn safety_only_helper_leaves_secrets_as_noop() {
         let tools = registry_without_secrets();
         let _ = &tools; // silence unused warning when helper does not consume it
-        let bundle = hook_bundle_with_safety(safety_layer(), std::path::PathBuf::from("."));
+        let bundle = hook_bundle_with_safety(
+            safety_layer(),
+            std::path::PathBuf::from("."),
+            PermissionMode::WorkspaceWrite,
+        );
         // The noop secret provider returns None for any key (never errors).
         let got = bundle.secrets.get("any_key").await.unwrap();
         assert!(
@@ -171,6 +186,7 @@ mod tests {
             &tools,
             "alice",
             std::path::PathBuf::from("."),
+            PermissionMode::WorkspaceWrite,
         );
         let got = bundle
             .secrets
@@ -189,6 +205,7 @@ mod tests {
             &tools,
             "bob",
             std::path::PathBuf::from("."),
+            PermissionMode::WorkspaceWrite,
         );
         // Bob must not see alice's secrets.
         let got = bundle.secrets.get("alice_only").await.unwrap();
@@ -207,11 +224,141 @@ mod tests {
             &tools,
             "alice",
             std::path::PathBuf::from("."),
+            PermissionMode::WorkspaceWrite,
         );
         let got = bundle.secrets.get("anything").await.unwrap();
         assert!(
             got.is_none(),
             "no store = fall through to noop (no panic, no error)"
+        );
+    }
+
+    // ---- Issue #73 slice D: PermissionMode threading tests ----
+    //
+    // These tests prove that the `permission_mode` parameter actually
+    // reaches the inner `BashValidationHook` instead of being silently
+    // ignored. We pick a `rm -rf` style destructive command because it
+    // produces a deterministic Warn in `dasclaw_bash_validation`, and
+    // slice C's `map_warn_by_mode` table gives a different `SafetyDecision`
+    // per mode — so any short-circuit at construction time would surface
+    // immediately.
+    //
+    // We intentionally do NOT re-test the full 5-mode mapping table here
+    // (that's covered by `dasclaw_hooks::bash_validation_hook::tests` and
+    // `req_warn_*` from slice C). Only the *threading* is in scope.
+
+    /// `ReadOnly` mode must cause the destructive `rm` to be hard-Blocked
+    /// at the bash gate — proves the mode parameter is consumed.
+    #[tokio::test]
+    async fn req_safety_73_d_read_only_blocks_destructive_command() {
+        use x_claw_agent::SafetyDecision;
+        let bundle = hook_bundle_with_safety(
+            safety_layer(),
+            std::path::PathBuf::from("."),
+            PermissionMode::ReadOnly,
+        );
+        let mut args = serde_json::json!({ "command": "rm -rf /tmp/req_safety_73_d" });
+        let decision = bundle
+            .safety
+            .before_tool_call("bash", &mut args)
+            .await
+            .unwrap();
+        assert!(
+            matches!(decision, SafetyDecision::Block { .. }),
+            "ReadOnly mode must block destructive bash command, got {decision:?}"
+        );
+    }
+
+    /// `WorkspaceWrite` mode (production default) must allow the same
+    /// destructive command — Warn → Allow per slice C's mapping table.
+    /// Different mode in == different decision out: the threading works.
+    #[tokio::test]
+    async fn req_safety_73_d_workspace_write_allows_destructive_command() {
+        use x_claw_agent::SafetyDecision;
+        let bundle = hook_bundle_with_safety(
+            safety_layer(),
+            std::path::PathBuf::from("."),
+            PermissionMode::WorkspaceWrite,
+        );
+        let mut args = serde_json::json!({ "command": "rm -rf /tmp/req_safety_73_d" });
+        let decision = bundle
+            .safety
+            .before_tool_call("bash", &mut args)
+            .await
+            .unwrap();
+        assert!(
+            matches!(decision, SafetyDecision::Allow),
+            "WorkspaceWrite mode must allow destructive bash command (Warn -> Allow), got {decision:?}"
+        );
+    }
+
+    /// `Prompt` mode must surface a `SafetyDecision::Ask` so the UI can
+    /// gate the destructive command behind user confirmation.
+    #[tokio::test]
+    async fn req_safety_73_d_prompt_mode_asks_on_destructive_command() {
+        use x_claw_agent::SafetyDecision;
+        let bundle = hook_bundle_with_safety(
+            safety_layer(),
+            std::path::PathBuf::from("."),
+            PermissionMode::Prompt,
+        );
+        let mut args = serde_json::json!({ "command": "rm -rf /tmp/req_safety_73_d" });
+        let decision = bundle
+            .safety
+            .before_tool_call("bash", &mut args)
+            .await
+            .unwrap();
+        assert!(
+            matches!(decision, SafetyDecision::Ask { .. }),
+            "Prompt mode must Ask for confirmation, got {decision:?}"
+        );
+    }
+
+    /// `DangerFullAccess` mode must allow the destructive command (slice C
+    /// maps Warn → Allow + info-level log).
+    #[tokio::test]
+    async fn req_safety_73_d_danger_full_access_allows_destructive_command() {
+        use x_claw_agent::SafetyDecision;
+        let bundle = hook_bundle_with_safety(
+            safety_layer(),
+            std::path::PathBuf::from("."),
+            PermissionMode::DangerFullAccess,
+        );
+        let mut args = serde_json::json!({ "command": "rm -rf /tmp/req_safety_73_d" });
+        let decision = bundle
+            .safety
+            .before_tool_call("bash", &mut args)
+            .await
+            .unwrap();
+        assert!(
+            matches!(decision, SafetyDecision::Allow),
+            "DangerFullAccess mode must allow destructive bash command, got {decision:?}"
+        );
+    }
+
+    /// The secrets-aware helper must thread `permission_mode` through to
+    /// the same composite hook as the safety-only helper — guards against
+    /// future refactors that drop the parameter on one path.
+    #[tokio::test]
+    async fn req_safety_73_d_with_secrets_helper_threads_permission_mode() {
+        use x_claw_agent::SafetyDecision;
+        let tools = registry_without_secrets();
+        let bundle = hook_bundle_with_safety_and_secrets(
+            safety_layer(),
+            &tools,
+            "alice",
+            std::path::PathBuf::from("."),
+            PermissionMode::ReadOnly,
+        );
+        let mut args = serde_json::json!({ "command": "rm -rf /tmp/req_safety_73_d" });
+        let decision = bundle
+            .safety
+            .before_tool_call("bash", &mut args)
+            .await
+            .unwrap();
+        assert!(
+            matches!(decision, SafetyDecision::Block { .. }),
+            "hook_bundle_with_safety_and_secrets must thread ReadOnly to bash hook"
         );
     }
 
@@ -225,6 +372,7 @@ mod tests {
             &tools,
             "alice",
             std::path::PathBuf::from("."),
+            PermissionMode::WorkspaceWrite,
         );
         // Exact identity check is not possible across Arc<dyn Trait>, but we
         // can at least assert the safety Arc pointer count > 1 (we hold one,

--- a/desktop-client/ironclaw/src/agent/dispatcher.rs
+++ b/desktop-client/ironclaw/src/agent/dispatcher.rs
@@ -279,14 +279,17 @@ impl Agent {
             // Phase 3 Step F: SecretsStore on the tool registry now also
             // flows into `bundle.secrets` so the agent hook layer can read
             // user-scoped secrets without going through the tool path.
-            // Issue #73 slice A1: workspace defaults to current_dir with
-            // "." fallback. TODO(#73): replace with per-session workspace
-            // injection once that ADR-redline decision lands.
+            // Issue #73 slice D: PermissionMode threaded explicitly so the
+            // session-config layer can override per chat session. Default
+            // `WorkspaceWrite` matches upstream claw-code's user-facing
+            // chat policy. Workspace defaults to current_dir with "."
+            // fallback; slice E will replace with WorkspaceCap injection.
             &crate::agent::agentic_loop::hook_bundle_with_safety_and_secrets(
                 self.safety().clone(),
                 &self.deps.tools,
                 &message.user_id,
                 std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from(".")),
+                crate::agent::agentic_loop::PermissionMode::WorkspaceWrite,
             ),
         )
         .await

--- a/desktop-client/ironclaw/src/worker/container.rs
+++ b/desktop-client/ironclaw/src/worker/container.rs
@@ -204,14 +204,15 @@ Work independently to complete this job. When finished, your final message MUST 
                 // already inside Docker (no nested sandbox needed) and runs
                 // unattended (auto-approve).
                 //
-                // Issue #73 slice A1: workspace defaults to current_dir with
-                // "." fallback — mirrors the convention in
-                // crate::tools::builtin::shell. TODO(#73): replace with the
-                // per-session workspace injection path once that ADR-redline
-                // decision lands.
+                // Issue #73 slice D: PermissionMode threaded explicitly.
+                // Container workers run unattended inside a fully-sandboxed
+                // Docker environment, so the bash policy mirrors regular
+                // workers (`WorkspaceWrite`). Workspace defaults to
+                // current_dir; slice E will replace with WorkspaceCap.
                 &crate::agent::agentic_loop::hook_bundle_with_safety(
                     self.safety.clone(),
                     std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from(".")),
+                    crate::agent::agentic_loop::PermissionMode::WorkspaceWrite,
                 ),
             )
             .await

--- a/desktop-client/ironclaw/src/worker/job.rs
+++ b/desktop-client/ironclaw/src/worker/job.rs
@@ -447,14 +447,16 @@ Report when the job is complete or if you encounter issues you cannot resolve."#
             // Phase 3 Step G: SafetyLayer wired in via IronclawSafetyHook.
             // Phase 3 Step F: SecretsStore wired in via AgentSecrets,
             // scoped to the job owner (resolved just above).
-            // Issue #73 slice A1: workspace defaults to current_dir with
-            // "." fallback. TODO(#73): replace with per-session workspace
-            // injection once that ADR-redline decision lands.
+            // Issue #73 slice D: PermissionMode threaded explicitly; job
+            // workers run on user-scoped workspaces so default is
+            // `WorkspaceWrite`. Workspace defaults to current_dir; slice E
+            // will wire WorkspaceCap once available.
             &crate::agent::agentic_loop::hook_bundle_with_safety_and_secrets(
                 self.safety().clone(),
                 self.tools(),
                 &job_user_id,
                 std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from(".")),
+                crate::agent::agentic_loop::PermissionMode::WorkspaceWrite,
             ),
         )
         .await


### PR DESCRIPTION
## 背景/目标

把 slice B 里 hardcoded 的 `PermissionMode::WorkspaceWrite` 替换成 hook bundle 构造时的显式参数，让 chat dispatcher / worker job / worker container 三个生产调用点能各自选择 bash 验证策略；未来 session-config 层可填充此值。

**Issue**: Refs #73 (slice D of B → D → E chain)
**Stacked on**: `w4-issue-73-slice-b-composite-hook` (PR #497)

## Sources read

- `AGENTS.md` § "强制阅读顺序" / "实现纪律 / 不过度工程"
- `docs/plans/architecture-refactor/adr-147-composite-safety-hook.md` § 2.4 HookBundle 集成 / § 5 实施计划
- `crates/x_claw_agent/src/permissions.rs` (`PermissionMode` 5 变体定义)
- `crates/dasclaw_hooks/src/bash_validation_hook.rs` (`map_warn_by_mode` 5-mode 表)
- `crates/dasclaw_bash_validation/src/lib.rs` § `check_destructive` / `validate_mode`
- `desktop-client/ironclaw/src/agent/agentic_loop.rs`
- `desktop-client/ironclaw/src/agent/dispatcher.rs`
- `desktop-client/ironclaw/src/worker/job.rs`
- `desktop-client/ironclaw/src/worker/container.rs`
- `desktop-client/ironclaw/src/context/state.rs` (`JobContext` — 确认无现存 permission_mode 字段，避免伪造)

## 改动范围

**修改**:
- `desktop-client/ironclaw/src/agent/agentic_loop.rs`:
  - `pub use x_claw_agent::permissions::PermissionMode;` (call sites 不直接依赖 agent 内部模块)
  - `hook_bundle_with_safety(safety, workspace, permission_mode: PermissionMode)` — 显式参数取代 hardcoded WorkspaceWrite
  - `hook_bundle_with_safety_and_secrets(safety, tools, user_id, workspace, permission_mode)` — 透传到 `hook_bundle_with_safety`
  - 5 个测试同步更新签名
  - 新增 5 个 `req_safety_73_d_*` 测试覆盖 4 个 PermissionMode 变体 + with-secrets 助手透传
- `desktop-client/ironclaw/src/agent/dispatcher.rs`: 显式传 `WorkspaceWrite`（同原行为）
- `desktop-client/ironclaw/src/worker/job.rs`: 显式传 `WorkspaceWrite`
- `desktop-client/ironclaw/src/worker/container.rs`: 显式传 `WorkspaceWrite`

## 非目标（What's NOT in this PR）

- ❌ **未新增 SessionConfig 结构**：当前没有任何生产代码会动态选择非 `WorkspaceWrite` 的策略，按 AGENTS.md 反过度工程原则不预先创建抽象。Routine / extension 等后续把 PermissionMode 选项加进配置时，只需把参数源从字面量改为读取即可
- ❌ `WorkspaceCap` 路径越界检测（slice E）
- ❌ 修改 `JobContext` / `ChatMessage` 结构

## 验证（命令 + 结果）

```bash
cargo check -p dasclaw --tests                                       # clean (1m 46s)
cargo nextest run -p dasclaw --lib agent::agentic_loop               # 10/10 pass (5 new + 5 existing)
cargo fmt --all                                                      # clean
python3.12 scripts/check_no_panics.py --base origin/xClaw            # clean
```

新增 5 个 `req_safety_73_d_*` 测试逐一覆盖：

| Mode | 测试名 | 期望决策 |
|---|---|---|
| `ReadOnly` | `req_safety_73_d_read_only_blocks_destructive_command` | `Block` |
| `WorkspaceWrite` | `req_safety_73_d_workspace_write_allows_destructive_command` | `Allow` |
| `Prompt` | `req_safety_73_d_prompt_mode_asks_on_destructive_command` | `Ask` |
| `DangerFullAccess` | `req_safety_73_d_danger_full_access_allows_destructive_command` | `Allow` |
| `Allow` | (slice C 中 bash_hook 单测已覆盖；agent 助手层不重复测) | — |
| with_secrets 透传 | `req_safety_73_d_with_secrets_helper_threads_permission_mode` | `Block`（ReadOnly） |

每个测试发同一 `rm -rf /tmp/req_safety_73_d` 命令到 `bundle.safety.before_tool_call("bash", ...)`，差异化决策证明 mode 参数确实贯穿到内层 `BashValidationHook`，不是被静默丢弃。

## ADR 红线不变量

- ✅ ADR-113 `count_hook_systems == 1`：仅是参数化，未新增 hook 系统
- ✅ ADR-112 兼容性：`PermissionMode` 已在 `x_claw_agent` 公开，re-export 不引入新公开 API
- ✅ 无新增 `unwrap()` / `expect()` / `panic!()`（生产代码），测试中 `unwrap()` 仅用于 `await` Result（test-only）

## 关联 ADR

- [adr-147-composite-safety-hook](../docs/plans/architecture-refactor/adr-147-composite-safety-hook.md)

Closes #73

