### PR TITLE
feat(bash-perm): Slice 2.2.m — detect_unreachable_rules_from_context bridge

### DIFF
--- a/crates/dasclaw_bash_permissions/src/context_collectors.rs
+++ b/crates/dasclaw_bash_permissions/src/context_collectors.rs
@@ -32,6 +32,9 @@
 //! (which uses `find()`, first-match-wins).
 
 use crate::exact_match::BASH_TOOL_NAME;
+use crate::shadowed_rule_detection::{
+    detect_unreachable_rules, DetectUnreachableRulesOptions, UnreachableRule,
+};
 use crate::types::{
     PermissionBehavior, PermissionRule, PermissionRuleValue, ToolPermissionContext,
     ToolPermissionRulesBySource,
@@ -85,4 +88,30 @@ fn collect(
         }
     }
     out
+}
+
+/// Bridge — Slice 2.2.m (Issue #490 Phase 2.2).
+///
+/// Drives [`detect_unreachable_rules`] directly from a
+/// [`ToolPermissionContext`] by collecting the three behavior buckets
+/// via [`get_allow_rules`] / [`get_ask_rules`] / [`get_deny_rules`].
+///
+/// This is the integration point promised by Slice 2.2.k's reserved
+/// `req_perm_490_p2_2_k_12` smoke slot: callers no longer need to
+/// thread the three lists manually.
+///
+/// Determinism: inherits from `BTreeMap` source ordering in
+/// [`ToolPermissionContext`]; `detect_unreachable_rules` itself uses
+/// first-match-wins (upstream parity).
+///
+/// Fail-Safe: pure delegation. Empty context → empty output, no
+/// allocation beyond the three collector `Vec`s.
+pub fn detect_unreachable_rules_from_context(
+    ctx: &ToolPermissionContext,
+    options: DetectUnreachableRulesOptions,
+) -> Vec<UnreachableRule> {
+    let allows = get_allow_rules(ctx);
+    let asks = get_ask_rules(ctx);
+    let denies = get_deny_rules(ctx);
+    detect_unreachable_rules(&allows, &asks, &denies, options)
 }

--- a/crates/dasclaw_bash_permissions/src/lib.rs
+++ b/crates/dasclaw_bash_permissions/src/lib.rs
@@ -31,7 +31,9 @@ pub mod strip_env;
 pub mod types;
 
 pub use compound_match::{check_compound_match, MAX_SUBCOMMANDS_FOR_SECURITY_CHECK};
