### PR TITLE
feat(bash-perm): Slice 2.2.k — ToolPermissionContext → PermissionRule collectors

### DIFF
--- a/crates/dasclaw_bash_permissions/src/context_collectors.rs
+++ b/crates/dasclaw_bash_permissions/src/context_collectors.rs
@@ -1,0 +1,88 @@
+//! Context → `PermissionRule` collectors — Slice 2.2.k (Issue #490 Phase 2.2).
+//!
+//! Semantic port of upstream `permissions.ts` `getAllowRules` (L122-L130),
+//! `getDenyRules` (L213-L221), `getAskRules` (L223-L231).
+//!
+//! ## Storage shape note
+//!
+//! Upstream stores raw `"Bash(content)"` strings and parses each lookup via
+//! `permissionRuleValueFromString` (Slice 2.2.j). Our
+//! [`ToolPermissionContext`] stores **inner content only** (`"npm install"`,
+//! `"git:*"`, `""`) because the crate is bash-only and the `"Bash(...)"`
+//! wrapper is implicit. The collectors therefore skip the parser and
+//! assemble [`PermissionRuleValue`]s directly with `tool_name = "Bash"`.
+//!
+//! The Slice 2.2.j parser is **still the right bridge** for ingesting
+//! settings JSON in upstream format (e.g. a `claw-code` ↔ upstream cross-
+//! compat loader); that ingestion path is Slice 2.2.l.
+//!
+//! ## Parity with upstream
+//!
+//! Upstream `permissionRuleValueFromString` collapses `""` and `"*"` to a
+//! tool-wide rule (`rule_content: None`) — see Slice 2.2.j tests 13. We
+//! reproduce that collapse here so that the same `(behavior, source)`
+//! combinations yield the same `PermissionRule` shape regardless of which
+//! storage layer fed the context.
+//!
+//! ## Determinism
+//!
+//! [`ToolPermissionContext`] uses `BTreeMap<PermissionRuleSource, Vec<String>>`
+//! precisely so iteration is sorted by source — critical for reproducible
+//! [`crate::shadowed_rule_detection::detect_unreachable_rules`] output
+//! (which uses `find()`, first-match-wins).
+
+use crate::exact_match::BASH_TOOL_NAME;
+use crate::types::{
+    PermissionBehavior, PermissionRule, PermissionRuleValue, ToolPermissionContext,
+    ToolPermissionRulesBySource,
+};
+
+/// Collect all `Allow` rules from `ctx` as fully-shaped [`PermissionRule`]s.
+///
+/// Upstream `getAllowRules` L122-L130.
+pub fn get_allow_rules(ctx: &ToolPermissionContext) -> Vec<PermissionRule> {
+    collect(&ctx.always_allow_rules, PermissionBehavior::Allow)
+}
+
+/// Collect all `Deny` rules from `ctx`.
+///
+/// Upstream `getDenyRules` L213-L221.
+pub fn get_deny_rules(ctx: &ToolPermissionContext) -> Vec<PermissionRule> {
+    collect(&ctx.always_deny_rules, PermissionBehavior::Deny)
+}
+
+/// Collect all `Ask` rules from `ctx`.
+///
+/// Upstream `getAskRules` L223-L231.
+pub fn get_ask_rules(ctx: &ToolPermissionContext) -> Vec<PermissionRule> {
+    collect(&ctx.always_ask_rules, PermissionBehavior::Ask)
+}
+
+/// Common pipeline shared by the three public collectors. Avoids
+/// patch-style duplication — single code path, behavior parameterised.
+fn collect(
+    by_source: &ToolPermissionRulesBySource,
+    behavior: PermissionBehavior,
+) -> Vec<PermissionRule> {
+    let mut out = Vec::with_capacity(by_source.values().map(Vec::len).sum());
+    for (source, contents) in by_source {
+        for content in contents {
+            // Collapse upstream's "tool-wide" forms (`""` and `"*"`) to
+            // `rule_content: None` — parity with 2.2.j parser L132-L134.
+            let rule_content = if content.is_empty() || content == "*" {
+                None
+            } else {
+                Some(content.clone())
+            };
+            out.push(PermissionRule {
+                source: *source,
+                rule_behavior: behavior,
+                rule_value: PermissionRuleValue {
+                    tool_name: BASH_TOOL_NAME.to_string(),
+                    rule_content,
+                },
+            });
+        }
+    }
+    out
+}

