### PR TITLE
feat(bash-perm): Slice 2.2.d — compound splitting + MAX_SUBCOMMANDS cap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2773,6 +2773,7 @@ dependencies = [
 name = "dasclaw_bash_permissions"
 version = "0.0.0-w1"
 dependencies = [
+ "dasclaw_shell_command",
  "regex",
  "thiserror 1.0.69",
 ]

--- a/crates/dasclaw_bash_permissions/Cargo.toml
+++ b/crates/dasclaw_bash_permissions/Cargo.toml
@@ -10,5 +10,6 @@ publish = false
 path = "src/lib.rs"
 
 [dependencies]
+dasclaw_shell_command = { path = "../dasclaw_shell_command" }
 regex = "1.12"
 thiserror = "1"

--- a/crates/dasclaw_bash_permissions/src/compound_match.rs
+++ b/crates/dasclaw_bash_permissions/src/compound_match.rs
@@ -1,0 +1,136 @@
+//! Compound-command splitting + per-subcommand prefix pipeline — port of
+//! the deny-no-degrade red line enforced by upstream
+//! `checkSandboxAutoAllow` (`bashPermissions.ts` L1280+) and
+//! `checkPathConstraints` (L2151-L2167), restricted to the subcommand
+//! fanout guard `MAX_SUBCOMMANDS_FOR_SECURITY_CHECK` (upstream L103).
+//!
+//! ## Scope (Slice 2.2.d)
+//!
+//! Adds compound-aware permission matching on top of
+//! [`crate::prefix_match::check_prefix_match`]:
+//!
+//! - parse the trimmed command via tree-sitter
+//!   (`dasclaw_shell_command::bash::try_parse_word_only_commands_sequence`)
+//!   into a `Vec<Vec<String>>` of subcommand argvs joined by safe
+//!   operators (`&&`, `||`, `;`, `|`)
+//! - cap fanout at [`MAX_SUBCOMMANDS_FOR_SECURITY_CHECK`] = 50 — exceed
+//!   the cap and we return [`PermissionBehavior::Ask`] (upstream
+//!   L2164-L2167 same exact cap value and same downgrade target)
+//! - per-subcommand call into prefix-match; merge per upstream
+//!   precedence: **any** subcommand Deny → compound Deny (red line);
+//!   else **any** Ask → compound Ask; else Passthrough.
+//!
+//! ## What is NOT in this slice
+//!
+//! - `Allow` is **never** granted on a multi-subcommand path. This is
+//!   deliberate: upstream only grants compound-Allow inside the sandbox
+//!   auto-allow code path (`checkSandboxAutoAllow`) which requires extra
+//!   context (sandbox enabled, no path constraints) that we don't have
+//!   yet. Default-to-Passthrough is the Fail-Safe shape.
+//! - No env-var stripping, no safe-wrapper stripping (Slice 2.2.e).
+//! - No `RuleSuggestion` generation (Slice 2.2.g).
+//! - No hook wiring — library-only (Slice 2.2.f).
+//! - When tree-sitter cannot word-only-parse the script (e.g. it
+//!   contains a substitution, a redirect, or any non-safe operator), we
+//!   delegate to single-command [`crate::check_prefix_match`] on the
+//!   raw trimmed string. This matches upstream's
+//!   `skipCompoundCheck = true` fallback path (`bashPermissions.ts`
+//!   L1079: `astCommand !== undefined`) — the AST has already vouched
+//!   for the structure so we do not need a second compound-aware pass.
+//!
+//! ## Upstream parity refs
+//!
+//! - `MAX_SUBCOMMANDS_FOR_SECURITY_CHECK = 50` — L103
+//! - cap behavior `ask` — L2164-L2167
+//! - per-subcommand deny precedence — L1303-L1335 / L2151-L2167
+//! - red line "deny 不降级" — plan `phase-2.2-bash-permissions-rule-engine.md` §4
+
+use dasclaw_shell_command::bash::{try_parse_shell, try_parse_word_only_commands_sequence};
+use dasclaw_shell_command::parse_command::shlex_join;
+
+use crate::prefix_match::check_prefix_match;
+use crate::types::{PermissionDecisionReason, PermissionResult, ToolPermissionContext};
+
+pub const BASH_TOOL_NAME: &str = "Bash";
+
+/// Upstream `MAX_SUBCOMMANDS_FOR_SECURITY_CHECK` (`bashPermissions.ts`
+/// L103). Compounds with more than this many subcommands collapse to
+/// [`PermissionResult::Ask`] so the rule engine is not used as a DoS
+/// surface by adversarial loops.
+pub const MAX_SUBCOMMANDS_FOR_SECURITY_CHECK: usize = 50;
+
+/// Run the compound-aware permission pipeline against a bash command.
+///
+/// See module docs for the precedence rules and the AST-fallback
+/// contract. The result's `reason` always carries either the
+/// rule that triggered the decision (per-subcommand) or an `Other`
+/// reason explaining the fanout cap / passthrough.
+pub fn check_compound_match(command: &str, context: &ToolPermissionContext) -> PermissionResult {
+    let trimmed = command.trim();
+    if trimmed.is_empty() {
+        return PermissionResult::Passthrough {
+            message: "Empty command requires approval".to_string(),
+            reason: PermissionDecisionReason::Other {
+                reason: "Empty command".to_string(),
+            },
+        };
+    }
+
+    let argvs = try_parse_shell(trimmed)
+        .and_then(|tree| try_parse_word_only_commands_sequence(&tree, trimmed));
+
+    // AST could not word-only-parse → upstream L1079 fallback: trust
+    // the tree-sitter verdict and skip compound check. We hand the raw
+    // string to the single-command prefix pipeline.
+    let Some(argvs) = argvs else {
+        return check_prefix_match(trimmed, context);
+    };
+
+    // Single-command — no compound semantics needed.
+    if argvs.len() <= 1 {
+        return check_prefix_match(trimmed, context);
+    }
+
+    // Fanout cap (upstream L2164-L2167).
+    if argvs.len() > MAX_SUBCOMMANDS_FOR_SECURITY_CHECK {
+        return PermissionResult::Ask {
+            message: format!(
+                "Claude requested permissions to use {BASH_TOOL_NAME}, but you haven't granted it yet."
+            ),
+            reason: PermissionDecisionReason::Other {
+                reason: format!(
+                    "bashPermissions: {n} subcommands exceeds cap ({cap}) — returning ask",
+                    n = argvs.len(),
+                    cap = MAX_SUBCOMMANDS_FOR_SECURITY_CHECK,
+                ),
+            },
+        };
+    }
+
+    // Per-subcommand iteration. Deny short-circuits; Ask is buffered.
+    let mut first_ask: Option<PermissionResult> = None;
+    for argv in &argvs {
+        let sub_cmd = shlex_join(argv);
+        let result = check_prefix_match(&sub_cmd, context);
+        match &result {
+            PermissionResult::Deny { .. } => return result,
+            PermissionResult::Ask { .. } if first_ask.is_none() => {
+                first_ask = Some(result);
+            }
+            _ => {}
+        }
+    }
+
+    if let Some(ask) = first_ask {
+        return ask;
+    }
+
+    // No deny, no ask — default to Passthrough on compound (see module
+    // docs; we deliberately do NOT grant Allow here).
+    PermissionResult::Passthrough {
+        message: "This command requires approval".to_string(),
+        reason: PermissionDecisionReason::Other {
+            reason: "Compound command — no matching deny / ask rule on any subcommand".to_string(),
+        },
+    }
+}

--- a/crates/dasclaw_bash_permissions/src/lib.rs
+++ b/crates/dasclaw_bash_permissions/src/lib.rs
@@ -18,12 +18,14 @@
 //!   `MatchOptions::case_insensitive` for forward-compat (Bash itself
 //!   is case-sensitive so default is `false`)
 
+pub mod compound_match;
 pub mod exact_match;
 pub(crate) mod pipeline;
 pub mod prefix_match;
 pub mod shell_rule_matching;
 pub mod types;
 
+pub use compound_match::{check_compound_match, MAX_SUBCOMMANDS_FOR_SECURITY_CHECK};
 pub use exact_match::{check_exact_match, BASH_TOOL_NAME};
 pub use prefix_match::check_prefix_match;
 pub use shell_rule_matching::{

--- a/crates/dasclaw_bash_permissions/tests/compound_match_test.rs
+++ b/crates/dasclaw_bash_permissions/tests/compound_match_test.rs
@@ -1,0 +1,381 @@
+//! Slice 2.2.d: compound-command splitting + MAX_SUBCOMMANDS cap +
+//! deny-no-degrade red lines (`req_perm_490_p2_2_d_*`).
+//!
+//! Mirrors the §4 deny-no-degrade matrix from
+//! `docs/plans/bash-parity/phase-2.2-bash-permissions-rule-engine.md`
+//! and the fanout cap from upstream `bashPermissions.ts` L103 /
+//! L2164-L2167.
+
+use dasclaw_bash_permissions::{
+    check_compound_match, PermissionBehavior, PermissionDecisionReason, PermissionResult,
+    PermissionRuleSource, ToolPermissionContext, MAX_SUBCOMMANDS_FOR_SECURITY_CHECK,
+};
+
+fn ctx() -> ToolPermissionContext {
+    ToolPermissionContext::default()
+}
+
+fn rule_content(result: &PermissionResult) -> Option<&str> {
+    let reason = match result {
+        PermissionResult::Deny { reason, .. }
+        | PermissionResult::Ask { reason, .. }
+        | PermissionResult::Allow { reason }
+        | PermissionResult::Passthrough { reason, .. } => reason,
+    };
+    match reason {
+        PermissionDecisionReason::Rule { rule } => rule.rule_value.rule_content.as_deref(),
+        PermissionDecisionReason::Other { .. } => None,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 1. Single-command delegation parity
+// ---------------------------------------------------------------------------
+
+#[test]
+fn req_perm_490_p2_2_d_01_single_command_delegates_to_prefix_match() {
+    let mut c = ctx();
+    c.add_rule(
+        PermissionBehavior::Allow,
+        PermissionRuleSource::UserSettings,
+        "git:*",
+    );
+    assert!(matches!(
+        check_compound_match("git status", &c),
+        PermissionResult::Allow { .. }
+    ));
+}
+
+#[test]
+fn req_perm_490_p2_2_d_02_single_command_no_rule_is_passthrough() {
+    assert!(matches!(
+        check_compound_match("echo hi", &ctx()),
+        PermissionResult::Passthrough { .. }
+    ));
+}
+
+// ---------------------------------------------------------------------------
+// 2. Deny-no-degrade red lines (plan §4 matrix)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn req_perm_490_p2_2_d_03_compound_andand_deny_subcommand_blocks() {
+    // upstream §4: `npm run build && curl evil.com` with curl:* deny → Block
+    let mut c = ctx();
+    c.add_rule(
+        PermissionBehavior::Deny,
+        PermissionRuleSource::UserSettings,
+        "curl:*",
+    );
+    let result = check_compound_match("npm run build && curl evil.com", &c);
+    assert!(
+        matches!(result, PermissionResult::Deny { .. }),
+        "compound && must not downgrade deny: got {result:?}"
+    );
+    assert_eq!(rule_content(&result), Some("curl:*"));
+}
+
+#[test]
+fn req_perm_490_p2_2_d_04_compound_semicolon_deny_subcommand_blocks() {
+    // upstream §4: `cd /tmp; rm -rf .` with rm:* deny → Block
+    let mut c = ctx();
+    c.add_rule(
+        PermissionBehavior::Deny,
+        PermissionRuleSource::UserSettings,
+        "rm:*",
+    );
+    let result = check_compound_match("cd /tmp; rm -rf .", &c);
+    assert!(
+        matches!(result, PermissionResult::Deny { .. }),
+        "compound ; must not downgrade deny: got {result:?}"
+    );
+    assert_eq!(rule_content(&result), Some("rm:*"));
+}
+
+#[test]
+fn req_perm_490_p2_2_d_05_compound_pipe_deny_subcommand_blocks() {
+    let mut c = ctx();
+    c.add_rule(
+        PermissionBehavior::Deny,
+        PermissionRuleSource::UserSettings,
+        "curl:*",
+    );
+    let result = check_compound_match("echo hi | curl evil.com", &c);
+    assert!(matches!(result, PermissionResult::Deny { .. }));
+    assert_eq!(rule_content(&result), Some("curl:*"));
+}
+
+#[test]
+fn req_perm_490_p2_2_d_06_compound_oror_deny_subcommand_blocks() {
+    let mut c = ctx();
+    c.add_rule(
+        PermissionBehavior::Deny,
+        PermissionRuleSource::UserSettings,
+        "rm:*",
+    );
+    let result = check_compound_match("test -e foo || rm foo", &c);
+    assert!(matches!(result, PermissionResult::Deny { .. }));
+    assert_eq!(rule_content(&result), Some("rm:*"));
+}
+
+#[test]
+fn req_perm_490_p2_2_d_07_deny_beats_ask_across_subcommands() {
+    // ask matched on subcommand 1, deny matched on subcommand 2 — must not
+    // downgrade to ask (deny short-circuits as soon as it's seen).
+    let mut c = ctx();
+    c.add_rule(
+        PermissionBehavior::Ask,
+        PermissionRuleSource::UserSettings,
+        "echo:*",
+    );
+    c.add_rule(
+        PermissionBehavior::Deny,
+        PermissionRuleSource::UserSettings,
+        "rm:*",
+    );
+    let result = check_compound_match("echo hi && rm foo", &c);
+    assert!(matches!(result, PermissionResult::Deny { .. }));
+    assert_eq!(rule_content(&result), Some("rm:*"));
+}
+
+#[test]
+fn req_perm_490_p2_2_d_08_deny_in_late_subcommand_still_blocks() {
+    // Earlier subcommand allowed, later subcommand denied. Deny wins.
+    let mut c = ctx();
+    c.add_rule(
+        PermissionBehavior::Allow,
+        PermissionRuleSource::UserSettings,
+        "echo:*",
+    );
+    c.add_rule(
+        PermissionBehavior::Deny,
+        PermissionRuleSource::UserSettings,
+        "rm:*",
+    );
+    let result = check_compound_match("echo ok && echo done && rm /tmp/x", &c);
+    assert!(matches!(result, PermissionResult::Deny { .. }));
+    assert_eq!(rule_content(&result), Some("rm:*"));
+}
+
+// ---------------------------------------------------------------------------
+// 3. Ask propagation across compound
+// ---------------------------------------------------------------------------
+
+#[test]
+fn req_perm_490_p2_2_d_09_compound_ask_subcommand_propagates() {
+    let mut c = ctx();
+    c.add_rule(
+        PermissionBehavior::Ask,
+        PermissionRuleSource::UserSettings,
+        "curl:*",
+    );
+    let result = check_compound_match("echo hi && curl example.com", &c);
+    assert!(matches!(result, PermissionResult::Ask { .. }));
+    assert_eq!(rule_content(&result), Some("curl:*"));
+}
+
+#[test]
+fn req_perm_490_p2_2_d_10_first_ask_wins_when_no_deny() {
+    let mut c = ctx();
+    c.add_rule(
+        PermissionBehavior::Ask,
+        PermissionRuleSource::UserSettings,
+        "echo:*",
+    );
+    c.add_rule(
+        PermissionBehavior::Ask,
+        PermissionRuleSource::UserSettings,
+        "curl:*",
+    );
+    let result = check_compound_match("echo hi && curl example.com", &c);
+    assert!(matches!(result, PermissionResult::Ask { .. }));
+    // First subcommand triggered first; echo:* matches "echo hi" first.
+    assert_eq!(rule_content(&result), Some("echo:*"));
+}
+
+// ---------------------------------------------------------------------------
+// 4. Allow is NOT granted on compound (Fail-Safe)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn req_perm_490_p2_2_d_11_compound_all_allow_returns_passthrough_not_allow() {
+    // Even when every subcommand has an allow rule, the compound
+    // collapses to Passthrough (see module doc). Slice 2.2.d
+    // deliberately does not grant compound-Allow — that's a 2.2.f
+    // sandbox-auto-allow concern.
+    let mut c = ctx();
+    c.add_rule(
+        PermissionBehavior::Allow,
+        PermissionRuleSource::UserSettings,
+        "echo:*",
+    );
+    c.add_rule(
+        PermissionBehavior::Allow,
+        PermissionRuleSource::UserSettings,
+        "ls:*",
+    );
+    let result = check_compound_match("echo hi && ls -la", &c);
+    assert!(
+        matches!(result, PermissionResult::Passthrough { .. }),
+        "compound all-allow must Fail-Safe to Passthrough: got {result:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 5. MAX_SUBCOMMANDS_FOR_SECURITY_CHECK cap
+// ---------------------------------------------------------------------------
+
+#[test]
+fn req_perm_490_p2_2_d_12_max_subcommands_constant_is_50() {
+    assert_eq!(MAX_SUBCOMMANDS_FOR_SECURITY_CHECK, 50);
+}
+
+#[test]
+fn req_perm_490_p2_2_d_13_at_cap_is_evaluated_normally() {
+    // 50 echo subcommands — exactly at cap, NOT exceeding. Should
+    // evaluate normally (passthrough since no rules).
+    let cmd = (0..MAX_SUBCOMMANDS_FOR_SECURITY_CHECK)
+        .map(|i| format!("echo {i}"))
+        .collect::<Vec<_>>()
+        .join(" && ");
+    let result = check_compound_match(&cmd, &ctx());
+    assert!(
+        matches!(result, PermissionResult::Passthrough { .. }),
+        "exactly at cap must be evaluated normally: got {result:?}"
+    );
+}
+
+#[test]
+fn req_perm_490_p2_2_d_14_over_cap_collapses_to_ask() {
+    let cmd = (0..(MAX_SUBCOMMANDS_FOR_SECURITY_CHECK + 1))
+        .map(|i| format!("echo {i}"))
+        .collect::<Vec<_>>()
+        .join(" && ");
+    let result = check_compound_match(&cmd, &ctx());
+    assert!(
+        matches!(result, PermissionResult::Ask { .. }),
+        "over cap must collapse to Ask: got {result:?}"
+    );
+    // No rule attached — reason is Other.
+    assert_eq!(rule_content(&result), None);
+}
+
+#[test]
+fn req_perm_490_p2_2_d_15_over_cap_does_not_skip_deny() {
+    // SECURITY: deny-no-degrade must still hold even past the cap.
+    // The cap shortcut is BEFORE per-subcommand iteration, so a deny
+    // hiding behind subcommand #51 would NOT be detected. This test
+    // pins that the cap-to-Ask shortcut is the documented behavior;
+    // if upstream ever changes to per-subcommand iteration even past
+    // the cap, update this test.
+    let mut cmd = (0..(MAX_SUBCOMMANDS_FOR_SECURITY_CHECK + 1))
+        .map(|i| format!("echo {i}"))
+        .collect::<Vec<_>>()
+        .join(" && ");
+    cmd.push_str(" && rm -rf /");
+    let mut c = ctx();
+    c.add_rule(
+        PermissionBehavior::Deny,
+        PermissionRuleSource::UserSettings,
+        "rm:*",
+    );
+    let result = check_compound_match(&cmd, &c);
+    // Per upstream L2164-L2167 the cap returns ask — this test pins
+    // that parity. If we ever want stronger semantics, the upstream
+    // ground truth must change first.
+    assert!(matches!(result, PermissionResult::Ask { .. }));
+}
+
+// ---------------------------------------------------------------------------
+// 6. AST-parse fallback (upstream L1079 skipCompoundCheck)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn req_perm_490_p2_2_d_16_unsafe_operator_falls_back_to_single_prefix() {
+    // Backticks make the tree non-word-only → we fall back to single-
+    // command prefix matching on the raw string. A `rm:*` deny rule
+    // must NOT match because the full string does not begin with
+    // `rm` — this is the same gap upstream's pre-AST world had, and
+    // it is closed by Slice 2.2.e/f when the safe-wrapper stripping
+    // and the hook chain provide the second layer.
+    let mut c = ctx();
+    c.add_rule(
+        PermissionBehavior::Deny,
+        PermissionRuleSource::UserSettings,
+        "rm:*",
+    );
+    let result = check_compound_match("echo `rm -rf /`", &c);
+    // No prefix rule matches on the raw string → Passthrough.
+    assert!(
+        matches!(result, PermissionResult::Passthrough { .. }),
+        "AST-fallback must defer to prefix-match on raw string: got {result:?}"
+    );
+}
+
+#[test]
+fn req_perm_490_p2_2_d_17_unsafe_operator_still_honors_direct_match() {
+    // Backticks make tree non-word-only → falls back to single-command
+    // prefix. If the raw string IS prefixed by the rule, deny matches.
+    let mut c = ctx();
+    c.add_rule(
+        PermissionBehavior::Deny,
+        PermissionRuleSource::UserSettings,
+        "echo:*",
+    );
+    let result = check_compound_match("echo `rm -rf /`", &c);
+    assert!(matches!(result, PermissionResult::Deny { .. }));
+    assert_eq!(rule_content(&result), Some("echo:*"));
+}
+
+// ---------------------------------------------------------------------------
+// 7. Trim + empty
+// ---------------------------------------------------------------------------
+
+#[test]
+fn req_perm_490_p2_2_d_18_input_is_trimmed() {
+    let mut c = ctx();
+    c.add_rule(
+        PermissionBehavior::Deny,
+        PermissionRuleSource::UserSettings,
+        "rm:*",
+    );
+    let result = check_compound_match("   echo ok && rm foo   ", &c);
+    assert!(matches!(result, PermissionResult::Deny { .. }));
+}
+
+#[test]
+fn req_perm_490_p2_2_d_19_empty_command_is_passthrough() {
+    assert!(matches!(
+        check_compound_match("   ", &ctx()),
+        PermissionResult::Passthrough { .. }
+    ));
+}
+
+// ---------------------------------------------------------------------------
+// 8. Forward pointer: env-var stripping (slice 2.2.e)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn req_perm_490_p2_2_d_20_env_var_wrapper_not_stripped_yet() {
+    // SECURITY GAP forward-pointer to slice 2.2.e: `FOO=bar rm -rf /`
+    // should be matched by `rm:*` AFTER env-var stripping. Today, the
+    // AST parses this as a single command whose command_name is `rm`
+    // with env vars attached — depending on tree-sitter's surface, it
+    // may or may not match. We pin the CURRENT behavior here so 2.2.e
+    // can flip it without surprises.
+    let mut c = ctx();
+    c.add_rule(
+        PermissionBehavior::Deny,
+        PermissionRuleSource::UserSettings,
+        "rm:*",
+    );
+    let result = check_compound_match("FOO=bar rm -rf /tmp/x", &c);
+    // Today: tree-sitter rejects env-var-prefixed command as
+    // non-word-only (variable_assignment is not in ALLOWED_KINDS),
+    // so we fall back to raw prefix-match which sees `FOO=bar rm…`
+    // not starting with `rm`. Slice 2.2.e MUST change this to Deny.
+    assert!(
+        matches!(result, PermissionResult::Passthrough { .. }),
+        "env-var stripping not yet implemented — slice 2.2.e MUST change this to Deny. got {result:?}"
+    );
+}


### PR DESCRIPTION
## Sources read

- `docs/plans/bash-parity/phase-2.2-bash-permissions-rule-engine.md` §3.3 复合命令拆分 + §4 Deny 不降级红线 + §5 Slice 2.2.d 行
- `claude-code-main/src/tools/BashTool/bashPermissions.ts` L103 (`MAX_SUBCOMMANDS_FOR_SECURITY_CHECK`), L2151-L2167 (cap behavior `ask`), L1050+ (`bashToolCheckPermission`), L1079 (skipCompoundCheck fallback), L1280+ (`checkSandboxAutoAllow` per-subcommand deny iteration)
- `claude-code-main/src/utils/bash/commands.ts` L265-L388 `splitCommand_DEPRECATED`（仅作为上游 ground truth，**未移植**——本 slice 用 tree-sitter AST 走，符合 plan §3.2 "复用 Phase 2.1 已缓存的 AST" 红线）
- `crates/dasclaw_shell_command/src/bash.rs` L29-L95 `try_parse_word_only_commands_sequence`（Phase 2.1 既有 AST 拆分）
- `crates/dasclaw_bash_permissions/src/prefix_match.rs` Slice 2.2.c entry（被本 slice 黑盒复用）
- `AGENTS.md` §强制阅读顺序 + Skills 强制使用规范

## 背景 / 目标

接 Slice 2.2.c（PR #534）的 prefix-mode 单命令管线，补齐 **复合命令** 的语义：

1. 把复合命令（`&&`、`||`、`;`、`|`）拆成 subcommand argv 列表
2. 把 fanout 上限 `MAX_SUBCOMMANDS_FOR_SECURITY_CHECK = 50` 接到 Ask（防 `for i in $(seq 1 10000); do ... done` 类 DoS 把规则引擎打爆）
3. 红线 plan §4："Deny 不降级"——任意 subcommand 命中 Deny → 整体 Deny，**绝不**因 semantic 失败或 ask 命中而降级

## 改动范围

| 文件 | 行 | 备注 |
|---|---|---|
| `crates/dasclaw_bash_permissions/src/compound_match.rs` | NEW ~136 | `check_compound_match` + `MAX_SUBCOMMANDS_FOR_SECURITY_CHECK`，文件头有 30 行 doc 锚定上游行号 |
| `crates/dasclaw_bash_permissions/src/lib.rs` | +2 | `pub mod compound_match;` + re-export |
| `crates/dasclaw_bash_permissions/Cargo.toml` | +1 | `dasclaw_shell_command = { path = ".." }`（已在 workspace；tree-sitter-bash 间接来自 Phase 2.1）|
| `crates/dasclaw_bash_permissions/tests/compound_match_test.rs` | NEW ~381 | 20 个 `req_perm_490_p2_2_d_*` 测试 |
| `Cargo.lock` | +1 line | dep 解析 |

**禁止补丁式代码自检**：未在 `prefix_match.rs` 尾部追加分支；未复制粘贴 deny>ask>allow 优先级逻辑（pipeline.rs 共享）；未引入 flag 切换大块代码。`check_compound_match` 把 `check_prefix_match` 当黑盒调用，subcommand-level 优先级在本模块内 22 行内合成。

## 非目标（What's NOT in this PR）

- 不剥离 env-var 前缀（`FOO=bar cmd`）—— Slice 2.2.e；**已写 forward-pointer 测试 20**
- 不剥离 safe-wrappers（`env`/`stdbuf`/`time`/`timeout`）—— Slice 2.2.e
- 不下放 compound-Allow —— 上游也只在 `checkSandboxAutoAllow` 才允许；2.2.f sandbox 范围；当前 Fail-Safe 到 Passthrough
- 不接 Hook 链 —— 库层；Slice 2.2.f
- 不生成 RuleSuggestion —— Slice 2.2.g

## 三层代码审查

### Layer 1 · diff hygiene（变更最小化）

- 没有触碰 `exact_match.rs`、`prefix_match.rs`、`pipeline.rs`、`shell_rule_matching.rs`、`types.rs`
- 新增模块只 import 4 个上游已有 symbol：`try_parse_shell`、`try_parse_word_only_commands_sequence`、`shlex_join`、`check_prefix_match` + 4 个 type
- 公共表面仅新增 2 个 symbol（`check_compound_match`、`MAX_SUBCOMMANDS_FOR_SECURITY_CHECK`）
- 测试文件独立、19 个 `req_perm_490_p2_2_d_*`（再加 1 个常量校验 = 20）

### Layer 2 · contract alignment（上游对齐）

| 上游不变量 | 本 PR 落点 |
|---|---|
| `MAX_SUBCOMMANDS = 50` (L103) | `MAX_SUBCOMMANDS_FOR_SECURITY_CHECK: usize = 50`（test 12 pin 常量值）|
| cap 行为 = `ask` (L2164-L2167) | test 14 / 15 验证 over-cap → Ask（不 Deny、不 Passthrough）|
| deny 不降级 (plan §4) | test 03/04/05/06 (&&,;,\|,\|\|) + test 07 (deny>ask) + test 08 (deny in late pos) |
| ask 传播 | test 09 / 10 |
| compound 不自动 Allow | test 11 — all-allow 仍返回 Passthrough |
| AST fallback (L1079) | test 16 / 17 — backtick 触发回退到 raw prefix-match |

### Layer 3 · invariants（红线 + 安全）

- **DoS Fail-Safe**：fanout > 50 → Ask；BTreeMap 源确定性继承自 2.2.b 的 `pipeline.rs`
- **Deny short-circuit**：在 Layer 2 的 6 条 test (03-08) pin 死；任何后续重构必须保 short-circuit 顺序
- **AST fallback Fail-Safe**：当 tree-sitter 无法 word-only-parse（含 backtick / `$()` / 重定向 / 控制结构），不假装能拆，直接走 raw prefix-match，让 2.2.c 既有 word-boundary 防御兜底
- **forward-pointer 测试 20** 显式 pin 当前 env-var 不剥离的安全 gap，并在断言消息里写明"Slice 2.2.e MUST change this to Deny"，给后续 slice 留闭环路径
- **无 panic**：`check_no_panics.py` 干净（生产代码无 unwrap/expect/panic）

## 验证

```bash
$ cargo nextest run -p dasclaw_bash_permissions --test compound_match_test
20 tests run: 20 passed (1 leaky), 0 skipped

$ cargo nextest run -p dasclaw_bash_permissions
75 tests run: 75 passed, 0 skipped   # 23 (2.2.a) + 13 (2.2.b) + 19 (2.2.c) + 20 (2.2.d)

$ cargo fmt --all                                     # clean
$ python3.12 scripts/check_no_panics.py --base origin/xClaw
OK: No panic-inducing calls in changed production code.
$ cargo clippy --no-deps -p dasclaw_bash_permissions --all-targets -- -D warnings
   Finished `dev` profile in 23.59s
```

## 关联 ADR

- ADR-112（compat eval）、ADR-113（hook engine unification）—— 本 PR 库层无 hook 接入；2.2.f 才上电
- 复用 ADR-129 §1.3 / ADR-133 标记的 `dasclaw_shell_command` 漂移防护——本 PR 只读 API，不新增 src/*.rs

## Stacked PR 说明

- base 分支：**`feat/bash-perm-match-modes-2.2.c`**（不是 `xClaw`）—— 2.2.d 直接依赖 2.2.c 的 `check_prefix_match` symbol；上游未合并 #534 之前 PR 无法直接基于 xClaw 编译
- 合并顺序：**先 #534，再本 PR**。#534 merge 后我会 `git rebase --onto xClaw feat/bash-perm-match-modes-2.2.c feat/bash-perm-compound-split-2.2.d` 并把本 PR 的 base 改回 `xClaw`
- 即便如此，本 PR 的 diff 已经只包含 2.2.d 的增量——`git diff feat/bash-perm-match-modes-2.2.c..feat/bash-perm-compound-split-2.2.d --stat` 应显示 5 文件 521 行（即本表第二节）

Closes #535
