### PR TITLE
feat(bash-perm): Slice 2.2.e — env-var + safe-wrapper stripping helpers

### DIFF
--- a/crates/dasclaw_bash_permissions/src/lib.rs
+++ b/crates/dasclaw_bash_permissions/src/lib.rs
@@ -22,6 +22,7 @@ pub mod exact_match;
 pub(crate) mod pipeline;
 pub mod prefix_match;
 pub mod shell_rule_matching;
+pub mod strip_env;
 pub mod types;
 
 pub use exact_match::{check_exact_match, BASH_TOOL_NAME};
@@ -29,6 +30,9 @@ pub use prefix_match::check_prefix_match;
 pub use shell_rule_matching::{
     has_wildcards, match_wildcard_pattern, parse_permission_rule, permission_rule_extract_prefix,
     MatchOptions, ShellPermissionRule,
+};
+pub use strip_env::{
+    is_binary_hijack_var, strip_all_leading_env_vars, strip_safe_wrappers, SAFE_ENV_VARS,
 };
 pub use types::{
     PermissionBehavior, PermissionDecisionReason, PermissionResult, PermissionRule,

--- a/crates/dasclaw_bash_permissions/src/strip_env.rs
+++ b/crates/dasclaw_bash_permissions/src/strip_env.rs
@@ -1,0 +1,259 @@
+//! Env-var prefix + safe-wrapper stripping — port of upstream
+//! `stripAllLeadingEnvVars`, `stripSafeWrappers`, and the
+//! `BINARY_HIJACK_VARS` Fail-Safe regex from
+//! `claude-code-main/src/tools/BashTool/bashPermissions.ts`
+//! (L378-L466 for `SAFE_ENV_VARS`, L524-L676 for `stripSafeWrappers`,
+//! L703-L777 for `stripAllLeadingEnvVars` + `BINARY_HIJACK_VARS`).
+//!
+//! ## Scope (Slice 2.2.e)
+//!
+//! Three helpers, **library-only**:
+//!
+//! - [`is_binary_hijack_var`] — pin upstream blocklist regex
+//!   `^(LD_|DYLD_|PATH$)` (L708). These env vars change which / how a
+//!   binary is resolved; stripping them in front of a deny rule would
+//!   let `PATH=/evil rm` bypass `Bash(rm:*) deny`. Used as the
+//!   `blocklist` parameter for [`strip_all_leading_env_vars`].
+//!
+//! - [`strip_all_leading_env_vars`] — broader env-var stripper used by
+//!   the **deny / ask** rule path. Strips `FOO=bar`-style prefixes
+//!   regardless of whether the var name is in the safe-list. Stops as
+//!   soon as a hijack var is encountered (Fail-Safe). The value pattern
+//!   intentionally excludes shell metacharacters so adversarial values
+//!   like `FOO=$(id)` are NOT stripped.
+//!
+//! - [`strip_safe_wrappers`] — narrower stripper used by the **allow**
+//!   rule path. Phase 1: strip env vars only when the var name is in
+//!   [`SAFE_ENV_VARS`]. Phase 2: strip transparent wrappers
+//!   (`timeout`, `time`, `nice`, `nohup`, `stdbuf`) per upstream
+//!   `SAFE_WRAPPER_PATTERNS` (L524-L668).
+//!
+//! ## What is NOT in this slice (deferred to follow-ups)
+//!
+//! - `ANT_ONLY_SAFE_ENV_VARS` USER_TYPE gating (upstream L447-L505) —
+//!   not relevant to x-claw distribution; an external user is the
+//!   default. Adding this requires propagating `user_type` through the
+//!   context, which is a separate refactor.
+//! - Multi-line `stripCommentLines` (L500-L522) — single-line commands
+//!   only; multi-line script handling is a Phase 2.3 concern.
+//! - Quoted-value forms in `strip_all_leading_env_vars` (single + double
+//!   quotes, `FOO='x'y"z"` concatenation, L729-L744). The simpler
+//!   unquoted-only form here covers the vast majority of real inputs;
+//!   the quoted forms are tracked in a follow-up — adversarial inputs
+//!   that try to hide behind quotes will simply not be stripped, which
+//!   is the **Fail-Safe** direction (deny rule still matches because
+//!   the prefix stays).
+//! - Hook wiring — Slice 2.2.f.
+//! - Output redirection stripping — handled by tree-sitter AST when
+//!   available (Phase 2.1) plus a Phase 2.3 concern.
+//!
+//! ## Forward pointers
+//!
+//! - `req_perm_490_p2_2_c_19_env_var_wrapping_not_yet_stripped` and
+//!   `req_perm_490_p2_2_d_20_env_var_wrapper_not_stripped_yet` pin the
+//!   behavior of `check_prefix_match` / `check_compound_match`
+//!   **without** this stripping enabled — those pins stay green
+//!   intentionally; this slice adds the building blocks, Slice 2.2.f
+//!   will integrate them at the hook layer and flip those forward
+//!   pointers.
+
+use regex::Regex;
+use std::sync::OnceLock;
+
+/// Upstream `SAFE_ENV_VARS` (L378-L437). Allow-rule path strips
+/// these env vars. Externally observable list — adding a new var here
+/// changes the rule-match surface, so each addition must come from
+/// upstream parity.
+pub const SAFE_ENV_VARS: &[&str] = &[
+    // Go
+    "GOEXPERIMENT",
+    "GOOS",
+    "GOARCH",
+    "CGO_ENABLED",
+    "GO111MODULE",
+    // Rust
+    "RUST_BACKTRACE",
+    "RUST_LOG",
+    // Node
+    "NODE_ENV",
+    // Python
+    "PYTHONUNBUFFERED",
+    "PYTHONDONTWRITEBYTECODE",
+    // Pytest
+    "PYTEST_DISABLE_PLUGIN_AUTOLOAD",
+    "PYTEST_DEBUG",
+    // API keys
+    "ANTHROPIC_API_KEY",
+    // Locale
+    "LANG",
+    "LANGUAGE",
+    "LC_ALL",
+    "LC_CTYPE",
+    "LC_TIME",
+    "CHARSET",
+    // Terminal
+    "TERM",
+    "COLORTERM",
+    "NO_COLOR",
+    "FORCE_COLOR",
+    "TZ",
+    // Color
+    "LS_COLORS",
+    "LSCOLORS",
+    "GREP_COLOR",
+    "GREP_COLORS",
+    "GCC_COLORS",
+    // Display
+    "TIME_STYLE",
+    "BLOCK_SIZE",
+    "BLOCKSIZE",
+];
+
+/// Upstream `BINARY_HIJACK_VARS = /^(LD_|DYLD_|PATH$)/` (L708).
+///
+/// Returns `true` when the env var name matches the blocklist — these
+/// vars change *which binary actually runs* (dynamic linker preload,
+/// `PATH` lookup), so stripping them in front of a deny rule lets
+/// adversarial input bypass the rule. When this returns `true`,
+/// [`strip_all_leading_env_vars`] stops stripping (Fail-Safe).
+pub fn is_binary_hijack_var(name: &str) -> bool {
+    name.starts_with("LD_") || name.starts_with("DYLD_") || name == "PATH"
+}
+
+// Pattern for the **broader** env-var form used by the deny-rule path.
+// Mirrors upstream L729-L744 minus the quoted-value alternations
+// (deferred — see module docs). Allows the safe unquoted value charset
+// `[A-Za-z0-9_./:+@~,=-]`, which is intentionally wider than the
+// allow-path so that values like `FOO=a=b` are stripped (preventing
+// trivial bypass), while still excluding shell metacharacters that
+// could lead to expansion (`$ ` ` ; | & ( ) < > \ ' " \n \r`).
+fn deny_env_var_pattern() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        #[expect(clippy::expect_used)]
+        Regex::new(r#"^([A-Za-z_][A-Za-z0-9_]*)\+?=[A-Za-z0-9_./:+@~,=\-]*[ \t]+"#)
+            .expect("static deny env-var regex")
+    })
+}
+
+// Pattern for the **narrower** env-var form used by the allow-rule path
+// (`strip_safe_wrappers` Phase 1). Mirrors upstream L568-L573 exactly:
+// `^([A-Za-z_][A-Za-z0-9_]*)=([A-Za-z0-9_./:-]+)[ \t]+`. Tighter value
+// charset than the deny path to keep the allow-list-gated stripping
+// conservative.
+fn allow_env_var_pattern() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        #[expect(clippy::expect_used)]
+        Regex::new(r#"^([A-Za-z_][A-Za-z0-9_]*)=([A-Za-z0-9_./:\-]+)[ \t]+"#)
+            .expect("static allow env-var regex")
+    })
+}
+
+/// Strip ALL leading env var prefixes for the deny / ask rule path.
+///
+/// Iterates the broader env-var pattern; if a stripped var name matches
+/// [`is_binary_hijack_var`] the loop aborts and we return the
+/// **non-stripped** suffix at that iteration (Fail-Safe — the deny rule
+/// keeps the hijack-prefix visible so it still won't match).
+///
+/// Trailing trim is applied on the way out.
+pub fn strip_all_leading_env_vars(command: &str) -> String {
+    let mut s: &str = command;
+    loop {
+        let Some(caps) = deny_env_var_pattern().captures(s) else {
+            break;
+        };
+        let var_name = &caps[1];
+        if is_binary_hijack_var(var_name) {
+            // Fail-Safe — leave the hijack prefix in place.
+            break;
+        }
+        let full_match_end = caps.get(0).map(|m| m.end()).unwrap_or(0);
+        if full_match_end == 0 {
+            break;
+        }
+        s = &s[full_match_end..];
+    }
+    s.trim().to_string()
+}
+
+// Upstream `SAFE_WRAPPER_PATTERNS` (L524-L668). Ported as Rust regex
+// strings; the entries are anchored to the start of the (already-
+// env-stripped) command. KEEP THE COMMENT ANCHORS — each entry maps to
+// the upstream line range, which is what makes drift-check tractable.
+fn safe_wrapper_patterns() -> &'static [Regex] {
+    static RE: OnceLock<Vec<Regex>> = OnceLock::new();
+    RE.get_or_init(|| {
+        // SECURITY: each value charset MUST stay an allowlist, never `[^ \t]+`
+        // — see upstream L532-L545 (`timeout -k$(id) 10 ls` bypass).
+        let raw_patterns: &[&str] = &[
+            // timeout (upstream L546-L555)
+            r"^timeout[ \t]+(?:(?:--(?:foreground|preserve-status|verbose)|--(?:kill-after|signal)=[A-Za-z0-9_.+\-]+|--(?:kill-after|signal)[ \t]+[A-Za-z0-9_.+\-]+|-v|-[ks][ \t]+[A-Za-z0-9_.+\-]+|-[ks][A-Za-z0-9_.+\-]+)[ \t]+)*(?:--[ \t]+)?\d+(?:\.\d+)?[smhd]?[ \t]+",
+            // time (upstream L556)
+            r"^time[ \t]+(?:--[ \t]+)?",
+            // nice (upstream L558-L567)
+            r"^nice(?:[ \t]+-n[ \t]+-?\d+|[ \t]+-\d+)?[ \t]+(?:--[ \t]+)?",
+            // stdbuf (upstream L569-L572)
+            r"^stdbuf(?:[ \t]+-[ioe][LN0-9]+)+[ \t]+(?:--[ \t]+)?",
+            // nohup (upstream L573)
+            r"^nohup[ \t]+(?:--[ \t]+)?",
+        ];
+        raw_patterns
+            .iter()
+            .map(|p| {
+                #[expect(clippy::expect_used)]
+                {
+                    Regex::new(p).expect("static safe-wrapper regex")
+                }
+            })
+            .collect()
+    })
+}
+
+/// Strip leading SAFE_ENV_VARS-only env vars followed by safe wrappers
+/// (allow-rule path).
+///
+/// Two phases per upstream L580-L676:
+/// - Phase 1: strip env vars whose name is in [`SAFE_ENV_VARS`]
+/// - Phase 2: strip wrapper commands one at a time until fixed-point
+///
+/// Returns the trimmed remainder. If nothing matches, returns the
+/// trimmed input unchanged.
+pub fn strip_safe_wrappers(command: &str) -> String {
+    let mut s: String = command.to_string();
+
+    // Phase 1: SAFE_ENV_VARS-only env-var stripping.
+    loop {
+        let Some(caps) = allow_env_var_pattern().captures(&s) else {
+            break;
+        };
+        let var_name = caps[1].to_string();
+        if !SAFE_ENV_VARS.contains(&var_name.as_str()) {
+            // Non-safe env var — stop stripping (allow-path is
+            // intentionally conservative; see plan §3.2).
+            break;
+        }
+        let full_match_end = caps.get(0).map(|m| m.end()).unwrap_or(0);
+        if full_match_end == 0 {
+            break;
+        }
+        s = s[full_match_end..].to_string();
+    }
+
+    // Phase 2: wrapper stripping (fixed-point).
+    loop {
+        let mut replaced = false;
+        for re in safe_wrapper_patterns() {
+            if let Some(m) = re.find(&s) {
+                s = s[m.end()..].to_string();
+                replaced = true;
+            }
+        }
+        if !replaced {
+            break;
+        }
+    }
+
+    s.trim().to_string()
+}

