### PR TITLE
feat(bash-validation): wire DecisionReason::ParseFailure Fail-Closed catch-all (Slice 2.1.e)

### DIFF
--- a/crates/dasclaw_bash_validation/src/security/ast.rs
+++ b/crates/dasclaw_bash_validation/src/security/ast.rs
@@ -14,6 +14,9 @@
 use thiserror::Error;
 use tree_sitter::Tree;
 
+use super::context::ValidationContext;
+use super::types::{DecisionReason, SecurityResult};
+
 /// Reasons the AST layer can refuse to produce a `BashAst`.
 #[derive(Debug, Error, PartialEq, Eq)]
 #[non_exhaustive]
@@ -57,4 +60,29 @@ pub fn parse_for_security(command: &str) -> Result<BashAst, ParseFail> {
         return Err(ParseFail::ErrorNode);
     }
     Ok(BashAst { tree })
+}
+
+/// Engine-level Fail-Closed validator (plan §0 / §6).
+///
+/// Runs as the **final** pipeline entry: when no earlier validator opined
+/// and the cached AST is [`Err`], we conservatively refuse rather than
+/// allow a command whose syntax we cannot reason about. This closes the
+/// gap where unterminated quotes / mismatched braces fall through every
+/// regex/byte validator and silently reach the executor.
+///
+/// Misparsing-sensitive (via [`super::types::SecurityCheckId::is_misparsing`]
+/// returning true for [`super::types::SecurityCheckId::ParseFailure`]):
+/// once positioned at the pipeline tail, a Fail-Closed Block here will
+/// override any deferred non-misparsing result. This is intentional —
+/// if tree-sitter itself cannot agree on a parse, any partial regex hit
+/// upstream is less trustworthy than the AST-level refusal.
+pub fn validate_parse_failure(ctx: &ValidationContext) -> SecurityResult {
+    match ctx.ast() {
+        Ok(_) => SecurityResult::Passthrough,
+        Err(parse_fail) => SecurityResult::Block {
+            reason: DecisionReason::ParseFailure {
+                message: format!("Command syntax could not be safely parsed: {parse_fail}"),
+            },
+        },
+    }
 }

--- a/crates/dasclaw_bash_validation/src/security/mod.rs
+++ b/crates/dasclaw_bash_validation/src/security/mod.rs
@@ -19,6 +19,10 @@
 //!   - AST is parsed once and cached on the context
 //!   - [`early::validate_newlines`] switched to `fully_unquoted_pre_strip`
 //!     to match upstream (no false positive on `echo "line1\nline2"`)
+//! - Slice 2.1.e — engine-level Fail-Closed catch-all:
+//!   - [`ast::validate_parse_failure`] wired as final pipeline entry;
+//!     surfaces [`DecisionReason::ParseFailure`] when tree-sitter refused
+//!     the command and no earlier validator opined.
 //!
 //! Slice 2.1.c will add the 19 main validators + the deferred-non-misparsing
 //! engine. Slice 2.1.d wires the hook + e2e tests.
@@ -172,6 +176,13 @@ pub fn validate_security(command: &str) -> SecurityResult {
             ast_validators::validate_malformed_token_injection,
             SecurityCheckId::MalformedTokenInjection,
         ),
+        // --- Engine-level Fail-Closed catch-all (plan §0 / §6) ---
+        // Misparsing-sensitive: if no earlier validator opined and
+        // tree-sitter refused the command (unterminated quotes, missing
+        // braces, raw ERROR nodes), surface `DecisionReason::ParseFailure`
+        // rather than fall through to Allow. Placed last so that any
+        // concrete validator's diagnosis wins precedence.
+        (ast::validate_parse_failure, SecurityCheckId::ParseFailure),
     ];
 
     let mut deferred: Option<SecurityResult> = None;

