### PR TITLE
feat(bash-perm): Slice 2.2.c — port prefix / wildcard match pipeline

### DIFF
--- a/crates/dasclaw_bash_permissions/src/exact_match.rs
+++ b/crates/dasclaw_bash_permissions/src/exact_match.rs
@@ -3,35 +3,24 @@
 //! and its filter helper `filterRulesByContentsMatchingInput` restricted
 //! to `matchMode = 'exact'` (L800-L935).
 //!
-//! ## Scope (Slice 2.2.b)
+//! ## Scope
 //!
-//! This slice implements **exact-match only**. Prefix / wildcard match
-//! modes (prefix-mode in upstream parlance — `startsWith`, `xargs <p>`
-//! word-boundary, compound-command splitting, env-var stripping) land
-//! in subsequent slices per plan §5:
-//!
-//! - Slice 2.2.c → prefix / wildcard match
-//! - Slice 2.2.d → compound operator splitting + `MAX_SUBCOMMANDS_FOR_SECURITY_CHECK`
-//! - Slice 2.2.e → `stripSafeWrappers` + `stripAllLeadingEnvVars` + `BINARY_HIJACK_VARS`
-//! - Slice 2.2.f → `BashPermissionHook` impl + `CompositeSafetyHook` wiring
+//! This module implements **exact-mode matching only**. Prefix /
+//! wildcard mode lives in [`crate::prefix_match`] (slice 2.2.c).
+//! Compound splitting (2.2.d), env-var / safe-wrapper stripping (2.2.e),
+//! and hook wiring (2.2.f) land in later slices.
 //!
 //! ## Security posture
 //!
 //! - **Deny precedence**: deny rules checked first across all sources.
-//!   Matches upstream L996-L1010. A deny match short-circuits — no ask /
-//!   allow can override (deny-不降级 red line in plan §4).
-//! - **Source-deterministic ordering**: rules are iterated in
-//!   [`PermissionRuleSource`] enum order via `BTreeMap` keys, then in
-//!   insertion order within each source. This makes `rule_id` audit
-//!   attribution reproducible across runs (regression target for the
-//!   audit-log pinning pattern established in #524 / #530).
-//! - **Library-only until 2.2.f**: nothing in this slice is wired into
-//!   `CompositeSafetyHook`. The engine is callable from tests + future
-//!   slices but cannot affect runtime behavior yet.
-//! - **No env-var stripping** in this slice. A rule `Bash(npm:*)` will
-//!   NOT match `FOO=bar npm test` here — that is Fail-Safe for *allow*
-//!   rules (won't auto-allow a wrapped command) but Fail-Open for *deny*
-//!   rules. Documented as a known gap closed by slice 2.2.e.
+//!   Matches upstream L996-L1010. A deny match short-circuits — no ask
+//!   / allow can override (deny-不降级 red line in plan §4).
+//! - **Source-deterministic ordering**: see
+//!   [`crate::pipeline::first_matching_rule`].
+//! - **No env-var stripping** in this slice. A rule `Bash(rm -rf /)`
+//!   will NOT match `FOO=bar rm -rf /` here — Fail-Safe for allow,
+//!   Fail-Open for deny. Closed by slice 2.2.e.
+//! - **Library-only** until slice 2.2.f.
 //!
 //! ## Upstream parity
 //!
@@ -39,23 +28,22 @@
 //!
 //! - `Exact { command }` → matches iff `rule.command == cmd_to_match`
 //! - `Prefix { prefix }` → matches iff `rule.prefix == cmd_to_match`
-//!   (NOT `startsWith` — that's prefix *mode*, a different parameter)
+//!   (NOT `startsWith` — that is prefix *mode*, in
+//!   [`crate::prefix_match`])
 //! - `Wildcard { .. }` → **always false** in exact mode (upstream L920:
 //!   "wildcards must NOT match because we're checking the full unparsed
 //!   command. Wildcard matching on unparsed commands allows `foo *` to
 //!   match `foo arg && curl evil.com` since `.*` matches operators.")
 
+use crate::pipeline::{run_pipeline, RulePredicate};
 use crate::shell_rule_matching::{parse_permission_rule, ShellPermissionRule};
-use crate::types::{
-    PermissionBehavior, PermissionDecisionReason, PermissionResult, PermissionRule,
-    PermissionRuleValue, ToolPermissionContext, ToolPermissionRulesBySource,
-};
+use crate::types::{PermissionResult, ToolPermissionContext};
 
 /// Bash tool name — separated as a const so future tool-agnostic
 /// refactors (slice 2.2.f) can override.
 pub const BASH_TOOL_NAME: &str = "Bash";
 
-/// Determine whether `rule_content` matches `cmd_to_match` in **exact mode**.
+/// Per-rule predicate for `matchMode = 'exact'`.
 ///
 /// Direct port of the inner `commandsToTry.some(...)` predicate from
 /// upstream `filterRulesByContentsMatchingInput` (L870-L935), specialised
@@ -68,33 +56,7 @@ fn rule_matches_in_exact_mode(rule_content: &str, cmd_to_match: &str) -> bool {
     }
 }
 
