### PR TITLE
feat(bash-validation): Phase 2.1.a — AST wrapper + 5 early validators (refs #490 #502)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2773,7 +2773,13 @@ dependencies = [
 name = "dasclaw_bash_validation"
 version = "0.0.0-w1"
 dependencies = [
+ "dasclaw_shell_command",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
  "thiserror 1.0.69",
+ "tree-sitter",
 ]
 
 [[package]]

--- a/crates/dasclaw_bash_validation/Cargo.toml
+++ b/crates/dasclaw_bash_validation/Cargo.toml
@@ -10,4 +10,16 @@ publish = false
 path = "src/lib.rs"
 
 [dependencies]
+dasclaw_shell_command = { path = "../dasclaw_shell_command" }
+once_cell = "1.20"
+regex = "1.12"
 thiserror = "1"
+# Only used to name the `tree_sitter::Tree` type returned by
+# `dasclaw_shell_command::bash::try_parse_shell`. We deliberately do NOT
+# depend on `tree-sitter-bash` here — the grammar wiring lives in
+# `dasclaw_shell_command` as the single AST source (plan §4.2).
+tree-sitter = "0.25.10"
+
+[dev-dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/crates/dasclaw_bash_validation/src/lib.rs
+++ b/crates/dasclaw_bash_validation/src/lib.rs
@@ -15,6 +15,7 @@
 use std::path::Path;
 
 pub mod permissions;
+pub mod security;
 pub use permissions::PermissionMode;
 
 /// Result of validating a bash command before execution.

--- a/crates/dasclaw_bash_validation/src/security/ast.rs
+++ b/crates/dasclaw_bash_validation/src/security/ast.rs
@@ -1,0 +1,60 @@
+//! Fail-Closed wrapper around `dasclaw_shell_command::bash::try_parse_shell`.
+//!
+//! Re-uses the workspace's single tree-sitter-bash wiring so we have one AST
+//! source of truth (plan §4.2). The Fail-Closed contract is:
+//!
+//! - Parse failure → [`ParseFail::TreeSitterError`]
+//! - Parse with `ERROR` nodes in the tree → [`ParseFail::ErrorNode`]
+//!
+//! Slice 2.1.b will extend [`BashAst`] with a typed walk (allowlist of
+//! `ALLOWED_KINDS`) that returns [`ParseFail::UnknownNode`] on any node not
+//! on the allowlist; the deferred engine then maps that to
+//! [`crate::security::DecisionReason::ParseFailure`].
+
+use thiserror::Error;
+use tree_sitter::Tree;
+
+/// Reasons the AST layer can refuse to produce a `BashAst`.
+#[derive(Debug, Error, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ParseFail {
+    /// tree-sitter-bash returned `None` (corrupted grammar load, OOM, etc.).
+    #[error("tree-sitter-bash failed to parse the command")]
+    TreeSitterError,
+    /// Parse succeeded but the tree contains `ERROR` nodes (syntactic
+    /// fragments, mismatched quotes, etc.).
+    #[error("bash AST contains ERROR nodes")]
+    ErrorNode,
+}
+
+/// Owning wrapper around the validated tree-sitter `Tree`.
+///
+/// Slice 2.1.a stores only the tree; Slice 2.1.b will add cached structural
+/// queries (heredoc list, quote-context map, etc.).
+#[derive(Debug)]
+pub struct BashAst {
+    tree: Tree,
+}
+
+impl BashAst {
+    pub fn root_has_error(&self) -> bool {
+        self.tree.root_node().has_error()
+    }
+
+    /// Returns the underlying tree for consumers that need raw access.
+    /// Slice 2.1.b will replace most callers with typed accessors.
+    pub fn tree(&self) -> &Tree {
+        &self.tree
+    }
+}
+
+/// Parse `command` via the shared `dasclaw_shell_command` parser, returning
+/// a [`BashAst`] on success or a [`ParseFail`] otherwise.
+pub fn parse_for_security(command: &str) -> Result<BashAst, ParseFail> {
+    let tree =
+        dasclaw_shell_command::bash::try_parse_shell(command).ok_or(ParseFail::TreeSitterError)?;
+    if tree.root_node().has_error() {
+        return Err(ParseFail::ErrorNode);
+    }
+    Ok(BashAst { tree })
+}

--- a/crates/dasclaw_bash_validation/src/security/context.rs
+++ b/crates/dasclaw_bash_validation/src/security/context.rs
@@ -1,0 +1,25 @@
+//! [`ValidationContext`] — read-only bundle handed to every validator.
+//!
+//! Slice 2.1.a only populates `original_command`. Phase 2.1.b will compute
+//! `fully_unquoted_pre_strip`, `unquoted_keep_quote_chars`, AST cache, etc.
+//! (mirroring upstream `ValidationContext` in `bashSecurity.ts` L162-L196).
+
+/// Read-only bundle of pre-computed views of the command, shared across
+/// validators within a single security gate evaluation.
+#[derive(Debug, Clone)]
+pub struct ValidationContext<'a> {
+    /// Exact bytes the user provided, untouched.
+    original_command: &'a str,
+}
+
+impl<'a> ValidationContext<'a> {
+    pub fn new(command: &'a str) -> Self {
+        Self {
+            original_command: command,
+        }
+    }
+
+    pub fn original_command(&self) -> &str {
+        self.original_command
+    }
+}

