### PR TITLE
feat(bash-perm): Slice 2.2.g — DANGEROUS_BASH_PATTERNS + is_dangerous_bash_allow_rule

### DIFF
--- a/crates/dasclaw_bash_permissions/src/dangerous_patterns.rs
+++ b/crates/dasclaw_bash_permissions/src/dangerous_patterns.rs
@@ -61,7 +61,7 @@ pub const CROSS_PLATFORM_CODE_EXEC: &[&str] = &[
 const EXTRA_BASH_PATTERNS: &[&str] = &[
     // Shells (upstream L46-L47)
     "zsh", "fish", // Direct shell exec primitives (upstream L48-L50)
-    "eval", "exec", "env", // Argv-feeders (upstream L51)
+    "eval", "exec", "env",   // Argv-feeders (upstream L51)
     "xargs", // Privilege escalation (upstream L52)
     "sudo",
 ];

--- a/crates/dasclaw_bash_permissions/src/dangerous_patterns.rs
+++ b/crates/dasclaw_bash_permissions/src/dangerous_patterns.rs
@@ -1,0 +1,156 @@
+//! Dangerous bash allow-rule predicate — port of upstream
+//! `claude-code-main/src/utils/permissions/dangerousPatterns.ts`
+//! (L17-L42 `CROSS_PLATFORM_CODE_EXEC` + L45-L80 `DANGEROUS_BASH_PATTERNS`)
+//! and `permissionSetup.ts` (L94-L147 `isDangerousBashPermission`).
+//!
+//! ## Purpose
+//!
+//! Allow rules like `Bash(python:*)` or `Bash(node*)` give the model a free
+//! pass to execute arbitrary code through that interpreter, bypassing every
+//! downstream safety check (compound split, env-var stripping, deny rules,
+//! sandbox). This module is the **rule-loading safety filter**: hosts call
+//! [`is_dangerous_bash_allow_rule`] before promoting a rule to active state
+//! and **must refuse** rules that match. (Slice 2.2.h will wire it into
+//! `permissions_loader`; this slice ships the predicate + tests only.)
+//!
+//! ## Scope (Slice 2.2.g)
+//!
+//! - `DANGEROUS_BASH_PATTERNS` external-user subset only
+//! - `is_dangerous_bash_allow_rule(tool, content)` predicate
+//!
+//! ## What is NOT in this slice
+//!
+//! - **`ANT_ONLY` patterns** (upstream L57-L78: `fa run`, `coo`, `gh`,
+//!   `gh api`, `curl`, `wget`, `git`, `kubectl`, `aws`, `gcloud`, `gsutil`):
+//!   Issue #490 epic explicitly forbids ANT-only porting. The set is empty
+//!   for x-claw (`USER_TYPE === 'ant'` branch hard-coded false). Test 11
+//!   pins this regression-defense.
+//! - **PowerShell**: separate `isDangerousPowerShellPermission` upstream
+//!   (L161+); out of scope for the bash-parity epic. Track separately.
+//! - **Auto-mode entry stripping**: upstream `permissionSetup.ts` L281+
+//!   uses the predicate to filter rules at auto-mode entry. This slice
+//!   ships the predicate; wiring is Slice 2.2.h.
+
+use crate::exact_match::BASH_TOOL_NAME;
+use crate::types::PermissionRuleValue;
+
+/// Cross-platform code-exec interpreters + package runners + shells +
+/// ssh — upstream `CROSS_PLATFORM_CODE_EXEC` (L17-L42).
+///
+/// Allowing any of these as a broad rule (`python:*`, `npm run*`,
+/// `node *`) lets the model execute arbitrary code through them,
+/// bypassing every downstream check.
+pub const CROSS_PLATFORM_CODE_EXEC: &[&str] = &[
+    // Interpreters (upstream L19-L29)
+    "python", "python3", "python2", "node", "deno", "tsx", "ruby", "perl", "php", "lua",
+    // Package runners (upstream L30-L36)
+    "npx", "bunx", "npm run", "yarn run", "pnpm run", "bun run",
+    // Shells reachable from both (upstream L37-L40)
+    "bash", "sh", // Remote arbitrary-command wrapper (upstream L41-L42)
+    "ssh",
+];
+
+/// Non-cross-platform but still cross-environment dangerous patterns —
+/// upstream `DANGEROUS_BASH_PATTERNS` L45-L56 (excluding ANT-only L57-L78).
+///
+/// **SECURITY PIN**: ANT-only patterns are INTENTIONALLY EXCLUDED. Issue
+/// #490 explicitly forbids porting ANT-only constants. Adding any of
+/// `fa run` / `coo` / `gh` / `gh api` / `curl` / `wget` / `git` /
+/// `kubectl` / `aws` / `gcloud` / `gsutil` here violates the epic's red
+/// line. Test 11 pins this guard.
+const EXTRA_BASH_PATTERNS: &[&str] = &[
+    // Shells (upstream L46-L47)
+    "zsh", "fish", // Direct shell exec primitives (upstream L48-L50)
+    "eval", "exec", "env", // Argv-feeders (upstream L51)
+    "xargs", // Privilege escalation (upstream L52)
+    "sudo",
+];
+
+/// Iterator over **all** dangerous bash patterns for external (non-ANT)
+/// users. Order is preserved per upstream for log/diff stability.
+pub fn dangerous_bash_patterns() -> impl Iterator<Item = &'static &'static str> {
+    CROSS_PLATFORM_CODE_EXEC
+        .iter()
+        .chain(EXTRA_BASH_PATTERNS.iter())
+}
+
+/// Predicate counterpart of upstream `isDangerousBashPermission`
+/// (`permissionSetup.ts` L94-L147).
+///
+/// Returns `true` when the (tool, rule-content) pair would grant the
+/// model an arbitrary-code-execution shortcut and must be refused at
+/// rule-load time.
+///
+/// Match semantics (upstream L117-L145):
+/// - tool name must be the Bash tool
+/// - `None` / `""` rule content → tool-level allow → dangerous
+/// - rule content `*` → universal wildcard → dangerous
+/// - for each dangerous pattern (lowercased):
+///   * exact match → dangerous
+///   * `pattern:*` → dangerous
+///   * `pattern*` → dangerous
+///   * `pattern *` → dangerous
+///   * starts with `pattern -` AND ends with `*` → dangerous (e.g.
+///     `python -c*`, `python -m*`)
+///
+/// Content comparison is **case-insensitive after trim**, matching
+/// upstream L106 `content.trim().toLowerCase()`.
+pub fn is_dangerous_bash_allow_rule(tool_name: &str, rule_content: Option<&str>) -> bool {
+    // Only Bash rules (upstream L95-L97).
+    if tool_name != BASH_TOOL_NAME {
+        return false;
+    }
+
+    let Some(raw) = rule_content else {
+        // Tool-level allow `Bash` with no content (upstream L100-L102).
+        return true;
+    };
+    if raw.is_empty() {
+        return true;
+    }
+
+    let content = raw.trim().to_lowercase();
+    if content.is_empty() {
+        // `Bash("   ")` — trim-equivalent to no content (defensive).
+        return true;
+    }
+
+    // Standalone wildcard (upstream L109-L111).
+    if content == "*" {
+        return true;
+    }
+
+    for pattern in dangerous_bash_patterns() {
+        let p = pattern.to_lowercase();
+        // Exact (upstream L120-L122)
+        if content == p {
+            return true;
+        }
+        // `pattern:*` (upstream L125-L127)
+        if content == format!("{}:*", p) {
+            return true;
+        }
+        // `pattern*` (upstream L130-L132)
+        if content == format!("{}*", p) {
+            return true;
+        }
+        // `pattern *` (upstream L135-L137)
+        if content == format!("{} *", p) {
+            return true;
+        }
+        // `pattern -...*` (upstream L140-L142)
+        let dash_prefix = format!("{} -", p);
+        if content.starts_with(&dash_prefix) && content.ends_with('*') {
+            return true;
+        }
+    }
+
+    false
+}
+
+/// Convenience wrapper for callers holding a [`PermissionRuleValue`].
+/// Extracts `tool_name` + `rule_content` and forwards to
+/// [`is_dangerous_bash_allow_rule`].
+pub fn is_dangerous_bash_allow_rule_value(value: &PermissionRuleValue) -> bool {
+    is_dangerous_bash_allow_rule(&value.tool_name, value.rule_content.as_deref())
+}

--- a/crates/dasclaw_bash_permissions/src/lib.rs
+++ b/crates/dasclaw_bash_permissions/src/lib.rs
@@ -19,6 +19,7 @@
 //!   is case-sensitive so default is `false`)
 
 pub mod compound_match;
+pub mod dangerous_patterns;
 pub mod exact_match;
 pub(crate) mod pipeline;
 pub mod prefix_match;
@@ -26,6 +27,10 @@ pub mod shell_rule_matching;
 pub mod types;
 
 pub use compound_match::{check_compound_match, MAX_SUBCOMMANDS_FOR_SECURITY_CHECK};
+pub use dangerous_patterns::{
+    dangerous_bash_patterns, is_dangerous_bash_allow_rule, is_dangerous_bash_allow_rule_value,
+    CROSS_PLATFORM_CODE_EXEC,
+};
 pub use exact_match::{check_exact_match, BASH_TOOL_NAME};
 pub use prefix_match::check_prefix_match;
 pub use shell_rule_matching::{

--- a/crates/dasclaw_bash_permissions/tests/dangerous_patterns_test.rs
+++ b/crates/dasclaw_bash_permissions/tests/dangerous_patterns_test.rs
@@ -1,0 +1,312 @@
+//! Slice 2.2.g — `DANGEROUS_BASH_PATTERNS` + `is_dangerous_bash_allow_rule`
+//! verbatim port from
+//! `claude-code-main/src/utils/permissions/dangerousPatterns.ts` (L1-L80)
+//! and `permissionSetup.ts` (L94-L147).
+
+use dasclaw_bash_permissions::{
+    is_dangerous_bash_allow_rule, is_dangerous_bash_allow_rule_value, CROSS_PLATFORM_CODE_EXEC,
+};
+use dasclaw_bash_permissions::{PermissionRuleValue, BASH_TOOL_NAME};
+
+// ---------- non-Bash tool gate ----------
+
+#[test]
+fn req_perm_490_p2_2_g_01_non_bash_tool_never_dangerous() {
+    // Upstream L95-L97. Only Bash rules are checked.
+    assert!(!is_dangerous_bash_allow_rule("Read", Some("python:*")));
+    assert!(!is_dangerous_bash_allow_rule("Edit", Some("*")));
+    assert!(!is_dangerous_bash_allow_rule("WebFetch", None));
+}
+
+// ---------- tool-level allow ----------
+
+#[test]
+fn req_perm_490_p2_2_g_02_tool_level_allow_no_content() {
+    // Upstream L100-L102. `Bash` with no rule content = allow ALL.
+    assert!(is_dangerous_bash_allow_rule(BASH_TOOL_NAME, None));
+}
+
+#[test]
+fn req_perm_490_p2_2_g_03_tool_level_allow_empty_content() {
+    assert!(is_dangerous_bash_allow_rule(BASH_TOOL_NAME, Some("")));
+}
+
+#[test]
+fn req_perm_490_p2_2_g_04_tool_level_allow_whitespace_content() {
+    // Defensive — `Bash("   ")` is trim-equivalent to no content.
+    assert!(is_dangerous_bash_allow_rule(BASH_TOOL_NAME, Some("   ")));
+}
+
+// ---------- standalone wildcard ----------
+
+#[test]
+fn req_perm_490_p2_2_g_05_standalone_wildcard() {
+    // Upstream L109-L111.
+    assert!(is_dangerous_bash_allow_rule(BASH_TOOL_NAME, Some("*")));
+    assert!(is_dangerous_bash_allow_rule(BASH_TOOL_NAME, Some("  *  ")));
+}
+
+// ---------- per-pattern match shapes ----------
+
+#[test]
+fn req_perm_490_p2_2_g_06_exact_pattern_python() {
+    // Upstream L120-L122. Exact pattern is dangerous (it's a rule
+    // saying "any python execution is allowed").
+    assert!(is_dangerous_bash_allow_rule(BASH_TOOL_NAME, Some("python")));
+    assert!(is_dangerous_bash_allow_rule(
+        BASH_TOOL_NAME,
+        Some("python3")
+    ));
+}
+
+#[test]
+fn req_perm_490_p2_2_g_07_colon_star_pattern() {
+    // Upstream L125-L127.
+    assert!(is_dangerous_bash_allow_rule(
+        BASH_TOOL_NAME,
+        Some("python:*")
+    ));
+    assert!(is_dangerous_bash_allow_rule(BASH_TOOL_NAME, Some("node:*")));
+    assert!(is_dangerous_bash_allow_rule(BASH_TOOL_NAME, Some("bash:*")));
+}
+
+#[test]
+fn req_perm_490_p2_2_g_08_trailing_star() {
+    // Upstream L130-L132. `python*` matches python, python3, etc.
+    assert!(is_dangerous_bash_allow_rule(
+        BASH_TOOL_NAME,
+        Some("python*")
+    ));
+    assert!(is_dangerous_bash_allow_rule(BASH_TOOL_NAME, Some("npx*")));
+}
+
+#[test]
+fn req_perm_490_p2_2_g_09_space_star() {
+    // Upstream L135-L137. `python *` matches `python script.py`.
+    assert!(is_dangerous_bash_allow_rule(
+        BASH_TOOL_NAME,
+        Some("python *")
+    ));
+    assert!(is_dangerous_bash_allow_rule(BASH_TOOL_NAME, Some("node *")));
+}
+
+#[test]
+fn req_perm_490_p2_2_g_10_dash_flag_star() {
+    // Upstream L140-L142. `python -c*` matches `python -c 'evil'`.
+    assert!(is_dangerous_bash_allow_rule(
+        BASH_TOOL_NAME,
+        Some("python -c*")
+    ));
+    assert!(is_dangerous_bash_allow_rule(
+        BASH_TOOL_NAME,
+        Some("python -m *")
+    ));
+    assert!(is_dangerous_bash_allow_rule(
+        BASH_TOOL_NAME,
+        Some("node -e*")
+    ));
+}
+
+// ---------- SECURITY: ANT_ONLY entries MUST NOT leak ----------
+
+#[test]
+fn req_perm_490_p2_2_g_11_ant_only_entries_not_ported() {
+    // PIN — Issue #490 epic explicitly forbids porting ANT-only
+    // patterns. None of these may be treated as dangerous bash allow
+    // rules in x-claw (external user). If any one returns true, the
+    // ANT-only segment has leaked into the cross-environment set —
+    // **revert immediately**.
+    let ant_only_excluded = [
+        "fa run",
+        "fa run:*",
+        "fa run*",
+        "coo",
+        "coo:*",
+        "coo*",
+        "gh",
+        "gh:*",
+        "gh*",
+        "gh api",
+        "gh api:*",
+        "gh api*",
+        "curl",
+        "curl:*",
+        "curl*",
+        "wget",
+        "wget:*",
+        "wget*",
+        "git",
+        "git:*",
+        "git*",
+        "kubectl",
+        "kubectl:*",
+        "kubectl*",
+        "aws",
+        "aws:*",
+        "aws*",
+        "gcloud",
+        "gcloud:*",
+        "gcloud*",
+        "gsutil",
+        "gsutil:*",
+        "gsutil*",
+    ];
+    for content in ant_only_excluded {
+        assert!(
+            !is_dangerous_bash_allow_rule(BASH_TOOL_NAME, Some(content)),
+            "ANT-only pattern leaked: {} (Issue #490 red line — must stay false for external users)",
+            content
+        );
+    }
+}
+
+// ---------- per-pattern coverage ----------
+
+#[test]
+fn req_perm_490_p2_2_g_12_every_cross_platform_pattern_dangerous() {
+    // Every entry in CROSS_PLATFORM_CODE_EXEC must trigger `:*` dangerous.
+    for pat in CROSS_PLATFORM_CODE_EXEC {
+        let s = format!("{}:*", pat);
+        assert!(
+            is_dangerous_bash_allow_rule(BASH_TOOL_NAME, Some(&s)),
+            "expected dangerous for {}:*",
+            pat
+        );
+    }
+}
+
+#[test]
+fn req_perm_490_p2_2_g_13_extra_patterns_dangerous() {
+    // The non-cross-platform extras (zsh, fish, eval, exec, env, xargs,
+    // sudo) must also trigger dangerous.
+    let extras = ["zsh", "fish", "eval", "exec", "env", "xargs", "sudo"];
+    for pat in extras {
+        let s = format!("{}:*", pat);
+        assert!(
+            is_dangerous_bash_allow_rule(BASH_TOOL_NAME, Some(&s)),
+            "expected dangerous for {}:*",
+            pat
+        );
+    }
+}
+
+// ---------- non-dangerous ----------
+
+#[test]
+fn req_perm_490_p2_2_g_14_specific_command_safe() {
+    // Narrow rules — fine. `python script.py` is exact, not a prefix.
+    assert!(!is_dangerous_bash_allow_rule(
+        BASH_TOOL_NAME,
+        Some("python script.py")
+    ));
+    // `git status` not in cross-platform list (git is ANT-only) — safe
+    // for external users.
+    assert!(!is_dangerous_bash_allow_rule(
+        BASH_TOOL_NAME,
+        Some("git status")
+    ));
+    // `npm test` is exact, not `npm run:*`.
+    assert!(!is_dangerous_bash_allow_rule(
+        BASH_TOOL_NAME,
+        Some("npm test")
+    ));
+}
+
+#[test]
+fn req_perm_490_p2_2_g_15_dash_pattern_without_trailing_star() {
+    // PIN — `python -c 'print(1)'` is a SPECIFIC rule, not a wildcard.
+    // Upstream L140 requires BOTH `starts_with("pattern -")` AND
+    // `ends_with('*')`. Missing trailing star → not dangerous.
+    assert!(!is_dangerous_bash_allow_rule(
+        BASH_TOOL_NAME,
+        Some("python -c 'print(1)'")
+    ));
+}
+
+#[test]
+fn req_perm_490_p2_2_g_16_substring_not_matching() {
+    // `pyranha` contains `py` but doesn't match any pattern.
+    assert!(!is_dangerous_bash_allow_rule(
+        BASH_TOOL_NAME,
+        Some("pyranha:*")
+    ));
+    // `mybash:*` shouldn't match `bash:*` (different name).
+    assert!(!is_dangerous_bash_allow_rule(
+        BASH_TOOL_NAME,
+        Some("mybash:*")
+    ));
+}
+
+// ---------- case insensitivity ----------
+
+#[test]
+fn req_perm_490_p2_2_g_17_case_insensitive() {
+    // Upstream L106 lowercases the content.
+    assert!(is_dangerous_bash_allow_rule(
+        BASH_TOOL_NAME,
+        Some("PYTHON:*")
+    ));
+    assert!(is_dangerous_bash_allow_rule(
+        BASH_TOOL_NAME,
+        Some("Python *")
+    ));
+    assert!(is_dangerous_bash_allow_rule(BASH_TOOL_NAME, Some("BASH")));
+    assert!(is_dangerous_bash_allow_rule(
+        BASH_TOOL_NAME,
+        Some("Npm Run:*")
+    ));
+}
+
+#[test]
+fn req_perm_490_p2_2_g_18_trim_whitespace() {
+    // Upstream L106 trims first.
+    assert!(is_dangerous_bash_allow_rule(
+        BASH_TOOL_NAME,
+        Some("   python:*   ")
+    ));
+}
+
+// ---------- multi-word patterns ----------
+
+#[test]
+fn req_perm_490_p2_2_g_19_multi_word_pattern_npm_run() {
+    // `npm run` is a multi-word entry — same shape rules apply.
+    assert!(is_dangerous_bash_allow_rule(
+        BASH_TOOL_NAME,
+        Some("npm run")
+    ));
+    assert!(is_dangerous_bash_allow_rule(
+        BASH_TOOL_NAME,
+        Some("npm run:*")
+    ));
+    assert!(is_dangerous_bash_allow_rule(
+        BASH_TOOL_NAME,
+        Some("npm run *")
+    ));
+    // But `npm` alone is NOT in the list (only `npm run` is) — exact
+    // `npm` not dangerous. Sanity-pins the matcher boundary.
+    assert!(!is_dangerous_bash_allow_rule(BASH_TOOL_NAME, Some("npm")));
+}
+
+// ---------- convenience wrapper ----------
+
+#[test]
+fn req_perm_490_p2_2_g_20_value_wrapper_delegates() {
+    let v = PermissionRuleValue {
+        tool_name: BASH_TOOL_NAME.to_string(),
+        rule_content: Some("python:*".to_string()),
+    };
+    assert!(is_dangerous_bash_allow_rule_value(&v));
+
+    let safe = PermissionRuleValue {
+        tool_name: BASH_TOOL_NAME.to_string(),
+        rule_content: Some("git status".to_string()),
+    };
+    assert!(!is_dangerous_bash_allow_rule_value(&safe));
+
+    let other_tool = PermissionRuleValue {
+        tool_name: "Edit".to_string(),
+        rule_content: Some("*".to_string()),
+    };
+    assert!(!is_dangerous_bash_allow_rule_value(&other_tool));
+}


### PR DESCRIPTION
feat(bash-perm): Slice 2.2.g — DANGEROUS_BASH_PATTERNS + is_dangerous_bash_allow_rule

Closes #540

Part of #490 — Phase 2.2 Slice 2.2.g of N (independent of 2.2.f hook wiring).
safety filter; independent of hook pipeline接线 in 2.2.f).

## 背景 / 目标

Issue #490 Phase 2.2 第 6 个最小切片。逐字（verbatim）从上游：

- `claude-code-main/src/utils/permissions/dangerousPatterns.ts` L1-L80
  (`CROSS_PLATFORM_CODE_EXEC` + `DANGEROUS_BASH_PATTERNS`)
- `claude-code-main/src/utils/permissions/permissionSetup.ts` L94-L147
  (`isDangerousBashPermission` predicate)

防御场景：阻止用户/项目设置中残留 `Bash(python:*)` / `Bash(node*)` /
`Bash(*)` 这种"任意代码执行 hatch"型 allow 规则在 auto 模式下激活。本
切片只交付 predicate + 模式常量；wiring 到 `permissions_loader` 是
后续 Slice 2.2.h。

## 改动范围

- NEW `crates/dasclaw_bash_permissions/src/dangerous_patterns.rs` (~180 LOC)
  - `pub const CROSS_PLATFORM_CODE_EXEC: &[&str]` — 20 项跨平台代码
    执行入口（python/python3/python2/node/deno/tsx/ruby/perl/php/lua
    /npx/bunx/npm run/yarn run/pnpm run/bun run/bash/sh/ssh），对齐
    上游 L17-L42
  - `EXTRA_BASH_PATTERNS` (crate-private) — 7 项非跨平台危险模式
    （zsh/fish/eval/exec/env/xargs/sudo），对齐上游 L45-L52
  - `pub fn dangerous_bash_patterns() -> impl Iterator<...>` — 完整
    迭代器
  - `pub fn is_dangerous_bash_allow_rule(tool_name, rule_content) -> bool`
    — 5 种匹配形状（exact / `:*` / `*` 后缀 / 空格-`*` / `-...*`），
    完全对齐上游 L94-L147
  - `pub fn is_dangerous_bash_allow_rule_value(&PermissionRuleValue) -> bool`
    — `PermissionRuleValue` 形态便捷封装
- MODIFIED `crates/dasclaw_bash_permissions/src/lib.rs` — 新增 `pub mod
  dangerous_patterns;` + 4 个 re-export
- NEW `crates/dasclaw_bash_permissions/tests/dangerous_patterns_test.rs`
  — 20 tests `req_perm_490_p2_2_g_01..20`

## 非目标（What's NOT in this PR）

- **ANT_ONLY 模式**（上游 L57-L78：`fa run`/`coo`/`gh`/`gh api`/`curl`/
  `wget`/`git`/`kubectl`/`aws`/`gcloud`/`gsutil`）— Issue #490 epic
  明确禁止 port ANT-only 常量。**测试 11 钉住这条红线**：如果回归引入
  ANT-only 条目，10 个 pattern × 多种形状 = 30+ assertion 会立即失败
- **PowerShell `isDangerousPowerShellPermission`**（上游 L161+）— bash
  parity epic 范围外，单独追踪
- **接入 `permissions_loader` / auto-mode 入口过滤**（上游
  `permissionSetup.ts` L281+）— Slice 2.2.h
- **`shadowedRuleDetection`** — 另一个独立可选切片，本 PR 不包含

## 验证

```bash
cargo nextest run -p dasclaw_bash_permissions
# Summary [25.663s] 95 tests run: 95 passed, 0 skipped
#   (23 a + 13 b + 19 c + 20 d + 20 g；2.2.e 在另一 PR #539 中)

cargo fmt --all                                             # clean
python3.12 scripts/check_no_panics.py --base origin/xClaw   # OK
cargo clippy --no-deps -p dasclaw_bash_permissions --all-targets -- -D warnings  # clean
```

### 测试矩阵亮点

| ID | 场景 | 验证 |
|----|------|------|
| 01 | 非 Bash 工具 | Read/Edit/WebFetch 永远 false（上游 L95-L97） |
| 02-04 | Tool-level allow | `Bash` / `Bash("")` / `Bash("   ")` 全部 dangerous |
| 05 | Standalone `*` | `*` / `  *  ` dangerous |
| 06-10 | 五种 shape | exact / `:*` / `*` 后缀 / ` *` / `-...*` 全覆盖 |
| **11** | **ANT-only 红线 PIN** | 30+ ANT-only 形态全部断言 false（Issue #490 红线） |
| 12 | 跨平台覆盖 | `CROSS_PLATFORM_CODE_EXEC` 20 项 `:*` 全部 dangerous |
| 13 | 非跨平台危险 | `zsh/fish/eval/exec/env/xargs/sudo:*` 全部 dangerous |
| 14-16 | 非危险规则 | `python script.py` / `git status` / `npm test` / `pyranha:*` / `mybash:*` 全部 false |
| 15 | shape 边界 | `python -c 'print(1)'`（无尾 `*`）不危险（上游 L140 双条件 PIN） |
| 17 | 大小写不敏感 | `PYTHON:*` / `Npm Run:*` / `BASH` 全部 dangerous（上游 L106） |
| 18 | trim | `   python:*   ` dangerous |
| 19 | 多词 pattern | `npm run` 全 shape 危险；`npm` 单独不在列表中（边界 PIN） |
| 20 | wrapper | `is_dangerous_bash_allow_rule_value` 三种 PermissionRuleValue 形态 |

## 三层代码审查

**Layer 1 — 上游对照**：
- `CROSS_PLATFORM_CODE_EXEC` 20 项与上游 L17-L42 同序、同名、同分组注释
- `EXTRA_BASH_PATTERNS` 7 项与上游 L46-L52 同序
- `is_dangerous_bash_allow_rule` 5 种 shape 全部标注上游 L120-L142 行号
- ANT-only 段（L57-L78）在 doc + 测试 11 双重 PIN — 任何漂移立即失败

**Layer 2 — Fail-Safe 不变量**：
- 非 Bash 工具立即返回 false（不影响 Read/Edit 等的允许规则）
- `None` / `""` / 纯空白 / 单独 `*` 全部 dangerous → tool-level allow
  绝不可激活
- shape 匹配是允许集合而非排除集合 → 默认 false，新增 shape 必须显式
  扩展（缩小攻击面）
- 大小写归一化在 `to_lowercase` 之后做比较，与上游 `toLowerCase` 等价

**Layer 3 — 红线检查**：
- 无生产 `.unwrap()` / `.expect()` / `panic!()`（`scripts/check_no_panics.py` 通过）
- 无补丁式代码：单独模块，零侵入现有 matcher / pipeline / lib 导出
- 无新增 crate 依赖（纯字符串处理）
- ANT-only 段编译期不可见（无 `cfg(feature)` / 环境分支），唯一红线
  即 EXTRA_BASH_PATTERNS 常量 —— 测试 11 是覆盖性回归 PIN


## Sources read

- `claude-code-main/src/utils/permissions/dangerousPatterns.ts` L1-L80 §CROSS_PLATFORM_CODE_EXEC + §DANGEROUS_BASH_PATTERNS
- `claude-code-main/src/utils/permissions/permissionSetup.ts` L94-L147 §isDangerousBashPermission
- `docs/plans/architecture-refactor/adr-112-compatibility-evaluation.md` §兼容红线
- `AGENTS.md` §Skills 强制使用规范 + §会话轮换
- `.github/copilot-instructions.md` §强制阅读顺序 + §PR 必填项 + §测试纪律
- `crates/dasclaw_bash_permissions/src/lib.rs` §模块导出约定
- `crates/dasclaw_bash_permissions/src/exact_match.rs` §`BASH_TOOL_NAME` 常量
- `crates/dasclaw_bash_permissions/src/types.rs` §`PermissionRuleValue` 形态
