### PR TITLE
feat(bash-perm): Slice 2.2.j — permission rule string parser

### DIFF
--- a/crates/dasclaw_bash_permissions/src/lib.rs
+++ b/crates/dasclaw_bash_permissions/src/lib.rs
@@ -23,6 +23,7 @@ pub mod dangerous_patterns;
 pub mod exact_match;
 pub(crate) mod pipeline;
 pub mod prefix_match;
+pub mod rule_parser;
 pub mod shadowed_rule_detection;
 pub mod shell_rule_matching;
 pub mod strip_env;
@@ -35,6 +36,10 @@ pub use dangerous_patterns::{
 };
 pub use exact_match::{check_exact_match, BASH_TOOL_NAME};
 pub use prefix_match::check_prefix_match;
+pub use rule_parser::{
+    escape_rule_content, get_legacy_tool_names, normalize_legacy_tool_name,
+    permission_rule_value_from_string, permission_rule_value_to_string, unescape_rule_content,
+};
 pub use shadowed_rule_detection::{
     detect_unreachable_rules, is_shared_setting_source, permission_rule_source_display_string,
     DetectUnreachableRulesOptions, ShadowType, UnreachableRule,

--- a/crates/dasclaw_bash_permissions/src/rule_parser.rs
+++ b/crates/dasclaw_bash_permissions/src/rule_parser.rs
@@ -1,0 +1,264 @@
+//! Permission rule parser — Slice 2.2.j (Issue #490 Phase 2.2).
+//!
+//! Semantic port of upstream
+//! `claude-code-main/src/utils/permissions/permissionRuleParser.ts`
+//! L1-L198 (TypeScript). Provides parsing/serialization of the
+//! `"Tool"` / `"Tool(content)"` permission rule string format with
+//! correct handling of escaped parentheses, plus a legacy-tool-name
+//! alias map.
+//!
+//! ## Why a separate parser slice
+//!
+//! Storage shapes diverge between codebases:
+//!   - upstream stores raw `"Bash(content)"` strings in settings JSON,
+//!     parsed at every lookup;
+//!   - our [`crate::types::PermissionRuleValue`] stores the parsed
+//!     `(tool_name, rule_content)` pair eagerly.
+//!
+//! This module provides the **string ↔ struct** bridge so the
+//! analyzer in Slice 2.2.i can be reached from any storage layer
+//! (Slice 2.2.k will wire it into `permissions_loader`).
+//!
+//! ## ANT-only segment intentionally OMITTED
+//!
+//! Upstream L7-L17 + L26-L28 wire a `Brief` legacy alias behind the
+//! `KAIROS` / `KAIROS_BRIEF` feature flag. This is the ANT-only
+//! `BriefTool` and is forbidden by Issue #490 red line. The remaining
+//! 4 aliases (`Task` → `Agent`, `KillShell` → `TaskStop`,
+//! `AgentOutputTool` → `TaskOutput`, `BashOutputTool` → `TaskOutput`)
+//! are upstream-canonical and ported verbatim.
+
+/// Maps legacy tool names to their current canonical names.
+///
+/// Verbatim from upstream L20-L29, minus the ANT-only `Brief` entry.
+/// **Order**: `(legacy, canonical)`.
+const LEGACY_TOOL_NAME_ALIASES: &[(&str, &str)] = &[
+    ("Task", "Agent"),                 // AGENT_TOOL_NAME
+    ("KillShell", "TaskStop"),         // TASK_STOP_TOOL_NAME
+    ("AgentOutputTool", "TaskOutput"), // TASK_OUTPUT_TOOL_NAME
+    ("BashOutputTool", "TaskOutput"),  // TASK_OUTPUT_TOOL_NAME
+];
+
+/// Returns the canonical tool name for a possibly-legacy `name`.
+///
+/// Upstream `normalizeLegacyToolName` L31-L33. If `name` is not a
+/// legacy alias the input is returned unchanged.
+pub fn normalize_legacy_tool_name(name: &str) -> &str {
+    for &(legacy, canonical) in LEGACY_TOOL_NAME_ALIASES {
+        if legacy == name {
+            return canonical;
+        }
+    }
+    name
+}
+
+/// Returns all legacy aliases that resolve to `canonical_name`.
+///
+/// Upstream `getLegacyToolNames` L35-L41. The returned slice ordering
+/// matches the [`LEGACY_TOOL_NAME_ALIASES`] declaration order, so
+/// callers using this for UI display get a stable list.
+pub fn get_legacy_tool_names(canonical_name: &str) -> Vec<&'static str> {
+    let mut result = Vec::new();
+    for &(legacy, canonical) in LEGACY_TOOL_NAME_ALIASES {
+        if canonical == canonical_name {
+            result.push(legacy);
+        }
+    }
+    result
+}
+
+/// Escape `\`, `(`, `)` in `content` for safe storage inside a
+/// `"Tool(content)"` permission-rule string.
+///
+/// Order matters (upstream L52-L59):
+///   1. backslashes first (`\` → `\\`)
+///   2. then parens (`(` → `\(`, `)` → `\)`)
+///
+/// `escape_rule_content` is the inverse of [`unescape_rule_content`].
+pub fn escape_rule_content(content: &str) -> String {
+    let mut out = String::with_capacity(content.len());
+    for ch in content.chars() {
+        match ch {
+            '\\' => out.push_str(r"\\"),
+            '(' => out.push_str(r"\("),
+            ')' => out.push_str(r"\)"),
+            other => out.push(other),
+        }
+    }
+    out
+}
+
+/// Unescape a `content` string previously produced by
+/// [`escape_rule_content`].
+///
+/// Order matters (upstream L73-L80, **reverse** of escape):
+///   1. parens first (`\(` → `(`, `\)` → `)`)
+///   2. then backslashes (`\\` → `\`)
+///
+/// We hand-roll the loop instead of three sequential string-replace
+/// passes (upstream's approach) because chained replaces in Rust
+/// would force two extra allocations. The single-pass walk preserves
+/// the same semantics — including the **doubled-backslash followed by
+/// paren** case (`\\(` ⇒ `\(`, not `\` then literal `(`): we consume
+/// `\\` as a unit first, then the bare `(` is a literal.
+pub fn unescape_rule_content(content: &str) -> String {
+    let bytes = content.as_bytes();
+    let mut out = String::with_capacity(content.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        // Try a two-byte escape sequence.
+        if bytes[i] == b'\\' && i + 1 < bytes.len() {
+            match bytes[i + 1] {
+                b'(' => {
+                    out.push('(');
+                    i += 2;
+                    continue;
+                }
+                b')' => {
+                    out.push(')');
+                    i += 2;
+                    continue;
+                }
+                b'\\' => {
+                    out.push('\\');
+                    i += 2;
+                    continue;
+                }
+                _ => {}
+            }
+        }
+        // Fall through: copy the next UTF-8 code-point verbatim.
+        let ch = content[i..]
+            .chars()
+            .next()
+            .expect("non-empty remaining slice has at least one char"); // safety: i < bytes.len() guarantees remaining slice has ≥1 char
+        let n = ch.len_utf8();
+        out.push(ch);
+        i += n;
+    }
+    out
+}
+
+/// Parse a permission rule string into a `(tool_name, rule_content)`
+/// pair.
+///
+/// Semantic port of upstream `permissionRuleValueFromString` L94-L137.
+///
+/// Format: `"ToolName"` or `"ToolName(content)"`. Content may
+/// contain escaped parens (`\(`, `\)`).
+///
+/// **Fail-Safe**: when the string is malformed (no closing paren,
+/// content after closing paren, empty tool name), the entire input is
+/// treated as a tool name — never crashes, never partially-parses.
+/// This matches upstream's "treat as tool name" branches verbatim.
+///
+/// **Special cases** (upstream L132-L135): empty content (`Bash()`)
+/// and standalone wildcard content (`Bash(*)`) collapse to a
+/// tool-wide rule with `rule_content = None`.
+///
+/// Returns `(tool_name, rule_content)` as owned strings; the caller
+/// assembles them into a [`crate::types::PermissionRuleValue`] (kept
+/// out of this module's API to preserve its independence from the
+/// `types` module).
+pub fn permission_rule_value_from_string(rule_string: &str) -> (String, Option<String>) {
+    // Find first unescaped '('.
+    let open_paren_index = match find_first_unescaped_char(rule_string, '(') {
+        Some(i) => i,
+        None => return (normalize_legacy_tool_name(rule_string).to_string(), None),
+    };
+
+    // Find last unescaped ')'.
+    let close_paren_index = match find_last_unescaped_char(rule_string, ')') {
+        Some(i) if i > open_paren_index => i,
+        // Includes both `None` and `Some(i) where i <= open`.
+        _ => return (normalize_legacy_tool_name(rule_string).to_string(), None),
+    };
+
+    // Closing paren must be at the very end (upstream L117-L120).
+    if close_paren_index != rule_string.len() - 1 {
+        return (normalize_legacy_tool_name(rule_string).to_string(), None);
+    }
+
+    let tool_name = &rule_string[..open_paren_index];
+    let raw_content = &rule_string[open_paren_index + 1..close_paren_index];
+
+    // Empty tool name (e.g. `(foo)`) — treat whole string as tool name.
+    if tool_name.is_empty() {
+        return (normalize_legacy_tool_name(rule_string).to_string(), None);
+    }
+
+    // Empty content or standalone `*` ⇒ tool-wide rule.
+    if raw_content.is_empty() || raw_content == "*" {
+        return (normalize_legacy_tool_name(tool_name).to_string(), None);
+    }
+
+    let rule_content = unescape_rule_content(raw_content);
+    (
+        normalize_legacy_tool_name(tool_name).to_string(),
+        Some(rule_content),
+    )
+}
+
+/// Serialize a `(tool_name, rule_content)` pair back to a permission
+/// rule string.
+///
+/// Semantic port of upstream `permissionRuleValueToString` L147-L155.
+///
+/// `None` or empty content ⇒ bare tool name (e.g. `"Bash"`).
+/// Non-empty content is escaped via [`escape_rule_content`].
+pub fn permission_rule_value_to_string(tool_name: &str, rule_content: Option<&str>) -> String {
+    match rule_content {
+        None | Some("") => tool_name.to_string(),
+        Some(c) => format!("{}({})", tool_name, escape_rule_content(c)),
+    }
+}
+
+/// Find the byte index of the first unescaped occurrence of `target`.
+///
+/// A character is escaped iff preceded by an **odd** number of
+/// backslashes. Upstream `findFirstUnescapedChar` L161-L178.
+///
+/// `target` must be ASCII (`(`, `)` in our usage); we work on bytes
+/// for efficiency.
+fn find_first_unescaped_char(s: &str, target: char) -> Option<usize> {
+    debug_assert!(target.is_ascii(), "target must be ASCII");
+    let target_b = target as u8;
+    let bytes = s.as_bytes();
+    for i in 0..bytes.len() {
+        if bytes[i] == target_b {
+            let mut backslash_count = 0usize;
+            let mut j = i;
+            while j > 0 && bytes[j - 1] == b'\\' {
+                backslash_count += 1;
+                j -= 1;
+            }
+            if backslash_count.is_multiple_of(2) {
+                return Some(i);
+            }
+        }
+    }
+    None
+}
+
+/// Find the byte index of the last unescaped occurrence of `target`.
+///
+/// Upstream `findLastUnescapedChar` L184-L198.
+fn find_last_unescaped_char(s: &str, target: char) -> Option<usize> {
+    debug_assert!(target.is_ascii(), "target must be ASCII");
+    let target_b = target as u8;
+    let bytes = s.as_bytes();
+    for i in (0..bytes.len()).rev() {
+        if bytes[i] == target_b {
+            let mut backslash_count = 0usize;
+            let mut j = i;
+            while j > 0 && bytes[j - 1] == b'\\' {
+                backslash_count += 1;
+                j -= 1;
+            }
+            if backslash_count.is_multiple_of(2) {
+                return Some(i);
+            }
+        }
+    }
+    None
+}

