### PR TITLE
test(bash-validation): pin rule_id=ControlCharacters audit-log surface

### DIFF
--- a/crates/dasclaw_hooks/tests/bash_security_audit_log.rs
+++ b/crates/dasclaw_hooks/tests/bash_security_audit_log.rs
@@ -23,6 +23,13 @@
 //! until a Phase 2.2 validator (or the differential CI from plan §12)
 //! exercises it.
 //!
+//! `ControlCharacters` *does* have a production emit path as of PR #519
+//! (first early gate, see
+//! `crates/dasclaw_bash_validation/src/security/early.rs::validate_control_characters`).
+//! `req_security_490_p2_1_d_audit_log_control_chars_surface_rule_id`
+//! pins its `rule_id=ControlCharacters` audit surface so pipeline
+//! reorders can't silently demote it.
+//!
 //! Naming: `req_security_490_p2_1_d_audit_log_<scenario>` — same family as
 //! the existing Slice 2.1.d e2e tests so coverage tooling can group them.
 
@@ -121,5 +128,38 @@ async fn req_security_490_p2_1_d_audit_log_silent_on_safe_command() {
     assert!(
         !logs_contain("bash_security::block"),
         "audit tag must only fire on Block, never on Allow"
+    );
+}
+
+#[tokio::test]
+#[traced_test]
+async fn req_security_490_p2_1_d_audit_log_control_chars_surface_rule_id() {
+    // PR #519 (Slice 2.1.e prerequisite) added `validate_control_characters`
+    // as the *first* gate in `validate_security`. Pin its audit-log
+    // surface so future refactors of the pipeline order can't silently
+    // demote it without breaking this test.
+    //
+    // Input carries a literal null byte — caught only by the
+    // control-character gate; every later validator either ignores
+    // non-printable bytes or runs out of order.
+    let decision = fire_bash(PermissionMode::WorkspaceWrite, "echo safe\u{0}value").await;
+    assert!(
+        matches!(decision, SafetyDecision::Block { .. }),
+        "null byte must Block; got {decision:?}"
+    );
+
+    assert!(
+        logs_contain("bash_security::block"),
+        "audit tag must fire on control-character refusal"
+    );
+    // Exact rule_id — protects against pipeline-reorder regressions that
+    // would let a later (less specific) validator claim the rule_id.
+    assert!(
+        logs_contain("rule_id=ControlCharacters"),
+        "control-character refusal must surface `rule_id=ControlCharacters`, not a substitute"
+    );
+    assert!(
+        logs_contain("workspace-write"),
+        "audit log must carry the active PermissionMode slug"
     );
 }


### PR DESCRIPTION
## What

Test-only PR. Pins `rule_id=ControlCharacters` in the `bash_security::block` audit log now that PR #519 has landed the production emit path. Without this paired test, a future pipeline reorder could silently demote ControlCharacters to a substitute rule_id without breaking CI.

## Why this is not a patch

The new test (`req_security_490_p2_1_d_audit_log_control_chars_surface_rule_id`) follows the exact same shape as the three existing `req_security_490_p2_1_d_audit_log_*` tests — same fixture helper (`fire_bash`), same `#[traced_test]` plumbing, same assert pattern (block + tag + rule_id + mode slug). It's a row-addition to an existing test table, not a special-case wedge.

Input is a literal null byte (`echo safe\u{0}value`) chosen specifically because it is caught *only* by the control-character gate — every other validator either ignores non-printable bytes or runs at a position the control-char gate already short-circuited past. This proves pipeline order, not just rule presence.

## 3-layer code review

- **Layer 1 (diff hygiene)**: +40 LOC, test-only, zero production touch. Module doc updated alongside (no stale "no production code path emits it" claim).
- **Layer 2 (contract alignment)**: Pins exact `rule_id=ControlCharacters` substring against the `tracing-test` captured event — same contract style as the three existing tests in this file.
- **Layer 3 (invariants)**: `cargo nextest run -p dasclaw_hooks` 69/69 with the new test included. Test will fail loudly if the first-gate position established by PR #519 is silently demoted.

## Validation

- `cargo nextest run -p dasclaw_hooks --test bash_security_audit_log` → 4/4
- `cargo nextest run -p dasclaw_hooks` → 69/69
- `cargo fmt --all`
- `python3.12 scripts/check_no_panics.py --base origin/xClaw` → OK
- `cargo clippy --no-deps -p dasclaw_hooks --all-targets -- -D warnings` → clean

## What's NOT in this PR

- ParseFailure audit-log pinning — waits on PR #522
- Differential CI scaffolding (plan §12) — separate slice
- Any production touch to validators / pipeline order

## Sources read

- `AGENTS.md` §"任务启动 4 问" / §"GitHub PR 工作流"
- `.github/copilot-instructions.md` §"强制阅读顺序"
- `crates/dasclaw_hooks/tests/bash_security_audit_log.rs` — existing 3 tests in the family
- `crates/dasclaw_bash_validation/src/security/early.rs::validate_control_characters` — production gate landed in PR #519
- `crates/dasclaw_bash_validation/src/security/mod.rs` — pipeline first-entry confirms only ControlCharacters can catch a bare null byte

Closes #523

Refs #490 #502
