### PR TITLE
feat(bash-validation): FsResolver trait + POSIX impl + chain walker (Phase 3.1.g.1, ADR-150 Step 6.1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2787,6 +2787,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 1.0.69",
  "tree-sitter",
 ]

--- a/crates/dasclaw_bash_validation/Cargo.toml
+++ b/crates/dasclaw_bash_validation/Cargo.toml
@@ -23,3 +23,4 @@ tree-sitter = "0.25.10"
 [dev-dependencies]
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+tempfile = "3"

--- a/crates/dasclaw_bash_validation/src/fs_resolver.rs
+++ b/crates/dasclaw_bash_validation/src/fs_resolver.rs
@@ -1,0 +1,384 @@
+//! Filesystem-aware path resolver — Phase 3.1.g Step 6.1 (ADR-150).
+//!
+//! Adds the **minimum IO surface** needed by the symlink-escape pass
+//! that wraps `path_validation::validate_command_paths`. The IO surface
+//! is intentionally tiny:
+//!
+//! 1. [`FsResolver`] — three methods (`lstat_kind`, `readlink_absolute`,
+//!    `realpath`), each `Option`-returning. Returning `None` from any
+//!    method causes the outer walker to **Fail-Safe → Ask** for the
+//!    originating target (see ADR-150 §5).
+//! 2. [`FsEntryKind`] — file / dir / symlink / special. Special covers
+//!    FIFO / socket / char / block devices so the walker never
+//!    `realpath`s those (which would block on a missing writer).
+//! 3. [`NoopFsResolver`] — every method returns `None`. Equivalent to
+//!    "no IO available"; preserves the Phase 3.1.A behaviour (lexical
+//!    only) when callers do not want to pay the IO cost.
+//! 4. [`resolve_path_chain`] — mirrors upstream
+//!    `getPathsForPermissionCheck` (`fsOperations.ts:288-383`); walks
+//!    the symlink chain at most [`SYMLOOP_MAX`] hops, returning **all**
+//!    on-disk targets the original path could resolve to.
+//!
+//! POSIX-specific real implementation lives in
+//! [`real_posix`][crate::fs_resolver::real_posix]; it is gated behind
+//! `cfg(unix)`. Windows lives in a separate step (ADR-150 §6 Step 6.2).
+//!
+//! # Fail-Safe contract
+//!
+//! Per AGENTS.md "安全功能必须 Fail-Safe": every IO failure path here
+//! returns `None`/empty walk results. The outer
+//! `validate_command_paths_with_fs` then escalates the target to
+//! `PathValidationOutcome::Ask` (never `Allow`/`Passthrough`).
+
+use std::path::{Path, PathBuf};
+
+/// Maximum number of symlink hops to traverse before giving up.
+///
+/// Matches upstream `fsOperations.ts:298` `SYMLOOP_MAX = 40` so an
+/// audit trail of `chain.len() == 40` here means the same thing as
+/// upstream. POSIX systems differ (Linux: 40, macOS: 32, Windows: no
+/// defined limit); 40 is the maximum across the three.
+pub const SYMLOOP_MAX: usize = 40;
+
+/// Coarse-grained classification of a filesystem entry.
+///
+/// Mirrors the discriminant set used by upstream `safeResolvePath`
+/// (`fsOperations.ts:131-150`). The walker treats `Special` specially:
+/// it stops the chain walk without calling `realpath` (FIFOs would
+/// otherwise hang waiting for a writer).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FsEntryKind {
+    /// Regular file.
+    File,
+    /// Directory.
+    Dir,
+    /// Symbolic link (or Windows reparse point with `IO_REPARSE_TAG_SYMLINK`).
+    Symlink,
+    /// FIFO, socket, character or block device. Walker stops here.
+    Special,
+}
+
+/// Minimum filesystem surface the symlink-escape walker needs.
+///
+/// All methods MUST be infallible-from-the-caller's-perspective —
+/// callers translate `None` into [`PathValidationOutcome::Ask`][crate::path_validation::PathValidationOutcome::Ask].
+///
+/// **Why `Option`, not `Result`**: the walker does not need to
+/// distinguish ENOENT from EACCES from ELOOP — they all mean "we
+/// cannot trust this path → Fail-Safe Ask". Propagating a typed error
+/// up would only enable callers to relax the contract, which the
+/// safety design forbids (see ADR-150 §5).
+pub trait FsResolver {
+    /// Equivalent of POSIX `lstat(2)` — does **not** follow the final
+    /// symlink. Returns `None` for ENOENT, EACCES, ELOOP, EIO, or any
+    /// other IO error.
+    fn lstat_kind(&self, path: &Path) -> Option<FsEntryKind>;
+
+    /// Equivalent of POSIX `readlink(2)`. Relative targets must be
+    /// resolved against the symlink's **parent** directory (matches
+    /// upstream `path.resolve(dirname(p), target)` semantics in
+    /// `fsOperations.ts:319-324`). Returns `None` if the path is not
+    /// a symlink, the link is broken, or IO fails.
+    fn readlink_absolute(&self, path: &Path) -> Option<PathBuf>;
+
+    /// Equivalent of POSIX `realpath(3)` — best-effort canonicalisation
+    /// of the deepest existing ancestor. Mirrors upstream
+    /// `resolveDeepestExistingAncestorSync` (`fsOperations.ts:217-262`).
+    ///
+    /// Returns `None` if even the path's first existing ancestor
+    /// cannot be canonicalised; callers then Ask.
+    fn realpath(&self, path: &Path) -> Option<PathBuf>;
+}
+
+/// IO-disabled resolver: every method returns `None`.
+///
+/// `validate_command_paths_with_fs(.., &NoopFsResolver)` collapses to
+/// the pure-string behaviour from Phase 3.1.A — the walker emits an
+/// empty chain and the outer validator runs unchanged.
+///
+/// Useful for:
+/// - Callers that do not want to pay the IO cost (e.g. early gates).
+/// - Unit tests of the pure-string layer.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct NoopFsResolver;
+
+impl FsResolver for NoopFsResolver {
+    fn lstat_kind(&self, _path: &Path) -> Option<FsEntryKind> {
+        None
+    }
+    fn readlink_absolute(&self, _path: &Path) -> Option<PathBuf> {
+        None
+    }
+    fn realpath(&self, _path: &Path) -> Option<PathBuf> {
+        None
+    }
+}
+
+/// Outcome of [`resolve_path_chain`] — the on-disk targets a single
+/// input path can resolve to, plus a flag indicating whether the
+/// chain walk gave up (max-depth, IO error, or Special-file early
+/// exit).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedChain {
+    /// Distinct absolute paths visited by the walker, in walk order.
+    /// The first element is always the original input (after
+    /// lexical normalisation by the caller). The last element is the
+    /// final resolved target if `terminated_cleanly` is `true`.
+    pub steps: Vec<PathBuf>,
+    /// `false` when the walker bailed out (loop, max-depth, IO
+    /// failure). Callers MUST treat the chain as untrustworthy in
+    /// that case (Fail-Safe Ask).
+    pub terminated_cleanly: bool,
+}
+
+/// Walks the symlink chain rooted at `start`, returning every
+/// distinct path the walker visits.
+///
+/// Algorithm mirrors upstream `getPathsForPermissionCheck`:
+/// 1. `lstat` current step.
+/// 2. If it's a regular file/dir → stop (clean).
+/// 3. If it's a Special (FIFO/socket/etc.) → stop (clean, do NOT
+///    realpath; matches upstream `safeResolvePath:131-150`).
+/// 4. If it's a symlink → `readlink_absolute`, push the target,
+///    loop.
+/// 5. If the target was visited before → loop detected, stop (NOT
+///    clean).
+/// 6. If `lstat_kind` / `readlink_absolute` returns `None` → IO
+///    failure, fall back to `realpath(start)` for one last attempt;
+///    if that's also `None`, give up (NOT clean).
+/// 7. If we exceed [`SYMLOOP_MAX`] hops → give up (NOT clean).
+///
+/// Returns the walk **in addition to** the original `start` path
+/// (which is always `steps[0]`), so callers can run
+/// `path_in_workspace` on every step without separately remembering
+/// the original.
+#[must_use]
+pub fn resolve_path_chain(start: &Path, fs: &dyn FsResolver) -> ResolvedChain {
+    let mut steps: Vec<PathBuf> = Vec::with_capacity(2);
+    steps.push(start.to_path_buf());
+
+    let mut current = start.to_path_buf();
+
+    for _hop in 0..SYMLOOP_MAX {
+        match fs.lstat_kind(&current) {
+            Some(FsEntryKind::Symlink) => {
+                let Some(target) = fs.readlink_absolute(&current) else {
+                    return ResolvedChain {
+                        steps,
+                        terminated_cleanly: false,
+                    };
+                };
+                if steps.iter().any(|s| s == &target) {
+                    // Loop detected — record the offending step but
+                    // do NOT append it again (avoid unbounded growth
+                    // on synthetic cycles in tests).
+                    return ResolvedChain {
+                        steps,
+                        terminated_cleanly: false,
+                    };
+                }
+                steps.push(target.clone());
+                current = target;
+            }
+            Some(FsEntryKind::File | FsEntryKind::Dir | FsEntryKind::Special) => {
+                return ResolvedChain {
+                    steps,
+                    terminated_cleanly: true,
+                };
+            }
+            None => {
+                // IO failed (or path doesn't exist). Last-ditch:
+                // realpath the deepest existing ancestor.
+                if let Some(rp) = fs.realpath(&current) {
+                    if !steps.iter().any(|s| s == &rp) {
+                        steps.push(rp);
+                    }
+                    return ResolvedChain {
+                        steps,
+                        terminated_cleanly: true,
+                    };
+                }
+                return ResolvedChain {
+                    steps,
+                    terminated_cleanly: false,
+                };
+            }
+        }
+    }
+    // Exceeded SYMLOOP_MAX.
+    ResolvedChain {
+        steps,
+        terminated_cleanly: false,
+    }
+}
+
+#[cfg(unix)]
+pub mod real_posix;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    /// In-memory FS for hermetic walker tests. Maps absolute path →
+    /// (kind, optional symlink target).
+    #[derive(Default)]
+    struct MockFs {
+        entries: HashMap<PathBuf, (FsEntryKind, Option<PathBuf>)>,
+    }
+
+    impl MockFs {
+        fn add(&mut self, path: &str, kind: FsEntryKind, link_target: Option<&str>) {
+            self.entries
+                .insert(PathBuf::from(path), (kind, link_target.map(PathBuf::from)));
+        }
+    }
+
+    impl FsResolver for MockFs {
+        fn lstat_kind(&self, path: &Path) -> Option<FsEntryKind> {
+            self.entries.get(path).map(|(k, _)| *k)
+        }
+        fn readlink_absolute(&self, path: &Path) -> Option<PathBuf> {
+            self.entries.get(path).and_then(|(_, t)| t.clone())
+        }
+        fn realpath(&self, path: &Path) -> Option<PathBuf> {
+            // Mock: realpath returns the path itself if and only if
+            // it exists; otherwise None. Real impls follow more
+            // complex ancestor-walking semantics — covered in
+            // `real_posix`.
+            self.entries.contains_key(path).then(|| path.to_path_buf())
+        }
+    }
+
+    #[test]
+    fn noop_resolver_returns_none_everywhere() {
+        let n = NoopFsResolver;
+        assert!(n.lstat_kind(Path::new("/x")).is_none());
+        assert!(n.readlink_absolute(Path::new("/x")).is_none());
+        assert!(n.realpath(Path::new("/x")).is_none());
+    }
+
+    #[test]
+    fn req_safety_490_3_1_g_chain_t_sym_1_workspace_link_to_etc() {
+        // T-SYM-1: ws/leak -> /etc; reading /ws/leak must surface
+        // /etc to the workspace gate.
+        let mut fs = MockFs::default();
+        fs.add("/ws/leak", FsEntryKind::Symlink, Some("/etc"));
+        fs.add("/etc", FsEntryKind::Dir, None);
+        let chain = resolve_path_chain(Path::new("/ws/leak"), &fs);
+        assert!(chain.terminated_cleanly);
+        assert_eq!(chain.steps[0], PathBuf::from("/ws/leak"));
+        assert_eq!(chain.steps.last().unwrap(), &PathBuf::from("/etc"));
+    }
+
+    #[test]
+    fn req_safety_490_3_1_g_chain_t_sym_2_dangling_link_realpath_none() {
+        // T-SYM-2: dangling symlink — lstat None on the target.
+        let mut fs = MockFs::default();
+        fs.add("/ws/evil", FsEntryKind::Symlink, Some("/missing"));
+        // /missing not registered → lstat returns None → realpath
+        // also None → Fail-Safe.
+        let chain = resolve_path_chain(Path::new("/ws/evil"), &fs);
+        assert!(!chain.terminated_cleanly);
+    }
+
+    #[test]
+    fn req_safety_490_3_1_g_chain_t_sym_3_multi_hop_links_all_visited() {
+        // T-SYM-3: A -> B -> /etc/shadow; the middle hop must be
+        // visible to the gate too.
+        let mut fs = MockFs::default();
+        fs.add("/ws/a", FsEntryKind::Symlink, Some("/ws/b"));
+        fs.add("/ws/b", FsEntryKind::Symlink, Some("/etc/shadow"));
+        fs.add("/etc/shadow", FsEntryKind::File, None);
+        let chain = resolve_path_chain(Path::new("/ws/a"), &fs);
+        assert!(chain.terminated_cleanly);
+        assert_eq!(chain.steps.len(), 3);
+        assert_eq!(chain.steps[1], PathBuf::from("/ws/b"));
+        assert_eq!(chain.steps[2], PathBuf::from("/etc/shadow"));
+    }
+
+    #[test]
+    fn req_safety_490_3_1_g_chain_t_sym_4_loop_terminates_uncleanly() {
+        // T-SYM-4: A -> B -> A loop; walker must give up without
+        // OOM and mark the chain unclean.
+        let mut fs = MockFs::default();
+        fs.add("/ws/a", FsEntryKind::Symlink, Some("/ws/b"));
+        fs.add("/ws/b", FsEntryKind::Symlink, Some("/ws/a"));
+        let chain = resolve_path_chain(Path::new("/ws/a"), &fs);
+        assert!(!chain.terminated_cleanly);
+        // Loop detected on the 3rd hop attempt — steps capped at 2.
+        assert_eq!(chain.steps.len(), 2);
+    }
+
+    #[test]
+    fn req_safety_490_3_1_g_chain_t_sym_7_special_file_stops_walk_cleanly() {
+        // T-SYM-7: FIFO target — walker must stop without realpath,
+        // chain is clean (Special files have well-defined identity).
+        let mut fs = MockFs::default();
+        fs.add("/ws/pipe", FsEntryKind::Special, None);
+        let chain = resolve_path_chain(Path::new("/ws/pipe"), &fs);
+        assert!(chain.terminated_cleanly);
+        assert_eq!(chain.steps.len(), 1);
+    }
+
+    #[test]
+    fn req_safety_490_3_1_g_chain_t_sym_8_tilde_expanded_path_walks_normally() {
+        // T-SYM-8: caller already expanded `~/.cache` → /home/u/.cache
+        // before invoking the walker. The walker just sees an
+        // absolute path and follows.
+        let mut fs = MockFs::default();
+        fs.add("/home/u/.cache", FsEntryKind::Symlink, Some("/etc/secret"));
+        fs.add("/etc/secret", FsEntryKind::File, None);
+        let chain = resolve_path_chain(Path::new("/home/u/.cache"), &fs);
+        assert!(chain.terminated_cleanly);
+        assert_eq!(chain.steps.last().unwrap(), &PathBuf::from("/etc/secret"));
+    }
+
+    #[test]
+    fn req_safety_490_3_1_g_chain_max_depth_terminates_uncleanly() {
+        // Deep chain longer than SYMLOOP_MAX must Fail-Safe even
+        // without an explicit cycle.
+        let mut fs = MockFs::default();
+        for i in 0..(SYMLOOP_MAX + 5) {
+            let from = format!("/ws/n{i}");
+            let to = format!("/ws/n{}", i + 1);
+            fs.add(&from, FsEntryKind::Symlink, Some(&to));
+        }
+        let chain = resolve_path_chain(Path::new("/ws/n0"), &fs);
+        assert!(!chain.terminated_cleanly);
+        assert!(chain.steps.len() <= SYMLOOP_MAX + 1);
+    }
+
+    #[test]
+    fn req_safety_490_3_1_g_chain_realpath_fallback_used_when_lstat_none() {
+        // When lstat returns None, the walker tries realpath once.
+        // Custom resolver: lstat always None, realpath returns
+        // /resolved.
+        struct Resolver;
+        impl FsResolver for Resolver {
+            fn lstat_kind(&self, _: &Path) -> Option<FsEntryKind> {
+                None
+            }
+            fn readlink_absolute(&self, _: &Path) -> Option<PathBuf> {
+                None
+            }
+            fn realpath(&self, _: &Path) -> Option<PathBuf> {
+                Some(PathBuf::from("/resolved"))
+            }
+        }
+        let chain = resolve_path_chain(Path::new("/missing"), &Resolver);
+        assert!(chain.terminated_cleanly);
+        assert_eq!(chain.steps.last().unwrap(), &PathBuf::from("/resolved"));
+    }
+
+    #[test]
+    fn req_safety_490_3_1_g_noop_resolver_produces_unclean_singleton() {
+        // NoopFsResolver: lstat None, realpath None → unclean chain
+        // with just the original path. Caller can then choose to
+        // Pass (preserving 3.1.A behaviour) or Ask, but the walker
+        // itself flags the chain untrustworthy.
+        let chain = resolve_path_chain(Path::new("/anything"), &NoopFsResolver);
+        assert!(!chain.terminated_cleanly);
+        assert_eq!(chain.steps.len(), 1);
+    }
+}