--- a/crates/dasclaw_bash_permissions/tests/rule_parser_test.rs
+++ b/crates/dasclaw_bash_permissions/tests/rule_parser_test.rs
@@ -1,0 +1,361 @@
+//! Tests for `rule_parser` — Slice 2.2.j (Issue #490 Phase 2.2).
+//!
+//! Semantic parity with upstream `permissionRuleParser.ts` L1-L198.
+//! Test ID: `req_perm_490_p2_2_j_NN_<desc>`.
+
+use dasclaw_bash_permissions::{
+    escape_rule_content, get_legacy_tool_names, normalize_legacy_tool_name,
+    permission_rule_value_from_string, permission_rule_value_to_string, unescape_rule_content,
+};
+
+// -----------------------------------------------------------------
+// 01 — legacy tool name aliases (4 mappings, NOT Brief which is ANT-only)
+// -----------------------------------------------------------------
+#[test]
+fn req_perm_490_p2_2_j_01_normalize_legacy_4_aliases() {
+    assert_eq!(normalize_legacy_tool_name("Task"), "Agent");
+    assert_eq!(normalize_legacy_tool_name("KillShell"), "TaskStop");
+    assert_eq!(normalize_legacy_tool_name("AgentOutputTool"), "TaskOutput");
+    assert_eq!(normalize_legacy_tool_name("BashOutputTool"), "TaskOutput");
+}
+
+// -----------------------------------------------------------------
+// 02 — non-legacy names returned unchanged
+// -----------------------------------------------------------------
+#[test]
+fn req_perm_490_p2_2_j_02_non_legacy_passthrough() {
+    assert_eq!(normalize_legacy_tool_name("Bash"), "Bash");
+    assert_eq!(normalize_legacy_tool_name("Agent"), "Agent");
+    assert_eq!(normalize_legacy_tool_name(""), "");
+    assert_eq!(normalize_legacy_tool_name("UnknownTool"), "UnknownTool");
+}
+
+// -----------------------------------------------------------------
+// 03 — Brief ANT-only regression PIN: must NOT be aliased.
+// (Upstream L26-L28 wires `Brief` under feature('KAIROS') —
+// Issue #490 red line forbids porting ANT-only segments.)
+// -----------------------------------------------------------------
+#[test]
+fn req_perm_490_p2_2_j_03_brief_ant_only_not_aliased() {
+    // `Brief` is not a legacy alias in our port. It must passthrough
+    // unchanged. If a future commit accidentally restores the
+    // ANT-only mapping `Brief -> "BriefTool"` this test will fire.
+    assert_eq!(normalize_legacy_tool_name("Brief"), "Brief");
+    // And no canonical name should claim "Brief" as one of its legacies.
+    assert!(get_legacy_tool_names("BriefTool").is_empty());
+    assert!(get_legacy_tool_names("Brief").is_empty());
+}
+
+// -----------------------------------------------------------------
+// 04 — reverse lookup: get_legacy_tool_names
+// -----------------------------------------------------------------
+#[test]
+fn req_perm_490_p2_2_j_04_get_legacy_tool_names_reverse() {
+    assert_eq!(get_legacy_tool_names("Agent"), vec!["Task"]);
+    assert_eq!(get_legacy_tool_names("TaskStop"), vec!["KillShell"]);
+    // TaskOutput has two legacy aliases — order must be stable (decl order).
+    assert_eq!(
+        get_legacy_tool_names("TaskOutput"),
+        vec!["AgentOutputTool", "BashOutputTool"]
+    );
+    assert!(get_legacy_tool_names("Bash").is_empty());
+    assert!(get_legacy_tool_names("UnknownTool").is_empty());
+}
+
+// -----------------------------------------------------------------
+// 05 — escape: round-trip identity for content without specials
+// -----------------------------------------------------------------
+#[test]
+fn req_perm_490_p2_2_j_05_escape_passthrough_no_specials() {
+    assert_eq!(escape_rule_content(""), "");
+    assert_eq!(escape_rule_content("npm install"), "npm install");
+    assert_eq!(escape_rule_content("git status"), "git status");
+    assert_eq!(escape_rule_content("foo:*"), "foo:*");
+}
+
+// -----------------------------------------------------------------
+// 06 — escape parentheses
+// -----------------------------------------------------------------
+#[test]
+fn req_perm_490_p2_2_j_06_escape_parens() {
+    // Upstream L60 doctest: `escapeRuleContent('psycopg2.connect()') -> 'psycopg2.connect\\(\\)'`
+    assert_eq!(
+        escape_rule_content("psycopg2.connect()"),
+        r"psycopg2.connect\(\)"
+    );
+    assert_eq!(escape_rule_content("("), r"\(");
+    assert_eq!(escape_rule_content(")"), r"\)");
+    assert_eq!(escape_rule_content("(a)(b)"), r"\(a\)\(b\)");
+}
+
+// -----------------------------------------------------------------
+// 07 — escape order: backslashes first, then parens. SECURITY PIN.
+// If order is reversed (parens-first), `(` -> `\(` -> `\\(` and we'd
+// lose injection-safety: an attacker-supplied `(` would round-trip to
+// a *literal* `\(` then unescape to `\` then `(` (broken).
+// -----------------------------------------------------------------
+#[test]
+fn req_perm_490_p2_2_j_07_escape_order_backslash_first() {
+    // Upstream L61: `escapeRuleContent('echo "test\\nvalue"') -> 'echo "test\\\\nvalue"'`
+    // (single backslash → double backslash).
+    assert_eq!(
+        escape_rule_content(r"echo test\nvalue"),
+        r"echo test\\nvalue"
+    );
+    // The combined case that breaks if order is wrong:
+    //   input: `\(`  (literal backslash + literal paren)
+    //   correct: backslash→`\\`, then `(`→`\(`  ⇒ `\\\(`
+    //   wrong:   `(`→`\(` first, then both backslashes→`\\` ⇒ `\\\\(`  ← breaks!
+    assert_eq!(escape_rule_content(r"\("), r"\\\(");
+}
+
+// -----------------------------------------------------------------
+// 08 — unescape inverse of escape
+// -----------------------------------------------------------------
+#[test]
+fn req_perm_490_p2_2_j_08_unescape_inverse() {
+    assert_eq!(unescape_rule_content(r"\("), "(");
+    assert_eq!(unescape_rule_content(r"\)"), ")");
+    assert_eq!(unescape_rule_content(r"\\"), r"\");
+    assert_eq!(
+        unescape_rule_content(r"psycopg2.connect\(\)"),
+        "psycopg2.connect()"
+    );
+    assert_eq!(
+        unescape_rule_content(r"echo test\\nvalue"),
+        r"echo test\nvalue"
+    );
+}
+
+// -----------------------------------------------------------------
+// 09 — escape/unescape round trip on a corpus.
+// -----------------------------------------------------------------
+#[test]
+fn req_perm_490_p2_2_j_09_round_trip_corpus() {
+    for input in &[
+        "",
+        "npm install",
+        "git status",
+        "python -c \"print(1)\"",
+        "echo (",
+        "echo )",
+        "echo )(",
+        r"a\b",
+        r"a\(b",
+        r"\\\(\)",
+        "α∑→λ",           // non-ASCII passthrough
+        "echo (a (b) c)", // nested parens
+    ] {
+        let escaped = escape_rule_content(input);
+        let restored = unescape_rule_content(&escaped);
+        assert_eq!(
+            &restored, input,
+            "round-trip failed for {input:?} (escaped: {escaped:?})"
+        );
+    }
+}
+
+// -----------------------------------------------------------------
+// 10 — from_string: bare tool name (no parens)
+// -----------------------------------------------------------------
+#[test]
+fn req_perm_490_p2_2_j_10_from_string_bare_tool() {
+    assert_eq!(
+        permission_rule_value_from_string("Bash"),
+        ("Bash".to_string(), None)
+    );
+    assert_eq!(
+        permission_rule_value_from_string("Read"),
+        ("Read".to_string(), None)
+    );
+}
+
+// -----------------------------------------------------------------
+// 11 — from_string: tool with content
+// -----------------------------------------------------------------
+#[test]
+fn req_perm_490_p2_2_j_11_from_string_with_content() {
+    assert_eq!(
+        permission_rule_value_from_string("Bash(npm install)"),
+        ("Bash".to_string(), Some("npm install".to_string()))
+    );
+    assert_eq!(
+        permission_rule_value_from_string("Bash(git:*)"),
+        ("Bash".to_string(), Some("git:*".to_string()))
+    );
+}
+
+// -----------------------------------------------------------------
+// 12 — from_string: escaped parens in content (upstream L92 doctest)
+// -----------------------------------------------------------------
+#[test]
+fn req_perm_490_p2_2_j_12_from_string_escaped_parens() {
+    assert_eq!(
+        permission_rule_value_from_string(r"Bash(python -c \(1\))"),
+        ("Bash".to_string(), Some("python -c (1)".to_string()))
+    );
+}
+
+// -----------------------------------------------------------------
+// 13 — from_string Fail-Safe: empty content collapses to tool-wide rule.
+// Upstream L132-L134. Bash() and Bash(*) both mean "any Bash invocation".
+// -----------------------------------------------------------------
+#[test]
+fn req_perm_490_p2_2_j_13_from_string_empty_and_wildcard_collapse() {
+    assert_eq!(
+        permission_rule_value_from_string("Bash()"),
+        ("Bash".to_string(), None)
+    );
+    assert_eq!(
+        permission_rule_value_from_string("Bash(*)"),
+        ("Bash".to_string(), None)
+    );
+}
+
+// -----------------------------------------------------------------
+// 14 — from_string Fail-Safe: malformed inputs treated as tool name.
+// SECURITY PIN: never partial-parses, never panics. Upstream L99-L120.
+// -----------------------------------------------------------------
+#[test]
+fn req_perm_490_p2_2_j_14_from_string_malformed_fail_safe() {
+    // No closing paren — treat whole string as tool name.
+    let (n, c) = permission_rule_value_from_string("Bash(npm");
+    assert_eq!(n, "Bash(npm");
+    assert_eq!(c, None);
+    // Closing paren before opening (impossible match — find_last after
+    // find_first finds same/earlier index).
+    let (n, c) = permission_rule_value_from_string("Bash)npm(");
+    assert_eq!(n, "Bash)npm(");
+    assert_eq!(c, None);
+    // Content after closing paren — treat as tool name.
+    let (n, c) = permission_rule_value_from_string("Bash(npm)extra");
+    assert_eq!(n, "Bash(npm)extra");
+    assert_eq!(c, None);
+    // Empty tool name — treat whole string as tool name.
+    let (n, c) = permission_rule_value_from_string("(foo)");
+    assert_eq!(n, "(foo)");
+    assert_eq!(c, None);
+}
+
+// -----------------------------------------------------------------
+// 15 — from_string applies legacy alias resolution.
+// Upstream L102+L114+L130+L134 all pipe through normalizeLegacyToolName.
+// -----------------------------------------------------------------
+#[test]
+fn req_perm_490_p2_2_j_15_from_string_normalizes_legacy() {
+    // Bare legacy name.
+    assert_eq!(
+        permission_rule_value_from_string("Task"),
+        ("Agent".to_string(), None)
+    );
+    // Legacy name with content.
+    assert_eq!(
+        permission_rule_value_from_string("Task(do something)"),
+        ("Agent".to_string(), Some("do something".to_string()))
+    );
+    // Empty-content collapse + legacy.
+    assert_eq!(
+        permission_rule_value_from_string("KillShell()"),
+        ("TaskStop".to_string(), None)
+    );
+    // Malformed legacy passes through normalize on the whole string.
+    assert_eq!(
+        permission_rule_value_from_string("Task(npm"),
+        ("Task(npm".to_string(), None) // whole string is NOT a legacy alias
+    );
+}
+
+// -----------------------------------------------------------------
+// 16 — to_string: bare and content forms
+// -----------------------------------------------------------------
+#[test]
+fn req_perm_490_p2_2_j_16_to_string_basic() {
+    assert_eq!(permission_rule_value_to_string("Bash", None), "Bash");
+    assert_eq!(permission_rule_value_to_string("Bash", Some("")), "Bash"); // empty == bare
+    assert_eq!(
+        permission_rule_value_to_string("Bash", Some("npm install")),
+        "Bash(npm install)"
+    );
+}
+
+// -----------------------------------------------------------------
+// 17 — to_string: escapes parens in content (upstream L144 doctest)
+// -----------------------------------------------------------------
+#[test]
+fn req_perm_490_p2_2_j_17_to_string_escapes_parens() {
+    assert_eq!(
+        permission_rule_value_to_string("Bash", Some("python -c \"print(1)\"")),
+        r#"Bash(python -c "print\(1\)")"#
+    );
+}
+
+// -----------------------------------------------------------------
+// 18 — full round trip: from_string → to_string → from_string preserves
+// the (tool_name, rule_content) pair for canonical inputs.
+// -----------------------------------------------------------------
+#[test]
+fn req_perm_490_p2_2_j_18_round_trip_canonical() {
+    for input in &[
+        "Bash",
+        "Bash(npm install)",
+        "Bash(git:*)",
+        "Bash(python -c \"print(1)\")",
+        "Bash(echo a)(b))", // edge: paren in content at the end
+        "Read",
+        "Edit(/tmp/foo.txt)",
+    ] {
+        let (n1, c1) = permission_rule_value_from_string(input);
+        let s = permission_rule_value_to_string(&n1, c1.as_deref());
+        let (n2, c2) = permission_rule_value_from_string(&s);
+        assert_eq!(
+            (&n1, &c1),
+            (&n2, &c2),
+            "round trip changed semantics for {input:?} (mid: {s:?})"
+        );
+    }
+}
+
+// -----------------------------------------------------------------
+// 19 — unescaped-char finder semantics PIN: backslash count parity.
+// `\\(` (escaped backslash + bare paren) is UNESCAPED; `\(` (escaped
+// paren) is ESCAPED. Upstream L161-L198 walks the backslash run before
+// each candidate and checks parity.
+// -----------------------------------------------------------------
+#[test]
+fn req_perm_490_p2_2_j_19_backslash_parity_semantics() {
+    // 0 preceding backslashes ⇒ even ⇒ unescaped.
+    // Input `Bash(npm)` — `(` at idx 4 has 0 backslashes ⇒ open.
+    assert_eq!(
+        permission_rule_value_from_string("Bash(npm)"),
+        ("Bash".to_string(), Some("npm".to_string()))
+    );
+    // 1 preceding backslash ⇒ odd ⇒ escaped, no open paren found
+    // ⇒ treat whole string as tool name.
+    let (n, c) = permission_rule_value_from_string(r"Bash\(npm)");
+    assert_eq!(n, r"Bash\(npm)");
+    assert_eq!(c, None);
+    // 2 preceding backslashes ⇒ even ⇒ unescaped open paren found.
+    // (Literal `\\` then `(` opens the content; close paren at end.)
+    let (n, c) = permission_rule_value_from_string(r"Bash\\(npm)");
+    assert_eq!(n, r"Bash\\");
+    assert_eq!(c, Some("npm".to_string()));
+}
+
+// -----------------------------------------------------------------
+// 20 — non-ASCII content survives the parser intact.
+// (Bytes-based finder must not break UTF-8 multi-byte sequences.)
+// -----------------------------------------------------------------
+#[test]
+fn req_perm_490_p2_2_j_20_non_ascii_content() {
+    assert_eq!(
+        permission_rule_value_from_string("Bash(echo αβγ)"),
+        ("Bash".to_string(), Some("echo αβγ".to_string()))
+    );
+    assert_eq!(
+        permission_rule_value_to_string("Bash", Some("echo αβγ")),
+        "Bash(echo αβγ)"
+    );
+    // Round-trip escape with multi-byte chars + parens.
+    let s = "echo (αβ) γ";
+    assert_eq!(unescape_rule_content(&escape_rule_content(s)), s);
+}


### PR DESCRIPTION
feat(bash-perm): Slice 2.2.j — permission rule string parser

## 背景

Issue #490 Phase 2.2 第 8 个最小切片 —— **permission rule 字符串解析器**。
语义移植上游 `claude-code-main/src/utils/permissions/permissionRuleParser.ts`
L1-L198：处理 `"Tool"` / `"Tool(content)"` 格式的解析/序列化，含
反斜杠转义括号的正确处理，以及 4 条 legacy tool 名映射（Task→Agent /
KillShell→TaskStop / AgentOutputTool|BashOutputTool→TaskOutput）。

ANT-only 段（KAIROS 特性下的 `Brief` 别名，上游 L7-L17 + L26-L28）
**按 Issue #490 红线刻意省略**，并由测试 03 钉死回归。

## 范围

- **新增** `crates/dasclaw_bash_permissions/src/rule_parser.rs` (~245 LOC)
  - `pub fn normalize_legacy_tool_name(&str) -> &str`
  - `pub fn get_legacy_tool_names(&str) -> Vec<&'static str>`
  - `pub fn escape_rule_content(&str) -> String`
  - `pub fn unescape_rule_content(&str) -> String`
  - `pub fn permission_rule_value_from_string(&str) -> (String, Option<String>)`
  - `pub fn permission_rule_value_to_string(&str, Option<&str>) -> String`
  - 内部 `find_first_unescaped_char` / `find_last_unescaped_char`
- **修改** `src/lib.rs`：`pub mod rule_parser;` + 6 个 re-export
- **新增** `tests/rule_parser_test.rs` — 20 tests `req_perm_490_p2_2_j_01..20`

返回 `(String, Option<String>)` 而不是 `PermissionRuleValue`，是为了
让本模块对 `types` 模块零依赖 —— 后续 Slice 2.2.k 在 loader 层组装。

## 三层代码审查

**Layer 1 — 上游对照**
- 转义/反转义顺序 vs L52-L80：顺序敏感性测试 07/08 钉死
- 解析的 4 个 Fail-Safe 分支 vs L99-L120：测试 14 全覆盖
- 空内容/`*` 折叠为 tool-wide rule vs L132-L134：测试 13
- legacy 别名应用点 vs L102+L114+L130+L134：测试 15

**Layer 2 — Fail-Safe / SECURITY**
- 测试 07 转义顺序 PIN：若先 escape parens 再 escape backslashes，
  `\(` 会被双重转义并失去 injection 安全性
- 测试 14 malformed 输入降级：永不 panic / 永不部分解析
- 测试 19 反斜杠奇偶语义 PIN：0/1/2 三向覆盖 `\\(` 与 `\(` 区别
- 测试 03 Brief ANT-only 回归 PIN：未来误加 KAIROS Brief 别名立即报警

**Layer 3 — 红线**
- 无 unwrap / panic（唯一 `.expect()` 在 `unescape` 内部 `chars().next()`
  上，附同行 `// safety:` 注释，且由 `i < bytes.len()` 不变量保证）
- 无补丁式代码：单一新文件 + 单一 mod + 单一 re-export 块
- 无新增 deps
- 不依赖未移植的 upstream parser
- 不含 ANT-only 段（KAIROS Brief 别名）

## 验证

```bash
cargo fmt --all -- --check                                                # clean
python3.12 scripts/check_no_panics.py --base origin/xClaw                 # OK
cargo clippy --no-deps -p dasclaw_bash_permissions --all-targets -- -D warnings   # clean
cargo nextest run -p dasclaw_bash_permissions
#   95 tests run: 95 passed
#   (23 a + 13 b + 19 c + 20 d + 20 j)
```

## 测试矩阵 `req_perm_490_p2_2_j_01..20`

01-04 legacy 别名（4 条规范映射 + 非别名透传 + reverse lookup + ANT 回归）
05-09 escape/unescape 单元 + 顺序 SECURITY PIN + 大语料 round-trip
10-15 from_string 6 个分支（bare/with-content/escaped-parens/empty-collapse/
       wildcard-collapse/malformed Fail-Safe/legacy normalization）
16-17 to_string 基础 + 转义
18    完整 from→to→from round trip
19    反斜杠奇偶 SECURITY PIN（0/1/2 三向）
20    非 ASCII / UTF-8 多字节安全

## 子任务

- [ ] Slice 2.2.k — 在 `permissions_loader` 中调用本 parser，把 settings JSON
      的 `"Bash(content)"` 字符串解析成 `PermissionRule` 并喂给 Slice 2.2.i
      的 `detect_unreachable_rules`
- [ ] Slice 2.2.l — 上游 `permissionExplainer.ts` (250 LOC) 解释器

## Sources read

- `claude-code-main/src/utils/permissions/permissionRuleParser.ts` L1-L198 §全文
- `claude-code-main/src/utils/permissions/PermissionRule.ts`（PermissionRuleValue 类型）
- `claude-code-main/src/tools/AgentTool/constants.ts` L1（AGENT_TOOL_NAME=Agent）
- `claude-code-main/src/tools/TaskStopTool/prompt.ts`（TASK_STOP_TOOL_NAME=TaskStop）
- `claude-code-main/src/tools/TaskOutputTool/constants.ts`（TASK_OUTPUT_TOOL_NAME=TaskOutput）
- `crates/dasclaw_bash_permissions/src/types.rs` L55-L75 §PermissionRuleValue
- `crates/dasclaw_bash_permissions/src/lib.rs` §module declarations
- `docs/plans/architecture-refactor/adr-112-compatibility-evaluation.md` §兼容红线
- `AGENTS.md` §Skills 强制使用规范 + §测试纪律
- `.github/copilot-instructions.md` §PR 必填项

Closes #544
Refs #490
