### PR TITLE
feat(hooks): Slice 2.2.f BashPermissionHook adapter (Phase 2.2 完结接线)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2879,6 +2879,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "chrono",
+ "dasclaw_bash_permissions",
  "dasclaw_bash_validation",
  "regex",
  "reqwest 0.12.28",

--- a/crates/dasclaw_bash_permissions/src/prefix_match.rs
+++ b/crates/dasclaw_bash_permissions/src/prefix_match.rs
@@ -33,9 +33,10 @@
 //!   under `req_perm_490_p2_2_c_19_env_var_wrapping_now_stripped`.
 //! - Output-redirection stripping (`extractOutputRedirections`,
 //!   upstream L791-L801) — applies to both modes; deferred follow-up.
-//! - Slice 2.2.f → `BashPermissionHook` adapter + `CompositeSafetyHook`
-//!   wiring. Until then this module is library-only — the deferred
-//!   gaps cannot affect runtime safety.
+//! - Slice 2.2.f ✅ — `BashPermissionHook` adapter lives in
+//!   [`dasclaw_hooks::BashPermissionHook`] (tracker: issue #556) and
+//!   composes after `BashValidationHook` in the `CompositeSafetyHook`
+//!   chain.
 //!
 //! ## Security posture
 //!

--- a/crates/dasclaw_hooks/Cargo.toml
+++ b/crates/dasclaw_hooks/Cargo.toml
@@ -28,6 +28,10 @@ x_claw_agent = { path = "../x_claw_agent", version = "0.1.0" }
 # into `BashValidationHook::before_tool_call`).
 dasclaw_bash_validation = { path = "../dasclaw_bash_validation", version = "0.0.0-w1" }
 
+# Phase 2.2 bash permission rule engine (Slice 2.2.f hook adapter wraps the
+# `check_exact_match` / `check_compound_match` pipeline as `BashPermissionHook`).
+dasclaw_bash_permissions = { path = "../dasclaw_bash_permissions" }
+
 [dev-dependencies]
 tokio = { version = "1", features = ["sync", "macros", "time", "rt", "rt-multi-thread"] }
 tracing-test = { version = "0.2", features = ["no-env-filter"] }

