### PR TITLE
feat(safety): bash validation hard block via IronclawSafetyHook [#73 slice A1]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5747,6 +5747,7 @@ version = "0.2.0"
 dependencies = [
  "aho-corasick",
  "async-trait",
+ "dasclaw_hooks",
  "regex",
  "serde_json",
  "thiserror 2.0.18",

--- a/crates/dasclaw_hooks/src/bash_validation_hook.rs
+++ b/crates/dasclaw_hooks/src/bash_validation_hook.rs
@@ -1,0 +1,335 @@
+//! `BashValidationHook` — wraps [`x_claw_agent::bash_validation::validate_command`]
+//! as a [`SafetyHook`] implementation.
+//!
+//! # Status
+//!
+//! **Scaffold only.** This module is intentionally **not registered in any
+//! production `SafetyHook` chain**. It exists so a future PR (tracked by
+//! parent issue [#73]) can wire it into ironclaw's `IronclawSafetyHook`
+//! composition after the red-line decisions are settled (PermissionMode
+//! injection path, Warn handling policy, error-message redaction contract).
+//!
+//! See [`docs/plans/architecture-refactor/32-execution-plan.md`] §W4 D10.
+//!
+//! # Design (Fail-Safe)
+//!
+//! Only `before_tool_call` does real work. The other three [`SafetyHook`]
+//! methods pass through unchanged so this hook composes cleanly with other
+//! safety hooks (e.g. `IronclawSafetyHook`, prompt-injection scanners).
+//!
+//! For tools whose name matches [`BashValidationHook::bash_tool_names`]
+//! (default `["bash", "shell", "BashTool"]`), the hook:
+//!
+//! 1. Extracts the `command` field from `args`. Missing or non-string ⇒
+//!    [`SafetyDecision::Block`] (Fail-Safe: never let a malformed bash call
+//!    through).
+//! 2. Calls `validate_command(cmd, mode, workspace)`.
+//! 3. Maps the result:
+//!    - `Allow` ⇒ [`SafetyDecision::Allow`].
+//!    - `Block { reason }` ⇒ [`SafetyDecision::Block { reason }`]. The
+//!      `reason` string comes from `validate_command`, which by design
+//!      references the *command name or pattern*, **not the full original
+//!      argument string** — see the safety-audit test below.
+//!    - `Warn { message }` ⇒ **TODO** ([#73]): emit `tracing::warn!` and
+//!      return `Allow`. The final policy (approval-gate / silent allow /
+//!      escalate) is an ADR-redline decision and is not made here.
+//!
+//! For non-bash tools the hook short-circuits to `Allow` so it can be
+//! installed globally without disturbing other tool calls.
+//!
+//! # Why this is not yet wired up
+//!
+//! Three red-line decisions still belong to parent issue [#73]:
+//!
+//! - How `PermissionMode` is resolved per invocation (session config /
+//!   per-request / workspace-level).
+//! - How `Warn` results are surfaced to the user (approval gate vs log only).
+//! - How [`SafetyError`] returned by hooks is finalised into a `Block` at
+//!   the orchestrator boundary (the agent loop must Fail-Safe, never
+//!   Fail-Open, but the exact orchestration is the parent issue's scope).
+//!
+//! [#73]: https://github.com/Linnanli/xClaw/issues/73
+
+use std::path::PathBuf;
+
+use async_trait::async_trait;
+use serde_json::Value;
+use x_claw_agent::bash_validation::{ValidationResult, validate_command};
+use x_claw_agent::permissions::PermissionMode;
+use x_claw_agent::{SafetyDecision, SafetyError, SafetyHook};
+
+/// Default list of tool names treated as bash invocations.
+///
+/// Tool names are matched case-sensitively against [`SafetyHook::before_tool_call`]'s
+/// `tool` argument. Callers can override via [`BashValidationHook::with_tool_names`]
+/// when their tool registry uses different names.
+pub const DEFAULT_BASH_TOOL_NAMES: &[&str] = &["bash", "shell", "BashTool"];
+
+/// Hook that runs `validate_command` on bash tool calls.
+///
+/// See module-level documentation for the full contract.
+#[derive(Debug, Clone)]
+pub struct BashValidationHook {
+    permission_mode: PermissionMode,
+    workspace: PathBuf,
+    bash_tool_names: Vec<String>,
+}
+
+impl BashValidationHook {
+    /// Create a hook with the given permission mode and workspace root.
+    ///
+    /// Uses [`DEFAULT_BASH_TOOL_NAMES`] for the tool-name allowlist.
+    #[must_use]
+    pub fn new(permission_mode: PermissionMode, workspace: PathBuf) -> Self {
+        Self {
+            permission_mode,
+            workspace,
+            bash_tool_names: DEFAULT_BASH_TOOL_NAMES
+                .iter()
+                .map(|s| (*s).to_string())
+                .collect(),
+        }
+    }
+
+    /// Override the bash tool-name allowlist.
+    ///
+    /// Useful when the tool registry exposes bash under a custom name.
+    #[must_use]
+    pub fn with_tool_names<I, S>(mut self, names: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.bash_tool_names = names.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Returns `true` if `tool` should be treated as a bash invocation.
+    fn is_bash_tool(&self, tool: &str) -> bool {
+        self.bash_tool_names.iter().any(|n| n == tool)
+    }
+}
+
+#[async_trait]
+impl SafetyHook for BashValidationHook {
+    async fn before_prompt(&self, _prompt: &mut String) -> Result<SafetyDecision, SafetyError> {
+        Ok(SafetyDecision::Allow)
+    }
+
+    async fn after_completion(&self, _completion: &mut String) -> Result<(), SafetyError> {
+        Ok(())
+    }
+
+    async fn before_tool_call(
+        &self,
+        tool: &str,
+        args: &mut Value,
+    ) -> Result<SafetyDecision, SafetyError> {
+        if !self.is_bash_tool(tool) {
+            return Ok(SafetyDecision::Allow);
+        }
+
+        // Fail-Safe: bash tools without a parseable `command` are refused
+        // rather than passed through. Returning a generic reason avoids
+        // leaking the malformed args back into a model-visible error.
+        let command = match args.get("command").and_then(Value::as_str) {
+            Some(s) if !s.is_empty() => s,
+            _ => {
+                return Ok(SafetyDecision::Block {
+                    reason: "bash tool call missing required 'command' string field".to_string(),
+                });
+            }
+        };
+
+        match validate_command(command, self.permission_mode, &self.workspace) {
+            ValidationResult::Allow => Ok(SafetyDecision::Allow),
+            ValidationResult::Block { reason } => Ok(SafetyDecision::Block { reason }),
+            ValidationResult::Warn { message } => {
+                // TODO(#73): final Warn handling is a red-line decision.
+                // For now, log and allow so callers wiring this scaffold up
+                // get explicit signal without a behaviour change.
+                tracing::warn!(
+                    tool,
+                    %message,
+                    "BashValidationHook Warn (TODO #73: final policy pending)"
+                );
+                Ok(SafetyDecision::Allow)
+            }
+        }
+    }
+
+    async fn after_tool_output(
+        &self,
+        _tool: &str,
+        _output: &mut String,
+    ) -> Result<(), SafetyError> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn hook(mode: PermissionMode) -> BashValidationHook {
+        BashValidationHook::new(mode, PathBuf::from("/workspace"))
+    }
+
+    #[tokio::test]
+    async fn non_bash_tool_short_circuits_to_allow() {
+        let h = hook(PermissionMode::ReadOnly);
+        let mut args = json!({ "path": "/etc/passwd" });
+        let decision = h
+            .before_tool_call("read_file", &mut args)
+            .await
+            .expect("hook should not error");
+        assert_eq!(decision, SafetyDecision::Allow);
+    }
+
+    #[tokio::test]
+    async fn bash_tool_with_safe_command_is_allowed() {
+        let h = hook(PermissionMode::WorkspaceWrite);
+        let mut args = json!({ "command": "ls -la" });
+        let decision = h
+            .before_tool_call("bash", &mut args)
+            .await
+            .expect("hook should not error");
+        assert_eq!(decision, SafetyDecision::Allow);
+    }
+
+    #[tokio::test]
+    async fn bash_tool_missing_command_field_is_blocked_fail_safe() {
+        let h = hook(PermissionMode::WorkspaceWrite);
+        let mut args = json!({ "not_command": "ls" });
+        let decision = h
+            .before_tool_call("bash", &mut args)
+            .await
+            .expect("hook should not error");
+        match decision {
+            SafetyDecision::Block { reason } => {
+                assert!(
+                    reason.contains("missing"),
+                    "expected Fail-Safe reason mentioning missing field, got: {reason}"
+                );
+            }
+            other => panic!("expected Block (Fail-Safe), got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn bash_tool_empty_command_field_is_blocked_fail_safe() {
+        let h = hook(PermissionMode::WorkspaceWrite);
+        let mut args = json!({ "command": "" });
+        let decision = h
+            .before_tool_call("bash", &mut args)
+            .await
+            .expect("hook should not error");
+        assert!(matches!(decision, SafetyDecision::Block { .. }));
+    }
+
+    #[tokio::test]
+    async fn destructive_command_in_read_only_mode_is_blocked() {
+        let h = hook(PermissionMode::ReadOnly);
+        let mut args = json!({ "command": "rm -rf /tmp/secret-payload.bin" });
+        let decision = h
+            .before_tool_call("bash", &mut args)
+            .await
+            .expect("hook should not error");
+        match decision {
+            SafetyDecision::Block { reason } => {
+                // Safety-audit: the block reason describes the command class,
+                // not the original argument list. The full argument path
+                // (which may contain secrets) must NOT appear verbatim.
+                assert!(
+                    !reason.contains("/tmp/secret-payload.bin"),
+                    "block reason leaked original command path: {reason}"
+                );
+            }
+            other => panic!("expected Block, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn write_command_in_read_only_mode_is_blocked() {
+        let h = hook(PermissionMode::ReadOnly);
+        let mut args = json!({ "command": "cp src.txt dst.txt" });
+        let decision = h
+            .before_tool_call("bash", &mut args)
+            .await
+            .expect("hook should not error");
+        assert!(matches!(decision, SafetyDecision::Block { .. }));
+    }
+
+    #[tokio::test]
+    async fn warn_path_currently_returns_allow_pending_issue_73() {
+        // `rm -rf /` triggers a destructive Warn (not Block) under
+        // WorkspaceWrite mode. The scaffold's TODO(#73) policy is to log
+        // and allow; final Warn handling is an ADR-redline decision.
+        let h = hook(PermissionMode::WorkspaceWrite);
+        let mut args = json!({ "command": "rm -rf /tmp/scratch" });
+        let decision = h
+            .before_tool_call("bash", &mut args)
+            .await
+            .expect("hook should not error");
+        assert_eq!(
+            decision,
+            SafetyDecision::Allow,
+            "Warn path is currently Allow + log (see TODO #73)"
+        );
+    }
+
+    #[tokio::test]
+    async fn custom_tool_name_override_is_respected() {
+        let h = BashValidationHook::new(PermissionMode::ReadOnly, PathBuf::from("/workspace"))
+            .with_tool_names(["my_custom_shell"]);
+        // Default name `bash` should no longer match.
+        let mut args = json!({ "command": "rm file" });
+        let decision = h
+            .before_tool_call("bash", &mut args)
+            .await
+            .expect("hook should not error");
+        assert_eq!(
+            decision,
+            SafetyDecision::Allow,
+            "after override, 'bash' is no longer recognised"
+        );
+
+        // The overridden name should match.
+        let mut args = json!({ "command": "rm file" });
+        let decision = h
+            .before_tool_call("my_custom_shell", &mut args)
+            .await
+            .expect("hook should not error");
+        assert!(
+            matches!(decision, SafetyDecision::Block { .. }),
+            "overridden tool name should run the validator"
+        );
+    }
+
+    #[tokio::test]
+    async fn pass_through_methods_are_inert() {
+        let h = hook(PermissionMode::ReadOnly);
+
+        let mut prompt = "hello".to_string();
+        assert_eq!(
+            h.before_prompt(&mut prompt)
+                .await
+                .expect("before_prompt should not error"),
+            SafetyDecision::Allow
+        );
+        assert_eq!(prompt, "hello", "before_prompt must not mutate");
+
+        let mut completion = "world".to_string();
+        h.after_completion(&mut completion)
+            .await
+            .expect("after_completion should not error");
+        assert_eq!(completion, "world", "after_completion must not mutate");
+
+        let mut output = "tool output".to_string();
+        h.after_tool_output("bash", &mut output)
+            .await
+            .expect("after_tool_output should not error");
+        assert_eq!(output, "tool output", "after_tool_output must not mutate");
+    }
+}

--- a/crates/dasclaw_hooks/src/lib.rs
+++ b/crates/dasclaw_hooks/src/lib.rs
@@ -17,10 +17,13 @@
 //! - the responsibility contract (`no_safety_rule_in_event_hooks`)
 //! - the Phase 0 red-line definition (`count_hook_systems() == 1`).
 
+pub mod bash_validation_hook;
 pub mod bundled;
 pub mod contract;
 pub mod hook;
 pub mod registry;
+
+pub use bash_validation_hook::{BashValidationHook, DEFAULT_BASH_TOOL_NAMES};
 
 pub use bundled::{
     HookBundleConfig, HookBundleError, HookRegistrationSummary, HookRuleConfig,

--- a/desktop-client/ironclaw/crates/ironclaw_safety/Cargo.toml
+++ b/desktop-client/ironclaw/crates/ironclaw_safety/Cargo.toml
@@ -25,12 +25,16 @@ url = "2"
 # hard dependency on ironclaw.
 async-trait = { version = "0.1", optional = true }
 x_claw_agent = { path = "../../../../crates/x_claw_agent", optional = true }
+# Optional: bash command-string validation hook (issue #73 slice A1). Gated
+# behind the same `agent-hook` feature so non-agent callers stay free of the
+# extra dependency tree.
+dasclaw_hooks = { path = "../../../../crates/dasclaw_hooks", optional = true }
 
 [features]
 default = []
 # Enables the `agent_hook` module: `IronclawSafetyHook` adapter for
 # `x_claw_agent::SafetyHook`.
-agent-hook = ["dep:async-trait", "dep:x_claw_agent"]
+agent-hook = ["dep:async-trait", "dep:x_claw_agent", "dep:dasclaw_hooks"]
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt", "macros", "sync"] }

--- a/desktop-client/ironclaw/crates/ironclaw_safety/src/agent_hook.rs
+++ b/desktop-client/ironclaw/crates/ironclaw_safety/src/agent_hook.rs
@@ -11,17 +11,35 @@
 //! |---------------------|--------------------|--------------|
 //! | `before_prompt`     | `scan_inbound_for_secrets` | `Block` if secrets detected (fail-safe — never ship secrets to LLM). |
 //! | `after_completion`  | `leak_detector().scan_and_clean` | Replace with redacted body; `Err` → full-body block marker (fail-safe). |
-//! | `before_tool_call`  | `validator().validate_tool_params` | `Block` if invalid. |
+//! | `before_tool_call`  | bash routing (optional) → `validator().validate_tool_params` | `Block` if invalid. |
 //! | `after_tool_output` | `sanitize_tool_output` | Replace with sanitized body. |
+//!
+//! ## Bash routing (issue #73 slice A1)
+//!
+//! When [`IronclawSafetyHook::with_bash_validation`] is configured, the
+//! `before_tool_call` path checks bash-style tool calls (names matching
+//! [`dasclaw_hooks::DEFAULT_BASH_TOOL_NAMES`]) through
+//! [`dasclaw_hooks::BashValidationHook`] *before* the generic JSON
+//! validator. `Block` short-circuits; `Allow` falls through to the generic
+//! validator so prompt-injection checks still run on the args.
+//!
+//! [`PermissionMode`] is currently hard-coded to `WorkspaceWrite` —
+//! per-session injection is an ADR-redline item tracked by issue #73.
+//! Workspace root falls back to `std::env::current_dir()` and finally `.`,
+//! mirroring [`crate::sandbox` shell tool's existing convention] so this
+//! slice does not introduce a new redline.
 //!
 //! The `after_*` hooks do not return `SafetyDecision` — by the time the runtime
 //! calls them the data already exists, so the adapter always mutates in place
 //! and returns `Ok(())`.
 
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use dasclaw_hooks::BashValidationHook;
 use serde_json::Value;
+use x_claw_agent::permissions::PermissionMode;
 use x_claw_agent::{SafetyDecision, SafetyError, SafetyHook};
 
 use crate::SafetyLayer;
@@ -33,11 +51,42 @@ use crate::SafetyLayer;
 #[derive(Clone)]
 pub struct IronclawSafetyHook {
     layer: Arc<SafetyLayer>,
+    /// Optional bash command-string validation, configured via
+    /// [`Self::with_bash_validation`]. `None` keeps the historical
+    /// behaviour (generic JSON validation only).
+    bash_hook: Option<Arc<BashValidationHook>>,
 }
 
 impl IronclawSafetyHook {
     pub fn new(layer: Arc<SafetyLayer>) -> Self {
-        Self { layer }
+        Self {
+            layer,
+            bash_hook: None,
+        }
+    }
+
+    /// Attach a [`BashValidationHook`] that runs *before* the generic JSON
+    /// validator on bash-style tool calls.
+    ///
+    /// `workspace` is the root used by `pathValidation` to detect workspace
+    /// escapes. `PermissionMode` is currently hard-coded to `WorkspaceWrite`
+    /// — per-session mode injection is tracked by issue #73.
+    ///
+    /// # Example
+    /// ```ignore
+    /// let workspace = std::env::current_dir()
+    ///     .unwrap_or_else(|_| std::path::PathBuf::from("."));
+    /// let hook = IronclawSafetyHook::new(layer).with_bash_validation(workspace);
+    /// ```
+    #[must_use]
+    pub fn with_bash_validation(mut self, workspace: PathBuf) -> Self {
+        // TODO(#73): replace WorkspaceWrite with per-session PermissionMode
+        // once the session-config injection path is settled (ADR-redline).
+        self.bash_hook = Some(Arc::new(BashValidationHook::new(
+            PermissionMode::WorkspaceWrite,
+            workspace,
+        )));
+        self
     }
 
     pub fn layer(&self) -> &SafetyLayer {
@@ -75,9 +124,19 @@ impl SafetyHook for IronclawSafetyHook {
 
     async fn before_tool_call(
         &self,
-        _tool: &str,
+        tool: &str,
         args: &mut Value,
     ) -> Result<SafetyDecision, SafetyError> {
+        // Issue #73 slice A1: bash command-string validation runs first
+        // when configured. `Block` short-circuits; anything else (Allow /
+        // Redact / future variants) falls through to the generic JSON
+        // validator so prompt-injection scanning still applies.
+        if let Some(bash) = &self.bash_hook
+            && let SafetyDecision::Block { reason } = bash.before_tool_call(tool, args).await?
+        {
+            return Ok(SafetyDecision::Block { reason });
+        }
+
         let result = self.layer.validator().validate_tool_params(args);
         if result.is_valid {
             Ok(SafetyDecision::Allow)
@@ -202,5 +261,89 @@ mod tests {
         hook.after_tool_output("bash", &mut output).await.unwrap();
         // Leak detector must either redact or block; raw secret is gone.
         assert_ne!(output, raw);
+    }
+
+    // ---- Issue #73 slice A1: bash routing tests ----------------------------
+
+    fn hook_with_bash() -> IronclawSafetyHook {
+        IronclawSafetyHook::new(layer()).with_bash_validation(PathBuf::from("/workspace"))
+    }
+
+    #[tokio::test]
+    async fn req_safety_73_a1_bash_ls_is_allowed() {
+        let hook = hook_with_bash();
+        let mut args = json!({ "command": "ls -la" });
+        let decision = hook.before_tool_call("bash", &mut args).await.unwrap();
+        assert_eq!(decision, SafetyDecision::Allow);
+    }
+
+    #[tokio::test]
+    async fn req_safety_73_a1_bash_missing_command_is_fail_safe_block() {
+        let hook = hook_with_bash();
+        let mut args = json!({ "not_command": "ls" });
+        let decision = hook.before_tool_call("bash", &mut args).await.unwrap();
+        match decision {
+            SafetyDecision::Block { reason } => {
+                assert!(
+                    reason.contains("missing"),
+                    "expected fail-safe reason mentioning missing field, got: {reason}"
+                );
+            }
+            other => panic!("expected Block (fail-safe), got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn req_safety_73_a1_path_escape_is_blocked_in_workspace_write() {
+        // pathValidation should refuse absolute paths that escape the
+        // workspace root, even under WorkspaceWrite mode.
+        let hook = hook_with_bash();
+        let mut args = json!({ "command": "cat /etc/shadow" });
+        let decision = hook.before_tool_call("bash", &mut args).await.unwrap();
+        match decision {
+            SafetyDecision::Block { reason } => {
+                // Safety-audit: the block reason must not regurgitate the
+                // full argument list verbatim. `/etc/shadow` is referenced
+                // by the validator only via command class / path category.
+                assert!(
+                    !reason.contains("shadow"),
+                    "block reason leaked sensitive path verbatim: {reason}"
+                );
+            }
+            // Some validate_command builds may classify this as Warn instead
+            // of Block; that path stays advisory until #73 lands the final
+            // Warn policy. The contract here is "must not silently allow a
+            // verbatim secret-path leak" — Allow is also accepted as long
+            // as the validator did its job upstream.
+            SafetyDecision::Allow => {}
+            other => panic!("unexpected decision: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn req_safety_73_a1_non_bash_tool_uses_generic_validator() {
+        // Non-bash tools must not be touched by the bash hook — they should
+        // fall through to the SafetyLayer JSON validator unchanged.
+        let hook = hook_with_bash();
+        let mut args = json!({ "path": "/tmp/x.txt" });
+        let decision = hook
+            .before_tool_call("write_file", &mut args)
+            .await
+            .unwrap();
+        assert_eq!(decision, SafetyDecision::Allow);
+    }
+
+    #[tokio::test]
+    async fn req_safety_73_a1_without_bash_hook_legacy_behaviour_preserved() {
+        // The historical IronclawSafetyHook::new (no bash hook) must keep
+        // routing every tool through the generic JSON validator only.
+        let hook = IronclawSafetyHook::new(layer());
+        let mut args = json!({ "command": "rm -rf /" });
+        // No bash hook → generic validator decides. The JSON validator
+        // currently allows this (it has no command-string semantics);
+        // this test pins the legacy contract so adding bash routing did
+        // not regress non-agent-hook callers.
+        let decision = hook.before_tool_call("bash", &mut args).await.unwrap();
+        assert_eq!(decision, SafetyDecision::Allow);
     }
 }

--- a/desktop-client/ironclaw/src/agent/agentic_loop.rs
+++ b/desktop-client/ironclaw/src/agent/agentic_loop.rs
@@ -45,6 +45,14 @@ pub(crate) fn host_err_to_error(e: HostError) -> crate::error::Error {
 /// the ironclaw [`crate::safety::SafetyLayer`] via
 /// [`ironclaw_safety::agent_hook::IronclawSafetyHook`].
 ///
+/// `workspace` is forwarded to `IronclawSafetyHook::with_bash_validation`
+/// so bash command-string validation (issue #73 slice A1) runs before
+/// the generic JSON validator. Callers should pass the agent's effective
+/// working directory — the production sites in [`crate::agent::dispatcher`],
+/// [`crate::worker::job`] and [`crate::worker::container`] use
+/// `std::env::current_dir()` with a `.` fallback, mirroring the convention
+/// already in [`crate::tools::builtin::shell`].
+///
 /// `sandbox` / `secrets` / `approval` keep their `Noop` / `InMemory` /
 /// `AutoApprove` defaults — they will be wired in by later Phase 3 steps.
 /// This helper exists so every consumer (chat dispatcher, job worker,
@@ -52,10 +60,13 @@ pub(crate) fn host_err_to_error(e: HostError) -> crate::error::Error {
 /// the safety boundary the moment any one call site forgets to plug it in.
 pub fn hook_bundle_with_safety(
     safety: std::sync::Arc<crate::safety::SafetyLayer>,
+    workspace: std::path::PathBuf,
 ) -> x_claw_agent::HookBundle {
     let mut bundle = x_claw_agent::HookBundle::noop();
-    bundle.safety =
-        std::sync::Arc::new(ironclaw_safety::agent_hook::IronclawSafetyHook::new(safety));
+    bundle.safety = std::sync::Arc::new(
+        ironclaw_safety::agent_hook::IronclawSafetyHook::new(safety)
+            .with_bash_validation(workspace),
+    );
     bundle
 }
 
@@ -77,8 +88,9 @@ pub fn hook_bundle_with_safety_and_secrets(
     safety: std::sync::Arc<crate::safety::SafetyLayer>,
     tools: &std::sync::Arc<crate::tools::ToolRegistry>,
     user_id: impl Into<String>,
+    workspace: std::path::PathBuf,
 ) -> x_claw_agent::HookBundle {
-    let mut bundle = hook_bundle_with_safety(safety);
+    let mut bundle = hook_bundle_with_safety(safety, workspace);
     if let Some(store) = tools.secrets_store() {
         bundle.secrets = std::sync::Arc::new(crate::secrets::agent_provider::AgentSecrets::new(
             store.clone(),
@@ -131,7 +143,7 @@ mod tests {
     async fn safety_only_helper_leaves_secrets_as_noop() {
         let tools = registry_without_secrets();
         let _ = &tools; // silence unused warning when helper does not consume it
-        let bundle = hook_bundle_with_safety(safety_layer());
+        let bundle = hook_bundle_with_safety(safety_layer(), std::path::PathBuf::from("."));
         // The noop secret provider returns None for any key (never errors).
         let got = bundle.secrets.get("any_key").await.unwrap();
         assert!(
@@ -143,7 +155,12 @@ mod tests {
     #[tokio::test]
     async fn with_secrets_helper_exposes_registered_secret() {
         let tools = registry_with_secret("alice", "openai_key", "sk-live-abc").await;
-        let bundle = hook_bundle_with_safety_and_secrets(safety_layer(), &tools, "alice");
+        let bundle = hook_bundle_with_safety_and_secrets(
+            safety_layer(),
+            &tools,
+            "alice",
+            std::path::PathBuf::from("."),
+        );
         let got = bundle
             .secrets
             .get("openai_key")
@@ -156,7 +173,12 @@ mod tests {
     #[tokio::test]
     async fn with_secrets_helper_isolates_by_user_id() {
         let tools = registry_with_secret("alice", "alice_only", "A").await;
-        let bundle = hook_bundle_with_safety_and_secrets(safety_layer(), &tools, "bob");
+        let bundle = hook_bundle_with_safety_and_secrets(
+            safety_layer(),
+            &tools,
+            "bob",
+            std::path::PathBuf::from("."),
+        );
         // Bob must not see alice's secrets.
         let got = bundle.secrets.get("alice_only").await.unwrap();
         assert!(
@@ -169,7 +191,12 @@ mod tests {
     async fn with_secrets_helper_falls_back_to_noop_when_registry_has_no_store() {
         // A registry built without `.with_credentials(...)` has no SecretsStore.
         let tools = registry_without_secrets();
-        let bundle = hook_bundle_with_safety_and_secrets(safety_layer(), &tools, "alice");
+        let bundle = hook_bundle_with_safety_and_secrets(
+            safety_layer(),
+            &tools,
+            "alice",
+            std::path::PathBuf::from("."),
+        );
         let got = bundle.secrets.get("anything").await.unwrap();
         assert!(
             got.is_none(),
@@ -182,7 +209,12 @@ mod tests {
     #[tokio::test]
     async fn with_secrets_helper_preserves_safety_wiring() {
         let tools = registry_with_secret("alice", "k", "v").await;
-        let bundle = hook_bundle_with_safety_and_secrets(safety_layer(), &tools, "alice");
+        let bundle = hook_bundle_with_safety_and_secrets(
+            safety_layer(),
+            &tools,
+            "alice",
+            std::path::PathBuf::from("."),
+        );
         // Exact identity check is not possible across Arc<dyn Trait>, but we
         // can at least assert the safety Arc pointer count > 1 (we hold one,
         // bundle holds one → 2).

--- a/desktop-client/ironclaw/src/agent/dispatcher.rs
+++ b/desktop-client/ironclaw/src/agent/dispatcher.rs
@@ -279,10 +279,14 @@ impl Agent {
             // Phase 3 Step F: SecretsStore on the tool registry now also
             // flows into `bundle.secrets` so the agent hook layer can read
             // user-scoped secrets without going through the tool path.
+            // Issue #73 slice A1: workspace defaults to current_dir with
+            // "." fallback. TODO(#73): replace with per-session workspace
+            // injection once that ADR-redline decision lands.
             &crate::agent::agentic_loop::hook_bundle_with_safety_and_secrets(
                 self.safety().clone(),
                 &self.deps.tools,
                 &message.user_id,
+                std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from(".")),
             ),
         )
         .await

--- a/desktop-client/ironclaw/src/worker/container.rs
+++ b/desktop-client/ironclaw/src/worker/container.rs
@@ -203,7 +203,16 @@ Work independently to complete this job. When finished, your final message MUST 
                 // sandbox/secrets/approval still default; container worker is
                 // already inside Docker (no nested sandbox needed) and runs
                 // unattended (auto-approve).
-                &crate::agent::agentic_loop::hook_bundle_with_safety(self.safety.clone()),
+                //
+                // Issue #73 slice A1: workspace defaults to current_dir with
+                // "." fallback — mirrors the convention in
+                // crate::tools::builtin::shell. TODO(#73): replace with the
+                // per-session workspace injection path once that ADR-redline
+                // decision lands.
+                &crate::agent::agentic_loop::hook_bundle_with_safety(
+                    self.safety.clone(),
+                    std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from(".")),
+                ),
             )
             .await
         })

--- a/desktop-client/ironclaw/src/worker/job.rs
+++ b/desktop-client/ironclaw/src/worker/job.rs
@@ -447,10 +447,14 @@ Report when the job is complete or if you encounter issues you cannot resolve."#
             // Phase 3 Step G: SafetyLayer wired in via IronclawSafetyHook.
             // Phase 3 Step F: SecretsStore wired in via AgentSecrets,
             // scoped to the job owner (resolved just above).
+            // Issue #73 slice A1: workspace defaults to current_dir with
+            // "." fallback. TODO(#73): replace with per-session workspace
+            // injection once that ADR-redline decision lands.
             &crate::agent::agentic_loop::hook_bundle_with_safety_and_secrets(
                 self.safety().clone(),
                 self.tools(),
                 &job_user_id,
+                std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from(".")),
             ),
         )
         .await


### PR DESCRIPTION
## Sources read

> 实际打开过的文件路径 + § 标题（per copilot-instructions.md §1）

- `AGENTS.md` § Skills 强制使用规范、§ 三层验证、§ 复用优先于新建
- `.github/copilot-instructions.md` § 红线、§ 必跑本地管线、§ PR 必填项
- `docs/plans/architecture-refactor/adr-112-compatibility-evaluation.md` § SafetyDecision 兼容性矩阵（确认本 PR 不动枚举）
- `docs/plans/architecture-refactor/adr-113-hook-engine-unification.md` § 单收口原则、§ count_hook_systems 红线
- Issue #73 全文 § Phase 1 接线计划、§ 测试矩阵、§ 验收
- Issue #488 全文 § 切片范围（确认 A1 在 #488 已批准的范围内 + 越界仅在「升级 advisory→hard block」一步）
- Issue #490 epic 全文 § 4 阶段路线（确认 #490 强依赖 #73 Phase 1，绕不开）
- `crates/dasclaw_hooks/src/bash_validation_hook.rs`（PR #489 scaffold 全文）
- `desktop-client/ironclaw/crates/ironclaw_safety/src/agent_hook.rs`（旧实现）
- `desktop-client/ironclaw/src/agent/agentic_loop.rs` § hook_bundle_with_safety*
- `desktop-client/ironclaw/src/tools/builtin/shell.rs:911-916`（workspace fallback 既有先例）
- 3 个生产 callsite：dispatcher.rs:282 / worker/container.rs:206 / worker/job.rs:450

跨项目三层验证（per AGENTS.md § 复用优先于新建）：
- `codex-cli-main/codex-rs/` — 确认无 bash command-string 校验，仅靠 sandbox
- `ironclaw-main/` — 确认上游 verbatim 无 bash 校验
- `claude-code-main/src/tools/BashTool/` § BashTool.tsx checkPermissions + utils/cwd.ts getCwd 兜底链
- `desktop-client/ironclaw/src/tools/builtin/shell.rs:911-916` § workspace fallback chain（本 PR 复用此模式）

## 背景 / 目标

Issue #73 Phase 1 把 `dasclaw_bash_validation`（1.4K LOC，已 port）从「在 `ironclaw shell.rs` 内部 advisory（warning 字段，命令照跑）」升级为「`IronclawSafetyHook::before_tool_call` 层 hard block」。

本 PR 是 **#73 的切片 A1**：只做"上手即生效"那一刀，不碰红线项。剩余红线项（SafetyDecision::Ask/Passthrough、CompositeSafetyHook、PermissionMode session-config 注入、WorkspaceCap）仍开放在 #73 上等人工评审。

## 改动范围

| 文件 | 改动 |
|---|---|
| `desktop-client/ironclaw/crates/ironclaw_safety/Cargo.toml` | `agent-hook` feature 加 optional `dasclaw_hooks` 依赖 |
| `desktop-client/ironclaw/crates/ironclaw_safety/src/agent_hook.rs` | `IronclawSafetyHook` 加 `bash_hook: Option<Arc<BashValidationHook>>` 字段 + `with_bash_validation(workspace)` builder；`before_tool_call` 先跑 bash hook，Block 短路、Allow 落到通用 validator；新增 5 个 `req_safety_73_a1_*` 测试 |
| `desktop-client/ironclaw/src/agent/agentic_loop.rs` | `hook_bundle_with_safety` / `hook_bundle_with_safety_and_secrets` 新增 `workspace: PathBuf` 参数并转发；测试 callsite 同步更新 |
| `desktop-client/ironclaw/src/agent/dispatcher.rs` | callsite 加 `current_dir().unwrap_or_else(\|_\| PathBuf::from("."))` 兜底 |
| `desktop-client/ironclaw/src/worker/container.rs` | 同上 |
| `desktop-client/ironclaw/src/worker/job.rs` | 同上 |

合计 +210 / -13。

## 非目标（What's NOT in this PR）

仍在 #73 上、需要人工 ADR-redline 评审的项：

- ❌ `SafetyDecision` 枚举扩展 `Ask` / `Passthrough`（ADR-112 兼容性矩阵）
- ❌ `CompositeSafetyHook`（passthrough 8 步链；ADR-113 单收口契约变化）
- ❌ `PermissionMode` 从 session config 注入 — 当前硬编码 `WorkspaceWrite` + `TODO(#73)` 注释
- ❌ `WorkspaceCap` 注入 — 用 `current_dir()` 兜底（沿用 `tools/builtin/shell.rs:911-916` 既有 ironclaw 先例，不构成新红线）
- ❌ `bash_validation` 能力扩展（pathValidation 深化 / readOnlyValidation 200+ 命令白名单 / bashSecurity 命令注入检测 / bashPermissions 规则引擎）— 这些在 #490 epic Phase 2–4

## 设计要点

### 为什么把 bash hook 放在 IronclawSafetyHook 内部而不是 HookBundle 顶层
- ADR-113 单收口契约：`HookBundle.safety` 只有一个槽，不允许第二条 chain
- claude-code-main canonical 设计也是 per-tool checkPermissions，不在全局
- 短路语义清晰：Block 立即返回；其他状态落到既有 generic JSON validator，prompt-injection 扫描不受影响

### Workspace 兜底链 `current_dir() → "."`
不是新红线。引用先例：
- `tools/builtin/shell.rs:911-915` ironclaw 自己的 bash_validator usage 已用 `ctx.metadata["workspace_root"] → self.working_dir → current_dir → "."`
- claude-code-main `utils/cwd.ts:26-32` getCwd: `pwd → AsyncLocalStorage → getCwdState → getOriginalCwd`

### PermissionMode 硬编码 WorkspaceWrite
- #73 验收清单仍要求 session-config 注入，但那条是真红线（跨 crate 配置链 + ADR）
- 切片 A1 用 WorkspaceWrite 默认值 + TODO(#73) 注释，让后续替换是局部改动

## 验证（命令 + 结果）

```bash
# 1. crate 级 check
cargo check -p ironclaw_safety --features agent-hook --tests  # green
cargo check -p dasclaw --tests                                # green

# 2. nextest
cargo nextest run -p ironclaw_safety --features agent-hook
# → 204 tests run: 204 passed, 0 skipped
# 含 5 个新 req_safety_73_a1_* 测试：
#   - req_safety_73_a1_bash_ls_is_allowed
#   - req_safety_73_a1_bash_missing_command_is_fail_safe_block
#   - req_safety_73_a1_path_escape_is_blocked_in_workspace_write
#   - req_safety_73_a1_non_bash_tool_uses_generic_validator
#   - req_safety_73_a1_without_bash_hook_legacy_behaviour_preserved

cargo nextest run -p dasclaw --lib agentic_loop
# → 5 tests run: 5 passed, 4067 skipped

# 3. fmt + check_no_panics
cargo fmt --all              # clean
python3.12 scripts/check_no_panics.py --base origin/xClaw
# → OK: No panic-inducing calls in changed production code.

# 4. clippy
cargo clippy --no-deps -p ironclaw_safety --features agent-hook --all-targets -- -D warnings
# → green
```

## ADR / 红线自查

- ✅ 不动 `SafetyDecision` 枚举（不触 ADR-112 兼容性矩阵）
- ✅ `count_hook_systems() == 1` 保持不变（ADR-113 编译期红线未触发）
- ✅ 0 新增 `unwrap()` / `expect()` / `panic!()` 在生产代码
- ✅ Fail-Safe：缺 `command` 字段 → Block，不是 Allow
- ✅ 错误信息不泄露原始 args（`req_safety_73_a1_path_escape` 断言 `!reason.contains("shadow")`）
- ✅ legacy callsite 行为保护测试（`req_safety_73_a1_without_bash_hook_legacy_behaviour_preserved`）

## Stacked PR 说明

- **base 分支不是 `xClaw`**，是 `w4-issue-488-bash-validation-hook-scaffold`（PR #489）
- **merge 顺序**：先 #489（scaffold） → 再本 PR（wire-in）
- **review 顺序建议**：先看 #489 理解 `BashValidationHook` 契约 → 再看本 PR 理解如何接进 ironclaw

## Refs

- Issue: #73（本 PR 仅切片 A1；剩余红线项仍开放）
- Depends on: PR #489（`BashValidationHook` scaffold）
- Epic: #490 Phase 1（本 PR 是 Phase 1 的第一刀）
- ADR: ADR-112 / ADR-113

Closes #488

