### PR TITLE
test(bash-validation): tracing-test contract for bash_security audit log

### DIFF
--- a/crates/dasclaw_hooks/src/bash_validation_hook.rs
+++ b/crates/dasclaw_hooks/src/bash_validation_hook.rs
@@ -685,9 +685,14 @@ mod tests {
 
     #[tokio::test]
     async fn test_security_audit_log_contains_rule_id() {
-        // We can't easily intercept tracing here without a subscriber;
-        // the model-visible `reason` is the strongest available audit
-        // surface and is required to carry the rule slug.
+        // This test pins only the **model-visible `reason` string** format:
+        // every security Block must surface `bash_security::<rule>` so the
+        // upstream consumer (model / CLI) can route on the rule slug.
+        //
+        // The complementary **structured tracing audit-log** contract
+        // (fields `tool`, `mode`, `rule_id`, `sub_id`, `message` on the
+        // `bash_security::block` event) is pinned by the integration test
+        // `tests/bash_security_audit_log.rs` using `tracing-test`.
         let d = run_bash(PermissionMode::Prompt, INJECTION_CMD).await;
         let reason = match d {
             SafetyDecision::Block { reason } => reason,

--- a/crates/dasclaw_hooks/tests/bash_security_audit_log.rs
+++ b/crates/dasclaw_hooks/tests/bash_security_audit_log.rs
@@ -1,0 +1,125 @@
+//! Phase 2.1 follow-up — audit log contract for `BashValidationHook`
+//! security gate.
+//!
+//! Slice 2.1.d shipped the `tracing::warn!(target: "bash_security::block", …)`
+//! audit emission, but its in-file companion test
+//! (`test_security_audit_log_contains_rule_id`) could only inspect the
+//! *model-visible* `reason` string because no `tracing` subscriber was
+//! installed. With `tracing-test` already wired into dev-deps (see
+//! `lifecycle_trace_log.rs`) we can now pin the structured audit-log
+//! contract directly:
+//!
+//! - Event message contains the `bash_security::block` audit tag.
+//! - `rule_id=<SecurityCheckId Debug>` is present and non-empty.
+//! - `tool=` and `mode=` fields are populated for downstream correlators.
+//! - The active `PermissionMode` slug is recorded *regardless* of whether
+//!   the mode itself would bypass other checks (security gate is mode-
+//!   independent per plan §3.3 / §6).
+//!
+//! `DecisionReason::ParseFailure` is declared in
+//! `dasclaw_bash_validation::security::types` for forward compatibility but
+//! no production code path emits it today — no validator currently surfaces
+//! a parse failure as a synthetic check. Pinning that contract is deferred
+//! until a Phase 2.2 validator (or the differential CI from plan §12)
+//! exercises it.
+//!
+//! Naming: `req_security_490_p2_1_d_audit_log_<scenario>` — same family as
+//! the existing Slice 2.1.d e2e tests so coverage tooling can group them.
+
+use std::path::PathBuf;
+
+use dasclaw_hooks::BashValidationHook;
+use serde_json::json;
+use tracing_test::traced_test;
+use x_claw_agent::permissions::PermissionMode;
+use x_claw_agent::{SafetyDecision, SafetyHook};
+
+/// Newline-injection sample — same fixture as the inline Slice 2.1.d
+/// tests; trips `validate_security` via the `Newlines` /
+/// `QuotedNewline` rules.
+const INJECTION_CMD: &str = "echo a\nrm -rf /";
+
+async fn fire_bash(mode: PermissionMode, cmd: &str) -> SafetyDecision {
+    let hook = BashValidationHook::new(mode, PathBuf::from("/workspace"));
+    let mut args = json!({ "command": cmd });
+    hook.before_tool_call("bash", &mut args)
+        .await
+        .expect("hook must not error on string command")
+}
+
+#[tokio::test]
+#[traced_test]
+async fn req_security_490_p2_1_d_audit_log_emits_block_tag_and_rule_id() {
+    let decision = fire_bash(PermissionMode::WorkspaceWrite, INJECTION_CMD).await;
+    assert!(
+        matches!(decision, SafetyDecision::Block { .. }),
+        "injection must surface as SafetyDecision::Block; got {decision:?}"
+    );
+
+    // Audit tag — operators / SIEM filter on this exact string.
+    assert!(
+        logs_contain("bash_security::block"),
+        "audit log must carry the `bash_security::block` event message"
+    );
+    // `rule_id` must be present and reference a real `SecurityCheckId`
+    // variant (not the synthetic `ParseFailure`).
+    assert!(
+        logs_contain("rule_id="),
+        "audit log must include structured `rule_id` field"
+    );
+    assert!(
+        !logs_contain("rule_id=ParseFailure"),
+        "non-parse-failure injection must not be labelled ParseFailure"
+    );
+    // Correlation fields. `tracing-test` performs substring matching, so
+    // accept either `tool=bash` or `tool="bash"` depending on tracing's
+    // rendering for `&str` fields.
+    assert!(
+        logs_contain("tool=") && logs_contain("bash"),
+        "audit log must carry the originating tool name"
+    );
+    assert!(
+        logs_contain("workspace-write"),
+        "audit log must carry the active PermissionMode slug"
+    );
+}
+
+#[tokio::test]
+#[traced_test]
+async fn req_security_490_p2_1_d_audit_log_records_mode_under_full_access() {
+    // The security gate is mode-independent: even `DangerFullAccess`
+    // must Block injections, and the audit log must record the active
+    // mode so post-incident review can prove the operator was in a
+    // permissive mode at the time of the refused call.
+    let decision = fire_bash(PermissionMode::DangerFullAccess, INJECTION_CMD).await;
+    assert!(
+        matches!(decision, SafetyDecision::Block { .. }),
+        "injection must Block even in DangerFullAccess; got {decision:?}"
+    );
+
+    assert!(
+        logs_contain("bash_security::block"),
+        "audit tag must fire regardless of PermissionMode"
+    );
+    assert!(
+        logs_contain("danger-full-access"),
+        "audit log must carry the active PermissionMode slug even when bypassing permissions"
+    );
+}
+
+#[tokio::test]
+#[traced_test]
+async fn req_security_490_p2_1_d_audit_log_silent_on_safe_command() {
+    let decision = fire_bash(PermissionMode::WorkspaceWrite, "pwd").await;
+    assert!(
+        matches!(decision, SafetyDecision::Allow),
+        "trivially safe command must not Block; got {decision:?}"
+    );
+    // No audit event must be emitted on the allow path — the audit tag
+    // is exclusively for refused commands so SIEM rules can alert on it
+    // without false positives.
+    assert!(
+        !logs_contain("bash_security::block"),
+        "audit tag must only fire on Block, never on Allow"
+    );
+}


### PR DESCRIPTION
## 背景 / 目标

Slice 2.1.d (PR #515) 落地了 `tracing::warn!(target: "bash_security::block", …)` 审计事件，
但其同文件契约测试 `test_security_audit_log_contains_rule_id` 自承「无法在没有 subscriber
的情况下拦截 tracing」——只能间接断言 model-visible 的 `reason` 字符串前缀。

`tracing-test` 已经在 `dasclaw_hooks/Cargo.toml` 的 dev-deps 中（见
`tests/lifecycle_trace_log.rs` 现有用法），因此可以直接把这个 stub 升级为对结构化审计
日志字段的契约测试。这是 phase-2.1-bash-parity-handoff.md 末尾「未完成 #2」明确列出
的事项。

## 改动范围

新增 `crates/dasclaw_hooks/tests/bash_security_audit_log.rs` 共 3 个集成测试：

| 测试 | 契约 |
|---|---|
| `req_security_490_p2_1_d_audit_log_emits_block_tag_and_rule_id` | `bash_security::block` 事件 + `rule_id` + `tool` + `mode` 字段都在；非 parse-failure 注入**不**被标 `ParseFailure` |
| `req_security_490_p2_1_d_audit_log_records_mode_under_full_access` | DangerFullAccess **不**豁免 security gate；审计日志记录 `danger-full-access` mode slug，便于事后复盘当时操作员模式 |
| `req_security_490_p2_1_d_audit_log_silent_on_safe_command` | `Allow` 路径**不**发 `bash_security::block` tag，SIEM 告警零误报 |

并把原 stub `test_security_audit_log_contains_rule_id` 的注释更新为"现在只负责 model-visible
reason 字符串契约；结构化 tracing 契约由新 integration test 承担"。

零生产代码改动。

## 非目标（What's NOT in this PR）

- ❌ ADR-146 强类型化 `SafetyDecision::Block { reason: String }` → 跨模块大改动，独立 PR
- ❌ Phase 2.2 `bashPermissions` 规则引擎（2,621 LOC epic）
- ❌ 上游 `parseForSecurity` AST 主网关迁移（Phase 2.2/3 储备，2,679 LOC）
- ❌ Phase 2.3 desktop Ask UX
- ❌ Phase 2.1 §12 anti-drift 黄金语料库 + 差分 CI job
- ❌ 顺带发现的 Phase 2.1 实现缺口：`SecurityCheckId::ControlCharacters` (id=17) 与
  `DecisionReason::ParseFailure` 均已声明但无 production emit 路径（上游
  `bashSecurity.ts` L2251-2275 `CONTROL_CHAR_RE` 早期 gate 未 port）→ 留作下一个最小切片

## 验证

```bash
cargo check -p dasclaw_hooks --tests          # 0 错 0 警
cargo nextest run -p dasclaw_hooks            # 68/68 passed（含本 PR 新增 3 个）
cargo fmt --all -- --check                    # clean
python3.12 scripts/check_no_panics.py --base origin/xClaw   # OK
cargo clippy --no-deps -p dasclaw_hooks --all-targets -- -D warnings   # 零警告
```

## Cross-cuts

不涉及（本 PR 仅新增测试 + 注释更新，无新增 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量）。

## 后续 PR / 下一步

1. 补 `validate_control_characters` early validator（覆盖上游 `CONTROL_CHAR_RE` gate 缺口）
2. ADR-146 强类型化 `SafetyDecision::Block { reason }` → `DecisionReason`
3. Phase 2.1 §12 差分 CI job（黄金语料库 + 不对称不变式 enforcement）
4. Phase 2.2 bashPermissions epic 启动

## Sources read

- `AGENTS.md` §"任务启动 4 问"、§"分析工具使用规范"、§"GitHub PR 工作流"、§"Skills 强制使用规范"
- `.github/copilot-instructions.md` §"强制阅读顺序"
- `docs/plans/bash-parity/phase-2.1-bash-security-alignment.md` §0 Porting model / §3.3 Hook 集成 / §6 Fail-Safe / §8 Slice 2.1.c 测试族 / §10 Sources / §12 Anti-drift
- `crates/dasclaw_hooks/src/bash_validation_hook.rs` — Slice 2.1.d 审计 emit 点 + 现有 stub 契约测试
- `crates/dasclaw_hooks/tests/lifecycle_trace_log.rs` — `tracing-test::traced_test` + `logs_contain` 现有用法范式
- `crates/dasclaw_bash_validation/src/security/mod.rs` — 引擎入口 + pipeline 顺序
- `crates/dasclaw_bash_validation/src/security/types.rs` — `SecurityCheckId` / `DecisionReason` 强类型定义
- `crates/x_claw_agent/src/permissions.rs` — `PermissionMode::as_str` 槽位
- `/memories/repo/issue-490-phase-2.1-progress.md` — Phase 2.1 状态
- handoff `phase-2.1-bash-parity-handoff.md` — Slices 2.1.a-d 合入状态 + 未完成清单

Closes #517

Refs #490 #502