--- a/crates/dasclaw_bash_validation/src/security/early.rs
+++ b/crates/dasclaw_bash_validation/src/security/early.rs
@@ -1,0 +1,196 @@
+//! Slice 2.1.a — five **early** validators.
+//!
+//! Order matches upstream `bashSecurity.ts` (L2257-L2424) so differential
+//! testing can compare on a check-by-check basis.
+//!
+//! These run **before** the AST is consulted and reject obviously hostile
+//! syntactic shapes (tabs, lone flags, control characters, U+00A0-style
+//! invisible whitespace). They establish the Fail-Safe baseline that Phase
+//! 2.1.b's main validators rely on.
+
+use once_cell::sync::Lazy;
+use regex::Regex;
+
+use super::context::ValidationContext;
+use super::types::{DecisionReason, SecurityCheckId, SecurityResult};
+
+// ─────────────────────────── helpers ────────────────────────────────────────
+
+fn block(check_id: SecurityCheckId, sub_id: u32, message: &str) -> SecurityResult {
+    SecurityResult::Block {
+        reason: DecisionReason::CommandInjection {
+            check_id,
+            sub_id,
+            message: message.to_string(),
+        },
+    }
+}
+
+// ─────────────────────────── validate_empty ─────────────────────────────────
+
+/// Upstream `validateEmpty` (L233-L242). An empty command is explicitly safe
+/// and short-circuits the entire pipeline.
+pub fn validate_empty(ctx: &ValidationContext) -> SecurityResult {
+    if ctx.original_command().trim().is_empty() {
+        return SecurityResult::Allow;
+    }
+    SecurityResult::Passthrough
+}
+
+// ─────────────────────────── validate_incomplete_commands ───────────────────
+
+static INCOMPLETE_TAB_START: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"^\s*\t").expect("static regex") // safety: literal pattern, build-time correctness
+});
+static INCOMPLETE_OPERATOR_START: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"^\s*(&&|\|\||;|>>?|<)").expect("static regex") // safety: literal pattern, build-time correctness
+});
+
+/// Upstream `validateIncompleteCommands` (L244-L292). Three sub-checks:
+/// 1. starts with TAB → likely a continuation of a previous line
+/// 2. trimmed starts with `-` → looks like just flags
+/// 3. starts with an operator → looks like a continuation
+pub fn validate_incomplete_commands(ctx: &ValidationContext) -> SecurityResult {
+    let original = ctx.original_command();
+
+    if INCOMPLETE_TAB_START.is_match(original) {
+        return block(
+            SecurityCheckId::IncompleteCommands,
+            1,
+            "Command appears to be an incomplete fragment (starts with tab)",
+        );
+    }
+
+    if original.trim_start().starts_with('-') {
+        return block(
+            SecurityCheckId::IncompleteCommands,
+            2,
+            "Command appears to be an incomplete fragment (starts with flags)",
+        );
+    }
+
+    if INCOMPLETE_OPERATOR_START.is_match(original) {
+        return block(
+            SecurityCheckId::IncompleteCommands,
+            3,
+            "Command appears to be a continuation line (starts with operator)",
+        );
+    }
+
+    SecurityResult::Passthrough
+}
+
+// ─────────────────────────── validate_newlines ──────────────────────────────
+
+/// Upstream `validateNewlines` (L905-L943). Slice 2.1.a uses
+/// `original_command` directly (Slice 2.1.b will switch to
+/// `fully_unquoted_pre_strip` once that context view exists).
+///
+/// Rust's `regex` crate has no look-behind, so we replicate the upstream
+/// `/(?<![\s]\\)[\n\r]\s*\S/` semantics with a manual byte walk: scan for
+/// a LF / CR followed by optional whitespace and a non-whitespace byte,
+/// permitting `<whitespace>\<newline>` (a bash continuation at a word
+/// boundary) as the **only** exception.
+pub fn validate_newlines(ctx: &ValidationContext) -> SecurityResult {
+    let bytes = ctx.original_command().as_bytes();
+    if !bytes.iter().any(|b| *b == b'\n' || *b == b'\r') {
+        return SecurityResult::Passthrough;
+    }
+
+    let mut i = 0;
+    while i < bytes.len() {
+        let b = bytes[i];
+        if b == b'\n' || b == b'\r' {
+            let preceded_by_safe_cont =
+                i >= 2 && bytes[i - 1] == b'\\' && bytes[i - 2].is_ascii_whitespace();
+            let mut j = i + 1;
+            while j < bytes.len() && bytes[j].is_ascii_whitespace() {
+                j += 1;
+            }
+            let followed_by_non_ws = j < bytes.len();
+            if followed_by_non_ws && !preceded_by_safe_cont {
+                return block(
+                    SecurityCheckId::Newlines,
+                    1,
+                    "Command contains newlines that could separate multiple commands",
+                );
+            }
+        }
+        i += 1;
+    }
+
+    SecurityResult::Passthrough
+}
+
+// ─────────────────────────── validate_carriage_return ───────────────────────
+
+/// Upstream `validateCarriageReturn` (L971-L1015). Carriage return outside of
+/// **double** quotes is a misparsing concern (shell-quote vs bash IFS
+/// differential) — block on first occurrence.
+pub fn validate_carriage_return(ctx: &ValidationContext) -> SecurityResult {
+    let original = ctx.original_command();
+    if !original.contains('\r') {
+        return SecurityResult::Passthrough;
+    }
+
+    let mut in_single = false;
+    let mut in_double = false;
+    let mut escaped = false;
+    for c in original.chars() {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+        match c {
+            '\\' if !in_single => {
+                escaped = true;
+            }
+            '\'' if !in_double => {
+                in_single = !in_single;
+            }
+            '"' if !in_single => {
+                in_double = !in_double;
+            }
+            '\r' if !in_double => {
+                return block(
+                    SecurityCheckId::Newlines,
+                    2,
+                    "Command contains carriage return (\\r) which shell-quote and bash tokenize differently",
+                );
+            }
+            _ => {}
+        }
+    }
+
+    SecurityResult::Passthrough
+}
+
+// ─────────────────────────── validate_unicode_whitespace ────────────────────
+
+/// Upstream `UNICODE_WS_RE` (L1899) — the precise set of unicode whitespace
+/// codepoints that shell-quote treats as word separators but bash does not.
+fn is_unicode_whitespace(c: char) -> bool {
+    matches!(
+        c,
+        '\u{00A0}' | '\u{1680}' | '\u{2000}'
+            ..='\u{200A}'
+                | '\u{2028}'
+                | '\u{2029}'
+                | '\u{202F}'
+                | '\u{205F}'
+                | '\u{3000}'
+                | '\u{FEFF}'
+    )
+}
+
+/// Upstream `validateUnicodeWhitespace` (L1902-L1917).
+pub fn validate_unicode_whitespace(ctx: &ValidationContext) -> SecurityResult {
+    if ctx.original_command().chars().any(is_unicode_whitespace) {
+        return block(
+            SecurityCheckId::UnicodeWhitespace,
+            1,
+            "Command contains Unicode whitespace characters that could cause parsing inconsistencies",
+        );
+    }
+    SecurityResult::Passthrough
+}