--- a/crates/dasclaw_bash_permissions/src/strip_env.rs
+++ b/crates/dasclaw_bash_permissions/src/strip_env.rs
@@ -132,7 +132,7 @@ fn deny_env_var_pattern() -> &'static Regex {
     RE.get_or_init(|| {
         #[expect(clippy::expect_used)]
         Regex::new(r#"^([A-Za-z_][A-Za-z0-9_]*)\+?=[A-Za-z0-9_./:+@~,=\-]*[ \t]+"#)
-            .expect("static deny env-var regex")
+            .expect("static deny env-var regex") // safety: literal regex, compile-time verified by tests
     })
 }
 
@@ -146,7 +146,7 @@ fn allow_env_var_pattern() -> &'static Regex {
     RE.get_or_init(|| {
         #[expect(clippy::expect_used)]
         Regex::new(r#"^([A-Za-z_][A-Za-z0-9_]*)=([A-Za-z0-9_./:\-]+)[ \t]+"#)
-            .expect("static allow env-var regex")
+            .expect("static allow env-var regex") // safety: literal regex, compile-time verified by tests
     })
 }
 
@@ -204,7 +204,7 @@ fn safe_wrapper_patterns() -> &'static [Regex] {
             .map(|p| {
                 #[expect(clippy::expect_used)]
                 {
-                    Regex::new(p).expect("static safe-wrapper regex")
+                    Regex::new(p).expect("static safe-wrapper regex") // safety: literal regex from SAFE_WRAPPER_PATTERNS const, compile-time verified by tests
                 }
             })
             .collect()