--- a/crates/dasclaw_hooks/src/bash_permission_hook.rs
+++ b/crates/dasclaw_hooks/src/bash_permission_hook.rs
@@ -1,0 +1,261 @@
+//! `BashPermissionHook` — wraps the `dasclaw_bash_permissions` rule
+//! engine (Slices 2.2.a-n) as a [`SafetyHook`] implementation.
+//!
+//! # Slice 2.2.f (hook adapter)
+//!
+//! Phase 2.2 of [Issue #490][issue-490]. Plan §5 row "2.2.f" defined
+//! this slice as "`BashPermissionHook` impl + 接入 `CompositeSafetyHook`
+//! 在 `BashValidationHook` 之后". PR #549 used the 2.2.f letter for the
+//! `strip_env` wiring into `prefix_match`/`compound_match`; the hook
+//! adapter — the actual integration point — remained TODO. This module
+//! closes that gap. Tracker: issue #556.
+//!
+//! [issue-490]: https://github.com/Linnanli/xClaw/issues/490
+//!
+//! # Pipeline
+//!
+//! Only `before_tool_call` does real work; the other three [`SafetyHook`]
+//! methods pass through so this hook composes cleanly with
+//! `BashValidationHook` (Phase 2.1 command-injection gate) and other
+//! safety hooks in a [`x_claw_agent::CompositeSafetyHook`] chain.
+//!
+//! For tools whose name matches [`BashPermissionHook::bash_tool_names`]
+//! (default `["bash", "shell", "BashTool"]`), the hook:
+//!
+//! 1. Extracts the `command` field from `args`. Missing or non-string
+//!    is Fail-Safe-mapped to [`SafetyDecision::Block`] (same shape as
+//!    [`crate::BashValidationHook`]).
+//! 2. Runs the rule pipeline:
+//!    - [`check_exact_match`] first (upstream `bashPermissions.ts`
+//!      L991, fast path), and if it returns
+//!      [`PermissionResult::Passthrough`],
+//!    - [`check_compound_match`] (compound splitting + per-subcommand
+//!      prefix-match, upstream L1050).
+//! 3. Maps the [`PermissionResult`] to a [`SafetyDecision`] per
+//!    ADR-146:
+//!    - `Allow` ⇒ [`SafetyDecision::Allow`].
+//!    - `Deny { message, reason }` ⇒ [`SafetyDecision::Block { reason }`]
+//!      with audit log `bash_perm::block`.
+//!    - `Ask { message, reason }` ⇒ [`SafetyDecision::Ask`] with audit
+//!      log `bash_perm::ask` and a [`RuleSuggestion`] list built from
+//!      [`suggestion_for_exact_command`] (Slice 2.2.n generators).
+//!    - `Passthrough { .. }` ⇒ [`SafetyDecision::Passthrough`] — this
+//!      hook abstains and lets later hooks in the chain decide.
+//!
+//! Non-bash tools short-circuit to [`SafetyDecision::Allow`] so the
+//! hook can be registered globally without disturbing other tools.
+//!
+//! # Audit log shape
+//!
+//! Decisions emit `tracing::warn!` with structured fields:
+//!
+//! | Field      | Source                                       |
+//! |------------|----------------------------------------------|
+//! | `tool`     | the tool name passed to `before_tool_call`   |
+//! | `rule_id`  | Debug of the matched [`PermissionRule`] or `"Other"` |
+//! | `message`  | the engine's `message` string                |
+//!
+//! Event message is `bash_perm::block` or `bash_perm::ask`. This
+//! deliberately mirrors the `bash_security::block` shape from PR
+//! #522/#524/#530 so SIEM filters can use the `bash_*::block` prefix.
+//!
+//! # What is NOT in this slice
+//!
+//! - `BashValidationHook` is still the security gate; this hook is
+//!   added **after** it in the chain. Audit-log contract pinning (the
+//!   2.2.h companion to PR #524's `bash_security::block` pin) is a
+//!   follow-up PR.
+//! - Desktop Ask UX is Phase 2.3.
+//! - Configuration ingestion (loading the `ToolPermissionContext` from
+//!   admin-backend / settings files) is Phase 2.3 too. For now callers
+//!   construct the context directly and pass it in at hook
+//!   construction time.
+
+use async_trait::async_trait;
+use dasclaw_bash_permissions::{
+    BashRuleSuggestion, PermissionBehavior, PermissionDecisionReason, PermissionResult,
+    PermissionRule, ToolPermissionContext, check_compound_match, check_exact_match,
+    permission_rule_value_to_string, suggestion_for_exact_command,
+};
+use serde_json::Value;
+use x_claw_agent::{RuleAction, RuleSuggestion, SafetyDecision, SafetyError, SafetyHook};
+
+use crate::bash_validation_hook::DEFAULT_BASH_TOOL_NAMES;
+
+/// `SafetyHook` adapter for the bash permission rule engine.
+///
+/// See module-level documentation for the contract.
+#[derive(Debug, Clone)]
+pub struct BashPermissionHook {
+    context: ToolPermissionContext,
+    bash_tool_names: Vec<String>,
+}
+
+impl BashPermissionHook {
+    /// Create a hook with the given permission rule context.
+    ///
+    /// Uses [`crate::DEFAULT_BASH_TOOL_NAMES`] for the tool-name
+    /// allowlist.
+    #[must_use]
+    pub fn new(context: ToolPermissionContext) -> Self {
+        Self {
+            context,
+            bash_tool_names: DEFAULT_BASH_TOOL_NAMES
+                .iter()
+                .map(|s| (*s).to_string())
+                .collect(),
+        }
+    }
+
+    /// Override the bash tool-name allowlist.
+    #[must_use]
+    pub fn with_tool_names<I, S>(mut self, names: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.bash_tool_names = names.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Returns `true` if `tool` should be treated as a bash invocation.
+    fn is_bash_tool(&self, tool: &str) -> bool {
+        self.bash_tool_names.iter().any(|n| n == tool)
+    }
+}
+
+#[async_trait]
+impl SafetyHook for BashPermissionHook {
+    async fn before_prompt(&self, _prompt: &mut String) -> Result<SafetyDecision, SafetyError> {
+        Ok(SafetyDecision::Allow)
+    }
+
+    async fn after_completion(&self, _completion: &mut String) -> Result<(), SafetyError> {
+        Ok(())
+    }
+
+    async fn before_tool_call(
+        &self,
+        tool: &str,
+        args: &mut Value,
+    ) -> Result<SafetyDecision, SafetyError> {
+        if !self.is_bash_tool(tool) {
+            return Ok(SafetyDecision::Allow);
+        }
+
+        let command = match args.get("command").and_then(Value::as_str) {
+            Some(s) if !s.is_empty() => s,
+            _ => {
+                return Ok(SafetyDecision::Block {
+                    reason: "bash tool call missing required 'command' string field".to_string(),
+                });
+            }
+        };
+
+        // Upstream pipeline (bashPermissions.ts L1663-L1820): exact
+        // match wins first (fast path, no AST cost). Only when the
+        // engine has no exact opinion do we run the compound /
+        // prefix / wildcard pipeline.
+        let result = match check_exact_match(command, &self.context) {
+            PermissionResult::Passthrough { .. } => check_compound_match(command, &self.context),
+            decided => decided,
+        };
+
+        Ok(map_permission_result(tool, command, result))
+    }
+
+    async fn after_tool_output(
+        &self,
+        _tool: &str,
+        _output: &mut String,
+    ) -> Result<(), SafetyError> {
+        Ok(())
+    }
+}
+
+/// Maps a [`PermissionResult`] into a [`SafetyDecision`] and emits an
+/// audit log line for `Deny` / `Ask` outcomes.
+fn map_permission_result(tool: &str, command: &str, result: PermissionResult) -> SafetyDecision {
+    match result {
+        PermissionResult::Allow { .. } => SafetyDecision::Allow,
+        PermissionResult::Deny { message, reason } => {
+            let rule_id = format_rule_id(&reason);
+            tracing::warn!(
+                tool,
+                rule_id = %rule_id,
+                %message,
+                "bash_perm::block"
+            );
+            SafetyDecision::Block {
+                reason: format!("bash_perm::{rule_id}: {message}"),
+            }
+        }
+        PermissionResult::Ask { message, reason } => {
+            let rule_id = format_rule_id(&reason);
+            tracing::warn!(
+                tool,
+                rule_id = %rule_id,
+                %message,
+                "bash_perm::ask"
+            );
+            SafetyDecision::Ask {
+                reason: message,
+                suggestions: build_rule_suggestions(command),
+            }
+        }
+        PermissionResult::Passthrough { .. } => SafetyDecision::Passthrough,
+    }
+}
+
+/// Renders a [`PermissionDecisionReason`] into the `rule_id` audit
+/// surface. For `Rule` variants this is the upstream-equivalent
+/// `"Bash(content)"` rendering of the matching rule's pattern. For
+/// `Other` variants (cap exceeded, empty input, no rule fired) we use
+/// the literal string `"Other"` so audit dashboards have a stable
+/// dimension to filter on.
+fn format_rule_id(reason: &PermissionDecisionReason) -> String {
+    match reason {
+        PermissionDecisionReason::Rule {
+            rule: PermissionRule { rule_value, .. },
+        } => permission_rule_value_to_string(
+            &rule_value.tool_name,
+            rule_value.rule_content.as_deref(),
+        ),
+        PermissionDecisionReason::Other { .. } => "Other".to_string(),
+    }
+}
+
+/// Builds the [`RuleSuggestion`] list shown in the desktop Ask UX. Each
+/// suggestion encodes the rule pattern (so the user can persist it
+/// via a one-click "Always allow" button) plus a human-readable label.
+fn build_rule_suggestions(command: &str) -> Vec<RuleSuggestion> {
+    suggestion_for_exact_command(command)
+        .into_iter()
+        .map(rule_suggestion_from_bash)
+        .collect()
+}
+
+fn rule_suggestion_from_bash(s: BashRuleSuggestion) -> RuleSuggestion {
+    let rule_pattern = permission_rule_value_to_string(
+        &s.rule_value.tool_name,
+        s.rule_value.rule_content.as_deref(),
+    );
+    let action = match s.behavior {
+        PermissionBehavior::Allow => RuleAction::Allow,
+        PermissionBehavior::Deny => RuleAction::Deny,
+        PermissionBehavior::Ask => RuleAction::Ask,
+    };
+    let label = match action {
+        RuleAction::Allow => format!("Always allow `{rule_pattern}`"),
+        RuleAction::Deny => format!("Always deny `{rule_pattern}`"),
+        RuleAction::Ask => format!("Always ask for `{rule_pattern}`"),
+        // `RuleAction` is `#[non_exhaustive]`; future variants fall back
+        // to a generic label so the UX always has something to render.
+        _ => format!("Rule `{rule_pattern}`"),
+    };
+    RuleSuggestion {
+        label,
+        rule_pattern,
+        action,
+    }
+}

--- a/crates/dasclaw_hooks/src/lib.rs
+++ b/crates/dasclaw_hooks/src/lib.rs
@@ -17,12 +17,14 @@
 //! - the responsibility contract (`no_safety_rule_in_event_hooks`)
 //! - the Phase 0 red-line definition (`count_hook_systems() == 1`).
 
+pub mod bash_permission_hook;
 pub mod bash_validation_hook;
 pub mod bundled;
 pub mod contract;
 pub mod hook;
 pub mod registry;
 
+pub use bash_permission_hook::BashPermissionHook;
 pub use bash_validation_hook::{BashValidationHook, DEFAULT_BASH_TOOL_NAMES};
 
 pub use bundled::{

--- a/crates/dasclaw_hooks/tests/bash_permission_hook.rs
+++ b/crates/dasclaw_hooks/tests/bash_permission_hook.rs
@@ -1,0 +1,237 @@
+//! Slice 2.2.f hook adapter — wiring `BashPermissionHook` into the
+//! `SafetyHook` chain.
+//!
+//! Tracker: issue #556. Tests follow the
+//! `req_perm_490_p2_2_f_hook_<id>_<desc>` family so coverage tooling
+//! groups them with the other Phase 2.2 slices.
+//!
+//! Each test constructs a [`ToolPermissionContext`] in-line (the
+//! production loader lives in Phase 2.3) and asserts the
+//! [`SafetyDecision`] returned by [`BashPermissionHook::before_tool_call`].
+//! `tracing-test` is used to pin the audit-log surface (`bash_perm::block`
+//! / `bash_perm::ask` event messages) so a future pipeline reorder can
+//! not silently demote a Deny to an Allow.
+
+use dasclaw_bash_permissions::{PermissionBehavior, PermissionRuleSource, ToolPermissionContext};
+use dasclaw_hooks::BashPermissionHook;
+use serde_json::json;
+use tracing_test::traced_test;
+use x_claw_agent::{RuleAction, SafetyDecision, SafetyHook};
+
+fn ctx_with(behavior: PermissionBehavior, rule_content: &str) -> ToolPermissionContext {
+    let mut ctx = ToolPermissionContext::default();
+    ctx.add_rule(
+        behavior,
+        PermissionRuleSource::ProjectSettings,
+        rule_content,
+    );
+    ctx
+}
+
+async fn fire(ctx: ToolPermissionContext, tool: &str, command: &str) -> SafetyDecision {
+    let hook = BashPermissionHook::new(ctx);
+    let mut args = json!({ "command": command });
+    hook.before_tool_call(tool, &mut args)
+        .await
+        .expect("hook must not error on string command")
+}
+
+// -- 01: non-bash tools short-circuit ----------------------------------
+
+#[tokio::test]
+async fn req_perm_490_p2_2_f_hook_01_non_bash_tool_short_circuits_to_allow() {
+    // A deny rule that *would* fire if the tool name matched. The
+    // non-bash short-circuit must win before the engine is consulted.
+    let ctx = ctx_with(PermissionBehavior::Deny, "rm");
+    let decision = fire(ctx, "FileSearch", "rm -rf /").await;
+    assert_eq!(decision, SafetyDecision::Allow);
+}
+
+// -- 02: Fail-Safe on missing/empty command ----------------------------
+
+#[tokio::test]
+async fn req_perm_490_p2_2_f_hook_02_missing_command_field_fails_closed() {
+    let hook = BashPermissionHook::new(ToolPermissionContext::default());
+    let mut args = json!({ "not_command": "ls" });
+    let decision = hook
+        .before_tool_call("bash", &mut args)
+        .await
+        .expect("hook must not error on malformed args");
+    assert!(
+        matches!(decision, SafetyDecision::Block { ref reason } if reason.contains("'command'")),
+        "missing command must Fail-Safe Block; got {decision:?}"
+    );
+}
+
+#[tokio::test]
+async fn req_perm_490_p2_2_f_hook_03_empty_command_string_fails_closed() {
+    let decision = fire(ToolPermissionContext::default(), "bash", "").await;
+    assert!(
+        matches!(decision, SafetyDecision::Block { .. }),
+        "empty command must Fail-Safe Block; got {decision:?}"
+    );
+}
+
+#[tokio::test]
+async fn req_perm_490_p2_2_f_hook_04_non_string_command_fails_closed() {
+    let hook = BashPermissionHook::new(ToolPermissionContext::default());
+    let mut args = json!({ "command": 42 });
+    let decision = hook
+        .before_tool_call("bash", &mut args)
+        .await
+        .expect("hook must not error");
+    assert!(matches!(decision, SafetyDecision::Block { .. }));
+}
+
+// -- 05: empty context → Passthrough (engine has no opinion) -----------
+
+#[tokio::test]
+async fn req_perm_490_p2_2_f_hook_05_empty_context_passes_through() {
+    let decision = fire(ToolPermissionContext::default(), "bash", "git status").await;
+    assert_eq!(
+        decision,
+        SafetyDecision::Passthrough,
+        "no rule configured → hook abstains; got {decision:?}"
+    );
+}
+
+// -- 06: deny rule short-circuits to Block ------------------------------
+
+#[tokio::test]
+#[traced_test]
+async fn req_perm_490_p2_2_f_hook_06_deny_rule_blocks_and_audits() {
+    let ctx = ctx_with(PermissionBehavior::Deny, "rm:*");
+    let decision = fire(ctx, "bash", "rm -rf /tmp/scratch").await;
+    let SafetyDecision::Block { reason } = decision else {
+        panic!("deny rule must Block; got {decision:?}");
+    };
+    assert!(
+        reason.starts_with("bash_perm::"),
+        "block reason must carry `bash_perm::` audit prefix; got {reason}"
+    );
+
+    // Audit log surface (#516/#522/#530 same shape).
+    assert!(
+        logs_contain("bash_perm::block"),
+        "audit log must include `bash_perm::block` event message"
+    );
+    assert!(
+        logs_contain("rule_id="),
+        "audit log must include structured `rule_id` field"
+    );
+}
+
+// -- 07: allow rule grants Allow ---------------------------------------
+
+#[tokio::test]
+async fn req_perm_490_p2_2_f_hook_07_allow_rule_grants_allow() {
+    let ctx = ctx_with(PermissionBehavior::Allow, "git status");
+    let decision = fire(ctx, "bash", "git status").await;
+    assert_eq!(decision, SafetyDecision::Allow);
+}
+
+// -- 08: ask rule → Ask with suggestions -------------------------------
+
+#[tokio::test]
+#[traced_test]
+async fn req_perm_490_p2_2_f_hook_08_ask_rule_returns_ask_and_audits() {
+    let ctx = ctx_with(PermissionBehavior::Ask, "git push:*");
+    let decision = fire(ctx, "bash", "git push").await;
+    let SafetyDecision::Ask {
+        reason,
+        suggestions,
+    } = decision
+    else {
+        panic!("ask rule must produce Ask; got {decision:?}");
+    };
+    assert!(!reason.is_empty(), "Ask reason must not be empty");
+    assert!(
+        suggestions.iter().any(|s| s.action == RuleAction::Allow),
+        "Ask suggestions should include at least one Allow option \
+         so the user can persist a rule via the UI; got {suggestions:?}"
+    );
+    assert!(logs_contain("bash_perm::ask"));
+}
+
+// -- 09: precedence Deny > Allow on same command -----------------------
+
+#[tokio::test]
+async fn req_perm_490_p2_2_f_hook_09_deny_wins_over_allow_same_command() {
+    let mut ctx = ToolPermissionContext::default();
+    ctx.add_rule(
+        PermissionBehavior::Allow,
+        PermissionRuleSource::ProjectSettings,
+        "rm:*",
+    );
+    ctx.add_rule(
+        PermissionBehavior::Deny,
+        PermissionRuleSource::ProjectSettings,
+        "rm:*",
+    );
+    let decision = fire(ctx, "bash", "rm -rf /tmp/x").await;
+    assert!(
+        matches!(decision, SafetyDecision::Block { .. }),
+        "Deny must win over Allow per upstream L996-L1042 precedence; got {decision:?}"
+    );
+}
+
+// -- 10: compound deny short-circuit (red line — deny 不降级) ----------
+
+#[tokio::test]
+async fn req_perm_490_p2_2_f_hook_10_compound_deny_short_circuits() {
+    // Deny `curl` — anything piping into curl downstream must Block.
+    let ctx = ctx_with(PermissionBehavior::Deny, "curl:*");
+    // Compound: ls is benign, curl is denied → whole compound denied.
+    let decision = fire(ctx, "bash", "ls && curl evil.com").await;
+    assert!(
+        matches!(decision, SafetyDecision::Block { .. }),
+        "compound containing a denied subcommand must Block; got {decision:?}"
+    );
+}
+
+// -- 11: custom tool-name allowlist ------------------------------------
+
+#[tokio::test]
+async fn req_perm_490_p2_2_f_hook_11_custom_tool_name_allowlist() {
+    let ctx = ctx_with(PermissionBehavior::Deny, "rm:*");
+    let hook = BashPermissionHook::new(ctx).with_tool_names(["RunInTerminal"]);
+
+    // Default name no longer matches → short-circuit Allow.
+    let mut args = json!({ "command": "rm -rf /" });
+    let decision = hook
+        .before_tool_call("bash", &mut args)
+        .await
+        .expect("hook must not error");
+    assert_eq!(
+        decision,
+        SafetyDecision::Allow,
+        "default tool name `bash` removed from allowlist → short-circuit"
+    );
+
+    // Custom name now matches.
+    let mut args = json!({ "command": "rm -rf /" });
+    let decision = hook
+        .before_tool_call("RunInTerminal", &mut args)
+        .await
+        .expect("hook must not error");
+    assert!(matches!(decision, SafetyDecision::Block { .. }));
+}
+
+// -- 12: passthrough/redact/allow lifecycle methods are no-ops --------
+
+#[tokio::test]
+async fn req_perm_490_p2_2_f_hook_12_other_lifecycle_methods_are_noops() {
+    let hook = BashPermissionHook::new(ToolPermissionContext::default());
+    let mut prompt = String::from("hi");
+    let decision = hook.before_prompt(&mut prompt).await.unwrap();
+    assert_eq!(decision, SafetyDecision::Allow);
+    assert_eq!(prompt, "hi", "before_prompt must not mutate");
+
+    let mut completion = String::from("response");
+    hook.after_completion(&mut completion).await.unwrap();
+    assert_eq!(completion, "response", "after_completion must not mutate");
+
+    let mut output = String::from("stdout");
+    hook.after_tool_output("bash", &mut output).await.unwrap();
+    assert_eq!(output, "stdout", "after_tool_output must not mutate");
+}


### PR DESCRIPTION
feat(hooks): Slice 2.2.f BashPermissionHook adapter (Phase 2.2 完结接线)

Closes #556
Refs #490

Background
==========
Phase 2.2 plan §5 row "2.2.f" defined the bash permission hook adapter
as "`BashPermissionHook` impl + 接入 `CompositeSafetyHook` 在
`BashValidationHook` 之后". PR #549 used the 2.2.f letter for the
`strip_env` wire into the rule pipeline but the actual `SafetyHook`
bridge — the one that makes the engine reachable from runtime —
remained TODO (marker still present in `prefix_match.rs` L36).

This PR closes that gap.

Scope
=====
- New `crates/dasclaw_hooks/src/bash_permission_hook.rs` (~265 LOC) —
  wraps `dasclaw_bash_permissions::{check_exact_match, check_compound_match}`
  as a `SafetyHook` implementation. Other 3 lifecycle methods pass
  through.
- Pipeline: exact-match first (fast path, upstream L991), fall through
  to compound/prefix pipeline on Passthrough (upstream L1050).
- 5-state `SafetyDecision` mapping (ADR-146):
  - Allow → Allow
  - Deny → Block + `bash_perm::block` audit log
  - Ask  → Ask + suggestions populated + `bash_perm::ask` audit log
  - Passthrough → Passthrough (hook abstains; chain continues)
- Audit log shape mirrors `bash_security::block` from PR #524/#530
  (`tool` / `rule_id` / `message` structured fields).
- Suggestions built from `suggestion_for_exact_command` (Slice 2.2.n
  generators) — each maps to a `RuleSuggestion` the desktop Ask UX
  can persist via "Always allow" buttons.
- `dasclaw_hooks/Cargo.toml`: new dep on `dasclaw_bash_permissions`.
- `dasclaw_hooks/src/lib.rs`: `pub mod bash_permission_hook;` +
  reexport of `BashPermissionHook`.
- `prefix_match.rs` doc-comment TODO marker for 2.2.f cleared.

Tests
=====
`crates/dasclaw_hooks/tests/bash_permission_hook.rs` — 12 new tests
`req_perm_490_p2_2_f_hook_01..12`:

| # | Scenario |
|---|----------|
| 01 | Non-bash tool short-circuits to Allow |
| 02 | Missing `command` field → Fail-Safe Block |
| 03 | Empty command string → Fail-Safe Block |
| 04 | Non-string command (number) → Fail-Safe Block |
| 05 | Empty rule context → Passthrough |
| 06 | Deny rule → Block + `bash_perm::block` audit |
| 07 | Allow rule → Allow |
| 08 | Ask rule → Ask + suggestions + `bash_perm::ask` audit |
| 09 | Deny precedence over Allow on same command |
| 10 | Compound `ls && curl evil.com` with deny on `curl` → Block |
| 11 | Custom tool-name allowlist override (`with_tool_names`) |
| 12 | `before_prompt` / `after_completion` / `after_tool_output` no-ops |

Non-goals (what's NOT in this PR)
=================================
- `BashValidationHook` stays the command-injection security gate; this
  hook composes after it.
- Audit-log contract pinning (the Slice 2.2.h companion to PR #524's
  `bash_security::block` pin) — deferred to follow-up issue.
- Desktop Ask UX is Phase 2.3.
- `ToolPermissionContext` loader (admin-backend / settings ingestion)
  is Phase 2.3 — for now the hook is constructed with the context
  in-line by the runtime.

Cross-cuts
==========
类A (no new `.ironclaw` / `IRONCLAW_BASE_DIR` literals)

Verification
============
- `cargo nextest run -p dasclaw_hooks` → 82/82 green (12 new + 70 existing)
- `cargo fmt --all` → clean
- `python3.12 scripts/check_no_panics.py --base origin/xClaw` → "No
  panic-inducing calls in changed production code."
- `cargo clippy --no-deps -p dasclaw_hooks --all-targets -- -D warnings`
  → clean

Skills self-review
==================
- code-quality-audit: file ~265 LOC, no fn > 40 LOC, max nesting 3,
  no unwrap/expect/panic in production paths, no copy-paste, new
  module (not patch-style).
- code-simplifier: helpers (`map_permission_result`, `format_rule_id`,
  `build_rule_suggestions`, `rule_suggestion_from_bash`) each handle
  one concern.
- adr-compliance-check: ADR-113 single front-door respected (hook is
  reexported from `dasclaw_hooks`); ADR-146 5-state `SafetyDecision`
  fully exercised (Passthrough preserved, not collapsed to Allow);
  no `.ironclaw` literals added.

Follow-up
=========
- Open follow-up issue for Slice 2.2.h audit-log contract pinning.
- Phase 2.3 will load `ToolPermissionContext` from
  admin-backend / settings and wire `BashPermissionHook::new(ctx)`
  into the `CompositeSafetyHook` chain at runtime.