--- a/crates/dasclaw_bash_validation/src/security/mod.rs
+++ b/crates/dasclaw_bash_validation/src/security/mod.rs
@@ -1,0 +1,66 @@
+//! Bash command-injection security gate (Phase 2.1 port of upstream
+//! `claude-code-main/src/tools/BashTool/bashSecurity.ts`).
+//!
+//! See [`docs/plans/bash-parity/phase-2.1-bash-security-alignment.md`] for the
+//! semantic-port contract, deviations from the upstream TypeScript, and the
+//! anti-drift strategy (asymmetric invariant + differential CI).
+//!
+//! ## Slice 2.1.a scope
+//!
+//! This module currently implements:
+//! - [`SecurityCheckId`] — strongly-typed enumeration of all 24 check IDs
+//! - [`SecurityResult`] — port of upstream `PermissionResult` (semantic; not 1:1)
+//! - [`ValidationContext`] — context passed to each validator
+//! - [`ast::parse_for_security`] — Fail-Closed AST wrapper (re-uses
+//!   `dasclaw_shell_command::bash::try_parse_shell`)
+//! - [`early`] — 4 early validators: incomplete commands, newlines (LF),
+//!   carriage return (with quote state machine), unicode whitespace
+//!
+//! Phase 2.1.b will add the 19 main validators + deferred-non-misparsing
+//! engine. Phase 2.1.c wires the hook + e2e tests.
+//!
+//! ## Asymmetric invariant
+//!
+//! ```text
+//! ∀ command c:
+//!   upstream_blocks(c) ⟹ xclaw_blocks(c)        // false negatives forbidden
+//!   xclaw_blocks(c)    ⟹⁄ upstream_blocks(c)   // we may be stricter
+//! ```
+
+pub mod ast;
+pub mod context;
+pub mod early;
+mod types;
+
+pub use ast::{BashAst, ParseFail};
+pub use context::ValidationContext;
+pub use types::{DecisionReason, SecurityCheckId, SecurityResult};
+
+/// Public entry point for the Phase 2.1 security gate.
+///
+/// Runs the four early validators sequentially; first non-Passthrough result
+/// wins.
+///
+/// **Slice 2.1.a behaviour**: only the four early validators run. Slice 2.1.b
+/// will splice in the deferred-non-misparsing engine (upstream
+/// `bashSecurity.ts` L2371-2387) and the 19 main validators.
+pub fn validate_security(command: &str) -> SecurityResult {
+    let ctx = ValidationContext::new(command);
+
+    let validators: &[fn(&ValidationContext) -> SecurityResult] = &[
+        early::validate_empty,
+        early::validate_incomplete_commands,
+        early::validate_newlines,
+        early::validate_carriage_return,
+        early::validate_unicode_whitespace,
+    ];
+
+    for validator in validators {
+        match validator(&ctx) {
+            SecurityResult::Passthrough => continue,
+            decisive => return decisive,
+        }
+    }
+
+    SecurityResult::Passthrough
+}

