### PR TITLE
feat(bash-perm): Slice 2.2.b — port bashToolCheckExactMatchPermission

### DIFF
--- a/crates/dasclaw_bash_permissions/src/exact_match.rs
+++ b/crates/dasclaw_bash_permissions/src/exact_match.rs
@@ -1,0 +1,154 @@
+//! Exact-match permission pipeline — port of upstream
+//! `bashToolCheckExactMatchPermission` (`bashPermissions.ts` L991-L1048)
+//! and its filter helper `filterRulesByContentsMatchingInput` restricted
+//! to `matchMode = 'exact'` (L800-L935).
+//!
+//! ## Scope (Slice 2.2.b)
+//!
+//! This slice implements **exact-match only**. Prefix / wildcard match
+//! modes (prefix-mode in upstream parlance — `startsWith`, `xargs <p>`
+//! word-boundary, compound-command splitting, env-var stripping) land
+//! in subsequent slices per plan §5:
+//!
+//! - Slice 2.2.c → prefix / wildcard match
+//! - Slice 2.2.d → compound operator splitting + `MAX_SUBCOMMANDS_FOR_SECURITY_CHECK`
+//! - Slice 2.2.e → `stripSafeWrappers` + `stripAllLeadingEnvVars` + `BINARY_HIJACK_VARS`
+//! - Slice 2.2.f → `BashPermissionHook` impl + `CompositeSafetyHook` wiring
+//!
+//! ## Security posture
+//!
+//! - **Deny precedence**: deny rules checked first across all sources.
+//!   Matches upstream L996-L1010. A deny match short-circuits — no ask /
+//!   allow can override (deny-不降级 red line in plan §4).
+//! - **Source-deterministic ordering**: rules are iterated in
+//!   [`PermissionRuleSource`] enum order via `BTreeMap` keys, then in
+//!   insertion order within each source. This makes `rule_id` audit
+//!   attribution reproducible across runs (regression target for the
+//!   audit-log pinning pattern established in #524 / #530).
+//! - **Library-only until 2.2.f**: nothing in this slice is wired into
+//!   `CompositeSafetyHook`. The engine is callable from tests + future
+//!   slices but cannot affect runtime behavior yet.
+//! - **No env-var stripping** in this slice. A rule `Bash(npm:*)` will
+//!   NOT match `FOO=bar npm test` here — that is Fail-Safe for *allow*
+//!   rules (won't auto-allow a wrapped command) but Fail-Open for *deny*
+//!   rules. Documented as a known gap closed by slice 2.2.e.
+//!
+//! ## Upstream parity
+//!
+//! Exact-mode per-rule matching from upstream L872-895:
+//!
+//! - `Exact { command }` → matches iff `rule.command == cmd_to_match`
+//! - `Prefix { prefix }` → matches iff `rule.prefix == cmd_to_match`
+//!   (NOT `startsWith` — that's prefix *mode*, a different parameter)
+//! - `Wildcard { .. }` → **always false** in exact mode (upstream L920:
+//!   "wildcards must NOT match because we're checking the full unparsed
+//!   command. Wildcard matching on unparsed commands allows `foo *` to
+//!   match `foo arg && curl evil.com` since `.*` matches operators.")
+
+use crate::shell_rule_matching::{parse_permission_rule, ShellPermissionRule};
+use crate::types::{
+    PermissionBehavior, PermissionDecisionReason, PermissionResult, PermissionRule,
+    PermissionRuleValue, ToolPermissionContext, ToolPermissionRulesBySource,
+};
+
+/// Bash tool name — separated as a const so future tool-agnostic
+/// refactors (slice 2.2.f) can override.
+pub const BASH_TOOL_NAME: &str = "Bash";
+
+/// Determine whether `rule_content` matches `cmd_to_match` in **exact mode**.
+///
+/// Direct port of the inner `commandsToTry.some(...)` predicate from
+/// upstream `filterRulesByContentsMatchingInput` (L870-L935), specialised
+/// to `matchMode === 'exact'`.
+fn rule_matches_in_exact_mode(rule_content: &str, cmd_to_match: &str) -> bool {
+    match parse_permission_rule(rule_content) {
+        ShellPermissionRule::Exact { command } => command == cmd_to_match,
+        ShellPermissionRule::Prefix { prefix } => prefix == cmd_to_match,
+        ShellPermissionRule::Wildcard { .. } => false,
+    }
+}
+
+/// Scan a `ToolPermissionRulesBySource` and return the first matching
+/// rule (if any), preserving (source, content) provenance for audit logs.
+///
+/// Returns `None` if no rule matches. Iteration order is deterministic:
+/// sources in [`PermissionRuleSource`] enum order (via `BTreeMap`), then
+/// insertion order within each source's `Vec<String>`.
+fn first_matching_rule(
+    rules_by_source: &ToolPermissionRulesBySource,
+    cmd_to_match: &str,
+    behavior: PermissionBehavior,
+) -> Option<PermissionRule> {
+    for (source, rule_contents) in rules_by_source {
+        for rule_content in rule_contents {
+            if rule_matches_in_exact_mode(rule_content, cmd_to_match) {
+                return Some(PermissionRule {
+                    source: *source,
+                    rule_behavior: behavior,
+                    rule_value: PermissionRuleValue {
+                        tool_name: BASH_TOOL_NAME.to_string(),
+                        rule_content: Some(rule_content.clone()),
+                    },
+                });
+            }
+        }
+    }
+    None
+}
+
+/// Run the exact-match permission pipeline against a bash command.
+///
+/// Returns a [`PermissionResult`] following upstream precedence
+/// `Deny > Ask > Allow > Passthrough` (upstream L996-L1048).
+///
+/// `command` is trimmed before matching, mirroring upstream L995
+/// (`const command = input.command.trim()`). No env-var stripping or
+/// compound-splitting happens here — see slice 2.2.d/e.
+pub fn check_exact_match(command: &str, context: &ToolPermissionContext) -> PermissionResult {
+    let cmd = command.trim();
+
+    // 1. Deny rules — checked first across all sources. A match here
+    //    short-circuits regardless of any ask / allow rule. Matches the
+    //    "deny-不降级" red line in plan §4.
+    if let Some(rule) =
+        first_matching_rule(&context.always_deny_rules, cmd, PermissionBehavior::Deny)
+    {
+        return PermissionResult::Deny {
+            message: format!(
+                "Permission to use {tool} with command {cmd} has been denied.",
+                tool = BASH_TOOL_NAME,
+            ),
+            reason: PermissionDecisionReason::Rule { rule },
+        };
+    }
+
+    // 2. Ask rules — matched commands require user approval.
+    if let Some(rule) = first_matching_rule(&context.always_ask_rules, cmd, PermissionBehavior::Ask)
+    {
+        return PermissionResult::Ask {
+            message: format!(
+                "Claude requested permissions to use {tool}, but you haven't granted it yet.",
+                tool = BASH_TOOL_NAME,
+            ),
+            reason: PermissionDecisionReason::Rule { rule },
+        };
+    }
+
+    // 3. Allow rules — explicit user grants.
+    if let Some(rule) =
+        first_matching_rule(&context.always_allow_rules, cmd, PermissionBehavior::Allow)
+    {
+        return PermissionResult::Allow {
+            reason: PermissionDecisionReason::Rule { rule },
+        };
+    }
+
+    // 4. Passthrough — no engine-level rule fired. Caller (slice 2.2.f
+    //    hook adapter) decides next: prompt user, run classifier, etc.
+    PermissionResult::Passthrough {
+        message: "This command requires approval".to_string(),
+        reason: PermissionDecisionReason::Other {
+            reason: "This command requires approval".to_string(),
+        },
+    }
+}