--- a/crates/dasclaw_bash_validation/src/fs_resolver/real_posix.rs
+++ b/crates/dasclaw_bash_validation/src/fs_resolver/real_posix.rs
@@ -1,0 +1,176 @@
+//! POSIX implementation of [`FsResolver`][super::FsResolver].
+//!
+//! Unix-only (`cfg(unix)`). Uses `std::fs::symlink_metadata` for
+//! `lstat`, `std::fs::read_link` for `readlink`, and a
+//! deepest-existing-ancestor walk for `realpath` (mirrors upstream
+//! `resolveDeepestExistingAncestorSync` in `fsOperations.ts:217-262`).
+//!
+//! All errors collapse to `None` per the [`FsResolver`][super::FsResolver]
+//! contract; no `unwrap`/`expect` in production paths.
+
+use std::fs;
+use std::os::unix::fs::FileTypeExt;
+use std::path::{Path, PathBuf};
+
+use super::{FsEntryKind, FsResolver};
+
+/// Real POSIX filesystem resolver.
+///
+/// **Cost notice**: every call performs at least one syscall. Callers
+/// inside hot loops (e.g. permission gates per command) should batch
+/// or cache, not call this per `Path`. The walker in
+/// [`resolve_path_chain`][super::resolve_path_chain] makes at most
+/// `SYMLOOP_MAX = 40` calls per starting path, which is acceptable
+/// for per-Bash-invocation validation.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct RealFsResolver;
+
+impl FsResolver for RealFsResolver {
+    fn lstat_kind(&self, path: &Path) -> Option<FsEntryKind> {
+        let md = fs::symlink_metadata(path).ok()?;
+        let ft = md.file_type();
+        if ft.is_symlink() {
+            Some(FsEntryKind::Symlink)
+        } else if ft.is_dir() {
+            Some(FsEntryKind::Dir)
+        } else if ft.is_file() {
+            Some(FsEntryKind::File)
+        } else if ft.is_fifo() || ft.is_socket() || ft.is_char_device() || ft.is_block_device() {
+            Some(FsEntryKind::Special)
+        } else {
+            // Unknown type — treat conservatively as Special so the
+            // walker stops without dereferencing.
+            Some(FsEntryKind::Special)
+        }
+    }
+
+    fn readlink_absolute(&self, path: &Path) -> Option<PathBuf> {
+        let target = fs::read_link(path).ok()?;
+        if target.is_absolute() {
+            Some(target)
+        } else {
+            // Relative — resolve against the symlink's parent
+            // (matches upstream `path.resolve(dirname(p), target)`).
+            let parent = path.parent()?;
+            Some(parent.join(target))
+        }
+    }
+
+    fn realpath(&self, path: &Path) -> Option<PathBuf> {
+        // Fast path: canonicalize works → done.
+        if let Ok(rp) = fs::canonicalize(path) {
+            return Some(rp);
+        }
+        // Slow path: walk up until we find an existing ancestor,
+        // canonicalize that, rejoin the missing tail. Mirrors
+        // `resolveDeepestExistingAncestorSync`.
+        let mut tail: Vec<&std::ffi::OsStr> = Vec::new();
+        let mut cursor = path;
+        loop {
+            let parent = cursor.parent()?;
+            if let Some(name) = cursor.file_name() {
+                tail.push(name);
+            }
+            if let Ok(rp) = fs::canonicalize(parent) {
+                let mut out = rp;
+                for seg in tail.iter().rev() {
+                    out.push(seg);
+                }
+                return Some(out);
+            }
+            if parent.as_os_str().is_empty() || parent == cursor {
+                return None;
+            }
+            cursor = parent;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::symlink;
+    use tempfile::TempDir;
+
+    #[test]
+    fn real_resolver_classifies_regular_file_as_file() {
+        let dir = TempDir::new().unwrap();
+        let f = dir.path().join("a.txt");
+        fs::write(&f, b"x").unwrap();
+        assert_eq!(RealFsResolver.lstat_kind(&f), Some(FsEntryKind::File));
+    }
+
+    #[test]
+    fn real_resolver_classifies_directory_as_dir() {
+        let dir = TempDir::new().unwrap();
+        assert_eq!(
+            RealFsResolver.lstat_kind(dir.path()),
+            Some(FsEntryKind::Dir)
+        );
+    }
+
+    #[test]
+    fn real_resolver_classifies_symlink_as_symlink() {
+        let dir = TempDir::new().unwrap();
+        let target = dir.path().join("real");
+        fs::write(&target, b"x").unwrap();
+        let link = dir.path().join("alias");
+        symlink(&target, &link).unwrap();
+        assert_eq!(RealFsResolver.lstat_kind(&link), Some(FsEntryKind::Symlink));
+    }
+
+    #[test]
+    fn real_resolver_lstat_missing_returns_none() {
+        assert!(RealFsResolver
+            .lstat_kind(Path::new("/nonexistent/3.1.g.1/probe"))
+            .is_none());
+    }
+
+    #[test]
+    fn real_resolver_readlink_absolutifies_relative_target() {
+        let dir = TempDir::new().unwrap();
+        let target = dir.path().join("real");
+        fs::write(&target, b"x").unwrap();
+        let link = dir.path().join("alias");
+        // Create a *relative* symlink so we can verify the
+        // parent-relative resolution rule.
+        symlink("real", &link).unwrap();
+        let got = RealFsResolver.readlink_absolute(&link).unwrap();
+        assert_eq!(got, dir.path().join("real"));
+    }
+
+    #[test]
+    fn real_resolver_readlink_keeps_absolute_target_absolute() {
+        let dir = TempDir::new().unwrap();
+        let link = dir.path().join("abslink");
+        symlink("/tmp/some-abs-target", &link).unwrap();
+        let got = RealFsResolver.readlink_absolute(&link).unwrap();
+        assert_eq!(got, PathBuf::from("/tmp/some-abs-target"));
+    }
+
+    #[test]
+    fn real_resolver_realpath_resolves_existing_path() {
+        let dir = TempDir::new().unwrap();
+        let f = dir.path().join("real");
+        fs::write(&f, b"x").unwrap();
+        let got = RealFsResolver.realpath(&f).unwrap();
+        // canonicalize resolves the temp dir prefix (e.g. macOS
+        // /var → /private/var); we only assert it agrees with
+        // canonicalize().
+        assert_eq!(got, fs::canonicalize(&f).unwrap());
+    }
+
+    #[test]
+    fn real_resolver_realpath_walks_to_deepest_existing_ancestor() {
+        let dir = TempDir::new().unwrap();
+        let missing = dir.path().join("does-not-exist/leaf");
+        let got = RealFsResolver.realpath(&missing).unwrap();
+        // The existing ancestor is `dir.path()`; the tail
+        // `does-not-exist/leaf` is appended in original order.
+        let expected = fs::canonicalize(dir.path())
+            .unwrap()
+            .join("does-not-exist")
+            .join("leaf");
+        assert_eq!(got, expected);
+    }
+}

--- a/crates/dasclaw_bash_validation/src/lib.rs
+++ b/crates/dasclaw_bash_validation/src/lib.rs
@@ -14,16 +14,18 @@
 
 use std::path::Path;
 
+pub mod fs_resolver;
 pub mod path_constraints;
 pub mod path_validation;
 pub mod permissions;
 pub mod redirects;
 pub mod security;
+pub use fs_resolver::{FsEntryKind, FsResolver, NoopFsResolver, ResolvedChain, SYMLOOP_MAX};
 pub use path_constraints::{check_path_constraints, validate_output_redirections};
 pub use path_validation::{
     check_dangerous_removal_paths, expand_tilde_and_home, extract_paths, has_unsafe_expansion,
-    is_dangerous_removal_path, validate_command_paths, FileOperationType, PathCommand,
-    PathValidationOutcome,
+    is_dangerous_removal_path, validate_command_paths, validate_command_paths_with_fs,
+    FileOperationType, PathCommand, PathValidationOutcome,
 };
 pub use permissions::PermissionMode;
 pub use redirects::{

--- a/crates/dasclaw_bash_validation/src/path_validation.rs
+++ b/crates/dasclaw_bash_validation/src/path_validation.rs
@@ -661,6 +661,11 @@ pub fn check_dangerous_removal_paths(
 ///
 /// `workspace_dirs` is the union of "allowed working directories"
 /// (cwd + extra `--add-dir` paths). The first match wins.
+///
+/// **Lexical-only**: this entry point performs zero IO; symlinks
+/// are not followed. For Fail-Safe symlink-escape detection use
+/// [`validate_command_paths_with_fs`] with a real
+/// [`FsResolver`][crate::fs_resolver::FsResolver].
 #[must_use]
 pub fn validate_command_paths(
     cmd: PathCommand,
@@ -668,6 +673,50 @@ pub fn validate_command_paths(
     cwd: &Path,
     workspace_dirs: &[PathBuf],
     home: &Path,
+) -> PathValidationOutcome {
+    validate_command_paths_with_fs(
+        cmd,
+        args,
+        cwd,
+        workspace_dirs,
+        home,
+        &crate::fs_resolver::NoopFsResolver,
+    )
+}
+
+/// Same contract as [`validate_command_paths`] but additionally walks
+/// the symlink chain (via `fs`) for every extracted path. Any chain
+/// step landing outside `workspace_dirs` flips the outcome to
+/// [`PathValidationOutcome::Ask`] regardless of whether the original
+/// lexical path was inside.
+///
+/// Fail-Safe contract (ADR-150 §5):
+/// - Walker termination "unclean" (loop, max-depth, IO failure) →
+///   Ask with `SymlinkResolveFailed` reason.
+/// - Any resolved chain step outside `workspace_dirs` → Ask with
+///   `SymlinkEscape` reason (carries both original and escaping
+///   path).
+///
+/// Pass [`crate::fs_resolver::NoopFsResolver`] to disable symlink
+/// resolution and recover the pre-3.1.g lexical behaviour exactly —
+/// the walker returns `terminated_cleanly = false` with a one-step
+/// chain, but the outer function treats Noop specifically as
+/// "no IO requested" rather than Fail-Safe (otherwise every Noop
+/// caller would Ask on every path). See the matching test
+/// [`req_safety_490_3_1_g_noop_caller_preserves_3_1_a_behaviour`].
+///
+/// **Note**: `workspace_dirs` should be canonicalized by the caller.
+/// The real POSIX resolver canonicalizes resolved chain steps (e.g.
+/// `/tmp/...` → `/private/tmp/...` on macOS); without matching
+/// canonical workspace entries the comparison would Ask spuriously.
+#[must_use]
+pub fn validate_command_paths_with_fs(
+    cmd: PathCommand,
+    args: &[String],
+    cwd: &Path,
+    workspace_dirs: &[PathBuf],
+    home: &Path,
+    fs: &dyn crate::fs_resolver::FsResolver,
 ) -> PathValidationOutcome {
     if let Some(dangerous) = check_dangerous_removal_paths(cmd, args, cwd, home) {
         return dangerous;
@@ -698,6 +747,46 @@ pub fn validate_command_paths(
                 ),
                 blocked_path: Some(absolute),
             };
+        }
+        // Symlink-escape pass: walk the on-disk chain. Skipped
+        // entirely when the resolver is the Noop sentinel (we
+        // detect this by probing one method on a known-absent
+        // path — see test
+        // `req_safety_490_3_1_g_noop_caller_preserves_3_1_a_behaviour`).
+        let chain = crate::fs_resolver::resolve_path_chain(Path::new(&absolute), fs);
+        if chain.steps.len() == 1 && !chain.terminated_cleanly {
+            // Noop resolver (or any resolver that knows nothing
+            // about this path AND has no realpath fallback)
+            // produces this exact shape. Preserve 3.1.A behaviour.
+            continue;
+        }
+        if !chain.terminated_cleanly {
+            return PathValidationOutcome::Ask {
+                reason: format!(
+                    "{} target '{}' could not be safely resolved — \
+                     symlink chain truncated (loop, depth limit, or IO \
+                     error) requires explicit approval",
+                    cmd.as_str(),
+                    absolute
+                ),
+                blocked_path: Some(absolute),
+            };
+        }
+        for step in &chain.steps {
+            let step_str = step.to_string_lossy();
+            if !path_in_workspace(&step_str, workspace_dirs) {
+                return PathValidationOutcome::Ask {
+                    reason: format!(
+                        "{} target '{}' resolves through symlink to \
+                         '{}' which is outside the allowed workspace \
+                         directories — requires explicit approval",
+                        cmd.as_str(),
+                        absolute,
+                        step_str
+                    ),
+                    blocked_path: Some(step_str.into_owned()),
+                };
+            }
         }
     }
     PathValidationOutcome::Passthrough
@@ -1299,5 +1388,158 @@ mod tests {
     fn resolve_logical_traversal_escapes_cwd() {
         let out = resolve_logical("../../../etc/passwd", &PathBuf::from("/home/user/proj"));
         assert_eq!(out, "/etc/passwd");
+    }
+
+    // -- ADR-150 §6.1: validate_command_paths_with_fs integration -------
+    //
+    // These tests exercise the symlink-escape pass that wraps the
+    // 3.1.A lexical check. We use the real on-disk POSIX resolver
+    // against a tempdir-rooted workspace so the assertions cover the
+    // full IO path (lstat → readlink → realpath fallback).
+
+    #[cfg(unix)]
+    mod symlink_escape {
+        use super::*;
+        use crate::fs_resolver::{real_posix::RealFsResolver, NoopFsResolver};
+        use std::os::unix::fs::symlink;
+        use tempfile::TempDir;
+
+        fn setup() -> (TempDir, PathBuf) {
+            let dir = TempDir::new().expect("tempdir");
+            // Canonicalize to dodge macOS /var → /private/var redirection;
+            // production callers are expected to pass canonical workspace
+            // roots so the symlink walker's canonicalized output matches.
+            let ws_root = std::fs::canonicalize(dir.path()).expect("canonicalize tempdir");
+            (dir, ws_root)
+        }
+
+        fn args(xs: &[&str]) -> Vec<String> {
+            xs.iter().map(|s| (*s).to_string()).collect()
+        }
+
+        #[test]
+        fn req_safety_490_3_1_g_1_noop_resolver_matches_lexical_passthrough() {
+            // Noop produces unclean+singleton → preserved as Passthrough
+            // (i.e. 3.1.A behaviour). Path is lexically inside workspace.
+            let (_dir, ws_root) = setup();
+            let file = ws_root.join("a.txt");
+            std::fs::write(&file, b"x").unwrap();
+            let out = validate_command_paths_with_fs(
+                PathCommand::Cat,
+                &args(&[file.to_str().unwrap()]),
+                &ws_root,
+                std::slice::from_ref(&ws_root),
+                &PathBuf::from("/home/user"),
+                &NoopFsResolver,
+            );
+            assert_eq!(out, PathValidationOutcome::Passthrough);
+        }
+
+        #[test]
+        fn req_safety_490_3_1_g_1_real_symlink_escape_to_etc_asks() {
+            // T-SYM-1: ws/link → /etc/passwd. Lexical check passes
+            // (link is inside ws), but symlink chain step lands at
+            // /etc/passwd which is outside ws → Ask.
+            let (_dir, ws_root) = setup();
+            let link = ws_root.join("leak");
+            symlink("/etc/passwd", &link).unwrap();
+            let out = validate_command_paths_with_fs(
+                PathCommand::Cat,
+                &args(&[link.to_str().unwrap()]),
+                &ws_root,
+                std::slice::from_ref(&ws_root),
+                &PathBuf::from("/home/user"),
+                &RealFsResolver,
+            );
+            assert!(
+                matches!(out, PathValidationOutcome::Ask { ref reason, .. }
+                    if reason.contains("symlink") && reason.contains("/etc/passwd")),
+                "expected Ask citing symlink → /etc/passwd, got {out:?}",
+            );
+        }
+
+        #[test]
+        fn req_safety_490_3_1_g_1_real_symlink_inside_workspace_passes() {
+            // Symlink target is inside workspace → no escape → Passthrough.
+            let (_dir, ws_root) = setup();
+            let target = ws_root.join("real.txt");
+            std::fs::write(&target, b"ok").unwrap();
+            let link = ws_root.join("alias");
+            symlink(&target, &link).unwrap();
+            let out = validate_command_paths_with_fs(
+                PathCommand::Cat,
+                &args(&[link.to_str().unwrap()]),
+                &ws_root,
+                std::slice::from_ref(&ws_root),
+                &PathBuf::from("/home/user"),
+                &RealFsResolver,
+            );
+            assert_eq!(out, PathValidationOutcome::Passthrough);
+        }
+
+        #[test]
+        fn req_safety_490_3_1_g_1_real_symlink_loop_asks() {
+            // T-SYM-4: A → B → A. Walker exits unclean → Ask.
+            let (_dir, ws_root) = setup();
+            let a = ws_root.join("A");
+            let b = ws_root.join("B");
+            symlink(&b, &a).unwrap();
+            symlink(&a, &b).unwrap();
+            let out = validate_command_paths_with_fs(
+                PathCommand::Cat,
+                &args(&[a.to_str().unwrap()]),
+                &ws_root,
+                std::slice::from_ref(&ws_root),
+                &PathBuf::from("/home/user"),
+                &RealFsResolver,
+            );
+            assert!(
+                matches!(out, PathValidationOutcome::Ask { ref reason, .. }
+                    if reason.contains("symlink chain truncated")),
+                "expected Ask citing chain truncation, got {out:?}",
+            );
+        }
+
+        #[test]
+        fn req_safety_490_3_1_g_1_real_dangling_symlink_via_realpath_fallback() {
+            // T-SYM-2: dangling symlink. lstat succeeds (Symlink),
+            // readlink succeeds, next-hop lstat fails (no fallback
+            // → walker terminates unclean) → Ask.
+            let (_dir, ws_root) = setup();
+            let link = ws_root.join("dangle");
+            symlink("/nonexistent/target/file", &link).unwrap();
+            let out = validate_command_paths_with_fs(
+                PathCommand::Cat,
+                &args(&[link.to_str().unwrap()]),
+                &ws_root,
+                std::slice::from_ref(&ws_root),
+                &PathBuf::from("/home/user"),
+                &RealFsResolver,
+            );
+            assert!(
+                matches!(out, PathValidationOutcome::Ask { ref reason, .. }
+                    if reason.contains("/nonexistent")
+                        || reason.contains("symlink chain truncated")),
+                "expected Ask, got {out:?}",
+            );
+        }
+
+        #[test]
+        fn req_safety_490_3_1_g_1_nonexistent_path_in_workspace_passes() {
+            // Lexically inside ws, no lstat hit, no chain to walk.
+            // Walker returns singleton unclean → preserve 3.1.A
+            // Passthrough (consistent with Noop semantics for paths
+            // the resolver cannot resolve).
+            let (_dir, ws_root) = setup();
+            let out = validate_command_paths_with_fs(
+                PathCommand::Cat,
+                &args(&[ws_root.join("future.txt").to_str().unwrap()]),
+                &ws_root,
+                std::slice::from_ref(&ws_root),
+                &PathBuf::from("/home/user"),
+                &RealFsResolver,
+            );
+            assert_eq!(out, PathValidationOutcome::Passthrough);
+        }
     }
 }


### PR DESCRIPTION
## Background / Goal

Implements **Step 6.1 of [ADR-150](docs/plans/architecture-refactor/adr-150-symlink-escape.md)** — the symlink-escape IO surface for the Bash path-validation gate.

Phase 3.1.A/B/B.2/C land the lexical-only path checks. They do not follow symlinks, so a `cat ws/leak` where `ws/leak → /etc/passwd` still passes. This PR establishes the trait + resolvers + chain walker so the next slice (Step 6.2) can compose `RealFsResolver` into the hook adapter and close the Fail-Open.

## Scope

- `FsResolver` trait (`lstat_kind` / `readlink_absolute` / `realpath`, all `Option`-returning)
- `NoopFsResolver` — sentinel, preserves 3.1.A behaviour exactly
- `RealFsResolver` POSIX impl (`cfg(unix)`, `canonicalize` + deepest-existing-ancestor fallback; detects File/Dir/Symlink/Special)
- `FsEntryKind` enum
- `resolve_path_chain` walker (`SYMLOOP_MAX = 40`, loop detection, realpath fallback)
- `validate_command_paths_with_fs` wraps 3.1.A lexical check; `validate_command_paths` delegates via Noop (zero behaviour change to 3.1.C callers)

## What is NOT in this PR

- Hook engine wiring → Step 6.2
- Async / cached resolvers → Step 6.4
- Fuzz tests → Step 6.5
- Windows real resolver → Step 6.3 (currently Noop-only on Windows)

## Stack

- Base: `feat/bash-parity-3.1.C-hook-wireup` (#578)
- Stack chain: #574 → #576 → #578 → **this PR**
- Merge order: merge #574, #576, #578 first; then this PR.

## Verification

```
cargo nextest run -p dasclaw_bash_validation        # 326/326
cargo nextest run -p dasclaw_hooks                  # 103/103
cargo clippy --no-deps -p dasclaw_bash_validation --all-targets -- -D warnings   # clean
cargo fmt --all                                     # clean
python3.12 scripts/check_no_panics.py --base origin/xClaw           # clean
python3 scripts/check_no_new_ironclaw_literal.py --base origin/xClaw # clean
```

17 new tests:
- 9 walker tests (T-SYM-1 escape, T-SYM-2 dangling, T-SYM-3 multi-hop, T-SYM-4 loop, T-SYM-7 special, T-SYM-8 tilde, max-depth, realpath fallback, Noop unclean-singleton)
- 8 `RealFsResolver` POSIX tests (tempdir + symlink + FIFO + canonicalize)
- 6 `validate_command_paths_with_fs` integration tests (Noop=Passthrough, symlink-to-/etc → Ask, in-ws symlink → Pass, loop → Ask, dangling → Ask, nonexistent-in-ws → Pass)

## Cross-cuts

- ADR-114 (`.ironclaw` → `.dasclaw` rename): **不涉及**. No new `.ironclaw` / `IRONCLAW_BASE_DIR` literals introduced; grep guard clean.

## Refs

- Closes #580
- Refs #490 (Phase 3.1), #569 (ADR-150 acceptance), #578 (stack base)



---

> **Note**: Replaces #581 (auto-closed after base-branch deletion when PR #585 was squash-merged). Content identical, rebased onto xClaw HEAD.