--- a/crates/dasclaw_bash_validation/src/security/types.rs
+++ b/crates/dasclaw_bash_validation/src/security/types.rs
@@ -1,0 +1,119 @@
+//! Strongly-typed enum of every check ID + result/reason types.
+//!
+//! Ported from upstream `BASH_SECURITY_CHECK_IDS` constants in
+//! `claude-code-main/src/tools/BashTool/bashSecurity.ts` L82-L125. Each
+//! variant corresponds 1:1 to an upstream check ID; the numeric mapping is
+//! preserved via [`SecurityCheckId::as_u32`] so that differential testing can
+//! compare results across the TS / Rust boundary.
+
+/// Every distinct security check the engine can emit.
+///
+/// `numbering` matches upstream `BASH_SECURITY_CHECK_IDS`. New variants must
+/// preserve gaps so existing IDs never shift.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum SecurityCheckId {
+    IncompleteCommands = 1,
+    JqSystemFunction = 2,
+    XargsRedirection = 3,
+    SafeCommandSubstitution = 4,
+    GitCommit = 5,
+    JqCommand = 6,
+    ShellMetacharacters = 7,
+    DangerousVariables = 8,
+    DangerousPatterns = 9,
+    Redirections = 10,
+    Newlines = 11,
+    IfsInjection = 12,
+    ProcEnvironAccess = 13,
+    MalformedTokenInjection = 14,
+    ObfuscatedFlags = 15,
+    BackslashEscapedWhitespace = 16,
+    BackslashEscapedOperators = 17,
+    BraceExpansion = 18,
+    UnicodeWhitespace = 19,
+    MidWordHash = 20,
+    CommentQuoteDesync = 21,
+    HeredocQuoted = 22,
+    TrailingBackslash = 23,
+    /// Parse failure — Fail-Closed catch-all.
+    ParseFailure = 24,
+}
+
+impl SecurityCheckId {
+    pub fn as_u32(self) -> u32 {
+        self as u32
+    }
+
+    /// Whether this check is sensitive to upstream misparsing (i.e. its
+    /// `ask` result becomes `block` at the bashPermissions gate).
+    ///
+    /// Mirrors upstream `isBashSecurityCheckForMisparsing` (L130-L160). Used
+    /// by the deferred-non-misparsing engine in Slice 2.1.b.
+    pub fn is_misparsing(self) -> bool {
+        matches!(
+            self,
+            Self::ShellMetacharacters
+                | Self::DangerousVariables
+                | Self::DangerousPatterns
+                | Self::Redirections
+                | Self::IfsInjection
+                | Self::ProcEnvironAccess
+                | Self::MalformedTokenInjection
+                | Self::ObfuscatedFlags
+                | Self::BackslashEscapedWhitespace
+                | Self::BackslashEscapedOperators
+                | Self::BraceExpansion
+                | Self::MidWordHash
+                | Self::CommentQuoteDesync
+                | Self::TrailingBackslash
+                | Self::ParseFailure
+        )
+    }
+}
+
+/// Why a particular [`SecurityResult::Block`] was emitted.
+///
+/// Strongly typed (vs upstream's loose `decisionReason: { type, reason }`)
+/// so downstream policy / telemetry can pattern-match exhaustively.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DecisionReason {
+    /// Bash command-injection detected by a specific validator.
+    CommandInjection {
+        check_id: SecurityCheckId,
+        /// Upstream `subId` (1-based; some validators emit multiple sub-cases).
+        sub_id: u32,
+        /// Human-readable explanation; safe to surface to operators.
+        message: String,
+    },
+    /// The command failed to parse and the engine refused on a Fail-Closed
+    /// basis (no validator had the chance to opine).
+    ParseFailure { message: String },
+}
+
+/// Result of a single validator or of the overall engine.
+///
+/// Maps upstream `PermissionResult` semantically:
+/// - upstream `behavior: 'allow'`        → [`SecurityResult::Allow`]
+/// - upstream `behavior: 'passthrough'`  → [`SecurityResult::Passthrough`]
+/// - upstream `behavior: 'ask'` / `'block'` (Phase 2.1) → [`SecurityResult::Block`]
+///
+/// See plan §0 (Porting model) for the rationale of collapsing `ask` into
+/// `block`: Phase 2.1 has no Ask UX (desktop will land in Phase 2.3); the
+/// safe default is to Block until the user explicitly upgrades the channel.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SecurityResult {
+    /// The command is explicitly trusted by this validator (rare; only
+    /// `validate_empty` returns this currently).
+    Allow,
+    /// This validator has no opinion; continue to the next.
+    Passthrough,
+    /// The command must not run. Always Fail-Safe.
+    Block { reason: DecisionReason },
+}
+
+impl SecurityResult {
+    pub fn is_block(&self) -> bool {
+        matches!(self, Self::Block { .. })
+    }
+}

