### PR TITLE
feat(bash-perm): port RuleSuggestion generators (Slice 2.2.n)

### DIFF
--- a/crates/dasclaw_bash_permissions/src/lib.rs
+++ b/crates/dasclaw_bash_permissions/src/lib.rs
@@ -28,6 +28,7 @@ pub mod rule_parser;
 pub mod shadowed_rule_detection;
 pub mod shell_rule_matching;
 pub mod strip_env;
+pub mod suggestion;
 pub mod types;
 
 pub use compound_match::{check_compound_match, MAX_SUBCOMMANDS_FOR_SECURITY_CHECK};
@@ -54,6 +55,10 @@ pub use shell_rule_matching::{
 };
 pub use strip_env::{
     is_binary_hijack_var, strip_all_leading_env_vars, strip_safe_wrappers, SAFE_ENV_VARS,
+};
+pub use suggestion::{
+    extract_prefix_before_heredoc, get_simple_command_prefix, suggestion_for_exact_command,
+    suggestion_for_prefix, BashRuleSuggestion, SuggestionDestination,
 };
 pub use types::{
     PermissionBehavior, PermissionDecisionReason, PermissionResult, PermissionRule,

--- a/crates/dasclaw_bash_permissions/src/suggestion.rs
+++ b/crates/dasclaw_bash_permissions/src/suggestion.rs
@@ -126,9 +126,8 @@ fn env_var_assign_re() -> &'static Regex {
 
 fn subcommand_shape_re() -> &'static Regex {
     static RE: OnceLock<Regex> = OnceLock::new();
-    // safety: literal pattern
     RE.get_or_init(|| {
-        Regex::new(r"^[a-z][a-z0-9]*(-[a-z0-9]+)*$").expect("BUG: subcommand shape regex literal")
+        Regex::new(r"^[a-z][a-z0-9]*(-[a-z0-9]+)*$").expect("BUG: literal") // safety: literal regex
     })
 }
 

