### PR TITLE
feat(bash-validation): wire RealFsResolver into BashValidationHook [3.1.g.2] (replaces #583)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2886,6 +2886,7 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 1.0.69",
  "tokio",
  "tracing",

--- a/crates/dasclaw_bash_validation/src/lib.rs
+++ b/crates/dasclaw_bash_validation/src/lib.rs
@@ -22,7 +22,9 @@ pub mod readonly;
 pub mod redirects;
 pub mod security;
 pub use fs_resolver::{FsEntryKind, FsResolver, NoopFsResolver, ResolvedChain, SYMLOOP_MAX};
-pub use path_constraints::{check_path_constraints, validate_output_redirections};
+pub use path_constraints::{
+    check_path_constraints, check_path_constraints_with_fs, validate_output_redirections,
+};
 pub use path_validation::{
     check_dangerous_removal_paths, expand_tilde_and_home, extract_paths, has_unsafe_expansion,
     is_dangerous_removal_path, validate_command_paths, validate_command_paths_with_fs,

--- a/crates/dasclaw_bash_validation/src/path_constraints.rs
+++ b/crates/dasclaw_bash_validation/src/path_constraints.rs
@@ -25,10 +25,11 @@ use std::path::PathBuf;
 use dasclaw_shell_command::bash::try_parse_shell;
 use tree_sitter::Node;
 
+use crate::fs_resolver::{FsResolver, NoopFsResolver};
 use crate::path_validation::expand_tilde_and_home;
 use crate::path_validation::path_in_workspace;
 use crate::path_validation::resolve_logical;
-use crate::path_validation::validate_command_paths;
+use crate::path_validation::validate_command_paths_with_fs;
 use crate::path_validation::PathCommand;
 use crate::path_validation::PathValidationOutcome;
 use crate::redirects::extract_output_redirections;
@@ -114,19 +115,46 @@ fn check_single_redirect(
 ///    classify it safely → Fail-Closed Ask.
 /// 4. For each extracted argv: if the base command is in
 ///    [`PathCommand::parse`]'s allow-list, dispatch to
-///    [`validate_command_paths`]. Unknown base commands are Passthrough
-///    (they are gated by other validators / deny-rules at a higher layer).
+///    [`validate_command_paths_with_fs`] with a [`NoopFsResolver`] (lexical-
+///    only). Unknown base commands are Passthrough (they are gated by other
+///    validators / deny-rules at a higher layer).
 ///
 /// `workspace_dirs` is the caller-provided set of permissible workspace
 /// roots — typically `[project_root, additional_directories…]` from the
 /// IDE/desktop client. An empty list means **no path is allowed** (Ask for
 /// every captured path), which is the safe default.
+///
+/// **Lexical-only**: this entry performs zero IO; symlinks are not
+/// followed. For Fail-Safe symlink-escape detection use
+/// [`check_path_constraints_with_fs`] with a real [`FsResolver`].
 #[must_use]
 pub fn check_path_constraints(
     src: &str,
     cwd: &Path,
     workspace_dirs: &[PathBuf],
     home: &Path,
+) -> PathValidationOutcome {
+    check_path_constraints_with_fs(src, cwd, workspace_dirs, home, &NoopFsResolver)
+}
+
+/// Same contract as [`check_path_constraints`] but additionally walks the
+/// on-disk symlink chain (via `fs`) for every extracted argv path. Any
+/// chain step landing outside `workspace_dirs` flips the outcome to
+/// [`PathValidationOutcome::Ask`] regardless of whether the lexical path
+/// was inside the workspace.
+///
+/// See [`validate_command_paths_with_fs`] for the per-command walker
+/// contract (Fail-Safe on unclean termination, canonicalization caveat).
+///
+/// Pass [`NoopFsResolver`] to recover the pure-lexical behaviour exactly
+/// — the [`check_path_constraints`] wrapper does this for you.
+#[must_use]
+pub fn check_path_constraints_with_fs(
+    src: &str,
+    cwd: &Path,
+    workspace_dirs: &[PathBuf],
+    home: &Path,
+    fs: &dyn FsResolver,
 ) -> PathValidationOutcome {
     // Step 1: redirections (independent of base command dispatch).
     let extraction = extract_output_redirections(src);
@@ -161,7 +189,7 @@ pub fn check_path_constraints(
         let Some(cmd) = PathCommand::parse(base) else {
             continue;
         };
-        let outcome = validate_command_paths(cmd, args, cwd, workspace_dirs, home);
+        let outcome = validate_command_paths_with_fs(cmd, args, cwd, workspace_dirs, home, fs);
         if !matches!(outcome, PathValidationOutcome::Passthrough) {
             return outcome;
         }

--- a/crates/dasclaw_hooks/Cargo.toml
+++ b/crates/dasclaw_hooks/Cargo.toml
@@ -35,3 +35,4 @@ dasclaw_bash_permissions = { path = "../dasclaw_bash_permissions" }
 [dev-dependencies]
 tokio = { version = "1", features = ["sync", "macros", "time", "rt", "rt-multi-thread"] }
 tracing-test = { version = "0.2", features = ["no-env-filter"] }
+tempfile = "3"

--- a/crates/dasclaw_hooks/src/bash_validation_hook.rs
+++ b/crates/dasclaw_hooks/src/bash_validation_hook.rs
@@ -27,8 +27,12 @@
 //! 2. **Phase 2.1 command-injection gate** ([`validate_security`]) — runs
 //!    BEFORE the path gate and BEFORE [`validate_command`]. Mode-independent
 //!    (Block fires even under `DangerFullAccess` / `Allow`).
-//! 3. **Phase 3.1 path-constraint gate** ([`check_path_constraints`],
-//!    Slice 3.1.C) — runs BEFORE [`validate_command`]:
+//! 3. **Phase 3.1 path-constraint gate** ([`check_path_constraints_with_fs`],
+//!    Slice 3.1.C + Phase 3.1.g.2 ADR-150 Step 6.2) — runs BEFORE
+//!    [`validate_command`]. On Unix the gate uses `RealFsResolver` so
+//!    symlink chains that escape the workspace flip Passthrough → Ask
+//!    (Fail-Safe); on non-Unix the gate stays lexical-only until ADR-150
+//!    Step 6.3 lands the Windows real resolver:
 //!    - `Passthrough` ⇒ continue to step 4.
 //!    - `Block { reason }` ⇒ [`SafetyDecision::Block`] regardless of mode.
 //!    - `Ask { reason, blocked_path }` ⇒ mapped by mode same as Warn:
@@ -60,7 +64,12 @@
 use std::path::{Path, PathBuf};
 
 use async_trait::async_trait;
-use dasclaw_bash_validation::check_path_constraints;
+use dasclaw_bash_validation::check_path_constraints_with_fs;
+use dasclaw_bash_validation::fs_resolver::FsResolver;
+#[cfg(not(unix))]
+use dasclaw_bash_validation::fs_resolver::NoopFsResolver;
+#[cfg(unix)]
+use dasclaw_bash_validation::fs_resolver::real_posix::RealFsResolver;
 use dasclaw_bash_validation::path_validation::PathValidationOutcome;
 use dasclaw_bash_validation::security::{
     DecisionReason as SecurityDecisionReason, SecurityResult, validate_security,
@@ -95,8 +104,16 @@ impl BashValidationHook {
     /// reads `$HOME` from the environment for the path-validation home
     /// directory. To override either, chain
     /// [`Self::with_tool_names`] / [`Self::with_home_dir`].
+    ///
+    /// `workspace` is canonicalized via [`std::fs::canonicalize`] so that
+    /// the symlink-walk path-gate (Phase 3.1.g, ADR-150) compares chain
+    /// steps against a real-path workspace root. On platforms / paths
+    /// where canonicalization fails the original `workspace` is kept —
+    /// the path-gate then degrades to lexical matching for that root,
+    /// which preserves the pre-3.1.g behaviour.
     #[must_use]
     pub fn new(permission_mode: PermissionMode, workspace: PathBuf) -> Self {
+        let workspace = std::fs::canonicalize(&workspace).unwrap_or(workspace);
         Self {
             permission_mode,
             workspace,
@@ -135,6 +152,23 @@ impl BashValidationHook {
     /// Returns `true` if `tool` should be treated as a bash invocation.
     fn is_bash_tool(&self, tool: &str) -> bool {
         self.bash_tool_names.iter().any(|n| n == tool)
+    }
+
+    /// Pick the [`FsResolver`] backing the Phase 3.1.g symlink-escape
+    /// walker. Unix targets get the real POSIX resolver (Fail-Safe on
+    /// symlink escape); other targets keep the lexical-only Noop resolver
+    /// until Step 6.3 ships a Windows real resolver (ADR-150 §6.3).
+    fn fs_resolver(&self) -> &'static dyn FsResolver {
+        #[cfg(unix)]
+        {
+            static R: RealFsResolver = RealFsResolver;
+            &R
+        }
+        #[cfg(not(unix))]
+        {
+            static R: NoopFsResolver = NoopFsResolver;
+            &R
+        }
     }
 }
 
@@ -181,20 +215,24 @@ impl SafetyHook for BashValidationHook {
             });
         }
 
-        // Phase 3.1 path-constraint gate (Slice 3.1.C).
+        // Phase 3.1 path-constraint gate (Slice 3.1.C + Phase 3.1.g.2).
         //
         // Runs AFTER the injection gate and BEFORE `validate_command` so
         // that path violations short-circuit the legacy validator with a
         // mode-aware decision. `Passthrough` falls through unchanged.
         //
-        // SECURITY: `Ask` in `ReadOnly` mode is mapped to `Block`
-        // (Fail-Safe). `WorkspaceWrite` / `DangerFullAccess` / `Allow`
-        // log and allow, mirroring [`map_warn_by_mode`].
-        let path_outcome = check_path_constraints(
+        // SECURITY: Phase 3.1.g.2 (ADR-150 Step 6.2) wires the real POSIX
+        // symlink resolver on Unix; non-Unix retains the lexical-only
+        // Noop resolver until Step 6.3. `Ask` in `ReadOnly` mode is
+        // mapped to `Block` (Fail-Safe). `WorkspaceWrite` /
+        // `DangerFullAccess` / `Allow` log and allow, mirroring
+        // [`map_warn_by_mode`].
+        let path_outcome = check_path_constraints_with_fs(
             command,
             &self.workspace,
             std::slice::from_ref(&self.workspace),
             self.home_dir.as_deref().unwrap_or_else(|| Path::new("")),
+            self.fs_resolver(),
         );
         if let Some(decision) = map_path_outcome_by_mode(tool, self.permission_mode, path_outcome) {
             return Ok(decision);

--- a/crates/dasclaw_hooks/tests/bash_validation_symlink_escape.rs
+++ b/crates/dasclaw_hooks/tests/bash_validation_symlink_escape.rs
@@ -1,0 +1,244 @@
+//! Phase 3.1.g.2 (ADR-150 Step 6.2) — `BashValidationHook` symlink-escape
+//! integration tests.
+//!
+//! Phase 3.1.A (PR #574) shipped the lexical path-gate; Phase 3.1.g.1
+//! (PR #581) shipped the `FsResolver` trait + `RealFsResolver` POSIX
+//! implementation + walker. Step 6.2 is the wireup: the hook's
+//! `before_tool_call` now invokes
+//! [`dasclaw_bash_validation::check_path_constraints_with_fs`] with the
+//! real POSIX resolver on Unix, closing the Fail-Open on symlink escape
+//! that 3.1.A left behind.
+//!
+//! These tests are deliberately *hook-level integration tests* (not
+//! `validate_command_paths_with_fs` unit tests — those already live in
+//! `crates/dasclaw_bash_validation/src/path_validation.rs::symlink_escape`).
+//! They pin the seam between the hook adapter and the resolver-aware
+//! path-gate, including:
+//!
+//! - canonical-workspace handling (macOS `/tmp` ↔ `/private/tmp`),
+//! - `PermissionMode` → `SafetyDecision` mapping for path-gate `Ask`,
+//! - bash AST → argv → resolver round-trip preserves the chain reason.
+//!
+//! Naming follows the `req_safety_490_3_1_g_2_hook_*` family so coverage
+//! tooling groups them with the parent ADR-150 PIN set.
+
+#![cfg(unix)]
+
+use std::os::unix::fs::symlink;
+use std::path::{Path, PathBuf};
+
+use dasclaw_hooks::BashValidationHook;
+use serde_json::json;
+use tempfile::TempDir;
+use x_claw_agent::permissions::PermissionMode;
+use x_claw_agent::{SafetyDecision, SafetyHook};
+
+/// Build a tempdir + canonical workspace root pair. Canonicalization is
+/// **the test's job** here only so we control the comparison anchor;
+/// `BashValidationHook::new` canonicalizes on its own so production
+/// callers don't have to.
+fn ws() -> (TempDir, PathBuf) {
+    let dir = TempDir::new().expect("tempdir");
+    let root = std::fs::canonicalize(dir.path()).expect("canonicalize tempdir");
+    (dir, root)
+}
+
+/// Build a hook rooted at `ws_root` in `Prompt` mode (so path-gate `Ask`
+/// surfaces as `SafetyDecision::Ask` rather than being folded into
+/// `Block` / `Allow` by the permission matrix). Home is set to a hermetic
+/// non-existent path to make `~` expansion deterministic across hosts.
+fn hook_at(ws_root: &Path) -> BashValidationHook {
+    BashValidationHook::new(PermissionMode::Prompt, ws_root.to_path_buf())
+        .with_home_dir(Some(PathBuf::from("/nonexistent-home")))
+}
+
+async fn fire(hook: &BashValidationHook, command: &str) -> SafetyDecision {
+    let mut args = json!({ "command": command });
+    hook.before_tool_call("bash", &mut args)
+        .await
+        .expect("hook must not error on a string command")
+}
+
+// ---------------------------------------------------------------------
+// T-SYM-1: workspace-local symlink to /etc/passwd → Ask via path-gate
+// ---------------------------------------------------------------------
+#[tokio::test]
+async fn req_safety_490_3_1_g_2_hook_t_sym_1_link_to_etc_passwd_asks() {
+    let (_dir, ws_root) = ws();
+    let link = ws_root.join("leak");
+    symlink("/etc/passwd", &link).expect("create symlink");
+
+    let h = hook_at(&ws_root);
+    let cmd = format!("cat {}", link.display());
+    let decision = fire(&h, &cmd).await;
+
+    match decision {
+        SafetyDecision::Ask { reason, .. } => {
+            assert!(
+                reason.starts_with("bash_path_constraints::ask"),
+                "expected path-gate Ask prefix, got: {reason}"
+            );
+            assert!(
+                reason.contains("/etc/passwd"),
+                "Ask reason must cite the escaping chain step (/etc/passwd), got: {reason}"
+            );
+            assert!(
+                reason.contains("symlink"),
+                "Ask reason must mention symlink resolution, got: {reason}"
+            );
+        }
+        other => panic!("expected Ask, got {other:?}"),
+    }
+}
+
+// ---------------------------------------------------------------------
+// T-SYM-3: multi-hop chain ending outside workspace → Ask
+// (workspace-internal symlink → another workspace-internal symlink →
+//  /etc/passwd)
+// ---------------------------------------------------------------------
+#[tokio::test]
+async fn req_safety_490_3_1_g_2_hook_t_sym_3_multi_hop_escape_asks() {
+    let (_dir, ws_root) = ws();
+    let hop_a = ws_root.join("a");
+    let hop_b = ws_root.join("b");
+    symlink(&hop_b, &hop_a).expect("a -> b");
+    symlink("/etc/passwd", &hop_b).expect("b -> /etc/passwd");
+
+    let h = hook_at(&ws_root);
+    let cmd = format!("cat {}", hop_a.display());
+    let decision = fire(&h, &cmd).await;
+
+    match decision {
+        SafetyDecision::Ask { reason, .. } => {
+            assert!(reason.contains("/etc/passwd"), "got: {reason}");
+        }
+        other => panic!("expected Ask for multi-hop escape, got {other:?}"),
+    }
+}
+
+// ---------------------------------------------------------------------
+// T-SYM-4: A↔B loop → Ask (chain truncated)
+// ---------------------------------------------------------------------
+#[tokio::test]
+async fn req_safety_490_3_1_g_2_hook_t_sym_4_loop_asks_with_chain_truncated() {
+    let (_dir, ws_root) = ws();
+    let a = ws_root.join("loop_a");
+    let b = ws_root.join("loop_b");
+    symlink(&b, &a).expect("a -> b");
+    symlink(&a, &b).expect("b -> a");
+
+    let h = hook_at(&ws_root);
+    let cmd = format!("cat {}", a.display());
+    let decision = fire(&h, &cmd).await;
+
+    match decision {
+        SafetyDecision::Ask { reason, .. } => {
+            assert!(
+                reason.contains("symlink chain truncated"),
+                "expected truncation reason, got: {reason}"
+            );
+        }
+        other => panic!("expected Ask for symlink loop, got {other:?}"),
+    }
+}
+
+// ---------------------------------------------------------------------
+// Plain in-workspace path → Passthrough → `validate_command` decides.
+// This pins the no-regression invariant vs 3.1.C: ordinary reads
+// inside the workspace must not be perturbed by the resolver wireup.
+// ---------------------------------------------------------------------
+#[tokio::test]
+async fn req_safety_490_3_1_g_2_hook_plain_in_workspace_path_allows() {
+    let (_dir, ws_root) = ws();
+    let file = ws_root.join("README.md");
+    std::fs::write(&file, b"hi").expect("write");
+
+    let h = hook_at(&ws_root);
+    let cmd = format!("cat {}", file.display());
+    let decision = fire(&h, &cmd).await;
+
+    assert_eq!(
+        decision,
+        SafetyDecision::Allow,
+        "plain in-workspace cat must Allow (no regression vs 3.1.C)"
+    );
+}
+
+// ---------------------------------------------------------------------
+// Workspace-internal symlink to another workspace-internal file →
+// Passthrough → Allow. Confirms the walker does not over-trigger on
+// every symlink, only on chains that escape.
+// ---------------------------------------------------------------------
+#[tokio::test]
+async fn req_safety_490_3_1_g_2_hook_internal_symlink_allows() {
+    let (_dir, ws_root) = ws();
+    let target = ws_root.join("real.txt");
+    std::fs::write(&target, b"ok").expect("write");
+    let link = ws_root.join("alias");
+    symlink(&target, &link).expect("symlink");
+
+    let h = hook_at(&ws_root);
+    let cmd = format!("cat {}", link.display());
+    let decision = fire(&h, &cmd).await;
+
+    assert_eq!(
+        decision,
+        SafetyDecision::Allow,
+        "internal symlink must not trigger path-gate Ask"
+    );
+}
+
+// ---------------------------------------------------------------------
+// PermissionMode interaction: same T-SYM-1 escape under `ReadOnly`
+// must Fail-Safe Block (not Ask), matching `map_path_outcome_by_mode`.
+// ---------------------------------------------------------------------
+#[tokio::test]
+async fn req_safety_490_3_1_g_2_hook_symlink_escape_readonly_blocks_fail_safe() {
+    let (_dir, ws_root) = ws();
+    let link = ws_root.join("leak");
+    symlink("/etc/passwd", &link).expect("create symlink");
+
+    let h = BashValidationHook::new(PermissionMode::ReadOnly, ws_root.clone())
+        .with_home_dir(Some(PathBuf::from("/nonexistent-home")));
+    let cmd = format!("cat {}", link.display());
+    let decision = fire(&h, &cmd).await;
+
+    match decision {
+        SafetyDecision::Block { reason } => {
+            assert!(
+                reason.starts_with("bash_path_constraints::ask"),
+                "ReadOnly must surface the path-gate reason verbatim, got: {reason}"
+            );
+            assert!(reason.contains("/etc/passwd"), "got: {reason}");
+        }
+        other => panic!("expected Block (Fail-Safe), got {other:?}"),
+    }
+}
+
+// ---------------------------------------------------------------------
+// Constructor canonicalization: caller passes the un-canonical tempdir
+// path (e.g. /tmp/... on macOS, which canonicalizes to /private/tmp/...).
+// The hook must canonicalize internally so the chain-step comparison
+// matches RealFsResolver's canonical output.
+// ---------------------------------------------------------------------
+#[tokio::test]
+async fn req_safety_490_3_1_g_2_hook_canonicalizes_workspace() {
+    let dir = TempDir::new().expect("tempdir");
+    let raw = dir.path().to_path_buf();
+    let canonical = std::fs::canonicalize(&raw).expect("canonicalize");
+    // Sanity-guard the test: if the tempdir is already canonical the
+    // assertion below degenerates but stays correct.
+    let target = canonical.join("file.txt");
+    std::fs::write(&target, b"x").expect("write");
+
+    let h = BashValidationHook::new(PermissionMode::Prompt, raw)
+        .with_home_dir(Some(PathBuf::from("/nonexistent-home")));
+    let cmd = format!("cat {}", target.display());
+    let decision = fire(&h, &cmd).await;
+
+    assert_eq!(
+        decision,
+        SafetyDecision::Allow,
+        "hook must canonicalize workspace so /tmp ↔ /private/tmp matches"
+    );
+}


### PR DESCRIPTION
## Background

Closes #582. ADR-150 Step 6.2. Phase 3.1.g.1 (PR #581) introduced
`FsResolver` + `RealFsResolver` (POSIX) + `resolve_path_chain` +
`validate_command_paths_with_fs`. The hook engine was still wired to the
lexical-only `validate_command_paths` and therefore still **Fail-Open** on
symlink escape: `cat ws/leak` where `ws/leak → /etc/passwd` slipped
through with `SafetyDecision::Allow`.

This PR closes that gap on Unix by routing the hook's path-gate through
`check_path_constraints_with_fs(.., &RealFsResolver)`. Non-Unix continues
to use `NoopFsResolver` until ADR-150 Step 6.3 ships the Windows real
resolver.

**Stack note**: based on `feat/bash-parity-3.1.g.1-fs-resolver` (PR #581).
Please merge #581 first; this PR will then auto-retarget `xClaw`.
Merge order: **#581 → this PR**.

## Scope of this slice

- `crates/dasclaw_bash_validation/src/path_constraints.rs`
  - New `check_path_constraints_with_fs(src, cwd, ws, home, fs)` is the
    real impl.
  - `check_path_constraints(...)` is now a thin wrapper that delegates
    with `&NoopFsResolver`. **Existing callers (all internal tests)
    keep their pre-3.1.g lexical semantics, byte-for-byte.**
- `crates/dasclaw_bash_validation/src/lib.rs`: re-export
  `check_path_constraints_with_fs`.
- `crates/dasclaw_hooks/src/bash_validation_hook.rs`:
  - `BashValidationHook::new` now canonicalizes the workspace via
    `std::fs::canonicalize(...).unwrap_or(workspace)` so chain-step
    comparison matches `RealFsResolver`'s canonical output (covers the
    macOS `/tmp` ↔ `/private/tmp` case called out in the issue body).
  - New private `fs_resolver()` returns `&'static dyn FsResolver`:
    `RealFsResolver` on `cfg(unix)`, `NoopFsResolver` otherwise. Uses
    static items so we get true `'static` references without leaking.
  - `before_tool_call` calls `check_path_constraints_with_fs(..., self.fs_resolver())`.
  - Module doc updated to record the new wireup and the Step 6.3 caveat.
- `crates/dasclaw_hooks/tests/bash_validation_symlink_escape.rs` (NEW,
  `#![cfg(unix)]`): 7 hook-level integration tests proving the seam.
- `crates/dasclaw_hooks/Cargo.toml`: `tempfile = "3"` dev-dep.

## What is NOT in this slice

- Step 6.3 Windows real resolver
- Step 6.4 async / cached resolvers
- Step 6.5 fuzz tests for the walker
- Step 6.6 ADR finalization / closeout doc

## Test surface

**New** (`crates/dasclaw_hooks/tests/bash_validation_symlink_escape.rs`):
- `req_safety_490_3_1_g_2_hook_t_sym_1_link_to_etc_passwd_asks` — T-SYM-1
- `req_safety_490_3_1_g_2_hook_t_sym_3_multi_hop_escape_asks` — T-SYM-3
- `req_safety_490_3_1_g_2_hook_t_sym_4_loop_asks_with_chain_truncated` — T-SYM-4
- `req_safety_490_3_1_g_2_hook_plain_in_workspace_path_allows`
- `req_safety_490_3_1_g_2_hook_internal_symlink_allows`
- `req_safety_490_3_1_g_2_hook_symlink_escape_readonly_blocks_fail_safe`
- `req_safety_490_3_1_g_2_hook_canonicalizes_workspace`

**Regression**: all 326/326 `dasclaw_bash_validation` + 103/103 prior
`dasclaw_hooks` tests still green; new total **436/436**.

## Verification

```bash
cargo nextest run -p dasclaw_bash_validation -p dasclaw_hooks
# 436/436 passed

cargo clippy --no-deps -p dasclaw_hooks -p dasclaw_bash_validation --all-targets -- -D warnings
# clean

cargo fmt --all
python3.12 scripts/check_no_panics.py --base origin/xClaw
# OK: No panic-inducing calls in changed production code.
python3 scripts/check_no_new_ironclaw_literal.py --base origin/xClaw
# OK: No new .ironclaw / IRONCLAW_BASE_DIR literals introduced.
```

## Skill self-review

- `code-quality-audit`: pass — no patch-style branches, no copy-paste,
  `fs_resolver()` is a true abstraction (not flag-controlled), no new
  production `unwrap()`/`expect()`, dev-dep reuse (`tempfile`) instead
  of rolling temp-dir helpers.
- `code-simplifier`: pass — call sites unchanged in shape; the only
  new code is the trait-selection helper + canonicalization fallback.
- `code-review-expert`: pass — Fail-Safe degradation verified (if
  `canonicalize` fails, chain steps simply no longer match the
  workspace prefix → spurious `Ask`, never Fail-Open); no SOLID/security
  regressions; `RealFsResolver` is a zero-sized unit struct so the
  `static R: RealFsResolver = RealFsResolver;` pattern is sound.

## Cross-cuts

ADR-114 (`.ironclaw` → `.dasclaw`): **类A** — no new `.ironclaw` /
`IRONCLAW_BASE_DIR` literals; grep guard green.

## Refs

- Closes #582
- Parent tracker: #561
- ADR: `docs/plans/architecture-refactor/adr-150-symlink-escape.md`
- Predecessor stack: #574 (3.1.B) → #576 (3.1.B.2) → #578 (3.1.C) → #581 (3.1.g.1)



---

> **Note**: Replaces #583 (auto-closed when PR #586 was squash-merged and its branch deleted). Branch rebased onto current xClaw HEAD (`4283b9d8`, which includes #586 + #588). No code changes vs the original #583; 3-layer review applied in the prior session for the original branch still holds. CI will re-run from scratch on the new parent.