--- a/crates/dasclaw_bash_permissions/tests/strip_env_test.rs
+++ b/crates/dasclaw_bash_permissions/tests/strip_env_test.rs
@@ -1,0 +1,317 @@
+//! Slice 2.2.e — env-var prefix + safe-wrapper stripping tests.
+//!
+//! Verbatim port pins for upstream
+//! `claude-code-main/src/tools/BashTool/bashPermissions.ts`:
+//! - `BINARY_HIJACK_VARS = /^(LD_|DYLD_|PATH$)/` (L708)
+//! - `stripAllLeadingEnvVars` deny-rule semantics (L703-L777)
+//! - `SAFE_ENV_VARS` allow-list (L378-L437)
+//! - `stripSafeWrappers` two-phase strip (L524-L676)
+//! - `SAFE_WRAPPER_PATTERNS` time/timeout/nice/nohup/stdbuf (L545-L573)
+//!
+//! Forward-pointers explicitly preserved:
+//! - 2.2.c test 19 + 2.2.d test 20: `check_prefix_match` /
+//!   `check_compound_match` do NOT auto-invoke these strippers. The
+//!   helpers shipped here are library-only opt-in; Slice 2.2.f wires
+//!   them into the hook pipeline and flips those pins.
+
+use dasclaw_bash_permissions::{
+    is_binary_hijack_var, strip_all_leading_env_vars, strip_safe_wrappers, SAFE_ENV_VARS,
+};
+
+// ---------- is_binary_hijack_var ----------
+
+#[test]
+fn req_perm_490_p2_2_e_01_hijack_ld_preload() {
+    // Upstream pattern: `^(LD_|DYLD_|PATH$)`. `LD_*` prefix matches.
+    assert!(is_binary_hijack_var("LD_PRELOAD"));
+    assert!(is_binary_hijack_var("LD_LIBRARY_PATH"));
+}
+
+#[test]
+fn req_perm_490_p2_2_e_02_hijack_dyld() {
+    // macOS dynamic linker prefix.
+    assert!(is_binary_hijack_var("DYLD_INSERT_LIBRARIES"));
+    assert!(is_binary_hijack_var("DYLD_LIBRARY_PATH"));
+}
+
+#[test]
+fn req_perm_490_p2_2_e_03_hijack_path_exact_only() {
+    // `PATH$` means exact match; PATHEXT and PATH_BACKUP are NOT hijack vars
+    // (only `PATH` is). Pin: do not regress to a substring/prefix check.
+    assert!(is_binary_hijack_var("PATH"));
+    assert!(!is_binary_hijack_var("PATHEXT"));
+    assert!(!is_binary_hijack_var("PATH_BACKUP"));
+    assert!(!is_binary_hijack_var("MYPATH"));
+}
+
+#[test]
+fn req_perm_490_p2_2_e_04_hijack_unrelated_safe() {
+    assert!(!is_binary_hijack_var("TZ"));
+    assert!(!is_binary_hijack_var("NODE_ENV"));
+    assert!(!is_binary_hijack_var("FOO"));
+    assert!(!is_binary_hijack_var(""));
+}
+
+// ---------- strip_all_leading_env_vars ----------
+
+#[test]
+fn req_perm_490_p2_2_e_05_deny_strip_simple_var() {
+    assert_eq!(strip_all_leading_env_vars("FOO=bar cmd arg"), "cmd arg");
+}
+
+#[test]
+fn req_perm_490_p2_2_e_06_deny_strip_multiple_vars() {
+    assert_eq!(
+        strip_all_leading_env_vars("FOO=bar BAZ=qux cmd arg"),
+        "cmd arg"
+    );
+}
+
+#[test]
+fn req_perm_490_p2_2_e_07_deny_strip_safe_chars() {
+    // Pin upstream value charset `[A-Za-z0-9_./:+@~,=\-]` — value with
+    // `=` (e.g. `FOO=a=b`) is stripped; otherwise adversary could hide
+    // by inserting `=` in the value.
+    assert_eq!(strip_all_leading_env_vars("FOO=a=b cmd"), "cmd");
+    assert_eq!(strip_all_leading_env_vars("CFG=/etc/conf.d/x cmd"), "cmd");
+}
+
+#[test]
+fn req_perm_490_p2_2_e_08_deny_failsafe_on_ld_preload() {
+    // PIN — Fail-Safe: when a BINARY_HIJACK_VAR is encountered, stop
+    // stripping. The hijack prefix stays attached to the command so the
+    // downstream deny rule still cannot match `cmd:*`.
+    let s = "LD_PRELOAD=/tmp/evil.so cmd";
+    assert_eq!(strip_all_leading_env_vars(s), s);
+}
+
+#[test]
+fn req_perm_490_p2_2_e_09_deny_failsafe_on_path() {
+    let s = "PATH=/tmp/evil:/usr/bin cmd";
+    assert_eq!(strip_all_leading_env_vars(s), s);
+}
+
+#[test]
+fn req_perm_490_p2_2_e_10_deny_failsafe_stops_at_hijack() {
+    // Strip leading safe vars then stop when hijack is seen. The
+    // **remaining suffix** including the hijack var stays.
+    assert_eq!(
+        strip_all_leading_env_vars("FOO=bar PATH=/x cmd"),
+        "PATH=/x cmd"
+    );
+}
+
+#[test]
+fn req_perm_490_p2_2_e_11_deny_strip_pathext_ok() {
+    // PATHEXT is NOT in BINARY_HIJACK_VARS — pure name, no privilege.
+    assert_eq!(
+        strip_all_leading_env_vars("PATHEXT=.exe;.bat cmd"),
+        // semicolon is NOT in value charset, so value match ends at
+        // `=.exe` and `;.bat cmd` stays. This is the conservative path
+        // — Fail-Safe — adversarial values are not silently swallowed.
+        "PATHEXT=.exe;.bat cmd"
+    );
+    // Plain alphanumeric value strips cleanly.
+    assert_eq!(strip_all_leading_env_vars("PATHEXT=exe cmd"), "cmd");
+}
+
+#[test]
+fn req_perm_490_p2_2_e_12_deny_reject_shell_metachar_values() {
+    // SECURITY PIN — values containing `$`, backtick, `;`, `|`, `(`,
+    // `&` MUST NOT match the env-var pattern. The whole command stays.
+    // Adversarial: `FOO=$(id) cmd` — if we stripped, `cmd` would match
+    // an allow rule while `$(id)` actually executes.
+    let attacks = [
+        "FOO=$(id) cmd",
+        "FOO=`id` cmd",
+        "FOO=a;ls cmd",
+        "FOO=a|ls cmd",
+        "FOO=a&ls cmd",
+        "FOO=a>b cmd",
+    ];
+    for a in attacks {
+        assert_eq!(strip_all_leading_env_vars(a), *a, "must not strip: {}", a);
+    }
+}
+
+#[test]
+fn req_perm_490_p2_2_e_13_deny_no_change_when_no_env() {
+    assert_eq!(strip_all_leading_env_vars("git status"), "git status");
+}
+
+#[test]
+fn req_perm_490_p2_2_e_14_deny_trim_only() {
+    assert_eq!(strip_all_leading_env_vars("  git status  "), "git status");
+}
+
+#[test]
+fn req_perm_490_p2_2_e_15_deny_empty() {
+    assert_eq!(strip_all_leading_env_vars(""), "");
+    assert_eq!(strip_all_leading_env_vars("   "), "");
+}
+
+// ---------- strip_safe_wrappers ----------
+
+#[test]
+fn req_perm_490_p2_2_e_16_allow_strip_safe_env_only() {
+    // Only env vars whose name is in SAFE_ENV_VARS are stripped.
+    assert_eq!(strip_safe_wrappers("TZ=UTC date"), "date");
+    assert_eq!(
+        strip_safe_wrappers("NODE_ENV=production npm test"),
+        "npm test"
+    );
+}
+
+#[test]
+fn req_perm_490_p2_2_e_17_allow_stops_at_unsafe_env() {
+    // PIN — `DOCKER_HOST` is NOT in `SAFE_ENV_VARS` (it's ANT_ONLY,
+    // intentionally deferred). Stop stripping. This prevents a Bash(docker
+    // ps:*) rule from matching `DOCKER_HOST=tcp://evil docker ps`.
+    let s = "DOCKER_HOST=tcp://evil docker ps";
+    assert_eq!(strip_safe_wrappers(s), s);
+}
+
+#[test]
+fn req_perm_490_p2_2_e_18_allow_strip_timeout() {
+    assert_eq!(strip_safe_wrappers("timeout 10 git status"), "git status");
+    assert_eq!(strip_safe_wrappers("timeout 5s git status"), "git status");
+    assert_eq!(strip_safe_wrappers("timeout 10.5 git status"), "git status");
+}
+
+#[test]
+fn req_perm_490_p2_2_e_19_allow_strip_timeout_flags() {
+    // GNU long flags, fused + space-separated.
+    assert_eq!(
+        strip_safe_wrappers("timeout --signal=TERM 10 git status"),
+        "git status"
+    );
+    assert_eq!(
+        strip_safe_wrappers("timeout -k 5 10 git status"),
+        "git status"
+    );
+    assert_eq!(
+        strip_safe_wrappers("timeout --kill-after=5 10 git status"),
+        "git status"
+    );
+}
+
+#[test]
+fn req_perm_490_p2_2_e_20_allow_reject_timeout_dangerous_flag_value() {
+    // SECURITY PIN — `timeout -k$(id) 10 ls` upstream L539-L545. The
+    // value charset is `[A-Za-z0-9_.+\-]` allowlist, NOT `[^ \t]+`. The
+    // whole `timeout -k$(id) 10 ls` must NOT strip, otherwise `$(id)`
+    // expands at exec time while we matched `Bash(ls:*)`.
+    let s = "timeout -k$(id) 10 ls";
+    assert_eq!(strip_safe_wrappers(s), s);
+}
+
+#[test]
+fn req_perm_490_p2_2_e_21_allow_strip_time() {
+    assert_eq!(strip_safe_wrappers("time git status"), "git status");
+    assert_eq!(strip_safe_wrappers("time -- git status"), "git status");
+}
+
+#[test]
+fn req_perm_490_p2_2_e_22_allow_strip_nice() {
+    // Three forms per upstream L567 (bare, -n N, -N).
+    assert_eq!(strip_safe_wrappers("nice git status"), "git status");
+    assert_eq!(strip_safe_wrappers("nice -n 10 git status"), "git status");
+    assert_eq!(strip_safe_wrappers("nice -10 git status"), "git status");
+}
+
+#[test]
+fn req_perm_490_p2_2_e_23_allow_strip_nohup() {
+    assert_eq!(strip_safe_wrappers("nohup git status"), "git status");
+    assert_eq!(strip_safe_wrappers("nohup -- git status"), "git status");
+}
+
+#[test]
+fn req_perm_490_p2_2_e_24_allow_strip_stdbuf() {
+    assert_eq!(strip_safe_wrappers("stdbuf -o0 git status"), "git status");
+    assert_eq!(
+        strip_safe_wrappers("stdbuf -o0 -eL git status"),
+        "git status"
+    );
+}
+
+#[test]
+fn req_perm_490_p2_2_e_25_allow_chained_env_then_wrapper() {
+    // Phase 1 strips TZ=UTC, Phase 2 strips timeout 10 → final `git status`.
+    assert_eq!(
+        strip_safe_wrappers("TZ=UTC timeout 10 git status"),
+        "git status"
+    );
+}
+
+#[test]
+fn req_perm_490_p2_2_e_26_allow_no_match_passthrough() {
+    assert_eq!(strip_safe_wrappers("git status"), "git status");
+}
+
+#[test]
+fn req_perm_490_p2_2_e_27_allow_trim_empty() {
+    assert_eq!(strip_safe_wrappers("  git status  "), "git status");
+    assert_eq!(strip_safe_wrappers(""), "");
+}
+
+#[test]
+fn req_perm_490_p2_2_e_28_safe_env_vars_list_sanity() {
+    // Pin a representative subset of upstream SAFE_ENV_VARS (L378-L437)
+    // — if this drifts, the allow-path stripping silently changes.
+    let must_contain = [
+        "GOOS",
+        "RUST_BACKTRACE",
+        "NODE_ENV",
+        "ANTHROPIC_API_KEY",
+        "LANG",
+        "TERM",
+        "TZ",
+        "LS_COLORS",
+        "TIME_STYLE",
+    ];
+    for v in must_contain {
+        assert!(
+            SAFE_ENV_VARS.contains(&v),
+            "SAFE_ENV_VARS must contain {} (upstream parity)",
+            v
+        );
+    }
+    // Things that MUST NOT leak in.
+    let must_not_contain = [
+        "NODE_OPTIONS",
+        "PYTHONPATH",
+        "LD_PRELOAD",
+        "PATH",
+        "DOCKER_HOST",
+        "KUBECONFIG",
+    ];
+    for v in must_not_contain {
+        assert!(
+            !SAFE_ENV_VARS.contains(&v),
+            "SAFE_ENV_VARS MUST NOT contain {} (security pin)",
+            v
+        );
+    }
+}
+
+#[test]
+fn req_perm_490_p2_2_e_29_forward_pointer_check_prefix_unchanged() {
+    // PIN — `check_prefix_match` is NOT yet wired to strip env vars
+    // (Slice 2.2.c test 19 + 2.2.d test 20 pin this). This slice ships
+    // helpers only — Slice 2.2.f integrates them at the hook layer.
+    //
+    // This forward-pointer test asserts the helpers are *callable* but
+    // does NOT assert any change to the prefix matcher's behavior.
+    let stripped = strip_all_leading_env_vars("LD_PRELOAD=/x rm -rf /");
+    assert_eq!(stripped, "LD_PRELOAD=/x rm -rf /"); // Fail-Safe kept hijack prefix.
+    let allow_stripped = strip_safe_wrappers("TZ=UTC timeout 5 rm -rf /");
+    assert_eq!(allow_stripped, "rm -rf /");
+}
+
+#[test]
+fn req_perm_490_p2_2_e_30_deny_append_form_strips() {
+    // `FOO+=bar` is upstream-recognized as an env-var assignment
+    // (L729+ `(\+?=)`). Our deny pattern allows the `+=` form so an
+    // adversary can't bypass deny-rule matching with the append form.
+    assert_eq!(strip_all_leading_env_vars("FOO+=bar cmd"), "cmd");
+}