--- a/crates/dasclaw_bash_permissions/src/lib.rs
+++ b/crates/dasclaw_bash_permissions/src/lib.rs
@@ -18,9 +18,16 @@
 //!   `MatchOptions::case_insensitive` for forward-compat (Bash itself
 //!   is case-sensitive so default is `false`)
 
+pub mod exact_match;
 pub mod shell_rule_matching;
+pub mod types;
 
+pub use exact_match::{check_exact_match, BASH_TOOL_NAME};
 pub use shell_rule_matching::{
     has_wildcards, match_wildcard_pattern, parse_permission_rule, permission_rule_extract_prefix,
     MatchOptions, ShellPermissionRule,
+};
+pub use types::{
+    PermissionBehavior, PermissionDecisionReason, PermissionResult, PermissionRule,
+    PermissionRuleSource, PermissionRuleValue, ToolPermissionContext, ToolPermissionRulesBySource,
 };

--- a/crates/dasclaw_bash_permissions/src/types.rs
+++ b/crates/dasclaw_bash_permissions/src/types.rs
@@ -1,0 +1,174 @@
+//! Shared permission types — semantic port of upstream
+//! `claude-code-main/src/types/permissions.ts` (L50-L450 region).
+//!
+//! Scope of this Slice 2.2.b port:
+//! - [`PermissionBehavior`] — 3-variant `Allow|Ask|Deny`
+//! - [`PermissionRuleSource`] — 8 origin tags (where a rule was loaded from)
+//! - [`PermissionRuleValue`] / [`PermissionRule`] — rule shape
+//! - [`ToolPermissionContext`] — bash-relevant subset of upstream context
+//! - [`PermissionResult`] — `Deny | Ask | Allow | Passthrough` with rule
+//!   attribution (the `decisionReason: { type: 'rule', rule }` variant of
+//!   upstream `PermissionDecisionReason`)
+//!
+//! Deliberate non-port (matches plan §5):
+//! - Bash-classifier / pendingClassifierCheck / hooks / sandboxOverride
+//!   reasons are NOT ported here (forbidden by Issue #490 epic and/or
+//!   deferred to later slices).
+//! - `additionalWorkingDirectories` / `isBypassPermissionsModeAvailable` /
+//!   `strippedDangerousRules` etc. are deferred to slice 2.2.e (compound
+//!   command + env stripping) where they actually become load-bearing.
+//! - `metadata` / `contentBlocks` / `blockedPath` / `toolUseID` etc. are
+//!   message-level concerns that belong to the eventual `BashPermissionHook`
+//!   adapter (slice 2.2.f), not the rule-engine core.
+//!
+//! All maps use `BTreeMap` for deterministic iteration order — critical
+//! because the FIRST matching rule per behavior wins (upstream picks
+//! `matchingDenyRules[0]`), and undefined ordering would break
+//! reproducibility of the audit-log `rule_id`.
+
+use std::collections::BTreeMap;
+
+/// Permission behavior verb. Maps to upstream
+/// `PermissionBehavior = 'allow' | 'ask' | 'deny'`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum PermissionBehavior {
+    Allow,
+    Ask,
+    Deny,
+}
+
+/// Where a permission rule originated from. Semantic port of upstream
+/// `PermissionRuleSource` (L54-L65 of `types/permissions.ts`). The 8
+/// variants are preserved verbatim — downstream slices (2.2.f, 2.2.h)
+/// will surface this in audit logs + UI suggestions, and we don't want
+/// to collapse `localSettings` into `projectSettings` (different trust
+/// posture) or `flagSettings` into `cliArg` (different lifetime).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum PermissionRuleSource {
+    UserSettings,
+    ProjectSettings,
+    LocalSettings,
+    FlagSettings,
+    PolicySettings,
+    CliArg,
+    Command,
+    Session,
+}
+
+/// What a permission rule targets. Upstream `PermissionRuleValue`.
+///
+/// For Bash, `tool_name = "Bash"` and `rule_content` carries the
+/// raw rule string (e.g. `"npm:*"`, `"git status"`, `"docker *"`) —
+/// the rule-string format is parsed by
+/// [`crate::shell_rule_matching::parse_permission_rule`].
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct PermissionRuleValue {
+    pub tool_name: String,
+    pub rule_content: Option<String>,
+}
+
+/// A permission rule with its source + behavior. Upstream `PermissionRule`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct PermissionRule {
+    pub source: PermissionRuleSource,
+    pub rule_behavior: PermissionBehavior,
+    pub rule_value: PermissionRuleValue,
+}
+
+/// Permission decision reason — bash-engine-relevant subset of upstream
+/// `PermissionDecisionReason`. Slice 2.2.b only emits the `Rule` variant
+/// (rule-driven matches). Other variants (`Mode`, `Hook`, `Classifier`,
+/// `Other`, …) will be added by their respective owning slices.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PermissionDecisionReason {
+    /// A specific permission rule matched the input.
+    Rule { rule: PermissionRule },
+    /// Catch-all — no rule matched and no other mechanism opined.
+    /// Used by the `Passthrough` result to carry a free-form note.
+    Other { reason: String },
+}
+
+/// Outcome of running the permission pipeline against a single command.
+///
+/// Mirrors upstream `PermissionResult`'s discriminated union over
+/// `behavior: 'allow' | 'ask' | 'deny' | 'passthrough'`.
+///
+/// **Precedence** (asserted by [`crate::exact_match::check_exact_match`]):
+///
+///   `Deny` > `Ask` > `Allow` > `Passthrough`
+///
+/// This is the same order upstream applies at L996-L1042 of `bashPermissions.ts`:
+/// deny rules are checked first (defense-in-depth, refuse before asking
+/// or allowing), then ask, then allow. Passthrough means *no engine-level
+/// rule fired* — the caller (hook adapter in slice 2.2.f) decides what
+/// to do next (typically: ask the user, run classifier, etc.).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PermissionResult {
+    /// Command refused by a deny rule. The `rule` field tells the audit log
+    /// which rule was the match (critical for `rule_id` surface — see
+    /// existing `bash_security::block` pinning tests).
+    Deny {
+        message: String,
+        reason: PermissionDecisionReason,
+    },
+    /// Command requires user approval (matched an `ask` rule).
+    Ask {
+        message: String,
+        reason: PermissionDecisionReason,
+    },
+    /// Command allowed by an explicit allow rule.
+    Allow { reason: PermissionDecisionReason },
+    /// No rule matched — caller decides next step. Upstream populates
+    /// `suggestions` here to recommend an exact-match rule to the user;
+    /// that suggestion logic lives in slice 2.2.g.
+    Passthrough {
+        message: String,
+        reason: PermissionDecisionReason,
+    },
+}
+
+/// Per-behavior rule storage, grouped by [`PermissionRuleSource`]. Upstream
+/// `ToolPermissionRulesBySource`. Stores raw rule-content strings only;
+/// they are parsed lazily by the engine via
+/// [`crate::shell_rule_matching::parse_permission_rule`].
+///
+/// `BTreeMap` (not `HashMap`) so iteration is **deterministic across runs**
+/// for any given source set — critical for reproducible audit-log
+/// `rule_id` ordering.
+pub type ToolPermissionRulesBySource = BTreeMap<PermissionRuleSource, Vec<String>>;
+
+/// Context the bash permission pipeline reads from. Bash-relevant subset
+/// of upstream `ToolPermissionContext`.
+///
+/// Per-slice fields actually used by `check_exact_match` (this slice):
+/// - [`Self::always_deny_rules`] — checked first
+/// - [`Self::always_ask_rules`] — checked second
+/// - [`Self::always_allow_rules`] — checked third
+///
+/// Fields deferred to later slices (kept absent here to avoid premature
+/// API commitment): `mode`, `additionalWorkingDirectories`,
+/// `isBypassPermissionsModeAvailable`, `strippedDangerousRules`, etc.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ToolPermissionContext {
+    pub always_allow_rules: ToolPermissionRulesBySource,
+    pub always_deny_rules: ToolPermissionRulesBySource,
+    pub always_ask_rules: ToolPermissionRulesBySource,
+}
+
+impl ToolPermissionContext {
+    /// Convenience builder used by tests + slice 2.2.f wire-up. Adds a
+    /// single rule content string under a given source + behavior.
+    pub fn add_rule(
+        &mut self,
+        behavior: PermissionBehavior,
+        source: PermissionRuleSource,
+        rule_content: impl Into<String>,
+    ) {
+        let bucket = match behavior {
+            PermissionBehavior::Allow => &mut self.always_allow_rules,
+            PermissionBehavior::Ask => &mut self.always_ask_rules,
+            PermissionBehavior::Deny => &mut self.always_deny_rules,
+        };
+        bucket.entry(source).or_default().push(rule_content.into());
+    }
+}

