### PR TITLE
feat(bash-validation): port validate_control_characters as first early gate

### DIFF
--- a/crates/dasclaw_bash_validation/src/security/early.rs
+++ b/crates/dasclaw_bash_validation/src/security/early.rs
@@ -164,6 +164,39 @@ pub fn validate_carriage_return(ctx: &ValidationContext) -> SecurityResult {
     SecurityResult::Passthrough
 }
 
+// ─────────────────────────── validate_control_characters ───────────────────
+
+/// Upstream `CONTROL_CHAR_RE` (`bashSecurity.ts` L2251) — non-printable
+/// control bytes that have no legitimate use in shell commands and that bash
+/// silently drops or ignores. Excludes tab (`0x09`), newline (`0x0A`) and
+/// carriage return (`0x0D`), which are handled by [`validate_newlines`] /
+/// [`validate_carriage_return`].
+///
+/// Pattern: `[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]`.
+fn is_control_character(b: u8) -> bool {
+    matches!(b, 0x00..=0x08 | 0x0B | 0x0C | 0x0E..=0x1F | 0x7F)
+}
+
+/// Upstream `bashSecurity.ts` L2260-L2273 / L2440-L2453 — the absolute first
+/// gate in both the deprecated and modern entry points. Null bytes and other
+/// non-printable bytes are silently dropped by bash but confuse our quote /
+/// AST tracking, letting metacharacters adjacent to them slip through
+/// (`echo safe\x00; rm -rf /`).
+///
+/// Misparsing-sensitive: short-circuits the pipeline on first hit
+/// ([`SecurityCheckId::ControlCharacters`] is the default-true case of
+/// [`SecurityCheckId::is_misparsing`]).
+pub fn validate_control_characters(ctx: &ValidationContext) -> SecurityResult {
+    if ctx.original_command().bytes().any(is_control_character) {
+        return block(
+            SecurityCheckId::ControlCharacters,
+            1,
+            "Command contains non-printable control characters that could be used to bypass security checks",
+        );
+    }
+    SecurityResult::Passthrough
+}
+
 // ─────────────────────────── validate_unicode_whitespace ────────────────────
 
 /// Upstream `UNICODE_WS_RE` (L1899) — the precise set of unicode whitespace

--- a/crates/dasclaw_bash_validation/src/security/mod.rs
+++ b/crates/dasclaw_bash_validation/src/security/mod.rs
@@ -10,8 +10,8 @@
 //! - Slice 2.1.a — early validators + AST wrapper:
 //!   - [`SecurityCheckId`] / [`SecurityResult`] / [`DecisionReason`]
 //!   - [`ast::parse_for_security`] Fail-Closed AST wrapper
-//!   - [`early`] — 5 early validators (empty / incomplete / newlines / CR /
-//!     unicode whitespace)
+//!   - [`early`] — 6 early validators (control_characters / empty /
+//!     incomplete / newlines / CR / unicode whitespace)
 //! - Slice 2.1.b — context & quote infrastructure:
 //!   - [`ValidationContext`] now carries the 5 derived views upstream uses
 //!   - [`quote_extract`] ports `extractQuotedContent`,