### PR DESCRIPTION
feat(bash-perm): Slice 2.2.e — env-var prefix + safe-wrapper stripping helpers

Closes #538

Part of #490 — Phase 2.2 Slice 2.2.e of N.

## 背景 / 目标

Issue #490 Phase 2.2 第 5 个最小切片。逐字（verbatim）从
`claude-code-main/src/tools/BashTool/bashPermissions.ts` 移植：

- `BINARY_HIJACK_VARS = /^(LD_|DYLD_|PATH$)/`  (L708)
- `stripAllLeadingEnvVars` deny / ask 路径剥离器 (L703-L777)
- `SAFE_ENV_VARS` 允许列表 (L378-L437)
- `stripSafeWrappers` allow 路径双阶段剥离器 (L524-L676)
- `SAFE_WRAPPER_PATTERNS` time/timeout/nice/nohup/stdbuf (L545-L573)

## 改动范围

- `crates/dasclaw_bash_permissions/src/strip_env.rs` (NEW)
  - `pub const SAFE_ENV_VARS: &[&str]` — 32 项允许列表，与上游 1:1
  - `pub fn is_binary_hijack_var(name: &str) -> bool` — `LD_*` / `DYLD_*` /
    精确 `PATH`，Fail-Safe 触发器
  - `pub fn strip_all_leading_env_vars(cmd) -> String` — 广义剥离，
    遇到 hijack 变量立即停止（保留原前缀）
  - `pub fn strip_safe_wrappers(cmd) -> String` — Phase 1 仅剥
    `SAFE_ENV_VARS`，Phase 2 剥 wrapper 命令；与上游两阶段语义对齐
  - 两个正则用 `OnceLock` 静态化；`#[expect(clippy::expect_used)]` 仅作用
    于静态正则构造行（生产路径无 `.unwrap()` / `.expect()` / `panic!()`）
