### PR TITLE
feat(bash-validation): Slice 2.1.c1 — 9 string-only main validators + deferred-non-misparsing engine

### DIFF
--- a/crates/dasclaw_bash_validation/src/security/mod.rs
+++ b/crates/dasclaw_bash_validation/src/security/mod.rs
@@ -35,6 +35,7 @@ pub mod ast;
 pub mod context;
 pub mod early;
 pub mod quote_extract;
+pub mod regex_validators;
 mod types;
 
 pub use ast::{BashAst, ParseFail};
@@ -46,29 +47,113 @@ pub use types::{DecisionReason, SecurityCheckId, SecurityResult};
 
 /// Public entry point for the Phase 2.1 security gate.
 ///
-/// Runs the four early validators sequentially; first non-Passthrough result
-/// wins.
+/// Runs validators in upstream `bashSecurity.ts` order (L2348-L2377),
+/// preserving the **deferred-non-misparsing engine** (L2393-L2407):
 ///
-/// **Slice 2.1.a behaviour**: only the four early validators run. Slice 2.1.b
-/// will splice in the deferred-non-misparsing engine (upstream
-/// `bashSecurity.ts` L2371-2387) and the 19 main validators.
+/// - Validators flagged by [`SecurityCheckId::is_misparsing`] return
+///   immediately on the first non-Passthrough result.
+/// - Validators flagged as non-misparsing (`validate_newlines`,
+///   `validate_redirections`) have their decisive result *deferred*: a later
+///   misparsing-sensitive validator that fires gets priority. If no
+///   misparsing validator fires, the earliest deferred non-misparsing
+///   result is surfaced.
+///
+/// In Phase 2.1 we collapse `ask` → `Block` regardless, but preserving the
+/// deferred ordering means the surfaced [`DecisionReason`] mirrors upstream's
+/// precedence — a precondition for the differential test invariant.
 pub fn validate_security(command: &str) -> SecurityResult {
     let ctx = ValidationContext::new(command);
 
-    let validators: &[fn(&ValidationContext) -> SecurityResult] = &[
-        early::validate_empty,
-        early::validate_incomplete_commands,
-        early::validate_newlines,
-        early::validate_carriage_return,
-        early::validate_unicode_whitespace,
+    // Upstream pipeline order. Each entry: (validator, check_id_for_misparsing_flag).
+    //
+    // The check_id stored here is only used to consult `is_misparsing` — the
+    // validator itself populates the real check_id inside `DecisionReason`.
+    //
+    // NOTE: Slice 2.1.c1 lands only the 9 regex-only validators below
+    // (plus the 5 early ones). Slice 2.1.c2 will splice in the 9 AST-walking
+    // validators (jq*, obfuscated, backslash*, brace, zsh, malformed) at
+    // their upstream positions. Order matters for `DecisionReason`
+    // precedence; entries are placed at their final upstream slots so c2
+    // is a pure insertion.
+    type V = fn(&ValidationContext) -> SecurityResult;
+    let pipeline: &[(V, SecurityCheckId)] = &[
+        // --- Early phase (always misparsing-sensitive in our port) ---
+        (early::validate_empty, SecurityCheckId::IncompleteCommands),
+        (
+            early::validate_incomplete_commands,
+            SecurityCheckId::IncompleteCommands,
+        ),
+        // (Slice 2.1.c2) validate_jq_*, validate_obfuscated_flags
+        (
+            regex_validators::validate_shell_metacharacters,
+            SecurityCheckId::ShellMetacharacters,
+        ),
+        (
+            regex_validators::validate_dangerous_variables,
+            SecurityCheckId::DangerousVariables,
+        ),
+        (
+            regex_validators::validate_comment_quote_desync,
+            SecurityCheckId::CommentQuoteDesync,
+        ),
+        (
+            regex_validators::validate_quoted_newline,
+            SecurityCheckId::QuotedNewline,
+        ),
+        (
+            early::validate_carriage_return,
+            SecurityCheckId::IncompleteCommands,
+        ),
+        // validate_newlines is non-misparsing → deferred.
+        (early::validate_newlines, SecurityCheckId::Newlines),
+        (
+            regex_validators::validate_ifs_injection,
+            SecurityCheckId::IfsInjection,
+        ),
+        (
+            regex_validators::validate_proc_environ_access,
+            SecurityCheckId::ProcEnvironAccess,
+        ),
+        (
+            regex_validators::validate_dangerous_patterns,
+            SecurityCheckId::DangerousPatternsCommandSubstitution,
+        ),
+        // validate_redirections is non-misparsing → deferred.
+        (
+            regex_validators::validate_redirections,
+            SecurityCheckId::DangerousPatternsInputRedirection,
+        ),
+        // (Slice 2.1.c2) validate_backslash_escaped_whitespace,
+        //                validate_backslash_escaped_operators
+        (
+            early::validate_unicode_whitespace,
+            SecurityCheckId::UnicodeWhitespace,
+        ),
+        (
+            regex_validators::validate_mid_word_hash,
+            SecurityCheckId::MidWordHash,
+        ),
+        // (Slice 2.1.c2) validate_brace_expansion, validate_zsh_dangerous_commands,
+        //                validate_malformed_token_injection
     ];
 
-    for validator in validators {
+    let mut deferred: Option<SecurityResult> = None;
+
+    for (validator, flag_id) in pipeline {
         match validator(&ctx) {
             SecurityResult::Passthrough => continue,
-            decisive => return decisive,
+            SecurityResult::Allow => return SecurityResult::Allow,
+            decisive @ SecurityResult::Block { .. } => {
+                if flag_id.is_misparsing() {
+                    return decisive;
+                }
+                // Non-misparsing: defer (keep earliest only).
+                if deferred.is_none() {
+                    deferred = Some(decisive);
+                }
+            }
         }
     }
 
-    SecurityResult::Passthrough
+    deferred.unwrap_or(SecurityResult::Passthrough)
 }

--- a/crates/dasclaw_bash_validation/src/security/regex_validators.rs
+++ b/crates/dasclaw_bash_validation/src/security/regex_validators.rs
@@ -71,33 +71,33 @@ static SHELL_META_QUOTED: Lazy<Regex> = Lazy::new(|| {
     // safety: literal pattern
 });
 static SHELL_META_NAME: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r#"-name\s+["'][^"']*[;|&][^"']*["']"#).expect("static regex") // safety
+    Regex::new(r#"-name\s+["'][^"']*[;|&][^"']*["']"#).expect("static regex") // safety: static literal pattern, compile-time validated
 });
 static SHELL_META_PATH: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r#"-path\s+["'][^"']*[;|&][^"']*["']"#).expect("static regex") // safety
+    Regex::new(r#"-path\s+["'][^"']*[;|&][^"']*["']"#).expect("static regex") // safety: static literal pattern, compile-time validated
 });
 static SHELL_META_INAME: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r#"-iname\s+["'][^"']*[;|&][^"']*["']"#).expect("static regex") // safety
