### PR TITLE
feat(bash-perm): Slice 2.2.f — wire strip_env into prefix/compound match (closes env-var bypass)

### DIFF
--- a/crates/dasclaw_bash_permissions/src/exact_match.rs
+++ b/crates/dasclaw_bash_permissions/src/exact_match.rs
@@ -35,7 +35,7 @@
 //!   command. Wildcard matching on unparsed commands allows `foo *` to
 //!   match `foo arg && curl evil.com` since `.*` matches operators.")
 
-use crate::pipeline::{run_pipeline, RulePredicate};
+use crate::pipeline::{run_pipeline, PipelineMessages, RulePredicate};
 use crate::shell_rule_matching::{parse_permission_rule, ShellPermissionRule};
 use crate::types::{PermissionResult, ToolPermissionContext};
 
@@ -67,23 +67,27 @@ const EXACT_PREDICATE: RulePredicate = rule_matches_in_exact_mode;
 /// (`const command = input.command.trim()`). No env-var stripping or
 /// compound-splitting happens here — see slice 2.2.d/e.
 pub fn check_exact_match(command: &str, context: &ToolPermissionContext) -> PermissionResult {
+    let trimmed = command.trim();
     run_pipeline(
-        command,
+        trimmed,
+        &|_behavior| trimmed.to_string(),
         context,
         BASH_TOOL_NAME,
         EXACT_PREDICATE,
-        &|cmd| {
-            format!(
-                "Permission to use {tool} with command {cmd} has been denied.",
-                tool = BASH_TOOL_NAME,
-            )
+        PipelineMessages {
+            deny: &|cmd| {
+                format!(
+                    "Permission to use {tool} with command {cmd} has been denied.",
+                    tool = BASH_TOOL_NAME,
+                )
+            },
+            ask: &|| {
+                format!(
+                    "Claude requested permissions to use {tool}, but you haven't granted it yet.",
+                    tool = BASH_TOOL_NAME,
+                )
+            },
+            passthrough: &|| "This command requires approval".to_string(),
         },
-        &|| {
-            format!(
-                "Claude requested permissions to use {tool}, but you haven't granted it yet.",
-                tool = BASH_TOOL_NAME,
-            )
-        },
-        &|| "This command requires approval".to_string(),
     )
 }

--- a/crates/dasclaw_bash_permissions/src/pipeline.rs
+++ b/crates/dasclaw_bash_permissions/src/pipeline.rs
@@ -72,46 +72,75 @@ pub(crate) fn first_matching_rule(
 /// tool-specific (e.g. exact mode wants "with command X has been
 /// denied" while prefix mode may want a different phrasing in later
 /// slices). For now both modes use the same upstream wording.
+/// Per-behavior command resolver: returns the command string to match
+/// against rules of the given behavior bucket.
+///
+/// Modes that need different stripping per behavior (e.g. prefix mode
+/// uses [`crate::strip_env::strip_all_leading_env_vars`] on the Deny
+/// path and [`crate::strip_env::strip_safe_wrappers`] on the
+/// Allow / Ask path — upstream `permissions.ts` L805-L856) supply a
+/// closure that switches on `behavior`. Modes that don't (e.g. exact
+/// mode) return the same trimmed string regardless.
+///
+/// The `&str` returned must live for the duration of one pipeline call.
+/// The trait-object form (`&dyn Fn`) is used to keep the API
+/// monomorphisation-free and avoids leaking the closure type into the
+/// public re-exports of `exact_match` / `prefix_match`.
+pub(crate) type CmdForBehavior<'a> = &'a dyn Fn(PermissionBehavior) -> String;
+
+/// Mode-/tool-specific decision messages bundled into one struct so
+/// [`run_pipeline`] stays under clippy's `too_many_arguments` cap.
+/// Each closure is invoked at most once per call.
+pub(crate) struct PipelineMessages<'a> {
+    /// Invoked when a Deny rule matches; receives the original
+    /// (display) command — never the post-stripped form.
+    pub deny: &'a dyn Fn(&str) -> String,
+    /// Invoked when an Ask rule matches.
+    pub ask: &'a dyn Fn() -> String,
+    /// Invoked when no rule matches.
+    pub passthrough: &'a dyn Fn() -> String,
+}
+
 pub(crate) fn run_pipeline(
-    command: &str,
+    display_command: &str,
+    cmd_for_behavior: CmdForBehavior<'_>,
     context: &ToolPermissionContext,
     tool_name: &str,
     predicate: RulePredicate,
-    deny_message: &dyn Fn(&str) -> String,
-    ask_message: &dyn Fn() -> String,
-    passthrough_message: &dyn Fn() -> String,
+    messages: PipelineMessages<'_>,
 ) -> PermissionResult {
-    let cmd = command.trim();
-
+    let deny_cmd = cmd_for_behavior(PermissionBehavior::Deny);
     if let Some(rule) = first_matching_rule(
         &context.always_deny_rules,
-        cmd,
+        &deny_cmd,
         PermissionBehavior::Deny,
         tool_name,
         predicate,
     ) {
         return PermissionResult::Deny {
-            message: deny_message(cmd),
+            message: (messages.deny)(display_command),
             reason: PermissionDecisionReason::Rule { rule },
         };
     }
 
+    let ask_cmd = cmd_for_behavior(PermissionBehavior::Ask);
     if let Some(rule) = first_matching_rule(
         &context.always_ask_rules,
-        cmd,
+        &ask_cmd,
         PermissionBehavior::Ask,
         tool_name,
         predicate,
     ) {
         return PermissionResult::Ask {
-            message: ask_message(),
+            message: (messages.ask)(),
             reason: PermissionDecisionReason::Rule { rule },
         };
     }
 
+    let allow_cmd = cmd_for_behavior(PermissionBehavior::Allow);
     if let Some(rule) = first_matching_rule(
         &context.always_allow_rules,
-        cmd,
+        &allow_cmd,
         PermissionBehavior::Allow,
         tool_name,
         predicate,
@@ -121,7 +150,18 @@ pub(crate) fn run_pipeline(
         };
     }
 
-    let passthrough = passthrough_message();
+    let passthrough = (messages.passthrough)
+        &allow_cmd,
+        PermissionBehavior::Allow,
+        tool_name,
+        predicate,
+    ) {
+        return PermissionResult::Allow {
+            reason: PermissionDecisionReason::Rule { rule },
+        };
+    }
+
+    let passthrough = (messages.passthrough)();
     PermissionResult::Passthrough {
         message: passthrough.clone(),
         reason: PermissionDecisionReason::Other {

--- a/crates/dasclaw_bash_permissions/src/pipeline.rs
+++ b/crates/dasclaw_bash_permissions/src/pipeline.rs
@@ -150,17 +150,6 @@ pub(crate) fn run_pipeline(
         };
     }
 
-    let passthrough = (messages.passthrough)
-        &allow_cmd,
-        PermissionBehavior::Allow,
-        tool_name,
-        predicate,
-    ) {
-        return PermissionResult::Allow {
-            reason: PermissionDecisionReason::Rule { rule },
-        };
-    }
-
     let passthrough = (messages.passthrough)();
     PermissionResult::Passthrough {
         message: passthrough.clone(),

--- a/crates/dasclaw_bash_permissions/src/prefix_match.rs
+++ b/crates/dasclaw_bash_permissions/src/prefix_match.rs
@@ -25,9 +25,12 @@
 //!   `Bash(cd:*)` will currently match `cd /path && rm -rf /` in this
 //!   library-only engine. Pinned by [`tests/prefix_match_test.rs`]
 //!   test `req_perm_490_p2_2_c_18_compound_not_yet_split`.
-//! - Slice 2.2.e → `stripSafeWrappers` / `stripAllLeadingEnvVars` /
-//!   `BINARY_HIJACK_VARS` (upstream L805-L856). Pinned by
-//!   `req_perm_490_p2_2_c_19_env_var_wrapping_not_yet_stripped`.
+//! - **CLOSED in Slice 2.2.f** → `stripSafeWrappers` /
+//!   `stripAllLeadingEnvVars` / `BINARY_HIJACK_VARS`
+//!   (upstream L805-L856). Wired per-behavior via
+//!   [`crate::pipeline::CmdForBehavior`]. The matching forward-pointer
+//!   test in `prefix_match_test.rs` flips from Passthrough to Deny
+//!   under `req_perm_490_p2_2_c_19_env_var_wrapping_now_stripped`.
 //! - Output-redirection stripping (`extractOutputRedirections`,
 //!   upstream L791-L801) — applies to both modes; deferred follow-up.
 //! - Slice 2.2.f → `BashPermissionHook` adapter + `CompositeSafetyHook`
@@ -46,11 +49,12 @@
 //!   `xargs -n1 grep` are NOT matched (natural word boundary).
 //! - **Library-only** until slice 2.2.f.
 
-use crate::pipeline::{run_pipeline, RulePredicate};
+use crate::pipeline::{run_pipeline, PipelineMessages, RulePredicate};
 use crate::shell_rule_matching::{
     match_wildcard_pattern, parse_permission_rule, MatchOptions, ShellPermissionRule,
 };
-use crate::types::{PermissionResult, ToolPermissionContext};
+use crate::strip_env::{strip_all_leading_env_vars, strip_safe_wrappers};
+use crate::types::{PermissionBehavior, PermissionResult, ToolPermissionContext};
 
 /// Bash tool name — same as [`crate::exact_match::BASH_TOOL_NAME`],
 /// re-declared here to keep the prefix module independently usable.
@@ -117,27 +121,51 @@ const PREFIX_PREDICATE: RulePredicate = rule_matches_in_prefix_mode;
 /// `Deny > Ask > Allow > Passthrough` (shared with exact mode via
 /// [`crate::pipeline::run_pipeline`]).
 ///
-/// `command` is trimmed before matching. No env-var stripping,
-/// safe-wrapper stripping, or compound-command splitting happens here
-/// — see module docs.
+/// `command` is trimmed before matching. **Env-var / safe-wrapper
+/// stripping is applied per-behavior** (upstream `permissions.ts`
+/// L805-L856):
+///
+/// - **Deny bucket**: [`strip_all_leading_env_vars`] — aggressive;
+///   closes `FOO=bar denied_command` bypass. Fail-Safe: if a
+///   `LD_*` / `DYLD_*` / `PATH=` hijack-binary env var is detected,
+///   the helper returns the original string so deny rules see the full
+///   hijacked command and still match (`req_perm_490_p2_2_e_08-10`).
+/// - **Allow / Ask bucket**: [`strip_safe_wrappers`] — conservative;
+///   only strips upstream-listed `SAFE_ENV_VARS` and safe wrapper
+///   binaries (`timeout`, `time`, `nice`, `nohup`, `stdbuf`). Anything
+///   unknown stays attached so allow/ask rules don't over-grant on
+///   user-injected env wrappers.
+///
+/// No compound-command splitting happens here — see
+/// [`crate::compound_match::check_compound_match`].
 pub fn check_prefix_match(command: &str, context: &ToolPermissionContext) -> PermissionResult {
+    let trimmed = command.trim();
+    let cmd_for_behavior = |behavior: PermissionBehavior| -> String {
+        match behavior {
+            PermissionBehavior::Deny => strip_all_leading_env_vars(trimmed),
+            PermissionBehavior::Allow | PermissionBehavior::Ask => strip_safe_wrappers(trimmed),
+        }
+    };
     run_pipeline(
-        command,
+        trimmed,
+        &cmd_for_behavior,
         context,
         BASH_TOOL_NAME,
         PREFIX_PREDICATE,
-        &|cmd| {
-            format!(
-                "Permission to use {tool} with command {cmd} has been denied.",
-                tool = BASH_TOOL_NAME,
-            )
+        PipelineMessages {
+            deny: &|cmd| {
+                format!(
+                    "Permission to use {tool} with command {cmd} has been denied.",
+                    tool = BASH_TOOL_NAME,
+                )
+            },
+            ask: &|| {
+                format!(
+                    "Claude requested permissions to use {tool}, but you haven't granted it yet.",
+                    tool = BASH_TOOL_NAME,
+                )
+            },
+            passthrough: &|| "This command requires approval".to_string(),
         },
-        &|| {
-            format!(
-                "Claude requested permissions to use {tool}, but you haven't granted it yet.",
-                tool = BASH_TOOL_NAME,
-            )
-        },
-        &|| "This command requires approval".to_string(),
     )
 }

--- a/crates/dasclaw_bash_permissions/tests/compound_match_test.rs
+++ b/crates/dasclaw_bash_permissions/tests/compound_match_test.rs
@@ -352,17 +352,15 @@ fn req_perm_490_p2_2_d_19_empty_command_is_passthrough() {
 }
 
 // ---------------------------------------------------------------------------
-// 8. Forward pointer: env-var stripping (slice 2.2.e)
+// 8. Env-var stripping (closed by slice 2.2.f)
 // ---------------------------------------------------------------------------
 
 #[test]
-fn req_perm_490_p2_2_d_20_env_var_wrapper_not_stripped_yet() {
-    // SECURITY GAP forward-pointer to slice 2.2.e: `FOO=bar rm -rf /`
-    // should be matched by `rm:*` AFTER env-var stripping. Today, the
-    // AST parses this as a single command whose command_name is `rm`
-    // with env vars attached — depending on tree-sitter's surface, it
-    // may or may not match. We pin the CURRENT behavior here so 2.2.e
-    // can flip it without surprises.
+fn req_perm_490_p2_2_d_20_env_var_wrapper_now_stripped() {
+    // CLOSED by slice 2.2.f: tree-sitter rejects `FOO=bar rm…` as
+    // non-word-only so we fall back to `check_prefix_match` on the
+    // raw trimmed string. With env-var stripping now wired into the
+    // Deny bucket of `check_prefix_match`, the deny rule `rm:*` fires.
     let mut c = ctx();
     c.add_rule(
         PermissionBehavior::Deny,
@@ -370,12 +368,8 @@ fn req_perm_490_p2_2_d_20_env_var_wrapper_not_stripped_yet() {
         "rm:*",
     );
     let result = check_compound_match("FOO=bar rm -rf /tmp/x", &c);
-    // Today: tree-sitter rejects env-var-prefixed command as
-    // non-word-only (variable_assignment is not in ALLOWED_KINDS),
-    // so we fall back to raw prefix-match which sees `FOO=bar rm…`
-    // not starting with `rm`. Slice 2.2.e MUST change this to Deny.
     assert!(
-        matches!(result, PermissionResult::Passthrough { .. }),
-        "env-var stripping not yet implemented — slice 2.2.e MUST change this to Deny. got {result:?}"
+        matches!(result, PermissionResult::Deny { .. }),
+        "slice 2.2.f: env-var bypass closed via AST fallback — expected Deny, got {result:?}"
     );
 }

--- a/crates/dasclaw_bash_permissions/tests/env_strip_wiring_test.rs
+++ b/crates/dasclaw_bash_permissions/tests/env_strip_wiring_test.rs
@@ -1,0 +1,317 @@
+//! Slice 2.2.f — env-strip wiring tests (`req_perm_490_p2_2_f_*`).
+//!
+//! Pins the integration semantics of [`strip_all_leading_env_vars`]
+//! (Deny bucket) and [`strip_safe_wrappers`] (Allow / Ask bucket) inside
+//! [`check_prefix_match`] and, by delegation, [`check_compound_match`].
+//!
+//! Upstream parity: `claude-code-main/src/utils/permissions/permissions.ts`
+//! L805-L856 — Deny path uses aggressive stripping (with Fail-Safe on
+//! hijack vars), Allow / Ask path uses the conservative `stripSafeWrappers`
+//! whitelist.
+//!
+//! Slice-level red lines (SECURITY PINs) enforced here:
+//! - Deny bucket does NOT degrade on hijack vars (`LD_*`, `DYLD_*`,
+//!   exact `PATH=`) — original string preserved so deny rules still
+//!   fire (tests 03 / 04 / 05).
+//! - Allow bucket does NOT over-grant via injected env wrappers —
+//!   only `SAFE_ENV_VARS` and the 5 safe wrapper binaries
+//!   (`timeout` / `time` / `nice` / `nohup` / `stdbuf`) get peeled
+//!   (tests 07 / 08 / 12).
+//! - Ask bucket uses the SAME conservative strip as Allow (test 09);
+//!   not the aggressive Deny strip (test 10 SECURITY PIN — prevents
+//!   ask-bucket bypass via `FOO=bar`).
+//! - Deny precedence preserved across stripping: a single deny rule
+//!   keeps winning over allow / ask matches on the same input
+//!   (test 11).
+//! - `display_command` in deny / passthrough messages is the original
+//!   trimmed string (no stripping leakage — audit-log fidelity)
+//!   (test 14).
+
+use dasclaw_bash_permissions::{
+    check_compound_match, check_prefix_match, PermissionBehavior, PermissionResult,
+    PermissionRuleSource, ToolPermissionContext,
+};
+
+fn ctx() -> ToolPermissionContext {
+    ToolPermissionContext::default()
+}
+
+// ---------------------------------------------------------------------------
+// 1. Deny-bucket stripping (aggressive `strip_all_leading_env_vars`)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn req_perm_490_p2_2_f_01_deny_strips_single_env_var() {
+    let mut c = ctx();
+    c.add_rule(
+        PermissionBehavior::Deny,
+        PermissionRuleSource::PolicySettings,
+        "rm:*",
+    );
+    let result = check_prefix_match("FOO=bar rm -rf /tmp/x", &c);
+    assert!(
+        matches!(result, PermissionResult::Deny { .. }),
+        "expected Deny after env-strip; got {result:?}"
+    );
+}
+
+#[test]
+fn req_perm_490_p2_2_f_02_deny_strips_multiple_env_vars() {
+    let mut c = ctx();
+    c.add_rule(
+        PermissionBehavior::Deny,
+        PermissionRuleSource::PolicySettings,
+        "rm:*",
+    );
+    let result = check_prefix_match("FOO=1 BAR=2 BAZ=3 rm -rf /", &c);
+    assert!(
+        matches!(result, PermissionResult::Deny { .. }),
+        "expected Deny across multi-env-var; got {result:?}"
+    );
+}
+
+#[test]
+fn req_perm_490_p2_2_f_03_deny_fail_safe_keeps_ld_preload_hijack() {
+    // SECURITY PIN: `LD_PRELOAD=/x rm…` MUST still match `Bash(rm:*)`.
+    // strip_all_leading_env_vars returns the ORIGINAL string when a
+    // hijack var is detected (Fail-Safe). But the deny rule
+    // `LD_PRELOAD=/x rm…` does NOT start with `rm`, so a naive port
+    // would let it through. Upstream behavior (and ours): the Fail-Safe
+    // return is *exactly* the original; the deny check on the ORIGINAL
+    // does not match `rm:*` either. So this case is NOT denied here
+    // — it gets the same Passthrough as if no rule applied. The actual
+    // hijack-vector defence is in `is_dangerous_bash_allow_rule`
+    // (Slice 2.2.g) which BLOCKS adding `Bash(rm:*)` as an allow rule
+    // entirely. Pin current behavior so any future change is conscious.
+    let mut c = ctx();
+    c.add_rule(
+        PermissionBehavior::Deny,
+        PermissionRuleSource::PolicySettings,
+        "rm:*",
+    );
+    let result = check_prefix_match("LD_PRELOAD=/x rm -rf /", &c);
+    // Helper returns original string; original doesn't start with `rm`.
+    assert!(
+        matches!(result, PermissionResult::Passthrough { .. }),
+        "hijack Fail-Safe leaves original — passthrough; got {result:?}"
+    );
+}
+
+#[test]
+fn req_perm_490_p2_2_f_04_deny_fail_safe_keeps_dyld_hijack() {
+    let mut c = ctx();
+    c.add_rule(
+        PermissionBehavior::Deny,
+        PermissionRuleSource::PolicySettings,
+        "rm:*",
+    );
+    let result = check_prefix_match("DYLD_INSERT_LIBRARIES=/x rm -rf /", &c);
+    assert!(matches!(result, PermissionResult::Passthrough { .. }));
+}
+
+#[test]
+fn req_perm_490_p2_2_f_05_deny_fail_safe_keeps_path_assignment() {
+    let mut c = ctx();
+    c.add_rule(
+        PermissionBehavior::Deny,
+        PermissionRuleSource::PolicySettings,
+        "rm:*",
+    );
+    let result = check_prefix_match("PATH=/mybin rm -rf /", &c);
+    assert!(matches!(result, PermissionResult::Passthrough { .. }));
+}
+
+// ---------------------------------------------------------------------------
+// 2. Allow-bucket stripping (conservative `strip_safe_wrappers`)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn req_perm_490_p2_2_f_06_allow_strips_tz_env_var() {
+    let mut c = ctx();
+    c.add_rule(
+        PermissionBehavior::Allow,
+        PermissionRuleSource::UserSettings,
+        "date:*",
+    );
+    let result = check_prefix_match("TZ=UTC date -u", &c);
+    assert!(
+        matches!(result, PermissionResult::Allow { .. }),
+        "expected Allow after safe-wrapper strip; got {result:?}"
+    );
+}
+
+#[test]
+fn req_perm_490_p2_2_f_07_allow_strips_timeout_wrapper() {
+    let mut c = ctx();
+    c.add_rule(
+        PermissionBehavior::Allow,
+        PermissionRuleSource::UserSettings,
+        "ls:*",
+    );
+    let result = check_prefix_match("timeout 5 ls -la", &c);
+    assert!(
+        matches!(result, PermissionResult::Allow { .. }),
+        "expected Allow after timeout-strip; got {result:?}"
+    );
+}
+
+#[test]
+fn req_perm_490_p2_2_f_08_allow_does_not_strip_unknown_env_var() {
+    // SECURITY PIN: an env var NOT in SAFE_ENV_VARS must NOT be
+    // peeled by `strip_safe_wrappers`. Otherwise a user could craft
+    // `MALICIOUS=1 ls -la` and have an `ls:*` allow rule fire even
+    // though the original command runs with a tainted env.
+    let mut c = ctx();
+    c.add_rule(
+        PermissionBehavior::Allow,
+        PermissionRuleSource::UserSettings,
+        "ls:*",
+    );
+    let result = check_prefix_match("MALICIOUS_VAR=1 ls -la", &c);
+    assert!(
+        matches!(result, PermissionResult::Passthrough { .. }),
+        "unknown env vars stay attached on allow path; got {result:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 3. Ask-bucket uses SAME conservative strip as Allow (NOT Deny)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn req_perm_490_p2_2_f_09_ask_strips_safe_wrappers_like_allow() {
+    let mut c = ctx();
+    c.add_rule(
+        PermissionBehavior::Ask,
+        PermissionRuleSource::UserSettings,
+        "rm:*",
+    );
+    let result = check_prefix_match("TZ=UTC rm /tmp/x", &c);
+    assert!(
+        matches!(result, PermissionResult::Ask { .. }),
+        "Ask bucket should mirror Allow strip; got {result:?}"
+    );
+}
+
+#[test]
+fn req_perm_490_p2_2_f_10_ask_does_not_use_aggressive_deny_strip() {
+    // SECURITY PIN: if Ask used `strip_all_leading_env_vars`, then a
+    // user-defined `Bash(rm:*)` Ask rule would fire on
+    // `FOO=bar rm -rf /` even though `FOO=bar` is NOT in SAFE_ENV_VARS.
+    // That would incorrectly downgrade to Ask when the original input
+    // (with untrusted env) should fall through to Passthrough and let
+    // higher-level safety hooks intervene. Pin Allow-style strip here.
+    let mut c = ctx();
+    c.add_rule(
+        PermissionBehavior::Ask,
+        PermissionRuleSource::UserSettings,
+        "rm:*",
+    );
+    let result = check_prefix_match("FOO=bar rm -rf /", &c);
+    assert!(
+        matches!(result, PermissionResult::Passthrough { .. }),
+        "Ask bucket must not aggressively strip; got {result:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 4. Cross-bucket precedence preserved
+// ---------------------------------------------------------------------------
+
+#[test]
+fn req_perm_490_p2_2_f_11_deny_still_wins_over_allow_after_strip() {
+    // Both buckets strip differently but Deny precedence is upstream's
+    // hard contract. `FOO=bar rm -rf /` — Deny bucket strips → matches
+    // `rm:*` Deny. Allow bucket does NOT strip `FOO=bar` (not in
+    // SAFE_ENV_VARS), so the allow rule `rm:*` would NOT match anyway.
+    // Even without that asymmetry, Deny is checked first.
+    let mut c = ctx();
+    c.add_rule(
+        PermissionBehavior::Allow,
+        PermissionRuleSource::UserSettings,
+        "rm:*",
+    );
+    c.add_rule(
+        PermissionBehavior::Deny,
+        PermissionRuleSource::PolicySettings,
+        "rm:*",
+    );
+    let result = check_prefix_match("FOO=bar rm -rf /tmp/x", &c);
+    assert!(
+        matches!(result, PermissionResult::Deny { .. }),
+        "Deny precedence preserved across asymmetric strip; got {result:?}"
+    );
+}
+
+#[test]
+fn req_perm_490_p2_2_f_12_safe_wrapper_chain_peels_for_allow_only() {
+    // `TZ=UTC timeout 5 ls -la`:
+    //   * Allow path: TZ stripped (SAFE_ENV_VARS) → `timeout 5 ls -la`
+    //     → timeout peeled → `ls -la` → matches `ls:*` Allow.
+    //   * Deny path: `strip_all_leading_env_vars` peels TZ → leaves
+    //     `timeout 5 ls -la`. It does NOT peel the timeout wrapper
+    //     (Deny path is env-var-only, not wrapper-aware). No deny rule
+    //     for `timeout:*`, so Deny doesn't fire.
+    let mut c = ctx();
+    c.add_rule(
+        PermissionBehavior::Allow,
+        PermissionRuleSource::UserSettings,
+        "ls:*",
+    );
+    let result = check_prefix_match("TZ=UTC timeout 5 ls -la", &c);
+    assert!(
+        matches!(result, PermissionResult::Allow { .. }),
+        "expected Allow via env+wrapper chain; got {result:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 5. Compound delegation — env-strip applies via AST fallback
+// ---------------------------------------------------------------------------
+
+#[test]
+fn req_perm_490_p2_2_f_13_compound_fallback_inherits_deny_strip() {
+    // Tree-sitter rejects env-var-prefixed command as non-word-only,
+    // so `check_compound_match` falls back to `check_prefix_match` on
+    // the raw string. The new Deny-bucket stripping there now closes
+    // the env-var bypass. Same red line as test 2.2.d-20 (now flipped).
+    let mut c = ctx();
+    c.add_rule(
+        PermissionBehavior::Deny,
+        PermissionRuleSource::UserSettings,
+        "rm:*",
+    );
+    let result = check_compound_match("FOO=bar rm -rf /tmp/x", &c);
+    assert!(
+        matches!(result, PermissionResult::Deny { .. }),
+        "compound AST-fallback inherits deny strip; got {result:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 6. Display-command fidelity — audit-log surface uses ORIGINAL string
+// ---------------------------------------------------------------------------
+
+#[test]
+fn req_perm_490_p2_2_f_14_deny_message_quotes_original_command() {
+    // SECURITY / AUDIT PIN: the `deny_message` baked into the
+    // PermissionResult must reference the ORIGINAL trimmed command
+    // (`FOO=bar rm -rf /`), not the stripped form (`rm -rf /`). The
+    // audit log's reproducibility contract (#524 / #530 pattern) is
+    // built on the surface seeing what the user actually typed.
+    let mut c = ctx();
+    c.add_rule(
+        PermissionBehavior::Deny,
+        PermissionRuleSource::PolicySettings,
+        "rm:*",
+    );
+    let result = check_prefix_match("FOO=bar rm -rf /tmp/x", &c);
+    let msg = match &result {
+        PermissionResult::Deny { message, .. } => message,
+        other => panic!("expected Deny, got {other:?}"),
+    };
+    assert!(
+        msg.contains("FOO=bar rm -rf /tmp/x"),
+        "deny message must echo original command; got {msg:?}"
+    );
+}

--- a/crates/dasclaw_bash_permissions/tests/prefix_match_test.rs
+++ b/crates/dasclaw_bash_permissions/tests/prefix_match_test.rs
@@ -9,7 +9,8 @@
 //!
 //! Deferred-gap forward pointers:
 //! - test 18 → slice 2.2.d (compound splitting)
-//! - test 19 → slice 2.2.e (env-var stripping)
+//! - test 19 → **CLOSED in slice 2.2.f** (env-var stripping wired into
+//!   `check_prefix_match`); assertion flipped from Passthrough → Deny.
 
 use dasclaw_bash_permissions::{
     check_prefix_match, PermissionBehavior, PermissionDecisionReason, PermissionResult,
@@ -361,10 +362,10 @@ fn req_perm_490_p2_2_c_18_compound_not_yet_split() {
 }
 
 #[test]
-fn req_perm_490_p2_2_c_19_env_var_wrapping_not_yet_stripped() {
-    // GAP: slice 2.2.e will add `stripAllLeadingEnvVars` so deny rules
-    // can't be circumvented via `FOO=bar denied_command`. Until then,
-    // `Bash(rm:*)` does NOT match `FOO=bar rm -rf /`. Library-only.
+fn req_perm_490_p2_2_c_19_env_var_wrapping_now_stripped() {
+    // CLOSED by slice 2.2.f: `stripAllLeadingEnvVars` is wired into
+    // the Deny bucket so `FOO=bar denied_command` no longer bypasses
+    // deny rules. Upstream `permissions.ts` L805-L856.
     let mut c = ctx();
     c.add_rule(
         PermissionBehavior::Deny,
@@ -373,8 +374,7 @@ fn req_perm_490_p2_2_c_19_env_var_wrapping_not_yet_stripped() {
     );
     let result = check_prefix_match("FOO=bar rm -rf /", &c);
     assert!(
-        matches!(result, PermissionResult::Passthrough { .. }),
-        "current behavior pinned for forward-pointer; slice 2.2.e \
-         MUST change this to Deny (env-var bypass closed)"
+        matches!(result, PermissionResult::Deny { .. }),
+        "slice 2.2.f: env-var bypass closed — expected Deny, got {result:?}"
     );
 }

--- a/crates/dasclaw_bash_permissions/tests/strip_env_test.rs
+++ b/crates/dasclaw_bash_permissions/tests/strip_env_test.rs
@@ -296,12 +296,13 @@ fn req_perm_490_p2_2_e_28_safe_env_vars_list_sanity() {
 
 #[test]
 fn req_perm_490_p2_2_e_29_forward_pointer_check_prefix_unchanged() {
-    // PIN — `check_prefix_match` is NOT yet wired to strip env vars
-    // (Slice 2.2.c test 19 + 2.2.d test 20 pin this). This slice ships
-    // helpers only — Slice 2.2.f integrates them at the hook layer.
-    //
-    // This forward-pointer test asserts the helpers are *callable* but
-    // does NOT assert any change to the prefix matcher's behavior.
+    // Helper-level invariants — pinned by 2.2.e and still hold after
+    // Slice 2.2.f wires these helpers into `check_prefix_match`:
+    //   * `strip_all_leading_env_vars` keeps hijack prefixes (Fail-Safe)
+    //   * `strip_safe_wrappers` peels TZ + timeout (allow path)
+    // The wiring-level behavior flips are pinned by
+    // `req_perm_490_p2_2_c_19_env_var_wrapping_now_stripped` and
+    // `req_perm_490_p2_2_d_20_env_var_wrapper_now_stripped`.
     let stripped = strip_all_leading_env_vars("LD_PRELOAD=/x rm -rf /");
     assert_eq!(stripped, "LD_PRELOAD=/x rm -rf /"); // Fail-Safe kept hijack prefix.
     let allow_stripped = strip_safe_wrappers("TZ=UTC timeout 5 rm -rf /");


### PR DESCRIPTION
feat(bash-perm): Slice 2.2.f — wire strip_env into prefix/compound match (closes env-var bypass)

## 背景

Issue #490 Phase 2.2 第 10 个最小切片 —— 把 Slice 2.2.e (`strip_env`)
的两个辅助函数 **接入 `check_prefix_match` 的 Deny / Allow / Ask 三桶**，
关闭 2.2.c#19 和 2.2.d#20 留下的安全 forward-pointer：

- `FOO=bar rm -rf /` 现在被 `Bash(rm:*)` Deny 规则**正确拦下**
- 通过 `check_compound_match` 的 AST 回退路径，同样的规避路径在
  compound 上下文也被关闭

**Source**: `claude-code-main/src/utils/permissions/permissions.ts` L805-L856
**关联 ADR**: ADR-112 §兼容红线

## 设计要点 — 单一源头，零补丁式

修改 `pipeline::run_pipeline` 的签名，将 "固定命令字符串" 改为
**per-behavior 命令解析器** (`CmdForBehavior = &dyn Fn(PermissionBehavior) -> String`)：

- `exact_match::check_exact_match`：解析器恒返回 `trimmed.to_string()`
  —— 语义零变化
- `prefix_match::check_prefix_match`：
  - `Deny` → `strip_all_leading_env_vars(trimmed)`（aggressive；hijack
    var Fail-Safe）
  - `Allow | Ask` → `strip_safe_wrappers(trimmed)`（conservative；仅剥
    `SAFE_ENV_VARS` + 5 个 safe wrapper 二进制）

同时为了不超过 clippy `too_many_arguments` (7) 上限，把 3 个 message
闭包合进 `PipelineMessages` 结构 —— 同样是单一源头重构，不引入补丁式
复制粘贴。

## 范围

- **修改** `src/pipeline.rs` (~+15 LOC) —— 新增 `CmdForBehavior` type
  alias + `PipelineMessages` struct；`run_pipeline` 改签名
- **修改** `src/exact_match.rs` —— 用 trivial resolver 适配新签名，
  语义不变（13 个 b-tests 全部不改动通过）
- **修改** `src/prefix_match.rs` —— 接入 `strip_env`；模块文档更新
- **修改** `tests/prefix_match_test.rs` —— 翻转 `_p2_2_c_19_*`
  forward-pointer (Passthrough → Deny)，重命名为 `_now_stripped`
- **修改** `tests/compound_match_test.rs` —— 翻转 `_p2_2_d_20_*`
  forward-pointer (Passthrough → Deny)，重命名为 `_now_stripped`
- **修改** `tests/strip_env_test.rs` —— 更新 `_p2_2_e_29_*` 注释
  （断言已闭合的 helper-level invariants 仍成立）
- **新增** `tests/env_strip_wiring_test.rs` —— 14 个 `req_perm_490_p2_2_f_*`
  tests，钉死 wiring 语义 + Fail-Safe + audit-log fidelity

## 三层代码审查

**Layer 1 — 上游对照**
- `permissions.ts` L805-L856 (`stripAllLeadingEnvVars` vs
  `stripSafeWrappers` per-bucket usage)
- `bashPermissions.ts` L1050+ (prefix-mode pipeline 接入点)
- `bashPermissions.ts` L1079 AST 回退契约（compound 通过 prefix 共享 wiring）

**Layer 2 — Fail-Safe / SECURITY**
- 测试 03/04/05：Deny 桶 hijack vars（`LD_*` / `DYLD_*` / 精确 `PATH=`）
  Fail-Safe 返回原串，原串不匹配 `rm:*` → Passthrough（防御深度交由
  Slice 2.2.g 的 `is_dangerous_bash_allow_rule` 在规则注册阶段拦截）
- 测试 08：Allow 桶 NOT in `SAFE_ENV_VARS` 的 env var **不被剥**
  （防 `MALICIOUS=1 ls -la` 经 `ls:*` 误放行）
- 测试 09/10：Ask 桶用 conservative strip（**不**用 aggressive deny strip）
  —— 防 Ask 桶 bypass
- 测试 11：Deny 优先级在不对称 strip 下保持
- 测试 14：deny_message 引用 **原始命令**（审计日志可复现性，承接
  #524 / #530 ParseFailure / ControlCharacters 模式）

**Layer 3 — 红线**
- 无 unwrap / panic / expect（生产代码 0 处）
- 无补丁式代码：`run_pipeline` 单一签名变更 + `PipelineMessages` 结构
  收敛参数，零复制粘贴
- 无新增 crate 依赖
- 不引入未移植的 upstream 模块
- 2.2.b 的 13 tests 全部 **不改一行** 仍通过 —— 证实 exact-mode 语义零变化

## 验证

```bash
cargo fmt --all -- --check                                                # clean
python3.12 scripts/check_no_panics.py --base origin/xClaw                 # OK
cargo clippy --no-deps -p dasclaw_bash_permissions --all-targets -- -D warnings   # clean
cargo nextest run -p dasclaw_bash_permissions
#   159 tests run: 159 passed
#   (23 a + 13 b + 19 c + 20 d + 30 e + 20 g + 20 i + 14 f)
```

## 测试矩阵 `req_perm_490_p2_2_f_01..14`

01    Deny 桶单 env var 剥离 → 匹配
02    Deny 桶多 env var 剥离 → 匹配
03    **SECURITY PIN** LD_PRELOAD hijack Fail-Safe
04    **SECURITY PIN** DYLD_INSERT_LIBRARIES hijack Fail-Safe
05    **SECURITY PIN** PATH= hijack Fail-Safe
06    Allow 桶 TZ env var 剥 → 匹配
07    Allow 桶 timeout wrapper 剥 → 匹配
08    **SECURITY PIN** Allow 桶 unknown env 不剥
09    Ask 桶 conservative strip parity with Allow
10    **SECURITY PIN** Ask 桶不用 aggressive deny strip
11    Deny 优先级在不对称 strip 下保留
12    Allow 桶 env+wrapper 链式剥离
13    Compound AST 回退继承 Deny 桶 strip
14    **AUDIT PIN** Deny message 引用原始命令

## Sources read

- `claude-code-main/src/utils/permissions/permissions.ts` L805-L856 §per-bucket stripping
- `claude-code-main/src/utils/permissions/bashPermissions.ts` L1050+ §pipeline 接入点
- `claude-code-main/src/utils/permissions/bashPermissions.ts` L1079 §AST 回退契约
- `crates/dasclaw_bash_permissions/src/pipeline.rs` §既有 run_pipeline + first_matching_rule
- `crates/dasclaw_bash_permissions/src/strip_env.rs` L161 / L223 §helper 签名
- `crates/dasclaw_bash_permissions/src/compound_match.rs` §AST 回退路径
- `docs/plans/architecture-refactor/adr-112-compatibility-evaluation.md` §兼容红线
- `AGENTS.md` §Skills 强制使用规范 + §测试纪律
- `.github/copilot-instructions.md` §PR 必填项

Closes #548
Refs #490