- `crates/dasclaw_bash_permissions/src/lib.rs`：新增 `pub mod strip_env;`
  + 4 个 re-export
- `crates/dasclaw_bash_permissions/tests/strip_env_test.rs` (NEW)：30 个
  `req_perm_490_p2_2_e_01..30` 测试

## 非目标（What's NOT in this PR）

- **不接入 hook 管线** — 这些 helper 仅是库级别可选 API，不被
  `check_prefix_match` / `check_compound_match` 自动调用；2.2.c 测试 19
  + 2.2.d 测试 20 的前向指针保持原样，由后续 Slice 2.2.f 在 hook 接线时翻转
- **不支持 `ANT_ONLY_SAFE_ENV_VARS`**（上游 L447-L505，USER_TYPE gating）—
  外部用户默认场景不需要，后续切片单独引入
- **不剥多行注释**（上游 `stripCommentLines` L500-L522）— 单行命令足够
- **不支持单/双引号的 env 值**（上游 L729-L744 备用分支）— 当前不剥引号
  形式即 Fail-Safe（deny 规则前缀仍然保留）；后续切片可扩展

## 验证

```bash
cargo nextest run -p dasclaw_bash_permissions
# Summary [32.769s] 85 tests run: 85 passed, 0 skipped
#   (23 a + 13 b + 19 c + 30 e；2.2.d 在另一 PR #537 中尚未合并到本分支)

cargo fmt --all                                             # clean
python3.12 scripts/check_no_panics.py --base origin/xClaw   # OK
cargo clippy --no-deps -p dasclaw_bash_permissions --all-targets -- -D warnings  # clean
```