+    Regex::new(r#"-iname\s+["'][^"']*[;|&][^"']*["']"#).expect("static regex") // safety: static literal pattern, compile-time validated
 });
 static SHELL_META_REGEX: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r#"-regex\s+["'][^"']*[;&][^"']*["']"#).expect("static regex") // safety
+    Regex::new(r#"-regex\s+["'][^"']*[;&][^"']*["']"#).expect("static regex") // safety: static literal pattern, compile-time validated
 });
 
 // validateDangerousVariables (L828-L831)
 static DANGEROUS_VAR_REDIR_TO: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r"[<>|]\s*\$[A-Za-z_]").expect("static regex") // safety
+    Regex::new(r"[<>|]\s*\$[A-Za-z_]").expect("static regex") // safety: static literal pattern, compile-time validated
 });
 static DANGEROUS_VAR_REDIR_FROM: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r"\$[A-Za-z_][A-Za-z0-9_]*\s*[|<>]").expect("static regex") // safety
+    Regex::new(r"\$[A-Za-z_][A-Za-z0-9_]*\s*[|<>]").expect("static regex") // safety: static literal pattern, compile-time validated
 });
 
 // validateIFSInjection (L1023)
 static IFS_INJECTION_RE: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"\$IFS|\$\{[^}]*IFS").expect("static regex")); // safety
+    Lazy::new(|| Regex::new(r"\$IFS|\$\{[^}]*IFS").expect("static regex")); // safety: static literal pattern, compile-time validated
 
 // validateProcEnvironAccess (L1057)
 static PROC_ENVIRON_RE: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"/proc/.*/environ").expect("static regex")); // safety
+    Lazy::new(|| Regex::new(r"/proc/.*/environ").expect("static regex")); // safety: static literal pattern, compile-time validated
 
 // =========================================================================
 // Validators