--- a/crates/dasclaw_bash_validation/tests/security_early_unit_tests.rs
+++ b/crates/dasclaw_bash_validation/tests/security_early_unit_tests.rs
@@ -1,0 +1,257 @@
+//! Slice 2.1.a — unit tests for the five early security validators.
+//!
+//! Naming follows AGENTS.md `req_security_490_p2_1_a_*`. Tests are organized
+//! into:
+//! - happy-path: command should pass through
+//! - block-path: command should be Block-ed with the expected `SecurityCheckId`
+//! - parse-path: AST wrapper happy/sad paths
+//!
+//! Phase 2.1.b will add the differential-CI fixture-driven corpus tests.
+
+use dasclaw_bash_validation::security::{
+    ast, early, validate_security, DecisionReason, SecurityCheckId, SecurityResult,
+    ValidationContext,
+};
+
+fn assert_block(result: &SecurityResult, expected_id: SecurityCheckId, expected_sub_id: u32) {
+    match result {
+        SecurityResult::Block {
+            reason:
+                DecisionReason::CommandInjection {
+                    check_id, sub_id, ..
+                },
+        } => {
+            assert_eq!(
+                *check_id, expected_id,
+                "expected check_id={expected_id:?}, got {check_id:?}"
+            );
+            assert_eq!(
+                *sub_id, expected_sub_id,
+                "expected sub_id={expected_sub_id}, got {sub_id}"
+            );
+        }
+        other => panic!("expected Block({expected_id:?},{expected_sub_id}), got {other:?}"),
+    }
+}
+
+// ───────────────────────────── empty ────────────────────────────────────────
+
+#[test]
+fn req_security_490_p2_1_a_empty_allow() {
+    let ctx = ValidationContext::new("   ");
+    assert_eq!(early::validate_empty(&ctx), SecurityResult::Allow);
+}
+
+#[test]
+fn req_security_490_p2_1_a_nonempty_passthrough() {
+    let ctx = ValidationContext::new("ls -la");
+    assert_eq!(early::validate_empty(&ctx), SecurityResult::Passthrough);
+}
+
+// ───────────────────────────── incomplete_commands ──────────────────────────
+
+#[test]
+fn req_security_490_p2_1_a_incomplete_tab_blocks() {
+    let ctx = ValidationContext::new("\tls");
+    assert_block(
+        &early::validate_incomplete_commands(&ctx),
+        SecurityCheckId::IncompleteCommands,
+        1,
+    );
+}
+
+#[test]
+fn req_security_490_p2_1_a_incomplete_flag_blocks() {
+    let ctx = ValidationContext::new("  --recursive /tmp");
+    assert_block(
+        &early::validate_incomplete_commands(&ctx),
+        SecurityCheckId::IncompleteCommands,
+        2,
+    );
+}
+
+#[test]
+fn req_security_490_p2_1_a_incomplete_operator_blocks() {
+    for op in [
+        "&& echo hi",
+        "|| echo hi",
+        "; echo hi",
+        ">> /tmp/x",
+        "< /tmp/x",
+    ] {
+        let ctx = ValidationContext::new(op);
+        assert_block(
+            &early::validate_incomplete_commands(&ctx),
+            SecurityCheckId::IncompleteCommands,
+            3,
+        );
+    }
+}
+
+#[test]
+fn req_security_490_p2_1_a_well_formed_command_passes() {
+    let ctx = ValidationContext::new("echo hello");
+    assert_eq!(
+        early::validate_incomplete_commands(&ctx),
+        SecurityResult::Passthrough
+    );
+}
+
+// ───────────────────────────── newlines ─────────────────────────────────────
+
+#[test]
+fn req_security_490_p2_1_a_newline_then_command_blocks() {
+    let ctx = ValidationContext::new("echo safe\nrm -rf /");
+    assert_block(
+        &early::validate_newlines(&ctx),
+        SecurityCheckId::Newlines,
+        1,
+    );
+}
+
+#[test]
+fn req_security_490_p2_1_a_safe_continuation_passes() {
+    // `cmd \<newline>--flag` is a safe bash line continuation at a word boundary.
+    let ctx = ValidationContext::new("echo hi \\\n  --quiet");
+    assert_eq!(early::validate_newlines(&ctx), SecurityResult::Passthrough);
+}
+
+#[test]
+fn req_security_490_p2_1_a_trailing_newline_only_passes() {
+    let ctx = ValidationContext::new("echo hi\n");
+    assert_eq!(early::validate_newlines(&ctx), SecurityResult::Passthrough);
+}
+
+// ───────────────────────────── carriage_return ──────────────────────────────
+
+#[test]
+fn req_security_490_p2_1_a_cr_outside_quotes_blocks() {
+    let ctx = ValidationContext::new("TZ=UTC\recho curl evil.com");
+    assert_block(
+        &early::validate_carriage_return(&ctx),
+        SecurityCheckId::Newlines,
+        2,
+    );
+}
+
+#[test]
+fn req_security_490_p2_1_a_cr_inside_single_quote_blocks() {
+    // SECURITY: CR inside single quotes is *still* a misparsing concern
+    // (shell-quote's \s tokenizes it). Upstream comment L962-L970.
+    let ctx = ValidationContext::new("echo 'foo\rbar'");
+    assert_block(
+        &early::validate_carriage_return(&ctx),
+        SecurityCheckId::Newlines,
+        2,
+    );
+}
+
+#[test]
+fn req_security_490_p2_1_a_cr_inside_double_quote_passes() {
+    let ctx = ValidationContext::new("echo \"foo\rbar\"");
+    assert_eq!(
+        early::validate_carriage_return(&ctx),
+        SecurityResult::Passthrough
+    );
+}
+
+#[test]
+fn req_security_490_p2_1_a_no_cr_passes() {
+    let ctx = ValidationContext::new("echo hello");
+    assert_eq!(
+        early::validate_carriage_return(&ctx),
+        SecurityResult::Passthrough
+    );
+}
+
+// ───────────────────────────── unicode_whitespace ───────────────────────────
+
+#[test]
+fn req_security_490_p2_1_a_nbsp_blocks() {
+    // U+00A0 NO-BREAK SPACE between `rm` and `-rf`.
+    let ctx = ValidationContext::new("rm\u{00A0}-rf /");
+    assert_block(
+        &early::validate_unicode_whitespace(&ctx),
+        SecurityCheckId::UnicodeWhitespace,
+        1,
+    );
+}
+
+#[test]
+fn req_security_490_p2_1_a_zwnbsp_blocks() {
+    let ctx = ValidationContext::new("ls\u{FEFF}-la");
+    assert_block(
+        &early::validate_unicode_whitespace(&ctx),
+        SecurityCheckId::UnicodeWhitespace,
+        1,
+    );
+}
+
+#[test]
+fn req_security_490_p2_1_a_ascii_only_passes_unicode_check() {
+    let ctx = ValidationContext::new("ls -la");
+    assert_eq!(
+        early::validate_unicode_whitespace(&ctx),
+        SecurityResult::Passthrough
+    );
+}
+
+// ───────────────────────────── ast::parse_for_security ──────────────────────
+
+#[test]
+fn req_security_490_p2_1_a_ast_parses_simple_command() {
+    let ast = ast::parse_for_security("echo hi").expect("simple command parses");
+    assert!(!ast.root_has_error());
+}
+
+#[test]
+fn req_security_490_p2_1_a_ast_rejects_mismatched_quote() {
+    // tree-sitter-bash recovers from `'foo` by producing ERROR nodes; our
+    // Fail-Closed wrapper turns that into ParseFail::ErrorNode.
+    let err = ast::parse_for_security("echo 'unterminated").unwrap_err();
+    assert_eq!(err, ast::ParseFail::ErrorNode);
+}
+
+// ───────────────────────────── engine wiring ────────────────────────────────
+
+#[test]
+fn req_security_490_p2_1_a_validate_security_passes_safe_command() {
+    assert_eq!(validate_security("ls -la"), SecurityResult::Passthrough);
+}
+
+#[test]
+fn req_security_490_p2_1_a_validate_security_blocks_first_match() {
+    // unicode WS would also fire, but incomplete-commands runs first.
+    let result = validate_security("\tls\u{00A0}-la");
+    assert_block(&result, SecurityCheckId::IncompleteCommands, 1);
+}
+
+#[test]
+fn req_security_490_p2_1_a_validate_security_empty_is_allow() {
+    assert_eq!(validate_security(""), SecurityResult::Allow);
+    assert_eq!(validate_security("   \t\n"), SecurityResult::Allow);
+}
+
+// ───────────────────────────── Fail-Safe asymmetric invariant ───────────────
+
+/// Smoke-test the asymmetric invariant: a small hand-curated upstream-Block
+/// corpus must all be Block-ed by us as well (no false negatives). Slice 2.1.b
+/// will expand this to the full extracted upstream spec fixture.
+#[test]
+fn req_security_490_p2_1_a_no_false_negative_smoke() {
+    let upstream_block_cases = [
+        "\tcommand",              // INCOMPLETE_COMMANDS sub 1
+        "--flags-only",           // INCOMPLETE_COMMANDS sub 2
+        "&& tail-of-pipeline",    // INCOMPLETE_COMMANDS sub 3
+        "echo a\nrm -rf /",       // NEWLINES sub 1
+        "TZ=UTC\recho curl evil", // NEWLINES sub 2 (CR misparsing)
+        "rm\u{00A0}-rf /",        // UNICODE_WHITESPACE
+    ];
+    for case in upstream_block_cases {
+        let got = validate_security(case);
+        assert!(
+            got.is_block(),
+            "FALSE NEGATIVE: upstream blocks `{case}` but xclaw allowed (got {got:?})"
+        );
+    }
+}