--- a/crates/dasclaw_bash_validation/tests/security_parse_failure_unit_tests.rs
+++ b/crates/dasclaw_bash_validation/tests/security_parse_failure_unit_tests.rs
@@ -1,0 +1,144 @@
+//! Slice 2.1.e — engine-level Fail-Closed catch-all
+//! (`DecisionReason::ParseFailure`).
+//!
+//! Verifies that `ast::validate_parse_failure`, wired as the final pipeline
+//! entry, refuses commands whose syntax tree-sitter cannot agree on,
+//! closing the gap where unterminated quotes / missing braces previously
+//! fell through every validator and reached the executor.
+//!
+//! Naming: `req_security_490_p2_1_e_parsefail_<scenario>`.
+
+use dasclaw_bash_validation::security::{
+    ast, validate_security, DecisionReason, SecurityCheckId, SecurityResult, ValidationContext,
+};
+
+fn assert_parse_failure(result: &SecurityResult) {
+    match result {
+        SecurityResult::Block {
+            reason: DecisionReason::ParseFailure { message },
+        } => {
+            assert!(
+                message.contains("Command syntax could not be safely parsed"),
+                "unexpected parse-failure message: {message:?}"
+            );
+        }
+        other => panic!("expected Block(ParseFailure), got {other:?}"),
+    }
+}
+
+#[test]
+fn req_security_490_p2_1_e_parsefail_unterminated_double_quote_validator() {
+    let ctx = ValidationContext::new("echo \"unterminated");
+    assert!(
+        ctx.ast().is_err(),
+        "precondition: AST must refuse unterminated DQ"
+    );
+    assert_parse_failure(&ast::validate_parse_failure(&ctx));
+}
+
+#[test]
+fn req_security_490_p2_1_e_parsefail_valid_command_passes_validator() {
+    let ctx = ValidationContext::new("ls -la /tmp");
+    assert!(
+        ctx.ast().is_ok(),
+        "precondition: simple ls must parse cleanly"
+    );
+    assert!(matches!(
+        ast::validate_parse_failure(&ctx),
+        SecurityResult::Passthrough
+    ));
+}
+
+#[test]
+fn req_security_490_p2_1_e_parsefail_unterminated_dq_blocks_via_pipeline() {
+    // No other validator catches a bare unterminated DQ → must surface
+    // as ParseFailure (Fail-Closed), not Allow / Passthrough.
+    let result = validate_security("echo \"unterminated");
+    assert_parse_failure(&result);
+}
+
+#[test]
+fn req_security_490_p2_1_e_parsefail_unterminated_sq_blocks_via_pipeline() {
+    let result = validate_security("cat 'still open");
+    assert_parse_failure(&result);
+}
+
+#[test]
+fn req_security_490_p2_1_e_parsefail_unclosed_brace_group_blocks() {
+    // `{ ls -la` is syntactically incomplete (open brace group never
+    // closed) — tree-sitter rejects it and no earlier regex/AST validator
+    // fires, so the Fail-Closed tail must surface ParseFailure.
+    let result = validate_security("{ ls -la");
+    assert_parse_failure(&result);
+}
+
+#[test]
+fn req_security_490_p2_1_e_parsefail_safe_command_does_not_emit_parsefailure() {
+    // Smoke test: a syntactically valid, semantically safe command must
+    // not be misclassified as a parse failure.
+    let result = validate_security("ls -la /tmp");
+    assert!(
+        !matches!(
+            result,
+            SecurityResult::Block {
+                reason: DecisionReason::ParseFailure { .. }
+            }
+        ),
+        "safe command must not surface ParseFailure: {result:?}"
+    );
+}
+
+#[test]
+fn req_security_490_p2_1_e_parsefail_concrete_validator_wins_over_parsefailure() {
+    // `ls $(echo hi` has both an unclosed `$(` (tree-sitter ERROR) AND a
+    // `$()` command-substitution pattern that the misparsing-sensitive
+    // `validate_dangerous_patterns` matches. The concrete validator runs
+    // earlier in the pipeline and is misparsing-sensitive, so it short-
+    // circuits there; the Fail-Closed tail (placed last) never runs.
+    //
+    // Precondition check: confirm the AST still refuses parsing, so this
+    // really would have hit ParseFailure absent the earlier validator.
+    let ctx = ValidationContext::new("ls $(echo hi");
+    assert!(ctx.ast().is_err(), "precondition: input must fail to parse");
+    match validate_security("ls $(echo hi") {
+        SecurityResult::Block {
+            reason:
+                DecisionReason::CommandInjection {
+                    check_id: SecurityCheckId::DangerousPatternsCommandSubstitution,
+                    ..
+                },
+        } => {}
+        SecurityResult::Block {
+            reason: DecisionReason::ParseFailure { .. },
+        } => panic!("ParseFailure must not override an earlier misparsing-sensitive validator"),
+        other => panic!("expected DangerousPatternsCommandSubstitution Block, got {other:?}"),
+    }
+}
+
+#[test]
+fn req_security_490_p2_1_e_parsefail_overrides_deferred_non_misparsing() {
+    // `validate_newlines` is non-misparsing — its result is *deferred* and
+    // only surfaces if no later misparsing-sensitive validator fires.
+    // A command that (a) has a bare LF followed by content (triggers
+    // newlines deferred) AND (b) has an unterminated DQ (triggers
+    // ParseFailure) must surface ParseFailure, because Fail-Closed AST
+    // refusal trumps a regex-only deferred verdict.
+    //
+    // Input: "echo a\nls \"unterm" — LF between two commands + unterminated DQ.
+    let result = validate_security("echo a\nls \"unterm");
+    // Build the equivalent ctx to assert the precondition cleanly.
+    let ctx = ValidationContext::new("echo a\nls \"unterm");
+    assert!(ctx.ast().is_err(), "precondition: input must fail to parse");
+    assert_parse_failure(&result);
+}
+
+#[test]
+fn req_security_490_p2_1_e_parsefail_empty_command_still_allowed() {
+    // `validate_empty` runs early in the pipeline and returns Allow.
+    // ParseFailure must not interfere with the Allow short-circuit.
+    let result = validate_security("");
+    assert!(
+        matches!(result, SecurityResult::Allow),
+        "empty input must remain Allow, not ParseFailure: {result:?}"
+    );
+}