--- a/crates/dasclaw_bash_validation/src/security/regex_validators.rs
+++ b/crates/dasclaw_bash_validation/src/security/regex_validators.rs
@@ -1,0 +1,394 @@
+//! Slice 2.1.c1 — 9 regex / state-machine main validators.
+//!
+//! 1:1 port of upstream `bashSecurity.ts` validators that operate purely on
+//! string views (no AST decoding):
+//!
+//! - [`validate_shell_metacharacters`] (L783-L822, check_id 5)
+//! - [`validate_dangerous_variables`] (L823-L845, check_id 6)
+//! - [`validate_dangerous_patterns`] (L846-L874, check_ids 8 / backtick)
+//! - [`validate_redirections`] (L875-L903, check_ids 9 / 10)
+//! - [`validate_ifs_injection`] (L1017-L1039, check_id 11)
+//! - [`validate_proc_environ_access`] (L1041-L1079, check_id 13)
+//! - [`validate_mid_word_hash`] (L1919-L1988, check_id 19)
+//! - [`validate_comment_quote_desync`] (L1990-L2107, check_id 22)
+//! - [`validate_quoted_newline`] (L2109-L2184, check_id 23)
+//!
+//! All `behavior: 'ask'` upstream outcomes are collapsed to
+//! [`SecurityResult::Block`] in Phase 2.1 per plan §0 (Porting model);
+//! the deferred-non-misparsing engine still preserves upstream's surfaced
+//! [`DecisionReason`] precedence (see `mod.rs`).
+
+use once_cell::sync::Lazy;
+use regex::Regex;
+
+use super::context::ValidationContext;
+use super::quote_extract::has_unescaped_char;
+use super::types::{DecisionReason, SecurityCheckId, SecurityResult};
+
+// =========================================================================
+// Static patterns
+// =========================================================================
+
+/// Upstream `COMMAND_SUBSTITUTION_PATTERNS` (L14-L42). Each entry maps to a
+/// human-readable substring of the upstream message format
+/// `"Command contains <message>"`.
+struct CommandSubstitutionPattern {
+    re: Regex,
+    message: &'static str,
+}
+
+static COMMAND_SUBSTITUTION_PATTERNS: Lazy<Vec<CommandSubstitutionPattern>> = Lazy::new(|| {
+    let entries: &[(&str, &str)] = &[
+        (r"<\(", "process substitution <()"),
+        (r">\(", "process substitution >()"),
+        (r"=\(", "Zsh process substitution =()"),
+        // Zsh EQUALS expansion: =cmd at word start (not VAR=val).
+        (r"(?:^|[\s;&|])=[a-zA-Z_]", "Zsh equals expansion (=cmd)"),
+        (r"\$\(", "$() command substitution"),
+        (r"\$\{", "${} parameter substitution"),
+        (r"\$\[", "$[] legacy arithmetic expansion"),
+        (r"~\[", "Zsh-style parameter expansion"),
+        (r"\(e:", "Zsh-style glob qualifiers"),
+        (r"\(\+", "Zsh glob qualifier with command execution"),
+        (
+            r"\}\s*always\s*\{",
+            "Zsh always block (try/always construct)",
+        ),
+        (r"<#", "PowerShell comment syntax"),
+    ];
+    entries
+        .iter()
+        .map(|(p, m)| CommandSubstitutionPattern {
+            re: Regex::new(p).expect("static regex"), // safety: literal pattern, compile-time validated
+            message: m,
+        })
+        .collect()
+});
+
+// validateShellMetacharacters sub-patterns (L791, L798-L802, L815)
+static SHELL_META_QUOTED: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r#"(?:^|\s)["'][^"']*[;&][^"']*["'](?:\s|$)"#).expect("static regex")
+    // safety: literal pattern
+});
+static SHELL_META_NAME: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r#"-name\s+["'][^"']*[;|&][^"']*["']"#).expect("static regex") // safety
+});
+static SHELL_META_PATH: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r#"-path\s+["'][^"']*[;|&][^"']*["']"#).expect("static regex") // safety
+});
+static SHELL_META_INAME: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r#"-iname\s+["'][^"']*[;|&][^"']*["']"#).expect("static regex") // safety
+});
+static SHELL_META_REGEX: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r#"-regex\s+["'][^"']*[;&][^"']*["']"#).expect("static regex") // safety
+});
+
+// validateDangerousVariables (L828-L831)
+static DANGEROUS_VAR_REDIR_TO: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"[<>|]\s*\$[A-Za-z_]").expect("static regex") // safety
+});
+static DANGEROUS_VAR_REDIR_FROM: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"\$[A-Za-z_][A-Za-z0-9_]*\s*[|<>]").expect("static regex") // safety
+});
+
+// validateIFSInjection (L1023)
+static IFS_INJECTION_RE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"\$IFS|\$\{[^}]*IFS").expect("static regex")); // safety
+
+// validateProcEnvironAccess (L1057)
+static PROC_ENVIRON_RE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"/proc/.*/environ").expect("static regex")); // safety
+
+// =========================================================================
+// Validators
+// =========================================================================
+
+fn injection(check_id: SecurityCheckId, sub_id: u32, message: &str) -> SecurityResult {
+    SecurityResult::Block {
+        reason: DecisionReason::CommandInjection {
+            check_id,
+            sub_id,
+            message: message.to_string(),
+        },
+    }
+}
+
+/// Upstream `validateShellMetacharacters` (L783-L822). 3 sub-IDs.
+pub fn validate_shell_metacharacters(ctx: &ValidationContext) -> SecurityResult {
+    let unquoted = ctx.unquoted_content();
+    let msg = "Command contains shell metacharacters (;, |, or &) in arguments";
+
+    if SHELL_META_QUOTED.is_match(unquoted) {
+        return injection(SecurityCheckId::ShellMetacharacters, 1, msg);
+    }
+    if SHELL_META_NAME.is_match(unquoted)
+        || SHELL_META_PATH.is_match(unquoted)
+        || SHELL_META_INAME.is_match(unquoted)
+    {
+        return injection(SecurityCheckId::ShellMetacharacters, 2, msg);
+    }
+    if SHELL_META_REGEX.is_match(unquoted) {
+        return injection(SecurityCheckId::ShellMetacharacters, 3, msg);
+    }
+    SecurityResult::Passthrough
+}
+
+/// Upstream `validateDangerousVariables` (L823-L845).
+pub fn validate_dangerous_variables(ctx: &ValidationContext) -> SecurityResult {
+    let fully_unquoted = ctx.fully_unquoted_content();
+    if DANGEROUS_VAR_REDIR_TO.is_match(fully_unquoted)
+        || DANGEROUS_VAR_REDIR_FROM.is_match(fully_unquoted)
+    {
+        return injection(
+            SecurityCheckId::DangerousVariables,
+            1,
+            "Command contains variables in dangerous contexts (redirections or pipes)",
+        );
+    }
+    SecurityResult::Passthrough
+}
+
+/// Upstream `validateDangerousPatterns` (L846-L874).
+///
+/// Reports check_id `DangerousPatternsCommandSubstitution` (8) for all
+/// branches. Sub-IDs:
+///   - `0` — unescaped backtick (upstream emits no `logEvent` here; we assign
+///     `0` to distinguish from the regex-pattern branch)
+///   - `1` — any [`COMMAND_SUBSTITUTION_PATTERNS`] hit
+pub fn validate_dangerous_patterns(ctx: &ValidationContext) -> SecurityResult {
+    let unquoted = ctx.unquoted_content();
+
+    if has_unescaped_char(unquoted, '`') {
+        return injection(
+            SecurityCheckId::DangerousPatternsCommandSubstitution,
+            0,
+            "Command contains backticks (`) for command substitution",
+        );
+    }
+
+    for entry in COMMAND_SUBSTITUTION_PATTERNS.iter() {
+        if entry.re.is_match(unquoted) {
+            return injection(
+                SecurityCheckId::DangerousPatternsCommandSubstitution,
+                1,
+                &format!("Command contains {}", entry.message),
+            );
+        }
+    }
+    SecurityResult::Passthrough
+}
+
+/// Upstream `validateRedirections` (L875-L903). Two distinct check IDs.
+pub fn validate_redirections(ctx: &ValidationContext) -> SecurityResult {
+    let fully_unquoted = ctx.fully_unquoted_content();
+
+    if fully_unquoted.contains('<') {
+        return injection(
+            SecurityCheckId::DangerousPatternsInputRedirection,
+            1,
+            "Command contains input redirection (<) which could read sensitive files",
+        );
+    }
+    if fully_unquoted.contains('>') {
+        return injection(
+            SecurityCheckId::DangerousPatternsOutputRedirection,
+            1,
+            "Command contains output redirection (>) which could write to arbitrary files",
+        );
+    }
+    SecurityResult::Passthrough
+}
+
+/// Upstream `validateIFSInjection` (L1017-L1039).
+pub fn validate_ifs_injection(ctx: &ValidationContext) -> SecurityResult {
+    if IFS_INJECTION_RE.is_match(ctx.original_command()) {
+        return injection(
+            SecurityCheckId::IfsInjection,
+            1,
+            "Command contains IFS variable usage which could bypass security validation",
+        );
+    }
+    SecurityResult::Passthrough
+}
+
+/// Upstream `validateProcEnvironAccess` (L1041-L1079).
+pub fn validate_proc_environ_access(ctx: &ValidationContext) -> SecurityResult {
+    if PROC_ENVIRON_RE.is_match(ctx.original_command()) {
+        return injection(
+            SecurityCheckId::ProcEnvironAccess,
+            1,
+            "Command accesses /proc/*/environ which could expose sensitive environment variables",
+        );
+    }
+    SecurityResult::Passthrough
+}
+
+/// Upstream `validateMidWordHash` (L1919-L1962).
+///
+/// Detects `#` preceded by a non-whitespace char (mid-word hash) — a
+/// shell-quote vs bash parser differential. Excludes `${#` (bash string-length).
+/// Also checks the continuation-joined form to catch backslash-newline bypasses.
+pub fn validate_mid_word_hash(ctx: &ValidationContext) -> SecurityResult {
+    let keep = ctx.unquoted_keep_quote_chars();
+    if mid_word_hash_present(keep) || mid_word_hash_present(&join_continuations(keep)) {
+        return injection(
+            SecurityCheckId::MidWordHash,
+            1,
+            "Command contains mid-word # which is parsed differently by shell-quote vs bash",
+        );
+    }
+    SecurityResult::Passthrough
+}
+
+/// Replicates upstream's `/\S(?<!\$\{)#/` lookbehind: returns true iff there
+/// is a `#` whose preceding character is non-whitespace AND the two chars
+/// before that `#` are not `${`.
+fn mid_word_hash_present(s: &str) -> bool {
+    let bytes = s.as_bytes();
+    for (i, &b) in bytes.iter().enumerate() {
+        if b != b'#' || i == 0 {
+            continue;
+        }
+        let prev = bytes[i - 1];
+        if prev.is_ascii_whitespace() {
+            continue;
+        }
+        // Exclude `${#` — i.e. prev=='{' and bytes[i-2]=='$'
+        if prev == b'{' && i >= 2 && bytes[i - 2] == b'$' {
+            continue;
+        }
+        return true;
+    }
+    false
+}
+
+/// Mirrors upstream's `/\\+\n/g` continuation-join (L1944-L1946):
+/// odd backslash count → drop the trailing backslash and the newline;
+/// even backslash count → leave the match unchanged.
+fn join_continuations(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let bytes = s.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'\\' {
+            // Count consecutive backslashes
+            let start = i;
+            while i < bytes.len() && bytes[i] == b'\\' {
+                i += 1;
+            }
+            let count = i - start;
+            // Followed by '\n'?
+            if i < bytes.len() && bytes[i] == b'\n' {
+                if count % 2 == 1 {
+                    // odd → drop one backslash + the newline
+                    out.push_str(&"\\".repeat(count - 1));
+                } else {
+                    out.push_str(&"\\".repeat(count));
+                    out.push('\n');
+                }
+                i += 1; // skip the newline
+            } else {
+                out.push_str(&"\\".repeat(count));
+            }
+            continue;
+        }
+        // SAFETY: bytes[i] is ASCII or start of a UTF-8 sequence; we copy by char.
+        let ch_start = i;
+        let ch_len = utf8_char_len(bytes[i]);
+        let end = (ch_start + ch_len).min(bytes.len());
+        // safety: indices ch_start..end are valid UTF-8 char boundaries by construction
+        out.push_str(&s[ch_start..end]);
+        i = end;
+    }
+    out
+}
+
+fn utf8_char_len(first_byte: u8) -> usize {
+    match first_byte {
+        b if b < 0x80 => 1,
+        b if b < 0xC0 => 1, // invalid leading byte; advance by 1 to make progress
+        b if b < 0xE0 => 2,
+        b if b < 0xF0 => 3,
+        _ => 4,
+    }
+}
+
+/// Upstream `validateCommentQuoteDesync` (L1990-L2106).
+///
+/// Per upstream L1994-L2000: when tree-sitter is the authoritative quote
+/// context (which is always the case in our port), this validator is a
+/// pure passthrough — the regex-tracker desync that this check defends
+/// against cannot occur when the AST is the source of truth.
+pub fn validate_comment_quote_desync(_ctx: &ValidationContext) -> SecurityResult {
+    // Tree-sitter is always available in our port (single AST source per
+    // plan §4.2). The desync the upstream regex path defends against is
+    // structurally impossible when the AST is authoritative.
+    SecurityResult::Passthrough
+}
+
+/// Upstream `validateQuotedNewline` (L2109-L2184).
+///
+/// Detects an in-quotes newline followed by a line whose `trim()` starts
+/// with `#` — exactly the trigger that upstream `stripCommentLines` would
+/// drop, hiding arguments from downstream path validation.
+pub fn validate_quoted_newline(ctx: &ValidationContext) -> SecurityResult {
+    let cmd = ctx.original_command();
+
+    // Fast path: must have both '\n' and '#' somewhere.
+    if !cmd.contains('\n') || !cmd.contains('#') {
+        return SecurityResult::Passthrough;
+    }
+
+    let bytes = cmd.as_bytes();
+    let mut in_single = false;
+    let mut in_double = false;
+    let mut escaped = false;
+    let mut i = 0;
+    while i < bytes.len() {
+        let b = bytes[i];
+
+        if escaped {
+            escaped = false;
+            i += 1;
+            continue;
+        }
+
+        if b == b'\\' && !in_single {
+            escaped = true;
+            i += 1;
+            continue;
+        }
+
+        if b == b'\'' && !in_double {
+            in_single = !in_single;
+            i += 1;
+            continue;
+        }
+
+        if b == b'"' && !in_single {
+            in_double = !in_double;
+            i += 1;
+            continue;
+        }
+
+        if b == b'\n' && (in_single || in_double) {
+            // Find the next line's bounds.
+            let line_start = i + 1;
+            let next_nl = cmd[line_start..]
+                .find('\n')
+                .map(|p| line_start + p)
+                .unwrap_or(cmd.len());
+            let next_line = &cmd[line_start..next_nl];
+            if next_line.trim_start().starts_with('#') {
+                return injection(
+                    SecurityCheckId::QuotedNewline,
+                    1,
+                    "Command contains a quoted newline followed by a #-prefixed line, which can hide arguments from line-based permission checks",
+                );
+            }
+        }
+        i += 1;
+    }
+
+    SecurityResult::Passthrough
+}

