### PR TITLE
feat(bash-validation): port GIT + GH + ANT_ONLY readonly tables [3.2.C.rest]

### DIFF
--- a/crates/dasclaw_bash_validation/src/readonly/bash_allowlist.rs
+++ b/crates/dasclaw_bash_validation/src/readonly/bash_allowlist.rs
@@ -8,9 +8,13 @@
 //! The dispatcher and callbacks integration land in Phase 3.2.C/D/E per
 //! ADR-129 verbatim-port discipline.
 //!
-//! Spreads deferred to Phase 3.2.C: `GIT_READ_ONLY_COMMANDS`,
-//! `RIPGREP_READ_ONLY_COMMANDS`, `DOCKER_READ_ONLY_COMMANDS`,
-//! `PYRIGHT_READ_ONLY_COMMANDS`, `ANT_ONLY_COMMAND_ALLOWLIST` (gh, aki).
+//! Phase 3.2.C wires all external tables: `GIT_READ_ONLY_COMMANDS`
+//! (`super::git_allowlist`), `RIPGREP_READ_ONLY_COMMANDS`,
+//! `DOCKER_READ_ONLY_COMMANDS`, `PYRIGHT_READ_ONLY_COMMANDS`
+//! (`super::external_tables`), and `ANT_ONLY_COMMANDS` (gh + aki,
+//! `super::gh_allowlist`). `get_command_allowlist()` applies the
+//! `USER_TYPE=ant` + Windows-xargs-strip gates that mirror upstream
+//! `getCommandAllowlist()` (readOnlyValidation.ts L1199-L1213).
 //!
 //! See `docs/plans/bash-parity/phase-3.2-readonly-validation-deepening.md`
 //! and ADR-129 (verbatim-port discipline).
@@ -21,6 +25,8 @@ use super::external_tables::{
     DOCKER_READ_ONLY_COMMANDS, PYRIGHT_READ_ONLY_COMMANDS, RIPGREP_READ_ONLY_COMMANDS,
 };
 use super::flag_parser::{validate_flags, CommandConfig, FlagArgType, ValidateOptions};
+use super::gh_allowlist::ANT_ONLY_COMMANDS;
+use super::git_allowlist::GIT_READ_ONLY_COMMANDS;
 
 // ============================================================================
 // Shared safe flags for `fd` and `fdfind` (Debian/Ubuntu package name).
