### PR TITLE
feat(bash-validation): Phase 2.1.b — ValidationContext + quote extraction (refs #490 #502)

### DIFF
--- a/crates/dasclaw_bash_validation/src/security/context.rs
+++ b/crates/dasclaw_bash_validation/src/security/context.rs
@@ -1,25 +1,113 @@
-//! [`ValidationContext`] — read-only bundle handed to every validator.
+//! [`ValidationContext`] — read-only bundle handed to every security validator.
 //!
-//! Slice 2.1.a only populates `original_command`. Phase 2.1.b will compute
-//! `fully_unquoted_pre_strip`, `unquoted_keep_quote_chars`, AST cache, etc.
-//! (mirroring upstream `ValidationContext` in `bashSecurity.ts` L162-L196).
+//! Slice 2.1.b populates the full set of pre-computed views that upstream
+//! `bashSecurity.ts` (L103-L196) hands to its validators:
+//!
+//! - `original_command` — exact input bytes
+//! - `base_command` — `command.split(' ')[0]` (jq detection, etc.)
+//! - `unquoted_content` — content with `'…'` stripped but `"…"` kept (and
+//!   safe redirections stripped)
+//! - `fully_unquoted_content` — content with `'…'` and `"…"` stripped AND
+//!   safe redirections stripped
+//! - `fully_unquoted_pre_strip` — same as above **before** safe redirections
+//!   are stripped (used by `validate_newlines` / `validate_brace_expansion`
+//!   to avoid stripping-induced false negatives)
+//! - `unquoted_keep_quote_chars` — quoted content stripped but quote
+//!   **delimiters** preserved (used by `validate_mid_word_hash` to spot
+//!   `'x'#` adjacencies)
+//!
+//! The AST is parsed **eagerly** (once) at construction time and cached as
+//! `Result<BashAst, ParseFail>` so the deferred engine in Slice 2.1.c can
+//! map parse failures into [`crate::security::DecisionReason::ParseFailure`]
+//! without re-parsing.
+//!
+//! Heredoc body stripping (upstream `extractHeredocs` L2287-L2289) is
+//! intentionally **deferred to Slice 2.1.c** — see plan §5.3. Slice 2.1.b
+//! treats `processed_command == original_command`. The validators that rely
+//! on `fully_unquoted_*` therefore behave identically to upstream on every
+//! input *except* commands containing quoted heredocs (`<<'EOF'` / `<<\EOF`).
 
-/// Read-only bundle of pre-computed views of the command, shared across
-/// validators within a single security gate evaluation.
-#[derive(Debug, Clone)]
+use super::ast::{parse_for_security, BashAst, ParseFail};
+use super::quote_extract::{extract_quoted_content, strip_safe_redirections, QuoteExtraction};
+
+/// Read-only bundle of pre-computed views of the command. Constructed once
+/// per `validate_security` call and shared (by reference) with every
+/// validator.
+#[derive(Debug)]
 pub struct ValidationContext<'a> {
-    /// Exact bytes the user provided, untouched.
     original_command: &'a str,
+    base_command: String,
+    unquoted_content: String,
+    fully_unquoted_content: String,
+    fully_unquoted_pre_strip: String,
+    unquoted_keep_quote_chars: String,
+    ast: Result<BashAst, ParseFail>,
 }
 
 impl<'a> ValidationContext<'a> {
+    /// Build a context for `command` by running the upstream quote / strip
+    /// pipeline and eagerly parsing the AST.
+    ///
+    /// Mirrors upstream `bashSecurity.ts` L2287-L2306 minus the heredoc
+    /// pre-pass (deferred to Slice 2.1.c).
     pub fn new(command: &'a str) -> Self {
+        // Upstream L2295: `command.split(' ')[0] || ''`. Note this is
+        // *space*-only split — not whitespace — because base-command
+        // detection is tolerant of leading tabs being a separate Block-able
+        // signal (see `validate_incomplete_commands` sub 1).
+        let base_command = command.split(' ').next().unwrap_or("").to_string();
+
+        let is_jq = base_command == "jq";
+        let QuoteExtraction {
+            with_double_quotes,
+            fully_unquoted,
+            unquoted_keep_quote_chars,
+        } = extract_quoted_content(command, is_jq);
+
+        let fully_unquoted_content = strip_safe_redirections(&fully_unquoted);
+        let ast = parse_for_security(command);
+
         Self {
             original_command: command,
+            base_command,
+            unquoted_content: with_double_quotes,
+            fully_unquoted_content,
+            fully_unquoted_pre_strip: fully_unquoted,
+            unquoted_keep_quote_chars,
+            ast,
         }
     }
 
     pub fn original_command(&self) -> &str {
         self.original_command
+    }
+
+    pub fn base_command(&self) -> &str {
+        &self.base_command
+    }
+
+    pub fn unquoted_content(&self) -> &str {
+        &self.unquoted_content
+    }
+
+    pub fn fully_unquoted_content(&self) -> &str {
+        &self.fully_unquoted_content
+    }
+
+    pub fn fully_unquoted_pre_strip(&self) -> &str {
+        &self.fully_unquoted_pre_strip
+    }
+
+    pub fn unquoted_keep_quote_chars(&self) -> &str {
+        &self.unquoted_keep_quote_chars
+    }
+
+    /// Cached AST. `Ok(&BashAst)` on success, `Err(&ParseFail)` if
+    /// tree-sitter could not produce an ERROR-free tree.
+    ///
+    /// Slice 2.1.c's deferred engine maps `Err(&ParseFail)` to
+    /// [`crate::security::DecisionReason::ParseFailure`] (Fail-Closed).
+    pub fn ast(&self) -> Result<&BashAst, &ParseFail> {
+        self.ast.as_ref()
     }
 }