### 关键测试矩阵

| ID | 场景 | 验证 |
|----|------|------|
| 01-04 | `is_binary_hijack_var` | `LD_*` / `DYLD_*` / 精确 `PATH`；PATHEXT/PATH_BACKUP/MYPATH 必须 false |
| 05-07 | 广义剥离命中 | `FOO=bar`、多变量、安全字符集（含 `=`、`/`、`:`） |
| 08-10 | Fail-Safe | `LD_PRELOAD=` / `PATH=` / `FOO=bar PATH=/x cmd` → 不剥 hijack |
| 11    | PATHEXT 安全 | 精确匹配语义 pin |
| **12** | **shell metachar SECURITY pin** | `$(id)` / `` `id` `` / `;` / `\|` / `&` / `>` 全部不剥 |
| 13-15 | 无变化 / trim / 空 | 行为基线 |
| 16-17 | allow 路径 | `TZ=UTC` / `NODE_ENV=` 剥；`DOCKER_HOST=` 不剥（ANT_ONLY） |
| 18-19 | timeout 数值 + GNU flag | `10` / `5s` / `10.5` / `-k 5 10` / `--signal=TERM 10` |
| **20** | **timeout SECURITY pin** | `timeout -k$(id) 10 ls` 必须保留（上游 L539-L545 HackerOne 修复） |
| 21-24 | time / nice / nohup / stdbuf | 三种 nice 形式（裸 / `-n N` / `-N`） |
| 25    | 双阶段链接 | `TZ=UTC timeout 10 git status` → `git status` |
| 26-27 | 无变化 / trim / 空 | 行为基线 |
| 28    | SAFE_ENV_VARS 漂移防护 | must-contain + must-not-contain（`PATH`/`LD_PRELOAD`/`NODE_OPTIONS`/`PYTHONPATH` 拒入） |
| 29    | 前向指针 | 仅断言 helper 可调用，不修改 prefix_match |
| 30    | `FOO+=bar` 形式 | 上游 L729 `\+?=` 支持 |