--- a/crates/dasclaw_bash_validation/src/security/types.rs
+++ b/crates/dasclaw_bash_validation/src/security/types.rs
@@ -1,43 +1,44 @@
 //! Strongly-typed enum of every check ID + result/reason types.
 //!
 //! Ported from upstream `BASH_SECURITY_CHECK_IDS` constants in
-//! `claude-code-main/src/tools/BashTool/bashSecurity.ts` L82-L125. Each
-//! variant corresponds 1:1 to an upstream check ID; the numeric mapping is
-//! preserved via [`SecurityCheckId::as_u32`] so that differential testing can
-//! compare results across the TS / Rust boundary.
+//! `claude-code-main/src/tools/BashTool/bashSecurity.ts` L77-L101 (1:1
+//! numbering). The numeric mapping is preserved via [`SecurityCheckId::as_u32`]
+//! so differential testing can compare results across the TS / Rust boundary.
 
 /// Every distinct security check the engine can emit.
 ///
-/// `numbering` matches upstream `BASH_SECURITY_CHECK_IDS`. New variants must
-/// preserve gaps so existing IDs never shift.
+/// Numbering matches upstream `BASH_SECURITY_CHECK_IDS` exactly (1-23). The
+/// extra [`Self::ParseFailure`] variant (`0`) is a Fail-Closed catch-all that
+/// does not correspond to any upstream ID — emitted by the engine itself
+/// when AST parsing fails before any validator can opine.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[non_exhaustive]
 pub enum SecurityCheckId {
+    /// Synthetic — not in upstream. Engine-level Fail-Closed when AST parse fails.
+    ParseFailure = 0,
     IncompleteCommands = 1,
     JqSystemFunction = 2,
-    XargsRedirection = 3,
-    SafeCommandSubstitution = 4,
-    GitCommit = 5,
-    JqCommand = 6,
-    ShellMetacharacters = 7,
-    DangerousVariables = 8,
-    DangerousPatterns = 9,
-    Redirections = 10,
-    Newlines = 11,
-    IfsInjection = 12,
+    JqFileArguments = 3,
+    ObfuscatedFlags = 4,
+    ShellMetacharacters = 5,
+    DangerousVariables = 6,
+    Newlines = 7,
+    DangerousPatternsCommandSubstitution = 8,
+    DangerousPatternsInputRedirection = 9,
+    DangerousPatternsOutputRedirection = 10,
+    IfsInjection = 11,
+    GitCommitSubstitution = 12,
     ProcEnvironAccess = 13,
     MalformedTokenInjection = 14,
-    ObfuscatedFlags = 15,
-    BackslashEscapedWhitespace = 16,
-    BackslashEscapedOperators = 17,
-    BraceExpansion = 18,
-    UnicodeWhitespace = 19,
-    MidWordHash = 20,
-    CommentQuoteDesync = 21,
-    HeredocQuoted = 22,
-    TrailingBackslash = 23,
-    /// Parse failure — Fail-Closed catch-all.
-    ParseFailure = 24,
+    BackslashEscapedWhitespace = 15,
+    BraceExpansion = 16,
+    ControlCharacters = 17,
+    UnicodeWhitespace = 18,
+    MidWordHash = 19,
+    ZshDangerousCommands = 20,
+    BackslashEscapedOperators = 21,
+    CommentQuoteDesync = 22,
+    QuotedNewline = 23,
 }
 
 impl SecurityCheckId {
@@ -45,34 +46,28 @@ impl SecurityCheckId {
         self as u32
     }
 
-    /// Whether this check is sensitive to upstream misparsing (i.e. its
-    /// `ask` result becomes `block` at the bashPermissions gate).
+    /// Whether this check is sensitive to upstream misparsing.
     ///
-    /// Mirrors upstream `isBashSecurityCheckForMisparsing` (L130-L160). Used
-    /// by the deferred-non-misparsing engine in Slice 2.1.b.
+    /// In upstream's two-phase pipeline (bashSecurity.ts L2343 `nonMisparsingValidators`),
+    /// only `validateNewlines` and `validateRedirections` are explicitly
+    /// non-misparsing — i.e., their `ask` result is *deferred* so that any
+    /// later misparsing-sensitive validator gets priority. All other
+    /// validators in the main pipeline are misparsing-sensitive.
+    ///
+    /// In Phase 2.1 we collapse `ask` → `Block` regardless, but we still
+    /// preserve the deferred-non-misparsing ordering so that the surfaced
+    /// `DecisionReason` matches upstream's user-visible precedence.
     pub fn is_misparsing(self) -> bool {
-        matches!(
+        !matches!(
             self,
-            Self::ShellMetacharacters
-                | Self::DangerousVariables
-                | Self::DangerousPatterns
-                | Self::Redirections
-                | Self::IfsInjection
-                | Self::ProcEnvironAccess
-                | Self::MalformedTokenInjection
-                | Self::ObfuscatedFlags
-                | Self::BackslashEscapedWhitespace
-                | Self::BackslashEscapedOperators
-                | Self::BraceExpansion
-                | Self::MidWordHash
-                | Self::CommentQuoteDesync
-                | Self::TrailingBackslash
-                | Self::ParseFailure
+            Self::Newlines
+                | Self::DangerousPatternsInputRedirection
+                | Self::DangerousPatternsOutputRedirection
         )
     }
 }
 
-/// Why a particular [`SecurityResult::Block`] was emitted.
+/// Why a [`SecurityResult::Block`] was emitted.
 ///
 /// Strongly typed (vs upstream's loose `decisionReason: { type, reason }`)
 /// so downstream policy / telemetry can pattern-match exhaustively.

--- a/crates/dasclaw_bash_validation/tests/security_regex_validators_unit_tests.rs
+++ b/crates/dasclaw_bash_validation/tests/security_regex_validators_unit_tests.rs
@@ -1,0 +1,340 @@
+//! Slice 2.1.c1 — unit tests for the 9 regex / state-machine main validators.
+//!
+//! Naming: `req_security_490_p2_1_c1_<area>_<scenario>`.
+//!
+//! Each validator is exercised through both its direct entry point AND via
+//! the top-level [`validate_security`] engine, so the deferred-non-misparsing
+//! engine ordering is exercised too.
+
+use dasclaw_bash_validation::security::{
+    regex_validators as r, validate_security, DecisionReason, SecurityCheckId, SecurityResult,
+    ValidationContext,
+};
+
+fn ctx(command: &str) -> ValidationContext<'_> {
+    ValidationContext::new(command)
+}
+
+fn assert_block(result: &SecurityResult, expected_id: SecurityCheckId, expected_sub_id: u32) {
+    match result {
+        SecurityResult::Block {
+            reason:
+                DecisionReason::CommandInjection {
+                    check_id, sub_id, ..
+                },
+        } => {
+            assert_eq!(*check_id, expected_id, "check_id mismatch");
+            assert_eq!(*sub_id, expected_sub_id, "sub_id mismatch");
+        }
+        other => panic!("expected Block({expected_id:?},{expected_sub_id}), got {other:?}"),
+    }
+}
+
+fn assert_pass(result: &SecurityResult) {
+    assert!(
+        matches!(result, SecurityResult::Passthrough),
+        "expected Passthrough, got {result:?}"
+    );
+}
+
+// ───────────────────────── shell metacharacters ─────────────────────────────
+//
+// NOTE on coverage: upstream's `validateShellMetacharacters` regexes all
+// require literal `"` / `'` delimiters to survive in `unquotedContent`, but
+// `extractQuotedContent` strips those delimiters. The 3 sub-IDs are dead
+// defensive code in upstream (verified against `bashSecurity.ts` L783-L822
+// + L122-L175). We assert the same passthrough behaviour our port produces.
+
+#[test]
+fn req_security_490_p2_1_c1_shell_meta_quoted_semicolon_passthrough_matches_upstream() {
+    // Upstream `extractQuotedContent` strips the `"` delimiters → regex
+    // `["'][^"']*[;&][^"']*["']` cannot match → upstream itself also returns
+    // passthrough here. 1:1 port preserves this.
+    let c = ctx(r#"echo "foo;bar""#);
+    assert_pass(&r::validate_shell_metacharacters(&c));
+}
+
+#[test]
+fn req_security_490_p2_1_c1_shell_meta_find_name_pipe_passthrough_matches_upstream() {
+    let c = ctx(r#"find . -name "foo|bar""#);
+    assert_pass(&r::validate_shell_metacharacters(&c));
+}
+
+#[test]
+fn req_security_490_p2_1_c1_shell_meta_find_regex_semicolon_passthrough_matches_upstream() {
+    let c = ctx(r#"find . -regex "a;b""#);
+    assert_pass(&r::validate_shell_metacharacters(&c));
+}
+
+#[test]
+fn req_security_490_p2_1_c1_shell_meta_passthrough_plain_echo() {
+    let c = ctx("echo hello");
+    assert_pass(&r::validate_shell_metacharacters(&c));
+}
+
+// ───────────────────────── dangerous variables ──────────────────────────────
+
+#[test]
+fn req_security_490_p2_1_c1_dangerous_vars_redir_to() {
+    let c = ctx("cat < $FOO");
+    assert_block(
+        &r::validate_dangerous_variables(&c),
+        SecurityCheckId::DangerousVariables,
+        1,
+    );
+}
+
+#[test]
+fn req_security_490_p2_1_c1_dangerous_vars_pipe_from() {
+    let c = ctx("$FOO | grep x");
+    assert_block(
+        &r::validate_dangerous_variables(&c),
+        SecurityCheckId::DangerousVariables,
+        1,
+    );
+}
+
+#[test]
+fn req_security_490_p2_1_c1_dangerous_vars_passthrough() {
+    let c = ctx("echo $FOO");
+    assert_pass(&r::validate_dangerous_variables(&c));
+}
+
+// ───────────────────────── dangerous patterns ───────────────────────────────
+
+#[test]
+fn req_security_490_p2_1_c1_dangerous_patterns_backtick() {
+    let c = ctx("echo `whoami`");
+    assert_block(
+        &r::validate_dangerous_patterns(&c),
+        SecurityCheckId::DangerousPatternsCommandSubstitution,
+        0,
+    );
+}
+
+#[test]
+fn req_security_490_p2_1_c1_dangerous_patterns_dollar_paren() {
+    let c = ctx("echo $(whoami)");
+    assert_block(
+        &r::validate_dangerous_patterns(&c),
+        SecurityCheckId::DangerousPatternsCommandSubstitution,
+        1,
+    );
+}
+
+#[test]
+fn req_security_490_p2_1_c1_dangerous_patterns_process_sub() {
+    let c = ctx("diff <(ls) <(ls -a)");
+    assert_block(
+        &r::validate_dangerous_patterns(&c),
+        SecurityCheckId::DangerousPatternsCommandSubstitution,
+        1,
+    );
+}
+
+#[test]
+fn req_security_490_p2_1_c1_dangerous_patterns_escaped_backtick_pass() {
+    // Escaped backtick should NOT trip — but our regex_validators is the
+    // unquoted view; in single-quoted view backticks survive but \` is
+    // literal. Conservative: ensure plain echo passes.
+    let c = ctx("echo plain text");
+    assert_pass(&r::validate_dangerous_patterns(&c));
+}
+
+// ───────────────────────── redirections ─────────────────────────────────────
+
+#[test]
+fn req_security_490_p2_1_c1_redirections_input() {
+    let c = ctx("cat < /etc/passwd");
+    assert_block(
+        &r::validate_redirections(&c),
+        SecurityCheckId::DangerousPatternsInputRedirection,
+        1,
+    );
+}
+
+#[test]
+fn req_security_490_p2_1_c1_redirections_output() {
+    let c = ctx("echo hi > /tmp/x");
+    assert_block(
+        &r::validate_redirections(&c),
+        SecurityCheckId::DangerousPatternsOutputRedirection,
+        1,
+    );
+}
+
+#[test]
+fn req_security_490_p2_1_c1_redirections_passthrough() {
+    let c = ctx("echo plain");
+    assert_pass(&r::validate_redirections(&c));
+}
+
+// ───────────────────────── IFS injection ────────────────────────────────────
+
+#[test]
+fn req_security_490_p2_1_c1_ifs_injection_direct() {
+    let c = ctx("cat$IFS/etc/passwd");
+    assert_block(
+        &r::validate_ifs_injection(&c),
+        SecurityCheckId::IfsInjection,
+        1,
+    );
+}
+
+#[test]
+fn req_security_490_p2_1_c1_ifs_injection_braced() {
+    let c = ctx("echo ${IFS}");
+    assert_block(
+        &r::validate_ifs_injection(&c),
+        SecurityCheckId::IfsInjection,
+        1,
+    );
+}
+
+#[test]
+fn req_security_490_p2_1_c1_ifs_injection_passthrough() {
+    let c = ctx("echo hello");
+    assert_pass(&r::validate_ifs_injection(&c));
+}
+
+// ───────────────────────── /proc/*/environ ──────────────────────────────────
+
+#[test]
+fn req_security_490_p2_1_c1_proc_environ_block() {
+    let c = ctx("cat /proc/self/environ");
+    assert_block(
+        &r::validate_proc_environ_access(&c),
+        SecurityCheckId::ProcEnvironAccess,
+        1,
+    );
+}
+
+#[test]
+fn req_security_490_p2_1_c1_proc_environ_passthrough() {
+    let c = ctx("cat /proc/cpuinfo");
+    assert_pass(&r::validate_proc_environ_access(&c));
+}
+
+// ───────────────────────── mid-word hash ────────────────────────────────────
+
+#[test]
+fn req_security_490_p2_1_c1_mid_word_hash_block() {
+    let c = ctx("echo foo#bar");
+    assert_block(
+        &r::validate_mid_word_hash(&c),
+        SecurityCheckId::MidWordHash,
+        1,
+    );
+}
+
+#[test]
+fn req_security_490_p2_1_c1_mid_word_hash_string_length_exempt() {
+    // ${#var} is bash string-length — must NOT trip.
+    let c = ctx("echo ${#var}");
+    assert_pass(&r::validate_mid_word_hash(&c));
+}
+
+#[test]
+fn req_security_490_p2_1_c1_mid_word_hash_leading_hash_pass() {
+    // Leading `#` (whitespace-preceded comment) must NOT trip.
+    let c = ctx("echo hi # a comment");
+    assert_pass(&r::validate_mid_word_hash(&c));
+}
+
+#[test]
+fn req_security_490_p2_1_c1_mid_word_hash_continuation_join() {
+    // backslash-newline join exposes a mid-word `#`.
+    let c = ctx("echo foo\\\n#bar");
+    assert_block(
+        &r::validate_mid_word_hash(&c),
+        SecurityCheckId::MidWordHash,
+        1,
+    );
+}
+
+// ───────────────────────── comment quote desync ─────────────────────────────
+
+#[test]
+fn req_security_490_p2_1_c1_comment_quote_desync_passthrough_when_ast_present() {
+    // In our port the AST is always authoritative, so this validator is a
+    // documented passthrough. See `regex_validators::validate_comment_quote_desync`.
+    let c = ctx("echo 'hello'");
+    assert_pass(&r::validate_comment_quote_desync(&c));
+}
+
+// ───────────────────────── quoted newline ───────────────────────────────────
+
+#[test]
+fn req_security_490_p2_1_c1_quoted_newline_double_quoted_hash() {
+    let c = ctx("echo \"line1\n# hidden\nline3\"");
+    assert_block(
+        &r::validate_quoted_newline(&c),
+        SecurityCheckId::QuotedNewline,
+        1,
+    );
+}
+
+#[test]
+fn req_security_490_p2_1_c1_quoted_newline_single_quoted_hash() {
+    let c = ctx("echo 'line1\n#hidden'");
+    assert_block(
+        &r::validate_quoted_newline(&c),
+        SecurityCheckId::QuotedNewline,
+        1,
+    );
+}
+
+#[test]
+fn req_security_490_p2_1_c1_quoted_newline_unquoted_hash_pass() {
+    // Newline + #-line OUTSIDE quotes is not the desync pattern.
+    let c = ctx("echo hi\n# a normal comment");
+    assert_pass(&r::validate_quoted_newline(&c));
+}
+
+#[test]
+fn req_security_490_p2_1_c1_quoted_newline_no_hash_pass() {
+    let c = ctx("echo \"line1\nline2\"");
+    assert_pass(&r::validate_quoted_newline(&c));
+}
+
+// ───────────────────────── deferred-non-misparsing engine ───────────────────
+
+#[test]
+fn req_security_490_p2_1_c1_engine_misparsing_wins_over_deferred() {
+    // `cat < $FOO` triggers BOTH:
+    //   - validate_redirections (non-misparsing, deferred)
+    //   - validate_dangerous_variables (misparsing, immediate)
+    //
+    // Pipeline order places dangerous_variables BEFORE redirections, but
+    // even if it were after, the misparsing one must surface.
+    let r = validate_security("cat < $FOO");
+    match r {
+        SecurityResult::Block {
+            reason: DecisionReason::CommandInjection { check_id, .. },
+        } => {
+            assert_eq!(
+                check_id,
+                SecurityCheckId::DangerousVariables,
+                "deferred-engine must surface misparsing reason over non-misparsing"
+            );
+        }
+        other => panic!("expected Block(DangerousVariables), got {other:?}"),
+    }
+}
+
+#[test]
+fn req_security_490_p2_1_c1_engine_deferred_surfaces_when_alone() {
+    // Plain output redirection — no other validator fires.
+    let r = validate_security("echo hi > /tmp/x");
+    match r {
+        SecurityResult::Block {
+            reason: DecisionReason::CommandInjection { check_id, .. },
+        } => {
+            assert_eq!(
+                check_id,
+                SecurityCheckId::DangerousPatternsOutputRedirection
+            );
+        }
+        other => panic!("expected Block(OutputRedirection), got {other:?}"),
+    }
+}


### PR DESCRIPTION
## 背景/目标

继续 #490 phase 2.1 的 1:1 端口。本切片落地 9 个**仅依赖字符串视图**的主验证器以及 `bashSecurity.ts` L2393-L2407 的 **deferred-non-misparsing 引擎**。

**Stacked PR**：base 不是 `xClaw`，而是 #508 (Slice 2.1.b)。请先 review #508 再看本 PR。Merge 顺序：#508 → 本 PR。

## 改动范围

- `security/types.rs`: `SecurityCheckId` 重新编号，与上游 `BASH_SECURITY_CHECK_IDS` (L77-L101) **逐位对齐**。
  - 之前的编号是从早期草稿误抄的；通过 `grep_search` 验证仓库内无 `as_u32` 数值消费方，因此为符号兼容重命名。
  - `is_misparsing()` 改为反向集合：只有 `Newlines` / 两个 `Redirection` 是 non-misparsing，匹配上游 `nonMisparsingValidators` set。
- 新增 `security/regex_validators.rs`：9 个验证器 verbatim port
  - `validate_shell_metacharacters` (L783-L822, check_id 5, 3 sub_ids)
  - `validate_dangerous_variables` (L823-L845, 6)
  - `validate_dangerous_patterns` (L846-L874, 8 + 13 条 `COMMAND_SUBSTITUTION_PATTERNS`)
  - `validate_redirections` (L875-L903, 9 / 10)
  - `validate_ifs_injection` (L1017-L1039, 11)
  - `validate_proc_environ_access` (L1041-L1079, 13)
  - `validate_mid_word_hash` (L1919-L1962, 19) — 含 `${#var}` 例外 + `\<newline>` continuation join
  - `validate_comment_quote_desync` (L1990-L2106, 22) — AST 始终权威 → 文档化 passthrough
  - `validate_quoted_newline` (L2109-L2184, 23) — 状态机端口
- `security/mod.rs`: `validate_security` 重写为带 deferred 槽位的单循环，按上游 pipeline 顺序排布；c2 的 AST 验证器位点已留好插入点（注释标注）。
- 新增 30 个 `req_security_490_p2_1_c1_*` 单元测试。

## 非目标（What's NOT in this PR）

- 9 个 AST-walking 验证器（jq*, obfuscated, backslash*, brace, zsh, malformed）— Slice **2.1.c2**
- Heredoc body stripping — 2.1.c2
- Hook 接线 + DecisionReason e2e — Slice **2.1.d**

## 验证（命令 + 结果）

```
cargo check -p dasclaw_bash_validation --tests                          # OK
cargo nextest run -p dasclaw_bash_validation                            # 111 passed, 0 failed (30 new)
cargo fmt --all                                                          # clean
python3.12 scripts/check_no_panics.py --base origin/xClaw               # OK
cargo clippy --no-deps -p dasclaw_bash_validation --all-targets -- -D warnings   # OK
```

## Sources read

- `AGENTS.md` §1-6
- `.github/copilot-instructions.md` §2-6
- `docs/plans/architecture-refactor/adr-112-compatibility-evaluation.md`
- `docs/plans/architecture-refactor/adr-113-hook-engine-unification.md`
- `claude-code-main/src/tools/BashTool/bashSecurity.ts`
  - L77-L101 `BASH_SECURITY_CHECK_IDS`
  - L122-L175 `extractQuotedContent`
  - L783-L903 shellMeta / dangerousVars / dangerousPatterns / redirections
  - L1017-L1079 ifsInjection / procEnviron
  - L1919-L2184 midWordHash / commentQuoteDesync / quotedNewline
  - L2280-L2306 main entrypoint context-build
  - L2343-L2407 nonMisparsingValidators set + 延迟引擎

Closes #509
Refs #490
