### PR TITLE
test(bash-security): pin rule_id=ParseFailure audit-log surface

### DIFF
--- a/crates/dasclaw_hooks/tests/bash_security_audit_log.rs
+++ b/crates/dasclaw_hooks/tests/bash_security_audit_log.rs
@@ -16,12 +16,14 @@
 //!   the mode itself would bypass other checks (security gate is mode-
 //!   independent per plan §3.3 / §6).
 //!
-//! `DecisionReason::ParseFailure` is declared in
-//! `dasclaw_bash_validation::security::types` for forward compatibility but
-//! no production code path emits it today — no validator currently surfaces
-//! a parse failure as a synthetic check. Pinning that contract is deferred
-//! until a Phase 2.2 validator (or the differential CI from plan §12)
-//! exercises it.
+//! `DecisionReason::ParseFailure` gained a production emit path with
+//! PR #522 (`ast::validate_parse_failure` as the final pipeline entry —
+//! Fail-Closed catch-all when tree-sitter refuses the input).
+//! `req_security_490_p2_1_d_audit_log_parse_failure_surface_rule_id`
+//! pins its `rule_id=ParseFailure` audit surface. Because the validator
+//! is *positioned last* in the pipeline (and is misparsing-sensitive),
+//! a pipeline reorder that demotes it would silently turn unparseable
+//! commands into Allow — this test guards against that.
 //!
 //! `ControlCharacters` *does* have a production emit path as of PR #519
 //! (first early gate, see