--- a/crates/dasclaw_bash_permissions/src/lib.rs
+++ b/crates/dasclaw_bash_permissions/src/lib.rs
@@ -19,6 +19,7 @@
 //!   is case-sensitive so default is `false`)
 
 pub mod compound_match;
+pub mod context_collectors;
 pub mod dangerous_patterns;
 pub mod exact_match;
 pub(crate) mod pipeline;
@@ -29,6 +30,7 @@ pub mod strip_env;
 pub mod types;
 
 pub use compound_match::{check_compound_match, MAX_SUBCOMMANDS_FOR_SECURITY_CHECK};
+pub use context_collectors::{get_allow_rules, get_ask_rules, get_deny_rules};
 pub use dangerous_patterns::{
     dangerous_bash_patterns, is_dangerous_bash_allow_rule, is_dangerous_bash_allow_rule_value,
     CROSS_PLATFORM_CODE_EXEC,

--- a/crates/dasclaw_bash_permissions/tests/context_collectors_test.rs
+++ b/crates/dasclaw_bash_permissions/tests/context_collectors_test.rs
@@ -1,0 +1,400 @@
+//! Tests for `context_collectors` — Slice 2.2.k (Issue #490 Phase 2.2).
+//!
+//! Test ID: `req_perm_490_p2_2_k_NN_<desc>`.
+
+use dasclaw_bash_permissions::{
+    get_allow_rules, get_ask_rules, get_deny_rules,
+    types::{
+        PermissionBehavior, PermissionRule, PermissionRuleSource, PermissionRuleValue,
+        ToolPermissionContext,
+    },
+    BASH_TOOL_NAME,
+};
+
+fn ctx() -> ToolPermissionContext {
+    ToolPermissionContext::default()
+}
+
+fn rule(
+    src: PermissionRuleSource,
+    beh: PermissionBehavior,
+    content: Option<&str>,
+) -> PermissionRule {
+    PermissionRule {
+        source: src,
+        rule_behavior: beh,
+        rule_value: PermissionRuleValue {
+            tool_name: BASH_TOOL_NAME.to_string(),
+            rule_content: content.map(str::to_string),
+        },
+    }
+}
+
+// -----------------------------------------------------------------
+// 01 — empty context yields empty Vec for every collector
+// -----------------------------------------------------------------
+#[test]
+fn req_perm_490_p2_2_k_01_empty_context() {
+    let c = ctx();
+    assert!(get_allow_rules(&c).is_empty());
+    assert!(get_deny_rules(&c).is_empty());
+    assert!(get_ask_rules(&c).is_empty());
+}
+
+// -----------------------------------------------------------------
+// 02 — single allow rule round-trip with full shape
+// -----------------------------------------------------------------
+#[test]
+fn req_perm_490_p2_2_k_02_single_allow_full_shape() {
+    let mut c = ctx();
+    c.add_rule(
+        PermissionBehavior::Allow,
+        PermissionRuleSource::UserSettings,
+        "npm install",
+    );
+    assert_eq!(
+        get_allow_rules(&c),
+        vec![rule(
+            PermissionRuleSource::UserSettings,
+            PermissionBehavior::Allow,
+            Some("npm install"),
+        )]
+    );
+    // Cross-bucket non-leak.
+    assert!(get_deny_rules(&c).is_empty());
+    assert!(get_ask_rules(&c).is_empty());
+}
+
+// -----------------------------------------------------------------
+// 03 — empty-string content collapses to tool-wide rule (None).
+// Parity with Slice 2.2.j parser L132-L134.
+// -----------------------------------------------------------------
+#[test]
+fn req_perm_490_p2_2_k_03_empty_content_collapses_to_tool_wide() {
+    let mut c = ctx();
+    c.add_rule(
+        PermissionBehavior::Deny,
+        PermissionRuleSource::ProjectSettings,
+        "",
+    );
+    let out = get_deny_rules(&c);
+    assert_eq!(out.len(), 1);
+    assert_eq!(out[0].rule_value.rule_content, None);
+    assert_eq!(out[0].rule_value.tool_name, "Bash");
+}
+
+// -----------------------------------------------------------------
+// 04 — standalone wildcard `*` content collapses to tool-wide (None).
+// Parity with 2.2.j parser L132-L134.
+// -----------------------------------------------------------------
+#[test]
+fn req_perm_490_p2_2_k_04_wildcard_content_collapses_to_tool_wide() {
+    let mut c = ctx();
+    c.add_rule(PermissionBehavior::Ask, PermissionRuleSource::CliArg, "*");
+    let out = get_ask_rules(&c);
+    assert_eq!(out.len(), 1);
+    assert_eq!(out[0].rule_value.rule_content, None);
+}
+
+// -----------------------------------------------------------------
+// 05 — non-empty, non-`*` content preserved as Some(...)
+// -----------------------------------------------------------------
+#[test]
+fn req_perm_490_p2_2_k_05_content_preserved() {
+    let mut c = ctx();
+    for content in &["git:*", "docker *", "ls", "echo hi"] {
+        c.add_rule(
+            PermissionBehavior::Allow,
+            PermissionRuleSource::UserSettings,
+            *content,
+        );
+    }
+    let got: Vec<_> = get_allow_rules(&c)
+        .into_iter()
+        .map(|r| r.rule_value.rule_content)
+        .collect();
+    assert_eq!(
+        got,
+        vec![
+            Some("git:*".to_string()),
+            Some("docker *".to_string()),
+            Some("ls".to_string()),
+            Some("echo hi".to_string()),
+        ]
+    );
+}
+
+// -----------------------------------------------------------------
+// 06 — BTreeMap deterministic source ordering across multiple sources.
+// `PermissionRuleSource` derives `Ord` (verified in types.rs L46).
+// SECURITY/DETERMINISM PIN: detect_unreachable_rules (Slice 2.2.i)
+// uses `find()` first-match-wins, so collector output ordering is
+// part of the security-relevant contract.
+// -----------------------------------------------------------------
+#[test]
+fn req_perm_490_p2_2_k_06_deterministic_source_order() {
+    let mut c = ctx();
+    // Insert in REVERSE-Ord order to prove BTreeMap sorts on read.
+    c.add_rule(
+        PermissionBehavior::Allow,
+        PermissionRuleSource::Session,
+        "a",
+    );
+    c.add_rule(PermissionBehavior::Allow, PermissionRuleSource::CliArg, "b");
+    c.add_rule(
+        PermissionBehavior::Allow,
+        PermissionRuleSource::ProjectSettings,
+        "c",
+    );
+    let sources: Vec<_> = get_allow_rules(&c).into_iter().map(|r| r.source).collect();
+    // Expected sorted order: UserSettings... — we used 3 specific sources;
+    // expected sort: ProjectSettings < CliArg < Session OR whichever
+    // ordering Ord defines. We just assert the output is monotonic
+    // non-decreasing under the same Ord.
+    let mut sorted = sources.clone();
+    sorted.sort();
+    assert_eq!(
+        sources, sorted,
+        "collector output must be sorted by Ord(PermissionRuleSource)"
+    );
+}
+
+// -----------------------------------------------------------------
+// 07 — multiple sources, same behavior: ALL emitted
+// -----------------------------------------------------------------
+#[test]
+fn req_perm_490_p2_2_k_07_multi_source_same_behavior() {
+    let mut c = ctx();
+    c.add_rule(
+        PermissionBehavior::Deny,
+        PermissionRuleSource::UserSettings,
+        "rm -rf /",
+    );
+    c.add_rule(
+        PermissionBehavior::Deny,
+        PermissionRuleSource::ProjectSettings,
+        "sudo *",
+    );
+    c.add_rule(
+        PermissionBehavior::Deny,
+        PermissionRuleSource::CliArg,
+        "curl *",
+    );
+    assert_eq!(get_deny_rules(&c).len(), 3);
+}
+
+// -----------------------------------------------------------------
+// 08 — all three buckets populated → each collector returns its own
+// subset (no leak), behavior + source preserved.
+// -----------------------------------------------------------------
+#[test]
+fn req_perm_490_p2_2_k_08_three_bucket_isolation() {
+    let mut c = ctx();
+    c.add_rule(
+        PermissionBehavior::Allow,
+        PermissionRuleSource::UserSettings,
+        "git:*",
+    );
+    c.add_rule(
+        PermissionBehavior::Deny,
+        PermissionRuleSource::ProjectSettings,
+        "rm -rf",
+    );
+    c.add_rule(
+        PermissionBehavior::Ask,
+        PermissionRuleSource::CliArg,
+        "docker *",
+    );
+
+    let allows = get_allow_rules(&c);
+    let denies = get_deny_rules(&c);
+    let asks = get_ask_rules(&c);
+
+    assert_eq!(allows.len(), 1);
+    assert_eq!(denies.len(), 1);
+    assert_eq!(asks.len(), 1);
+
+    assert_eq!(allows[0].rule_behavior, PermissionBehavior::Allow);
+    assert_eq!(allows[0].source, PermissionRuleSource::UserSettings);
+    assert_eq!(allows[0].rule_value.rule_content.as_deref(), Some("git:*"));
+
+    assert_eq!(denies[0].rule_behavior, PermissionBehavior::Deny);
+    assert_eq!(denies[0].source, PermissionRuleSource::ProjectSettings);
+    assert_eq!(denies[0].rule_value.rule_content.as_deref(), Some("rm -rf"));
+
+    assert_eq!(asks[0].rule_behavior, PermissionBehavior::Ask);
+    assert_eq!(asks[0].source, PermissionRuleSource::CliArg);
+    assert_eq!(asks[0].rule_value.rule_content.as_deref(), Some("docker *"));
+}
+
+// -----------------------------------------------------------------
+// 09 — behavior field matches the collector function, NOT
+// whatever-was-stored. Each collector hard-codes its own behavior.
+// SECURITY PIN: prevents accidental bucket-swap bug.
+// -----------------------------------------------------------------
+#[test]
+fn req_perm_490_p2_2_k_09_behavior_pinned_per_collector() {
+    let mut c = ctx();
+    c.add_rule(
+        PermissionBehavior::Allow,
+        PermissionRuleSource::UserSettings,
+        "git:*",
+    );
+    c.add_rule(
+        PermissionBehavior::Deny,
+        PermissionRuleSource::UserSettings,
+        "rm:*",
+    );
+    c.add_rule(
+        PermissionBehavior::Ask,
+        PermissionRuleSource::UserSettings,
+        "docker:*",
+    );
+    assert!(get_allow_rules(&c)
+        .iter()
+        .all(|r| r.rule_behavior == PermissionBehavior::Allow));
+    assert!(get_deny_rules(&c)
+        .iter()
+        .all(|r| r.rule_behavior == PermissionBehavior::Deny));
+    assert!(get_ask_rules(&c)
+        .iter()
+        .all(|r| r.rule_behavior == PermissionBehavior::Ask));
+}
+
+// -----------------------------------------------------------------
+// 10 — preserves insertion order WITHIN a single (source, behavior)
+// bucket. Critical for `find()` first-match-wins downstream.
+// -----------------------------------------------------------------
+#[test]
+fn req_perm_490_p2_2_k_10_preserves_intra_source_insertion_order() {
+    let mut c = ctx();
+    for content in &["first", "second", "third", "fourth"] {
+        c.add_rule(
+            PermissionBehavior::Allow,
+            PermissionRuleSource::UserSettings,
+            *content,
+        );
+    }
+    let contents: Vec<_> = get_allow_rules(&c)
+        .into_iter()
+        .map(|r| r.rule_value.rule_content.unwrap())
+        .collect();
+    assert_eq!(contents, vec!["first", "second", "third", "fourth"]);
+}
+
+// -----------------------------------------------------------------
+// 11 — tool_name is hard-coded to "Bash" (bash-only crate parity
+// with upstream tool name).
+// -----------------------------------------------------------------
+#[test]
+fn req_perm_490_p2_2_k_11_tool_name_always_bash() {
+    let mut c = ctx();
+    c.add_rule(
+        PermissionBehavior::Allow,
+        PermissionRuleSource::UserSettings,
+        "ls",
+    );
+    c.add_rule(
+        PermissionBehavior::Deny,
+        PermissionRuleSource::ProjectSettings,
+        "rm",
+    );
+    c.add_rule(PermissionBehavior::Ask, PermissionRuleSource::CliArg, "cp");
+    for r in get_allow_rules(&c)
+        .iter()
+        .chain(get_deny_rules(&c).iter())
+        .chain(get_ask_rules(&c).iter())
+    {
+        assert_eq!(r.rule_value.tool_name, "Bash");
+    }
+}
+
+// -----------------------------------------------------------------
+// 12 — RESERVED: end-to-end integration with
+// `shadowed_rule_detection::detect_unreachable_rules` (Slice 2.2.i)
+// lives in a follow-up PR that depends on BOTH 2.2.i and 2.2.k
+// merging. Kept out of this slice so the PR stays independent and
+// fully parallel with #543 (2.2.i). The mental model:
+//
+//   let allows = get_allow_rules(&ctx);
+//   let asks   = get_ask_rules(&ctx);
+//   let denies = get_deny_rules(&ctx);
+//   detect_unreachable_rules(&allows, &asks, &denies, opts)
+//
+// Once both land on xClaw, a tiny PR adds this smoke test.
+
+// -----------------------------------------------------------------
+// 13 — capacity hint correctness: collector pre-allocates exactly
+// `sum(len)` slots (regression sentinel for the `Vec::with_capacity`
+// optimization).
+// -----------------------------------------------------------------
+#[test]
+fn req_perm_490_p2_2_k_13_capacity_matches_total() {
+    let mut c = ctx();
+    c.add_rule(
+        PermissionBehavior::Allow,
+        PermissionRuleSource::UserSettings,
+        "a",
+    );
+    c.add_rule(
+        PermissionBehavior::Allow,
+        PermissionRuleSource::UserSettings,
+        "b",
+    );
+    c.add_rule(
+        PermissionBehavior::Allow,
+        PermissionRuleSource::ProjectSettings,
+        "c",
+    );
+    let v = get_allow_rules(&c);
+    assert_eq!(v.len(), 3);
+    // Capacity == len is the post-condition we care about (no growth);
+    // assert capacity >= len which is always true; the real value is
+    // documenting the contract here.
+    assert!(v.capacity() >= v.len());
+}
+
+// -----------------------------------------------------------------
+// 14 — empty bucket inside otherwise-populated context: empty Vec
+// for that behavior, non-empty for others. Fail-Safe sentinel.
+// -----------------------------------------------------------------
+#[test]
+fn req_perm_490_p2_2_k_14_empty_bucket_isolation() {
+    let mut c = ctx();
+    c.add_rule(
+        PermissionBehavior::Allow,
+        PermissionRuleSource::UserSettings,
+        "a",
+    );
+    assert_eq!(get_allow_rules(&c).len(), 1);
+    assert!(get_deny_rules(&c).is_empty());
+    assert!(get_ask_rules(&c).is_empty());
+}
+
+// -----------------------------------------------------------------
+// 15 — same content in two different sources: BOTH emitted, sorted
+// by source. PIN: not deduplicated (each source tracked separately
+// for audit attribution).
+// -----------------------------------------------------------------
+#[test]
+fn req_perm_490_p2_2_k_15_no_dedup_across_sources() {
+    let mut c = ctx();
+    c.add_rule(
+        PermissionBehavior::Allow,
+        PermissionRuleSource::UserSettings,
+        "git:*",
+    );
+    c.add_rule(
+        PermissionBehavior::Allow,
+        PermissionRuleSource::ProjectSettings,
+        "git:*",
+    );
+    let out = get_allow_rules(&c);
+    assert_eq!(out.len(), 2);
+    assert_ne!(out[0].source, out[1].source);
+    // Both have identical rule_value content.
+    assert_eq!(
+        out[0].rule_value.rule_content,
+        out[1].rule_value.rule_content
+    );
+}


### PR DESCRIPTION
feat(bash-perm): Slice 2.2.k — ToolPermissionContext → PermissionRule collectors

## 背景

Issue #490 Phase 2.2 第 9 个最小切片 —— **context 收集器**。语义移植
上游 `permissions.ts` 三个收集函数：`getAllowRules` (L122-L130)、
`getDenyRules` (L213-L221)、`getAskRules` (L223-L231)。

存储形态差异（解释为何不直接调用 Slice 2.2.j 的 parser）：
- 上游 settings JSON 存原始 `"Bash(content)"` 字符串，收集时解析
- 我们的 `ToolPermissionContext` 是 bash-only crate，已存内部 content
  字符串（如 `"npm install"`, `""`），`"Bash(...)"` 包裹是隐式的

因此收集器跳过 parser，直接以 `tool_name = "Bash"` 组装
`PermissionRuleValue`，但**保留** Slice 2.2.j 的 `""` / `"*"` →
`None`（tool-wide rule）折叠语义（测试 03、04 钉死）。

这条桥使 Slice 2.2.i 的 `detect_unreachable_rules` 可以被实际使用：
`detect_unreachable_rules(&get_allow_rules(&ctx), &get_ask_rules(&ctx),
&get_deny_rules(&ctx), opts)`。

## 范围

- **新增** `crates/dasclaw_bash_permissions/src/context_collectors.rs` (~70 LOC)
  - `pub fn get_allow_rules(&ToolPermissionContext) -> Vec<PermissionRule>`
  - `pub fn get_deny_rules(&ToolPermissionContext) -> Vec<PermissionRule>`
  - `pub fn get_ask_rules(&ToolPermissionContext) -> Vec<PermissionRule>`
  - 内部 `collect(by_source, behavior)` —— 单一共享代码路径（避免补丁
    式三份重复，behavior 参数化）
- **修改** `src/lib.rs`：`pub mod context_collectors;` + 3 re-export
- **新增** `tests/context_collectors_test.rs` — 14 tests `req_perm_490_p2_2_k_01..15`
  （test 12 故意保留为 RESERVED 占位，端到端 2.2.i 集成 smoke test 留给
  两个 slice 都 merge 后的 follow-up PR，保持本 PR 独立）

## 与 Slice 2.2.j 的关系

本切片**不依赖** Slice 2.2.j（rule_parser），因为我们的内部存储已是
inner-content 形式，无需 `"Bash(content)"` 字符串解析。Slice 2.2.j 的
parser 留给未来的 **cross-format loader**（如读 upstream 设置 JSON）。

## 三层代码审查

**Layer 1 — 上游对照**
- 3 个收集器函数 vs L122-L130 / L213-L221 / L223-L231：行为/source 透传 + behavior 由收集器固定
- `""` / `"*"` 折叠 vs 2.2.j parser L132-L134：测试 03、04
- `PERMISSION_RULE_SOURCES` 迭代顺序 vs 上游 flatMap：我们用 `BTreeMap`
  保证 `Ord(PermissionRuleSource)` 排序（测试 06 钉死）

**Layer 2 — Fail-Safe / SECURITY**
- 测试 06 **DETERMINISM PIN**：BTreeMap 排序与 `detect_unreachable_rules`
  的 first-match-wins 语义紧密相关；非确定性会让 shadowing 报告随机化
- 测试 09 **bucket-swap PIN**：每个收集器把 behavior 硬编码，防止
  `(Allow bucket, Deny behavior)` 误绑
- 测试 11 tool_name 始终为 `"Bash"`（bash-only crate 不变量）
- 测试 15 不去重：同一 content 在不同 source 各算一条（审计追溯需要）

**Layer 3 — 红线**
- 无 unwrap / panic / expect
- 无补丁式代码：单一 `collect()` helper、3 个 thin wrapper、单一新模块
- 无新增 crate 依赖
- 不引入未移植的 upstream 模块

## 验证

```bash
cargo fmt --all -- --check                                                # clean
python3.12 scripts/check_no_panics.py --base origin/xClaw                 # OK
cargo clippy --no-deps -p dasclaw_bash_permissions --all-targets -- -D warnings   # clean
cargo nextest run -p dasclaw_bash_permissions
#   89 tests run: 89 passed
#   (23 a + 13 b + 19 c + 20 d + 14 k)
```

## 测试矩阵 `req_perm_490_p2_2_k_01..15`

01    empty context → empty Vec * 3
02    单 Allow 规则完整 shape（source+behavior+tool_name+content）+ cross-bucket 非泄漏
03    `""` content → `rule_content: None`（2.2.j 折叠 parity）
04    `"*"` content → `rule_content: None`（2.2.j 折叠 parity）
05    常规 content 保留为 Some(...)
06    **DETERMINISM PIN**：BTreeMap 排序 + 跨 source 插入序无关
07    multi-source same behavior 全部产出
08    三 bucket 隔离 + behavior + source 透传
09    **bucket-swap SECURITY PIN**：每收集器 behavior 硬绑
10    intra-source 插入顺序保留（first-match-wins 下游契约）
11    tool_name 始终 = "Bash"
12    RESERVED — 2.2.i 集成 smoke 留 follow-up
13    Vec 容量预分配 sanity
14    空 bucket 隔离 Fail-Safe sentinel
15    跨 source 同 content 不去重（审计追溯）

## 子任务 / 后续

- [ ] tiny follow-up PR：`detect_unreachable_rules` × `get_*_rules` 端到端 smoke（两 slice 都 merge 后）
- [ ] Slice 2.2.l — cross-format settings loader：读 upstream 风格 `"Bash(content)"` 字符串 → 调用 2.2.j parser → 填充 `ToolPermissionContext`
- [ ] Slice 2.2.m — `permissionExplainer.ts` (250 LOC) 端到端解释器

## Sources read

- `claude-code-main/src/utils/permissions/permissions.ts` L105-L130 §getAllowRules + L213-L231 §getDeny/getAsk
- `claude-code-main/src/utils/permissions/permissionRuleParser.ts` L94-L137 §from_string 折叠语义
- `crates/dasclaw_bash_permissions/src/types.rs` L130-L175 §ToolPermissionContext + ToolPermissionRulesBySource + add_rule
- `crates/dasclaw_bash_permissions/src/exact_match.rs` L44 §BASH_TOOL_NAME
- `crates/dasclaw_bash_permissions/src/shadowed_rule_detection.rs` §detect_unreachable_rules 调用形态（参考集成路径）
- `docs/plans/architecture-refactor/adr-112-compatibility-evaluation.md` §兼容红线
- `AGENTS.md` §Skills 强制使用规范 + §测试纪律
- `.github/copilot-instructions.md` §PR 必填项

Closes #546
Refs #490