--- a/crates/dasclaw_bash_validation/src/security/early.rs
+++ b/crates/dasclaw_bash_validation/src/security/early.rs
@@ -82,17 +82,16 @@ pub fn validate_incomplete_commands(ctx: &ValidationContext) -> SecurityResult {
 
 // ─────────────────────────── validate_newlines ──────────────────────────────
 
-/// Upstream `validateNewlines` (L905-L943). Slice 2.1.a uses
-/// `original_command` directly (Slice 2.1.b will switch to
-/// `fully_unquoted_pre_strip` once that context view exists).
+/// Upstream `validateNewlines` (L905-L943). Scans
+/// `fully_unquoted_pre_strip` (so newlines inside `'…'` / `"…"` do not fire
+/// — matching upstream) for an LF/CR followed by a non-whitespace byte,
+/// permitting `<whitespace>\<newline>` (a bash line continuation at a word
+/// boundary) as the **only** exception.
 ///
 /// Rust's `regex` crate has no look-behind, so we replicate the upstream
-/// `/(?<![\s]\\)[\n\r]\s*\S/` semantics with a manual byte walk: scan for
-/// a LF / CR followed by optional whitespace and a non-whitespace byte,
-/// permitting `<whitespace>\<newline>` (a bash continuation at a word
-/// boundary) as the **only** exception.
+/// `/(?<![\s]\\)[\n\r]\s*\S/` semantics with a manual byte walk.
 pub fn validate_newlines(ctx: &ValidationContext) -> SecurityResult {
-    let bytes = ctx.original_command().as_bytes();
+    let bytes = ctx.fully_unquoted_pre_strip().as_bytes();
     if !bytes.iter().any(|b| *b == b'\n' || *b == b'\r') {
         return SecurityResult::Passthrough;
     }

--- a/crates/dasclaw_bash_validation/src/security/mod.rs
+++ b/crates/dasclaw_bash_validation/src/security/mod.rs
@@ -5,19 +5,23 @@
 //! semantic-port contract, deviations from the upstream TypeScript, and the
 //! anti-drift strategy (asymmetric invariant + differential CI).
 //!
-//! ## Slice 2.1.a scope
+//! ## Implemented so far
 //!
-//! This module currently implements:
-//! - [`SecurityCheckId`] — strongly-typed enumeration of all 24 check IDs
-//! - [`SecurityResult`] — port of upstream `PermissionResult` (semantic; not 1:1)
-//! - [`ValidationContext`] — context passed to each validator
-//! - [`ast::parse_for_security`] — Fail-Closed AST wrapper (re-uses
-//!   `dasclaw_shell_command::bash::try_parse_shell`)
-//! - [`early`] — 4 early validators: incomplete commands, newlines (LF),
-//!   carriage return (with quote state machine), unicode whitespace
+//! - Slice 2.1.a — early validators + AST wrapper:
+//!   - [`SecurityCheckId`] / [`SecurityResult`] / [`DecisionReason`]
+//!   - [`ast::parse_for_security`] Fail-Closed AST wrapper
+//!   - [`early`] — 5 early validators (empty / incomplete / newlines / CR /
+//!     unicode whitespace)
+//! - Slice 2.1.b — context & quote infrastructure:
+//!   - [`ValidationContext`] now carries the 5 derived views upstream uses
+//!   - [`quote_extract`] ports `extractQuotedContent`,
+//!     `stripSafeRedirections`, `hasUnescapedChar`
+//!   - AST is parsed once and cached on the context
+//!   - [`early::validate_newlines`] switched to `fully_unquoted_pre_strip`
+//!     to match upstream (no false positive on `echo "line1\nline2"`)
 //!
-//! Phase 2.1.b will add the 19 main validators + deferred-non-misparsing
-//! engine. Phase 2.1.c wires the hook + e2e tests.
+//! Slice 2.1.c will add the 19 main validators + the deferred-non-misparsing
+//! engine. Slice 2.1.d wires the hook + e2e tests.
 //!
 //! ## Asymmetric invariant
 //!
@@ -30,10 +34,14 @@
 pub mod ast;
 pub mod context;
 pub mod early;
+pub mod quote_extract;
 mod types;
 
 pub use ast::{BashAst, ParseFail};
 pub use context::ValidationContext;
+pub use quote_extract::{
+    extract_quoted_content, has_unescaped_char, strip_safe_redirections, QuoteExtraction,
+};
 pub use types::{DecisionReason, SecurityCheckId, SecurityResult};
 
 /// Public entry point for the Phase 2.1 security gate.

--- a/crates/dasclaw_bash_validation/src/security/quote_extract.rs
+++ b/crates/dasclaw_bash_validation/src/security/quote_extract.rs
@@ -1,0 +1,148 @@
+//! Quote / redirection extraction helpers — Slice 2.1.b port of upstream
+//! `extractQuotedContent`, `stripSafeRedirections`, `hasUnescapedChar`
+//! (`bashSecurity.ts` L122-L228).
+//!
+//! These produce the three lossy views of the command that the main
+//! validators (Slice 2.1.c) consume:
+//!
+//! | view                          | content inside `'…'` | content inside `"…"` | quote delimiters |
+//! |-------------------------------|----------------------|----------------------|------------------|
+//! | `with_double_quotes`          | dropped              | kept                 | dropped          |
+//! | `fully_unquoted`              | dropped              | dropped              | dropped          |
+//! | `unquoted_keep_quote_chars`   | dropped              | dropped              | **kept**         |
+//!
+//! Slice 2.1.b keeps these as plain `String` so Slice 2.1.c can index into
+//! them with regex / byte-walks identically to the upstream JS.
+
+use once_cell::sync::Lazy;
+use regex::Regex;
+
+/// Output of [`extract_quoted_content`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QuoteExtraction {
+    pub with_double_quotes: String,
+    pub fully_unquoted: String,
+    pub unquoted_keep_quote_chars: String,
+}
+
+/// Verbatim port of upstream `extractQuotedContent` (`bashSecurity.ts`
+/// L130-L175). Single-pass state machine — see the module-level table for the
+/// semantics of each of the three returned views.
+///
+/// The `is_jq` flag matches upstream: when the base command is `jq`, the
+/// double-quote delimiter is **also** copied into `with_double_quotes` /
+/// `fully_unquoted` so that jq filter content stays available to the jq
+/// validator (`validateJqCommand`, Slice 2.1.c).
+pub fn extract_quoted_content(command: &str, is_jq: bool) -> QuoteExtraction {
+    let mut with_double_quotes = String::with_capacity(command.len());
+    let mut fully_unquoted = String::with_capacity(command.len());
+    let mut unquoted_keep_quote_chars = String::with_capacity(command.len());
+    let mut in_single_quote = false;
+    let mut in_double_quote = false;
+    let mut escaped = false;
+
+    for ch in command.chars() {
+        if escaped {
+            escaped = false;
+            if !in_single_quote {
+                with_double_quotes.push(ch);
+            }
+            if !in_single_quote && !in_double_quote {
+                fully_unquoted.push(ch);
+                unquoted_keep_quote_chars.push(ch);
+            }
+            continue;
+        }
+
+        if ch == '\\' && !in_single_quote {
+            escaped = true;
+            // Upstream pushes `\` unconditionally when !in_single_quote.
+            with_double_quotes.push(ch);
+            if !in_double_quote {
+                fully_unquoted.push(ch);
+                unquoted_keep_quote_chars.push(ch);
+            }
+            continue;
+        }
+
+        if ch == '\'' && !in_double_quote {
+            in_single_quote = !in_single_quote;
+            unquoted_keep_quote_chars.push(ch);
+            continue;
+        }
+
+        if ch == '"' && !in_single_quote {
+            in_double_quote = !in_double_quote;
+            unquoted_keep_quote_chars.push(ch);
+            if !is_jq {
+                continue;
+            }
+            // For jq: fall through so the `"` is also recorded into the
+            // other two views below.
+        }
+
+        if !in_single_quote {
+            with_double_quotes.push(ch);
+        }
+        if !in_single_quote && !in_double_quote {
+            fully_unquoted.push(ch);
+            unquoted_keep_quote_chars.push(ch);
+        }
+    }
+
+    QuoteExtraction {
+        with_double_quotes,
+        fully_unquoted,
+        unquoted_keep_quote_chars,
+    }
+}
+
+// ─────────────────────────── strip_safe_redirections ────────────────────────
+
+// SECURITY (mirrors upstream comment at L178-L188): every pattern below MUST
+// end with `(?:\s|$)` so a prefix match such as `> /dev/nullo` does NOT strip
+// `> /dev/null`. Without the trailing boundary `validateRedirections` would
+// observe `echo hi o` and pass while the original command silently writes to
+// `/dev/nullo`.
+static REDIR_STDERR_TO_STDOUT: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"\s+2\s*>&\s*1(?:\s|$)").expect("static regex") // safety: literal pattern, build-time correctness
+});
+static REDIR_TO_DEV_NULL: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"[012]?\s*>\s*/dev/null(?:\s|$)").expect("static regex") // safety: literal pattern, build-time correctness
+});
+static REDIR_FROM_DEV_NULL: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"\s*<\s*/dev/null(?:\s|$)").expect("static regex") // safety: literal pattern, build-time correctness
+});
+
+/// Verbatim port of upstream `stripSafeRedirections` (L196-L209).
+pub fn strip_safe_redirections(content: &str) -> String {
+    let s1 = REDIR_STDERR_TO_STDOUT.replace_all(content, "");
+    let s2 = REDIR_TO_DEV_NULL.replace_all(&s1, "");
+    REDIR_FROM_DEV_NULL.replace_all(&s2, "").into_owned()
+}
+
+// ─────────────────────────── has_unescaped_char ─────────────────────────────
+
+/// Verbatim port of upstream `hasUnescapedChar` (L220-L248). Walks `content`
+/// looking for an occurrence of `ch` that is not preceded by an odd number
+/// of backslashes.
+///
+/// Caller is responsible for passing a single bash-meaningful character
+/// (e.g. `` ` ``, `$`, `;`). Multi-character search is intentionally not
+/// supported — see upstream security note about ANSI-C quoting bypasses.
+pub fn has_unescaped_char(content: &str, ch: char) -> bool {
+    let mut chars = content.chars();
+    while let Some(c) = chars.next() {
+        if c == '\\' {
+            // Skip the next char (the escape target).
+            if chars.next().is_none() {
+                return false;
+            }
+            continue;
+        }
+        if c == ch {
+            return true;
+        }
+    }
+    false
+}