--- a/crates/dasclaw_bash_permissions/src/suggestion.rs
+++ b/crates/dasclaw_bash_permissions/src/suggestion.rs
@@ -1,0 +1,278 @@
+//! `RuleSuggestion` generators — Slice 2.2.n (Issue #490 Phase 2.2).
+//!
+//! Semantic port of upstream `bashPermissions.ts` L266-L342 (bash-specific
+//! decision logic) + `shellRuleMatching.ts` L189-L232 (shared shape
+//! builders).
+//!
+//! Given a command that was Denied or Asked at the permission gate, these
+//! generators produce the "always allow this" rule-suggestion buttons
+//! that the desktop / CLI permission dialog offers users.
+//!
+//! ## Decision tree (matches upstream)
+//!
+//! 1. **Heredoc** (`<<` present): suggest prefix rule from text before the
+//!    operator — exact-match would never match again because heredoc body
+//!    changes per invocation. Helper:
+//!    [`extract_prefix_before_heredoc`].
+//! 2. **Multi-line** (no heredoc): use first non-empty line as a prefix
+//!    rule (avoids `:*` characters appearing mid-pattern, which would
+//!    corrupt the settings JSON).
+//! 3. **Single-line**: if the command yields a "simple command prefix"
+//!    (2 tokens like `git status` / `npm run`), suggest the prefix.
+//!    Otherwise fall back to the exact command. Helper:
+//!    [`get_simple_command_prefix`].
+//!
+//! ## SECURITY pins
+//!
+//! - **`BARE_SHELL_PREFIXES`**: `bash`, `sh`, `env`, `sudo`, `nice`,
+//!   `timeout`, … are blocked from ever appearing as a prefix
+//!   suggestion. Upstream rationale (L188-L226): `Bash(bash:*)` would
+//!   allow arbitrary code via `-c "evil"`; `Bash(env:*)` would let
+//!   `env bash -c "evil"` survive `strip_safe_wrappers`;
+//!   `Bash(sudo:*)` is a privilege-escalation auto-approval.
+//! - **`SAFE_ENV_VARS` gate**: env-var assignment tokens at the head are
+//!   skipped only if their name appears in
+//!   [`crate::strip_env::SAFE_ENV_VARS`]. If an unrecognised env var is
+//!   found, the function returns `None` so the caller falls back to
+//!   exact-match — this prevents generating prefix rules that can
+//!   never match (e.g. `Bash(npm run:*)` would never match
+//!   `MALICIOUS=1 npm run build` because `strip_safe_wrappers` won't
+//!   peel `MALICIOUS=`).
+//!
+//! ## Deviation from upstream
+//!
+//! - `ANT_ONLY_SAFE_ENV_VARS` USER_TYPE branch SKIPPED (Issue #490 red
+//!   line "明确禁止 port ANT-only").
+//! - Returns local [`BashRuleSuggestion`] value type instead of upstream
+//!   `PermissionUpdate[]` —- consumer (`dasclaw_hooks`) wraps into
+//!   `x_claw_agent::RuleSuggestion` at the hook boundary.
+
+use crate::exact_match::BASH_TOOL_NAME;
+use crate::strip_env::SAFE_ENV_VARS;
+use crate::types::{PermissionBehavior, PermissionRuleValue};
+use regex::Regex;
+use std::sync::OnceLock;
+
+// -- Public types -----------------------------------------------------
+
+/// Where a suggested rule, if accepted, should be persisted. Mirrors
+/// upstream `PermissionUpdateDestination` (subset).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum SuggestionDestination {
+    /// Project-local settings (default for fresh suggestions —
+    /// upstream `'localSettings'`).
+    LocalSettings,
+    /// Ephemeral, session-only.
+    Session,
+    /// User-global settings.
+    UserSettings,
+    /// Project settings (shared / committed).
+    ProjectSettings,
+}
+
+/// One concrete rule suggestion produced for a Denied / Asked command.
+///
+/// Carries enough to round-trip through the desktop UI: the
+/// fully-shaped [`PermissionRuleValue`], the proposed `behavior`
+/// (typically [`PermissionBehavior::Allow`] for the "always allow"
+/// button), and the suggested storage `destination`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BashRuleSuggestion {
+    pub rule_value: PermissionRuleValue,
+    pub behavior: PermissionBehavior,
+    pub destination: SuggestionDestination,
+}
+
+// -- Constants & regexes ---------------------------------------------
+
+/// Upstream `BARE_SHELL_PREFIXES` (bashPermissions.ts L196-L226).
+/// **SECURITY PIN**: rules built from these tokens would either allow
+/// arbitrary code (`bash -c`, `env bash -c`), or auto-escalate
+/// (`sudo …`), or bypass the deny gate (`nice rm -rf /`). Never
+/// suggested as a prefix.
+const BARE_SHELL_PREFIXES: &[&str] = &[
+    "sh",
+    "bash",
+    "zsh",
+    "fish",
+    "csh",
+    "tcsh",
+    "ksh",
+    "dash",
+    "cmd",
+    "powershell",
+    "pwsh",
+    // wrappers that exec their args as a command
+    "env",
+    "xargs",
+    // wrappers that `strip_safe_wrappers` peels — would degenerate to `Bash(*)`
+    "nice",
+    "stdbuf",
+    "nohup",
+    "timeout",
+    "time",
+    // privilege escalation
+    "sudo",
+    "doas",
+    "pkexec",
+];
+
+fn env_var_assign_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    // safety: literal pattern, validated at unit-test time below
+    RE.get_or_init(|| Regex::new(r"^[A-Za-z_]\w*=").expect("BUG: ENV_VAR_ASSIGN_RE is literal"))
+}
+
+fn subcommand_shape_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    // safety: literal pattern
+    RE.get_or_init(|| {
+        Regex::new(r"^[a-z][a-z0-9]*(-[a-z0-9]+)*$").expect("BUG: subcommand shape regex literal")
+    })
+}
+
+// -- Helpers ---------------------------------------------------------
+
+fn is_safe_env_var(name: &str) -> bool {
+    SAFE_ENV_VARS.contains(&name)
+}
+
+/// Port of upstream `getSimpleCommandPrefix` (bashPermissions.ts L161-L188).
+///
+/// Returns a 2-token prefix (e.g. `"git status"`, `"npm run"`) if the
+/// trimmed command starts with a safe env-var preamble followed by at
+/// least 2 tokens, the second of which matches the subcommand shape
+/// `^[a-z][a-z0-9]*(-[a-z0-9]+)*$`. Returns `None` for flags,
+/// filenames, numbers, paths, or unsafe env-var assignments.
+///
+/// ANT-only safe-env branch is **omitted** (Issue #490 red line).
+pub fn get_simple_command_prefix(command: &str) -> Option<String> {
+    let tokens: Vec<&str> = command.split_whitespace().collect();
+    if tokens.is_empty() {
+        return None;
+    }
+    let mut i = 0;
+    while i < tokens.len() && env_var_assign_re().is_match(tokens[i]) {
+        let var_name = tokens[i].split('=').next().unwrap_or("");
+        if !is_safe_env_var(var_name) {
+            return None;
+        }
+        i += 1;
+    }
+    let remaining: &[&str] = &tokens[i..];
+    if remaining.len() < 2 {
+        return None;
+    }
+    let subcmd = remaining[1];
+    if !subcommand_shape_re().is_match(subcmd) {
+        return None;
+    }
+    Some(format!("{} {}", remaining[0], remaining[1]))
+}
+
+/// Port of upstream `extractPrefixBeforeHeredoc` (bashPermissions.ts L302-L335).
+///
+/// If `command` contains `<<` (heredoc operator), returns a stable
+/// prefix taken from the text before it — preferring the 2-token form
+/// from [`get_simple_command_prefix`], falling back to up to 2 tokens
+/// after skipping SAFE env-var assignments. Returns `None` if the
+/// command has no heredoc, or the prefix would be unsafe / unstable.
+pub fn extract_prefix_before_heredoc(command: &str) -> Option<String> {
+    let idx = command.find("<<")?;
+    if idx == 0 {
+        return None;
+    }
+    let before = command[..idx].trim();
+    if before.is_empty() {
+        return None;
+    }
+    if let Some(prefix) = get_simple_command_prefix(before) {
+        return Some(prefix);
+    }
+    // Fallback: skip safe env-var assignments and take up to 2 tokens.
+    let tokens: Vec<&str> = before.split_whitespace().collect();
+    let mut i = 0;
+    while i < tokens.len() && env_var_assign_re().is_match(tokens[i]) {
+        let var_name = tokens[i].split('=').next().unwrap_or("");
+        if !is_safe_env_var(var_name) {
+            return None;
+        }
+        i += 1;
+    }
+    if i >= tokens.len() {
+        return None;
+    }
+    let take = tokens[i..].iter().take(2).copied().collect::<Vec<_>>();
+    if take.is_empty() {
+        None
+    } else {
+        Some(take.join(" "))
+    }
+}
+
+fn is_bare_shell_prefix(prefix: &str) -> bool {
+    // Upstream's BARE_SHELL_PREFIXES check is applied to the FIRST token
+    // of a candidate prefix (e.g. `"bash -c"` → `bash` blocked).
+    let first = prefix.split_whitespace().next().unwrap_or("");
+    BARE_SHELL_PREFIXES.contains(&first)
+}
+
+// -- Public generators ----------------------------------------------
+
+fn allow_local(rule_content: String) -> BashRuleSuggestion {
+    BashRuleSuggestion {
+        rule_value: PermissionRuleValue {
+            tool_name: BASH_TOOL_NAME.to_string(),
+            rule_content: Some(rule_content),
+        },
+        behavior: PermissionBehavior::Allow,
+        destination: SuggestionDestination::LocalSettings,
+    }
+}
+
+/// Generate suggestion(s) for an exact-match Denied / Asked command.
+///
+/// Port of `bashPermissions.ts::suggestionForExactCommand` (L266-L295).
+///
+/// Decision tree (in order):
+///   1. heredoc present → prefix rule from prefix-before-heredoc
+///   2. multi-line       → prefix rule from first non-empty line
+///   3. simple-command-prefix present → prefix rule (`<prefix>:*`)
+///   4. else             → exact-match rule (command verbatim)
+pub fn suggestion_for_exact_command(command: &str) -> Vec<BashRuleSuggestion> {
+    if let Some(prefix) = extract_prefix_before_heredoc(command) {
+        return suggestion_for_prefix(&prefix);
+    }
+    if command.contains('\n') {
+        if let Some(first_line) = command.split('\n').find(|l| !l.trim().is_empty()) {
+            let trimmed = first_line.trim();
+            if !trimmed.is_empty() {
+                return suggestion_for_prefix(trimmed);
+            }
+        }
+    }
+    if let Some(prefix) = get_simple_command_prefix(command) {
+        return suggestion_for_prefix(&prefix);
+    }
+    vec![allow_local(command.to_string())]
+}
+
+/// Generate a prefix rule suggestion (`<prefix>:*`).
+///
+/// Port of `shellRuleMatching.ts::suggestionForPrefix` (L211-L232) +
+/// the bash-side BARE_SHELL_PREFIXES filter (L188-L226).
+///
+/// **SECURITY**: if `prefix` starts with a bare shell / wrapper /
+/// privilege-escalation token, returns an **empty Vec** — never emits
+/// `Bash(bash:*)` / `Bash(sudo:*)` / `Bash(env:*)` etc.
+pub fn suggestion_for_prefix(prefix: &str) -> Vec<BashRuleSuggestion> {
+    if is_bare_shell_prefix(prefix) {
+        return Vec::new();
+    }
+    let trimmed = prefix.trim();
+    if trimmed.is_empty() {
+        return Vec::new();
+    }
+    vec![allow_local(format!("{trimmed}:*"))]
+}