-pub use context_collectors::{get_allow_rules, get_ask_rules, get_deny_rules};
+pub use context_collectors::{
+    detect_unreachable_rules_from_context, get_allow_rules, get_ask_rules, get_deny_rules,
+};
 pub use dangerous_patterns::{
     dangerous_bash_patterns, is_dangerous_bash_allow_rule, is_dangerous_bash_allow_rule_value,
     CROSS_PLATFORM_CODE_EXEC,

--- a/crates/dasclaw_bash_permissions/tests/unreachable_bridge_test.rs
+++ b/crates/dasclaw_bash_permissions/tests/unreachable_bridge_test.rs
@@ -1,0 +1,271 @@
+//! Tests for `detect_unreachable_rules_from_context` bridge —
+//! Slice 2.2.m (Issue #490 Phase 2.2).
+//!
+//! Integration smoke between Slice 2.2.k (context collectors) and
+//! Slice 2.2.i (shadowed-rule detection). The bridge itself is a
+//! 3-line composition; these tests pin that the composition
+//! preserves every contract of the underlying primitives when driven
+//! from a `ToolPermissionContext`.
+//!
+//! Test ID: `req_perm_490_p2_2_m_NN_<desc>`.
+
+use dasclaw_bash_permissions::{
+    detect_unreachable_rules_from_context,
+    shadowed_rule_detection::ShadowType,
+    types::{PermissionBehavior, PermissionRuleSource, ToolPermissionContext},
+    DetectUnreachableRulesOptions, BASH_TOOL_NAME,
+};
+
+fn ctx() -> ToolPermissionContext {
+    ToolPermissionContext::default()
+}
+
+const OPTS_OFF: DetectUnreachableRulesOptions = DetectUnreachableRulesOptions {
+    sandbox_auto_allow_enabled: false,
+};
+const OPTS_ON: DetectUnreachableRulesOptions = DetectUnreachableRulesOptions {
+    sandbox_auto_allow_enabled: true,
+};
+
+// -----------------------------------------------------------------
+// 01 — empty context yields empty Vec (baseline Fail-Safe)
+// -----------------------------------------------------------------
+#[test]
+fn req_perm_490_p2_2_m_01_empty_context() {
+    let c = ctx();
+    assert!(detect_unreachable_rules_from_context(&c, OPTS_OFF).is_empty());
+    assert!(detect_unreachable_rules_from_context(&c, OPTS_ON).is_empty());
+}
+
+// -----------------------------------------------------------------
+// 02 — context with only one bucket populated → no shadow
+// -----------------------------------------------------------------
+#[test]
+fn req_perm_490_p2_2_m_02_single_bucket_no_shadow() {
+    let mut c = ctx();
+    c.add_rule(
+        PermissionBehavior::Allow,
+        PermissionRuleSource::UserSettings,
+        "git:*",
+    );
+    assert!(detect_unreachable_rules_from_context(&c, OPTS_OFF).is_empty());
+}
+
+// -----------------------------------------------------------------
+// 03 — tool-wide Deny shadows specific Allow (end-to-end via context)
+// -----------------------------------------------------------------
+#[test]
+fn req_perm_490_p2_2_m_03_tool_wide_deny_shadows_allow() {
+    let mut c = ctx();
+    c.add_rule(
+        PermissionBehavior::Allow,
+        PermissionRuleSource::UserSettings,
+        "git:*",
+    );
+    // Tool-wide deny: `""` collapses to `rule_content: None` (parity
+    // with 2.2.j parser).
+    c.add_rule(
+        PermissionBehavior::Deny,
+        PermissionRuleSource::ProjectSettings,
+        "",
+    );
+    let out = detect_unreachable_rules_from_context(&c, OPTS_OFF);
+    assert_eq!(out.len(), 1);
+    assert_eq!(out[0].shadow_type, ShadowType::Deny);
+    assert_eq!(out[0].rule.rule_value.tool_name, BASH_TOOL_NAME);
+    assert_eq!(
+        out[0].rule.rule_value.rule_content.as_deref(),
+        Some("git:*")
+    );
+    assert!(out[0].shadowed_by.rule_value.rule_content.is_none());
+}
+
+// -----------------------------------------------------------------
+// 04 — tool-wide Ask shadows specific Allow when sandbox auto-allow
+//      disabled
+// -----------------------------------------------------------------
+#[test]
+fn req_perm_490_p2_2_m_04_tool_wide_ask_shadows_allow_sandbox_off() {
+    let mut c = ctx();
+    c.add_rule(
+        PermissionBehavior::Allow,
+        PermissionRuleSource::UserSettings,
+        "npm install",
+    );
+    c.add_rule(
+        PermissionBehavior::Ask,
+        PermissionRuleSource::ProjectSettings, // shared source
+        "*",
+    );
+    let out = detect_unreachable_rules_from_context(&c, OPTS_OFF);
+    assert_eq!(out.len(), 1);
+    assert_eq!(out[0].shadow_type, ShadowType::Ask);
+}
+
+// -----------------------------------------------------------------
+// 05 — **SECURITY PIN**: sandbox-on EXEMPTION is keyed on the *Ask*
+//      rule's source (upstream L141-L148 — see Slice 2.2.i tests 08+09).
+//      The bridge MUST preserve this so personal-Ask-only stays exempt.
+// -----------------------------------------------------------------
+#[test]
+fn req_perm_490_p2_2_m_05_sandbox_on_exempts_personal_ask() {
+    let mut c = ctx();
+    c.add_rule(
+        PermissionBehavior::Allow,
+        PermissionRuleSource::UserSettings,
+        "git:*",
+    );
+    // Personal Ask source (`UserSettings`) — exempt when sandbox on.
+    c.add_rule(
+        PermissionBehavior::Ask,
+        PermissionRuleSource::UserSettings,
+        "*",
+    );
+    let out = detect_unreachable_rules_from_context(&c, OPTS_ON);
+    assert!(
+        out.is_empty(),
+        "sandbox-on personal-Ask must NOT shadow specific allow: {out:?}"
+    );
+}
+
+// -----------------------------------------------------------------
+// 06 — **SECURITY PIN**: sandbox-on does NOT exempt a *shared* Ask
+//      (upstream L141 `isSharedSettingSource(askRule.source)` check
+//      — Slice 2.2.i test 11 three-way regression PIN).
+// -----------------------------------------------------------------
+#[test]
+fn req_perm_490_p2_2_m_06_sandbox_on_does_not_exempt_shared_ask() {
+    let mut c = ctx();
+    c.add_rule(
+        PermissionBehavior::Allow,
+        PermissionRuleSource::UserSettings,
+        "git:*",
+    );
+    c.add_rule(
+        PermissionBehavior::Ask,
+        PermissionRuleSource::ProjectSettings, // shared
+        "*",
+    );
+    let out = detect_unreachable_rules_from_context(&c, OPTS_ON);
+    assert_eq!(out.len(), 1, "shared-Ask must shadow even when sandbox on");
+    assert_eq!(out[0].shadow_type, ShadowType::Ask);
+}
+
+// -----------------------------------------------------------------
+// 07 — Deny precedence preserved: both tool-wide Ask AND Deny present
+//      → Deny wins (upstream `findShadowingRule` Deny checked first).
+// -----------------------------------------------------------------
+#[test]
+fn req_perm_490_p2_2_m_07_deny_precedence_over_ask() {
+    let mut c = ctx();
+    c.add_rule(
+        PermissionBehavior::Allow,
+        PermissionRuleSource::UserSettings,
+        "git:*",
+    );
+    c.add_rule(
+        PermissionBehavior::Deny,
+        PermissionRuleSource::ProjectSettings,
+        "*",
+    );
+    c.add_rule(
+        PermissionBehavior::Ask,
+        PermissionRuleSource::ProjectSettings,
+        "*",
+    );
+    let out = detect_unreachable_rules_from_context(&c, OPTS_OFF);
+    assert_eq!(out.len(), 1);
+    assert_eq!(out[0].shadow_type, ShadowType::Deny);
+}
+
+// -----------------------------------------------------------------
+// 08 — multiple Allow rules in same context, only the specific ones
+//      are reported (tool-wide allow never shadowed by deny since
+//      upstream short-circuits on `rule_content.is_none()`).
+// -----------------------------------------------------------------
+#[test]
+fn req_perm_490_p2_2_m_08_tool_wide_allow_not_shadowed() {
+    let mut c = ctx();
+    c.add_rule(
+        PermissionBehavior::Allow,
+        PermissionRuleSource::UserSettings,
+        "", // tool-wide → rule_content: None
+    );
+    c.add_rule(
+        PermissionBehavior::Allow,
+        PermissionRuleSource::UserSettings,
+        "git:*",
+    );
+    c.add_rule(
+        PermissionBehavior::Deny,
+        PermissionRuleSource::ProjectSettings,
+        "*",
+    );
+    let out = detect_unreachable_rules_from_context(&c, OPTS_OFF);
+    assert_eq!(out.len(), 1);
+    assert_eq!(
+        out[0].rule.rule_value.rule_content.as_deref(),
+        Some("git:*"),
+        "tool-wide allow must NOT be reported"
+    );
+}
+
+// -----------------------------------------------------------------
+// 09 — Determinism PIN: same context → identical Vec on repeated calls
+//      (relies on BTreeMap source ordering + first-match-wins).
+// -----------------------------------------------------------------
+#[test]
+fn req_perm_490_p2_2_m_09_deterministic_output() {
+    let mut c = ctx();
+    c.add_rule(
+        PermissionBehavior::Allow,
+        PermissionRuleSource::UserSettings,
+        "git:*",
+    );
+    c.add_rule(
+        PermissionBehavior::Allow,
+        PermissionRuleSource::ProjectSettings,
+        "npm:*",
+    );
+    c.add_rule(PermissionBehavior::Deny, PermissionRuleSource::CliArg, "");
+    let a = detect_unreachable_rules_from_context(&c, OPTS_OFF);
+    let b = detect_unreachable_rules_from_context(&c, OPTS_OFF);
+    assert_eq!(a, b);
+    assert_eq!(a.len(), 2);
+}
+
+// -----------------------------------------------------------------
+// 10 — Pure delegation PIN: bridge result MUST equal calling
+//      `detect_unreachable_rules` directly with the three collectors'
+//      output. Locks the "no extra logic" invariant.
+// -----------------------------------------------------------------
+#[test]
+fn req_perm_490_p2_2_m_10_pure_delegation_invariant() {
+    use dasclaw_bash_permissions::{
+        detect_unreachable_rules, get_allow_rules, get_ask_rules, get_deny_rules,
+    };
+    let mut c = ctx();
+    c.add_rule(
+        PermissionBehavior::Allow,
+        PermissionRuleSource::UserSettings,
+        "git:*",
+    );
+    c.add_rule(
+        PermissionBehavior::Ask,
+        PermissionRuleSource::ProjectSettings,
+        "*",
+    );
+    c.add_rule(
+        PermissionBehavior::Deny,
+        PermissionRuleSource::CliArg,
+        "rm:*",
+    );
+    let via_bridge = detect_unreachable_rules_from_context(&c, OPTS_OFF);
+    let manual = detect_unreachable_rules(
+        &get_allow_rules(&c),
+        &get_ask_rules(&c),
+        &get_deny_rules(&c),
+        OPTS_OFF,
+    );
+    assert_eq!(via_bridge, manual);
+}


### PR DESCRIPTION
feat(bash-perm): Slice 2.2.m — detect_unreachable_rules_from_context bridge

## 背景

Issue #490 Phase 2.2 第 11 个最小切片。

#543 (Slice 2.2.i) 落地了 `detect_unreachable_rules(allows, asks, denies,
opts)` 静态 API。#547 (Slice 2.2.k) 落地了 `get_allow_rules / get_ask_rules
/ get_deny_rules(ctx)` 三个 collectors。本切片 **关闭** Slice 2.2.k 内存
注释里预留的 `req_perm_490_p2_2_k_12_RESERVED for follow-up 2.2.i×k smoke`
位置 —— 提供 `detect_unreachable_rules_from_context(ctx, opts)` 单点
桥接，使调用方不再手工穿三个 collector。

**Source**: `claude-code-main/src/utils/permissions/shadowedRuleDetection.ts`
              `claude-code-main/src/utils/permissions/permissions.ts` L122-L231
**关联 ADR**: ADR-112 §兼容红线、ADR-129 §1.3

## 设计要点 — 纯组合，零新增逻辑

```rust
pub fn detect_unreachable_rules_from_context(
    ctx: &ToolPermissionContext,
    options: DetectUnreachableRulesOptions,
) -> Vec<UnreachableRule> {
    let allows = get_allow_rules(ctx);
    let asks   = get_ask_rules(ctx);
    let denies = get_deny_rules(ctx);
    detect_unreachable_rules(&allows, &asks, &denies, options)
}
```

- 单一职责：3 行委托，无新增分支、无新增 `match`，不复制 2.2.i 的 shadow
  判定。**测试 10 (PIN)** 直接断言 `bridge == manual_compose`，永远锁死
  "纯委托" 不变量。
- 放在已存在的 `context_collectors.rs` 模块尾部 —— collectors 的天然
  consumer，不新增 `unreachable_bridge.rs` 文件（避免补丁式拆模块）。
- `lib.rs` re-export 在 `context_collectors::*` 单行同步追加。

## 范围

- **修改** `src/context_collectors.rs` （+30 LOC）—— 新增 `pub fn
  detect_unreachable_rules_from_context` + 上述桥接 doc；追加 `use
  crate::shadowed_rule_detection::*`
- **修改** `src/lib.rs` （+1 LOC）—— `pub use context_collectors::{...
  detect_unreachable_rules_from_context}`
- **新增** `tests/unreachable_bridge_test.rs` （10 tests）

## 三层代码审查

**Layer 1 — 上游对照**
- `permissions.ts` L122-L231 (`get*Rules` 三个 collector)
- `shadowedRuleDetection.ts` L141-L148 (sandbox-on 个人 Ask 豁免)
- `shadowedRuleDetection.ts` L204-L232 (`detectUnreachableRules` 主循环)
- 上游有 `getRuleSuggestionsForContext` 类似模式 (permissions.ts L260+)
  —— 我们这个桥接函数语义与之同形：collect 三桶 → 委托给静态函数

**Layer 2 — Fail-Safe / SECURITY**
- **测试 05 SECURITY PIN**：sandbox-on **个人**（`UserSettings`）Ask
  **豁免** —— 上游 `isSharedSettingSource(askRule.source)` false 分支必须
  保留（与 Slice 2.2.i tests 08+09 配套）
- **测试 06 SECURITY PIN**：sandbox-on **共享**（`ProjectSettings`）Ask
  **仍 shadow** —— 防"sandbox=on 即整片放行"误读（与 Slice 2.2.i test 11
  三向回归 PIN 配套）
- **测试 07**：Deny 优先级凌驾 Ask —— 上游 `findShadowingRule` Deny
  先检查
- **测试 08**：tool-wide Allow (`rule_content: None`) **不** 被 deny
  shadow —— 上游短路；防 bridge 误报
- **测试 09 Determinism PIN**：相同 ctx 重复调用 → 相同 Vec；锁
  `BTreeMap` 源排序 + first-match-wins 链路稳定（审计可复现）
- **测试 10 PURE-DELEGATION PIN**：`bridge == detect_unreachable_rules(
  &get_allow_rules(ctx), &get_ask_rules(ctx), &get_deny_rules(ctx), opts)`
  —— 锁死 "bridge 永远不加额外逻辑"

**Layer 3 — 红线**
- 无 unwrap / panic / expect（生产 0 处）
- 无补丁式代码：桥接函数追加到已存在的 collectors 模块，3 行委托，无
  case 分支
- 无新增 crate 依赖
- 不引入 ANT-only 元素
- 不引入未移植的 upstream 模块

## 验证

```bash
cargo fmt --all -- --check                                                # clean
python3.12 scripts/check_no_panics.py --base origin/xClaw                 # OK
cargo clippy --no-deps -p dasclaw_bash_permissions --all-targets -- -D warnings   # clean
cargo nextest run -p dasclaw_bash_permissions
#   189 tests run: 189 passed
#   (23 a + 13 b + 19 c + 20 d + 30 e + 20 g + 20 i + 20 j + 14 k + 10 m)
```

## 测试矩阵 `req_perm_490_p2_2_m_01..10`

01    empty context → empty Vec (Fail-Safe baseline, OPTS on/off 双覆盖)
02    单 bucket（仅 allow）→ 无 shadow
03    tool-wide Deny shadow specific Allow（端到端 via ctx）
04    tool-wide shared Ask shadow specific Allow（sandbox off）
05    **SECURITY PIN** sandbox-on 豁免**个人** Ask
06    **SECURITY PIN** sandbox-on **不**豁免**共享** Ask
07    Deny 优先级凌驾 Ask（两者同时存在）
08    tool-wide Allow（`rule_content: None`）**不** 被 deny shadow
09    **Determinism PIN** 重复调用结果幂等
10    **PURE-DELEGATION PIN** `bridge == manual_compose(3 collectors)`

## Sources read

- `claude-code-main/src/utils/permissions/shadowedRuleDetection.ts` L141-L232 §sandbox 豁免 + 主循环
- `claude-code-main/src/utils/permissions/permissions.ts` L122-L231 §三个 collector
- `crates/dasclaw_bash_permissions/src/shadowed_rule_detection.rs` §`detect_unreachable_rules` 既有静态 API
- `crates/dasclaw_bash_permissions/src/context_collectors.rs` §三个 collector + 模块文档（"ingestion path is Slice 2.2.l" 不影响本切片）
- `docs/plans/architecture-refactor/adr-112-compatibility-evaluation.md` §兼容红线
- `AGENTS.md` §Skills 强制使用规范 + §测试纪律
- `.github/copilot-instructions.md` §PR 必填项

## 非目标

- upstream-format `"Bash(content)"` 字符串 ingestion via 2.2.j parser
  —— 留给独立的 settings-loader 切片（context_collectors 模块文档中预留
  位置）
- `getRuleSuggestionsForContext`（fix 建议聚合）—— 独立切片
- `BashPermissionHook` impl 接入 CompositeSafetyHook —— 大切片，独立

Closes #550
Refs #490