@@ -78,6 +78,13 @@ pub fn validate_security(command: &str) -> SecurityResult {
     // is a pure insertion.
     type V = fn(&ValidationContext) -> SecurityResult;
     let pipeline: &[(V, SecurityCheckId)] = &[
+        // --- Absolute first gate (upstream `bashSecurity.ts` L2260 / L2442) ---
+        // Misparsing-sensitive: control chars confuse quote / AST tracking,
+        // so we must reject *before* any other validator inspects the string.
+        (
+            early::validate_control_characters,
+            SecurityCheckId::ControlCharacters,
+        ),
         // --- Early phase (always misparsing-sensitive in our port) ---
         (early::validate_empty, SecurityCheckId::IncompleteCommands),
         (

--- a/crates/dasclaw_bash_validation/tests/security_early_unit_tests.rs
+++ b/crates/dasclaw_bash_validation/tests/security_early_unit_tests.rs
@@ -196,6 +196,88 @@ fn req_security_490_p2_1_a_ascii_only_passes_unicode_check() {
     );
 }
 
+// ───────────────────────────── control_characters ──────────────────────────
+
+#[test]
+fn req_security_490_p2_2_control_null_byte_blocks() {
+    let ctx = ValidationContext::new("echo safe\u{0}; rm -rf /");
+    assert_block(
+        &early::validate_control_characters(&ctx),
+        SecurityCheckId::ControlCharacters,
+        1,
+    );
+}
+
+#[test]
+fn req_security_490_p2_2_control_bel_blocks() {
+    let ctx = ValidationContext::new("echo \u{07}");
+    assert_block(
+        &early::validate_control_characters(&ctx),
+        SecurityCheckId::ControlCharacters,
+        1,
+    );
+}
+
+#[test]
+fn req_security_490_p2_2_control_unit_separator_blocks() {
+    // 0x1F (Unit Separator) — top of the upstream blocked range.
+    let ctx = ValidationContext::new("echo \u{1F}rm -rf /");
+    assert_block(
+        &early::validate_control_characters(&ctx),
+        SecurityCheckId::ControlCharacters,
+        1,
+    );
+}
+
+#[test]
+fn req_security_490_p2_2_control_del_blocks() {
+    let ctx = ValidationContext::new("echo \u{7F}");
+    assert_block(
+        &early::validate_control_characters(&ctx),
+        SecurityCheckId::ControlCharacters,
+        1,
+    );
+}
+
+#[test]
+fn req_security_490_p2_2_control_tab_newline_cr_pass() {
+    // Upstream comment L2244-L2247: tab / LF / CR are handled by other
+    // validators and must NOT trigger CONTROL_CHAR_RE.
+    for safe in ["echo\tfoo", "echo\nfoo", "echo\rfoo"] {
+        let ctx = ValidationContext::new(safe);
+        assert_eq!(
+            early::validate_control_characters(&ctx),
+            SecurityResult::Passthrough,
+            "{safe:?} should not trip control-char gate"
+        );
+    }
+}
+
+#[test]
+fn req_security_490_p2_2_control_printable_passes() {
+    let ctx = ValidationContext::new("echo hello world");
+    assert_eq!(
+        early::validate_control_characters(&ctx),
+        SecurityResult::Passthrough
+    );
+}
+
+#[test]
+fn req_security_490_p2_2_control_runs_before_other_gates() {
+    // SECURITY: control_characters must surface ahead of any other check
+    // (upstream L2260 / L2442). Here `\x00` is adjacent to `;`+`rm -rf /` —
+    // a downstream validator would otherwise fire `ShellMetacharacters`
+    // (id=5) or `DangerousPatternsCommandSubstitution` (id=8); we must see
+    // `ControlCharacters` (id=17) instead.
+    let result = validate_security("echo safe\u{0}; rm -rf /");
+    match result {
+        SecurityResult::Block {
+            reason: DecisionReason::CommandInjection { check_id, .. },
+        } => assert_eq!(check_id, SecurityCheckId::ControlCharacters),
+        other => panic!("expected ControlCharacters block, got {other:?}"),
+    }
+}
+
 // ───────────────────────────── ast::parse_for_security ──────────────────────
 
 #[test]


### PR DESCRIPTION
## 背景 / 目标

PR #516 在为 `bash_security::block` 审计日志补结构化契约测试时发现：
`SecurityCheckId::ControlCharacters` (id=17) 在
[`crates/dasclaw_bash_validation/src/security/types.rs`](crates/dasclaw_bash_validation/src/security/types.rs)
中已声明，但**没有任何 production emit 路径** — 三层验证（semantic_search +
`grep -r ControlCharacters` + grep `CONTROL_CHAR`）只返回 `types.rs` / 计划文档 /
handoff，没有任何 validator 会发射它。

这违反了 Phase 2.1 计划文档 §0 的对称性不变式：

```
∀ command c:
  upstream_blocks(c) ⟹ xclaw_blocks(c)   ← 控制字节路径目前违反
  xclaw_blocks(c)    ⟹⁄ upstream_blocks(c)
```

上游 `claude-code-main/src/tools/BashTool/bashSecurity.ts` L2260-L2273（deprecated 入口）
和 L2440-L2453（modern 入口）都把 `CONTROL_CHAR_RE = /[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/`
作为**绝对第一道 gate**，原因（上游注释 L2244-L2247）：bash 会**静默丢弃** null 字节
并忽略多数控制字符，攻击者可借此把元字符贴在控制字节旁边，绕过我们的 quote / AST
跟踪——典型攻击 `echo safe\x00; rm -rf /`。

## 改动范围

1. 新增 `early::validate_control_characters` validator（~25 LOC）
   - byte-level 扫描 `original_command()`；命中即 Block，rule_id=`ControlCharacters`/sub_id=1
   - 显式排除 tab (`0x09`) / LF (`0x0A`) / CR (`0x0D`) — 由现有
     `validate_newlines` / `validate_carriage_return` 处理
2. `validate_security` pipeline 增加**第一条**入口（mirrors 上游 L2260 / L2442）
3. 模块文档从「5 early validators」更新为「6 early validators」
4. 7 个新单元测试 `req_security_490_p2_2_control_*`，含一条**precedence 不变式**测试：
   `echo safe\u{0}; rm -rf /` 必须以 `ControlCharacters` 而非 `ShellMetacharacters` /
   `DangerousPatternsCommandSubstitution` 收尾

零生产代码外溢——仅触碰 security 子模块。

## 非目标（What's NOT in this PR）

- ❌ `DecisionReason::ParseFailure` emit 路径（需要 AST parse-error 接线，独立切片）
- ❌ 把 `bash_security_audit_log.rs` 集成测试扩到 ControlCharacters case（待 PR #516 合入后跟进）
- ❌ Phase 2.1 §12 anti-drift 差分 CI / 黄金语料库
- ❌ ADR-146 强类型化 `SafetyDecision::Block`
- ❌ Phase 2.2 `bashPermissions` 规则引擎

## 验证

```bash
cargo nextest run -p dasclaw_bash_validation --test security_early_unit_tests   # 29/29（含 7 新）
cargo nextest run -p dasclaw_bash_validation -p dasclaw_hooks                   # 236/236
cargo fmt --all
python3.12 scripts/check_no_panics.py --base origin/xClaw                       # OK
cargo clippy --no-deps -p dasclaw_bash_validation --all-targets -- -D warnings  # 零警告
```

## Cross-cuts

不涉及（仅 security 子模块 + 测试；无新增 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量）。

## Sources read

- `AGENTS.md` §"任务启动 4 问"、§"分析工具使用规范"、§"GitHub PR 工作流"、§"Skills 强制使用规范"
- `.github/copilot-instructions.md` §"强制阅读顺序" / §"红线"
- `docs/plans/bash-parity/phase-2.1-bash-security-alignment.md` §0 Porting model / §6 Fail-Safe / §12 Anti-drift
- `claude-code-main/src/tools/BashTool/bashSecurity.ts` L2240-L2273（deprecated 入口）、L2430-L2453（modern 入口）
- `crates/dasclaw_bash_validation/src/security/types.rs` — `SecurityCheckId::ControlCharacters` 缺口确认
- `crates/dasclaw_bash_validation/src/security/early.rs` — 现有 5 early validators 范式
- `crates/dasclaw_bash_validation/src/security/mod.rs` — pipeline 顺序 / deferred-non-misparsing 引擎
- `crates/dasclaw_bash_validation/tests/security_early_unit_tests.rs` — `req_security_490_p2_1_a_*` 测试范式
- `/memories/repo/issue-490-phase-2.1-progress.md` — Phase 2.1 状态 + 本 slice 由 PR #516 工作流派生

Closes #518

Refs #490 #502