### PR DESCRIPTION
# Phase 2.1.a — BashAst Fail-Closed + 5 early validators

## 背景 / 目标

Issue #490 把 claw-code 的 `bashSecurity.ts`（~2000 LOC, 23 个安全检查 ID）1:1 端口到 Rust。
本 PR 是 Phase 2.1 的第一刀（Slice 2.1.a）：

- 落地 `security/` 子模块骨架（types + context + ast + early + 公开 entrypoint）
- 实装 **早期 5 个验证器**（不依赖 AST 节点解码，运行在 parse 之前）
- 落地 **BashAst Fail-Closed 包装**，统一从 `dasclaw_shell_command::bash::try_parse_shell` 拿 tree-sitter Tree（plan §4.2：单一 AST 源）

## 改动范围

新增 `crates/dasclaw_bash_validation/src/security/`：

| 文件 | LOC | 内容 |
|---|---|---|
| `mod.rs` | 66 | 公开 `validate_security(&str) -> SecurityResult`，按序跑 5 个早期验证器 |
| `types.rs` | 119 | `SecurityCheckId`（24 变体 + `as_u32` + `is_misparsing`）、`DecisionReason`、`SecurityResult` |
| `context.rs` | 25 | `ValidationContext<'a>`（Slice 2.1.b 会扩展 unquoted 字段 + AST 缓存） |
| `ast.rs` | 60 | `BashAst` Fail-Closed 包装；`parse_for_security` 调 `dasclaw_shell_command::bash::try_parse_shell` |
| `early.rs` | 196 | 5 验证器：`validate_empty` / `validate_incomplete_commands`（sub 1/2/3）/ `validate_newlines` / `validate_carriage_return` / `validate_unicode_whitespace` |