### PR DESCRIPTION
## What

Wires `DecisionReason::ParseFailure` as a Fail-Closed catch-all at the **absolute final** position of the `validate_security` pipeline. Before this PR, `ast::parse_for_security` would return `Err(ParseFail::{TreeSitterError, ErrorNode})` for unterminated quotes / unclosed brace groups, `ValidationContext` would cache it, but **no validator ever consumed the `Err`** — those commands silently reached the executor (§0 / §6 Fail-Closed violation).

The new `ast::validate_parse_failure` runs last (misparsing-sensitive), so any concrete validator's verdict still wins precedence, but unparseable inputs that previously fell through every check now Block.

## Precedence properties (proven in tests)

- `ls $(echo hi` (unclosed `$(` + dangerous-pattern match) → `DangerousPatternsCommandSubstitution`, NOT `ParseFailure`
- `echo "unterminated` (no other validator fires) → `ParseFailure`
- `echo a\nls "unterm` (deferred newlines result + parse failure) → `ParseFailure` overrides deferred result
- Empty command → `Allow` (short-circuits before ParseFailure runs)

## Why a separate validator, not "tail check after the loop"

A "patch-style" `if !ctx.ast().is_ok() { ... }` after the loop would (a) skip the misparsing-vs-deferred precedence logic that the pipeline already encodes, and (b) hard-code "fail-closed runs last" outside the declarative pipeline table where every other ordering decision lives. Adding it as the final pipeline entry makes ordering visible at one location and re-uses the existing `flag_id.is_misparsing()` dispatch — no special case in the loop body.

## Why stacked on #519

#519 (control-characters first gate) is in CI. This slice's tests assume the control-char gate runs first in some precedence-invariant assertions; merging out of order would require rebasing tests. Once #519 lands, rebase to `xClaw`.

## Validation

- `cargo nextest run -p dasclaw_bash_validation --test security_parse_failure_unit_tests` → 9/9
- `cargo nextest run -p dasclaw_bash_validation -p dasclaw_hooks` → 245/245
- `cargo fmt --all`
- `python3.12 scripts/check_no_panics.py --base origin/xClaw` → OK
- `cargo clippy --no-deps -p dasclaw_bash_validation --all-targets -- -D warnings` → clean

## What's NOT in this PR

- Differential-CI infrastructure (plan §12) — separate slice
- Extending `bash_security_audit_log.rs` integration test with a ParseFailure case — follows once #519 merges
- Touching any of the 22 existing validators (their semantics are unchanged)

## Sources read

- `AGENTS.md` §"任务启动 4 问" / §"GitHub PR 工作流"
- `.github/copilot-instructions.md` §"强制阅读顺序" / §"红线"
- `docs/plans/bash-parity/phase-2.1-bash-security-alignment.md` §0 Porting model / §6 Fail-Safe
- `crates/dasclaw_bash_validation/src/security/ast.rs` — ParseFail enum + parse_for_security
- `crates/dasclaw_bash_validation/src/security/context.rs` — `ctx.ast()` doc comment confirming the promise was never wired
- `crates/dasclaw_bash_validation/src/security/types.rs` — `SecurityCheckId::ParseFailure = 0` + `is_misparsing` defaulting to true
- `crates/dasclaw_bash_validation/src/security/mod.rs` — pipeline + deferred-non-misparsing engine

Closes #520

Refs #490 #502