@@ -157,6 +159,53 @@ async fn req_security_490_p2_1_d_audit_log_control_chars_surface_rule_id() {
     assert!(
         logs_contain("rule_id=ControlCharacters"),
         "control-character refusal must surface `rule_id=ControlCharacters`, not a substitute"
+    );
+    assert!(
+        logs_contain("workspace-write"),
+        "audit log must carry the active PermissionMode slug"
+    );
+}
+
+#[tokio::test]
+#[traced_test]
+async fn req_security_490_p2_1_d_audit_log_parse_failure_surface_rule_id() {
+    // PR #522 (Phase 2.1 wrap-up) added `ast::validate_parse_failure` as the
+    // *final* gate in `validate_security`. Pin its audit-log surface so
+    // future refactors of the pipeline order can't silently demote it.
+    //
+    // Why this matters more than the typical pinning test:
+    //
+    // - `validate_parse_failure` is the engine-level Fail-Closed catch-all
+    //   for inputs tree-sitter refuses. If a refactor accidentally moved it
+    //   earlier in the pipeline OR removed it, unparseable commands would
+    //   stop emitting `rule_id=ParseFailure` — they'd either get attributed
+    //   to a less specific later validator OR (much worse) silently Allow.
+    // - Synthetic check id `0` (see `SecurityCheckId::ParseFailure`) is the
+    //   single rule_id whose audit surface is the *direct telemetry signal*
+    //   for "AST refused this input"; SIEM rules that alert on parser
+    //   anomalies in the corpus depend on it.
+    //
+    // Input is an unterminated double-quote — same canonical fixture as the
+    // unit-level tests in `security_parse_failure_unit_tests.rs`. It
+    // deliberately *doesn't* trip any earlier validator (no metacharacters
+    // in unsafe positions, no newlines, no control chars), so the only
+    // surface that can fire is `validate_parse_failure` itself.
+    let decision = fire_bash(PermissionMode::WorkspaceWrite, "echo \"unterminated").await;
+    assert!(
+        matches!(decision, SafetyDecision::Block { .. }),
+        "unterminated quote must Block via Fail-Closed parse-failure; got {decision:?}"
+    );
+
+    assert!(
+        logs_contain("bash_security::block"),
+        "audit tag must fire on parse-failure refusal"
+    );
+    // Exact rule_id — protects against pipeline-reorder regressions that
+    // would let a later (less specific) validator claim the rule_id, or a
+    // demotion that drops the synthetic check id entirely.
+    assert!(
+        logs_contain("rule_id=ParseFailure"),
+        "parse-failure refusal must surface `rule_id=ParseFailure`, not a substitute"
     );
     assert!(
         logs_contain("workspace-write"),


### PR DESCRIPTION
Closes #529

## 背景/目标

Follow-up pinning the audit-log contract for `SecurityCheckId::ParseFailure` (synthetic id `0`). PR #522 landed the production emit path (`ast::validate_parse_failure` as the final Fail-Closed pipeline entry). PR #524 established the pinning template with `rule_id=ControlCharacters`. This PR applies that same template to the next-highest-value rule_id.

Why this is high-priority among the still-unpinned check IDs:

- `validate_parse_failure` is the **final** pipeline entry. A refactor that moves it earlier OR removes it would silently turn unparseable inputs (unterminated quotes, mismatched braces, raw `ERROR` nodes) from `Block` → `Allow` (Fail-Open). The test catches either regression.
- `rule_id=ParseFailure` is the **direct telemetry signal** that SIEM rules consume to alert on parser anomalies in the corpus. Stale validators claiming this rule_id would poison that signal.
- The validator is misparsing-sensitive: positioned at the tail, a `Block` here overrides earlier deferred non-misparsing results. Pipeline reorders that demote it must be caught immediately.

## 改动范围

- `crates/dasclaw_hooks/tests/bash_security_audit_log.rs`
  - **module-doc** (L19-27): replace stale "no production code path emits ParseFailure today" wording with reference to PR #522
  - **NEW test** `req_security_490_p2_1_d_audit_log_parse_failure_surface_rule_id` (~46 LOC, same 4-assert template as ControlCharacters pin)

Test fixture: canonical `echo "unterminated` — matches `security_parse_failure_unit_tests.rs:31`. Deliberately tree-sitter-refuses cleanly + trips NO earlier validator (no metacharacters in unsafe positions, no newlines, no control chars), so `validate_parse_failure` is the only surface that can fire.

## 非目标 (What's NOT in this PR)

- Pinning the other 22 still-unpinned `SecurityCheckId` variants (will land per-rule when needed)
- Any production code change (test-only)
- Cross-mode coverage for ParseFailure (workspace-write suffices; DangerFullAccess case is implicit via the existing emits_block_tag test pattern)

## 验证

```
$ cargo nextest run -p dasclaw_hooks --test bash_security_audit_log
     Summary [   2.484s] 5 tests run: 5 passed, 0 skipped

$ cargo fmt --all
$ python3.12 scripts/check_no_panics.py --base origin/xClaw
OK: No panic-inducing calls in changed production code.

$ cargo clippy --no-deps -p dasclaw_hooks --tests -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 20.96s
```

## 3-layer code review summary

- **Layer 1 (diff hygiene)**: 1 file, test-only +55/−6. Zero production touch. Module-doc block update removes stale documentation.
- **Layer 2 (contract alignment)**: New test mirrors the proven 4-assert template (`Block` matcher + audit tag + exact `rule_id=` field + mode slug) from `req_security_490_p2_1_d_audit_log_control_chars_surface_rule_id` (L137-165). Fixture matches the canonical unit-level fixture in `security_parse_failure_unit_tests.rs`. Test name continues the `req_security_490_p2_1_d_audit_log_*` family.
- **Layer 3 (invariants)**: Pipeline-reorder regression coverage; pin protects against (a) demotion of `validate_parse_failure` earlier in the pipeline (would let a less specific validator claim the rule_id) and (b) silent removal of the validator (would turn unparseable input into Allow). No `unwrap`/`expect`/`panic!`.

## Sources read

- [AGENTS.md](AGENTS.md) §"GitHub PR 工作流" / §"测试纪律"
- [.github/copilot-instructions.md](.github/copilot-instructions.md) §"必跑的本地管线" / §"PR 必填项"
- [crates/dasclaw_hooks/tests/bash_security_audit_log.rs](crates/dasclaw_hooks/tests/bash_security_audit_log.rs#L137-L165) — existing pinning pattern (ControlCharacters)
- [crates/dasclaw_bash_validation/src/security/ast.rs](crates/dasclaw_bash_validation/src/security/ast.rs#L60-L88) — `validate_parse_failure` production emit path (landed in #522)
- [crates/dasclaw_bash_validation/tests/security_parse_failure_unit_tests.rs](crates/dasclaw_bash_validation/tests/security_parse_failure_unit_tests.rs#L31) — canonical fixture
- [crates/dasclaw_bash_validation/src/security/types.rs](crates/dasclaw_bash_validation/src/security/types.rs#L14-L42) — `SecurityCheckId::ParseFailure = 0` synthetic id

Refs #490 #502 #522 #524