--- a/crates/dasclaw_bash_permissions/tests/exact_match_test.rs
+++ b/crates/dasclaw_bash_permissions/tests/exact_match_test.rs
@@ -1,0 +1,319 @@
+//! Slice 2.2.b — `check_exact_match` tests.
+//!
+//! Naming family: `req_perm_490_p2_2_b_<id>_<desc>`.
+//!
+//! Coverage targets (mapped to plan §6 + upstream `bashPermissions.ts`
+//! L991-L1048):
+//!
+//! - precedence `Deny > Ask > Allow > Passthrough`
+//! - all 3 [`ShellPermissionRule`] variants in exact mode:
+//!   `Exact` matches, `Prefix` matches only on equality (not startsWith),
+//!   `Wildcard` never matches
+//! - command trimming (leading/trailing whitespace)
+//! - empty / no-match → Passthrough with `Other` reason
+//! - rule attribution: returned [`PermissionRule`] carries the rule
+//!   content + source + behavior that fired
+//! - deterministic source-iteration order
+
+use dasclaw_bash_permissions::{
+    check_exact_match, PermissionBehavior, PermissionDecisionReason, PermissionResult,
+    PermissionRuleSource, ToolPermissionContext, BASH_TOOL_NAME,
+};
+
+// ---------- helpers ----------
+
+fn ctx() -> ToolPermissionContext {
+    ToolPermissionContext::default()
+}
+
+fn assert_deny_with_rule_content(result: &PermissionResult, expected: &str) {
+    match result {
+        PermissionResult::Deny { reason, .. } => match reason {
+            PermissionDecisionReason::Rule { rule } => {
+                assert_eq!(rule.rule_value.tool_name, BASH_TOOL_NAME);
+                assert_eq!(rule.rule_value.rule_content.as_deref(), Some(expected));
+                assert_eq!(rule.rule_behavior, PermissionBehavior::Deny);
+            }
+            other => panic!("expected Rule reason, got {other:?}"),
+        },
+        other => panic!("expected Deny, got {other:?}"),
+    }
+}
+
+fn assert_allow_with_rule_content(result: &PermissionResult, expected: &str) {
+    match result {
+        PermissionResult::Allow { reason } => match reason {
+            PermissionDecisionReason::Rule { rule } => {
+                assert_eq!(rule.rule_value.rule_content.as_deref(), Some(expected));
+                assert_eq!(rule.rule_behavior, PermissionBehavior::Allow);
+            }
+            other => panic!("expected Rule reason, got {other:?}"),
+        },
+        other => panic!("expected Allow, got {other:?}"),
+    }
+}
+
+fn assert_ask_with_rule_content(result: &PermissionResult, expected: &str) {
+    match result {
+        PermissionResult::Ask { reason, .. } => match reason {
+            PermissionDecisionReason::Rule { rule } => {
+                assert_eq!(rule.rule_value.rule_content.as_deref(), Some(expected));
+                assert_eq!(rule.rule_behavior, PermissionBehavior::Ask);
+            }
+            other => panic!("expected Rule reason, got {other:?}"),
+        },
+        other => panic!("expected Ask, got {other:?}"),
+    }
+}
+
+// ---------- precedence ----------
+
+#[test]
+fn req_perm_490_p2_2_b_01_deny_short_circuits_allow() {
+    // Deny precedence — even if an allow rule matches the exact same
+    // command, deny wins. Mirrors upstream L996-L1010 + plan §4 red line.
+    let mut c = ctx();
+    c.add_rule(
+        PermissionBehavior::Deny,
+        PermissionRuleSource::UserSettings,
+        "rm -rf /",
+    );
+    c.add_rule(
+        PermissionBehavior::Allow,
+        PermissionRuleSource::UserSettings,
+        "rm -rf /",
+    );
+    assert_deny_with_rule_content(&check_exact_match("rm -rf /", &c), "rm -rf /");
+}
+
+#[test]
+fn req_perm_490_p2_2_b_02_deny_short_circuits_ask() {
+    let mut c = ctx();
+    c.add_rule(
+        PermissionBehavior::Deny,
+        PermissionRuleSource::ProjectSettings,
+        "curl evil.com",
+    );
+    c.add_rule(
+        PermissionBehavior::Ask,
+        PermissionRuleSource::ProjectSettings,
+        "curl evil.com",
+    );
+    assert_deny_with_rule_content(&check_exact_match("curl evil.com", &c), "curl evil.com");
+}
+
+#[test]
+fn req_perm_490_p2_2_b_03_ask_short_circuits_allow() {
+    let mut c = ctx();
+    c.add_rule(
+        PermissionBehavior::Ask,
+        PermissionRuleSource::UserSettings,
+        "git push",
+    );
+    c.add_rule(
+        PermissionBehavior::Allow,
+        PermissionRuleSource::UserSettings,
+        "git push",
+    );
+    assert_ask_with_rule_content(&check_exact_match("git push", &c), "git push");
+}
+
+#[test]
+fn req_perm_490_p2_2_b_04_passthrough_when_no_rule_matches() {
+    let mut c = ctx();
+    c.add_rule(
+        PermissionBehavior::Allow,
+        PermissionRuleSource::UserSettings,
+        "ls",
+    );
+    match check_exact_match("pwd", &c) {
+        PermissionResult::Passthrough { reason, .. } => match reason {
+            PermissionDecisionReason::Other { .. } => {}
+            other => panic!("expected Other reason on Passthrough, got {other:?}"),
+        },
+        other => panic!("expected Passthrough, got {other:?}"),
+    }
+}
+
+// ---------- rule-shape matching in exact mode ----------
+
+#[test]
+fn req_perm_490_p2_2_b_05_exact_rule_matches_exact_command() {
+    let mut c = ctx();
+    c.add_rule(
+        PermissionBehavior::Allow,
+        PermissionRuleSource::UserSettings,
+        "git status",
+    );
+    assert_allow_with_rule_content(&check_exact_match("git status", &c), "git status");
+}
+
+#[test]
+fn req_perm_490_p2_2_b_06_exact_rule_does_not_match_substring() {
+    let mut c = ctx();
+    c.add_rule(
+        PermissionBehavior::Allow,
+        PermissionRuleSource::UserSettings,
+        "git status",
+    );
+    assert!(matches!(
+        check_exact_match("git status --short", &c),
+        PermissionResult::Passthrough { .. }
+    ));
+}
+
+#[test]
+fn req_perm_490_p2_2_b_07_prefix_rule_matches_only_on_equality_in_exact_mode() {
+    // Upstream L876-L878: in exact mode, a Prefix rule matches iff
+    // `rule.prefix === cmdToMatch`. It must NOT do startsWith — that's
+    // prefix MODE (different parameter, lands in slice 2.2.c).
+    let mut c = ctx();
+    c.add_rule(
+        PermissionBehavior::Allow,
+        PermissionRuleSource::UserSettings,
+        "git:*",
+    );
+    // Equals the bare prefix → match
+    assert_allow_with_rule_content(&check_exact_match("git", &c), "git:*");
+    // startsWith → must NOT match in exact mode
+    assert!(matches!(
+        check_exact_match("git status", &c),
+        PermissionResult::Passthrough { .. }
+    ));
+}
+
+#[test]
+fn req_perm_490_p2_2_b_08_wildcard_rule_never_matches_in_exact_mode() {
+    // Upstream L920-L925 SECURITY FIX: in exact mode, wildcards MUST NOT
+    // match because `.*` would otherwise allow operator-injection like
+    // `foo arg && curl evil.com` against rule `foo *`.
+    let mut c = ctx();
+    c.add_rule(
+        PermissionBehavior::Allow,
+        PermissionRuleSource::UserSettings,
+        "foo *",
+    );
+    // Even a pure benign extension must not be allowed in exact mode.
+    assert!(matches!(
+        check_exact_match("foo arg", &c),
+        PermissionResult::Passthrough { .. }
+    ));
+    // The operator-injection variant must also Passthrough (Fail-Safe).
+    assert!(matches!(
+        check_exact_match("foo arg && curl evil.com", &c),
+        PermissionResult::Passthrough { .. }
+    ));
+}
+
+// ---------- command normalization ----------
+
+#[test]
+fn req_perm_490_p2_2_b_09_command_is_trimmed_before_matching() {
+    // Upstream L995: `const command = input.command.trim()`. Leading /
+    // trailing whitespace must not defeat an exact rule.
+    let mut c = ctx();
+    c.add_rule(
+        PermissionBehavior::Deny,
+        PermissionRuleSource::UserSettings,
+        "rm -rf /",
+    );
+    assert_deny_with_rule_content(&check_exact_match("   rm -rf /   ", &c), "rm -rf /");
+    assert_deny_with_rule_content(&check_exact_match("\trm -rf /\n", &c), "rm -rf /");
+}
+
+// ---------- multi-source determinism ----------
+
+#[test]
+fn req_perm_490_p2_2_b_10_source_iteration_is_deterministic() {
+    // Two deny rules in different sources, both match. The first match
+    // returned must always come from the source that sorts earlier in
+    // `PermissionRuleSource` enum order (UserSettings < ProjectSettings).
+    // This pins the audit-log `rule_id` reproducibility guarantee.
+    let mut c = ctx();
+    c.add_rule(
+        PermissionBehavior::Deny,
+        PermissionRuleSource::ProjectSettings,
+        "rm -rf /",
+    );
+    c.add_rule(
+        PermissionBehavior::Deny,
+        PermissionRuleSource::UserSettings,
+        "rm -rf /",
+    );
+    match check_exact_match("rm -rf /", &c) {
+        PermissionResult::Deny { reason, .. } => match reason {
+            PermissionDecisionReason::Rule { rule } => {
+                assert_eq!(
+                    rule.source,
+                    PermissionRuleSource::UserSettings,
+                    "first-matching-rule must follow PermissionRuleSource enum order"
+                );
+            }
+            other => panic!("expected Rule reason, got {other:?}"),
+        },
+        other => panic!("expected Deny, got {other:?}"),
+    }
+}
+
+#[test]
+fn req_perm_490_p2_2_b_11_rule_provenance_carries_source_and_behavior() {
+    // Audit log + UI need (source, behavior, content) on every rule-driven
+    // result. This pins all 3 across all 3 behaviors.
+    let mut c = ctx();
+    c.add_rule(
+        PermissionBehavior::Ask,
+        PermissionRuleSource::PolicySettings,
+        "docker run",
+    );
+    match check_exact_match("docker run", &c) {
+        PermissionResult::Ask { reason, .. } => match reason {
+            PermissionDecisionReason::Rule { rule } => {
+                assert_eq!(rule.source, PermissionRuleSource::PolicySettings);
+                assert_eq!(rule.rule_behavior, PermissionBehavior::Ask);
+                assert_eq!(rule.rule_value.rule_content.as_deref(), Some("docker run"));
+                assert_eq!(rule.rule_value.tool_name, "Bash");
+            }
+            other => panic!("expected Rule reason, got {other:?}"),
+        },
+        other => panic!("expected Ask, got {other:?}"),
+    }
+}
+
+// ---------- empty contexts ----------
+
+#[test]
+fn req_perm_490_p2_2_b_12_empty_context_returns_passthrough() {
+    // No rules of any kind → Passthrough with Other reason. This is the
+    // baseline state when a fresh process starts with no settings loaded.
+    let c = ctx();
+    assert!(matches!(
+        check_exact_match("ls -la", &c),
+        PermissionResult::Passthrough { .. }
+    ));
+}
+
+// ---------- known-gap pinning (deferred to 2.2.e) ----------
+
+#[test]
+fn req_perm_490_p2_2_b_13_env_var_wrapping_not_yet_stripped() {
+    // Documented known gap: this slice does NOT strip leading env var
+    // assignments. `FOO=bar rm -rf /` is NOT (yet) recognised as
+    // equivalent to `rm -rf /` — that recognition lands in slice 2.2.e
+    // (`stripAllLeadingEnvVars`). Pin the current behavior so 2.2.e
+    // landing flips this assertion intentionally (red test prompts the
+    // 2.2.e PR to update this test).
+    let mut c = ctx();
+    c.add_rule(
+        PermissionBehavior::Deny,
+        PermissionRuleSource::UserSettings,
+        "rm -rf /",
+    );
+    assert!(
+        matches!(
+            check_exact_match("FOO=bar rm -rf /", &c),
+            PermissionResult::Passthrough { .. }
+        ),
+        "PRE-2.2.e: env-var-wrapped command does not match bare-command rule. \
+         When slice 2.2.e lands `strip_all_leading_env_vars`, flip this to Deny."
+    );
+}