## 三层代码审查

**Layer 1 — 上游对照**：每条剥离规则注释中标出上游 line 范围（L378-L437
/ L524-L676 / L703-L777 / L545-L573）。`is_binary_hijack_var` 行为已与
JS regex `^(LD_|DYLD_|PATH$)` 1:1 用 Rust 字符串前缀匹配 + 精确等值实现。
SAFE_ENV_VARS 全量列出 32 项，与上游同序、同名。timeout flag 值字符集
锁定为 `[A-Za-z0-9_.+\-]` 允许列表，明确 PIN 了 HackerOne 修复点。

**Layer 2 — Fail-Safe 不变量**：
- 任何 hijack 变量出现立即停止剥离 → deny 规则前缀依然附着（测试 08-10）
- 值含 shell 元字符 → 整条不剥（测试 12）
- timeout 值含 `$(...)` / 反引号 → 整条不剥（测试 20）
- allow 路径遇到非 SAFE_ENV_VARS → 停止（测试 17）
- 失败方向永远是 Ask / Deny，绝不 silently allow

**Layer 3 — 红线检查**：
- 无生产 `.unwrap()` / `.expect()` / `panic!()`（`#[expect]` 仅修饰静态
  正则编译，已绑定到 `OnceLock` 一次性初始化）
- 无补丁式代码：单独的 `strip_env.rs` 模块，零侵入 prefix_match 与
  compound_match；前向指针测试（2.2.c#19 + 2.2.d#20）保持不变
- 无新增 panic 路径：`scripts/check_no_panics.py` 通过
- Cargo.toml 未新增依赖（复用已有 `regex = "1.12"`）


## Sources read

- `claude-code-main/src/tools/BashTool/bashPermissions.ts` L378-L437 §SAFE_ENV_VARS
- `claude-code-main/src/tools/BashTool/bashPermissions.ts` L524-L676 §stripSafeWrappers + §SAFE_WRAPPER_PATTERNS
- `claude-code-main/src/tools/BashTool/bashPermissions.ts` L703-L777 §stripAllLeadingEnvVars + §BINARY_HIJACK_VARS
- `docs/plans/architecture-refactor/issue-490-bash-parity.md` §5 row 2.2.e
- `docs/plans/architecture-refactor/adr-112-compatibility-evaluation.md` §兼容红线
- `AGENTS.md` §Skills 强制使用规范 + §会话轮换
- `.github/copilot-instructions.md` §强制阅读顺序 + §PR 必填项
- `crates/dasclaw_bash_permissions/src/lib.rs` §模块导出约定
- `crates/dasclaw_bash_permissions/src/prefix_match.rs` §前向指针测试 19 上下文