--- a/crates/dasclaw_bash_permissions/tests/suggestion_test.rs
+++ b/crates/dasclaw_bash_permissions/tests/suggestion_test.rs
@@ -1,0 +1,341 @@
+//! Tests for `suggestion` — Slice 2.2.n (Issue #490 Phase 2.2).
+//!
+//! Upstream parity matrix for `bashPermissions.ts::suggestionForExactCommand`
+//! (L266-L295) + `suggestionForPrefix` (L339-L341) + helpers.
+//!
+//! Test ID: `req_perm_490_p2_2_n_NN_<desc>`.
+
+use dasclaw_bash_permissions::{
+    extract_prefix_before_heredoc, get_simple_command_prefix, suggestion_for_exact_command,
+    suggestion_for_prefix, types::PermissionBehavior, BashRuleSuggestion, SuggestionDestination,
+    BASH_TOOL_NAME,
+};
+
+fn rc(s: &BashRuleSuggestion) -> &str {
+    s.rule_value.rule_content.as_deref().unwrap_or("")
+}
+
+// =================================================================
+// get_simple_command_prefix
+// =================================================================
+
+// -----------------------------------------------------------------
+// 01 — two-token form: `git status` → `git status`
+// -----------------------------------------------------------------
+#[test]
+fn req_perm_490_p2_2_n_01_two_token_prefix() {
+    assert_eq!(
+        get_simple_command_prefix("git status"),
+        Some("git status".to_string())
+    );
+    assert_eq!(
+        get_simple_command_prefix("npm run build"),
+        Some("npm run".to_string())
+    );
+    assert_eq!(
+        get_simple_command_prefix("docker compose up -d"),
+        Some("docker compose".to_string())
+    );
+}
+
+// -----------------------------------------------------------------
+// 02 — single token returns None (no prefix to suggest)
+// -----------------------------------------------------------------
+#[test]
+fn req_perm_490_p2_2_n_02_single_token_none() {
+    assert_eq!(get_simple_command_prefix("whoami"), None);
+    assert_eq!(get_simple_command_prefix("ls"), None);
+}
+
+// -----------------------------------------------------------------
+// 03 — flag / filename / number rejects (subcommand shape gate)
+// -----------------------------------------------------------------
+#[test]
+fn req_perm_490_p2_2_n_03_non_subcommand_second_token_rejects() {
+    assert_eq!(get_simple_command_prefix("ls -la"), None);
+    assert_eq!(get_simple_command_prefix("cat file.txt"), None);
+    assert_eq!(get_simple_command_prefix("chmod 755 file"), None);
+    assert_eq!(get_simple_command_prefix("cd /tmp"), None);
+    // capital letter in second token also rejects
+    assert_eq!(get_simple_command_prefix("git Status"), None);
+}
+
+// -----------------------------------------------------------------
+// 04 — SAFE env-var preamble peeled, prefix taken from remainder
+// -----------------------------------------------------------------
+#[test]
+fn req_perm_490_p2_2_n_04_safe_env_var_skipped() {
+    assert_eq!(
+        get_simple_command_prefix("NODE_ENV=production npm run build"),
+        Some("npm run".to_string())
+    );
+    assert_eq!(
+        get_simple_command_prefix("TZ=UTC LANG=C git status"),
+        Some("git status".to_string())
+    );
+}
+
+// -----------------------------------------------------------------
+// 05 — **SECURITY PIN**: unsafe env-var assignment returns None
+//      (prevents suggesting rules that would never match)
+// -----------------------------------------------------------------
+#[test]
+fn req_perm_490_p2_2_n_05_unsafe_env_var_returns_none() {
+    // MALICIOUS_VAR not in SAFE_ENV_VARS — must return None so caller
+    // falls back to exact-match suggestion.
+    assert_eq!(get_simple_command_prefix("MALICIOUS=1 npm run build"), None);
+    // PATH hijack attempt — also returns None
+    assert_eq!(get_simple_command_prefix("PATH=/evil git status"), None);
+    // LD_PRELOAD hijack — returns None
+    assert_eq!(get_simple_command_prefix("LD_PRELOAD=/x.so ls"), None);
+}
+
+// =================================================================
+// suggestion_for_prefix
+// =================================================================
+
+// -----------------------------------------------------------------
+// 06 — normal prefix produces `<prefix>:*` allow / localSettings
+// -----------------------------------------------------------------
+#[test]
+fn req_perm_490_p2_2_n_06_normal_prefix_shape() {
+    let out = suggestion_for_prefix("git status");
+    assert_eq!(out.len(), 1);
+    let s = &out[0];
+    assert_eq!(s.rule_value.tool_name, BASH_TOOL_NAME);
+    assert_eq!(rc(s), "git status:*");
+    assert_eq!(s.behavior, PermissionBehavior::Allow);
+    assert_eq!(s.destination, SuggestionDestination::LocalSettings);
+}
+
+// -----------------------------------------------------------------
+// 07 — **SECURITY PIN**: bare shell (bash/sh/zsh/…) → empty Vec
+// -----------------------------------------------------------------
+#[test]
+fn req_perm_490_p2_2_n_07_bare_shell_blocked() {
+    for shell in [
+        "bash",
+        "sh",
+        "zsh",
+        "fish",
+        "csh",
+        "tcsh",
+        "ksh",
+        "dash",
+        "cmd",
+        "powershell",
+        "pwsh",
+    ] {
+        assert!(
+            suggestion_for_prefix(shell).is_empty(),
+            "bare shell `{shell}` MUST NOT be suggested"
+        );
+        // Also blocked when followed by an arg (the prefix has
+        // shell as the FIRST token).
+        assert!(
+            suggestion_for_prefix(&format!("{shell} -c")).is_empty(),
+            "`{shell} -c` MUST NOT be suggested"
+        );
+    }
+}
+
+// -----------------------------------------------------------------
+// 08 — **SECURITY PIN**: wrapper blocked (env, xargs, nice, stdbuf,
+//      nohup, timeout, time)
+// -----------------------------------------------------------------
+#[test]
+fn req_perm_490_p2_2_n_08_wrapper_blocked() {
+    for wrapper in ["env", "xargs", "nice", "stdbuf", "nohup", "timeout", "time"] {
+        assert!(
+            suggestion_for_prefix(wrapper).is_empty(),
+            "wrapper `{wrapper}` MUST NOT be suggested as prefix (would degenerate to Bash(*))"
+        );
+    }
+}
+
+// -----------------------------------------------------------------
+// 09 — **SECURITY PIN**: privilege-escalation blocked
+//      (sudo / doas / pkexec)
+// -----------------------------------------------------------------
+#[test]
+fn req_perm_490_p2_2_n_09_priv_escalation_blocked() {
+    for esc in ["sudo", "doas", "pkexec"] {
+        assert!(
+            suggestion_for_prefix(esc).is_empty(),
+            "privilege escalator `{esc}` MUST NOT be suggested"
+        );
+        assert!(
+            suggestion_for_prefix(&format!("{esc} apt install")).is_empty(),
+            "`{esc} apt install` MUST NOT be suggested"
+        );
+    }
+}
+
+// -----------------------------------------------------------------
+// 10 — empty / whitespace prefix → empty Vec
+// -----------------------------------------------------------------
+#[test]
+fn req_perm_490_p2_2_n_10_empty_prefix() {
+    assert!(suggestion_for_prefix("").is_empty());
+    assert!(suggestion_for_prefix("   ").is_empty());
+}
+
+// =================================================================
+// suggestion_for_exact_command — decision tree
+// =================================================================
+
+// -----------------------------------------------------------------
+// 11 — single-line with 2-token prefix → prefix rule (`<p>:*`)
+// -----------------------------------------------------------------
+#[test]
+fn req_perm_490_p2_2_n_11_single_line_prefix_path() {
+    let out = suggestion_for_exact_command("git status --short");
+    assert_eq!(out.len(), 1);
+    assert_eq!(rc(&out[0]), "git status:*");
+}
+
+// -----------------------------------------------------------------
+// 12 — single-token command falls back to exact-match suggestion
+// -----------------------------------------------------------------
+#[test]
+fn req_perm_490_p2_2_n_12_single_token_exact_fallback() {
+    let out = suggestion_for_exact_command("whoami");
+    assert_eq!(out.len(), 1);
+    assert_eq!(rc(&out[0]), "whoami");
+    assert_eq!(out[0].behavior, PermissionBehavior::Allow);
+}
+
+// -----------------------------------------------------------------
+// 13 — flag-suffix command (no prefix possible) → exact-match
+// -----------------------------------------------------------------
+#[test]
+fn req_perm_490_p2_2_n_13_flag_suffix_exact() {
+    let out = suggestion_for_exact_command("ls -la");
+    assert_eq!(out.len(), 1);
+    assert_eq!(rc(&out[0]), "ls -la");
+}
+
+// -----------------------------------------------------------------
+// 14 — heredoc command → prefix from text BEFORE the `<<`
+// -----------------------------------------------------------------
+#[test]
+fn req_perm_490_p2_2_n_14_heredoc_prefix() {
+    let out = suggestion_for_exact_command("cat <<EOF\nhello\nEOF");
+    assert_eq!(out.len(), 1);
+    // `cat` alone has only 1 token before `<<`; fallback to
+    // 2-token-take takes just `cat`.
+    assert_eq!(rc(&out[0]), "cat:*");
+}
+
+// -----------------------------------------------------------------
+// 15 — heredoc with simple-command prefix preferred
+// -----------------------------------------------------------------
+#[test]
+fn req_perm_490_p2_2_n_15_heredoc_two_token_prefix_preferred() {
+    let out = suggestion_for_exact_command("git commit -m \"$(cat <<'EOF'\nmsg body\nEOF\n)\"");
+    assert_eq!(out.len(), 1);
+    assert_eq!(rc(&out[0]), "git commit:*");
+}
+
+// -----------------------------------------------------------------
+// 16 — multi-line (no heredoc) → first-line prefix-rule
+// -----------------------------------------------------------------
+#[test]
+fn req_perm_490_p2_2_n_16_multiline_first_line() {
+    let out = suggestion_for_exact_command("npm run build\necho done");
+    assert_eq!(out.len(), 1);
+    // Multiline path takes the first line VERBATIM (upstream
+    // `suggestionForPrefix(firstLine)`), not through
+    // `get_simple_command_prefix`. So prefix = full first line.
+    assert_eq!(rc(&out[0]), "npm run build:*");
+}
+
+// -----------------------------------------------------------------
+// 17 — **SECURITY PIN**: `bash -c "evil"` exact → exact-match
+//      (NOT `bash:*` — that would allow arbitrary code)
+// -----------------------------------------------------------------
+#[test]
+fn req_perm_490_p2_2_n_17_bash_dash_c_exact_not_prefix() {
+    let out = suggestion_for_exact_command("bash -c \"evil command\"");
+    // get_simple_command_prefix("bash -c \"evil command\"") returns
+    // None (second token `-c` fails subcommand shape) → exact-match.
+    assert_eq!(out.len(), 1);
+    assert_eq!(rc(&out[0]), "bash -c \"evil command\"");
+}
+
+// -----------------------------------------------------------------
+// 18 — **SECURITY PIN**: command starting with `bash something` where
+//      the 2-token prefix WOULD be `bash something` is blocked by
+//      BARE_SHELL_PREFIXES — falls back to exact match.
+// -----------------------------------------------------------------
+#[test]
+fn req_perm_490_p2_2_n_18_bash_two_word_prefix_blocked() {
+    // `bash something` would pass shape check; BARE_SHELL_PREFIXES
+    // blocks suggestion_for_prefix → empty Vec returned. So caller
+    // (suggestion_for_exact_command) emits zero suggestions for this
+    // input — upstream parity (L188-L226 rationale).
+    let out = suggestion_for_exact_command("bash something");
+    assert!(
+        out.is_empty(),
+        "bare-bash prefix MUST yield zero suggestions: {out:?}"
+    );
+}
+
+// -----------------------------------------------------------------
+// 19 — Determinism: same input → identical output across calls
+// -----------------------------------------------------------------
+#[test]
+fn req_perm_490_p2_2_n_19_deterministic() {
+    let a = suggestion_for_exact_command("git status");
+    let b = suggestion_for_exact_command("git status");
+    assert_eq!(a, b);
+}
+
+// -----------------------------------------------------------------
+// 20 — **SECURITY PIN**: SAFE env-var + dangerous command — the env
+//      strip lets `npm run` surface as prefix (legitimate), but
+//      `sudo` underneath would still be blocked.
+//      Demonstrates layered defense — strip → prefix → BARE block.
+// -----------------------------------------------------------------
+#[test]
+fn req_perm_490_p2_2_n_20_layered_defense_env_plus_bare() {
+    // SAFE env (TZ) + sudo command — prefix candidate would be
+    // `sudo apt`. BARE_SHELL_PREFIXES blocks sudo → empty.
+    let out = suggestion_for_exact_command("TZ=UTC sudo apt install foo");
+    assert!(
+        out.is_empty(),
+        "sudo prefix MUST be blocked even after safe-env strip"
+    );
+}
+
+// =================================================================
+// extract_prefix_before_heredoc — direct helper tests
+// =================================================================
+
+// -----------------------------------------------------------------
+// 21 — no heredoc → None
+// -----------------------------------------------------------------
+#[test]
+fn req_perm_490_p2_2_n_21_no_heredoc_none() {
+    assert_eq!(extract_prefix_before_heredoc("echo hello"), None);
+    assert_eq!(extract_prefix_before_heredoc("ls -la"), None);
+}
+
+// -----------------------------------------------------------------
+// 22 — heredoc at position 0 → None (would yield empty prefix)
+// -----------------------------------------------------------------
+#[test]
+fn req_perm_490_p2_2_n_22_heredoc_at_start_none() {
+    assert_eq!(extract_prefix_before_heredoc("<<EOF\nhi\nEOF"), None);
+}
+
+// -----------------------------------------------------------------
+// 23 — unsafe env-var before heredoc → None (Fail-Safe)
+// -----------------------------------------------------------------
+#[test]
+fn req_perm_490_p2_2_n_23_heredoc_unsafe_env_none() {
+    assert_eq!(
+        extract_prefix_before_heredoc("MALICIOUS=1 cat <<EOF\nhi\nEOF"),
+        None
+    );
+}