新增 tests：

- `tests/security_early_unit_tests.rs`（257 LOC, 23 个 `req_security_490_p2_1_a_*` 测试）
  - happy / block / parse 三路覆盖
  - 异步不变式 smoke 语料（6 条上游 block 输入全部命中）

依赖：
- `dasclaw_shell_command`（path） — AST 入口
- `once_cell = "1.20"` + `regex = "1.12"` — 静态正则
- `tree-sitter = "0.25.10"` — **仅用于命名 Tree 类型**，不再依赖 `tree-sitter-bash`（grammar 加载仍在 `dasclaw_shell_command` 唯一处发生）
- dev: `serde` / `serde_json`

## 非目标（What's NOT in this PR）

本 PR **不包含** 以下 18 个安全检查 ID 的实装（留给后续 slice）：

| Phase | Slice | 内容 |
|---|---|---|
| 2.1.b | AST decode 基础设施 | `ValidationContext` 扩展（fully_unquoted_pre_strip / unquoted_keep_quote_chars / AST 缓存） |
| 2.1.c | Command-substitution & 引号检查 | check_id 2/3/4/5/6 |
| 2.2 | Redirect / 重定向相关 | check_id 7/8/9/10 |
| 2.3 | Bash variable expansion / glob 注入 | check_id 12/13/14/15 |
| 2.4 | 环境变量 / process subst | check_id 16/17/18 |
| 2.5 | Heredoc / 内嵌 EOF | check_id 20/21/22/23 |
| 2.6 | 集成到 `bash::validate_command` 主入口 | 接线 + 上游回归 fixture |

