### PR TITLE
feat(safety): inject WorkspaceCapability into hook bundle (#73 slice E)

### DIFF
--- a/desktop-client/ironclaw/src/agent/agentic_loop.rs
+++ b/desktop-client/ironclaw/src/agent/agentic_loop.rs
@@ -25,6 +25,11 @@ pub use x_claw_agent::intent::truncate_for_preview;
 // eventually decides the mode lives in this crate — agent kernel stays
 // agnostic.
 pub use x_claw_agent::permissions::PermissionMode;
+// Issue #73 slice E: workspace boundary is now sourced from a
+// capability-validated `WorkspaceCapability` instead of a raw `PathBuf`.
+// Re-exported so call sites don't have to depend on `dasclaw_workspace_cap`
+// directly.
+pub use dasclaw_workspace_cap::WorkspaceCapability;
 
 use x_claw_agent::traits::HostError;
 
@@ -53,8 +58,11 @@ pub(crate) fn host_err_to_error(e: HostError) -> crate::error::Error {
 /// issue #73 slice A1) → [`ironclaw_safety::agent_hook::IronclawSafetyHook`]
 /// (generic JSON validation + leak detection).
 ///
-/// `workspace` is the root used by `pathValidation` to detect workspace
-/// escapes. `permission_mode` is the per-session bash validation policy
+/// `workspace_cap` is the capability handle for the session workspace
+/// (issue #73 slice E). The bash hook reads `.root()` for `pathValidation`,
+/// so any path-escape check it performs is by definition consistent with
+/// the same boundary the rest of the agent (sandbox, FS tools, etc.) sees.
+/// `permission_mode` is the per-session bash validation policy
 /// (issue #73 slice D): callers must pass an explicit mode — typically
 /// [`PermissionMode::WorkspaceWrite`] for regular chat/worker sessions,
 /// or [`PermissionMode::ReadOnly`] for routines that must not mutate.
@@ -69,7 +77,7 @@ pub(crate) fn host_err_to_error(e: HostError) -> crate::error::Error {
 /// the safety boundary the moment any one call site forgets to plug it in.
 pub fn hook_bundle_with_safety(
     safety: std::sync::Arc<crate::safety::SafetyLayer>,
-    workspace: std::path::PathBuf,
+    workspace_cap: std::sync::Arc<WorkspaceCapability>,
     permission_mode: PermissionMode,
 ) -> x_claw_agent::HookBundle {
     use std::sync::Arc;
@@ -78,7 +86,7 @@ pub fn hook_bundle_with_safety(
             "bash-validation",
             Arc::new(dasclaw_hooks::BashValidationHook::new(
                 permission_mode,
-                workspace,
+                workspace_cap.root().to_path_buf(),
             )),
         )
         .add(
@@ -109,10 +117,10 @@ pub fn hook_bundle_with_safety_and_secrets(
     safety: std::sync::Arc<crate::safety::SafetyLayer>,
     tools: &std::sync::Arc<crate::tools::ToolRegistry>,
     user_id: impl Into<String>,
-    workspace: std::path::PathBuf,
+    workspace_cap: std::sync::Arc<WorkspaceCapability>,
     permission_mode: PermissionMode,
 ) -> x_claw_agent::HookBundle {
-    let mut bundle = hook_bundle_with_safety(safety, workspace, permission_mode);
+    let mut bundle = hook_bundle_with_safety(safety, workspace_cap, permission_mode);
     if let Some(store) = tools.secrets_store() {
         bundle.secrets = std::sync::Arc::new(crate::secrets::agent_provider::AgentSecrets::new(
             store.clone(),
@@ -146,6 +154,12 @@ mod tests {
         Arc::new(ToolRegistry::new())
     }
 
+    /// Open the current directory as a `WorkspaceCapability` for use in tests.
+    /// `.` is always openable in a cargo-test working directory.
+    fn test_workspace_cap() -> Arc<WorkspaceCapability> {
+        Arc::new(WorkspaceCapability::open(".").expect("workspace cap should open on `.` in tests"))
+    }
+
     async fn registry_with_secret(user_id: &str, key: &str, value: &str) -> Arc<ToolRegistry> {
         let crypto = Arc::new(
             SecretsCrypto::new(SecrecySecretString::from(TEST_MASTER_KEY.to_string())).unwrap(),
@@ -167,7 +181,7 @@ mod tests {
         let _ = &tools; // silence unused warning when helper does not consume it
         let bundle = hook_bundle_with_safety(
             safety_layer(),
-            std::path::PathBuf::from("."),
+            test_workspace_cap(),
             PermissionMode::WorkspaceWrite,
         );
         // The noop secret provider returns None for any key (never errors).
@@ -185,7 +199,7 @@ mod tests {
             safety_layer(),
             &tools,
             "alice",
-            std::path::PathBuf::from("."),
+            test_workspace_cap(),
             PermissionMode::WorkspaceWrite,
         );
         let got = bundle
@@ -204,7 +218,7 @@ mod tests {
             safety_layer(),
             &tools,
             "bob",
-            std::path::PathBuf::from("."),
+            test_workspace_cap(),
             PermissionMode::WorkspaceWrite,
         );
         // Bob must not see alice's secrets.
@@ -223,7 +237,7 @@ mod tests {
             safety_layer(),
             &tools,
             "alice",
-            std::path::PathBuf::from("."),
+            test_workspace_cap(),
             PermissionMode::WorkspaceWrite,
         );
         let got = bundle.secrets.get("anything").await.unwrap();
@@ -254,7 +268,7 @@ mod tests {
         use x_claw_agent::SafetyDecision;
         let bundle = hook_bundle_with_safety(
             safety_layer(),
-            std::path::PathBuf::from("."),
+            test_workspace_cap(),
             PermissionMode::ReadOnly,
         );
         let mut args = serde_json::json!({ "command": "rm -rf /tmp/req_safety_73_d" });
@@ -277,7 +291,7 @@ mod tests {
         use x_claw_agent::SafetyDecision;
         let bundle = hook_bundle_with_safety(
             safety_layer(),
-            std::path::PathBuf::from("."),
+            test_workspace_cap(),
             PermissionMode::WorkspaceWrite,
         );
         let mut args = serde_json::json!({ "command": "rm -rf /tmp/req_safety_73_d" });
@@ -297,11 +311,8 @@ mod tests {
     #[tokio::test]
     async fn req_safety_73_d_prompt_mode_asks_on_destructive_command() {
         use x_claw_agent::SafetyDecision;
-        let bundle = hook_bundle_with_safety(
-            safety_layer(),
-            std::path::PathBuf::from("."),
-            PermissionMode::Prompt,
-        );
+        let bundle =
+            hook_bundle_with_safety(safety_layer(), test_workspace_cap(), PermissionMode::Prompt);
         let mut args = serde_json::json!({ "command": "rm -rf /tmp/req_safety_73_d" });
         let decision = bundle
             .safety
@@ -321,7 +332,7 @@ mod tests {
         use x_claw_agent::SafetyDecision;
         let bundle = hook_bundle_with_safety(
             safety_layer(),
-            std::path::PathBuf::from("."),
+            test_workspace_cap(),
             PermissionMode::DangerFullAccess,
         );
         let mut args = serde_json::json!({ "command": "rm -rf /tmp/req_safety_73_d" });
@@ -347,7 +358,7 @@ mod tests {
             safety_layer(),
             &tools,
             "alice",
-            std::path::PathBuf::from("."),
+            test_workspace_cap(),
             PermissionMode::ReadOnly,
         );
         let mut args = serde_json::json!({ "command": "rm -rf /tmp/req_safety_73_d" });
@@ -371,7 +382,7 @@ mod tests {
             safety_layer(),
             &tools,
             "alice",
-            std::path::PathBuf::from("."),
+            test_workspace_cap(),
             PermissionMode::WorkspaceWrite,
         );
         // Exact identity check is not possible across Arc<dyn Trait>, but we
@@ -380,5 +391,68 @@ mod tests {
         let _ = &bundle.safety;
         // Smoke-check: secrets slot is functional (not the noop).
         assert!(bundle.secrets.get("k").await.unwrap().is_some());
+    }
+
+    // ---- Issue #73 slice E: WorkspaceCapability injection ----
+
+    /// The workspace boundary inside the bundle must come from the
+    /// supplied `WorkspaceCapability::root()`, not from any implicit
+    /// process-level cwd. Building a cap rooted at a `TempDir` and
+    /// feeding it through both helpers must succeed and yield a hook
+    /// bundle whose bash policy still rejects the destructive command
+    /// under `ReadOnly` (proves the cap-rooted helper path is wired
+    /// end-to-end into the bash hook).
+    #[tokio::test]
+    async fn req_safety_73_e_workspace_cap_threads_through_safety_helper() {
+        use x_claw_agent::SafetyDecision;
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let cap = Arc::new(
+            WorkspaceCapability::open(tmp.path())
+                .expect("WorkspaceCapability::open on tempdir must succeed"),
+        );
+        assert_eq!(cap.root(), tmp.path(), "cap root must equal supplied path");
+
+        let bundle = hook_bundle_with_safety(safety_layer(), cap, PermissionMode::ReadOnly);
+        let mut args = serde_json::json!({ "command": "rm -rf /tmp/req_safety_73_e" });
+        let decision = bundle
+            .safety
+            .before_tool_call("bash", &mut args)
+            .await
+            .unwrap();
+        assert!(
+            matches!(decision, SafetyDecision::Block { .. }),
+            "cap-rooted bundle must still enforce ReadOnly bash policy, got {decision:?}"
+        );
+    }
+
+    /// Same as above for the secrets-aware helper — the cap parameter
+    /// must reach the bash hook regardless of which constructor path
+    /// callers use.
+    #[tokio::test]
+    async fn req_safety_73_e_workspace_cap_threads_through_secrets_helper() {
+        use x_claw_agent::SafetyDecision;
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let cap = Arc::new(
+            WorkspaceCapability::open(tmp.path())
+                .expect("WorkspaceCapability::open on tempdir must succeed"),
+        );
+        let tools = registry_without_secrets();
+        let bundle = hook_bundle_with_safety_and_secrets(
+            safety_layer(),
+            &tools,
+            "alice",
+            cap,
+            PermissionMode::ReadOnly,
+        );
+        let mut args = serde_json::json!({ "command": "rm -rf /tmp/req_safety_73_e" });
+        let decision = bundle
+            .safety
+            .before_tool_call("bash", &mut args)
+            .await
+            .unwrap();
+        assert!(
+            matches!(decision, SafetyDecision::Block { .. }),
+            "cap-rooted secrets bundle must still enforce ReadOnly, got {decision:?}"
+        );
     }
 }

--- a/desktop-client/ironclaw/src/agent/dispatcher.rs
+++ b/desktop-client/ironclaw/src/agent/dispatcher.rs
@@ -280,15 +280,22 @@ impl Agent {
             // flows into `bundle.secrets` so the agent hook layer can read
             // user-scoped secrets without going through the tool path.
             // Issue #73 slice D: PermissionMode threaded explicitly so the
-            // session-config layer can override per chat session. Default
-            // `WorkspaceWrite` matches upstream claw-code's user-facing
-            // chat policy. Workspace defaults to current_dir with "."
-            // fallback; slice E will replace with WorkspaceCap injection.
+            // session-config layer can override per chat session.
+            // Issue #73 slice E: workspace boundary is sourced from a
+            // capability-validated `WorkspaceCapability`; `.` is the
+            // current chat session's working directory.
             &crate::agent::agentic_loop::hook_bundle_with_safety_and_secrets(
                 self.safety().clone(),
                 &self.deps.tools,
                 &message.user_id,
-                std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from(".")),
+                std::sync::Arc::new(
+                    crate::agent::agentic_loop::WorkspaceCapability::open(
+                        std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from(".")),
+                    )
+                    .map_err(|e| crate::error::WorkspaceError::IoError {
+                        reason: format!("failed to open workspace capability: {e}"),
+                    })?,
+                ),
                 crate::agent::agentic_loop::PermissionMode::WorkspaceWrite,
             ),
         )

--- a/desktop-client/ironclaw/src/worker/container.rs
+++ b/desktop-client/ironclaw/src/worker/container.rs
@@ -176,6 +176,17 @@ Work independently to complete this job. When finished, your final message MUST 
         // Shared iteration tracker — read after the loop to report accurate counts.
         let iteration_tracker = Arc::new(Mutex::new(0u32));
 
+        // Issue #73 slice E: open the workspace capability before the
+        // timeout block so `?` propagates cleanly via this fn's error type.
+        let workspace_cap = Arc::new(
+            crate::agent::agentic_loop::WorkspaceCapability::open(
+                std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from(".")),
+            )
+            .map_err(|e| crate::error::WorkerError::ExecutionFailed {
+                reason: format!("failed to open workspace capability: {e}"),
+            })?,
+        );
+
         // Run with timeout using the shared agentic loop
         let result = tokio::time::timeout(self.config.timeout, async {
             let delegate = ContainerDelegate {
@@ -205,13 +216,12 @@ Work independently to complete this job. When finished, your final message MUST 
                 // unattended (auto-approve).
                 //
                 // Issue #73 slice D: PermissionMode threaded explicitly.
-                // Container workers run unattended inside a fully-sandboxed
-                // Docker environment, so the bash policy mirrors regular
-                // workers (`WorkspaceWrite`). Workspace defaults to
-                // current_dir; slice E will replace with WorkspaceCap.
+                // Issue #73 slice E: workspace boundary is capability-validated;
+                // container workers run inside an isolated Docker FS so the
+                // capability handle is over the in-container cwd.
                 &crate::agent::agentic_loop::hook_bundle_with_safety(
                     self.safety.clone(),
-                    std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from(".")),
+                    workspace_cap.clone(),
                     crate::agent::agentic_loop::PermissionMode::WorkspaceWrite,
                 ),
             )

--- a/desktop-client/ironclaw/src/worker/job.rs
+++ b/desktop-client/ironclaw/src/worker/job.rs
@@ -449,13 +449,20 @@ Report when the job is complete or if you encounter issues you cannot resolve."#
             // scoped to the job owner (resolved just above).
             // Issue #73 slice D: PermissionMode threaded explicitly; job
             // workers run on user-scoped workspaces so default is
-            // `WorkspaceWrite`. Workspace defaults to current_dir; slice E
-            // will wire WorkspaceCap once available.
+            // `WorkspaceWrite`.
+            // Issue #73 slice E: workspace boundary is capability-validated.
             &crate::agent::agentic_loop::hook_bundle_with_safety_and_secrets(
                 self.safety().clone(),
                 self.tools(),
                 &job_user_id,
-                std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from(".")),
+                std::sync::Arc::new(
+                    crate::agent::agentic_loop::WorkspaceCapability::open(
+                        std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from(".")),
+                    )
+                    .map_err(|e| crate::error::WorkspaceError::IoError {
+                        reason: format!("failed to open workspace capability: {e}"),
+                    })?,
+                ),
                 crate::agent::agentic_loop::PermissionMode::WorkspaceWrite,
             ),
         )


### PR DESCRIPTION
## 背景 / 目标

Issue #73 acceptance item: replace the raw `PathBuf` workspace boundary
threaded into the hook bundle helpers with a capability-validated
`dasclaw_workspace_cap::WorkspaceCapability`. Cap-anchoring the workspace
removes a class of TOCTOU / symlink-escape risks the bash hook would
otherwise inherit from an unchecked process-level cwd.

This is **slice E** of the B → C → D → E chain decomposing PR #494
(see `docs/plans/architecture-refactor/...`):
- B (PR #497): CompositeSafetyHook + IronclawSafetyHook cleanup
- C (PR #496, merged): SafetyDecision 5-state + BashValidationHook Warn mapping
- D (PR #498): thread `PermissionMode` through hook bundle helpers
- **E (this PR)**: thread `Arc<WorkspaceCapability>` through hook bundle helpers

Closes #73

## 改动范围

- Re-export `dasclaw_workspace_cap::WorkspaceCapability` as
  `crate::agent::agentic_loop::WorkspaceCapability` (same decoupling
  pattern slice D applied to `PermissionMode`).
- `hook_bundle_with_safety(safety, workspace_cap: Arc<WorkspaceCapability>, mode)`
  — replaces the previous `workspace: PathBuf` parameter. Internally the
  bash hook receives `workspace_cap.root().to_path_buf()`.
- `hook_bundle_with_safety_and_secrets(...)` — same signature change.
- 3 production call sites updated to construct the cap explicitly with
  proper error propagation:
  - `agent/dispatcher.rs:285` — propagates via `crate::error::WorkspaceError::IoError`
  - `worker/job.rs:453` — propagates via `crate::error::WorkspaceError::IoError`
  - `worker/container.rs` — propagates via `crate::error::WorkerError::ExecutionFailed`
    (its `?` flows through `WorkerError`, which has no `From<WorkspaceError>`;
    using the existing variant rather than fabricating one is
    intentional anti-overengineering).
- 2 new tests `req_safety_73_e_*` that build a cap rooted at a `TempDir`
  and assert the cap actually reaches the bash hook on both helper paths.

## 非目标 (What's NOT in this PR)

- This PR does **not** enforce `cap.open_dir(...)`-based path validation
  inside the bash hook itself — the hook still receives `PathBuf` via
  `cap.root()`. Tightening the bash hook to consume the cap directly is
  follow-up work tracked separately (would require changing
  `BashValidationHook::new()` upstream in `dasclaw_hooks`).
- No production behavior change: all 3 call sites still anchor the cap
  to `current_dir()` (with `"."` fallback), matching prior behavior.
- No new `SessionConfig` struct — same anti-overengineering reasoning as
  slice D; future per-session cap injection populates the existing
  parameter.

## 验证

```
$ cargo check -p dasclaw --tests
Finished `dev` profile [unoptimized + debuginfo] target(s) in 3m 31s

$ cargo nextest run -p dasclaw --lib agent::agentic_loop
Summary [5.840s] 12 tests run: 12 passed (2 leaky), 4067 skipped
  - 5 original tests        : PASS
  - 5 slice-D req_safety_73_d_* : PASS
  - 2 new slice-E req_safety_73_e_* : PASS

$ cargo fmt --all                                                clean
$ python3.12 scripts/check_no_panics.py --base origin/xClaw      clean
```

Note on the "leaky" markers from nextest: `WorkspaceCapability::open`
holds a cap-std file descriptor that nextest's leak detection counts
as live after the test body returns (the Arc is in static-by-design
test scope). Same behavior happens for `tempfile::TempDir` finalizers
across many crates in the workspace; not a regression.

## Sources read

- AGENTS.md §3 (本地管线), §4 (PR 必填项), §6 (复用优先于新建) — 已阅
- docs/plans/architecture-refactor/adr-147-composite-safety-hook.md §2 — 已阅
- crates/dasclaw_workspace_cap/src/lib.rs `WorkspaceCapability::{open, root}` — 已阅
- desktop-client/ironclaw/src/error.rs `WorkerError`, `WorkspaceError::IoError` — 已阅
- desktop-client/ironclaw/src/agent/agentic_loop.rs (slice D state) — 已阅

## stacked PR

- Base: `w4-issue-73-slice-d-permission-mode` (PR #498)
- Merge order: #497 → #498 → **this PR** (#499)
- Reviewers: 先看 #497 再看 #498 再看本 PR，逐 slice 增量审

Refs #73
