### PR TITLE
test(cli): refresh insta snapshots for cert + migrate subcommands (类B issue#555)

### DIFF
--- a/desktop-client/ironclaw/src/cli/snapshots/ironclaw__cli__tests__help_output.snap
+++ b/desktop-client/ironclaw/src/cli/snapshots/ironclaw__cli__tests__help_output.snap
@@ -1,5 +1,6 @@
 ---
-source: src/cli/mod.rs
+source: desktop-client/ironclaw/src/cli/mod.rs
+assertion_line: 420
 expression: help
 ---
 Secure personal AI assistant that protects your data and expands its capabilities
@@ -19,11 +20,13 @@ Commands:
   pairing     Manage DM pairing
   service     Manage OS service
   skills      Manage skills
+  cert        Manage MITM CA trust chain
   hooks       Manage lifecycle hooks
   models      Manage LLM providers and models
   doctor      Run diagnostics
   logs        View and manage gateway logs
   status      Show system status
+  migrate     Migrate ~/.ironclaw -> ~/.dasclaw
   completion  Generate completions
   import      Import from other AI systems
   login       Authenticate with a provider

--- a/desktop-client/ironclaw/src/cli/snapshots/ironclaw__cli__tests__long_help_output.snap
+++ b/desktop-client/ironclaw/src/cli/snapshots/ironclaw__cli__tests__long_help_output.snap
@@ -1,5 +1,6 @@
 ---
-source: src/cli/mod.rs
+source: desktop-client/ironclaw/src/cli/mod.rs
+assertion_line: 436
 expression: help
 ---
 IronClaw is a secure AI assistant. Use 'ironclaw <subcommand> --help' for details.
@@ -22,11 +23,13 @@ Commands:
   pairing     Manage DM pairing
   service     Manage OS service
   skills      Manage skills
+  cert        Manage MITM CA trust chain
   hooks       Manage lifecycle hooks
   models      Manage LLM providers and models
   doctor      Run diagnostics
   logs        View and manage gateway logs
   status      Show system status
+  migrate     Migrate ~/.ironclaw -> ~/.dasclaw
   completion  Generate completions
   import      Import from other AI systems
   login       Authenticate with a provider


### PR DESCRIPTION
Closes #555

## 背景 / 目标

修复 xClaw 上 `Tests (all-features)` 自 #547 起的 pre-existing 失败：`cli::tests::test_help_output` + `test_long_help_output` insta 快照不匹配。

## 根因

- `cert` 子命令（ADR-139 §4.5 PR1，#369）和 `migrate` 子命令（ADR-114 B-II，#119）已合入 CLI，但 `src/cli/snapshots/` 下的 help 快照从未更新
- 同时新版本 insta 在快照 metadata 中新增 `assertion_line` 字段并把 `source` 改为 workspace 相对路径，进一步加大差异

## 改动范围

仅刷新两个快照文件：

- `desktop-client/ironclaw/src/cli/snapshots/ironclaw__cli__tests__help_output.snap`
- `desktop-client/ironclaw/src/cli/snapshots/ironclaw__cli__tests__long_help_output.snap`

每个文件新增 4 行（2 行 metadata + `cert` 行 + `migrate` 行）。**零生产代码改动**。

## 非目标 (What's NOT in this PR)

- 不改 `mod.rs` 中的测试断言（无需）
- 不动 `_without_import` 变体快照（default features CI 一直绿，无需更新）
- 不改 lib 名 `ironclaw` → `dasclaw`（不在本 PR 范围）
- 不做任何补丁式逻辑修改

## 验证

```bash
# 1. import feature 路径（CI all-features 用）
cd desktop-client/ironclaw && cargo nextest run --features import --lib \
  cli::tests::test_help_output cli::tests::test_long_help_output
# → 2 passed, 0 failed

# 2. default features 路径（CI Tests default 用）
cd desktop-client/ironclaw && cargo nextest run --lib \
  cli::tests::test_help_output_without_import \
  cli::tests::test_long_help_output_without_import
# → 2 passed, 0 failed

# 3. no-panics gate
python3.12 scripts/check_no_panics.py --base origin/xClaw
# → OK
```

## Cross-cuts

ADR-114（`.ironclaw` → `.dasclaw` 命名迁移）：**类B issue#555**。

`migrate` 子命令的 help 文本本身含 `Migrate ~/.ironclaw -> ~/.dasclaw`（这正是该命令的描述），刷新快照后该字符串以新增形式出现在 diff 中，触发 ADR-114 grep guard。属于已合入的 #119 (migrate command) 的 fixture 跟进，非新引入的运行时引用。已打 `adr-114-class-b` label。

## 后续

PR 合入后，xClaw 上 `Tests (all-features)` 应转绿，后续 feature PR 不再受此 base-broken 拖累。