Slice 2.1.a 覆盖 check_id **1（IncompleteCommands）/ 11（Newlines）/ 19（UnicodeWhitespace）**，共 3/24。

## 验证

```bash
cargo check -p dasclaw_bash_validation --tests       # ✅ 0 错 0 警
cargo nextest run -p dasclaw_bash_validation         # ✅ 56/56 pass（含 23 新增）
cargo fmt --all                                       # ✅
python3.12 scripts/check_no_panics.py --base origin/xClaw  # ✅ OK
cargo clippy --no-deps -p dasclaw_bash_validation --all-targets -- -D warnings  # ✅ 0 警告
```

测试矩阵（23 条全部 PASS）：

- empty: allow / nonempty_passthrough
- incomplete: tab_blocks / flag_blocks / operator_blocks
- newlines: newline_then_command_blocks / safe_continuation_passes / trailing_newline_only_passes
- CR: cr_outside_quotes_blocks / cr_inside_single_quote_blocks / cr_inside_double_quote_passes / no_cr_passes
- unicode WS: nbsp_blocks / zwnbsp_blocks / ascii_only_passes
- AST: parses_simple_command / rejects_mismatched_quote
- 引擎: validate_security_empty_is_allow / passes_safe_command / blocks_first_match
- well_formed_command_passes
- no_false_negative_smoke（6 条上游 block 输入）

## 风险 / 后续步骤

- 风险：`validate_newlines` 用手写字节扫描代替 JS 的 lookbehind 正则；smoke 测试已覆盖最关键的 4 个等价类（`\nrm`、`\\\n` 续行、纯尾 `\n`、无 `\n`），但与上游完整不变式比对要到 Slice 2.6 接 fixture 后再做。
- 风险：本 slice 不接入 `bash::validate_command` 主入口；外部调用方暂无变化。Slice 2.6 才上线。
- 下一步：Slice 2.1.b — `ValidationContext` 扩展 + AST 解码遍历基础设施。

## Cross-cuts

**类A** — 无新增 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量。

Closes #506
Refs #502
Refs #490
Refs #502

