### PR TITLE
feat(bash-perm): Slice 2.2.i — shadowed (unreachable) rule detection

### DIFF
--- a/crates/dasclaw_bash_permissions/src/lib.rs
+++ b/crates/dasclaw_bash_permissions/src/lib.rs
@@ -22,12 +22,17 @@ pub mod compound_match;
 pub mod exact_match;
 pub(crate) mod pipeline;
 pub mod prefix_match;
+pub mod shadowed_rule_detection;
 pub mod shell_rule_matching;
 pub mod types;
 
 pub use compound_match::{check_compound_match, MAX_SUBCOMMANDS_FOR_SECURITY_CHECK};
 pub use exact_match::{check_exact_match, BASH_TOOL_NAME};
 pub use prefix_match::check_prefix_match;
+pub use shadowed_rule_detection::{
+    detect_unreachable_rules, is_shared_setting_source, permission_rule_source_display_string,
+    DetectUnreachableRulesOptions, ShadowType, UnreachableRule,
+};
 pub use shell_rule_matching::{
     has_wildcards, match_wildcard_pattern, parse_permission_rule, permission_rule_extract_prefix,
     MatchOptions, ShellPermissionRule,

--- a/crates/dasclaw_bash_permissions/src/shadowed_rule_detection.rs
+++ b/crates/dasclaw_bash_permissions/src/shadowed_rule_detection.rs
@@ -1,0 +1,290 @@
+//! Shadowed (unreachable) permission rule detection — verbatim port of
+//! upstream `claude-code-main/src/utils/permissions/shadowedRuleDetection.ts`
+//! L1-L234 plus the `permissionRuleSourceDisplayString` helper from
+//! `permissions.ts` L116-L120 and `getSettingSourceDisplayNameLowercase`
+//! from `utils/settings/constants.ts` L72-L93.
+//!
+//! ## Scope
+//!
+//! This slice (2.2.i) ports the **pure analyzer** that, given three
+//! pre-collected rule lists, identifies allow rules made unreachable by
+//! tool-wide deny/ask rules of the same tool. It is intentionally
+//! **input-driven** — callers pass `Vec<PermissionRule>` collected from
+//! their own settings layer. We do NOT port `getAllowRules` /
+//! `getAskRules` / `getDenyRules` here because our crate's
+//! [`crate::types::ToolPermissionContext`] is bash-only and stores
+//! parsed inner content strings (not the upstream
+//! `"Bash(content)" | "Bash"` raw form); the upstream collectors are
+//! storage-shape-dependent, the analyzer is not.
+//!
+//! ## Issue #490 red-line check
+//!
+//! - Algorithm L1-L234 ported verbatim; comments map shape-for-shape
+//! - Bash sandbox-auto-allow exception preserved (upstream L107-L114,
+//!   L141-L150), including the "ask-rule's-source matters, NOT allow's"
+//!   subtlety — pinned by `req_perm_490_p2_2_i_*` tests.
+//! - No upstream ANT-only code in this file
+//! - No new crate deps; pure Rust over existing
+//!   [`crate::types::PermissionRule`].
+
+use crate::exact_match::BASH_TOOL_NAME;
+use crate::types::{PermissionBehavior, PermissionRule, PermissionRuleSource};
+
+/// Type of shadowing that makes a rule unreachable. Mirrors upstream
+/// `ShadowType = 'ask' | 'deny'` (L14).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ShadowType {
+    Ask,
+    Deny,
+}
+
+/// An unreachable permission rule with explanation. Mirrors upstream
+/// `UnreachableRule` (L18-L24).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UnreachableRule {
+    pub rule: PermissionRule,
+    pub reason: String,
+    pub shadowed_by: PermissionRule,
+    pub shadow_type: ShadowType,
+    pub fix: String,
+}
+
+/// Options for detecting unreachable rules. Mirrors upstream
+/// `DetectUnreachableRulesOptions` (L28-L36).
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct DetectUnreachableRulesOptions {
+    /// Whether sandbox auto-allow is enabled for Bash commands. When
+    /// true, tool-wide Bash ask rules from **personal** settings don't
+    /// block specific Bash allow rules (sandboxed commands are
+    /// auto-allowed).
+    pub sandbox_auto_allow_enabled: bool,
+}
+
+/// Result of checking if a rule is shadowed. Discriminated union for
+/// type safety — mirrors upstream `ShadowResult` (L41-L43).
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ShadowResult {
+    NotShadowed,
+    Shadowed {
+        shadowed_by: PermissionRule,
+        shadow_type: ShadowType,
+    },
+}
+
+/// Check if a permission rule source is **shared** (visible to other
+/// users). Verbatim port of upstream `isSharedSettingSource` (L60-L66).
+///
+/// Shared:
+/// - `ProjectSettings` (committed to git, shared with team)
+/// - `PolicySettings` (enterprise-managed, pushed to all users)
+/// - `Command` (from slash command frontmatter, potentially shared)
+///
+/// Personal:
+/// - `UserSettings`, `LocalSettings`, `CliArg`, `Session`, `FlagSettings`
+pub fn is_shared_setting_source(source: PermissionRuleSource) -> bool {
+    matches!(
+        source,
+        PermissionRuleSource::ProjectSettings
+            | PermissionRuleSource::PolicySettings
+            | PermissionRuleSource::Command
+    )
+}
+
+/// Format a rule source for display in warning messages. Lowercase form,
+/// verbatim port of upstream `getSettingSourceDisplayNameLowercase`
+/// (`utils/settings/constants.ts` L72-L93).
+pub fn permission_rule_source_display_string(source: PermissionRuleSource) -> &'static str {
+    match source {
+        PermissionRuleSource::UserSettings => "user settings",
+        PermissionRuleSource::ProjectSettings => "shared project settings",
+        PermissionRuleSource::LocalSettings => "project local settings",
+        PermissionRuleSource::FlagSettings => "command line arguments",
+        PermissionRuleSource::PolicySettings => "enterprise managed settings",
+        PermissionRuleSource::CliArg => "CLI argument",
+        PermissionRuleSource::Command => "command configuration",
+        PermissionRuleSource::Session => "current session",
+    }
+}
+
+/// Generate a fix suggestion based on the shadow type. Verbatim port of
+/// upstream `generateFixSuggestion` (L77-L92).
+fn generate_fix_suggestion(
+    shadow_type: ShadowType,
+    shadowing_rule: &PermissionRule,
+    shadowed_rule: &PermissionRule,
+) -> String {
+    let shadowing_source = permission_rule_source_display_string(shadowing_rule.source);
+    let shadowed_source = permission_rule_source_display_string(shadowed_rule.source);
+    let tool_name = &shadowing_rule.rule_value.tool_name;
+    match shadow_type {
+        ShadowType::Deny => format!(
+            "Remove the \"{tool_name}\" deny rule from {shadowing_source}, or remove the specific allow rule from {shadowed_source}"
+        ),
+        ShadowType::Ask => format!(
+            "Remove the \"{tool_name}\" ask rule from {shadowing_source}, or remove the specific allow rule from {shadowed_source}"
+        ),
+    }
+}
+
+/// Check if a specific allow rule is shadowed (unreachable) by an
+/// **ask** rule. Verbatim port of `isAllowRuleShadowedByAskRule`
+/// (L116-L153).
+///
+/// An allow rule is unreachable when:
+/// 1. There's a tool-wide ask rule (e.g. `Bash` in ask list)
+/// 2. AND a specific allow rule (e.g. `Bash(ls:*)` in allow list)
+///
+/// Exception: for Bash with sandbox auto-allow enabled, tool-wide ask
+/// rules from **personal** settings don't shadow specific allow rules
+/// because sandboxed commands are auto-allowed regardless. The exception
+/// is keyed on the **ask** rule's source, not the allow rule's
+/// (upstream L141-L148) — Issue #490 SECURITY pin (`req_perm_490_p2_2_i_*`).
+fn is_allow_rule_shadowed_by_ask_rule(
+    allow_rule: &PermissionRule,
+    ask_rules: &[PermissionRule],
+    options: DetectUnreachableRulesOptions,
+) -> ShadowResult {
+    let tool_name = &allow_rule.rule_value.tool_name;
+    let rule_content = allow_rule.rule_value.rule_content.as_ref();
+
+    // Only check allow rules that have specific content (e.g.,
+    // `Bash(ls:*)`). Tool-wide allow rules cannot be shadowed by ask
+    // rules. (Upstream L122-L125.)
+    if rule_content.is_none() {
+        return ShadowResult::NotShadowed;
+    }
+
+    // Find any tool-wide ask rule for the same tool.
+    let Some(shadowing_ask_rule) = ask_rules
+        .iter()
+        .find(|r| &r.rule_value.tool_name == tool_name && r.rule_value.rule_content.is_none())
+    else {
+        return ShadowResult::NotShadowed;
+    };
+
+    // Special case: Bash with sandbox auto-allow from personal settings.
+    // (Upstream L141-L148.) Verbatim nested-if shape preserved to match
+    // the upstream control flow comment "Fall through to mark as
+    // shadowed - shared settings should always warn".
+    #[allow(clippy::collapsible_if, reason = "verbatim upstream control flow L141-L148")]
+    if tool_name == BASH_TOOL_NAME && options.sandbox_auto_allow_enabled {
+        if !is_shared_setting_source(shadowing_ask_rule.source) {
+            return ShadowResult::NotShadowed;
+        }
+        // Fall through — shared settings should always warn.
+    }
+
+    ShadowResult::Shadowed {
+        shadowed_by: shadowing_ask_rule.clone(),
+        shadow_type: ShadowType::Ask,
+    }
+}
+
+/// Check if an allow rule is shadowed (completely blocked) by a **deny**
+/// rule. Verbatim port of `isAllowRuleShadowedByDenyRule` (L166-L188).
+///
+/// More severe than ask shadowing — deny rules short-circuit the
+/// pipeline.
+fn is_allow_rule_shadowed_by_deny_rule(
+    allow_rule: &PermissionRule,
+    deny_rules: &[PermissionRule],
+) -> ShadowResult {
+    let tool_name = &allow_rule.rule_value.tool_name;
+    let rule_content = allow_rule.rule_value.rule_content.as_ref();
+
+    // Only check allow rules that have specific content. (Upstream
+    // L173-L176.)
+    if rule_content.is_none() {
+        return ShadowResult::NotShadowed;
+    }
+
+    let Some(shadowing_deny_rule) = deny_rules
+        .iter()
+        .find(|r| &r.rule_value.tool_name == tool_name && r.rule_value.rule_content.is_none())
+    else {
+        return ShadowResult::NotShadowed;
+    };
+
+    ShadowResult::Shadowed {
+        shadowed_by: shadowing_deny_rule.clone(),
+        shadow_type: ShadowType::Deny,
+    }
+}
+
+/// Detect all unreachable permission rules given the pre-collected
+/// allow / ask / deny rule lists. Verbatim port of
+/// `detectUnreachableRules` (L194-L233).
+///
+/// Currently detects:
+/// - Allow rules shadowed by tool-wide deny rules (more severe —
+///   completely blocked)
+/// - Allow rules shadowed by tool-wide ask rules (will always prompt)
+///
+/// **Caller responsibility**: pass only rules where `rule_behavior`
+/// matches the list slot (`Allow` in `allow_rules`, etc.). The function
+/// does not re-validate — that matches upstream where the three lists
+/// come from typed accessors.
+pub fn detect_unreachable_rules(
+    allow_rules: &[PermissionRule],
+    ask_rules: &[PermissionRule],
+    deny_rules: &[PermissionRule],
+    options: DetectUnreachableRulesOptions,
+) -> Vec<UnreachableRule> {
+    let mut unreachable: Vec<UnreachableRule> = Vec::new();
+
+    // (Upstream L204-L232.)
+    for allow_rule in allow_rules {
+        // Guard against caller passing a non-allow rule into the allow
+        // slot — silently skip rather than panic (Fail-Safe).
+        if allow_rule.rule_behavior != PermissionBehavior::Allow {
+            continue;
+        }
+
+        // Check deny shadowing first (more severe). (Upstream L206-L217.)
+        let deny_result = is_allow_rule_shadowed_by_deny_rule(allow_rule, deny_rules);
+        if let ShadowResult::Shadowed {
+            shadowed_by,
+            shadow_type,
+        } = deny_result
+        {
+            let shadow_source = permission_rule_source_display_string(shadowed_by.source);
+            let reason = format!(
+                "Blocked by \"{tool}\" deny rule (from {shadow_source})",
+                tool = shadowed_by.rule_value.tool_name,
+            );
+            let fix = generate_fix_suggestion(shadow_type, &shadowed_by, allow_rule);
+            unreachable.push(UnreachableRule {
+                rule: allow_rule.clone(),
+                reason,
+                shadowed_by,
+                shadow_type,
+                fix,
+            });
+            continue; // Don't also report ask-shadowing if deny-shadowed.
+        }
+
+        // Check ask shadowing. (Upstream L219-L231.)
+        let ask_result = is_allow_rule_shadowed_by_ask_rule(allow_rule, ask_rules, options);
+        if let ShadowResult::Shadowed {
+            shadowed_by,
+            shadow_type,
+        } = ask_result
+        {
+            let shadow_source = permission_rule_source_display_string(shadowed_by.source);
+            let reason = format!(
+                "Shadowed by \"{tool}\" ask rule (from {shadow_source})",
+                tool = shadowed_by.rule_value.tool_name,
+            );
+            let fix = generate_fix_suggestion(shadow_type, &shadowed_by, allow_rule);
+            unreachable.push(UnreachableRule {
+                rule: allow_rule.clone(),
+                reason,
+                shadowed_by,
+                shadow_type,
+                fix,
+            });
+        }
+    }
+
+    unreachable
+}