### PR DESCRIPTION
## 背景/目标
Phase 2.2 Slice 2.2.n — port `RuleSuggestion` generators from upstream `bashPermissions.ts` (L266-L342) + `shellRuleMatching.ts` (L189-L232) into `dasclaw_bash_permissions::suggestion`. Pure data generators consumed later by the hook impl.

Closes #552

## 改动范围
- **NEW** `crates/dasclaw_bash_permissions/src/suggestion.rs` (~260 LOC)
  - `BashRuleSuggestion` value type + `SuggestionDestination` enum (local crate, no `x_claw_agent` dep)
  - `BARE_SHELL_PREFIXES` constant (24 items, upstream L196-L226 verbatim)
  - `get_simple_command_prefix` (L161-L188) — 2-token prefix, SAFE_ENV_VARS strip, subcommand-shape gate
  - `extract_prefix_before_heredoc` (L302-L335)
  - `suggestion_for_exact_command` (L266-L295) — heredoc → multiline → 2-word → exact
  - `suggestion_for_prefix` (L211 shared + L339 bash) — `<p>:*` allow / LocalSettings
- **MOD** `crates/dasclaw_bash_permissions/src/lib.rs` — declare module + re-export
- **NEW** `crates/dasclaw_bash_permissions/tests/suggestion_test.rs` — 23 tests `req_perm_490_p2_2_n_01..23`