### PR DESCRIPTION
Closes #531

## 背景/目标

Second slice of Phase 2.2 (plan PR #526, foundation crate from #528). Adds the **exact-match permission pipeline**: types, source-grouped rule storage, and `check_exact_match` with `Deny > Ask > Allow > Passthrough` precedence.

Library-only: nothing here is wired into `CompositeSafetyHook`. That wiring lands in slice 2.2.f after the prefix/wildcard/compound/env-strip slices (2.2.c-e) close the security gaps documented inline.

Upstream canonical source: `claude-code-main/src/tools/BashTool/bashPermissions.ts` L991-L1048 (`bashToolCheckExactMatchPermission`) + L800-L935 (`filterRulesByContentsMatchingInput` exact-mode branch).

## 改动范围

- **NEW** `crates/dasclaw_bash_permissions/src/types.rs` (~145 LOC) — `PermissionBehavior`, `PermissionRuleSource` (8 variants verbatim from upstream `types/permissions.ts:54`), `PermissionRule`, `PermissionRuleValue`, `PermissionDecisionReason::{Rule, Other}`, `PermissionResult::{Deny, Ask, Allow, Passthrough}`, `ToolPermissionContext` with `always_{allow,deny,ask}_rules: BTreeMap<PermissionRuleSource, Vec<String>>` + `add_rule` builder
- **NEW** `crates/dasclaw_bash_permissions/src/exact_match.rs` (~125 LOC) — `check_exact_match` + per-rule predicate `rule_matches_in_exact_mode` + source-deterministic `first_matching_rule`
- **NEW** `crates/dasclaw_bash_permissions/tests/exact_match_test.rs` (~230 LOC) — 13 tests
- **MODIFIED** `crates/dasclaw_bash_permissions/src/lib.rs` — added 2 `pub mod` + matching re-exports

Exact-mode per-rule predicate (verbatim port of upstream L870-L895):

- `Exact { command }` matches iff `rule.command == cmd`
- `Prefix { prefix }` matches iff `rule.prefix == cmd` (NOT `startsWith` — that's prefix MODE, lands in slice 2.2.c)
- `Wildcard { .. }` always `false` — upstream L920 SECURITY FIX: `.*` against unparsed compound commands like `foo arg && curl evil.com` would otherwise allow operator injection

## 非目标 (What's NOT in this PR)

Deferred per plan §5:

- Prefix / wildcard match mode (slice 2.2.c)
- Compound operator splitting + MAX_SUBCOMMANDS_FOR_SECURITY_CHECK (2.2.d)
- `stripSafeWrappers` / `stripAllLeadingEnvVars` / `BINARY_HIJACK_VARS` (2.2.e). Until 2.2.e lands, `FOO=bar rm -rf /` does NOT match a `Bash(rm -rf /)` deny rule. Test 13 (`req_perm_490_p2_2_b_13_env_var_wrapping_not_yet_stripped`) pins this current behavior so 2.2.e landing flips it to Deny intentionally — the assertion failure message explicitly prompts the 2.2.e PR to update. This is library-only code right now, so the gap has no runtime security impact.
- `BashPermissionHook` adapter + `CompositeSafetyHook` wiring (2.2.f)
- `RuleSuggestion` generation (2.2.g)
- Audit-log contract pinning for bash_perm events (2.2.h)
- ANT-only forbidden ports per #490 epic (classifier / growthbook / bashClassifier)

## 验证

```
$ cargo nextest run -p dasclaw_bash_permissions
     Summary [  10.575s] 36 tests run: 36 passed, 0 skipped
        (23 from Slice 2.2.a + 13 new from this slice)

$ cargo nextest run -p dasclaw_bash_permissions --test exact_match_test
     Summary [   3.402s] 13 tests run: 13 passed, 0 skipped

$ cargo fmt --all
$ python3.12 scripts/check_no_panics.py --base origin/xClaw
OK: No panic-inducing calls in changed production code.

$ cargo clippy --no-deps -p dasclaw_bash_permissions --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.50s
```

Workspace build + cross-crate clippy + heavy integration left to CI per `.github/copilot-instructions.md` §3.

## 3-layer code review summary

- **Layer 1 (diff hygiene)**: 3 new files in the crate landed by #528; existing `shell_rule_matching.rs` untouched. `lib.rs` change is purely additive (2 new `pub mod` + matching re-exports). Zero touch outside `crates/dasclaw_bash_permissions/`.
- **Layer 2 (contract alignment)**:
  - 8-variant `PermissionRuleSource` verbatim from upstream `types/permissions.ts:54` (not collapsed)
  - Per-rule predicate L70-L80 of `exact_match.rs` is a byte-for-byte semantic port of upstream L870-L895 — including the `Wildcard → false` SECURITY FIX from upstream L920
  - Precedence `Deny > Ask > Allow > Passthrough` in `check_exact_match` mirrors upstream L996-L1048
  - Command trim mirrors upstream L995 `input.command.trim()`
- **Layer 3 (invariants)**:
  - `BTreeMap<PermissionRuleSource, Vec<String>>` → deterministic source iteration in enum order (test 10 pins this for audit-log `rule_id` reproducibility)
  - Test 08 (operator-injection probe): `foo *` MUST NOT match `foo arg && curl evil.com` in exact mode
  - Test 13 (known-gap forward pointer): env-var wrapping deferred to 2.2.e; flip-intent documented in assertion message
  - Library-only — no `CompositeSafetyHook` wiring, no runtime security impact yet
  - No `unwrap`/`expect`/`panic!` in production code (script confirmed)

## Sources read

- [AGENTS.md](AGENTS.md) §"任务启动 4 问" / §"测试纪律" / §"GitHub PR 工作流"
- [.github/copilot-instructions.md](.github/copilot-instructions.md) §"强制阅读顺序" / §"必跑的本地管线" / §"PR 必填项"
- [docs/plans/bash-parity/phase-2.2-bash-permissions-rule-engine.md](docs/plans/bash-parity/phase-2.2-bash-permissions-rule-engine.md) §0 / §3 / §4 (deny-不降级 red line) / §5 (slice 2.2.b row) / §6
- `claude-code-main/src/tools/BashTool/bashPermissions.ts` L800-L935 (`filterRulesByContentsMatchingInput` exact-mode branch) + L991-L1048 (`bashToolCheckExactMatchPermission`)
- `claude-code-main/src/types/permissions.ts` L50-L130 (`PermissionRuleSource`, `PermissionRuleValue`, `PermissionRule`) + L200-L330 (`PermissionResult`, `PermissionDecisionReason`) + L420-L450 (`ToolPermissionContext`)
- [crates/dasclaw_bash_permissions/src/shell_rule_matching.rs](crates/dasclaw_bash_permissions/src/shell_rule_matching.rs) — verified `parse_permission_rule` API stability (no churn in this PR)

Stacked-PR avoidance: this PR bases on **xClaw** directly. Depends on #528 (merged), so the new crate is present in the base. Independent of any other in-flight PR.

Refs #490 #502 #526 #528