--- a/crates/dasclaw_bash_permissions/src/shadowed_rule_detection.rs
+++ b/crates/dasclaw_bash_permissions/src/shadowed_rule_detection.rs
@@ -166,7 +166,10 @@ fn is_allow_rule_shadowed_by_ask_rule(
     // (Upstream L141-L148.) Verbatim nested-if shape preserved to match
     // the upstream control flow comment "Fall through to mark as
     // shadowed - shared settings should always warn".
-    #[allow(clippy::collapsible_if, reason = "verbatim upstream control flow L141-L148")]
+    #[allow(
+        clippy::collapsible_if,
+        reason = "verbatim upstream control flow L141-L148"
+    )]
     if tool_name == BASH_TOOL_NAME && options.sandbox_auto_allow_enabled {
         if !is_shared_setting_source(shadowing_ask_rule.source) {
             return ShadowResult::NotShadowed;

--- a/crates/dasclaw_bash_permissions/tests/shadowed_rule_detection_test.rs
+++ b/crates/dasclaw_bash_permissions/tests/shadowed_rule_detection_test.rs
@@ -1,0 +1,563 @@
+//! Slice 2.2.i — `req_perm_490_p2_2_i_*` request tests for
+//! `shadowed_rule_detection`. Verifies verbatim parity with upstream
+//! `claude-code-main/src/utils/permissions/shadowedRuleDetection.ts`
+//! L1-L234.
+
+use dasclaw_bash_permissions::shadowed_rule_detection::{
+    detect_unreachable_rules, is_shared_setting_source, permission_rule_source_display_string,
+    DetectUnreachableRulesOptions, ShadowType, UnreachableRule,
+};
+use dasclaw_bash_permissions::types::{
+    PermissionBehavior, PermissionRule, PermissionRuleSource, PermissionRuleValue,
+};
+use dasclaw_bash_permissions::BASH_TOOL_NAME;
+
+fn rule(
+    behavior: PermissionBehavior,
+    source: PermissionRuleSource,
+    tool: &str,
+    content: Option<&str>,
+) -> PermissionRule {
+    PermissionRule {
+        source,
+        rule_behavior: behavior,
+        rule_value: PermissionRuleValue {
+            tool_name: tool.to_string(),
+            rule_content: content.map(str::to_string),
+        },
+    }
+}
+
+fn allow(source: PermissionRuleSource, tool: &str, content: Option<&str>) -> PermissionRule {
+    rule(PermissionBehavior::Allow, source, tool, content)
+}
+fn ask(source: PermissionRuleSource, tool: &str, content: Option<&str>) -> PermissionRule {
+    rule(PermissionBehavior::Ask, source, tool, content)
+}
+fn deny(source: PermissionRuleSource, tool: &str, content: Option<&str>) -> PermissionRule {
+    rule(PermissionBehavior::Deny, source, tool, content)
+}
+
+const OPTS_OFF: DetectUnreachableRulesOptions = DetectUnreachableRulesOptions {
+    sandbox_auto_allow_enabled: false,
+};
+const OPTS_ON: DetectUnreachableRulesOptions = DetectUnreachableRulesOptions {
+    sandbox_auto_allow_enabled: true,
+};
+
+// ---------------------------------------------------------------------------
+// 01 — empty inputs → empty output (baseline)
+// ---------------------------------------------------------------------------
+#[test]
+fn req_perm_490_p2_2_i_01_empty_input_returns_empty() {
+    let res = detect_unreachable_rules(&[], &[], &[], OPTS_OFF);
+    assert!(res.is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// 02 — tool-wide allow rule NEVER reported as shadowed
+// ---------------------------------------------------------------------------
+#[test]
+fn req_perm_490_p2_2_i_02_tool_wide_allow_not_shadowed() {
+    let allows = vec![allow(
+        PermissionRuleSource::UserSettings,
+        BASH_TOOL_NAME,
+        None,
+    )];
+    let denies = vec![deny(
+        PermissionRuleSource::ProjectSettings,
+        BASH_TOOL_NAME,
+        None,
+    )];
+    let asks = vec![ask(
+        PermissionRuleSource::ProjectSettings,
+        BASH_TOOL_NAME,
+        None,
+    )];
+    let res = detect_unreachable_rules(&allows, &asks, &denies, OPTS_OFF);
+    assert!(res.is_empty(), "tool-wide allow can never be shadowed");
+}
+
+// ---------------------------------------------------------------------------
+// 03 — specific allow shadowed by tool-wide deny → reported with deny
+// ---------------------------------------------------------------------------
+#[test]
+fn req_perm_490_p2_2_i_03_specific_allow_shadowed_by_tool_wide_deny() {
+    let allows = vec![allow(
+        PermissionRuleSource::UserSettings,
+        BASH_TOOL_NAME,
+        Some("ls:*"),
+    )];
+    let denies = vec![deny(
+        PermissionRuleSource::ProjectSettings,
+        BASH_TOOL_NAME,
+        None,
+    )];
+    let res = detect_unreachable_rules(&allows, &[], &denies, OPTS_OFF);
+    assert_eq!(res.len(), 1);
+    let u: &UnreachableRule = &res[0];
+    assert_eq!(u.shadow_type, ShadowType::Deny);
+    assert!(u.reason.contains("Blocked by"));
+    assert!(u.reason.contains("Bash"));
+    assert!(u.reason.contains("shared project settings"));
+    assert!(u.fix.contains("deny rule"));
+    assert!(u.fix.contains("shared project settings"));
+    assert!(u.fix.contains("user settings"));
+}
+
+// ---------------------------------------------------------------------------
+// 04 — specific allow shadowed by tool-wide ask → reported with ask
+// ---------------------------------------------------------------------------
+#[test]
+fn req_perm_490_p2_2_i_04_specific_allow_shadowed_by_tool_wide_ask() {
+    let allows = vec![allow(
+        PermissionRuleSource::UserSettings,
+        BASH_TOOL_NAME,
+        Some("ls:*"),
+    )];
+    let asks = vec![ask(
+        PermissionRuleSource::ProjectSettings,
+        BASH_TOOL_NAME,
+        None,
+    )];
+    let res = detect_unreachable_rules(&allows, &asks, &[], OPTS_OFF);
+    assert_eq!(res.len(), 1);
+    let u: &UnreachableRule = &res[0];
+    assert_eq!(u.shadow_type, ShadowType::Ask);
+    assert!(u.reason.contains("Shadowed by"));
+    assert!(u.reason.contains("Bash"));
+    assert!(u.fix.contains("ask rule"));
+}
+
+// ---------------------------------------------------------------------------
+// 05 — deny takes precedence over ask (upstream L208 PIN)
+// ---------------------------------------------------------------------------
+#[test]
+fn req_perm_490_p2_2_i_05_deny_takes_precedence_over_ask() {
+    let allows = vec![allow(
+        PermissionRuleSource::UserSettings,
+        BASH_TOOL_NAME,
+        Some("ls:*"),
+    )];
+    let asks = vec![ask(
+        PermissionRuleSource::ProjectSettings,
+        BASH_TOOL_NAME,
+        None,
+    )];
+    let denies = vec![deny(
+        PermissionRuleSource::ProjectSettings,
+        BASH_TOOL_NAME,
+        None,
+    )];
+    let res = detect_unreachable_rules(&allows, &asks, &denies, OPTS_OFF);
+    assert_eq!(
+        res.len(),
+        1,
+        "deny-shadowed should not ALSO be reported ask-shadowed"
+    );
+    assert_eq!(res[0].shadow_type, ShadowType::Deny);
+}
+
+// ---------------------------------------------------------------------------
+// 06 — different tool tool-wide rule does NOT shadow Bash specific
+// ---------------------------------------------------------------------------
+#[test]
+fn req_perm_490_p2_2_i_06_different_tool_does_not_shadow() {
+    let allows = vec![allow(
+        PermissionRuleSource::UserSettings,
+        BASH_TOOL_NAME,
+        Some("ls:*"),
+    )];
+    let denies = vec![deny(PermissionRuleSource::UserSettings, "Edit", None)];
+    let asks = vec![ask(PermissionRuleSource::UserSettings, "Read", None)];
+    let res = detect_unreachable_rules(&allows, &asks, &denies, OPTS_OFF);
+    assert!(res.is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// 07 — specific deny / specific ask does NOT shadow (only tool-wide does)
+// ---------------------------------------------------------------------------
+#[test]
+fn req_perm_490_p2_2_i_07_specific_shadowing_rule_does_not_shadow() {
+    let allows = vec![allow(
+        PermissionRuleSource::UserSettings,
+        BASH_TOOL_NAME,
+        Some("ls:*"),
+    )];
+    let specific_deny = vec![deny(
+        PermissionRuleSource::ProjectSettings,
+        BASH_TOOL_NAME,
+        Some("rm:*"),
+    )];
+    let specific_ask = vec![ask(
+        PermissionRuleSource::ProjectSettings,
+        BASH_TOOL_NAME,
+        Some("npm:*"),
+    )];
+    let res = detect_unreachable_rules(&allows, &specific_ask, &specific_deny, OPTS_OFF);
+    assert!(
+        res.is_empty(),
+        "specific same-tool deny/ask must NOT shadow specific allow"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 08 — Bash sandbox auto-allow ON + ask from PERSONAL settings → NOT shadowed
+//      (upstream L141-L148 SECURITY pin — exception keyed on ASK rule's source)
+// ---------------------------------------------------------------------------
+#[test]
+fn req_perm_490_p2_2_i_08_bash_sandbox_personal_ask_not_shadowed() {
+    let personal_sources = [
+        PermissionRuleSource::UserSettings,
+        PermissionRuleSource::LocalSettings,
+        PermissionRuleSource::CliArg,
+        PermissionRuleSource::Session,
+        PermissionRuleSource::FlagSettings,
+    ];
+    for src in personal_sources {
+        let allows = vec![allow(
+            PermissionRuleSource::UserSettings,
+            BASH_TOOL_NAME,
+            Some("ls:*"),
+        )];
+        let asks = vec![ask(src, BASH_TOOL_NAME, None)];
+        let res = detect_unreachable_rules(&allows, &asks, &[], OPTS_ON);
+        assert!(
+            res.is_empty(),
+            "Bash sandbox auto-allow ON + personal ask source {src:?} must NOT shadow"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 09 — Bash sandbox auto-allow ON + ask from SHARED settings → STILL shadowed
+//      (upstream L146-L148 — shared settings always warn so other team
+//      members without sandbox aren't surprised)
+// ---------------------------------------------------------------------------
+#[test]
+fn req_perm_490_p2_2_i_09_bash_sandbox_shared_ask_still_shadowed() {
+    let shared_sources = [
+        PermissionRuleSource::ProjectSettings,
+        PermissionRuleSource::PolicySettings,
+        PermissionRuleSource::Command,
+    ];
+    for src in shared_sources {
+        let allows = vec![allow(
+            PermissionRuleSource::UserSettings,
+            BASH_TOOL_NAME,
+            Some("ls:*"),
+        )];
+        let asks = vec![ask(src, BASH_TOOL_NAME, None)];
+        let res = detect_unreachable_rules(&allows, &asks, &[], OPTS_ON);
+        assert_eq!(
+            res.len(),
+            1,
+            "Bash sandbox ON + shared ask source {src:?} must STILL shadow"
+        );
+        assert_eq!(res[0].shadow_type, ShadowType::Ask);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 10 — Bash sandbox auto-allow ON exception applies ONLY to Bash
+//      (non-Bash tool: still shadowed by personal ask)
+// ---------------------------------------------------------------------------
+#[test]
+fn req_perm_490_p2_2_i_10_sandbox_exception_only_for_bash() {
+    let allows = vec![allow(
+        PermissionRuleSource::UserSettings,
+        "Edit",
+        Some("path:*"),
+    )];
+    let asks = vec![ask(PermissionRuleSource::UserSettings, "Edit", None)];
+    let res = detect_unreachable_rules(&allows, &asks, &[], OPTS_ON);
+    assert_eq!(
+        res.len(),
+        1,
+        "Edit tool must NOT benefit from sandbox auto-allow"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 11 — sandbox exception is keyed on ASK rule's source NOT allow's
+//      (upstream L141-L148 SECURITY subtlety PIN)
+// ---------------------------------------------------------------------------
+#[test]
+fn req_perm_490_p2_2_i_11_sandbox_keyed_on_ask_source_not_allow() {
+    // Allow from SHARED source, ASK from PERSONAL source, sandbox ON,
+    // Bash: NOT shadowed (because ask is personal).
+    let allows = vec![allow(
+        PermissionRuleSource::ProjectSettings,
+        BASH_TOOL_NAME,
+        Some("ls:*"),
+    )];
+    let asks = vec![ask(
+        PermissionRuleSource::UserSettings,
+        BASH_TOOL_NAME,
+        None,
+    )];
+    let res = detect_unreachable_rules(&allows, &asks, &[], OPTS_ON);
+    assert!(
+        res.is_empty(),
+        "exception keyed on ASK source (personal) regardless of allow's source"
+    );
+
+    // Inverse: allow from PERSONAL, ask from SHARED → SHADOWED.
+    let allows2 = vec![allow(
+        PermissionRuleSource::UserSettings,
+        BASH_TOOL_NAME,
+        Some("ls:*"),
+    )];
+    let asks2 = vec![ask(
+        PermissionRuleSource::ProjectSettings,
+        BASH_TOOL_NAME,
+        None,
+    )];
+    let res2 = detect_unreachable_rules(&allows2, &asks2, &[], OPTS_ON);
+    assert_eq!(
+        res2.len(),
+        1,
+        "ask=shared → shadowed even if allow is personal"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 12 — sandbox OFF → personal ask STILL shadows (default path)
+// ---------------------------------------------------------------------------
+#[test]
+fn req_perm_490_p2_2_i_12_sandbox_off_personal_ask_shadows() {
+    let allows = vec![allow(
+        PermissionRuleSource::UserSettings,
+        BASH_TOOL_NAME,
+        Some("ls:*"),
+    )];
+    let asks = vec![ask(
+        PermissionRuleSource::UserSettings,
+        BASH_TOOL_NAME,
+        None,
+    )];
+    let res = detect_unreachable_rules(&allows, &asks, &[], OPTS_OFF);
+    assert_eq!(res.len(), 1, "sandbox OFF: personal ask still shadows");
+    assert_eq!(res[0].shadow_type, ShadowType::Ask);
+}
+
+// ---------------------------------------------------------------------------
+// 13 — is_shared_setting_source matrix (upstream L60-L66)
+// ---------------------------------------------------------------------------
+#[test]
+fn req_perm_490_p2_2_i_13_is_shared_setting_source_matrix() {
+    let shared = [
+        PermissionRuleSource::ProjectSettings,
+        PermissionRuleSource::PolicySettings,
+        PermissionRuleSource::Command,
+    ];
+    let personal = [
+        PermissionRuleSource::UserSettings,
+        PermissionRuleSource::LocalSettings,
+        PermissionRuleSource::CliArg,
+        PermissionRuleSource::Session,
+        PermissionRuleSource::FlagSettings,
+    ];
+    for s in shared {
+        assert!(is_shared_setting_source(s), "{s:?} must be shared");
+    }
+    for p in personal {
+        assert!(
+            !is_shared_setting_source(p),
+            "{p:?} must NOT be shared (personal)"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 14 — display string for every source (upstream constants.ts L72-L93)
+// ---------------------------------------------------------------------------
+#[test]
+fn req_perm_490_p2_2_i_14_display_string_for_every_source() {
+    let cases = [
+        (PermissionRuleSource::UserSettings, "user settings"),
+        (
+            PermissionRuleSource::ProjectSettings,
+            "shared project settings",
+        ),
+        (
+            PermissionRuleSource::LocalSettings,
+            "project local settings",
+        ),
+        (PermissionRuleSource::FlagSettings, "command line arguments"),
+        (
+            PermissionRuleSource::PolicySettings,
+            "enterprise managed settings",
+        ),
+        (PermissionRuleSource::CliArg, "CLI argument"),
+        (PermissionRuleSource::Command, "command configuration"),
+        (PermissionRuleSource::Session, "current session"),
+    ];
+    for (src, expected) in cases {
+        assert_eq!(
+            permission_rule_source_display_string(src),
+            expected,
+            "display string for {src:?}"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 15 — multiple specific allow rules all reported (loop iteration PIN)
+// ---------------------------------------------------------------------------
+#[test]
+fn req_perm_490_p2_2_i_15_multiple_specific_allows_all_reported() {
+    let allows = vec![
+        allow(
+            PermissionRuleSource::UserSettings,
+            BASH_TOOL_NAME,
+            Some("ls:*"),
+        ),
+        allow(
+            PermissionRuleSource::UserSettings,
+            BASH_TOOL_NAME,
+            Some("git status"),
+        ),
+        allow(
+            PermissionRuleSource::LocalSettings,
+            BASH_TOOL_NAME,
+            Some("npm test"),
+        ),
+    ];
+    let denies = vec![deny(
+        PermissionRuleSource::ProjectSettings,
+        BASH_TOOL_NAME,
+        None,
+    )];
+    let res = detect_unreachable_rules(&allows, &[], &denies, OPTS_OFF);
+    assert_eq!(res.len(), 3);
+    for u in &res {
+        assert_eq!(u.shadow_type, ShadowType::Deny);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 16 — non-allow rules in `allow_rules` slot silently skipped (Fail-Safe)
+// ---------------------------------------------------------------------------
+#[test]
+fn req_perm_490_p2_2_i_16_misplaced_rule_in_allow_slot_skipped() {
+    // Deliberately put a Deny rule in the allow_rules slot — should be
+    // skipped, not panic, not reported.
+    let allows = vec![
+        deny(
+            PermissionRuleSource::UserSettings,
+            BASH_TOOL_NAME,
+            Some("ls:*"),
+        ),
+        allow(
+            PermissionRuleSource::UserSettings,
+            BASH_TOOL_NAME,
+            Some("git:*"),
+        ),
+    ];
+    let denies = vec![deny(
+        PermissionRuleSource::ProjectSettings,
+        BASH_TOOL_NAME,
+        None,
+    )];
+    let res = detect_unreachable_rules(&allows, &[], &denies, OPTS_OFF);
+    assert_eq!(res.len(), 1, "only the real Allow rule is reported");
+    assert_eq!(
+        res[0].rule.rule_value.rule_content.as_deref(),
+        Some("git:*")
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 17 — first matching shadowing rule wins (find semantics PIN, upstream L132/L181)
+// ---------------------------------------------------------------------------
+#[test]
+fn req_perm_490_p2_2_i_17_first_matching_shadowing_wins() {
+    let allows = vec![allow(
+        PermissionRuleSource::UserSettings,
+        BASH_TOOL_NAME,
+        Some("ls:*"),
+    )];
+    let denies = vec![
+        deny(PermissionRuleSource::ProjectSettings, BASH_TOOL_NAME, None),
+        deny(PermissionRuleSource::PolicySettings, BASH_TOOL_NAME, None),
+    ];
+    let res = detect_unreachable_rules(&allows, &[], &denies, OPTS_OFF);
+    assert_eq!(res.len(), 1);
+    assert_eq!(
+        res[0].shadowed_by.source,
+        PermissionRuleSource::ProjectSettings,
+        "first deny in the list wins (upstream find() semantics)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 18 — fix suggestion mentions both shadowing and shadowed sources
+//      (upstream L86-L91 format pin)
+// ---------------------------------------------------------------------------
+#[test]
+fn req_perm_490_p2_2_i_18_fix_suggestion_format() {
+    let allows = vec![allow(
+        PermissionRuleSource::LocalSettings,
+        BASH_TOOL_NAME,
+        Some("npm test"),
+    )];
+    let denies = vec![deny(
+        PermissionRuleSource::PolicySettings,
+        BASH_TOOL_NAME,
+        None,
+    )];
+    let res = detect_unreachable_rules(&allows, &[], &denies, OPTS_OFF);
+    assert_eq!(res.len(), 1);
+    assert!(res[0].fix.contains("enterprise managed settings"));
+    assert!(res[0].fix.contains("project local settings"));
+    assert!(res[0].fix.contains("\"Bash\" deny rule"));
+}
+
+// ---------------------------------------------------------------------------
+// 19 — when allow rule has rule_content=Some(""), still treated as specific
+//      (only `None` is tool-wide per upstream `ruleContent === undefined`)
+// ---------------------------------------------------------------------------
+#[test]
+fn req_perm_490_p2_2_i_19_empty_string_content_treated_as_specific() {
+    let allows = vec![allow(
+        PermissionRuleSource::UserSettings,
+        BASH_TOOL_NAME,
+        Some(""),
+    )];
+    let denies = vec![deny(
+        PermissionRuleSource::ProjectSettings,
+        BASH_TOOL_NAME,
+        None,
+    )];
+    let res = detect_unreachable_rules(&allows, &[], &denies, OPTS_OFF);
+    assert_eq!(
+        res.len(),
+        1,
+        "Some(\"\") is NOT None — still a specific allow"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 20 — deny + ask with both specific (NOT tool-wide) leaves allow safe
+// ---------------------------------------------------------------------------
+#[test]
+fn req_perm_490_p2_2_i_20_no_tool_wide_shadowing_rule_no_report() {
+    let allows = vec![allow(
+        PermissionRuleSource::UserSettings,
+        BASH_TOOL_NAME,
+        Some("ls:*"),
+    )];
+    let denies = vec![deny(
+        PermissionRuleSource::ProjectSettings,
+        BASH_TOOL_NAME,
+        Some("rm:*"),
+    )];
+    let asks = vec![ask(
+        PermissionRuleSource::ProjectSettings,
+        BASH_TOOL_NAME,
+        Some("git:*"),
+    )];
+    assert!(detect_unreachable_rules(&allows, &asks, &denies, OPTS_OFF).is_empty());
+    assert!(detect_unreachable_rules(&allows, &asks, &denies, OPTS_ON).is_empty());
+}


### PR DESCRIPTION
feat(bash-perm): Slice 2.2.i — shadowed (unreachable) rule detection

Closes #542

Part of #490 — Phase 2.2 Slice 2.2.i of N (independent of 2.2.e env-var
strip / 2.2.f hook wiring / 2.2.g dangerous patterns; pure analyzer
over existing `PermissionRule` lists).

## 背景 / 目标

逐字（verbatim）从上游：

- `claude-code-main/src/utils/permissions/shadowedRuleDetection.ts`
  L1-L234 — 主算法
- `claude-code-main/src/utils/permissions/permissions.ts` L116-L120 —
  `permissionRuleSourceDisplayString`
- `claude-code-main/src/utils/settings/constants.ts` L72-L93 —
  `getSettingSourceDisplayNameLowercase`

防御场景：当用户/项目设置中同时存在 tool-wide deny/ask + specific allow
（例如 `Bash` deny + `Bash(ls:*)` allow），specific allow 永远不会被
执行（被 deny 阻断）或永远要弹问（被 ask 截胡）。本切片提供 **纯分析
器**：传入三个已分组的 `Vec<PermissionRule>`，返回每个不可达 allow
规则的 `UnreachableRule { reason, shadowedBy, shadowType, fix }`。

设计取舍：**不**移植 upstream `getAllowRules/getAskRules/getDenyRules`
收集器 —— 我们 crate 的 `ToolPermissionContext` 是 bash-only 且存储已
parse 的内容字符串（不是上游的 `"Bash(content)"|"Bash"` 原始形式）；
收集器与存储层耦合，分析器与之解耦。调用方负责构造三个列表，让本切
片 100% 上游-语义对齐。

## 改动范围

- **新增** `src/shadowed_rule_detection.rs` (~260 LOC)
  - `pub enum ShadowType { Ask, Deny }` — L14
  - `pub struct UnreachableRule { rule, reason, shadowed_by, shadow_type, fix }` — L18-L24
  - `pub struct DetectUnreachableRulesOptions { sandbox_auto_allow_enabled: bool }` — L28-L36
  - `pub fn is_shared_setting_source(PermissionRuleSource) -> bool` — L60-L66
  - `pub fn permission_rule_source_display_string(PermissionRuleSource) -> &'static str`
    — `constants.ts` L72-L93
  - `pub fn detect_unreachable_rules(allows, asks, denies, options) -> Vec<UnreachableRule>`
    — L194-L233
  - crate-private `is_allow_rule_shadowed_by_ask_rule` L116-L153 +
    `is_allow_rule_shadowed_by_deny_rule` L166-L188 + `generate_fix_suggestion`
    L77-L92 + `ShadowResult` 内部枚举 L41-L43
- **修改** `src/lib.rs` — 新增 `pub mod shadowed_rule_detection;` + 5 re-export
- **新增** `tests/shadowed_rule_detection_test.rs` — 20 tests
  `req_perm_490_p2_2_i_01..20`

## 非目标

- **upstream `getAllowRules/getAskRules/getDenyRules` 收集器** — 与
  上下文存储层耦合，留给 Slice 2.2.h（loader 接线）
- **PowerShell 阴影检测** — 上游算法 tool-agnostic，本 PR 已支持
  任意工具名；PS-specific 测试未覆盖
- **`PermissionRule` 字符串解析（`permissionRuleValueFromString`）** —
  独立 parser 切片（潜在 2.2.j）
- **UI / CLI 输出层** — 上游只在 settings inspector / sketch 显示

## 验证

```bash
cargo nextest run -p dasclaw_bash_permissions
# 115 tests run: 115 passed (23 a + 13 b + 19 c + 20 d + 20 g + 20 i — strip_env from #539 not on this branch)

cargo fmt --all                                             # clean
python3.12 scripts/check_no_panics.py --base origin/xClaw   # OK
cargo clippy --no-deps -p dasclaw_bash_permissions --all-targets -- -D warnings  # clean
```

### 测试矩阵亮点

| ID | 场景 | 验证 |
|----|------|------|
| 01 | 空输入 | 空输出（基线） |
| 02 | tool-wide allow 永不报告 | 上游 L122-L125 |
| 03-04 | specific allow 被 tool-wide deny/ask 阴影 | 标准用例 + reason/fix 格式 |
| 05 | deny > ask 优先级 | 上游 L208 `continue` PIN — 单次报告 |
| 06 | 不同 tool 不互相阴影 | toolName 严格相等 |
| 07 | specific shadowing 规则不阴影 | `ruleContent === undefined` PIN |
| **08-11** | **Bash sandbox 例外 4-向矩阵** | personal ask + sandbox ON → NOT shadowed；shared ask + sandbox ON → STILL shadowed；exception only for Bash；**SECURITY PIN — 例外 keyed on ASK source NOT allow source（上游 L141-L148）** |
| 12 | sandbox OFF | personal ask 仍阴影（默认路径） |
| 13 | `is_shared_setting_source` 全 8 source | 3 shared + 5 personal 全覆盖 |
| 14 | display string 全 8 source | constants.ts L72-L93 完全对齐 |
| 15 | 多个 specific allow 全部报告 | 循环迭代 PIN |
| 16 | 误放在 allow_rules 槽的非 Allow 规则 | Fail-Safe 跳过不 panic |
| 17 | 第一个匹配的 shadowing 规则胜 | upstream `find()` 语义 PIN |
| 18 | fix 建议格式 | 双 source + tool 名 + "deny rule" |
| 19 | `Some("")` ≠ `None` | 空字符串仍是 specific |
| 20 | 全是 specific shadowing 规则 | 不报告 |

## 三层代码审查

**Layer 1 — 上游对照**：
- 算法骨架 L194-L233 与上游 `detectUnreachableRules` shape-for-shape 对齐
- `isAllowRuleShadowedByAskRule` L116-L153 verbatim，包括 Bash sandbox
  例外内部嵌套 `if`（用 `#[allow(clippy::collapsible_if)]` + reason 注释保留
  上游控制流注释 "Fall through to mark as shadowed - shared settings
  should always warn"）
- `isAllowRuleShadowedByDenyRule` L166-L188 verbatim
- `permissionRuleSourceDisplayString` + `getSettingSourceDisplayNameLowercase`
  合并到单个 `match`，8 个 arm 与上游 `constants.ts` L72-L93 完全对齐

**Layer 2 — Fail-Safe / SECURITY**：
- Bash sandbox 例外严格 keyed on **ask 规则的 source**（不是 allow 的）—
  tests 08+09+11 三向 PIN，回归把条件搞反会立即 30+ assertion 失败
- `rule_behavior != Allow` 的规则在 allow_rules 槽内静默跳过（test 16），
  不 panic / 不假阳性
- `find()` 第一匹配语义保留（test 17），保证审计日志 `rule_id` 顺序可复现
- 默认 `DetectUnreachableRulesOptions { sandbox_auto_allow_enabled: false }`
  即"无 sandbox 例外"，最保守

**Layer 3 — 红线**：
- 无生产 `.unwrap()` / `.expect()` / `panic!()`
- 无补丁式代码：纯新模块，零侵入现有 matcher / pipeline / context
- 无新增 crate 依赖
- 不依赖 upstream parser（`permissionRuleValueFromString` 未移植），
  避免与未来 parser 切片冲突
- 上游 ANT-only 段在本文件不存在（shadowedRuleDetection.ts 本身没有
  ANT-gated 代码）；`is_shared_setting_source` 的三 shared sources
  与上游 L60-L66 一致

## 子任务

- [ ] Slice 2.2.h — `permissions_loader` 接入 `is_dangerous_bash_allow_rule`
- [ ] Slice 2.2.j — `permissionRuleParser.ts` (198 LOC) 端口 +
      `getAllowRules/getAskRules/getDenyRules` 收集器
- [ ] PowerShell 对应 shadowing pattern（如果需要单独追踪）

## Sources read

- `claude-code-main/src/utils/permissions/shadowedRuleDetection.ts` L1-L234 §detectUnreachableRules + §isAllowRuleShadowedByAskRule + §isAllowRuleShadowedByDenyRule + §isSharedSettingSource + §generateFixSuggestion
- `claude-code-main/src/utils/permissions/permissions.ts` L109-L228 §PERMISSION_RULE_SOURCES + §permissionRuleSourceDisplayString + §getAllowRules + §getDenyRules + §getAskRules
- `claude-code-main/src/utils/settings/constants.ts` L72-L93 §getSettingSourceDisplayNameLowercase
- `claude-code-main/src/utils/permissions/permissionRuleParser.ts` L85-L130 §permissionRuleValueFromString（仅 scope 边界确认，未移植）
- `docs/plans/architecture-refactor/adr-112-compatibility-evaluation.md` §兼容红线
- `crates/dasclaw_bash_permissions/src/types.rs` §PermissionRule + §PermissionRuleSource + §PermissionRuleValue
- `crates/dasclaw_bash_permissions/src/exact_match.rs` §`BASH_TOOL_NAME` 常量
- `AGENTS.md` §Skills 强制使用规范 + §会话轮换
- `.github/copilot-instructions.md` §强制阅读顺序 + §PR 必填项 + §测试纪律