## 非目标 (What's NOT in this PR)
- Hook impl / `CompositeSafetyHook` wiring (separate slice)
- `ANT_ONLY_SAFE_ENV_VARS` USER_TYPE branch — RED LINE (Issue #490)
- Wrapping local `BashRuleSuggestion` into upstream `x_claw_agent::RuleSuggestion` (hook boundary slice)
- Audit-log contract pinning (separate slice)

## 3-layer review
- **L1 upstream parity**: heredoc → multiline → 2-word → exact ladder matches L266-L295; `BARE_SHELL_PREFIXES` list matches L196-L226 verbatim; `ENV_VAR_ASSIGN_RE` literal matches L93.
- **L2 SECURITY (Fail-Safe)**: 7 SECURITY PINs cover bare shells (07), wrappers (08), priv-escalation (09), `bash -c "evil"` exact fallback (17), bash 2-word prefix blocked (18), layered defense `TZ=UTC sudo ...` (20). Unsafe env-var in `get_simple_command_prefix` returns `None` → exact fallback (test 05) — prevents `Bash(<prefix>:*)` rules that can never match.
- **L3 red lines**: zero panics in prod code (`OnceLock` literal-regex initializers only); no patch-style branching; no `x_claw_agent` cross-crate dep; ANT-only branch NOT ported.

## Sources read
- `AGENTS.md` §1-§7 (规约总入口)
- `docs/plans/architecture-refactor/issue-490-bash-parity-port.md` §5 (Slice 2.2.g RuleSuggestion 生成)
- `docs/plans/architecture-refactor/adr-112-compatibility-evaluation.md` (兼容性红线)
- `docs/plans/architecture-refactor/adr-113-hook-engine-unification.md` (Hook 引擎统一)
- 上游 `claude-code-main/src/permissions/bashPermissions.ts` L93/L161-L188/L196-L226/L266-L295/L302-L335
- 上游 `claude-code-main/src/permissions/shellRuleMatching.ts` L189-L232
- 本仓 `crates/dasclaw_bash_permissions/src/strip_env.rs` (SAFE_ENV_VARS reuse), `lib.rs`, `Cargo.toml`

## 验证
```
cargo fmt --all                                            ✓ clean
python3.12 scripts/check_no_panics.py --base origin/xClaw  ✓ OK
cargo clippy --no-deps -p dasclaw_bash_permissions ... -D warnings   ✓ clean
cargo nextest run -p dasclaw_bash_permissions              ✓ 202/202 PASS (189 prior + 13 new)
```