@@ -1040,22 +1046,37 @@ const FDFIND_CONFIG: CommandConfig = CommandConfig {
 // Master allowlist.
 // ============================================================================
 
-/// Master command allowlist. Each entry maps a command name to its
-/// [`CommandConfig`]. Looked up by the dispatcher.
+/// Base allowlist (USER_TYPE != ant). Order is SECURITY-significant —
+/// first-match-wins, matching upstream `readOnlyValidation.ts` L128-L1140.
 ///
-/// Order is SECURITY-significant — first-match-wins. Inline entries come
-/// first (matching upstream `readOnlyValidation.ts` L128–L1140), followed
-/// by the external tables (upstream L1135–L1136 spreads externals after
-/// inline). Multi-word entries (e.g. `docker logs`) precede any shorter
-/// prefix that could shadow them; none of the current inline entries
-/// collide with the external entries.
+/// Layout (in iteration order):
+///   1. 23 inline single-binary entries (xargs..fdfind). On Windows, `xargs`
+///      is omitted because file contents containing UNC paths can be piped
+///      to `xargs cat` to trigger SMB resolution — bypassing string-based
+///      detection (upstream L1193-L1198).
+///   2. DOCKER / RIPGREP / PYRIGHT external tables (multi-word entries like
+///      `docker logs` first, then single-binary `rg` / `pyright`). Order
+///      within externals (DOCKER → RIPGREP → PYRIGHT) differs cosmetically
+///      from upstream (PYRIGHT → DOCKER); since keys don't collide,
+///      first-match-wins behavior is identical.
+///   3. GIT_READ_ONLY_COMMANDS (`git diff`, `git log`, …) — 24 entries in
+///      longest-prefix order (`git remote show` before `git remote`).
 ///
-/// Phase 3.2.C.2.a wires DOCKER / RIPGREP / PYRIGHT external tables.
-/// GIT (3.2.C.1) and GH / AKI (3.2.C.2.b) ship in separate PRs.
-pub static COMMAND_ALLOWLIST: LazyLock<Vec<(&'static str, &'static CommandConfig)>> =
+/// Upstream `COMMAND_ALLOWLIST` interleaves GIT after line 164 and RIPGREP
+/// after line 559; we group all externals at the end because none of the
+/// external keys collide with inline keys (verified by Layer 1 audit), so
+/// first-match-wins lookup yields the same result.
+static COMMAND_ALLOWLIST_BASE: LazyLock<Vec<(&'static str, &'static CommandConfig)>> =
     LazyLock::new(|| {
-        let mut out: Vec<(&'static str, &'static CommandConfig)> = vec![
-            ("xargs", &XARGS_CONFIG),
+        let mut out: Vec<(&'static str, &'static CommandConfig)> = Vec::new();
+        // SECURITY: omit `xargs` on Windows. UNC paths in file contents can
+        // be piped to `xargs cat` triggering SMB resolution; regex-based
+        // detection cannot inspect file contents. Matches upstream
+        // `getCommandAllowlist()` L1193-L1198.
+        if !cfg!(target_os = "windows") {
+            out.push(("xargs", &XARGS_CONFIG));
+        }
+        out.extend_from_slice(&[
             ("file", &FILE_CONFIG),
             ("sed", &SED_CONFIG),
             ("sort", &SORT_CONFIG),
@@ -1078,24 +1099,39 @@ pub static COMMAND_ALLOWLIST: LazyLock<Vec<(&'static str, &'static CommandConfig
             ("ss", &SS_CONFIG),
             ("fd", &FD_CONFIG),
             ("fdfind", &FDFIND_CONFIG),
-        ];
-        // Append external tables AFTER the 23 inline entries. Upstream
-        // `readOnlyValidation.ts` L1135-L1140 spreads externals at the end
-        // of the inline literal in PYRIGHT → DOCKER order; we likewise
-        // append at the end. The order within externals (DOCKER → RIPGREP
-        // → PYRIGHT) diverges from upstream cosmetically only — none of
-        // these tables' keys collide with each other or with the inline
-        // 23 entries, so first-match-wins behavior is identical to the
-        // upstream order. Verified by Layer 1 audit.
+        ]);
         out.extend_from_slice(DOCKER_READ_ONLY_COMMANDS);
         out.extend_from_slice(RIPGREP_READ_ONLY_COMMANDS);
         out.extend_from_slice(PYRIGHT_READ_ONLY_COMMANDS);
+        out.extend(GIT_READ_ONLY_COMMANDS.iter().copied());
         out
     });
 
+/// Ant-extended allowlist (USER_TYPE == ant). Appends `ANT_ONLY_COMMANDS`
+/// (22 gh entries + aki) to the base allowlist. Matches upstream
+/// `{ ...allowlist, ...ANT_ONLY_COMMAND_ALLOWLIST }` (L1212).
+static COMMAND_ALLOWLIST_ANT: LazyLock<Vec<(&'static str, &'static CommandConfig)>> =
+    LazyLock::new(|| {
+        let mut out = COMMAND_ALLOWLIST_BASE.clone();
+        out.extend(ANT_ONLY_COMMANDS.iter().copied());
+        out
+    });
+
+/// Return the effective allowlist for the current process. Reads
+/// `USER_TYPE` on every call (matching upstream `getCommandAllowlist()`
+/// L1201-L1212 which reads `process.env.USER_TYPE` per call). Both base
+/// and ant variants are statically cached, so the per-call cost is one
+/// env lookup and one branch.
+pub fn get_command_allowlist() -> &'static [(&'static str, &'static CommandConfig)] {
+    if std::env::var("USER_TYPE").as_deref() == Ok("ant") {
+        &COMMAND_ALLOWLIST_ANT
+    } else {
+        &COMMAND_ALLOWLIST_BASE
+    }
+}
+
 /// Phase 3.2.B port of `isCommandSafeViaFlagParsing` (claude-code-main
-/// readOnlyValidation.ts L1245-L1408). Top-level `COMMAND_ALLOWLIST` only —
-/// external tables (GIT/GH/RIPGREP/DOCKER/PYRIGHT) deferred to 3.2.C.
+/// readOnlyValidation.ts L1245-L1408).
 pub fn is_command_safe_via_flag_parsing(command: &str) -> bool {
     let tokens = match shell_words::split(command) {
         Ok(t) if !t.is_empty() => t,
@@ -1104,11 +1140,11 @@ pub fn is_command_safe_via_flag_parsing(command: &str) -> bool {
 
     // Multi-word command lookup: first-match-wins, matching upstream
     // `for (cmd, config) of COMMAND_ALLOWLIST.entries()` with early break
-    // (readOnlyValidation.ts L1294-L1303). Order in COMMAND_ALLOWLIST is
-    // therefore SECURITY-significant for Phase 3.2.C when multi-word
-    // entries (e.g. `git diff`) are added.
+    // (readOnlyValidation.ts L1294-L1303). Order is SECURITY-significant:
+    // longest-prefix multi-word entries (e.g. `git remote show`) must
+    // precede shorter prefixes (`git remote`) in the underlying tables.
     let mut matched: Option<(usize, &CommandConfig)> = None;
-    for (cmd_pattern, config) in COMMAND_ALLOWLIST.iter() {
+    for (cmd_pattern, config) in get_command_allowlist().iter() {
         let cmd_tokens: Vec<&str> = cmd_pattern.split(' ').collect();
         if tokens.len() < cmd_tokens.len() {
             continue;

--- a/crates/dasclaw_bash_validation/src/readonly/gh_allowlist.rs
+++ b/crates/dasclaw_bash_validation/src/readonly/gh_allowlist.rs
@@ -1,0 +1,642 @@
+//! Verbatim port of `GH_READ_ONLY_COMMANDS` and `ANT_ONLY_COMMAND_ALLOWLIST`
+//! (gh + aki) from `claude-code-main/src/utils/shell/readOnlyCommandValidation.ts`
+//! (upstream L944-L1381) and `readOnlyValidation.ts` L1141-L1212.
+//!
+//! These commands are ant-only because they perform network requests, which
+//! violates the read-only validation principle of no network access. The
+//! refactored `get_command_allowlist()` in `bash_allowlist.rs` gates inclusion
+//! on `USER_TYPE=ant`.
+//!
+//! All 18 gh commands share `gh_is_dangerous_callback`, which rejects any
+//! token containing `://` (URL), `@` (SSH-style), or ≥2 slashes (3+ segments
+//! beyond gh's expected `OWNER/REPO` form). Five `gh search …` commands omit
+//! the callback because search queries legitimately contain those tokens
+//! (matching upstream).
+
+use std::sync::LazyLock;
+
+use super::flag_parser::{CommandConfig, FlagArgType};
+
+// SECURITY: Rejects any positional or flag-value token that looks like:
+//   - HOST/OWNER/REPO (3+ slash-separated segments)
+//   - Any token with `://` (URL)
+//   - Any token with `@` (SSH-style)
+// Covers BOTH `--repo VALUE` AND `--repo=VALUE` (cobra accepts both forms).
+fn gh_is_dangerous_callback(_raw_command: &str, args: &[&str]) -> bool {
+    for token in args {
+        if token.is_empty() {
+            continue;
+        }
+        // For flag tokens, extract VALUE after `=` for inspection. Without this
+        // `--repo=evil.com/SECRET/x` would be skipped, bypassing the HOST check.
+        let value: &str = if token.starts_with('-') {
+            match token.find('=') {
+                Some(eq_idx) => {
+                    let v = &token[eq_idx + 1..];
+                    if v.is_empty() {
+                        continue;
+                    }
+                    v
+                }
+                None => continue, // flag without inline value, nothing to inspect
+            }
+        } else {
+            token
+        };
+        // Skip values that are clearly not repo specs.
+        if !value.contains('/') && !value.contains("://") && !value.contains('@') {
+            continue;
+        }
+        // URL schemes: https://, http://, git://, ssh://
+        if value.contains("://") {
+            return true;
+        }
+        // SSH-style: git@host:owner/repo
+        if value.contains('@') {
+            return true;
+        }
+        // 3+ segments = HOST/OWNER/REPO (normal gh format is OWNER/REPO, 1 slash)
+        let slash_count = value.bytes().filter(|b| *b == b'/').count();
+        if slash_count >= 2 {
+            return true;
+        }
+    }
+    false
+}
+
+// ---------------------------------------------------------------------------
+// Per-command CommandConfig constants. 13 commands use the shared
+// `gh_is_dangerous_callback`; the 5 `gh search …` variants omit it because
+// search queries legitimately include `/`, `@`, and `://` characters.
+// ---------------------------------------------------------------------------
+
+// gh pr view — read-only PR details
+const GH_PR_VIEW_FLAGS: &[(&str, FlagArgType)] = &[
+    ("--json", FlagArgType::String),
+    ("--comments", FlagArgType::None),
+    ("--repo", FlagArgType::String),
+    ("-R", FlagArgType::String),
+];
+const GH_PR_VIEW_CONFIG: CommandConfig = CommandConfig {
+    safe_flags: GH_PR_VIEW_FLAGS,
+    additional_dangerous_callback: Some(gh_is_dangerous_callback),
+    respects_double_dash: true,
+};
+
+// gh pr list — read-only PR listing
+const GH_PR_LIST_FLAGS: &[(&str, FlagArgType)] = &[
+    ("--state", FlagArgType::String),
+    ("-s", FlagArgType::String),
+    ("--author", FlagArgType::String),
+    ("--assignee", FlagArgType::String),
+    ("--label", FlagArgType::String),
+    ("--limit", FlagArgType::Number),
+    ("-L", FlagArgType::Number),
+    ("--base", FlagArgType::String),
+    ("--head", FlagArgType::String),
+    ("--search", FlagArgType::String),
+    ("--json", FlagArgType::String),
+    ("--draft", FlagArgType::None),
+    ("--app", FlagArgType::String),
+    ("--repo", FlagArgType::String),
+    ("-R", FlagArgType::String),
+];
+const GH_PR_LIST_CONFIG: CommandConfig = CommandConfig {
+    safe_flags: GH_PR_LIST_FLAGS,
+    additional_dangerous_callback: Some(gh_is_dangerous_callback),
+    respects_double_dash: true,
+};
+
+// gh pr diff — read-only PR diff
+const GH_PR_DIFF_FLAGS: &[(&str, FlagArgType)] = &[
+    ("--color", FlagArgType::String),
+    ("--name-only", FlagArgType::None),
+    ("--patch", FlagArgType::None),
+    ("--repo", FlagArgType::String),
+    ("-R", FlagArgType::String),
+];
+const GH_PR_DIFF_CONFIG: CommandConfig = CommandConfig {
+    safe_flags: GH_PR_DIFF_FLAGS,
+    additional_dangerous_callback: Some(gh_is_dangerous_callback),
+    respects_double_dash: true,
+};
+
+// gh pr checks — read-only CI status checks
+const GH_PR_CHECKS_FLAGS: &[(&str, FlagArgType)] = &[
+    ("--watch", FlagArgType::None),
+    ("--required", FlagArgType::None),
+    ("--fail-fast", FlagArgType::None),
+    ("--json", FlagArgType::String),
+    ("--interval", FlagArgType::Number),
+    ("--repo", FlagArgType::String),
+    ("-R", FlagArgType::String),
+];
+const GH_PR_CHECKS_CONFIG: CommandConfig = CommandConfig {
+    safe_flags: GH_PR_CHECKS_FLAGS,
+    additional_dangerous_callback: Some(gh_is_dangerous_callback),
+    respects_double_dash: true,
+};
+
+// gh issue view — read-only issue details
+const GH_ISSUE_VIEW_FLAGS: &[(&str, FlagArgType)] = &[
+    ("--json", FlagArgType::String),
+    ("--comments", FlagArgType::None),
+    ("--repo", FlagArgType::String),
+    ("-R", FlagArgType::String),
+];
+const GH_ISSUE_VIEW_CONFIG: CommandConfig = CommandConfig {
+    safe_flags: GH_ISSUE_VIEW_FLAGS,
+    additional_dangerous_callback: Some(gh_is_dangerous_callback),
+    respects_double_dash: true,
+};
+
+// gh issue list — read-only issue listing
+const GH_ISSUE_LIST_FLAGS: &[(&str, FlagArgType)] = &[
+    ("--state", FlagArgType::String),
+    ("-s", FlagArgType::String),
+    ("--assignee", FlagArgType::String),
+    ("--author", FlagArgType::String),
+    ("--label", FlagArgType::String),
+    ("--limit", FlagArgType::Number),
+    ("-L", FlagArgType::Number),
+    ("--milestone", FlagArgType::String),
+    ("--search", FlagArgType::String),
+    ("--json", FlagArgType::String),
+    ("--app", FlagArgType::String),
+    ("--repo", FlagArgType::String),
+    ("-R", FlagArgType::String),
+];
+const GH_ISSUE_LIST_CONFIG: CommandConfig = CommandConfig {
+    safe_flags: GH_ISSUE_LIST_FLAGS,
+    additional_dangerous_callback: Some(gh_is_dangerous_callback),
+    respects_double_dash: true,
+};
+
+// gh repo view — uses positional argument, not --repo/-R flags
+const GH_REPO_VIEW_FLAGS: &[(&str, FlagArgType)] = &[("--json", FlagArgType::String)];
+const GH_REPO_VIEW_CONFIG: CommandConfig = CommandConfig {
+    safe_flags: GH_REPO_VIEW_FLAGS,
+    additional_dangerous_callback: Some(gh_is_dangerous_callback),
+    respects_double_dash: true,
+};
+
+// gh run list — read-only workflow runs listing
+const GH_RUN_LIST_FLAGS: &[(&str, FlagArgType)] = &[
+    ("--branch", FlagArgType::String),
+    ("-b", FlagArgType::String),
+    ("--status", FlagArgType::String),
+    ("-s", FlagArgType::String),
+    ("--workflow", FlagArgType::String),
+    // NOTE: -w is --workflow here, NOT --web (gh run list has no --web)
+    ("-w", FlagArgType::String),
+    ("--limit", FlagArgType::Number),
+    ("-L", FlagArgType::Number),
+    ("--json", FlagArgType::String),
+    ("--repo", FlagArgType::String),
+    ("-R", FlagArgType::String),
+    ("--event", FlagArgType::String),
+    ("-e", FlagArgType::String),
+    ("--user", FlagArgType::String),
+    ("-u", FlagArgType::String),
+    ("--created", FlagArgType::String),
+    ("--commit", FlagArgType::String),
+    ("-c", FlagArgType::String),
+];
+const GH_RUN_LIST_CONFIG: CommandConfig = CommandConfig {
+    safe_flags: GH_RUN_LIST_FLAGS,
+    additional_dangerous_callback: Some(gh_is_dangerous_callback),
+    respects_double_dash: true,
+};
+
+// gh run view — read-only workflow run details
+const GH_RUN_VIEW_FLAGS: &[(&str, FlagArgType)] = &[
+    ("--log", FlagArgType::None),
+    ("--log-failed", FlagArgType::None),
+    ("--exit-status", FlagArgType::None),
+    ("--verbose", FlagArgType::None),
+    // NOTE: -v is --verbose here, NOT --web
+    ("-v", FlagArgType::None),
+    ("--json", FlagArgType::String),
+    ("--repo", FlagArgType::String),
+    ("-R", FlagArgType::String),
+    ("--job", FlagArgType::String),
+    ("-j", FlagArgType::String),
+    ("--attempt", FlagArgType::Number),
+    ("-a", FlagArgType::Number),
+];
+const GH_RUN_VIEW_CONFIG: CommandConfig = CommandConfig {
+    safe_flags: GH_RUN_VIEW_FLAGS,
+    additional_dangerous_callback: Some(gh_is_dangerous_callback),
+    respects_double_dash: true,
+};
+
+// gh auth status — read-only auth state. --show-token/-t INTENTIONALLY excluded
+// (leaks secrets).
+const GH_AUTH_STATUS_FLAGS: &[(&str, FlagArgType)] = &[
+    ("--active", FlagArgType::None),
+    ("-a", FlagArgType::None),
+    ("--hostname", FlagArgType::String),
+    ("-h", FlagArgType::String),
+    ("--json", FlagArgType::String),
+];
+const GH_AUTH_STATUS_CONFIG: CommandConfig = CommandConfig {
+    safe_flags: GH_AUTH_STATUS_FLAGS,
+    additional_dangerous_callback: Some(gh_is_dangerous_callback),
+    respects_double_dash: true,
+};
+
+// gh pr status — read-only PR status overview
+const GH_PR_STATUS_FLAGS: &[(&str, FlagArgType)] = &[
+    ("--conflict-status", FlagArgType::None),
+    ("-c", FlagArgType::None),
+    ("--json", FlagArgType::String),
+    ("--repo", FlagArgType::String),
+    ("-R", FlagArgType::String),
+];
+const GH_PR_STATUS_CONFIG: CommandConfig = CommandConfig {
+    safe_flags: GH_PR_STATUS_FLAGS,
+    additional_dangerous_callback: Some(gh_is_dangerous_callback),
+    respects_double_dash: true,
+};
+
+// gh issue status — read-only issue status overview
+const GH_ISSUE_STATUS_FLAGS: &[(&str, FlagArgType)] = &[
+    ("--json", FlagArgType::String),
+    ("--repo", FlagArgType::String),
+    ("-R", FlagArgType::String),
+];
+const GH_ISSUE_STATUS_CONFIG: CommandConfig = CommandConfig {
+    safe_flags: GH_ISSUE_STATUS_FLAGS,
+    additional_dangerous_callback: Some(gh_is_dangerous_callback),
+    respects_double_dash: true,
+};
+
+// gh release list — read-only release listing
+const GH_RELEASE_LIST_FLAGS: &[(&str, FlagArgType)] = &[
+    ("--exclude-drafts", FlagArgType::None),
+    ("--exclude-pre-releases", FlagArgType::None),
+    ("--json", FlagArgType::String),
+    ("--limit", FlagArgType::Number),
+    ("-L", FlagArgType::Number),
+    ("--order", FlagArgType::String),
+    ("-O", FlagArgType::String),
+    ("--repo", FlagArgType::String),
+    ("-R", FlagArgType::String),
+];
+const GH_RELEASE_LIST_CONFIG: CommandConfig = CommandConfig {
+    safe_flags: GH_RELEASE_LIST_FLAGS,
+    additional_dangerous_callback: Some(gh_is_dangerous_callback),
+    respects_double_dash: true,
+};
+
+// gh release view — read-only release details. --web/-w INTENTIONALLY excluded
+// (opens browser).
+const GH_RELEASE_VIEW_FLAGS: &[(&str, FlagArgType)] = &[
+    ("--json", FlagArgType::String),
+    ("--repo", FlagArgType::String),
+    ("-R", FlagArgType::String),
+];
+const GH_RELEASE_VIEW_CONFIG: CommandConfig = CommandConfig {
+    safe_flags: GH_RELEASE_VIEW_FLAGS,
+    additional_dangerous_callback: Some(gh_is_dangerous_callback),
+    respects_double_dash: true,
+};
+
+// gh workflow list — read-only workflow file listing
+const GH_WORKFLOW_LIST_FLAGS: &[(&str, FlagArgType)] = &[
+    ("--all", FlagArgType::None),
+    ("-a", FlagArgType::None),
+    ("--json", FlagArgType::String),
+    ("--limit", FlagArgType::Number),
+    ("-L", FlagArgType::Number),
+    ("--repo", FlagArgType::String),
+    ("-R", FlagArgType::String),
+];
+const GH_WORKFLOW_LIST_CONFIG: CommandConfig = CommandConfig {
+    safe_flags: GH_WORKFLOW_LIST_FLAGS,
+    additional_dangerous_callback: Some(gh_is_dangerous_callback),
+    respects_double_dash: true,
+};
+
+// gh workflow view — read-only workflow summary. --web/-w INTENTIONALLY excluded
+// (opens browser).
+const GH_WORKFLOW_VIEW_FLAGS: &[(&str, FlagArgType)] = &[
+    ("--ref", FlagArgType::String),
+    ("-r", FlagArgType::String),
+    ("--yaml", FlagArgType::None),
+    ("-y", FlagArgType::None),
+    ("--repo", FlagArgType::String),
+    ("-R", FlagArgType::String),
+];
+const GH_WORKFLOW_VIEW_CONFIG: CommandConfig = CommandConfig {
+    safe_flags: GH_WORKFLOW_VIEW_FLAGS,
+    additional_dangerous_callback: Some(gh_is_dangerous_callback),
+    respects_double_dash: true,
+};
+
+// gh label list — read-only label listing. --web/-w INTENTIONALLY excluded
+// (opens browser).
+const GH_LABEL_LIST_FLAGS: &[(&str, FlagArgType)] = &[
+    ("--json", FlagArgType::String),
+    ("--limit", FlagArgType::Number),
+    ("-L", FlagArgType::Number),
+    ("--order", FlagArgType::String),
+    ("--search", FlagArgType::String),
+    ("-S", FlagArgType::String),
+    ("--sort", FlagArgType::String),
+    ("--repo", FlagArgType::String),
+    ("-R", FlagArgType::String),
+];
+const GH_LABEL_LIST_CONFIG: CommandConfig = CommandConfig {
+    safe_flags: GH_LABEL_LIST_FLAGS,
+    additional_dangerous_callback: Some(gh_is_dangerous_callback),
+    respects_double_dash: true,
+};
+
+// gh search repos — search repositories. NO callback because search queries
+// legitimately contain `/`, `@`, `://`. --web/-w INTENTIONALLY excluded.
+const GH_SEARCH_REPOS_FLAGS: &[(&str, FlagArgType)] = &[
+    ("--archived", FlagArgType::None),
+    ("--created", FlagArgType::String),
+    ("--followers", FlagArgType::String),
+    ("--forks", FlagArgType::String),
+    ("--good-first-issues", FlagArgType::String),
+    ("--help-wanted-issues", FlagArgType::String),
+    ("--include-forks", FlagArgType::String),
+    ("--json", FlagArgType::String),
+    ("--language", FlagArgType::String),
+    ("--license", FlagArgType::String),
+    ("--limit", FlagArgType::Number),
+    ("-L", FlagArgType::Number),
+    ("--match", FlagArgType::String),
+    ("--number-topics", FlagArgType::String),
+    ("--order", FlagArgType::String),
+    ("--owner", FlagArgType::String),
+    ("--size", FlagArgType::String),
+    ("--sort", FlagArgType::String),
+    ("--stars", FlagArgType::String),
+    ("--topic", FlagArgType::String),
+    ("--updated", FlagArgType::String),
+    ("--visibility", FlagArgType::String),
+];
+const GH_SEARCH_REPOS_CONFIG: CommandConfig = CommandConfig {
+    safe_flags: GH_SEARCH_REPOS_FLAGS,
+    additional_dangerous_callback: None,
+    respects_double_dash: true,
+};
+
+// gh search issues — search issues. NO callback. --web/-w INTENTIONALLY excluded.
+const GH_SEARCH_ISSUES_FLAGS: &[(&str, FlagArgType)] = &[
+    ("--app", FlagArgType::String),
+    ("--assignee", FlagArgType::String),
+    ("--author", FlagArgType::String),
+    ("--closed", FlagArgType::String),
+    ("--commenter", FlagArgType::String),
+    ("--comments", FlagArgType::String),
+    ("--created", FlagArgType::String),
+    ("--include-prs", FlagArgType::None),
+    ("--interactions", FlagArgType::String),
+    ("--involves", FlagArgType::String),
+    ("--json", FlagArgType::String),
+    ("--label", FlagArgType::String),
+    ("--language", FlagArgType::String),
+    ("--limit", FlagArgType::Number),
+    ("-L", FlagArgType::Number),
+    ("--locked", FlagArgType::None),
+    ("--match", FlagArgType::String),
+    ("--mentions", FlagArgType::String),
+    ("--milestone", FlagArgType::String),
+    ("--no-assignee", FlagArgType::None),
+    ("--no-label", FlagArgType::None),
+    ("--no-milestone", FlagArgType::None),
+    ("--no-project", FlagArgType::None),
+    ("--order", FlagArgType::String),
+    ("--owner", FlagArgType::String),
+    ("--project", FlagArgType::String),
+    ("--reactions", FlagArgType::String),
+    ("--repo", FlagArgType::String),
+    ("-R", FlagArgType::String),
+    ("--sort", FlagArgType::String),
+    ("--state", FlagArgType::String),
+    ("--team-mentions", FlagArgType::String),
+    ("--updated", FlagArgType::String),
+    ("--visibility", FlagArgType::String),
+];
+const GH_SEARCH_ISSUES_CONFIG: CommandConfig = CommandConfig {
+    safe_flags: GH_SEARCH_ISSUES_FLAGS,
+    additional_dangerous_callback: None,
+    respects_double_dash: true,
+};
+
+// gh search prs — search pull requests. NO callback. --web/-w INTENTIONALLY excluded.
+const GH_SEARCH_PRS_FLAGS: &[(&str, FlagArgType)] = &[
+    ("--app", FlagArgType::String),
+    ("--assignee", FlagArgType::String),
+    ("--author", FlagArgType::String),
+    ("--base", FlagArgType::String),
+    ("-B", FlagArgType::String),
+    ("--checks", FlagArgType::String),
+    ("--closed", FlagArgType::String),
+    ("--commenter", FlagArgType::String),
+    ("--comments", FlagArgType::String),
+    ("--created", FlagArgType::String),
+    ("--draft", FlagArgType::None),
+    ("--head", FlagArgType::String),
+    ("-H", FlagArgType::String),
+    ("--interactions", FlagArgType::String),
+    ("--involves", FlagArgType::String),
+    ("--json", FlagArgType::String),
+    ("--label", FlagArgType::String),
+    ("--language", FlagArgType::String),
+    ("--limit", FlagArgType::Number),
+    ("-L", FlagArgType::Number),
+    ("--locked", FlagArgType::None),
+    ("--match", FlagArgType::String),
+    ("--mentions", FlagArgType::String),
+    ("--merged", FlagArgType::None),
+    ("--merged-at", FlagArgType::String),
+    ("--milestone", FlagArgType::String),
+    ("--no-assignee", FlagArgType::None),
+    ("--no-label", FlagArgType::None),
+    ("--no-milestone", FlagArgType::None),
+    ("--no-project", FlagArgType::None),
+    ("--order", FlagArgType::String),
+    ("--owner", FlagArgType::String),
+    ("--project", FlagArgType::String),
+    ("--reactions", FlagArgType::String),
+    ("--repo", FlagArgType::String),
+    ("-R", FlagArgType::String),
+    ("--review", FlagArgType::String),
+    ("--review-requested", FlagArgType::String),
+    ("--reviewed-by", FlagArgType::String),
+    ("--sort", FlagArgType::String),
+    ("--state", FlagArgType::String),
+    ("--team-mentions", FlagArgType::String),
+    ("--updated", FlagArgType::String),
+    ("--visibility", FlagArgType::String),
+];
+const GH_SEARCH_PRS_CONFIG: CommandConfig = CommandConfig {
+    safe_flags: GH_SEARCH_PRS_FLAGS,
+    additional_dangerous_callback: None,
+    respects_double_dash: true,
+};
+
+// gh search commits — search commits. NO callback. --web/-w INTENTIONALLY excluded.
+const GH_SEARCH_COMMITS_FLAGS: &[(&str, FlagArgType)] = &[
+    ("--author", FlagArgType::String),
+    ("--author-date", FlagArgType::String),
+    ("--author-email", FlagArgType::String),
+    ("--author-name", FlagArgType::String),
+    ("--committer", FlagArgType::String),
+    ("--committer-date", FlagArgType::String),
+    ("--committer-email", FlagArgType::String),
+    ("--committer-name", FlagArgType::String),
+    ("--hash", FlagArgType::String),
+    ("--json", FlagArgType::String),
+    ("--limit", FlagArgType::Number),
+    ("-L", FlagArgType::Number),
+    ("--merge", FlagArgType::None),
+    ("--order", FlagArgType::String),
+    ("--owner", FlagArgType::String),
+    ("--parent", FlagArgType::String),
+    ("--repo", FlagArgType::String),
+    ("-R", FlagArgType::String),
+    ("--sort", FlagArgType::String),
+    ("--tree", FlagArgType::String),
+    ("--visibility", FlagArgType::String),
+];
+const GH_SEARCH_COMMITS_CONFIG: CommandConfig = CommandConfig {
+    safe_flags: GH_SEARCH_COMMITS_FLAGS,
+    additional_dangerous_callback: None,
+    respects_double_dash: true,
+};
+
+// gh search code — search code. NO callback. --web/-w INTENTIONALLY excluded.
+const GH_SEARCH_CODE_FLAGS: &[(&str, FlagArgType)] = &[
+    ("--extension", FlagArgType::String),
+    ("--filename", FlagArgType::String),
+    ("--json", FlagArgType::String),
+    ("--language", FlagArgType::String),
+    ("--limit", FlagArgType::Number),
+    ("-L", FlagArgType::Number),
+    ("--match", FlagArgType::String),
+    ("--owner", FlagArgType::String),
+    ("--repo", FlagArgType::String),
+    ("-R", FlagArgType::String),
+    ("--size", FlagArgType::String),
+];
+const GH_SEARCH_CODE_CONFIG: CommandConfig = CommandConfig {
+    safe_flags: GH_SEARCH_CODE_FLAGS,
+    additional_dangerous_callback: None,
+    respects_double_dash: true,
+};
+
+// ---------------------------------------------------------------------------
+// aki — Anthropic internal knowledge-base search CLI. Network read-only (same
+// policy as gh). --audit-csv INTENTIONALLY omitted (writes to disk).
+// ---------------------------------------------------------------------------
+const AKI_FLAGS: &[(&str, FlagArgType)] = &[
+    ("-h", FlagArgType::None),
+    ("--help", FlagArgType::None),
+    ("-k", FlagArgType::None),
+    ("--keyword", FlagArgType::None),
+    ("-s", FlagArgType::None),
+    ("--semantic", FlagArgType::None),
+    ("--no-adaptive", FlagArgType::None),
+    ("-n", FlagArgType::Number),
+    ("--limit", FlagArgType::Number),
+    ("-o", FlagArgType::Number),
+    ("--offset", FlagArgType::Number),
+    ("--source", FlagArgType::String),
+    ("--exclude-source", FlagArgType::String),
+    ("-a", FlagArgType::String),
+    ("--after", FlagArgType::String),
+    ("-b", FlagArgType::String),
+    ("--before", FlagArgType::String),
+    ("--collection", FlagArgType::String),
+    ("--drive", FlagArgType::String),
+    ("--folder", FlagArgType::String),
+    ("--descendants", FlagArgType::None),
+    ("-m", FlagArgType::String),
+    ("--meta", FlagArgType::String),
+    ("-t", FlagArgType::String),
+    ("--threshold", FlagArgType::String),
+    ("--kw-weight", FlagArgType::String),
+    ("--sem-weight", FlagArgType::String),
+    ("-j", FlagArgType::None),
+    ("--json", FlagArgType::None),
+    ("-c", FlagArgType::None),
+    ("--chunk", FlagArgType::None),
+    ("--preview", FlagArgType::None),
+    ("-d", FlagArgType::None),
+    ("--full-doc", FlagArgType::None),
+    ("-v", FlagArgType::None),
+    ("--verbose", FlagArgType::None),
+    ("--stats", FlagArgType::None),
+    ("-S", FlagArgType::Number),
+    ("--summarize", FlagArgType::Number),
+    ("--explain", FlagArgType::None),
+    ("--examine", FlagArgType::String),
+    ("--url", FlagArgType::String),
+    ("--multi-turn", FlagArgType::Number),
+    ("--multi-turn-model", FlagArgType::String),
+    ("--multi-turn-context", FlagArgType::String),
+    ("--no-rerank", FlagArgType::None),
+    ("--audit", FlagArgType::None),
+    ("--local", FlagArgType::None),
+    ("--staging", FlagArgType::None),
+];
+const AKI_CONFIG: CommandConfig = CommandConfig {
+    safe_flags: AKI_FLAGS,
+    additional_dangerous_callback: None,
+    respects_double_dash: true,
+};
+
+// ---------------------------------------------------------------------------
+// GH_READ_ONLY_COMMANDS — 22 gh commands in upstream object literal order.
+// Longest-prefix discipline: multi-word entries (`gh pr view`, `gh pr list`,
+// `gh pr diff`, `gh pr checks`, `gh pr status`) must precede any hypothetical
+// shorter `gh pr` entry; current set has none.
+//
+// SECURITY: All `gh search …` entries are AFTER the matching `gh issue …` /
+// `gh pr …` entries; since first-match-wins on tokens, this is safe because
+// `gh search issues` and `gh issue list` differ in their second token.
+// ---------------------------------------------------------------------------
+pub(crate) static GH_READ_ONLY_COMMANDS: LazyLock<Vec<(&'static str, &'static CommandConfig)>> =
+    LazyLock::new(|| {
+        vec![
+            ("gh pr view", &GH_PR_VIEW_CONFIG),
+            ("gh pr list", &GH_PR_LIST_CONFIG),
+            ("gh pr diff", &GH_PR_DIFF_CONFIG),
+            ("gh pr checks", &GH_PR_CHECKS_CONFIG),
+            ("gh issue view", &GH_ISSUE_VIEW_CONFIG),
+            ("gh issue list", &GH_ISSUE_LIST_CONFIG),
+            ("gh repo view", &GH_REPO_VIEW_CONFIG),
+            ("gh run list", &GH_RUN_LIST_CONFIG),
+            ("gh run view", &GH_RUN_VIEW_CONFIG),
+            ("gh auth status", &GH_AUTH_STATUS_CONFIG),
+            ("gh pr status", &GH_PR_STATUS_CONFIG),
+            ("gh issue status", &GH_ISSUE_STATUS_CONFIG),
+            ("gh release list", &GH_RELEASE_LIST_CONFIG),
+            ("gh release view", &GH_RELEASE_VIEW_CONFIG),
+            ("gh workflow list", &GH_WORKFLOW_LIST_CONFIG),
+            ("gh workflow view", &GH_WORKFLOW_VIEW_CONFIG),
+            ("gh label list", &GH_LABEL_LIST_CONFIG),
+            ("gh search repos", &GH_SEARCH_REPOS_CONFIG),
+            ("gh search issues", &GH_SEARCH_ISSUES_CONFIG),
+            ("gh search prs", &GH_SEARCH_PRS_CONFIG),
+            ("gh search commits", &GH_SEARCH_COMMITS_CONFIG),
+            ("gh search code", &GH_SEARCH_CODE_CONFIG),
+        ]
+    });
+
+// ---------------------------------------------------------------------------
+// ANT_ONLY_COMMANDS — gh + aki. Gated on USER_TYPE=ant in
+// `bash_allowlist::get_command_allowlist()` (matches upstream L1201-L1208).
+// ---------------------------------------------------------------------------
+pub(crate) static ANT_ONLY_COMMANDS: LazyLock<Vec<(&'static str, &'static CommandConfig)>> =
+    LazyLock::new(|| {
+        let mut out: Vec<(&'static str, &'static CommandConfig)> = GH_READ_ONLY_COMMANDS.clone();
+        out.push(("aki", &AKI_CONFIG));
+        out
+    });

--- a/crates/dasclaw_bash_validation/src/readonly/git_allowlist.rs
+++ b/crates/dasclaw_bash_validation/src/readonly/git_allowlist.rs
@@ -1,0 +1,1064 @@
+//! Phase 3.2.C.rest — verbatim port of `GIT_READ_ONLY_COMMANDS` and the
+//! 8 shared GIT flag groups from
+//! `claude-code-main/src/utils/shell/readOnlyCommandValidation.ts` L44-924.
+//!
+//! 24 git subcommands in upstream order:
+//!   git diff, git log, git show, git shortlog, git reflog,
+//!   git stash list, git ls-remote, git status, git blame, git ls-files,
+//!   git config --get, git remote show, git remote, git merge-base,
+//!   git rev-parse, git rev-list, git describe, git cat-file,
+//!   git for-each-ref, git grep, git stash show, git worktree list,
+//!   git tag, git branch.
+//!
+//! Five commands carry an `additional_dangerous_callback`:
+//!   - `git reflog`        : block `expire`/`delete`/`exists` subcommands.
+//!   - `git remote show`   : require exactly one alphanumeric remote name.
+//!   - `git remote`        : reject any positional argument.
+//!   - `git tag`           : reject positional tag creation without `-l/--list`.
+//!   - `git branch`        : reject positional branch creation without `-l/--list`
+//!     (or optional-arg `--merged`/`--no-merged`).
+//!
+//! All `// SECURITY:` comments from upstream are preserved verbatim.
+
+use std::sync::LazyLock;
+
+use super::flag_parser::{CommandConfig, FlagArgType};
+
+// ---------------------------------------------------------------------------
+// Shared git flag groups (upstream L44-103)
+// ---------------------------------------------------------------------------
+
+const GIT_REF_SELECTION_FLAGS: &[(&str, FlagArgType)] = &[
+    ("--all", FlagArgType::None),
+    ("--branches", FlagArgType::None),
+    ("--tags", FlagArgType::None),
+    ("--remotes", FlagArgType::None),
+];
+
+const GIT_DATE_FILTER_FLAGS: &[(&str, FlagArgType)] = &[
+    ("--since", FlagArgType::String),
+    ("--after", FlagArgType::String),
+    ("--until", FlagArgType::String),
+    ("--before", FlagArgType::String),
+];
+
+const GIT_LOG_DISPLAY_FLAGS: &[(&str, FlagArgType)] = &[
+    ("--oneline", FlagArgType::None),
+    ("--graph", FlagArgType::None),
+    ("--decorate", FlagArgType::None),
+    ("--no-decorate", FlagArgType::None),
+    ("--date", FlagArgType::String),
+    ("--relative-date", FlagArgType::None),
+];
+
+const GIT_COUNT_FLAGS: &[(&str, FlagArgType)] = &[
+    ("--max-count", FlagArgType::Number),
+    ("-n", FlagArgType::Number),
+];
+
+// Stat output flags - used in git log, show, diff
+const GIT_STAT_FLAGS: &[(&str, FlagArgType)] = &[
+    ("--stat", FlagArgType::None),
+    ("--numstat", FlagArgType::None),
+    ("--shortstat", FlagArgType::None),
+    ("--name-only", FlagArgType::None),
+    ("--name-status", FlagArgType::None),
+];
+
+// Color output flags - used in git log, show, diff
+const GIT_COLOR_FLAGS: &[(&str, FlagArgType)] = &[
+    ("--color", FlagArgType::None),
+    ("--no-color", FlagArgType::None),
+];
+
+// Patch display flags - used in git log, show
+const GIT_PATCH_FLAGS: &[(&str, FlagArgType)] = &[
+    ("--patch", FlagArgType::None),
+    ("-p", FlagArgType::None),
+    ("--no-patch", FlagArgType::None),
+    ("--no-ext-diff", FlagArgType::None),
+    ("-s", FlagArgType::None),
+];
+
+// Author/committer filter flags - used in git log, reflog
+const GIT_AUTHOR_FILTER_FLAGS: &[(&str, FlagArgType)] = &[
+    ("--author", FlagArgType::String),
+    ("--committer", FlagArgType::String),
+    ("--grep", FlagArgType::String),
+];
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Leak a vector of static-strized flag tuples to obtain a `&'static [...]`
+/// usable inside a `CommandConfig`. Called once per command at first access.
+fn leak_flags(v: Vec<(&'static str, FlagArgType)>) -> &'static [(&'static str, FlagArgType)] {
+    Box::leak(v.into_boxed_slice())
+}
+
+// ---------------------------------------------------------------------------
+// Callbacks (5)
+// ---------------------------------------------------------------------------
+
+// SECURITY: Block `git reflog expire`/`delete`/`exists` — they write to
+// .git/logs/**. Bare `git reflog` and `git reflog show` are safe.
+fn git_reflog_callback(_raw: &str, args: &[&str]) -> bool {
+    const DANGEROUS_SUBCOMMANDS: &[&str] = &["expire", "delete", "exists"];
+    for token in args {
+        if token.is_empty() || token.starts_with('-') {
+            continue;
+        }
+        if DANGEROUS_SUBCOMMANDS.contains(token) {
+            return true;
+        }
+        return false;
+    }
+    false
+}
+
+// Only allow optional -n, then one alphanumeric remote name.
+fn git_remote_show_callback(_raw: &str, args: &[&str]) -> bool {
+    let positional: Vec<&&str> = args.iter().filter(|a| **a != "-n").collect();
+    if positional.len() != 1 {
+        return true;
+    }
+    let name = positional[0];
+    if name.is_empty() {
+        return true;
+    }
+    !name
+        .bytes()
+        .all(|b| b.is_ascii_alphanumeric() || b == b'_' || b == b'-')
+}
+
+// Only allow bare `git remote` or `git remote -v/--verbose`.
+fn git_remote_callback(_raw: &str, args: &[&str]) -> bool {
+    args.iter().any(|a| *a != "-v" && *a != "--verbose")
+}
+
+// Helper for git tag / git branch: returns true if a short-flag bundle
+// (e.g. `-li`) contains `l`. Mirrors upstream `token.slice(1).includes('l')`.
+fn short_bundle_contains_l(token: &str) -> bool {
+    let b = token.as_bytes();
+    b.len() > 2 && b[0] == b'-' && b[1] != b'-' && !token.contains('=') && token[1..].contains('l')
+}
+
+// SECURITY: Block tag creation via positional args. `git tag foo` writes
+// .git/refs/tags/foo. Safe uses: bare `git tag`, `git tag -l <pattern>`,
+// `git tag --contains <ref>`.
+fn git_tag_callback(_raw: &str, args: &[&str]) -> bool {
+    const FLAGS_WITH_ARGS: &[&str] = &[
+        "--contains",
+        "--no-contains",
+        "--merged",
+        "--no-merged",
+        "--points-at",
+        "--sort",
+        "--format",
+        "-n",
+    ];
+    let mut i = 0;
+    let mut seen_list_flag = false;
+    let mut seen_dash_dash = false;
+    while i < args.len() {
+        let token = args[i];
+        if token.is_empty() {
+            i += 1;
+            continue;
+        }
+        if token == "--" && !seen_dash_dash {
+            seen_dash_dash = true;
+            i += 1;
+            continue;
+        }
+        if !seen_dash_dash && token.starts_with('-') {
+            if token == "--list" || token == "-l" || short_bundle_contains_l(token) {
+                seen_list_flag = true;
+            }
+            if token.contains('=') {
+                i += 1;
+            } else if FLAGS_WITH_ARGS.contains(&token) {
+                i += 2;
+            } else {
+                i += 1;
+            }
+        } else {
+            // Non-flag positional (or post-`--` positional). Safe only if
+            // preceded by -l/--list (then it's a pattern, not a tag name).
+            if !seen_list_flag {
+                return true;
+            }
+            i += 1;
+        }
+    }
+    false
+}
+
+// SECURITY: Block branch creation via positional args. Safe uses:
+// `git branch`, `git branch -flags` (list), or filtering via
+// --contains/--merged/etc.
+fn git_branch_callback(_raw: &str, args: &[&str]) -> bool {
+    // Flags that require an argument
+    const FLAGS_WITH_ARGS: &[&str] = &[
+        "--contains",
+        "--no-contains",
+        "--points-at",
+        "--sort",
+        // --abbrev REMOVED: git does NOT consume detached arg (PARSE_OPT_OPTARG)
+    ];
+    // Flags with optional arguments (don't require, but can take one)
+    const FLAGS_WITH_OPTIONAL_ARGS: &[&str] = &["--merged", "--no-merged"];
+    let mut i = 0;
+    let mut last_flag: &str = "";
+    let mut seen_list_flag = false;
+    let mut seen_dash_dash = false;
+    while i < args.len() {
+        let token = args[i];
+        if token.is_empty() {
+            i += 1;
+            continue;
+        }
+        // `--` ends flag parsing. `git branch -- -l` CREATES a branch named `-l`.
+        if token == "--" && !seen_dash_dash {
+            seen_dash_dash = true;
+            last_flag = "";
+            i += 1;
+            continue;
+        }
+        if !seen_dash_dash && token.starts_with('-') {
+            if token == "--list" || token == "-l" || short_bundle_contains_l(token) {
+                seen_list_flag = true;
+            }
+            if let Some(eq_idx) = token.find('=') {
+                last_flag = &token[..eq_idx];
+                i += 1;
+            } else if FLAGS_WITH_ARGS.contains(&token) {
+                last_flag = token;
+                i += 2;
+            } else {
+                last_flag = token;
+                i += 1;
+            }
+        } else {
+            let last_flag_has_optional_arg = FLAGS_WITH_OPTIONAL_ARGS.contains(&last_flag);
+            if !seen_list_flag && !last_flag_has_optional_arg {
+                return true; // Positional without --list = branch creation
+            }
+            i += 1;
+        }
+    }
+    false
+}
+
+// ---------------------------------------------------------------------------
+// Per-command flags + configs (block A: diff, log, show, shortlog, reflog,
+// stash list, ls-remote, status)
+// ---------------------------------------------------------------------------
+
+// ---- git diff (upstream L108-179) ------------------------------------------
+static GIT_DIFF_FLAGS: LazyLock<&'static [(&'static str, FlagArgType)]> = LazyLock::new(|| {
+    let mut v: Vec<(&'static str, FlagArgType)> = Vec::new();
+    v.extend_from_slice(GIT_STAT_FLAGS);
+    v.extend_from_slice(GIT_COLOR_FLAGS);
+    v.extend_from_slice(&[
+        ("--dirstat", FlagArgType::None),
+        ("--summary", FlagArgType::None),
+        ("--patch-with-stat", FlagArgType::None),
+        ("--word-diff", FlagArgType::None),
+        ("--word-diff-regex", FlagArgType::String),
+        ("--color-words", FlagArgType::None),
+        ("--no-renames", FlagArgType::None),
+        ("--no-ext-diff", FlagArgType::None),
+        ("--check", FlagArgType::None),
+        ("--ws-error-highlight", FlagArgType::String),
+        ("--full-index", FlagArgType::None),
+        ("--binary", FlagArgType::None),
+        ("--abbrev", FlagArgType::Number),
+        ("--break-rewrites", FlagArgType::None),
+        ("--find-renames", FlagArgType::None),
+        ("--find-copies", FlagArgType::None),
+        ("--find-copies-harder", FlagArgType::None),
+        ("--irreversible-delete", FlagArgType::None),
+        ("--diff-algorithm", FlagArgType::String),
+        ("--histogram", FlagArgType::None),
+        ("--patience", FlagArgType::None),
+        ("--minimal", FlagArgType::None),
+        ("--ignore-space-at-eol", FlagArgType::None),
+        ("--ignore-space-change", FlagArgType::None),
+        ("--ignore-all-space", FlagArgType::None),
+        ("--ignore-blank-lines", FlagArgType::None),
+        ("--inter-hunk-context", FlagArgType::Number),
+        ("--function-context", FlagArgType::None),
+        ("--exit-code", FlagArgType::None),
+        ("--quiet", FlagArgType::None),
+        ("--cached", FlagArgType::None),
+        ("--staged", FlagArgType::None),
+        ("--pickaxe-regex", FlagArgType::None),
+        ("--pickaxe-all", FlagArgType::None),
+        ("--no-index", FlagArgType::None),
+        ("--relative", FlagArgType::String),
+        ("--diff-filter", FlagArgType::String),
+        ("-p", FlagArgType::None),
+        ("-u", FlagArgType::None),
+        ("-s", FlagArgType::None),
+        ("-M", FlagArgType::None),
+        ("-C", FlagArgType::None),
+        ("-B", FlagArgType::None),
+        ("-D", FlagArgType::None),
+        ("-l", FlagArgType::None),
+        // SECURITY: -S/-G/-O take REQUIRED string arguments (pickaxe search,
+        // pickaxe regex, orderfile). Previously 'none' caused a parser
+        // differential with git: `git diff -S -- --output=/tmp/pwned` —
+        // validator sees -S as no-arg → advances 1 token → breaks on `--` →
+        // --output unchecked. git sees -S requires arg → consumes `--` as the
+        // pickaxe string (standard getopt: required-arg options consume next
+        // argv unconditionally, BEFORE the top-level `--` check) → cursor at
+        // --output=... → parses as long option → ARBITRARY FILE WRITE.
+        // git log config correctly has -S/-G as 'string'.
+        ("-S", FlagArgType::String),
+        ("-G", FlagArgType::String),
+        ("-O", FlagArgType::String),
+        ("-R", FlagArgType::None),
+    ]);
+    leak_flags(v)
+});
+static GIT_DIFF_CONFIG: LazyLock<CommandConfig> = LazyLock::new(|| CommandConfig {
+    safe_flags: *GIT_DIFF_FLAGS,
+    additional_dangerous_callback: None,
+    respects_double_dash: true,
+});
+
+// ---- git log (upstream L180-237) -------------------------------------------
+static GIT_LOG_FLAGS: LazyLock<&'static [(&'static str, FlagArgType)]> = LazyLock::new(|| {
+    let mut v: Vec<(&'static str, FlagArgType)> = Vec::new();
+    v.extend_from_slice(GIT_LOG_DISPLAY_FLAGS);
+    v.extend_from_slice(GIT_REF_SELECTION_FLAGS);
+    v.extend_from_slice(GIT_DATE_FILTER_FLAGS);
+    v.extend_from_slice(GIT_COUNT_FLAGS);
+    v.extend_from_slice(GIT_STAT_FLAGS);
+    v.extend_from_slice(GIT_COLOR_FLAGS);
+    v.extend_from_slice(GIT_PATCH_FLAGS);
+    v.extend_from_slice(GIT_AUTHOR_FILTER_FLAGS);
+    v.extend_from_slice(&[
+        ("--abbrev-commit", FlagArgType::None),
+        ("--full-history", FlagArgType::None),
+        ("--dense", FlagArgType::None),
+        ("--sparse", FlagArgType::None),
+        ("--simplify-merges", FlagArgType::None),
+        ("--ancestry-path", FlagArgType::None),
+        ("--source", FlagArgType::None),
+        ("--first-parent", FlagArgType::None),
+        ("--merges", FlagArgType::None),
+        ("--no-merges", FlagArgType::None),
+        ("--reverse", FlagArgType::None),
+        ("--walk-reflogs", FlagArgType::None),
+        ("--skip", FlagArgType::Number),
+        ("--max-age", FlagArgType::Number),
+        ("--min-age", FlagArgType::Number),
+        ("--no-min-parents", FlagArgType::None),
+        ("--no-max-parents", FlagArgType::None),
+        ("--follow", FlagArgType::None),
+        ("--no-walk", FlagArgType::None),
+        ("--left-right", FlagArgType::None),
+        ("--cherry-mark", FlagArgType::None),
+        ("--cherry-pick", FlagArgType::None),
+        ("--boundary", FlagArgType::None),
+        ("--topo-order", FlagArgType::None),
+        ("--date-order", FlagArgType::None),
+        ("--author-date-order", FlagArgType::None),
+        ("--pretty", FlagArgType::String),
+        ("--format", FlagArgType::String),
+        ("--diff-filter", FlagArgType::String),
+        ("-S", FlagArgType::String),
+        ("-G", FlagArgType::String),
+        ("--pickaxe-regex", FlagArgType::None),
+        ("--pickaxe-all", FlagArgType::None),
+    ]);
+    leak_flags(v)
+});
+static GIT_LOG_CONFIG: LazyLock<CommandConfig> = LazyLock::new(|| CommandConfig {
+    safe_flags: *GIT_LOG_FLAGS,
+    additional_dangerous_callback: None,
+    respects_double_dash: true,
+});
+
+// ---- git show (upstream L238-258) ------------------------------------------
+static GIT_SHOW_FLAGS: LazyLock<&'static [(&'static str, FlagArgType)]> = LazyLock::new(|| {
+    let mut v: Vec<(&'static str, FlagArgType)> = Vec::new();
+    v.extend_from_slice(GIT_LOG_DISPLAY_FLAGS);
+    v.extend_from_slice(GIT_STAT_FLAGS);
+    v.extend_from_slice(GIT_COLOR_FLAGS);
+    v.extend_from_slice(GIT_PATCH_FLAGS);
+    v.extend_from_slice(&[
+        ("--abbrev-commit", FlagArgType::None),
+        ("--word-diff", FlagArgType::None),
+        ("--word-diff-regex", FlagArgType::String),
+        ("--color-words", FlagArgType::None),
+        ("--pretty", FlagArgType::String),
+        ("--format", FlagArgType::String),
+        ("--first-parent", FlagArgType::None),
+        ("--raw", FlagArgType::None),
+        ("--diff-filter", FlagArgType::String),
+        ("-m", FlagArgType::None),
+        ("--quiet", FlagArgType::None),
+    ]);
+    leak_flags(v)
+});
+static GIT_SHOW_CONFIG: LazyLock<CommandConfig> = LazyLock::new(|| CommandConfig {
+    safe_flags: *GIT_SHOW_FLAGS,
+    additional_dangerous_callback: None,
+    respects_double_dash: true,
+});
+
+// ---- git shortlog (upstream L259-279) --------------------------------------
+static GIT_SHORTLOG_FLAGS: LazyLock<&'static [(&'static str, FlagArgType)]> = LazyLock::new(|| {
+    let mut v: Vec<(&'static str, FlagArgType)> = Vec::new();
+    v.extend_from_slice(GIT_REF_SELECTION_FLAGS);
+    v.extend_from_slice(GIT_DATE_FILTER_FLAGS);
+    v.extend_from_slice(&[
+        ("-s", FlagArgType::None),
+        ("--summary", FlagArgType::None),
+        ("-n", FlagArgType::None),
+        ("--numbered", FlagArgType::None),
+        ("-e", FlagArgType::None),
+        ("--email", FlagArgType::None),
+        ("-c", FlagArgType::None),
+        ("--committer", FlagArgType::None),
+        ("--group", FlagArgType::String),
+        ("--format", FlagArgType::String),
+        ("--no-merges", FlagArgType::None),
+        ("--author", FlagArgType::String),
+    ]);
+    leak_flags(v)
+});
+static GIT_SHORTLOG_CONFIG: LazyLock<CommandConfig> = LazyLock::new(|| CommandConfig {
+    safe_flags: *GIT_SHORTLOG_FLAGS,
+    additional_dangerous_callback: None,
+    respects_double_dash: true,
+});
+
+// ---- git reflog (upstream L280-322) ----------------------------------------
+// SECURITY: Block `git reflog expire` (positional subcommand) — it writes
+// to .git/logs/** by expiring reflog entries. `git reflog delete` similarly
+// writes. Only `git reflog` (bare = show) and `git reflog show` are safe.
+// The positional-arg fallthrough would otherwise accept `expire` as a
+// non-flag arg, and `--all` is in GIT_REF_SELECTION_FLAGS → passes.
+static GIT_REFLOG_FLAGS: LazyLock<&'static [(&'static str, FlagArgType)]> = LazyLock::new(|| {
+    let mut v: Vec<(&'static str, FlagArgType)> = Vec::new();
+    v.extend_from_slice(GIT_LOG_DISPLAY_FLAGS);
+    v.extend_from_slice(GIT_REF_SELECTION_FLAGS);
+    v.extend_from_slice(GIT_DATE_FILTER_FLAGS);
+    v.extend_from_slice(GIT_COUNT_FLAGS);
+    v.extend_from_slice(GIT_AUTHOR_FILTER_FLAGS);
+    leak_flags(v)
+});
+static GIT_REFLOG_CONFIG: LazyLock<CommandConfig> = LazyLock::new(|| CommandConfig {
+    safe_flags: *GIT_REFLOG_FLAGS,
+    additional_dangerous_callback: Some(git_reflog_callback),
+    respects_double_dash: true,
+});
+
+// ---- git stash list (upstream L323-329) ------------------------------------
+static GIT_STASH_LIST_FLAGS: LazyLock<&'static [(&'static str, FlagArgType)]> =
+    LazyLock::new(|| {
+        let mut v: Vec<(&'static str, FlagArgType)> = Vec::new();
+        v.extend_from_slice(GIT_LOG_DISPLAY_FLAGS);
+        v.extend_from_slice(GIT_REF_SELECTION_FLAGS);
+        v.extend_from_slice(GIT_COUNT_FLAGS);
+        leak_flags(v)
+    });
+static GIT_STASH_LIST_CONFIG: LazyLock<CommandConfig> = LazyLock::new(|| CommandConfig {
+    safe_flags: *GIT_STASH_LIST_FLAGS,
+    additional_dangerous_callback: None,
+    respects_double_dash: true,
+});
+
+// ---- git ls-remote (upstream L330-358) -------------------------------------
+// SECURITY: --server-option and -o are INTENTIONALLY EXCLUDED. They transmit
+// an arbitrary attacker-controlled string to the remote git server in the
+// protocol v2 capability advertisement. This is a network WRITE primitive
+// (sending data to remote) on what is supposed to be a read-only command.
+// Even without command substitution (which is caught elsewhere),
+// `--server-option="sensitive-data"` exfiltrates the value to whatever
+// `origin` points to. The read-only path should never enable network writes.
+const GIT_LS_REMOTE_FLAGS: &[(&str, FlagArgType)] = &[
+    ("--branches", FlagArgType::None),
+    ("-b", FlagArgType::None),
+    ("--tags", FlagArgType::None),
+    ("-t", FlagArgType::None),
+    ("--heads", FlagArgType::None),
+    ("-h", FlagArgType::None),
+    ("--refs", FlagArgType::None),
+    ("--quiet", FlagArgType::None),
+    ("-q", FlagArgType::None),
+    ("--exit-code", FlagArgType::None),
+    ("--get-url", FlagArgType::None),
+    ("--symref", FlagArgType::None),
+    ("--sort", FlagArgType::String),
+];
+const GIT_LS_REMOTE_CONFIG: CommandConfig = CommandConfig {
+    safe_flags: GIT_LS_REMOTE_FLAGS,
+    additional_dangerous_callback: None,
+    respects_double_dash: true,
+};
+
+// ---- git status (upstream L359-393) ----------------------------------------
+const GIT_STATUS_FLAGS: &[(&str, FlagArgType)] = &[
+    ("--short", FlagArgType::None),
+    ("-s", FlagArgType::None),
+    ("--branch", FlagArgType::None),
+    ("-b", FlagArgType::None),
+    ("--porcelain", FlagArgType::None),
+    ("--long", FlagArgType::None),
+    ("--verbose", FlagArgType::None),
+    ("-v", FlagArgType::None),
+    ("--untracked-files", FlagArgType::String),
+    ("-u", FlagArgType::String),
+    ("--ignored", FlagArgType::None),
+    ("--ignore-submodules", FlagArgType::String),
+    ("--column", FlagArgType::None),
+    ("--no-column", FlagArgType::None),
+    ("--ahead-behind", FlagArgType::None),
+    ("--no-ahead-behind", FlagArgType::None),
+    ("--renames", FlagArgType::None),
+    ("--no-renames", FlagArgType::None),
+    ("--find-renames", FlagArgType::String),
+    ("-M", FlagArgType::String),
+];
+const GIT_STATUS_CONFIG: CommandConfig = CommandConfig {
+    safe_flags: GIT_STATUS_FLAGS,
+    additional_dangerous_callback: None,
+    respects_double_dash: true,
+};
+
+// ---- git blame (upstream L394-422) -----------------------------------------
+// Verbatim port of upstream `git blame` safeFlags (readOnlyCommandValidation.ts L370-409).
+static GIT_BLAME_FLAGS: LazyLock<&'static [(&'static str, FlagArgType)]> = LazyLock::new(|| {
+    let mut v: Vec<(&'static str, FlagArgType)> = Vec::new();
+    v.extend_from_slice(GIT_COLOR_FLAGS);
+    v.extend_from_slice(&[
+        // Line range
+        ("-L", FlagArgType::String),
+        // Output format
+        ("--porcelain", FlagArgType::None),
+        ("-p", FlagArgType::None),
+        ("--line-porcelain", FlagArgType::None),
+        ("--incremental", FlagArgType::None),
+        ("--root", FlagArgType::None),
+        ("--show-stats", FlagArgType::None),
+        ("--show-name", FlagArgType::None),
+        ("--show-number", FlagArgType::None),
+        ("-n", FlagArgType::None),
+        ("--show-email", FlagArgType::None),
+        ("-e", FlagArgType::None),
+        ("-f", FlagArgType::None),
+        // Date formatting
+        ("--date", FlagArgType::String),
+        // Ignore whitespace
+        ("-w", FlagArgType::None),
+        // Ignore revisions
+        ("--ignore-rev", FlagArgType::String),
+        ("--ignore-revs-file", FlagArgType::String),
+        // Move/copy detection
+        ("-M", FlagArgType::None),
+        ("-C", FlagArgType::None),
+        ("--score-debug", FlagArgType::None),
+        // Abbreviation
+        ("--abbrev", FlagArgType::Number),
+        // Other options
+        ("-s", FlagArgType::None),
+        ("-l", FlagArgType::None),
+        ("-t", FlagArgType::None),
+    ]);
+    leak_flags(v)
+});
+static GIT_BLAME_CONFIG: LazyLock<CommandConfig> = LazyLock::new(|| CommandConfig {
+    safe_flags: *GIT_BLAME_FLAGS,
+    additional_dangerous_callback: None,
+    respects_double_dash: true,
+});
+
+// ---- git ls-files (upstream L423-462) --------------------------------------
+// Verbatim port — added `-f` (was missing); flag order matches upstream.
+const GIT_LS_FILES_FLAGS: &[(&str, FlagArgType)] = &[
+    // File selection
+    ("--cached", FlagArgType::None),
+    ("-c", FlagArgType::None),
+    ("--deleted", FlagArgType::None),
+    ("-d", FlagArgType::None),
+    ("--modified", FlagArgType::None),
+    ("-m", FlagArgType::None),
+    ("--others", FlagArgType::None),
+    ("-o", FlagArgType::None),
+    ("--ignored", FlagArgType::None),
+    ("-i", FlagArgType::None),
+    ("--stage", FlagArgType::None),
+    ("-s", FlagArgType::None),
+    ("--killed", FlagArgType::None),
+    ("-k", FlagArgType::None),
+    ("--unmerged", FlagArgType::None),
+    ("-u", FlagArgType::None),
+    // Output format
+    ("--directory", FlagArgType::None),
+    ("--no-empty-directory", FlagArgType::None),
+    ("--eol", FlagArgType::None),
+    ("--full-name", FlagArgType::None),
+    ("--abbrev", FlagArgType::Number),
+    ("--debug", FlagArgType::None),
+    ("-z", FlagArgType::None),
+    ("-t", FlagArgType::None),
+    ("-v", FlagArgType::None),
+    ("-f", FlagArgType::None),
+    // Exclude patterns
+    ("--exclude", FlagArgType::String),
+    ("-x", FlagArgType::String),
+    ("--exclude-from", FlagArgType::String),
+    ("-X", FlagArgType::String),
+    ("--exclude-per-directory", FlagArgType::String),
+    ("--exclude-standard", FlagArgType::None),
+    // Error handling
+    ("--error-unmatch", FlagArgType::None),
+    // Recursion
+    ("--recurse-submodules", FlagArgType::None),
+];
+const GIT_LS_FILES_CONFIG: CommandConfig = CommandConfig {
+    safe_flags: GIT_LS_FILES_FLAGS,
+    additional_dangerous_callback: None,
+    respects_double_dash: true,
+};
+
+// ---- git config --get (upstream L463-484) ----------------------------------
+// Verbatim port — upstream allows only read-side flags (no --get/--get-all
+// flags; the `git config --get` prefix itself signals read-mode).
+const GIT_CONFIG_GET_FLAGS: &[(&str, FlagArgType)] = &[
+    // No additional flags needed - just reading config values
+    ("--local", FlagArgType::None),
+    ("--global", FlagArgType::None),
+    ("--system", FlagArgType::None),
+    ("--worktree", FlagArgType::None),
+    ("--default", FlagArgType::String),
+    ("--type", FlagArgType::String),
+    ("--bool", FlagArgType::None),
+    ("--int", FlagArgType::None),
+    ("--bool-or-int", FlagArgType::None),
+    ("--path", FlagArgType::None),
+    ("--expiry-date", FlagArgType::None),
+    ("-z", FlagArgType::None),
+    ("--null", FlagArgType::None),
+    ("--name-only", FlagArgType::None),
+    ("--show-origin", FlagArgType::None),
+    ("--show-scope", FlagArgType::None),
+];
+const GIT_CONFIG_GET_CONFIG: CommandConfig = CommandConfig {
+    safe_flags: GIT_CONFIG_GET_FLAGS,
+    additional_dangerous_callback: None,
+    respects_double_dash: true,
+};
+
+// ---- git remote show (upstream L476-489) -----------------------------------
+// Only allow `git remote show [-n] <name>` where <name> is alphanumeric.
+// The callback enforces this; safe_flags only includes `-n`.
+const GIT_REMOTE_SHOW_FLAGS: &[(&str, FlagArgType)] = &[("-n", FlagArgType::None)];
+const GIT_REMOTE_SHOW_CONFIG: CommandConfig = CommandConfig {
+    safe_flags: GIT_REMOTE_SHOW_FLAGS,
+    additional_dangerous_callback: Some(git_remote_show_callback),
+    respects_double_dash: true,
+};
+
+// ---- git remote (upstream L490-505) ----------------------------------------
+// Only allow bare `git remote` or `git remote -v`/`--verbose`.
+// IMPORTANT: This entry must be matched AFTER `git remote show` because
+// longest-prefix lookup is required.
+const GIT_REMOTE_FLAGS: &[(&str, FlagArgType)] =
+    &[("-v", FlagArgType::None), ("--verbose", FlagArgType::None)];
+const GIT_REMOTE_CONFIG: CommandConfig = CommandConfig {
+    safe_flags: GIT_REMOTE_FLAGS,
+    additional_dangerous_callback: Some(git_remote_callback),
+    respects_double_dash: true,
+};
+
+// ---- git merge-base (upstream L506-518) ------------------------------------
+const GIT_MERGE_BASE_FLAGS: &[(&str, FlagArgType)] = &[
+    ("--all", FlagArgType::None),
+    ("--octopus", FlagArgType::None),
+    ("--independent", FlagArgType::None),
+    ("--is-ancestor", FlagArgType::None),
+    ("--fork-point", FlagArgType::None),
+];
+const GIT_MERGE_BASE_CONFIG: CommandConfig = CommandConfig {
+    safe_flags: GIT_MERGE_BASE_FLAGS,
+    additional_dangerous_callback: None,
+    respects_double_dash: true,
+};
+
+// ---- git rev-parse (upstream L519-555) -------------------------------------
+// Verbatim port — `--short` is `string` upstream (optional length via =N).
+const GIT_REV_PARSE_FLAGS: &[(&str, FlagArgType)] = &[
+    // SHA resolution and verification
+    ("--verify", FlagArgType::None),
+    ("--short", FlagArgType::String),
+    ("--abbrev-ref", FlagArgType::None),
+    ("--symbolic", FlagArgType::None),
+    ("--symbolic-full-name", FlagArgType::None),
+    // Repository path queries (all read-only)
+    ("--show-toplevel", FlagArgType::None),
+    ("--show-cdup", FlagArgType::None),
+    ("--show-prefix", FlagArgType::None),
+    ("--git-dir", FlagArgType::None),
+    ("--git-common-dir", FlagArgType::None),
+    ("--absolute-git-dir", FlagArgType::None),
+    ("--show-superproject-working-tree", FlagArgType::None),
+    // Boolean queries
+    ("--is-inside-work-tree", FlagArgType::None),
+    ("--is-inside-git-dir", FlagArgType::None),
+    ("--is-bare-repository", FlagArgType::None),
+    ("--is-shallow-repository", FlagArgType::None),
+    ("--is-shallow-update", FlagArgType::None),
+    ("--path-prefix", FlagArgType::None),
+];
+const GIT_REV_PARSE_CONFIG: CommandConfig = CommandConfig {
+    safe_flags: GIT_REV_PARSE_FLAGS,
+    additional_dangerous_callback: None,
+    respects_double_dash: true,
+};
+
+// ---- git rev-list (upstream L556-606) --------------------------------------
+static GIT_REV_LIST_FLAGS: LazyLock<&'static [(&'static str, FlagArgType)]> = LazyLock::new(|| {
+    let mut v: Vec<(&'static str, FlagArgType)> = Vec::new();
+    v.extend_from_slice(GIT_REF_SELECTION_FLAGS);
+    v.extend_from_slice(GIT_DATE_FILTER_FLAGS);
+    v.extend_from_slice(GIT_COUNT_FLAGS);
+    v.extend_from_slice(GIT_AUTHOR_FILTER_FLAGS);
+    v.extend_from_slice(&[
+        // Counting
+        ("--count", FlagArgType::None),
+        // Traversal control
+        ("--reverse", FlagArgType::None),
+        ("--first-parent", FlagArgType::None),
+        ("--ancestry-path", FlagArgType::None),
+        ("--merges", FlagArgType::None),
+        ("--no-merges", FlagArgType::None),
+        ("--min-parents", FlagArgType::Number),
+        ("--max-parents", FlagArgType::Number),
+        ("--no-min-parents", FlagArgType::None),
+        ("--no-max-parents", FlagArgType::None),
+        ("--skip", FlagArgType::Number),
+        ("--max-age", FlagArgType::Number),
+        ("--min-age", FlagArgType::Number),
+        ("--walk-reflogs", FlagArgType::None),
+        // Output formatting
+        ("--oneline", FlagArgType::None),
+        ("--abbrev-commit", FlagArgType::None),
+        ("--pretty", FlagArgType::String),
+        ("--format", FlagArgType::String),
+        ("--abbrev", FlagArgType::Number),
+        ("--full-history", FlagArgType::None),
+        ("--dense", FlagArgType::None),
+        ("--sparse", FlagArgType::None),
+        ("--source", FlagArgType::None),
+        ("--graph", FlagArgType::None),
+    ]);
+    leak_flags(v)
+});
+static GIT_REV_LIST_CONFIG: LazyLock<CommandConfig> = LazyLock::new(|| CommandConfig {
+    safe_flags: *GIT_REV_LIST_FLAGS,
+    additional_dangerous_callback: None,
+    respects_double_dash: true,
+});
+
+// ---- git describe (upstream L607-628) --------------------------------------
+// Verbatim port — added --first-match; dropped --all/--debug/--first-parent
+// (none present upstream).
+const GIT_DESCRIBE_FLAGS: &[(&str, FlagArgType)] = &[
+    // Tag selection
+    ("--tags", FlagArgType::None),
+    ("--match", FlagArgType::String),
+    ("--exclude", FlagArgType::String),
+    // Output control
+    ("--long", FlagArgType::None),
+    ("--abbrev", FlagArgType::Number),
+    ("--always", FlagArgType::None),
+    ("--contains", FlagArgType::None),
+    ("--first-match", FlagArgType::None),
+    ("--exact-match", FlagArgType::None),
+    ("--candidates", FlagArgType::Number),
+    // Suffix/dirty markers
+    ("--dirty", FlagArgType::None),
+    ("--broken", FlagArgType::None),
+];
+const GIT_DESCRIBE_CONFIG: CommandConfig = CommandConfig {
+    safe_flags: GIT_DESCRIBE_FLAGS,
+    additional_dangerous_callback: None,
+    respects_double_dash: true,
+};
+
+// ---- git cat-file (upstream L629-651) --------------------------------------
+// Verbatim port. NOTE: --batch (without --check) is intentionally excluded —
+// it reads arbitrary objects from stdin which could be exploited in piped
+// commands to dump sensitive objects. --batch-check is the safe variant.
+const GIT_CAT_FILE_FLAGS: &[(&str, FlagArgType)] = &[
+    // Object query modes (all purely read-only)
+    ("-t", FlagArgType::None),
+    ("-s", FlagArgType::None),
+    ("-p", FlagArgType::None),
+    ("-e", FlagArgType::None),
+    // Batch mode — read-only check variant only
+    ("--batch-check", FlagArgType::None),
+    // Output control
+    ("--allow-undetermined-type", FlagArgType::None),
+];
+const GIT_CAT_FILE_CONFIG: CommandConfig = CommandConfig {
+    safe_flags: GIT_CAT_FILE_FLAGS,
+    additional_dangerous_callback: None,
+    respects_double_dash: true,
+};
+
+// ---- git for-each-ref (upstream L652-672) ----------------------------------
+// Verbatim port — dropped --shell/--perl/--python/--tcl/--color/--no-color/
+// --ignore-case (none present upstream).
+const GIT_FOR_EACH_REF_FLAGS: &[(&str, FlagArgType)] = &[
+    // Output formatting
+    ("--format", FlagArgType::String),
+    // Sorting
+    ("--sort", FlagArgType::String),
+    // Limiting
+    ("--count", FlagArgType::Number),
+    // Filtering
+    ("--contains", FlagArgType::String),
+    ("--no-contains", FlagArgType::String),
+    ("--merged", FlagArgType::String),
+    ("--no-merged", FlagArgType::String),
+    ("--points-at", FlagArgType::String),
+];
+const GIT_FOR_EACH_REF_CONFIG: CommandConfig = CommandConfig {
+    safe_flags: GIT_FOR_EACH_REF_FLAGS,
+    additional_dangerous_callback: None,
+    respects_double_dash: true,
+};
+
+// ---- git grep (upstream L673-720) ------------------------------------------
+// Verbatim port. Dropped non-upstream flags (-a/--text/-I/--column/-z/--null/
+// -p/--show-function/--max-count/--all-match/-f file/--exclude-standard).
+const GIT_GREP_FLAGS: &[(&str, FlagArgType)] = &[
+    // Pattern matching modes
+    ("-e", FlagArgType::String),
+    ("-E", FlagArgType::None),
+    ("--extended-regexp", FlagArgType::None),
+    ("-G", FlagArgType::None),
+    ("--basic-regexp", FlagArgType::None),
+    ("-F", FlagArgType::None),
+    ("--fixed-strings", FlagArgType::None),
+    ("-P", FlagArgType::None),
+    ("--perl-regexp", FlagArgType::None),
+    // Match control
+    ("-i", FlagArgType::None),
+    ("--ignore-case", FlagArgType::None),
+    ("-v", FlagArgType::None),
+    ("--invert-match", FlagArgType::None),
+    ("-w", FlagArgType::None),
+    ("--word-regexp", FlagArgType::None),
+    // Output control
+    ("-n", FlagArgType::None),
+    ("--line-number", FlagArgType::None),
+    ("-c", FlagArgType::None),
+    ("--count", FlagArgType::None),
+    ("-l", FlagArgType::None),
+    ("--files-with-matches", FlagArgType::None),
+    ("-L", FlagArgType::None),
+    ("--files-without-match", FlagArgType::None),
+    ("-h", FlagArgType::None),
+    ("-H", FlagArgType::None),
+    ("--heading", FlagArgType::None),
+    ("--break", FlagArgType::None),
+    ("--full-name", FlagArgType::None),
+    ("--color", FlagArgType::None),
+    ("--no-color", FlagArgType::None),
+    ("-o", FlagArgType::None),
+    ("--only-matching", FlagArgType::None),
+    // Context
+    ("-A", FlagArgType::Number),
+    ("--after-context", FlagArgType::Number),
+    ("-B", FlagArgType::Number),
+    ("--before-context", FlagArgType::Number),
+    ("-C", FlagArgType::Number),
+    ("--context", FlagArgType::Number),
+    // Boolean operators for multi-pattern
+    ("--and", FlagArgType::None),
+    ("--or", FlagArgType::None),
+    ("--not", FlagArgType::None),
+    // Scope control
+    ("--max-depth", FlagArgType::Number),
+    ("--untracked", FlagArgType::None),
+    ("--no-index", FlagArgType::None),
+    ("--recurse-submodules", FlagArgType::None),
+    ("--cached", FlagArgType::None),
+    // Threads
+    ("--threads", FlagArgType::Number),
+    // Quiet
+    ("-q", FlagArgType::None),
+    ("--quiet", FlagArgType::None),
+];
+const GIT_GREP_CONFIG: CommandConfig = CommandConfig {
+    safe_flags: GIT_GREP_FLAGS,
+    additional_dangerous_callback: None,
+    respects_double_dash: true,
+};
+
+// ---- git stash show (upstream L721-735) ------------------------------------
+// Verbatim port of upstream `git stash show` safeFlags (L721-735) —
+// includes COLOR spread; replaces untracked options with diff-mode flags.
+static GIT_STASH_SHOW_FLAGS: LazyLock<&'static [(&'static str, FlagArgType)]> =
+    LazyLock::new(|| {
+        let mut v: Vec<(&'static str, FlagArgType)> = Vec::new();
+        v.extend_from_slice(GIT_STAT_FLAGS);
+        v.extend_from_slice(GIT_COLOR_FLAGS);
+        v.extend_from_slice(GIT_PATCH_FLAGS);
+        v.extend_from_slice(&[
+            // Diff options
+            ("--word-diff", FlagArgType::None),
+            ("--word-diff-regex", FlagArgType::String),
+            ("--diff-filter", FlagArgType::String),
+            ("--abbrev", FlagArgType::Number),
+        ]);
+        leak_flags(v)
+    });
+static GIT_STASH_SHOW_CONFIG: LazyLock<CommandConfig> = LazyLock::new(|| CommandConfig {
+    safe_flags: *GIT_STASH_SHOW_FLAGS,
+    additional_dangerous_callback: None,
+    respects_double_dash: true,
+});
+
+// ---- git worktree list (upstream L736-746) ---------------------------------
+// Verbatim port — dropped -z (not present upstream).
+const GIT_WORKTREE_LIST_FLAGS: &[(&str, FlagArgType)] = &[
+    ("--porcelain", FlagArgType::None),
+    ("-v", FlagArgType::None),
+    ("--verbose", FlagArgType::None),
+    ("--expire", FlagArgType::String),
+];
+const GIT_WORKTREE_LIST_CONFIG: CommandConfig = CommandConfig {
+    safe_flags: GIT_WORKTREE_LIST_FLAGS,
+    additional_dangerous_callback: None,
+    respects_double_dash: true,
+};
+
+// ---- git tag (upstream L747-839) -------------------------------------------
+// SECURITY: `git tag` is dual-purpose. With `-l`/`--list` (or filter flags
+// like --contains) it merely reads. Without those, ANY positional argument
+// creates a tag (writes .git/refs/tags/<name>). The callback enforces
+// "must have -l/--list before any positional appears (excluding pattern
+// arguments to filter flags)".
+// Verbatim port of upstream `git tag` safeFlags (L747-839) — dropped
+// --color/--no-color/--omit-empty/--create-reflog (not present upstream).
+const GIT_TAG_FLAGS: &[(&str, FlagArgType)] = &[
+    // List mode flags
+    ("-l", FlagArgType::None),
+    ("--list", FlagArgType::None),
+    ("-n", FlagArgType::Number),
+    ("--contains", FlagArgType::String),
+    ("--no-contains", FlagArgType::String),
+    ("--merged", FlagArgType::String),
+    ("--no-merged", FlagArgType::String),
+    ("--sort", FlagArgType::String),
+    ("--format", FlagArgType::String),
+    ("--points-at", FlagArgType::String),
+    ("--column", FlagArgType::None),
+    ("--no-column", FlagArgType::None),
+    ("-i", FlagArgType::None),
+    ("--ignore-case", FlagArgType::None),
+];
+const GIT_TAG_CONFIG: CommandConfig = CommandConfig {
+    safe_flags: GIT_TAG_FLAGS,
+    additional_dangerous_callback: Some(git_tag_callback),
+    respects_double_dash: true,
+};
+
+// ---- git branch (upstream L840-924) ----------------------------------------
+// SECURITY: Same dual-purpose pattern as `git tag`. Positional argument
+// without -l/--list creates a branch (writes .git/refs/heads/<name>).
+// Callback enforces this; additionally `--merged`/`--no-merged` have
+// OPTIONAL args, so a positional immediately after them is permitted.
+// Verbatim port of upstream `git branch` safeFlags (L840-867).
+// SECURITY: --format is INTENTIONALLY EXCLUDED — see upstream L865 comment.
+// --format with %(refname) etc. can be exploited; upstream blocks it.
+// --merged/--no-merged are 'none' (optional commit arg handled by callback).
+const GIT_BRANCH_FLAGS: &[(&str, FlagArgType)] = &[
+    // List mode flags
+    ("-l", FlagArgType::None),
+    ("--list", FlagArgType::None),
+    ("-a", FlagArgType::None),
+    ("--all", FlagArgType::None),
+    ("-r", FlagArgType::None),
+    ("--remotes", FlagArgType::None),
+    ("-v", FlagArgType::None),
+    ("-vv", FlagArgType::None),
+    ("--verbose", FlagArgType::None),
+    // Display options
+    ("--color", FlagArgType::None),
+    ("--no-color", FlagArgType::None),
+    ("--column", FlagArgType::None),
+    ("--no-column", FlagArgType::None),
+    // SECURITY: --abbrev stays 'number' so validateFlags accepts --abbrev=N
+    // (attached form, safe). DETACHED `--abbrev N` is caught by callback:
+    // --abbrev is NOT in FLAGS_WITH_ARGS, so callback treats N as positional
+    // without --list → dangerous. Two-layer defense matches upstream.
+    ("--abbrev", FlagArgType::Number),
+    ("--no-abbrev", FlagArgType::None),
+    // Filtering - these take commit/ref arguments
+    ("--contains", FlagArgType::String),
+    ("--no-contains", FlagArgType::String),
+    ("--merged", FlagArgType::None), // Optional commit argument - handled in callback
+    ("--no-merged", FlagArgType::None), // Optional commit argument - handled in callback
+    ("--points-at", FlagArgType::String),
+    // Sorting
+    ("--sort", FlagArgType::String),
+    // Note: --format is intentionally excluded as it could pose security risks
+    // Show current
+    ("--show-current", FlagArgType::None),
+    ("-i", FlagArgType::None),
+    ("--ignore-case", FlagArgType::None),
+];
+const GIT_BRANCH_CONFIG: CommandConfig = CommandConfig {
+    safe_flags: GIT_BRANCH_FLAGS,
+    additional_dangerous_callback: Some(git_branch_callback),
+    respects_double_dash: true,
+};
+
+// ---------------------------------------------------------------------------
+// Public table (longest-prefix order matters)
+// ---------------------------------------------------------------------------
+
+/// 24 read-only git command prefixes, ordered so longer prefixes appear
+/// before shorter ones (e.g. `git remote show` precedes `git remote`).
+/// Consumers should iterate in order and accept the first match.
+pub(crate) static GIT_READ_ONLY_COMMANDS: LazyLock<Vec<(&'static str, &'static CommandConfig)>> =
+    LazyLock::new(|| {
+        vec![
+            ("git diff", &*GIT_DIFF_CONFIG),
+            ("git log", &*GIT_LOG_CONFIG),
+            ("git show", &*GIT_SHOW_CONFIG),
+            ("git shortlog", &*GIT_SHORTLOG_CONFIG),
+            ("git reflog", &*GIT_REFLOG_CONFIG),
+            ("git stash list", &*GIT_STASH_LIST_CONFIG),
+            ("git ls-remote", &GIT_LS_REMOTE_CONFIG),
+            ("git status", &GIT_STATUS_CONFIG),
+            ("git blame", &GIT_BLAME_CONFIG),
+            ("git ls-files", &GIT_LS_FILES_CONFIG),
+            ("git config --get", &GIT_CONFIG_GET_CONFIG),
+            // longest-prefix: `git remote show` MUST come before `git remote`
+            ("git remote show", &GIT_REMOTE_SHOW_CONFIG),
+            ("git remote", &GIT_REMOTE_CONFIG),
+            ("git merge-base", &GIT_MERGE_BASE_CONFIG),
+            ("git rev-parse", &GIT_REV_PARSE_CONFIG),
+            ("git rev-list", &*GIT_REV_LIST_CONFIG),
+            ("git describe", &GIT_DESCRIBE_CONFIG),
+            ("git cat-file", &GIT_CAT_FILE_CONFIG),
+            ("git for-each-ref", &GIT_FOR_EACH_REF_CONFIG),
+            ("git grep", &GIT_GREP_CONFIG),
+            ("git stash show", &*GIT_STASH_SHOW_CONFIG),
+            ("git worktree list", &GIT_WORKTREE_LIST_CONFIG),
+            ("git tag", &GIT_TAG_CONFIG),
+            ("git branch", &GIT_BRANCH_CONFIG),
+        ]
+    });

--- a/crates/dasclaw_bash_validation/src/readonly/mod.rs
+++ b/crates/dasclaw_bash_validation/src/readonly/mod.rs
@@ -13,3 +13,5 @@
 pub mod bash_allowlist;
 pub mod external_tables;
 pub mod flag_parser;
+pub mod gh_allowlist;
+pub mod git_allowlist;

--- a/crates/dasclaw_bash_validation/tests/readonly_git_gh_ant_test.rs
+++ b/crates/dasclaw_bash_validation/tests/readonly_git_gh_ant_test.rs
@@ -1,0 +1,380 @@
+//! Phase 3.2.C.rest — readonly tests for `git_allowlist`, `gh_allowlist`,
+//! and the `USER_TYPE=ant` + Windows-xargs-strip gates in
+//! `bash_allowlist::get_command_allowlist()`.
+//!
+//! Each test name follows the AGENTS.md `req_<module>_<id>_<desc>` convention.
+//! Mutating `USER_TYPE` is process-global; we serialize ant-gated cases via
+//! a `Mutex` and always restore the prior value to avoid bleeding into other
+//! tests that may read the same variable.
+
+use std::sync::Mutex;
+
+use dasclaw_bash_validation::readonly::bash_allowlist::{
+    get_command_allowlist, is_command_safe_via_flag_parsing,
+};
+
+// ---------- env helpers ----------
+static USER_TYPE_LOCK: Mutex<()> = Mutex::new(());
+
+struct UserTypeGuard {
+    prev: Option<String>,
+    _lock: std::sync::MutexGuard<'static, ()>,
+}
+
+impl UserTypeGuard {
+    fn set(value: Option<&str>) -> Self {
+        let lock = USER_TYPE_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let prev = std::env::var("USER_TYPE").ok();
+        match value {
+            Some(v) => unsafe { std::env::set_var("USER_TYPE", v) },
+            None => unsafe { std::env::remove_var("USER_TYPE") },
+        }
+        Self { prev, _lock: lock }
+    }
+}
+
+impl Drop for UserTypeGuard {
+    fn drop(&mut self) {
+        match &self.prev {
+            Some(v) => unsafe { std::env::set_var("USER_TYPE", v) },
+            None => unsafe { std::env::remove_var("USER_TYPE") },
+        }
+    }
+}
+
+// ============================================================================
+// GIT — pickaxe / opt-arg parser differential pins
+// ============================================================================
+
+#[test]
+fn req_readonly_3_2_c_git_diff_pickaxe_consumes_output_flag() {
+    // SECURITY S20: `-S` declares FlagArgType::String so the parser consumes
+    // the NEXT token as its value. `--output=...` ends up as the consumed
+    // value rather than being interpreted as a redirect flag — but because
+    // the next-after token is missing, the validator rejects this anyway
+    // (pickaxe needs a pattern). The key invariant: if a user tries to slip
+    // `--output=FILE` past `-S`, it must not be treated as a top-level flag.
+    let _g = UserTypeGuard::set(None);
+    // `-S PAT --output=FILE` — pattern is consumed, --output=FILE then fails
+    // because it's not in safe_flags. Either way: blocked.
+    assert!(!is_command_safe_via_flag_parsing(
+        "git diff -S PAT --output=/tmp/leak"
+    ));
+}
+
+#[test]
+fn req_readonly_3_2_c_git_diff_orderfile_string_flag_accepted() {
+    let _g = UserTypeGuard::set(None);
+    // `-O orderfile` is FlagArgType::String — accepted with an argument.
+    assert!(is_command_safe_via_flag_parsing("git diff -O orderfile"));
+}
+
+#[test]
+fn req_readonly_3_2_c_git_ls_remote_server_option_blocked() {
+    // `--server-option` intentionally NOT in safe_flags.
+    let _g = UserTypeGuard::set(None);
+    assert!(!is_command_safe_via_flag_parsing(
+        "git ls-remote --server-option=x origin"
+    ));
+}
+
+#[test]
+fn req_readonly_3_2_c_git_cat_file_batch_blocked() {
+    // `--batch` intentionally excluded (can read arbitrary objects via stdin).
+    let _g = UserTypeGuard::set(None);
+    assert!(!is_command_safe_via_flag_parsing("git cat-file --batch"));
+}
+
+// ============================================================================
+// GIT — callback-driven rejection
+// ============================================================================
+
+#[test]
+fn req_readonly_3_2_c_git_remote_show_alphanumeric_only() {
+    let _g = UserTypeGuard::set(None);
+    assert!(is_command_safe_via_flag_parsing("git remote show origin"));
+    // Non-alphanumeric positional → rejected by git_remote_show_callback.
+    // NB: use `.` (not `$`) so the bypass scan for shell metacharacters does
+    // not short-circuit before the callback runs — we want to exercise the
+    // callback's `/^[a-zA-Z0-9_-]+$/` regex, not the meta-character bypass.
+    assert!(!is_command_safe_via_flag_parsing("git remote show foo.bar"));
+    assert!(!is_command_safe_via_flag_parsing("git remote show ../etc"));
+}
+
+#[test]
+fn req_readonly_3_2_c_git_remote_only_verbose_flag() {
+    let _g = UserTypeGuard::set(None);
+    // Bare `git remote` lists remotes.
+    assert!(is_command_safe_via_flag_parsing("git remote"));
+    // `-v` / `--verbose` accepted (only allowed flag for bare remote).
+    assert!(is_command_safe_via_flag_parsing("git remote -v"));
+    // Subcommand-style positional `add` blocked by git_remote_callback.
+    assert!(!is_command_safe_via_flag_parsing(
+        "git remote add origin https://x"
+    ));
+}
+
+#[test]
+fn req_readonly_3_2_c_git_tag_requires_list_flag() {
+    let _g = UserTypeGuard::set(None);
+    // Bare `git tag mytag` would CREATE a tag — must be blocked.
+    assert!(!is_command_safe_via_flag_parsing("git tag mytag"));
+    // `-l` / `--list` gate opens the listing form.
+    assert!(is_command_safe_via_flag_parsing("git tag -l v1.*"));
+    assert!(is_command_safe_via_flag_parsing("git tag --list"));
+    // `--` semantic: positional appearing after `--` is still creation.
+    assert!(!is_command_safe_via_flag_parsing("git tag -- mytag"));
+}
+
+#[test]
+fn req_readonly_3_2_c_git_branch_requires_list_flag() {
+    let _g = UserTypeGuard::set(None);
+    // Bare `git branch newbranch` would CREATE a branch — blocked.
+    assert!(!is_command_safe_via_flag_parsing("git branch newbranch"));
+    // `--merged HEAD` is an optional-arg listing form — accepted.
+    assert!(is_command_safe_via_flag_parsing("git branch --merged HEAD"));
+    // `-l` / `--list` gate.
+    assert!(is_command_safe_via_flag_parsing("git branch -l"));
+}
+
+#[test]
+fn req_readonly_3_2_c_git_reflog_blocks_destructive_subcommands() {
+    let _g = UserTypeGuard::set(None);
+    assert!(is_command_safe_via_flag_parsing("git reflog"));
+    // `expire` / `delete` / `exists` mutate the reflog — blocked by callback.
+    assert!(!is_command_safe_via_flag_parsing("git reflog expire HEAD"));
+    assert!(!is_command_safe_via_flag_parsing(
+        "git reflog delete HEAD@{0}"
+    ));
+    assert!(!is_command_safe_via_flag_parsing("git reflog exists HEAD"));
+}
+
+// ============================================================================
+// GIT — longest-prefix order
+// ============================================================================
+
+#[test]
+fn req_readonly_3_2_c_git_remote_show_precedes_git_remote() {
+    // `git remote show` is matched as a multi-word entry, NOT as
+    // `git remote` with a `show` positional (which the bare-remote callback
+    // would reject). Verifies longest-prefix order in GIT_READ_ONLY_COMMANDS.
+    let _g = UserTypeGuard::set(None);
+    assert!(is_command_safe_via_flag_parsing("git remote show origin"));
+}
+
+// ============================================================================
+// GH — danger callback rejects URL/SSH/HOST/OWNER/REPO
+// ============================================================================
+
+#[test]
+fn req_readonly_3_2_c_gh_callback_rejects_url_value() {
+    let _g = UserTypeGuard::set(Some("ant"));
+    // Positional URL.
+    assert!(!is_command_safe_via_flag_parsing(
+        "gh pr view https://evil.com/owner/repo/extra"
+    ));
+    // --repo=URL form (inline value).
+    assert!(!is_command_safe_via_flag_parsing(
+        "gh pr view --repo=https://evil.com/o/r"
+    ));
+}
+
+#[test]
+fn req_readonly_3_2_c_gh_callback_rejects_ssh_style() {
+    let _g = UserTypeGuard::set(Some("ant"));
+    assert!(!is_command_safe_via_flag_parsing(
+        "gh pr view --repo=git@github.com:o/r"
+    ));
+}
+
+#[test]
+fn req_readonly_3_2_c_gh_callback_rejects_three_segment_host() {
+    let _g = UserTypeGuard::set(Some("ant"));
+    // HOST/OWNER/REPO has 2 slashes → 3 segments → rejected.
+    assert!(!is_command_safe_via_flag_parsing(
+        "gh pr view --repo evil.com/owner/repo"
+    ));
+}
+
+#[test]
+fn req_readonly_3_2_c_gh_callback_accepts_owner_repo() {
+    let _g = UserTypeGuard::set(Some("ant"));
+    // Normal OWNER/REPO has 1 slash → accepted.
+    assert!(is_command_safe_via_flag_parsing(
+        "gh pr view --repo owner/repo"
+    ));
+    assert!(is_command_safe_via_flag_parsing("gh pr list -R owner/repo"));
+}
+
+// ============================================================================
+// USER_TYPE=ant gate
+// ============================================================================
+
+#[test]
+fn req_readonly_3_2_c_gh_blocked_when_user_type_not_ant() {
+    let _g = UserTypeGuard::set(None);
+    // gh entries are NOT in the base allowlist.
+    assert!(!is_command_safe_via_flag_parsing("gh pr list"));
+    assert!(!is_command_safe_via_flag_parsing("gh issue view 1"));
+    assert!(!is_command_safe_via_flag_parsing("aki -k foo"));
+}
+
+#[test]
+fn req_readonly_3_2_c_gh_accepted_when_user_type_is_ant() {
+    let _g = UserTypeGuard::set(Some("ant"));
+    assert!(is_command_safe_via_flag_parsing("gh pr list"));
+    assert!(is_command_safe_via_flag_parsing("gh auth status"));
+    assert!(is_command_safe_via_flag_parsing("aki -k foo --json"));
+}
+
+#[test]
+fn req_readonly_3_2_c_get_command_allowlist_ant_extends_base() {
+    let _g_base = UserTypeGuard::set(None);
+    let base_len = get_command_allowlist().len();
+    drop(_g_base);
+
+    let _g_ant = UserTypeGuard::set(Some("ant"));
+    let ant_len = get_command_allowlist().len();
+    // ANT adds 22 gh commands + aki = 23.
+    assert_eq!(ant_len, base_len + 23);
+}
+
+// ============================================================================
+// xargs windows strip (runtime cfg!() check)
+// ============================================================================
+
+#[cfg(not(target_os = "windows"))]
+#[test]
+fn req_readonly_3_2_c_xargs_present_on_non_windows() {
+    let _g = UserTypeGuard::set(None);
+    let names: Vec<&str> = get_command_allowlist().iter().map(|(n, _)| *n).collect();
+    assert!(names.contains(&"xargs"));
+}
+
+#[cfg(target_os = "windows")]
+#[test]
+fn req_readonly_3_2_c_xargs_stripped_on_windows() {
+    let _g = UserTypeGuard::set(None);
+    let names: Vec<&str> = get_command_allowlist().iter().map(|(n, _)| *n).collect();
+    assert!(!names.contains(&"xargs"));
+}
+
+// ============================================================================
+// Existing baseline (smoke) — confirm 3.2.B + 3.2.C.2.a entries still match
+// ============================================================================
+
+#[test]
+fn req_readonly_3_2_c_smoke_existing_entries_unaffected() {
+    let _g = UserTypeGuard::set(None);
+    assert!(is_command_safe_via_flag_parsing("grep -ri pat src"));
+    assert!(is_command_safe_via_flag_parsing("rg --type rust pat"));
+    assert!(is_command_safe_via_flag_parsing("docker logs container"));
+    assert!(is_command_safe_via_flag_parsing("pyright --outputjson"));
+}
+
+// ============================================================================
+// Regression pins for Layer 1 audit fixes (verbatim-parity invariants)
+// ============================================================================
+
+#[test]
+fn req_readonly_3_2_c_git_branch_format_excluded_security() {
+    // Upstream readOnlyCommandValidation.ts L865 intentionally excludes
+    // `--format` from `git branch` safeFlags. `--format=%(refname)` etc.
+    // can be exploited; this PIN ensures we never re-introduce it.
+    let _g = UserTypeGuard::set(None);
+    assert!(!is_command_safe_via_flag_parsing(
+        "git branch --format=%(refname) -l"
+    ));
+    assert!(!is_command_safe_via_flag_parsing(
+        "git branch --format=oops"
+    ));
+}
+
+#[test]
+fn req_readonly_3_2_c_git_branch_merged_no_arg_allowed() {
+    // Upstream L866-L867: --merged/--no-merged are 'none' (optional commit
+    // arg handled in callback). Bare `git branch --merged` lists merged
+    // branches; `git branch --merged HEAD` lists filtered.
+    let _g = UserTypeGuard::set(None);
+    assert!(is_command_safe_via_flag_parsing("git branch --merged"));
+    assert!(is_command_safe_via_flag_parsing("git branch --no-merged"));
+    assert!(is_command_safe_via_flag_parsing("git branch --merged HEAD"));
+}
+
+#[test]
+fn req_readonly_3_2_c_git_rev_parse_short_takes_string() {
+    // Upstream L522: `--short: 'string'` (optional length via =N). Both
+    // `--short` (no arg) and `--short=7` should be accepted, paired with
+    // `--verify <sha>` for a typical use case.
+    let _g = UserTypeGuard::set(None);
+    assert!(is_command_safe_via_flag_parsing(
+        "git rev-parse --short HEAD"
+    ));
+    assert!(is_command_safe_via_flag_parsing(
+        "git rev-parse --short=7 HEAD"
+    ));
+    assert!(is_command_safe_via_flag_parsing(
+        "git rev-parse --verify HEAD"
+    ));
+}
+
+#[test]
+fn req_readonly_3_2_c_git_cat_file_batch_check_and_undetermined() {
+    // Upstream L641: --batch-check is the safe stdin-batch variant.
+    // Upstream L645: spelling is `--allow-undetermined-type`, NOT
+    // `--allow-unknown-type` (real-git man page wording is misleading).
+    let _g = UserTypeGuard::set(None);
+    assert!(is_command_safe_via_flag_parsing(
+        "git cat-file --batch-check"
+    ));
+    assert!(is_command_safe_via_flag_parsing(
+        "git cat-file --allow-undetermined-type -p HEAD"
+    ));
+    // Misspelling — must NOT be accepted.
+    assert!(!is_command_safe_via_flag_parsing(
+        "git cat-file --allow-unknown-type -p HEAD"
+    ));
+    // --batch (without --check) is intentionally excluded.
+    assert!(!is_command_safe_via_flag_parsing("git cat-file --batch"));
+}
+
+#[test]
+fn req_readonly_3_2_c_git_tag_create_reflog_excluded() {
+    // `--create-reflog` was a stray in the Rust port not present upstream.
+    // Without --list it is interpreted as a flag-with-no-positional → still
+    // safe (no creation), but `git tag --create-reflog foo` previously
+    // mis-classified the bundle. After verbatim restore, --create-reflog is
+    // unknown so the whole command is unsafe.
+    let _g = UserTypeGuard::set(None);
+    assert!(!is_command_safe_via_flag_parsing(
+        "git tag --create-reflog -l v1*"
+    ));
+}
+
+#[test]
+fn req_readonly_3_2_c_git_for_each_ref_strays_excluded() {
+    // Upstream L652-L672 has NO --color/--no-color/--shell/--perl/--python/
+    // --tcl/--ignore-case. Regression pin for stray-flag drop.
+    let _g = UserTypeGuard::set(None);
+    assert!(!is_command_safe_via_flag_parsing(
+        "git for-each-ref --color refs/heads"
+    ));
+    assert!(!is_command_safe_via_flag_parsing(
+        "git for-each-ref --shell"
+    ));
+    // Known-safe flag still works.
+    assert!(is_command_safe_via_flag_parsing(
+        "git for-each-ref --format=%(refname) refs/heads"
+    ));
+}
+
+#[test]
+fn req_readonly_3_2_c_gh_respects_double_dash_true() {
+    // Audit Fix 8: all gh entries default to respects_double_dash=true.
+    // This means `gh pr view -- foo` ends flag parsing at `--`. Without a
+    // dangerous URL/SSH/owner-repo positional, gh entries accept harmless
+    // post-`--` tokens.
+    let _g = UserTypeGuard::set(Some("ant"));
+    assert!(is_command_safe_via_flag_parsing("gh pr view -- 123"));
+    assert!(is_command_safe_via_flag_parsing("gh repo view"));
+}


### PR DESCRIPTION
## Sources read

- `AGENTS.md` — 中文规约总入口 § 强制阅读顺序、§ 红线、§ Skills 强制使用规范
- `.github/copilot-instructions.md` — § 必跑的本地管线、§ PR 必填项
- `docs/plans/architecture-refactor/adr-129-verbatim-port.md` — § 验证清单
- `claude-code-main/src/utils/shell/readOnlyCommandValidation.ts` L1-L1385 — 全部 24 git 表 + 22 gh 表 + 5 callback
- `claude-code-main/src/utils/shell/readOnlyValidation.ts` L1130-L1220 — `ANT_ONLY_COMMANDS` + `getCommandAllowlist` 用户态门
- `crates/dasclaw_bash_validation/src/readonly/bash_allowlist.rs` 重构前后 § COMMAND_ALLOWLIST、§ is_command_safe_via_flag_parsing
- `crates/dasclaw_bash_validation/src/readonly/external_tables.rs` § 已存在的 DOCKER/RIPGREP/PYRIGHT 表（不动）

## 背景 / 目标

完成 Phase 3.2.C.rest（issue #595）：把上游 `readOnlyCommandValidation.ts` 中
剩余的三组只读白名单——**GIT (24 命令)**、**GH (22 命令) + aki**——一次性 verbatim
port 到 Rust 端，并把 `COMMAND_ALLOWLIST` 从单一 `pub static` 切换为按 `USER_TYPE`
环境变量分派的 `get_command_allowlist()` 函数（=上游 `getCommandAllowlist` 语义）。

## 改动范围

| 文件 | 状态 | 说明 |
|---|---|---|
| `crates/dasclaw_bash_validation/src/readonly/git_allowlist.rs` | NEW (~1060 行) | 24 git 表 + 5 callback（reflog/remote-show/remote/tag/branch）+ 8 共享 flag-group 切片 |
| `crates/dasclaw_bash_validation/src/readonly/gh_allowlist.rs` | NEW (~660 行) | 22 gh 表 + aki 表 + `gh_is_dangerous_callback`（URL/SSH/3-segment/owner-repo 检测）+ `GH_READ_ONLY_COMMANDS` + `ANT_ONLY_COMMANDS` |
| `crates/dasclaw_bash_validation/src/readonly/bash_allowlist.rs` | MOD | `pub static COMMAND_ALLOWLIST` → `pub fn get_command_allowlist()` + 私有 `COMMAND_ALLOWLIST_BASE`/`COMMAND_ALLOWLIST_ANT` LazyLock + Windows xargs 剥离 |
| `crates/dasclaw_bash_validation/src/readonly/mod.rs` | MOD | 增 `pub mod gh_allowlist;` |
| `crates/dasclaw_bash_validation/tests/readonly_git_gh_ant_test.rs` | NEW (~380 行, 26 tests) | 含 `UserTypeGuard`（Mutex 串行化 env mutation）+ 7 条 Layer 1 audit 回归 pin |

## 非目标（What's NOT in this PR）

- **不动** DOCKER / RIPGREP / PYRIGHT 表（已在 #594 落地）。
- **不重写** `is_command_safe_via_flag_parsing` 逻辑——仅把 `.iter()` 源从静态切片
  改为 `get_command_allowlist().iter()`。
- **不引入** 新的 callback 框架——所有 callback 仍是裸 `fn` 指针，与 3.2.B 一致。
- **不改** 上游不一致项的语义（例：`--abbrev` 在 git branch 中保留 `Number` +
  callback 双层防御，与上游完全对齐）。

## 验证

### 本地管线（按 `.github/copilot-instructions.md` 顺序）

```bash
cargo check -p dasclaw_bash_validation --tests
# Finished `dev` profile [unoptimized + debuginfo] target(s) in 4.29s

cargo nextest run -p dasclaw_bash_validation
# Summary [ 195.649s] 454 tests run: 454 passed, 0 skipped
# (= 428 baseline + 26 新 3.2.C.rest 测试)

cargo clippy --no-deps -p dasclaw_bash_validation --all-targets -- -D warnings
# clean

cargo fmt --all -- --check
# clean

python3.12 scripts/check_no_panics.py --base origin/xClaw
# OK: No panic-inducing calls in changed production code.
```

### 3 层代码审查

| Layer | 工具 | 模型 | 结论 |
|---|---|---|---|
| 1 | code-quality-audit (verbatim-parity) | Claude Opus 4.7 | **PASS** (re-audit) |
| 2 | code-simplifier | — | SKIP（verbatim port, ADR-129） |
| 3 | code-review-expert | Claude Opus 4.7 | **PASS** — 0 CRITICAL/MAJOR |

**Layer 1 初审 FAIL → 修复 → 复审 PASS**。FAIL 原因是 `git_allowlist.rs` 初版有
11 个 git 子表与上游有分歧，含 1 个安全回归（`git branch --format` 上游显式排除）。
本次 commit 已把全部 11 张表恢复为 verbatim 状态：

- ❌→✅ `git branch --format` 移除（上游 L865 显式排除）
- ❌→✅ `git branch --merged`/`--no-merged`: `String` → `None`（上游 'none'，callback 处理可选参数）
- ❌→✅ `git config --get` 16 条全表重写（上游 L463-484）
- ❌→✅ `git blame` 改为 `static LazyLock` + `GIT_COLOR_FLAGS` spread；移除 -c/--reverse/--first-parent/--encoding/--minimal/--color-lines/--color-by-age；添加 -M/-C/--score-debug
- ❌→✅ `git cat-file --allow-unknown-type` → `--allow-undetermined-type`（上游 L645 拼写）；添加 `--batch-check: None`（上游 L641）；移除 --textconv/--filters/--path
- ❌→✅ `git rev-parse --short`: `Number` → `String`（上游 L522）；移除重复 `--symbolic-full-name`；移除 15 个上游不存在的 flag；添加 `--path-prefix`/`--is-shallow-update`
- ❌→✅ `git rev-list` 移除 22 个上游不存在的 flag；添加 --skip/--max-age/--min-age/--walk-reflogs/--oneline/--full-history/--dense/--sparse/--source/--graph
- ❌→✅ `git describe` 添加 `--first-match`（上游 L617）；移除 --all/--debug/--first-parent
- ❌→✅ `git ls-files` 添加 `-f`（上游 L437）
- ❌→✅ `git for-each-ref` 移除 7 个上游不存在的 flag（--shell/--perl/--python/--tcl/--color/--no-color/--ignore-case）
- ❌→✅ `git grep` 移除 8 个上游不存在的 flag；添加 `-o`/`--only-matching`
- ❌→✅ `git stash show` 添加 `GIT_COLOR_FLAGS` spread；用 --word-diff/--word-diff-regex/--diff-filter/--abbrev 替换 --include-untracked/--only-untracked/-u
- ❌→✅ `git worktree list` 移除 `-z`
- ❌→✅ `git tag` 移除 --color/--no-color/--omit-empty/--create-reflog
- ❌→✅ gh 22 个表的 `respects_double_dash: false` → `true`（与上游默认值一致）

**Layer 3 findings**:
- MINOR-1：3 个 `pub static` 表降级为 `pub(crate)`（已应用）。
- MINOR-2 / NIT：暂不应用（mod.rs 可见性、测试 guard 注释），均为 cleanup-friendly follow-ups。

### 7 条 Layer 1 回归 pin（防止再次跑偏）

| 测试 | 锁定语义 |
|---|---|
| `req_readonly_3_2_c_git_branch_format_excluded_security` | `git branch --format=…` 必须被拒绝 |
| `req_readonly_3_2_c_git_branch_merged_no_arg_allowed` | `git branch --merged` 裸命令允许 |
| `req_readonly_3_2_c_git_rev_parse_short_takes_string` | `--short` / `--short=7` 都接受 |
| `req_readonly_3_2_c_git_cat_file_batch_check_and_undetermined` | `--batch-check`/`--allow-undetermined-type` 通过；`--batch`/`--allow-unknown-type` 被拒 |
| `req_readonly_3_2_c_git_tag_create_reflog_excluded` | `--create-reflog` 必须被拒绝 |
| `req_readonly_3_2_c_git_for_each_ref_strays_excluded` | `--color`/`--shell` 必须被拒绝 |
| `req_readonly_3_2_c_gh_respects_double_dash_true` | `gh pr view -- 123` 通过 |

Closes #595