-/// Scan a `ToolPermissionRulesBySource` and return the first matching
-/// rule (if any), preserving (source, content) provenance for audit logs.
-///
-/// Returns `None` if no rule matches. Iteration order is deterministic:
-/// sources in [`PermissionRuleSource`] enum order (via `BTreeMap`), then
-/// insertion order within each source's `Vec<String>`.
-fn first_matching_rule(
-    rules_by_source: &ToolPermissionRulesBySource,
-    cmd_to_match: &str,
-    behavior: PermissionBehavior,
-) -> Option<PermissionRule> {
-    for (source, rule_contents) in rules_by_source {
-        for rule_content in rule_contents {
-            if rule_matches_in_exact_mode(rule_content, cmd_to_match) {
-                return Some(PermissionRule {
-                    source: *source,
-                    rule_behavior: behavior,
-                    rule_value: PermissionRuleValue {
-                        tool_name: BASH_TOOL_NAME.to_string(),
-                        rule_content: Some(rule_content.clone()),
-                    },
-                });
-            }
-        }
-    }
-    None
-}
+const EXACT_PREDICATE: RulePredicate = rule_matches_in_exact_mode;
 
 /// Run the exact-match permission pipeline against a bash command.
 ///
@@ -105,50 +67,23 @@ fn first_matching_rule(
 /// (`const command = input.command.trim()`). No env-var stripping or
 /// compound-splitting happens here — see slice 2.2.d/e.
 pub fn check_exact_match(command: &str, context: &ToolPermissionContext) -> PermissionResult {
-    let cmd = command.trim();
-
-    // 1. Deny rules — checked first across all sources. A match here
-    //    short-circuits regardless of any ask / allow rule. Matches the
-    //    "deny-不降级" red line in plan §4.
-    if let Some(rule) =
-        first_matching_rule(&context.always_deny_rules, cmd, PermissionBehavior::Deny)
-    {
-        return PermissionResult::Deny {
-            message: format!(
+    run_pipeline(
+        command,
+        context,
+        BASH_TOOL_NAME,
+        EXACT_PREDICATE,
+        &|cmd| {
+            format!(
                 "Permission to use {tool} with command {cmd} has been denied.",
                 tool = BASH_TOOL_NAME,
-            ),
-            reason: PermissionDecisionReason::Rule { rule },
-        };
-    }
-
-    // 2. Ask rules — matched commands require user approval.
-    if let Some(rule) = first_matching_rule(&context.always_ask_rules, cmd, PermissionBehavior::Ask)
-    {
-        return PermissionResult::Ask {
-            message: format!(
+            )
+        },
+        &|| {
+            format!(
                 "Claude requested permissions to use {tool}, but you haven't granted it yet.",
                 tool = BASH_TOOL_NAME,
-            ),
-            reason: PermissionDecisionReason::Rule { rule },
-        };
-    }
-
-    // 3. Allow rules — explicit user grants.
-    if let Some(rule) =
-        first_matching_rule(&context.always_allow_rules, cmd, PermissionBehavior::Allow)
-    {
-        return PermissionResult::Allow {
-            reason: PermissionDecisionReason::Rule { rule },
-        };
-    }
-
-    // 4. Passthrough — no engine-level rule fired. Caller (slice 2.2.f
-    //    hook adapter) decides next: prompt user, run classifier, etc.
-    PermissionResult::Passthrough {
-        message: "This command requires approval".to_string(),
-        reason: PermissionDecisionReason::Other {
-            reason: "This command requires approval".to_string(),
+            )
         },
-    }
+        &|| "This command requires approval".to_string(),
+    )
 }

--- a/crates/dasclaw_bash_permissions/src/lib.rs
+++ b/crates/dasclaw_bash_permissions/src/lib.rs
@@ -19,10 +19,13 @@
 //!   is case-sensitive so default is `false`)
 
 pub mod exact_match;
+pub(crate) mod pipeline;
+pub mod prefix_match;
 pub mod shell_rule_matching;
 pub mod types;
 
 pub use exact_match::{check_exact_match, BASH_TOOL_NAME};
+pub use prefix_match::check_prefix_match;
 pub use shell_rule_matching::{
     has_wildcards, match_wildcard_pattern, parse_permission_rule, permission_rule_extract_prefix,
     MatchOptions, ShellPermissionRule,

--- a/crates/dasclaw_bash_permissions/src/pipeline.rs
+++ b/crates/dasclaw_bash_permissions/src/pipeline.rs
@@ -1,0 +1,131 @@
+//! Shared rule-matching pipeline used by both `exact_match` and
+//! `prefix_match` modes.
+//!
+//! Extracts the source-deterministic iteration over a
+//! [`ToolPermissionRulesBySource`] and the Deny>Ask>Allow>Passthrough
+//! precedence loop. Each match mode supplies its own per-rule predicate
+//! and the wrapping permission-decision messages; everything else is
+//! shared.
+//!
+//! This module is `pub(crate)`: callers go through
+//! [`crate::exact_match::check_exact_match`] or
+//! [`crate::prefix_match::check_prefix_match`].
+
+use crate::types::{
+    PermissionBehavior, PermissionDecisionReason, PermissionResult, PermissionRule,
+    PermissionRuleValue, ToolPermissionContext, ToolPermissionRulesBySource,
+};
+
+/// Per-rule predicate signature: given a rule's stored content string
+/// and the trimmed command, return whether the rule matches.
+///
+/// Modes differ only in this predicate. See:
+/// - [`crate::exact_match`] for `matchMode = 'exact'`
+/// - [`crate::prefix_match`] for `matchMode = 'prefix'`
+pub(crate) type RulePredicate = fn(rule_content: &str, cmd_to_match: &str) -> bool;
+
+/// Scan a [`ToolPermissionRulesBySource`] and return the first rule
+/// whose content satisfies `predicate`, preserving (source, content)
+/// provenance for audit logs.
+///
+/// Iteration order is deterministic:
+/// 1. sources in [`crate::types::PermissionRuleSource`] enum order
+///    (via `BTreeMap` keys)
+/// 2. insertion order within each source's `Vec<String>`
+///
+/// This determinism is the audit-log `rule_id` reproducibility contract
+/// pinned by tests in `bash_security_audit_log.rs` (#524 / #530 pattern).
+pub(crate) fn first_matching_rule(
+    rules_by_source: &ToolPermissionRulesBySource,
+    cmd_to_match: &str,
+    behavior: PermissionBehavior,
+    tool_name: &str,
+    predicate: RulePredicate,
+) -> Option<PermissionRule> {
+    for (source, rule_contents) in rules_by_source {
+        for rule_content in rule_contents {
+            if predicate(rule_content, cmd_to_match) {
+                return Some(PermissionRule {
+                    source: *source,
+                    rule_behavior: behavior,
+                    rule_value: PermissionRuleValue {
+                        tool_name: tool_name.to_string(),
+                        rule_content: Some(rule_content.clone()),
+                    },
+                });
+            }
+        }
+    }
+    None
+}
+
+/// Run the Deny > Ask > Allow > Passthrough pipeline against a trimmed
+/// command, parameterised by a per-rule predicate.
+///
+/// This mirrors upstream `bashToolCheckExactMatchPermission`
+/// (L996-L1048) and `bashToolCheckPermission` (L1050+) precedence,
+/// which is shared verbatim between both match modes. Both upstream
+/// entry points feed into `matchingRulesForInput` (L937-L985) with
+/// different `matchMode` values; the precedence loop is identical.
+///
+/// `deny_message` / `ask_message` / `passthrough_message` are mode- and
+/// tool-specific (e.g. exact mode wants "with command X has been
+/// denied" while prefix mode may want a different phrasing in later
+/// slices). For now both modes use the same upstream wording.
+pub(crate) fn run_pipeline(
+    command: &str,
+    context: &ToolPermissionContext,
+    tool_name: &str,
+    predicate: RulePredicate,
+    deny_message: &dyn Fn(&str) -> String,
+    ask_message: &dyn Fn() -> String,
+    passthrough_message: &dyn Fn() -> String,
+) -> PermissionResult {
+    let cmd = command.trim();
+
+    if let Some(rule) = first_matching_rule(
+        &context.always_deny_rules,
+        cmd,
+        PermissionBehavior::Deny,
+        tool_name,
+        predicate,
+    ) {
+        return PermissionResult::Deny {
+            message: deny_message(cmd),
+            reason: PermissionDecisionReason::Rule { rule },
+        };
+    }
+
+    if let Some(rule) = first_matching_rule(
+        &context.always_ask_rules,
+        cmd,
+        PermissionBehavior::Ask,
+        tool_name,
+        predicate,
+    ) {
+        return PermissionResult::Ask {
+            message: ask_message(),
+            reason: PermissionDecisionReason::Rule { rule },
+        };
+    }
+
+    if let Some(rule) = first_matching_rule(
+        &context.always_allow_rules,
+        cmd,
+        PermissionBehavior::Allow,
+        tool_name,
+        predicate,
+    ) {
+        return PermissionResult::Allow {
+            reason: PermissionDecisionReason::Rule { rule },
+        };
+    }
+
+    let passthrough = passthrough_message();
+    PermissionResult::Passthrough {
+        message: passthrough.clone(),
+        reason: PermissionDecisionReason::Other {
+            reason: passthrough,
+        },
+    }
+}

--- a/crates/dasclaw_bash_permissions/src/prefix_match.rs
+++ b/crates/dasclaw_bash_permissions/src/prefix_match.rs
@@ -1,0 +1,143 @@
+//! Prefix / wildcard permission pipeline — port of upstream
+//! `bashToolCheckPermission` (`bashPermissions.ts` L1050+) inner loop,
+//! restricted to `matchMode = 'prefix'` and the per-rule predicate
+//! within `filterRulesByContentsMatchingInput` (L800-L935).
+//!
+//! ## Scope (Slice 2.2.c)
+//!
+//! Adds prefix-mode rule matching on top of the shared
+//! [`crate::pipeline`]:
+//!
+//! - `Exact { command }` → equality (same as exact mode)
+//! - `Prefix { prefix }` → word-boundary `startsWith` **or** `xargs`
+//!   form (upstream L893-L912)
+//! - `Wildcard { pattern }` → [`match_wildcard_pattern`] (upstream
+//!   L926-L932)
+//!
+//! ## Deferred to later slices (NOT in this PR)
+//!
+//! These upstream behaviors are intentionally **not** included here.
+//! Each gap is documented in tests so the slice that closes it has an
+//! explicit forward-pointer.
+//!
+//! - Slice 2.2.d → compound-command splitting + `isCompoundCommand`
+//!   guard (upstream L894-L896 / L915-L919). Without it, a prefix rule
+//!   `Bash(cd:*)` will currently match `cd /path && rm -rf /` in this
+//!   library-only engine. Pinned by [`tests/prefix_match_test.rs`]
+//!   test `req_perm_490_p2_2_c_18_compound_not_yet_split`.
+//! - Slice 2.2.e → `stripSafeWrappers` / `stripAllLeadingEnvVars` /
+//!   `BINARY_HIJACK_VARS` (upstream L805-L856). Pinned by
+//!   `req_perm_490_p2_2_c_19_env_var_wrapping_not_yet_stripped`.
+//! - Output-redirection stripping (`extractOutputRedirections`,
+//!   upstream L791-L801) — applies to both modes; deferred follow-up.
+//! - Slice 2.2.f → `BashPermissionHook` adapter + `CompositeSafetyHook`
+//!   wiring. Until then this module is library-only — the deferred
+//!   gaps cannot affect runtime safety.
+//!
+//! ## Security posture
+//!
+//! - **Deny precedence**: shared with exact mode via
+//!   [`crate::pipeline::run_pipeline`].
+//! - **Word boundary**: prefix `ls` MUST NOT match `lsof` or `lsattr`.
+//!   Enforced by requiring `prefix == cmd` or `cmd.starts_with(prefix + ' ')`.
+//! - **`xargs <prefix>` form**: upstream allows `Bash(grep:*)` to match
+//!   `xargs grep pattern` so that `xargs` doesn't become a bypass for
+//!   deny rules. Bare `xargs <prefix>` only — flagged invocations like
+//!   `xargs -n1 grep` are NOT matched (natural word boundary).
+//! - **Library-only** until slice 2.2.f.
+
+use crate::pipeline::{run_pipeline, RulePredicate};
+use crate::shell_rule_matching::{
+    match_wildcard_pattern, parse_permission_rule, MatchOptions, ShellPermissionRule,
+};
+use crate::types::{PermissionResult, ToolPermissionContext};
+
+/// Bash tool name — same as [`crate::exact_match::BASH_TOOL_NAME`],
+/// re-declared here to keep the prefix module independently usable.
+pub const BASH_TOOL_NAME: &str = "Bash";
+
+/// Per-rule predicate for `matchMode = 'prefix'`.
+///
+/// Direct port of upstream L872-L932 predicate, specialised to
+/// `matchMode === 'prefix'`. **Compound-command guard NOT applied**
+/// here — see module-level docs. The `Wildcard` branch reuses
+/// [`match_wildcard_pattern`] which already implements upstream's
+/// escape handling + trailing-wildcard optionalization.
+fn rule_matches_in_prefix_mode(rule_content: &str, cmd_to_match: &str) -> bool {
+    match parse_permission_rule(rule_content) {
+        ShellPermissionRule::Exact { command } => command == cmd_to_match,
+        ShellPermissionRule::Prefix { prefix } => prefix_with_word_boundary(&prefix, cmd_to_match),
+        ShellPermissionRule::Wildcard { pattern } => {
+            match_wildcard_pattern(&pattern, cmd_to_match, MatchOptions::default())
+        }
+    }
+}
+
+/// Word-boundary prefix match — port of upstream L897-L912.
+///
+/// Returns true iff one of:
+///
+/// 1. `cmd == prefix` (e.g. rule `Bash(ls:*)` matches bare `ls`)
+/// 2. `cmd` starts with `prefix + ' '` (e.g. `Bash(ls:*)` matches
+///    `ls -la`)
+/// 3. `cmd == "xargs " + prefix` (e.g. `Bash(grep:*)` matches bare
+///    `xargs grep`)
+/// 4. `cmd` starts with `"xargs " + prefix + ' '` (e.g. `Bash(grep:*)`
+///    matches `xargs grep pattern`)
+///
+/// The space-suffix guard ensures `ls` does NOT match `lsof` / `lsattr`.
+fn prefix_with_word_boundary(prefix: &str, cmd: &str) -> bool {
+    if prefix == cmd {
+        return true;
+    }
+    if let Some(rest) = cmd.strip_prefix(prefix) {
+        if rest.starts_with(' ') {
+            return true;
+        }
+    }
+    // xargs <prefix> form (upstream L908-L912)
+    if let Some(after) = cmd.strip_prefix("xargs ") {
+        if after == prefix {
+            return true;
+        }
+        if let Some(rest) = after.strip_prefix(prefix) {
+            if rest.starts_with(' ') {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+const PREFIX_PREDICATE: RulePredicate = rule_matches_in_prefix_mode;
+
+/// Run the prefix-match permission pipeline against a bash command.
+///
+/// Returns a [`PermissionResult`] following upstream precedence
+/// `Deny > Ask > Allow > Passthrough` (shared with exact mode via
+/// [`crate::pipeline::run_pipeline`]).
+///
+/// `command` is trimmed before matching. No env-var stripping,
+/// safe-wrapper stripping, or compound-command splitting happens here
+/// — see module docs.
+pub fn check_prefix_match(command: &str, context: &ToolPermissionContext) -> PermissionResult {
+    run_pipeline(
+        command,
+        context,
+        BASH_TOOL_NAME,
+        PREFIX_PREDICATE,
+        &|cmd| {
+            format!(
+                "Permission to use {tool} with command {cmd} has been denied.",
+                tool = BASH_TOOL_NAME,
+            )
+        },
+        &|| {
+            format!(
+                "Claude requested permissions to use {tool}, but you haven't granted it yet.",
+                tool = BASH_TOOL_NAME,
+            )
+        },
+        &|| "This command requires approval".to_string(),
+    )
+}

--- a/crates/dasclaw_bash_permissions/tests/prefix_match_test.rs
+++ b/crates/dasclaw_bash_permissions/tests/prefix_match_test.rs
@@ -1,0 +1,380 @@
+//! Slice 2.2.c: prefix / wildcard match pipeline tests
+//! (`req_perm_490_p2_2_c_*`).
+//!
+//! Verbatim semantic parity with upstream
+//! `bashToolCheckPermission` → `matchingRulesForInput('prefix')` →
+//! `filterRulesByContentsMatchingInput(..., 'prefix')` predicate, minus
+//! features explicitly deferred to slices 2.2.d/e (compound splitting,
+//! env-var / safe-wrapper stripping).
+//!
+//! Deferred-gap forward pointers:
+//! - test 18 → slice 2.2.d (compound splitting)
+//! - test 19 → slice 2.2.e (env-var stripping)
+
+use dasclaw_bash_permissions::{
+    check_prefix_match, PermissionBehavior, PermissionDecisionReason, PermissionResult,
+    PermissionRuleSource, ToolPermissionContext,
+};
+
+fn ctx() -> ToolPermissionContext {
+    ToolPermissionContext::default()
+}
+
+fn rule_content(result: &PermissionResult) -> Option<&str> {
+    let reason = match result {
+        PermissionResult::Deny { reason, .. }
+        | PermissionResult::Ask { reason, .. }
+        | PermissionResult::Allow { reason }
+        | PermissionResult::Passthrough { reason, .. } => reason,
+    };
+    match reason {
+        PermissionDecisionReason::Rule { rule } => rule.rule_value.rule_content.as_deref(),
+        PermissionDecisionReason::Other { .. } => None,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 1. Exact-shape rules still work in prefix mode (parity baseline)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn req_perm_490_p2_2_c_01_exact_rule_strict_equality() {
+    let mut c = ctx();
+    c.add_rule(
+        PermissionBehavior::Allow,
+        PermissionRuleSource::UserSettings,
+        "git status",
+    );
+    assert!(matches!(
+        check_prefix_match("git status", &c),
+        PermissionResult::Allow { .. }
+    ));
+    assert!(matches!(
+        check_prefix_match("git status --short", &c),
+        PermissionResult::Passthrough { .. }
+    ));
+}
+
+// ---------------------------------------------------------------------------
+// 2. Prefix rule (legacy `name:*` syntax) — word boundary semantics
+// ---------------------------------------------------------------------------
+
+#[test]
+fn req_perm_490_p2_2_c_02_prefix_rule_bare_command_match() {
+    let mut c = ctx();
+    c.add_rule(
+        PermissionBehavior::Allow,
+        PermissionRuleSource::UserSettings,
+        "ls:*",
+    );
+    assert!(matches!(
+        check_prefix_match("ls", &c),
+        PermissionResult::Allow { .. }
+    ));
+}
+
+#[test]
+fn req_perm_490_p2_2_c_03_prefix_rule_with_args_match() {
+    let mut c = ctx();
+    c.add_rule(
+        PermissionBehavior::Allow,
+        PermissionRuleSource::UserSettings,
+        "ls:*",
+    );
+    assert!(matches!(
+        check_prefix_match("ls -la /tmp", &c),
+        PermissionResult::Allow { .. }
+    ));
+}
+
+#[test]
+fn req_perm_490_p2_2_c_04_prefix_rule_word_boundary_rejects_substring() {
+    // SECURITY: `ls:*` MUST NOT match `lsof` / `lsattr` — without the
+    // space-boundary guard, plain startsWith would let `ls:*` grant
+    // access to unrelated `ls`-prefixed binaries (upstream L897-L905).
+    let mut c = ctx();
+    c.add_rule(
+        PermissionBehavior::Allow,
+        PermissionRuleSource::UserSettings,
+        "ls:*",
+    );
+    assert!(matches!(
+        check_prefix_match("lsof", &c),
+        PermissionResult::Passthrough { .. }
+    ));
+    assert!(matches!(
+        check_prefix_match("lsattr -d /", &c),
+        PermissionResult::Passthrough { .. }
+    ));
+}
+
+// ---------------------------------------------------------------------------
+// 3. xargs <prefix> form (upstream L908-L912)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn req_perm_490_p2_2_c_05_xargs_prefix_bare_match() {
+    let mut c = ctx();
+    c.add_rule(
+        PermissionBehavior::Allow,
+        PermissionRuleSource::UserSettings,
+        "grep:*",
+    );
+    assert!(matches!(
+        check_prefix_match("xargs grep", &c),
+        PermissionResult::Allow { .. }
+    ));
+}
+
+#[test]
+fn req_perm_490_p2_2_c_06_xargs_prefix_with_args_match() {
+    let mut c = ctx();
+    c.add_rule(
+        PermissionBehavior::Allow,
+        PermissionRuleSource::UserSettings,
+        "grep:*",
+    );
+    assert!(matches!(
+        check_prefix_match("xargs grep pattern file.txt", &c),
+        PermissionResult::Allow { .. }
+    ));
+}
+
+#[test]
+fn req_perm_490_p2_2_c_07_xargs_flagged_invocation_not_matched() {
+    // Natural word-boundary: `xargs -n1 grep` does NOT start with
+    // `xargs grep ` so flagged xargs invocations are NOT matched
+    // (upstream comment L910-L912).
+    let mut c = ctx();
+    c.add_rule(
+        PermissionBehavior::Allow,
+        PermissionRuleSource::UserSettings,
+        "grep:*",
+    );
+    assert!(matches!(
+        check_prefix_match("xargs -n1 grep pattern", &c),
+        PermissionResult::Passthrough { .. }
+    ));
+}
+
+#[test]
+fn req_perm_490_p2_2_c_08_xargs_deny_blocks_circumvention() {
+    // Deny side: `Bash(rm:*)` must block `xargs rm file` so xargs
+    // doesn't become a deny-rule bypass (upstream comment L908).
+    let mut c = ctx();
+    c.add_rule(
+        PermissionBehavior::Deny,
+        PermissionRuleSource::ProjectSettings,
+        "rm:*",
+    );
+    assert!(matches!(
+        check_prefix_match("xargs rm /tmp/junk", &c),
+        PermissionResult::Deny { .. }
+    ));
+}
+
+// ---------------------------------------------------------------------------
+// 4. Wildcard rule — uses `match_wildcard_pattern` (slice 2.2.a port)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn req_perm_490_p2_2_c_09_wildcard_rule_matches_pattern() {
+    let mut c = ctx();
+    c.add_rule(
+        PermissionBehavior::Allow,
+        PermissionRuleSource::UserSettings,
+        "git diff *",
+    );
+    assert!(matches!(
+        check_prefix_match("git diff HEAD~1", &c),
+        PermissionResult::Allow { .. }
+    ));
+}
+
+#[test]
+fn req_perm_490_p2_2_c_10_wildcard_rule_trailing_optionalization() {
+    // `git *` matches both `git add` and bare `git` per upstream
+    // trailing-wildcard optionalization (shell_rule_matching docs).
+    let mut c = ctx();
+    c.add_rule(
+        PermissionBehavior::Allow,
+        PermissionRuleSource::UserSettings,
+        "git *",
+    );
+    assert!(matches!(
+        check_prefix_match("git", &c),
+        PermissionResult::Allow { .. }
+    ));
+    assert!(matches!(
+        check_prefix_match("git status", &c),
+        PermissionResult::Allow { .. }
+    ));
+}
+
+#[test]
+fn req_perm_490_p2_2_c_11_wildcard_rule_no_match() {
+    let mut c = ctx();
+    c.add_rule(
+        PermissionBehavior::Allow,
+        PermissionRuleSource::UserSettings,
+        "git diff *",
+    );
+    assert!(matches!(
+        check_prefix_match("git status", &c),
+        PermissionResult::Passthrough { .. }
+    ));
+}
+
+// ---------------------------------------------------------------------------
+// 5. Precedence (Deny > Ask > Allow > Passthrough) — same loop as exact mode
+// ---------------------------------------------------------------------------
+
+#[test]
+fn req_perm_490_p2_2_c_12_deny_overrides_allow_in_prefix_mode() {
+    let mut c = ctx();
+    c.add_rule(
+        PermissionBehavior::Allow,
+        PermissionRuleSource::UserSettings,
+        "rm:*",
+    );
+    c.add_rule(
+        PermissionBehavior::Deny,
+        PermissionRuleSource::PolicySettings,
+        "rm:*",
+    );
+    assert!(matches!(
+        check_prefix_match("rm -rf /tmp/foo", &c),
+        PermissionResult::Deny { .. }
+    ));
+}
+
+#[test]
+fn req_perm_490_p2_2_c_13_ask_overrides_allow_in_prefix_mode() {
+    let mut c = ctx();
+    c.add_rule(
+        PermissionBehavior::Allow,
+        PermissionRuleSource::UserSettings,
+        "ls:*",
+    );
+    c.add_rule(
+        PermissionBehavior::Ask,
+        PermissionRuleSource::ProjectSettings,
+        "ls:*",
+    );
+    assert!(matches!(
+        check_prefix_match("ls -la", &c),
+        PermissionResult::Ask { .. }
+    ));
+}
+
+// ---------------------------------------------------------------------------
+// 6. Trim + provenance + source determinism (shared with exact mode)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn req_perm_490_p2_2_c_14_command_trimming() {
+    let mut c = ctx();
+    c.add_rule(
+        PermissionBehavior::Allow,
+        PermissionRuleSource::UserSettings,
+        "ls:*",
+    );
+    assert!(matches!(
+        check_prefix_match("   ls -la   ", &c),
+        PermissionResult::Allow { .. }
+    ));
+}
+
+#[test]
+fn req_perm_490_p2_2_c_15_source_determinism_user_before_project() {
+    let mut c = ctx();
+    // Add in non-canonical order to ensure BTreeMap re-orders.
+    c.add_rule(
+        PermissionBehavior::Allow,
+        PermissionRuleSource::ProjectSettings,
+        "ls:*",
+    );
+    c.add_rule(
+        PermissionBehavior::Allow,
+        PermissionRuleSource::UserSettings,
+        "ls:*",
+    );
+    let result = check_prefix_match("ls -la", &c);
+    let reason = match &result {
+        PermissionResult::Allow { reason } => reason,
+        _ => panic!("expected Allow"),
+    };
+    match reason {
+        PermissionDecisionReason::Rule { rule } => {
+            assert_eq!(rule.source, PermissionRuleSource::UserSettings);
+        }
+        _ => panic!("expected rule reason"),
+    }
+}
+
+#[test]
+fn req_perm_490_p2_2_c_16_provenance_carries_rule_content() {
+    let mut c = ctx();
+    c.add_rule(
+        PermissionBehavior::Deny,
+        PermissionRuleSource::PolicySettings,
+        "rm:*",
+    );
+    let result = check_prefix_match("rm -rf /", &c);
+    assert_eq!(rule_content(&result), Some("rm:*"));
+}
+
+#[test]
+fn req_perm_490_p2_2_c_17_empty_context_is_passthrough() {
+    assert!(matches!(
+        check_prefix_match("anything goes here", &ctx()),
+        PermissionResult::Passthrough { .. }
+    ));
+}
+
+// ---------------------------------------------------------------------------
+// 7. Known gaps — forward pointers to slices 2.2.d and 2.2.e
+// ---------------------------------------------------------------------------
+
+#[test]
+fn req_perm_490_p2_2_c_18_compound_not_yet_split() {
+    // GAP: slice 2.2.d will add compound-command splitting +
+    // `isCompoundCommand` guard (upstream L894-L896 / L915-L919).
+    // Until then, `Bash(cd:*)` will still match
+    // `cd /path && rm -rf /` here because the engine sees the whole
+    // string as one command starting with `cd `. This is library-only
+    // and not wired anywhere; slice 2.2.d MUST flip this to
+    // Passthrough (and the matching deny-side test in 2.2.d MUST keep
+    // `Bash(rm:*)` matching `cd /path && rm -rf /` so denies survive).
+    let mut c = ctx();
+    c.add_rule(
+        PermissionBehavior::Allow,
+        PermissionRuleSource::UserSettings,
+        "cd:*",
+    );
+    let result = check_prefix_match("cd /path && rm -rf /", &c);
+    assert!(
+        matches!(result, PermissionResult::Allow { .. }),
+        "current behavior pinned for forward-pointer; slice 2.2.d \
+         MUST change this to Passthrough"
+    );
+}
+
+#[test]
+fn req_perm_490_p2_2_c_19_env_var_wrapping_not_yet_stripped() {
+    // GAP: slice 2.2.e will add `stripAllLeadingEnvVars` so deny rules
+    // can't be circumvented via `FOO=bar denied_command`. Until then,
+    // `Bash(rm:*)` does NOT match `FOO=bar rm -rf /`. Library-only.
+    let mut c = ctx();
+    c.add_rule(
+        PermissionBehavior::Deny,
+        PermissionRuleSource::PolicySettings,
+        "rm:*",
+    );
+    let result = check_prefix_match("FOO=bar rm -rf /", &c);
+    assert!(
+        matches!(result, PermissionResult::Passthrough { .. }),
+        "current behavior pinned for forward-pointer; slice 2.2.e \
+         MUST change this to Deny (env-var bypass closed)"
+    );
+}


### PR DESCRIPTION
Closes #533

## 背景/目标

Third slice of Phase 2.2 (plan PR #526). Adds the **prefix/wildcard match pipeline** and refactors the exact pipeline (#532) onto a shared internal helper so both modes share precedence + source-determinism without copy-paste.

Library-only — no `CompositeSafetyHook` wiring yet (slice 2.2.f).

Upstream canonical source: `claude-code-main/src/tools/BashTool/bashPermissions.ts` L872-L935 (`filterRulesByContentsMatchingInput` prefix-mode branch), L937-L985 (`matchingRulesForInput`), L1050+ (`bashToolCheckPermission` precedence).

## 改动范围

- **NEW** `crates/dasclaw_bash_permissions/src/pipeline.rs` (~130 LOC) — shared `first_matching_rule` + `run_pipeline` parameterised by a per-rule predicate (`pub(crate)` only)
- **NEW** `crates/dasclaw_bash_permissions/src/prefix_match.rs` (~145 LOC) — `check_prefix_match` + `rule_matches_in_prefix_mode` + `prefix_with_word_boundary`
- **REFACTORED** `crates/dasclaw_bash_permissions/src/exact_match.rs` — now a thin wrapper that supplies its predicate + messages to the shared pipeline. Public surface (`check_exact_match`, `BASH_TOOL_NAME`) is byte-identical; all 13 Slice 2.2.b tests pass unmodified.
- **MODIFIED** `crates/dasclaw_bash_permissions/src/lib.rs` — 2 new module declarations + 1 new re-export
- **NEW** `crates/dasclaw_bash_permissions/tests/prefix_match_test.rs` (~340 LOC) — 19 tests

Per-rule predicate (verbatim port of upstream L872-L932 prefix branch):

- `Exact { command }` → equality (same as exact mode)
- `Prefix { prefix }` → word-boundary `startsWith` OR `xargs <prefix>` form
- `Wildcard { pattern }` → `match_wildcard_pattern` (slice 2.2.a port)

Word-boundary helper (`prefix_with_word_boundary`, upstream L897-L912):

1. `cmd == prefix` (bare command)
2. `cmd starts with prefix + ' '`
3. `cmd == "xargs " + prefix` (bare xargs)
4. `cmd starts with "xargs " + prefix + ' '`

The space-suffix guard ensures `ls:*` does NOT match `lsof`/`lsattr`.

## 非目标 (What's NOT in this PR)

Deferred per plan §5:

- Slice 2.2.d → compound-command splitting + `MAX_SUBCOMMANDS_FOR_SECURITY_CHECK` + `isCompoundCommand` guard (upstream L894-L896 / L915-L919). Until 2.2.d lands, an Allow rule `Bash(cd:*)` will still match `cd /path && rm -rf /` in this library-only engine. **Test 18 pins this current behavior with a forward-pointer assertion** so 2.2.d landing flips it to Passthrough intentionally.
- Slice 2.2.e → `stripSafeWrappers` / `stripAllLeadingEnvVars` / `BINARY_HIJACK_VARS`. Test 19 pins the env-var gap.
- Slice 2.2.f → `BashPermissionHook` adapter + `CompositeSafetyHook` wiring. **Until then this module is library-only — the deferred gaps cannot affect runtime safety.**
- Output-redirection stripping (`extractOutputRedirections`) — shared follow-up between exact + prefix modes.

## 验证

```
$ cargo nextest run -p dasclaw_bash_permissions
     Summary [  20.557s] 55 tests run: 55 passed, 0 skipped
        (23 from 2.2.a + 13 from 2.2.b + 19 new from this slice)

$ cargo fmt --all
$ python3.12 scripts/check_no_panics.py --base origin/xClaw
OK: No panic-inducing calls in changed production code.

$ cargo clippy --no-deps -p dasclaw_bash_permissions --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 3.32s
```

Workspace build + cross-crate clippy + heavy integration left to CI.

## 3-layer code review summary

- **Layer 1 (diff hygiene)**: 2 new source files (`pipeline.rs`, `prefix_match.rs`) + 1 new test file + minimal `lib.rs` touch. `exact_match.rs` refactor preserves public surface (verified by all 13 2.2.b tests passing unchanged). Zero touch outside `crates/dasclaw_bash_permissions/`. **No patch-style copy-paste**: the shared pipeline module exists precisely so the two match modes don't duplicate Deny>Ask>Allow>Passthrough scaffolding.
- **Layer 2 (contract alignment)**:
  - `rule_matches_in_prefix_mode` byte-for-byte port of upstream L872-L932 prefix-mode predicate
  - Word-boundary helper mirrors upstream L897-L912 (bare / spaced / xargs-bare / xargs-spaced — four cases)
  - Wildcard branch delegates to existing `match_wildcard_pattern` so trailing-optionalization + escape handling stays canonical
  - Precedence (Deny > Ask > Allow > Passthrough) reused via shared pipeline so both modes are guaranteed identical (upstream L1050+)
- **Layer 3 (invariants)**:
  - Test 04: SECURITY word-boundary fix pinned (`ls:*` rejects `lsof`/`lsattr`)
  - Test 08: deny-side xargs circumvention block pinned (`rm:*` blocks `xargs rm <file>`)
  - Test 18: compound-command gap pinned with explicit slice 2.2.d forward-pointer
  - Test 19: env-var gap pinned with explicit slice 2.2.e forward-pointer
  - BTreeMap source determinism reused via shared pipeline → audit-log `rule_id` reproducibility (test 15 pins UserSettings before ProjectSettings)
  - Library-only — no runtime security impact yet
  - No `unwrap`/`expect`/`panic!` in production code

## Sources read

- [AGENTS.md](AGENTS.md) §"任务启动 4 问" / §"GitHub PR 工作流" / §"分析工具使用规范"
- [.github/copilot-instructions.md](.github/copilot-instructions.md) §"强制阅读顺序" / §"必跑的本地管线"
- [docs/plans/bash-parity/phase-2.2-bash-permissions-rule-engine.md](docs/plans/bash-parity/phase-2.2-bash-permissions-rule-engine.md) §0 / §3 / §4 (deny-不降级 red line) / §5 (slice 2.2.c row) / §6
- `claude-code-main/src/tools/BashTool/bashPermissions.ts` L800-L935 / L937-L985 / L1050+
- [crates/dasclaw_bash_permissions/src/shell_rule_matching.rs](crates/dasclaw_bash_permissions/src/shell_rule_matching.rs) — verified `match_wildcard_pattern` + `parse_permission_rule` API stable
- [crates/dasclaw_bash_permissions/src/exact_match.rs](crates/dasclaw_bash_permissions/src/exact_match.rs) — refactor base (slice 2.2.b)

Base: **xClaw** directly. Depends on #528 + #532 (both merged), so foundation + types already present. Independent of other in-flight PRs.

Refs #490 #502 #526 #528 #532