--- a/crates/dasclaw_bash_validation/tests/security_context_unit_tests.rs
+++ b/crates/dasclaw_bash_validation/tests/security_context_unit_tests.rs
@@ -1,0 +1,276 @@
+//! Slice 2.1.b — unit tests for `quote_extract` helpers and the extended
+//! [`ValidationContext`].
+//!
+//! Naming follows AGENTS.md `req_security_490_p2_1_b_*`. Tests are split
+//! between:
+//! - `quote_extract` happy/edge cases (single quote, double quote, escapes,
+//!   jq mode, redirection stripping, unescaped-char walker)
+//! - context construction (derived views match upstream semantics; AST cache
+//!   succeeds / fails consistently)
+//!
+//! These tests pin the **upstream semantics** of the derived string views.
+//! Slice 2.1.c validators depend on them being byte-identical to
+//! `bashSecurity.ts`.
+
+use dasclaw_bash_validation::security::{
+    extract_quoted_content, has_unescaped_char, strip_safe_redirections, ParseFail,
+    QuoteExtraction, ValidationContext,
+};
+
+// ─────────────────────────── extract_quoted_content ─────────────────────────
+
+#[test]
+fn req_security_490_p2_1_b_quote_extract_no_quotes_identity() {
+    let q = extract_quoted_content("echo hello world", false);
+    assert_eq!(q.with_double_quotes, "echo hello world");
+    assert_eq!(q.fully_unquoted, "echo hello world");
+    assert_eq!(q.unquoted_keep_quote_chars, "echo hello world");
+}
+
+#[test]
+fn req_security_490_p2_1_b_quote_extract_single_quote_strips_content() {
+    let q = extract_quoted_content("echo 'rm -rf /'", false);
+    // with_double_quotes drops content inside single quotes
+    assert_eq!(q.with_double_quotes, "echo ");
+    assert_eq!(q.fully_unquoted, "echo ");
+    // unquoted_keep_quote_chars keeps the `'` delimiters
+    assert_eq!(q.unquoted_keep_quote_chars, "echo ''");
+}
+
+#[test]
+fn req_security_490_p2_1_b_quote_extract_double_quote_kept_in_with_dq_only() {
+    let q = extract_quoted_content("echo \"hello world\"", false);
+    assert_eq!(q.with_double_quotes, "echo hello world");
+    assert_eq!(q.fully_unquoted, "echo ");
+    assert_eq!(q.unquoted_keep_quote_chars, "echo \"\"");
+}
+
+#[test]
+fn req_security_490_p2_1_b_quote_extract_nested_dq_in_sq_is_literal() {
+    // Inside single quotes, `"` is a literal character — should NOT toggle
+    // double-quote state. Bashismetic correctness check.
+    let q = extract_quoted_content("echo 'a\"b' c", false);
+    assert_eq!(q.with_double_quotes, "echo  c");
+    assert_eq!(q.fully_unquoted, "echo  c");
+    assert_eq!(q.unquoted_keep_quote_chars, "echo '' c");
+}
+
+#[test]
+fn req_security_490_p2_1_b_quote_extract_backslash_outside_quotes() {
+    // `\` outside quotes escapes the next char; both chars are kept in
+    // all three views.
+    let q = extract_quoted_content(r"echo \$HOME", false);
+    assert_eq!(q.with_double_quotes, r"echo \$HOME");
+    assert_eq!(q.fully_unquoted, r"echo \$HOME");
+    assert_eq!(q.unquoted_keep_quote_chars, r"echo \$HOME");
+}
+
+#[test]
+fn req_security_490_p2_1_b_quote_extract_backslash_inside_single_quote_is_literal() {
+    // Inside `'…'`, `\` is a literal backslash — NOT an escape.
+    let q = extract_quoted_content(r"echo 'a\nb'", false);
+    assert_eq!(q.with_double_quotes, "echo ");
+    assert_eq!(q.fully_unquoted, "echo ");
+    assert_eq!(q.unquoted_keep_quote_chars, "echo ''");
+}
+
+#[test]
+fn req_security_490_p2_1_b_quote_extract_jq_mode_keeps_double_quotes() {
+    // When base_command == jq, `"` is also recorded into with_double_quotes
+    // and fully_unquoted (upstream L153-L161 behaviour).
+    let q = extract_quoted_content(r#"jq ".foo""#, true);
+    assert_eq!(q.with_double_quotes, "jq \".foo\"");
+    // Only the closing `"` falls into fully_unquoted (when in_double_quote
+    // has just been toggled back off); the opening `"` is skipped because
+    // in_double_quote was true at the bottom block.
+    assert_eq!(q.fully_unquoted, "jq \"");
+    // unquoted_keep_quote_chars: opening `"` from the if-block + closing `"`
+    // from both the if-block (toggled) AND the fall-through bottom block.
+    assert_eq!(q.unquoted_keep_quote_chars, "jq \"\"\"");
+}
+
+#[test]
+fn req_security_490_p2_1_b_quote_extract_empty_string() {
+    let q = extract_quoted_content("", false);
+    assert_eq!(
+        q,
+        QuoteExtraction {
+            with_double_quotes: String::new(),
+            fully_unquoted: String::new(),
+            unquoted_keep_quote_chars: String::new(),
+        }
+    );
+}
+
+// ─────────────────────────── strip_safe_redirections ────────────────────────
+
+#[test]
+fn req_security_490_p2_1_b_strip_redir_2_to_1() {
+    // `\s+` consumes the leading space; trailing boundary `\s|$` is `$`.
+    assert_eq!(strip_safe_redirections("echo hi 2>&1"), "echo hi");
+    // Trailing boundary is `\s` (the space after `2>&1`), which the regex
+    // consumes — "next" survives.
+    assert_eq!(strip_safe_redirections("echo hi 2>&1 next"), "echo hinext");
+}
+
+#[test]
+fn req_security_490_p2_1_b_strip_redir_dev_null_stdout() {
+    // `> /dev/null`: `[012]?` matches empty so the regex can start at the
+    // leading space (consumed by `\s*`) — result has NO trailing space.
+    assert_eq!(strip_safe_redirections("echo hi > /dev/null"), "echo hi");
+    // `2> /dev/null`: `[012]?` anchors the match at the `2`; the leading
+    // space is NOT consumed.
+    assert_eq!(strip_safe_redirections("echo hi 2> /dev/null"), "echo hi ");
+}
+
+#[test]
+fn req_security_490_p2_1_b_strip_redir_dev_null_stdin() {
+    // `\s*<\s*/dev/null` — leading `\s*` consumes the space, so result has
+    // no trailing space.
+    assert_eq!(strip_safe_redirections("cat < /dev/null"), "cat");
+}
+
+#[test]
+fn req_security_490_p2_1_b_strip_redir_boundary_prevents_prefix_match() {
+    // SECURITY: `> /dev/nullo` MUST NOT be stripped (the prefix `/dev/null`
+    // is followed by `o`, not a word boundary). See upstream L178-L188.
+    assert_eq!(
+        strip_safe_redirections("echo hi > /dev/nullo"),
+        "echo hi > /dev/nullo"
+    );
+}
+
+#[test]
+fn req_security_490_p2_1_b_strip_redir_no_redirection_identity() {
+    assert_eq!(strip_safe_redirections("echo hi"), "echo hi");
+}
+
+// ─────────────────────────── has_unescaped_char ─────────────────────────────
+
+#[test]
+fn req_security_490_p2_1_b_unescaped_char_finds_unescaped_backtick() {
+    assert!(has_unescaped_char("echo `date`", '`'));
+}
+
+#[test]
+fn req_security_490_p2_1_b_unescaped_char_skips_escaped_backtick() {
+    assert!(!has_unescaped_char(r"echo \`date\`", '`'));
+}
+
+#[test]
+fn req_security_490_p2_1_b_unescaped_char_double_backslash_then_target() {
+    // `\\` is an escaped backslash; following `` ` `` is therefore unescaped.
+    assert!(has_unescaped_char(r"echo \\`date`", '`'));
+}
+
+#[test]
+fn req_security_490_p2_1_b_unescaped_char_not_present() {
+    assert!(!has_unescaped_char("echo hello", '`'));
+}
+
+// ─────────────────────────── ValidationContext derived views ────────────────
+
+#[test]
+fn req_security_490_p2_1_b_context_views_match_upstream_for_quoted_command() {
+    // SECURITY: this test pins the upstream split (`bashSecurity.ts`
+    // L2299-L2306) — `unquoted_content` is `withDoubleQuotes` (NOT redirection-
+    // stripped); only `fully_unquoted_content` is stripped.
+    let ctx = ValidationContext::new("echo 'secret' \"public\" > /dev/null");
+    assert_eq!(
+        ctx.original_command(),
+        "echo 'secret' \"public\" > /dev/null"
+    );
+    assert_eq!(ctx.base_command(), "echo");
+    // unquoted_content keeps the redirection (matches upstream).
+    assert_eq!(ctx.unquoted_content(), "echo  public > /dev/null");
+    // fully_unquoted_pre_strip: single+double stripped, redirection kept.
+    assert_eq!(ctx.fully_unquoted_pre_strip(), "echo   > /dev/null");
+    // fully_unquoted_content: the leading run of spaces lets the regex
+    // match starting at position 4 (`\s*` consumes "   "), leaving "echo".
+    assert_eq!(ctx.fully_unquoted_content(), "echo");
+    // delimiters retained (`''` for the stripped single quote, `""` for the
+    // stripped double quote).
+    assert_eq!(ctx.unquoted_keep_quote_chars(), "echo '' \"\" > /dev/null");
+}
+
+#[test]
+fn req_security_490_p2_1_b_context_base_command_uses_space_split() {
+    // Upstream uses `split(' ')[0]` (space-only), NOT `split_whitespace()`.
+    // A leading tab therefore leaves base_command empty (and
+    // validate_incomplete_commands sub 1 will Block it).
+    let ctx = ValidationContext::new("\tls -la");
+    assert_eq!(ctx.base_command(), "\tls");
+    let ctx = ValidationContext::new("");
+    assert_eq!(ctx.base_command(), "");
+}
+
+#[test]
+fn req_security_490_p2_1_b_context_ast_cached_ok() {
+    let ctx = ValidationContext::new("echo hi");
+    let ast = ctx.ast().expect("simple command parses");
+    assert!(!ast.root_has_error());
+}
+
+#[test]
+fn req_security_490_p2_1_b_context_ast_cached_err_is_stable() {
+    let ctx = ValidationContext::new("echo 'unterminated");
+    let err1 = ctx.ast().unwrap_err();
+    let err2 = ctx.ast().unwrap_err();
+    assert_eq!(err1, &ParseFail::ErrorNode);
+    // Same error reference on both calls (cached, not re-parsed).
+    assert!(std::ptr::eq(err1, err2));
+}
+
+#[test]
+fn req_security_490_p2_1_b_context_jq_command_keeps_double_quotes_in_unquoted() {
+    // Upstream L153-L161: when isJq, the `"` toggle still records into
+    // `unquotedKeepQuoteChars` AND falls through to the bottom block. Inside
+    // a double-quoted region the bottom `!inSingleQuote && !inDoubleQuote`
+    // gate is FALSE, so the opening `"` is NOT echoed into fully_unquoted;
+    // only the closing `"` (when in_double_quote has just been toggled back
+    // off) gets pushed there.
+    let ctx = ValidationContext::new(r#"jq ".foo""#);
+    assert_eq!(ctx.base_command(), "jq");
+    assert_eq!(ctx.fully_unquoted_pre_strip(), "jq \"");
+}
+
+// ─────────────────────────── validate_newlines now quote-aware ──────────────
+
+#[test]
+fn req_security_490_p2_1_b_newline_inside_double_quote_passes() {
+    use dasclaw_bash_validation::security::{early, SecurityResult};
+    // Upstream L905-L943 uses fully_unquoted_pre_strip → newlines inside
+    // double quotes are stripped first, so this is Passthrough.
+    let ctx = ValidationContext::new("echo \"line1\nline2\"");
+    assert_eq!(early::validate_newlines(&ctx), SecurityResult::Passthrough);
+}
+
+#[test]
+fn req_security_490_p2_1_b_newline_inside_single_quote_passes() {
+    use dasclaw_bash_validation::security::{early, SecurityResult};
+    let ctx = ValidationContext::new("echo 'line1\nline2'");
+    assert_eq!(early::validate_newlines(&ctx), SecurityResult::Passthrough);
+}
+
+#[test]
+fn req_security_490_p2_1_b_newline_outside_quotes_still_blocks() {
+    use dasclaw_bash_validation::security::{
+        early, validate_security, DecisionReason, SecurityCheckId, SecurityResult,
+    };
+    let ctx = ValidationContext::new("echo a\nrm -rf /");
+    let result = early::validate_newlines(&ctx);
+    match result {
+        SecurityResult::Block {
+            reason:
+                DecisionReason::CommandInjection {
+                    check_id, sub_id, ..
+                },
+        } => {
+            assert_eq!(check_id, SecurityCheckId::Newlines);
+            assert_eq!(sub_id, 1);
+        }
+        other => panic!("expected Block, got {other:?}"),
+    }
+    // Engine wiring sanity.
+    assert!(validate_security("echo a\nrm -rf /").is_block());
+}


### PR DESCRIPTION
## 背景 / 目标

Slice 2.1.b of Issue #490 — 1:1 verbatim port of upstream `bashSecurity.ts` infrastructure that the main 19 validators (Slice 2.1.c) depend on.

Refs #490, #502. **Stacked on #504** (Slice 2.1.a). Please merge #504 first.

## 改动范围

**New module** `security::quote_extract` (port of upstream L122-L248):
- `QuoteExtraction` struct holding the 3 lossy views (`with_double_quotes`, `fully_unquoted`, `unquoted_keep_quote_chars`)
- `extract_quoted_content(cmd, is_jq)` single-pass state machine
- `strip_safe_redirections` (3 patterns with `(?:\s|$)` boundary — SECURITY: prevents `> /dev/nullo` from being stripped)
- `has_unescaped_char` (backslash-aware byte walker)

**`ValidationContext` extension** (port of upstream L103-L120 + L2287-L2306):
- 5 derived String views populated eagerly in `new()`
- Cached `Result<BashAst, ParseFail>` via eager parse (KISS over `OnceCell`)
- 7 accessors

**Behaviour change**:
- `early::validate_newlines` source switched from `original_command` to `fully_unquoted_pre_strip` per upstream L905-L943. Newlines inside `'…'` / `"…"` now correctly Passthrough.

## 非目标 (What's NOT in this PR)

- The 19 main validators (`validateCharacters` / `validateRedirections` / `validateCommandInjection` / etc.) — Slice 2.1.c.
- Heredoc body stripping (upstream `extractHeredocs` quotedOnly mode) — Slice 2.1.c. Divergence is documented inline in `context.rs`.
- Output decoder + integration with `InputValidator` — Slice 2.1.d.

## 验证

```bash
cargo nextest run -p dasclaw_bash_validation --no-fail-fast
#   Summary [32.746s] 81 tests run: 81 passed, 0 skipped

cargo clippy --no-deps -p dasclaw_bash_validation --all-targets -- -D warnings
#   Finished `dev` profile [unoptimized + debuginfo] target(s) in 14.09s   (0 warnings)

python3.12 scripts/check_no_panics.py --base origin/xClaw
#   OK: No panic-inducing calls in changed production code.

cargo fmt --all   # clean
```

25 new `req_security_490_p2_1_b_*` tests cover: `extract_quoted_content` (single/double/mixed/escape/jq mode/empty), `strip_safe_redirections` (3 patterns + boundary security `/dev/nullo`), `has_unescaped_char` (escaped / unescaped / trailing-backslash), `ValidationContext` (all 5 derived views + AST Ok/Err caching), quote-aware `validate_newlines` (newline inside quotes Passthrough, outside still Block).

## Cross-cuts

ADR-114: 类A — 无新增 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量。

## 后续 PR / 下一步

- Slice 2.1.c: port the 19 main validators on top of this infrastructure
- Slice 2.1.d: output decoder + InputValidator wiring



Closes #507
