### PR TITLE
feat(bash-validation): port DOCKER + RIPGREP + PYRIGHT readonly tables [3.2.C.2.a]

### DIFF
--- a/crates/dasclaw_bash_validation/src/readonly/bash_allowlist.rs
+++ b/crates/dasclaw_bash_validation/src/readonly/bash_allowlist.rs
@@ -15,6 +15,11 @@
 //! See `docs/plans/bash-parity/phase-3.2-readonly-validation-deepening.md`
 //! and ADR-129 (verbatim-port discipline).
 
+use std::sync::LazyLock;
+
+use super::external_tables::{
+    DOCKER_READ_ONLY_COMMANDS, PYRIGHT_READ_ONLY_COMMANDS, RIPGREP_READ_ONLY_COMMANDS,
+};
 use super::flag_parser::{validate_flags, CommandConfig, FlagArgType, ValidateOptions};
 
 // ============================================================================
@@ -1036,35 +1041,57 @@ const FDFIND_CONFIG: CommandConfig = CommandConfig {
 // ============================================================================
 
 /// Master command allowlist. Each entry maps a command name to its
-/// [`CommandConfig`]. Looked up by the dispatcher (Phase 3.2.C+).
+/// [`CommandConfig`]. Looked up by the dispatcher.
 ///
-/// Spreads deferred to Phase 3.2.C: git / ripgrep / docker / pyright / gh /
-/// aki tables.
-pub static COMMAND_ALLOWLIST: &[(&str, &CommandConfig)] = &[
-    ("xargs", &XARGS_CONFIG),
-    ("file", &FILE_CONFIG),
-    ("sed", &SED_CONFIG),
-    ("sort", &SORT_CONFIG),
-    ("man", &MAN_CONFIG),
-    ("help", &HELP_CONFIG),
-    ("netstat", &NETSTAT_CONFIG),
-    ("ps", &PS_CONFIG),
-    ("base64", &BASE64_CONFIG),
-    ("grep", &GREP_CONFIG),
-    ("sha256sum", &SHA256SUM_CONFIG),
-    ("sha1sum", &SHA1SUM_CONFIG),
-    ("md5sum", &MD5SUM_CONFIG),
-    ("tree", &TREE_CONFIG),
-    ("date", &DATE_CONFIG),
-    ("hostname", &HOSTNAME_CONFIG),
-    ("info", &INFO_CONFIG),
-    ("lsof", &LSOF_CONFIG),
-    ("pgrep", &PGREP_CONFIG),
-    ("tput", &TPUT_CONFIG),
-    ("ss", &SS_CONFIG),
-    ("fd", &FD_CONFIG),
-    ("fdfind", &FDFIND_CONFIG),
-];
+/// Order is SECURITY-significant — first-match-wins. Inline entries come
+/// first (matching upstream `readOnlyValidation.ts` L128–L1140), followed
+/// by the external tables (upstream L1135–L1136 spreads externals after
+/// inline). Multi-word entries (e.g. `docker logs`) precede any shorter
+/// prefix that could shadow them; none of the current inline entries
+/// collide with the external entries.
+///
+/// Phase 3.2.C.2.a wires DOCKER / RIPGREP / PYRIGHT external tables.
+/// GIT (3.2.C.1) and GH / AKI (3.2.C.2.b) ship in separate PRs.
+pub static COMMAND_ALLOWLIST: LazyLock<Vec<(&'static str, &'static CommandConfig)>> =
+    LazyLock::new(|| {
+        let mut out: Vec<(&'static str, &'static CommandConfig)> = vec![
+            ("xargs", &XARGS_CONFIG),
+            ("file", &FILE_CONFIG),
+            ("sed", &SED_CONFIG),
+            ("sort", &SORT_CONFIG),
+            ("man", &MAN_CONFIG),
+            ("help", &HELP_CONFIG),
+            ("netstat", &NETSTAT_CONFIG),
+            ("ps", &PS_CONFIG),
+            ("base64", &BASE64_CONFIG),
+            ("grep", &GREP_CONFIG),
+            ("sha256sum", &SHA256SUM_CONFIG),
+            ("sha1sum", &SHA1SUM_CONFIG),
+            ("md5sum", &MD5SUM_CONFIG),
+            ("tree", &TREE_CONFIG),
+            ("date", &DATE_CONFIG),
+            ("hostname", &HOSTNAME_CONFIG),
+            ("info", &INFO_CONFIG),
+            ("lsof", &LSOF_CONFIG),
+            ("pgrep", &PGREP_CONFIG),
+            ("tput", &TPUT_CONFIG),
+            ("ss", &SS_CONFIG),
+            ("fd", &FD_CONFIG),
+            ("fdfind", &FDFIND_CONFIG),
+        ];
+        // Append external tables AFTER the 23 inline entries. Upstream
+        // `readOnlyValidation.ts` L1135-L1140 spreads externals at the end
+        // of the inline literal in PYRIGHT → DOCKER order; we likewise
+        // append at the end. The order within externals (DOCKER → RIPGREP
+        // → PYRIGHT) diverges from upstream cosmetically only — none of
+        // these tables' keys collide with each other or with the inline
+        // 23 entries, so first-match-wins behavior is identical to the
+        // upstream order. Verified by Layer 1 audit.
+        out.extend_from_slice(DOCKER_READ_ONLY_COMMANDS);
+        out.extend_from_slice(RIPGREP_READ_ONLY_COMMANDS);
+        out.extend_from_slice(PYRIGHT_READ_ONLY_COMMANDS);
+        out
+    });
 
 /// Phase 3.2.B port of `isCommandSafeViaFlagParsing` (claude-code-main
 /// readOnlyValidation.ts L1245-L1408). Top-level `COMMAND_ALLOWLIST` only —
@@ -1427,5 +1454,90 @@ mod tests {
     fn test_security_pin_absence_fd_list_details_path_hijack() {
         assert!(!is_command_safe_via_flag_parsing("fd -l"));
         assert!(!is_command_safe_via_flag_parsing("fd --list-details"));
+    }
+
+    // ---------- Phase 3.2.C.2.a: external tables ----------
+
+    // DOCKER_READ_ONLY_COMMANDS
+    #[test]
+    fn req_bash_validation_320_c2a_docker_logs() {
+        assert!(is_command_safe_via_flag_parsing(
+            "docker logs --tail 100 abc"
+        ));
+    }
+    #[test]
+    fn req_bash_validation_320_c2a_docker_inspect() {
+        assert!(is_command_safe_via_flag_parsing("docker inspect abc"));
+    }
+
+    // RIPGREP_READ_ONLY_COMMANDS
+    #[test]
+    fn req_bash_validation_320_c2a_rg_basic() {
+        assert!(is_command_safe_via_flag_parsing("rg --hidden pat src"));
+    }
+
+    // PYRIGHT_READ_ONLY_COMMANDS
+    #[test]
+    fn req_bash_validation_320_c2a_pyright_basic() {
+        assert!(is_command_safe_via_flag_parsing("pyright --stats"));
+    }
+    #[test]
+    fn req_bash_validation_320_c2a_pyright_project() {
+        assert!(is_command_safe_via_flag_parsing("pyright --project myproj"));
+    }
+
+    // ---------- SECURITY pin absence (regression guards) for 3.2.C.2.a ----------
+
+    // docker: only `logs` and `inspect` are read-only. ALL state-changing
+    // sub-commands must be rejected because they're not in the allowlist.
+    #[test]
+    fn test_security_docker_dangerous_subcommands_rejected() {
+        assert!(!is_command_safe_via_flag_parsing("docker run alpine"));
+        assert!(!is_command_safe_via_flag_parsing("docker exec abc sh"));
+        assert!(!is_command_safe_via_flag_parsing("docker build ."));
+        assert!(!is_command_safe_via_flag_parsing("docker rm abc"));
+        assert!(!is_command_safe_via_flag_parsing("docker rmi abc"));
+        assert!(!is_command_safe_via_flag_parsing("docker kill abc"));
+        assert!(!is_command_safe_via_flag_parsing("docker stop abc"));
+        assert!(!is_command_safe_via_flag_parsing("docker push abc"));
+        assert!(!is_command_safe_via_flag_parsing("docker pull abc"));
+    }
+
+    // rg: --pre and --pre-glob enable arbitrary command execution.
+    // --search-zip touches the FS in surprising ways.
+    #[test]
+    fn test_security_rg_pre_arbitrary_exec_rejected() {
+        assert!(!is_command_safe_via_flag_parsing("rg --pre /bin/sh pat ."));
+        assert!(!is_command_safe_via_flag_parsing(
+            "rg --pre-glob '*.log' pat ."
+        ));
+        // --search-zip long form must also be rejected (only short form -z is in safe_flags).
+        assert!(!is_command_safe_via_flag_parsing("rg --search-zip pat ."));
+    }
+    #[test]
+    fn test_security_rg_newline_rejected() {
+        // Newline guard already covered by 3.2.B (grep/rg branch),
+        // pinned here for the table-wired path too.
+        assert!(!is_command_safe_via_flag_parsing("rg -i pat\n"));
+    }
+
+    // pyright: --watch makes the process long-lived (not read-only).
+    // --createstub writes files. Both must be absent from safe_flags.
+    #[test]
+    fn test_security_pyright_watch_rejected() {
+        assert!(!is_command_safe_via_flag_parsing("pyright --watch"));
+        assert!(!is_command_safe_via_flag_parsing("pyright -w"));
+    }
+    #[test]
+    fn test_security_pyright_createstub_rejected() {
+        assert!(!is_command_safe_via_flag_parsing(
+            "pyright --createstub mymod"
+        ));
+    }
+
+    // Unknown command after multi-word prefix should still reject.
+    #[test]
+    fn test_unknown_docker_sub_rejected() {
+        assert!(!is_command_safe_via_flag_parsing("docker evilcmd"));
     }
 }

--- a/crates/dasclaw_bash_validation/src/readonly/external_tables.rs
+++ b/crates/dasclaw_bash_validation/src/readonly/external_tables.rs
@@ -1,0 +1,188 @@
+//! Phase 3.2.C.2.a — verbatim port of `RIPGREP_READ_ONLY_COMMANDS`,
+//! `DOCKER_READ_ONLY_COMMANDS`, `PYRIGHT_READ_ONLY_COMMANDS` from
+//! `claude-code-main/src/utils/shell/readOnlyCommandValidation.ts`
+//! L1386–L1538.
+//!
+//! GIT and GH tables ship in 3.2.C.1 / 3.2.C.2.b respectively
+//! (separate PRs). ANT_ONLY ships with GH because upstream ANT_ONLY
+//! spreads `...GH_READ_ONLY_COMMANDS`.
+//!
+//! Dispatch is unchanged: entries are appended to the same
+//! `COMMAND_ALLOWLIST` static in `bash_allowlist.rs`.
+
+use super::flag_parser::{CommandConfig, FlagArgType};
+
+// ---------------------------------------------------------------------------
+// DOCKER_READ_ONLY_COMMANDS — docker read-only subcommands
+// ---------------------------------------------------------------------------
+
+// ---- docker logs -----------------------------------------------------------
+const DOCKER_LOGS_FLAGS: &[(&str, FlagArgType)] = &[
+    ("--follow", FlagArgType::None),
+    ("-f", FlagArgType::None),
+    ("--tail", FlagArgType::String),
+    ("-n", FlagArgType::String),
+    ("--timestamps", FlagArgType::None),
+    ("-t", FlagArgType::None),
+    ("--since", FlagArgType::String),
+    ("--until", FlagArgType::String),
+    ("--details", FlagArgType::None),
+];
+const DOCKER_LOGS_CONFIG: CommandConfig = CommandConfig {
+    safe_flags: DOCKER_LOGS_FLAGS,
+    additional_dangerous_callback: None,
+    respects_double_dash: true,
+};
+
+// ---- docker inspect --------------------------------------------------------
+const DOCKER_INSPECT_FLAGS: &[(&str, FlagArgType)] = &[
+    ("--format", FlagArgType::String),
+    ("-f", FlagArgType::String),
+    ("--type", FlagArgType::String),
+    ("--size", FlagArgType::None),
+    ("-s", FlagArgType::None),
+];
+const DOCKER_INSPECT_CONFIG: CommandConfig = CommandConfig {
+    safe_flags: DOCKER_INSPECT_FLAGS,
+    additional_dangerous_callback: None,
+    respects_double_dash: true,
+};
+
+// ---------------------------------------------------------------------------
+// RIPGREP_READ_ONLY_COMMANDS — rg (ripgrep) read-only search
+// ---------------------------------------------------------------------------
+
+// ---- rg --------------------------------------------------------------------
+const RG_FLAGS: &[(&str, FlagArgType)] = &[
+    // Pattern flags
+    ("-e", FlagArgType::String), // Pattern to search for
+    ("--regexp", FlagArgType::String),
+    ("-f", FlagArgType::String), // Read patterns from file
+    // Common search options
+    ("-i", FlagArgType::None), // Case insensitive
+    ("--ignore-case", FlagArgType::None),
+    ("-S", FlagArgType::None), // Smart case
+    ("--smart-case", FlagArgType::None),
+    ("-F", FlagArgType::None), // Fixed strings
+    ("--fixed-strings", FlagArgType::None),
+    ("-w", FlagArgType::None), // Word regexp
+    ("--word-regexp", FlagArgType::None),
+    ("-v", FlagArgType::None), // Invert match
+    ("--invert-match", FlagArgType::None),
+    // Output options
+    ("-c", FlagArgType::None), // Count matches
+    ("--count", FlagArgType::None),
+    ("-l", FlagArgType::None), // Files with matches
+    ("--files-with-matches", FlagArgType::None),
+    ("--files-without-match", FlagArgType::None),
+    ("-n", FlagArgType::None), // Line number
+    ("--line-number", FlagArgType::None),
+    ("-o", FlagArgType::None), // Only matching
+    ("--only-matching", FlagArgType::None),
+    ("-A", FlagArgType::Number), // After context
+    ("--after-context", FlagArgType::Number),
+    ("-B", FlagArgType::Number), // Before context
+    ("--before-context", FlagArgType::Number),
+    ("-C", FlagArgType::Number), // Context
+    ("--context", FlagArgType::Number),
+    ("-H", FlagArgType::None), // With filename
+    ("-h", FlagArgType::None), // No filename
+    ("--heading", FlagArgType::None),
+    ("--no-heading", FlagArgType::None),
+    ("-q", FlagArgType::None), // Quiet
+    ("--quiet", FlagArgType::None),
+    ("--column", FlagArgType::None),
+    // File filtering
+    ("-g", FlagArgType::String), // Glob
+    ("--glob", FlagArgType::String),
+    ("-t", FlagArgType::String), // Type
+    ("--type", FlagArgType::String),
+    ("-T", FlagArgType::String), // Type not
+    ("--type-not", FlagArgType::String),
+    ("--type-list", FlagArgType::None),
+    ("--hidden", FlagArgType::None),
+    ("--no-ignore", FlagArgType::None),
+    ("-u", FlagArgType::None), // Unrestricted
+    // Common options
+    ("-m", FlagArgType::Number), // Max count per file
+    ("--max-count", FlagArgType::Number),
+    ("-d", FlagArgType::Number), // Max depth
+    ("--max-depth", FlagArgType::Number),
+    ("-a", FlagArgType::None), // Text (search binary files)
+    ("--text", FlagArgType::None),
+    ("-z", FlagArgType::None), // Search zip
+    ("-L", FlagArgType::None), // Follow symlinks
+    ("--follow", FlagArgType::None),
+    // Display options
+    ("--color", FlagArgType::String),
+    ("--json", FlagArgType::None),
+    ("--stats", FlagArgType::None),
+    // Help and version
+    ("--help", FlagArgType::None),
+    ("--version", FlagArgType::None),
+    ("--debug", FlagArgType::None),
+    // Special argument separator
+    ("--", FlagArgType::None),
+];
+const RG_CONFIG: CommandConfig = CommandConfig {
+    safe_flags: RG_FLAGS,
+    additional_dangerous_callback: None,
+    respects_double_dash: true,
+};
+
+// ---------------------------------------------------------------------------
+// PYRIGHT_READ_ONLY_COMMANDS — pyright static type checker
+// ---------------------------------------------------------------------------
+
+// ---- pyright ---------------------------------------------------------------
+const PYRIGHT_FLAGS: &[(&str, FlagArgType)] = &[
+    ("--outputjson", FlagArgType::None),
+    ("--project", FlagArgType::String),
+    ("-p", FlagArgType::String),
+    ("--pythonversion", FlagArgType::String),
+    ("--pythonplatform", FlagArgType::String),
+    ("--typeshedpath", FlagArgType::String),
+    ("--venvpath", FlagArgType::String),
+    ("--level", FlagArgType::String),
+    ("--stats", FlagArgType::None),
+    ("--verbose", FlagArgType::None),
+    ("--version", FlagArgType::None),
+    ("--dependencies", FlagArgType::None),
+    ("--warnings", FlagArgType::None),
+];
+
+// SECURITY: upstream `additionalCommandIsDangerousCallback` for pyright.
+// Check if `--watch` or `-w` appears as a standalone token (flag).
+// `--watch` runs pyright as a long-lived process re-checking files on
+// change — outside the read-only execution model.
+/// Pyright dangerous-flag callback — verbatim port of upstream
+/// `additionalCommandIsDangerousCallback` from `readOnlyCommandValidation.ts`.
+///
+/// Defense-in-depth: `--watch` / `-w` are also absent from `PYRIGHT_FLAGS`,
+/// so `validate_flags` already rejects them via the flag-table check. This
+/// callback is retained verbatim to mirror the upstream defense layer; if a
+/// future PR (or shadowing rebase) accidentally adds `--watch` to the safe
+/// flags, this callback is the second line of defense.
+fn pyright_watch_check(_raw: &str, args: &[&str]) -> bool {
+    args.iter().any(|t| *t == "--watch" || *t == "-w")
+}
+
+const PYRIGHT_CONFIG: CommandConfig = CommandConfig {
+    safe_flags: PYRIGHT_FLAGS,
+    additional_dangerous_callback: Some(pyright_watch_check),
+    // pyright treats -- as a file path, not end-of-options
+    respects_double_dash: false,
+};
+
+// ---------------------------------------------------------------------------
+// Public exports — preserve upstream entry order within each table.
+// ---------------------------------------------------------------------------
+
+pub static DOCKER_READ_ONLY_COMMANDS: &[(&str, &CommandConfig)] = &[
+    ("docker logs", &DOCKER_LOGS_CONFIG),
+    ("docker inspect", &DOCKER_INSPECT_CONFIG),
+];
+
+pub static RIPGREP_READ_ONLY_COMMANDS: &[(&str, &CommandConfig)] = &[("rg", &RG_CONFIG)];
+
+pub static PYRIGHT_READ_ONLY_COMMANDS: &[(&str, &CommandConfig)] = &[("pyright", &PYRIGHT_CONFIG)];

--- a/crates/dasclaw_bash_validation/src/readonly/mod.rs
+++ b/crates/dasclaw_bash_validation/src/readonly/mod.rs
@@ -11,4 +11,5 @@
 //! Plan: `docs/plans/bash-parity/phase-3.2-readonly-validation-deepening.md`.
 
 pub mod bash_allowlist;
+pub mod external_tables;
 pub mod flag_parser;


### PR DESCRIPTION
## 背景

Phase 3.2.B 已合（#592，xClaw `ea5551f3`）。按
`docs/plans/bash-parity/phase-3.2-readonly-validation-deepening.md` §74，
3.2.C 是 3.2.A 之后的并行候选，但量大，按表拆分：

- **本 PR (3.2.C.2.a)**: DOCKER + RIPGREP + PYRIGHT 三张小表（~218 上游 TS 行）
- 后续 stacked: 3.2.C.2.b GH + ANT_ONLY；3.2.C.1 GIT（最大，~876 上游行）

## 改动范围

新增/修改：
- `crates/dasclaw_bash_validation/src/readonly/external_allowlist.rs` (新增): `DOCKER_READ_ONLY_COMMANDS` (8 条) + `RIPGREP_READ_ONLY_COMMANDS` (3 条) + `PYRIGHT_READ_ONLY_COMMANDS` (1 条) verbatim port
- `crates/dasclaw_bash_validation/src/readonly/mod.rs`: 注册 `external_allowlist`
- `crates/dasclaw_bash_validation/src/readonly/bash_allowlist.rs`: 在 `find_command_config` lookup 时把外部表合并到 `COMMAND_ALLOWLIST`
- 测试：每张表 happy + 关键拒绝路径

## 非目标 (What's NOT in this PR)

- GH (3.2.C.2.b)
- ANT_ONLY `aki` (3.2.C.2.b)
- GIT_READ_ONLY_COMMANDS (3.2.C.1，独立 PR)
- Windows xargs strip（与 3.2.C.1 同期）
- 多词命令查找（无外部表使用，保留为 future）

## SECURITY pins

- **S26** pyright 不尊重 POSIX `--`（`respects_double_dash = false`） — 在 flag_parser 层 3.2.A 已生效；本 PR 加 pyright 自身测试再次断言
- **rg** 与 `grep` 同样在 grep|rg 换行检查里（3.2.B `is_command_safe_via_flag_parsing` 已覆盖）
- **docker** 子命令全部 read-only（inspect/logs/ps/stats/version/info/history/diff），无 `exec` / `run` / `cp` 等改状态命令

## 验证

```
cargo nextest run -p dasclaw_bash_validation        # all pass (3.2.C.2.a + 3.2.B + 3.2.A)
cargo clippy --no-deps -p dasclaw_bash_validation --all-targets -- -D warnings   # 0 warnings
cargo fmt --all
python3.12 scripts/check_no_panics.py --base origin/xClaw   # clean
```

## Cross-cuts

类A（无新增 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量）。

## 关联

- ADR-129 bash-parity
- Plan: `docs/plans/bash-parity/phase-3.2-readonly-validation-deepening.md` §74
- Foundation: PR #588 (3.2.A flag-parser) + PR #592 (3.2.B bash_allowlist)
- 上游: `claude-code-main/src/utils/shell/readOnlyCommandValidation.ts` L1386-L1538

## Sources read

- `AGENTS.md` § GitHub PR 工作流 / Skills 强制使用规范
- `docs/plans/bash-parity/phase-3.2-readonly-validation-deepening.md` §66 / §74
- `claude-code-main/src/utils/shell/readOnlyCommandValidation.ts` L1386-L1538

Closes #593