### PR TITLE
feat(bash-perm): Slice 2.2.a — port shell_rule_matching (ShellPermissionRule + wildcard matcher)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2770,6 +2770,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "dasclaw_bash_permissions"
+version = "0.0.0-w1"
+dependencies = [
+ "regex",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "dasclaw_bash_validation"
 version = "0.0.0-w1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,9 @@ members = [
 	"crates/dasclaw_apply_patch",
 	"crates/dasclaw_project_docs",
 	"crates/dasclaw_bash_validation",
+	# Phase 2.2 Slice 2.2.a — bashPermissions rule-engine port (see
+	# docs/plans/bash-parity/phase-2.2-bash-permissions-rule-engine.md).
+	"crates/dasclaw_bash_permissions",
 	"crates/dasclaw_governance",
 	"crates/dasclaw_mcp",
 	"crates/dasclaw_execpolicy",

--- a/crates/dasclaw_bash_permissions/Cargo.toml
+++ b/crates/dasclaw_bash_permissions/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "dasclaw_bash_permissions"
+version = "0.0.0-w1"
+edition = "2021"
+description = "Bash permission rule engine (port of upstream bashPermissions.ts pipeline)."
+license = "Apache-2.0 OR MIT"
+publish = false
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+regex = "1.12"
+thiserror = "1"

--- a/crates/dasclaw_bash_permissions/src/lib.rs
+++ b/crates/dasclaw_bash_permissions/src/lib.rs
@@ -1,0 +1,26 @@
+//! Bash permission rule engine — port of upstream `bashPermissions.ts`
+//! (2621 LOC) and its shared dependency `shellRuleMatching.ts` (~230 LOC).
+//!
+//! This is Slice 2.2.a of Phase 2.2 (see
+//! `docs/plans/bash-parity/phase-2.2-bash-permissions-rule-engine.md`).
+//! Only the rule-string parser + wildcard matcher are landed in this
+//! slice; the 8-step authorization pipeline (`bashToolHasPermission`)
+//! lands in subsequent slices 2.2.b-h.
+//!
+//! Upstream canonical source:
+//!   `claude-code-main/src/utils/permissions/shellRuleMatching.ts`
+//!
+//! Non-port deviations (deliberate, see plan §3.1):
+//! - upstream regex pipeline is reimplemented as char-by-char Rust loop +
+//!   single regex assembly to avoid double escaping; semantics asserted
+//!   equivalent by the test matrix
+//! - upstream's `caseInsensitive` parameter is preserved as
+//!   `MatchOptions::case_insensitive` for forward-compat (Bash itself
+//!   is case-sensitive so default is `false`)
+
+pub mod shell_rule_matching;
+
+pub use shell_rule_matching::{
+    has_wildcards, match_wildcard_pattern, parse_permission_rule, permission_rule_extract_prefix,
+    MatchOptions, ShellPermissionRule,
+};

--- a/crates/dasclaw_bash_permissions/src/shell_rule_matching.rs
+++ b/crates/dasclaw_bash_permissions/src/shell_rule_matching.rs
@@ -1,0 +1,191 @@
+//! Shell permission rule parsing + wildcard matching.
+//!
+//! Verbatim semantic port of `claude-code-main/src/utils/permissions/
+//! shellRuleMatching.ts` (~230 LOC). Algorithm matches upstream
+//! byte-for-byte; only language idioms differ (Rust `regex` crate vs JS
+//! `RegExp`).
+//!
+//! ## Three rule shapes (discriminated by [`ShellPermissionRule`])
+//!
+//! 1. **Exact** — literal string, no wildcards (`git status`)
+//! 2. **Prefix** — legacy `name:*` syntax (`npm:*` → prefix `npm`)
+//! 3. **Wildcard** — contains unescaped `*` (`git diff *`)
+//!
+//! ## Escaping in wildcard patterns
+//!
+//! - `\*` matches a literal asterisk
+//! - `\\` matches a literal backslash
+//! - all other regex metacharacters are escaped automatically
+//!
+//! ## Trailing-wildcard optionalization (`git *` semantics)
+//!
+//! When a pattern ends in ` *` (space + unescaped wildcard) and that is
+//! the **only** unescaped wildcard, the trailing space-and-args is made
+//! optional so `git *` matches both `git add` and bare `git`. Aligns
+//! wildcard rules with the legacy `git:*` prefix shape. Multi-wildcard
+//! patterns (e.g. `* run *`) are excluded so `npm run *` does not
+//! incorrectly match bare `npm run` with no trailing argument.
+
+use regex::Regex;
+
+/// Sentinel chars used to defer escaped-wildcard handling past the regex
+/// metachar escaping pass. PUA (Private Use Area) so they cannot
+/// collide with real pattern content.
+const ESC_STAR: char = '\u{E000}';
+const ESC_BACKSLASH: char = '\u{E001}';
+
+/// Parsed permission-rule shape.
+///
+/// Mirrors upstream `ShellPermissionRule` discriminated union.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ShellPermissionRule {
+    /// Literal command string, matched by equality.
+    Exact { command: String },
+    /// Legacy `name:*` prefix syntax — matches any command starting
+    /// with `prefix` followed by whitespace (or empty tail).
+    Prefix { prefix: String },
+    /// Glob pattern containing `*` wildcards.
+    Wildcard { pattern: String },
+}
+
+/// Options controlling wildcard matching behavior.
+///
+/// Bash itself is case-sensitive; `case_insensitive` is preserved for
+/// forward-compat with upstream's `caseInsensitive` parameter (used by
+/// non-Bash callers that share this module).
+#[derive(Debug, Clone, Copy, Default)]
+pub struct MatchOptions {
+    pub case_insensitive: bool,
+}
+
+/// Extract the prefix from legacy `name:*` syntax.
+///
+/// Returns `Some("npm")` for `"npm:*"`, `None` otherwise.
+#[must_use]
+pub fn permission_rule_extract_prefix(rule: &str) -> Option<&str> {
+    rule.strip_suffix(":*").filter(|s| !s.is_empty())
+}
+
+/// Check if `pattern` contains an unescaped `*` that is not part of
+/// trailing `:*` legacy syntax.
+///
+/// Returns `false` for `"npm:*"` (legacy prefix), `true` for `"npm *"`
+/// or `"git diff *"`.
+#[must_use]
+pub fn has_wildcards(pattern: &str) -> bool {
+    if pattern.ends_with(":*") {
+        return false;
+    }
+    let bytes = pattern.as_bytes();
+    for (i, &b) in bytes.iter().enumerate() {
+        if b == b'*' {
+            // Count preceding backslashes.
+            let mut backslash_count = 0usize;
+            let mut j = i;
+            while j > 0 && bytes[j - 1] == b'\\' {
+                backslash_count += 1;
+                j -= 1;
+            }
+            if backslash_count.is_multiple_of(2) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// Match a `command` against a wildcard `pattern`.
+///
+/// See module docs for escaping rules and trailing-wildcard semantics.
+///
+/// Returns `false` on the (theoretically impossible) event of an
+/// internally-malformed regex — see `it_never_produces_an_invalid_regex`
+/// test for the invariant.
+#[must_use]
+pub fn match_wildcard_pattern(pattern: &str, command: &str, opts: MatchOptions) -> bool {
+    let trimmed = pattern.trim();
+
+    // Pass 1: collapse `\*` and `\\` into PUA sentinels so the regex
+    // metachar escape pass below cannot touch them.
+    let mut processed = String::with_capacity(trimmed.len());
+    let mut chars = trimmed.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c == '\\' {
+            match chars.peek() {
+                Some(&'*') => {
+                    processed.push(ESC_STAR);
+                    chars.next();
+                    continue;
+                }
+                Some(&'\\') => {
+                    processed.push(ESC_BACKSLASH);
+                    chars.next();
+                    continue;
+                }
+                _ => {}
+            }
+        }
+        processed.push(c);
+    }
+
+    let unescaped_star_count = processed.chars().filter(|&c| c == '*').count();
+
+    // Pass 2: build the final regex pattern, escaping metachars and
+    // converting unescaped `*` → `.*`, PUA sentinels → literal escapes.
+    let mut regex_pattern = String::with_capacity(processed.len() * 2);
+    for c in processed.chars() {
+        match c {
+            '*' => regex_pattern.push_str(".*"),
+            ESC_STAR => regex_pattern.push_str("\\*"),
+            ESC_BACKSLASH => regex_pattern.push_str("\\\\"),
+            '.' | '+' | '?' | '^' | '$' | '{' | '}' | '(' | ')' | '|' | '[' | ']' | '\\' | '\''
+            | '"' => {
+                regex_pattern.push('\\');
+                regex_pattern.push(c);
+            }
+            _ => regex_pattern.push(c),
+        }
+    }
+
+    // Trailing-wildcard optionalization: `git *` → `git( .*)?`.
+    if regex_pattern.ends_with(" .*") && unescaped_star_count == 1 {
+        let new_len = regex_pattern.len() - 3;
+        regex_pattern.truncate(new_len);
+        regex_pattern.push_str("( .*)?");
+    }
+
+    let flag_prefix = if opts.case_insensitive {
+        "(?si)"
+    } else {
+        "(?s)"
+    };
+    let full = format!("{flag_prefix}^{regex_pattern}$");
+    match Regex::new(&full) {
+        Ok(re) => re.is_match(command),
+        Err(_) => false,
+    }
+}
+
+/// Parse a permission rule string into a [`ShellPermissionRule`].
+///
+/// Resolution order matches upstream:
+/// 1. Legacy `:*` prefix wins over wildcard parsing (so `foo:*` is a
+///    prefix, not a wildcard match against `foo:` followed by any tail)
+/// 2. Otherwise, if pattern contains unescaped `*`, it's a wildcard
+/// 3. Else it's an exact match
+#[must_use]
+pub fn parse_permission_rule(rule: &str) -> ShellPermissionRule {
+    if let Some(prefix) = permission_rule_extract_prefix(rule) {
+        return ShellPermissionRule::Prefix {
+            prefix: prefix.to_string(),
+        };
+    }
+    if has_wildcards(rule) {
+        return ShellPermissionRule::Wildcard {
+            pattern: rule.to_string(),
+        };
+    }
+    ShellPermissionRule::Exact {
+        command: rule.to_string(),
+    }
+}

--- a/crates/dasclaw_bash_permissions/tests/shell_rule_matching_test.rs
+++ b/crates/dasclaw_bash_permissions/tests/shell_rule_matching_test.rs
@@ -1,0 +1,253 @@
+//! Unit tests for `shell_rule_matching` — verbatim semantic port of
+//! `claude-code-main/src/utils/permissions/shellRuleMatching.test.ts`
+//! cases plus deviation-asserting probes.
+//!
+//! Test naming follows AGENTS.md §测试纪律: `req_perm_490_p2_2_a_<id>_<desc>`.
+
+use dasclaw_bash_permissions::{
+    has_wildcards, match_wildcard_pattern, parse_permission_rule, permission_rule_extract_prefix,
+    MatchOptions, ShellPermissionRule,
+};
+
+fn matches(pattern: &str, cmd: &str) -> bool {
+    match_wildcard_pattern(pattern, cmd, MatchOptions::default())
+}
+
+// === permission_rule_extract_prefix ===
+
+#[test]
+fn req_perm_490_p2_2_a_01_extract_prefix_legacy_star() {
+    assert_eq!(permission_rule_extract_prefix("npm:*"), Some("npm"));
+    assert_eq!(permission_rule_extract_prefix("git:*"), Some("git"));
+    assert_eq!(
+        permission_rule_extract_prefix("git push:*"),
+        Some("git push")
+    );
+}
+
+#[test]
+fn req_perm_490_p2_2_a_02_extract_prefix_returns_none_when_no_trailing_star() {
+    assert_eq!(permission_rule_extract_prefix("npm"), None);
+    assert_eq!(permission_rule_extract_prefix("git diff *"), None);
+    assert_eq!(permission_rule_extract_prefix("*:foo"), None);
+    assert_eq!(permission_rule_extract_prefix(""), None);
+    // Trailing `:*` with empty prefix yields None (matches upstream
+    // regex `^(.+):\*$` requiring at least one char).
+    assert_eq!(permission_rule_extract_prefix(":*"), None);
+}
+
+// === has_wildcards ===
+
+#[test]
+fn req_perm_490_p2_2_a_03_has_wildcards_legacy_prefix_is_not_wildcard() {
+    assert!(!has_wildcards("npm:*"));
+    assert!(!has_wildcards("git push:*"));
+}
+
+#[test]
+fn req_perm_490_p2_2_a_04_has_wildcards_detects_unescaped_star() {
+    assert!(has_wildcards("git diff *"));
+    assert!(has_wildcards("* run *"));
+    assert!(has_wildcards("npm run *"));
+}
+
+#[test]
+fn req_perm_490_p2_2_a_05_has_wildcards_skips_escaped_star() {
+    assert!(!has_wildcards("echo \\*"));
+    assert!(!has_wildcards("git status"));
+    // Even backslashes preceding `*` mean the `*` is unescaped.
+    assert!(has_wildcards("echo \\\\*")); // \\ + *
+}
+
+// === match_wildcard_pattern: literal/exact tail ===
+
+#[test]
+fn req_perm_490_p2_2_a_06_match_exact_pattern_without_wildcard() {
+    assert!(matches("git status", "git status"));
+    assert!(!matches("git status", "git statuss"));
+    assert!(!matches("git status", "git"));
+}
+
+#[test]
+fn req_perm_490_p2_2_a_07_match_single_wildcard_anywhere() {
+    assert!(matches("git *", "git add"));
+    assert!(matches("git *", "git push origin main"));
+    // Trailing-` *` optionalization: bare `git` matches `git *`.
+    assert!(matches("git *", "git"));
+}
+
+#[test]
+fn req_perm_490_p2_2_a_08_match_multi_wildcard_no_trailing_optionalization() {
+    // `* run *` has 2 wildcards; trailing ` *` is NOT optionalized.
+    // `npm run` (no trailing arg) must NOT match.
+    assert!(!matches("* run *", "npm run"));
+    assert!(matches("* run *", "npm run build"));
+    assert!(matches("* run *", "yarn run test --watch"));
+}
+
+#[test]
+fn req_perm_490_p2_2_a_09_match_escaped_star_is_literal() {
+    assert!(matches("echo \\*", "echo *"));
+    assert!(!matches("echo \\*", "echo anything"));
+}
+
+#[test]
+fn req_perm_490_p2_2_a_10_match_escaped_backslash_is_literal() {
+    assert!(matches("echo \\\\", "echo \\"));
+    assert!(!matches("echo \\\\", "echo "));
+}
+
+#[test]
+fn req_perm_490_p2_2_a_11_match_escapes_regex_metachars_in_pattern() {
+    // Patterns containing regex metachars must match literally.
+    assert!(matches("echo foo.bar", "echo foo.bar"));
+    assert!(!matches("echo foo.bar", "echo fooXbar"));
+
+    assert!(matches("echo (hi)", "echo (hi)"));
+    assert!(matches("echo a+b", "echo a+b"));
+    assert!(matches("echo $HOME", "echo $HOME"));
+    assert!(matches("echo a|b", "echo a|b"));
+    assert!(matches("echo [x]", "echo [x]"));
+}
+
+#[test]
+fn req_perm_490_p2_2_a_12_match_dotall_handles_embedded_newlines() {
+    // `s` (dotAll) flag is on so `.*` matches newlines too.
+    assert!(matches("git *", "git diff\nfile"));
+}
+
+#[test]
+fn req_perm_490_p2_2_a_13_match_pattern_is_trimmed() {
+    assert!(matches("   git status   ", "git status"));
+    assert!(matches("  git *  ", "git add"));
+}
+
+#[test]
+fn req_perm_490_p2_2_a_14_match_is_case_sensitive_by_default() {
+    // Bash itself is case-sensitive.
+    assert!(!matches("GIT status", "git status"));
+    assert!(!matches("git STATUS", "git status"));
+}
+
+#[test]
+fn req_perm_490_p2_2_a_15_match_case_insensitive_when_opted_in() {
+    let opts = MatchOptions {
+        case_insensitive: true,
+    };
+    assert!(match_wildcard_pattern("GIT status", "git status", opts));
+    assert!(match_wildcard_pattern("git *", "GIT add", opts));
+}
+
+#[test]
+fn req_perm_490_p2_2_a_16_match_anchors_whole_string() {
+    // `^...$` anchors mean the pattern must consume the full command.
+    assert!(!matches("git", "git status"));
+    assert!(!matches("status", "git status"));
+}
+
+#[test]
+fn req_perm_490_p2_2_a_17_match_empty_pattern_only_matches_empty_command() {
+    assert!(matches("", ""));
+    assert!(!matches("", "anything"));
+    // Whitespace-only pattern trims to empty.
+    assert!(matches("   ", ""));
+}
+
+// === parse_permission_rule ===
+
+#[test]
+fn req_perm_490_p2_2_a_18_parse_exact_rule() {
+    assert_eq!(
+        parse_permission_rule("git status"),
+        ShellPermissionRule::Exact {
+            command: "git status".to_string()
+        }
+    );
+}
+
+#[test]
+fn req_perm_490_p2_2_a_19_parse_legacy_prefix_wins_over_wildcard_check() {
+    // `foo:*` is prefix, NOT wildcard (rule extraction precedence).
+    assert_eq!(
+        parse_permission_rule("npm:*"),
+        ShellPermissionRule::Prefix {
+            prefix: "npm".to_string()
+        }
+    );
+    assert_eq!(
+        parse_permission_rule("git push:*"),
+        ShellPermissionRule::Prefix {
+            prefix: "git push".to_string()
+        }
+    );
+}
+
+#[test]
+fn req_perm_490_p2_2_a_20_parse_wildcard_rule() {
+    assert_eq!(
+        parse_permission_rule("git diff *"),
+        ShellPermissionRule::Wildcard {
+            pattern: "git diff *".to_string()
+        }
+    );
+    assert_eq!(
+        parse_permission_rule("* run *"),
+        ShellPermissionRule::Wildcard {
+            pattern: "* run *".to_string()
+        }
+    );
+}
+
+#[test]
+fn req_perm_490_p2_2_a_21_parse_escaped_star_is_exact_not_wildcard() {
+    // `\*` is escaped, so no unescaped `*` remains → exact match.
+    assert_eq!(
+        parse_permission_rule("echo \\*"),
+        ShellPermissionRule::Exact {
+            command: "echo \\*".to_string()
+        }
+    );
+}
+
+// === Internal invariant: assembled regex always compiles ===
+//
+// This is asserted indirectly by every match call above (the `match
+// Regex::new` arm returns `false` on error; if any of our patterns
+// triggered the error path, the matching tests would fail). Add an
+// explicit probe over a range of metachar-heavy patterns as a
+// belt-and-suspenders guard.
+
+#[test]
+fn req_perm_490_p2_2_a_22_never_produces_an_invalid_regex_for_heavy_metachars() {
+    let probes = [
+        r#"echo "$(curl x)" | tee -a /tmp/* "#,
+        r#"git diff -- '*.rs'"#,
+        r"^.*$",
+        r"\\\\\\\\",
+        r"a+b?c{1,2}|d(e)[f]g",
+        r"\\* \\* \\*",
+    ];
+    for pat in probes {
+        // We don't care about match outcome here; we care that the
+        // function returns *something* (i.e., regex compilation
+        // succeeded internally — otherwise we'd have a panic in the
+        // unwrap-less Regex::new path which we've already eliminated).
+        let _ = matches(pat, "anything");
+        let _ = matches(pat, pat);
+    }
+}
+
+#[test]
+fn req_perm_490_p2_2_a_23_upstream_parity_git_star_matches_bare_git() {
+    // Documented upstream invariant aligning wildcard with `git:*`
+    // semantics — single trailing wildcard is optionalized.
+    assert!(matches("git *", "git"));
+    // But `npm run *` (2 wildcards effective — leading `* run *` here)
+    // is NOT optionalized (see test 08). Single-wildcard rules with
+    // non-space-prefixed trailing wildcards are NOT optionalized:
+    // pattern `git*` (no space) has trailing `.*` but the assembled
+    // regex ends in `.*` not ` .*`, so the optionalization branch is
+    // skipped and `git` still matches because `.*` consumes empty.
+    assert!(matches("git*", "git"));
+    assert!(matches("git*", "git status"));
+}


### PR DESCRIPTION
Closes #527

## 背景/目标

Slice 2.2.a of Phase 2.2 (Issue #490). Lands the first implementation slice of the `bashPermissions.ts` rule-engine port planned in PR #526. Introduces a new crate `dasclaw_bash_permissions` containing the **shared rule-shape parser + wildcard matcher** — the foundation every subsequent rule-evaluation slice (2.2.b-h) will build on.

Verbatim semantic port of `claude-code-main/src/utils/permissions/shellRuleMatching.ts` (~230 LOC). The 8-step authorization pipeline itself (`bashToolHasPermission` L1663-1820) is deliberately NOT in this PR per the plan §5 slice scope.

## 改动范围

- **NEW crate** `crates/dasclaw_bash_permissions/`
  - `Cargo.toml` — minimal deps: `regex 1.12`, `thiserror 1`
  - `src/lib.rs` — re-exports + module docs + deviation notes
  - `src/shell_rule_matching.rs` — port (162 LOC + extensive docs)
  - `tests/shell_rule_matching_test.rs` — 23 tests
- `Cargo.toml` — workspace member added with rationale comment

**Public API**:
- `ShellPermissionRule::{Exact, Prefix, Wildcard}` — verbatim 3-variant union
- `permission_rule_extract_prefix(rule)` — `Some("npm")` for `"npm:*"`
- `has_wildcards(pattern)` — escape-aware unescaped-`*` detector
- `match_wildcard_pattern(pattern, command, opts)` + `MatchOptions { case_insensitive }`
- `parse_permission_rule(rule)` — Prefix > Wildcard > Exact precedence

## 非目标 (What's NOT in this PR)

- 8-step `bashToolHasPermission` pipeline (slices 2.2.b-h)
- Hook chain wiring / `BashPermissionHook` impl (slice 2.2.f)
- Audit-log contract pinning (slice 2.2.h)
- ANT-only telemetry / growthbook / bashClassifier (per Issue #490 epic forbidden ports)
- Any change to existing `dasclaw_bash_validation` crate

## 验证

```
$ cargo check -p dasclaw_bash_permissions --tests
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 7.55s

$ cargo nextest run -p dasclaw_bash_permissions
     Summary [   6.946s] 23 tests run: 23 passed, 0 skipped

$ cargo fmt --all
$ python3.12 scripts/check_no_panics.py --base origin/xClaw
OK: No panic-inducing calls in changed production code.

$ cargo clippy --no-deps -p dasclaw_bash_permissions --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.24s
```

Heavier workspace builds + cross-crate clippy left to CI per `.github/copilot-instructions.md` §3.

## 3-layer code review summary

- **Layer 1 (diff hygiene)**: new crate scaffold only; zero touch to `dasclaw_bash_validation`, `x_claw_agent`, or any other existing crate. Workspace `Cargo.toml` change is a single-member addition with anchor comment pointing to the plan doc.
- **Layer 2 (contract alignment)**: each upstream invariant has a paired pinned test —
  - PUA-sentinel-based escape pass: tests 09, 10, 21
  - regex metachar quoting set verbatim from upstream L130: test 11
  - trailing-` *` optionalization rule (only when `unescaped_star_count == 1`): tests 07, 08, 23
  - dotAll for heredoc content: test 12
  - case-sensitivity default + opt-in: tests 14, 15
  - precedence `prefix > wildcard > exact`: tests 18, 19, 20, 21
- **Layer 3 (invariants)**: Fail-Safe-to-`false` documented + probed (test 22); `permission_rule_extract_prefix(":*")` returns `None` (empty prefix rejected, mirrors upstream regex `^(.+):\*$`); no `unwrap`/`expect`/`panic!` (script confirmed).

## Sources read

- [AGENTS.md](AGENTS.md) §"任务启动 4 问" / §"复用优先于新建" / §"测试纪律" / §"GitHub PR 工作流"
- [.github/copilot-instructions.md](.github/copilot-instructions.md) §"强制阅读顺序" / §"红线" / §"必跑的本地管线"
- [docs/plans/bash-parity/phase-2.2-bash-permissions-rule-engine.md](docs/plans/bash-parity/phase-2.2-bash-permissions-rule-engine.md) §0, §1, §3.1, §5, §6 (full doc; landed in #526)
- `claude-code-main/src/utils/permissions/shellRuleMatching.ts` — full file (canonical upstream)
- `claude-code-main/src/tools/BashTool/bashPermissions.ts` L345-410 — confirms `bashPermissionRule = parsePermissionRule` delegation, `matchWildcardPattern = sharedMatchWildcardPattern` delegation
- [crates/x_claw_agent/src/hooks.rs](crates/x_claw_agent/src/hooks.rs#L57-L92) — `SafetyDecision::Ask` + `RuleSuggestion` for downstream slice 2.2.f wiring
- [crates/dasclaw_bash_validation/Cargo.toml](crates/dasclaw_bash_validation/Cargo.toml) — confirmed crate stays untouched; new crate has independent dep tree

Stacked-PR avoidance: this PR bases on **xClaw** directly (not on #526). Plan PR #526 and this implementation PR are independent — #526 is the design contract, this is the first implementation slice. If #526 lands first, that's preferred for reviewer flow; if this lands first, the plan-doc PR still applies retroactively.

Refs #490 #502 #526
