### PR TITLE
feat(bash-parity): Phase 3.2.E.rest — xargs decomposition + sandbox-escape audit pins (S21+S22)

### DIFF
--- a/crates/dasclaw_bash_permissions/src/types.rs
+++ b/crates/dasclaw_bash_permissions/src/types.rs
@@ -86,6 +86,32 @@ pub enum PermissionDecisionReason {
     /// Catch-all — no rule matched and no other mechanism opined.
     /// Used by the `Passthrough` result to carry a free-form note.
     Other { reason: String },
+    /// Sandbox-escape pin **S21** — the command invokes `xargs` with a
+    /// target that is not in `SAFE_TARGET_COMMANDS_FOR_XARGS`
+    /// (upstream `readOnlyValidation.ts` L1218–L1232). This is a
+    /// hard-deny reason emitted by the hook layer before the
+    /// rule pipeline — no user rule may legitimately allow `xargs`
+    /// targeting an arbitrary command.
+    ///
+    /// Carries the offending command verbatim for audit dashboards;
+    /// the `rule_id` surface renders as `"FlagNotInAllowlist"`.
+    ///
+    /// Added by Phase 3.2.E.rest (issue #603).
+    FlagNotInAllowlist { command: String },
+    /// Sandbox-escape pin **S22** — the command writes to one of the
+    /// four git-internal roots (`HEAD` / `objects/` / `refs/` /
+    /// `hooks/`) inside a compound that also contains a git
+    /// invocation, exploitable for the bare-repo masquerade attack
+    /// documented in
+    /// [`dasclaw_bash_validation::is_git_internal_path`] (upstream
+    /// `readOnlyValidation.ts` L1840–L1865). Hard-deny reason emitted
+    /// by the hook layer before the rule pipeline.
+    ///
+    /// Carries the offending command verbatim; the `rule_id` surface
+    /// renders as `"GitInternalPathWrite"`.
+    ///
+    /// Added by Phase 3.2.E.rest (issue #603).
+    GitInternalPathWrite { command: String },
 }
 
 /// Outcome of running the permission pipeline against a single command.

--- a/crates/dasclaw_bash_permissions/tests/compound_match_test.rs
+++ b/crates/dasclaw_bash_permissions/tests/compound_match_test.rs
@@ -24,7 +24,9 @@ fn rule_content(result: &PermissionResult) -> Option<&str> {
     };
     match reason {
         PermissionDecisionReason::Rule { rule } => rule.rule_value.rule_content.as_deref(),
-        PermissionDecisionReason::Other { .. } => None,
+        PermissionDecisionReason::Other { .. }
+        | PermissionDecisionReason::FlagNotInAllowlist { .. }
+        | PermissionDecisionReason::GitInternalPathWrite { .. } => None,
     }
 }
 

--- a/crates/dasclaw_bash_permissions/tests/prefix_match_test.rs
+++ b/crates/dasclaw_bash_permissions/tests/prefix_match_test.rs
@@ -30,7 +30,9 @@ fn rule_content(result: &PermissionResult) -> Option<&str> {
     };
     match reason {
         PermissionDecisionReason::Rule { rule } => rule.rule_value.rule_content.as_deref(),
-        PermissionDecisionReason::Other { .. } => None,
+        PermissionDecisionReason::Other { .. }
+        | PermissionDecisionReason::FlagNotInAllowlist { .. }
+        | PermissionDecisionReason::GitInternalPathWrite { .. } => None,
     }
 }
 

--- a/crates/dasclaw_bash_validation/src/lib.rs
+++ b/crates/dasclaw_bash_validation/src/lib.rs
@@ -37,6 +37,7 @@ pub use readonly::git_internal::{
 };
 pub use readonly::main_entry::{
     contains_unquoted_expansion, contains_vulnerable_unc_path, is_command_read_only,
+    is_unsafe_xargs_invocation,
 };
 pub use redirects::{
     extract_output_redirections, OutputRedirection, RedirectOperator, RedirectionExtraction,

--- a/crates/dasclaw_bash_validation/src/readonly/main_entry.rs
+++ b/crates/dasclaw_bash_validation/src/readonly/main_entry.rs
@@ -464,6 +464,50 @@ pub fn is_command_read_only(command: &str) -> bool {
 }
 
 // ---------------------------------------------------------------------------
+// is_unsafe_xargs_invocation — sandbox-escape pin S21 detector.
+// Upstream `readOnlyValidation.ts` L1376-L1377 (the xargs-target dispatcher
+// branch in `isCommandSafeViaFlagParsing`), surfaced here as a standalone
+// predicate so [`dasclaw_hooks::BashPermissionHook`] can hard-deny S21 with
+// a structured [`crate::PermissionDecisionReason::FlagNotInAllowlist`].
+//
+// Added by Phase 3.2.E.rest (issue #603).
+// ---------------------------------------------------------------------------
+
+/// Returns `true` when `command` is a single-subcommand `xargs`
+/// invocation whose target command or flag combination is NOT safe per
+/// the allowlist flag-parser. Compound `... | xargs ...` is **not**
+/// inspected here; the leading-pipe-into-xargs surface is rejected by
+/// [`is_command_read_only`] (the whole compound has no matching
+/// allowlist prefix) and by the legacy `validate_read_only` operator
+/// guard — defense in depth.
+///
+/// SECURITY pin **S21**: `xargs -I{} rm {} < list` and any variant
+/// targeting a command outside `SAFE_TARGET_COMMANDS_FOR_XARGS`
+/// (`echo` / `printf` / `wc` / `grep` / `head` / `tail`) returns
+/// `true` so the caller can refuse the invocation regardless of user
+/// permission rules — no rule may legitimately allow `xargs` to
+/// dispatch to arbitrary commands.
+///
+/// Returns `false` for any non-`xargs` leading token so the
+/// permission-hook pre-check can call this on every command without
+/// false positives on unrelated invocations.
+#[must_use]
+pub fn is_unsafe_xargs_invocation(command: &str) -> bool {
+    let trimmed = command.trim();
+    let tokens = match shell_words::split(trimmed) {
+        Ok(t) if !t.is_empty() => t,
+        _ => return false,
+    };
+    if tokens[0] != "xargs" {
+        return false;
+    }
+    // Reuse the dispatcher — it injects SAFE_TARGET_COMMANDS_FOR_XARGS
+    // when tokens[0] == "xargs" and returns false on any flag/target
+    // mismatch.
+    !is_command_safe_via_flag_parsing(trimmed)
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 

--- a/crates/dasclaw_bash_validation/tests/req_security_xargs_decomposition_tests.rs
+++ b/crates/dasclaw_bash_validation/tests/req_security_xargs_decomposition_tests.rs
@@ -1,0 +1,212 @@
+//! Phase 3.2.E SECURITY pin **S21** — xargs target decomposition.
+//!
+//! Integration tests at the [`is_command_read_only`] boundary that prove
+//! upstream `claude-code-main/src/tools/BashTool/readOnlyValidation.ts`
+//! L1218–L1232 (`SAFE_TARGET_COMMANDS_FOR_XARGS`) + L1376–L1377
+//! (dispatcher injection) + `readOnlyCommandValidation.ts` L1681–L1745
+//! (validator's xargs-target branch) compose end-to-end:
+//!
+//! * Targets in the safe set (`echo` / `printf` / `wc` / `grep` /
+//!   `head` / `tail`) are allowed under reasonable flag shapes.
+//! * Any unsafe target (`ls` / `rm` / `mkdir` / `sh` / `bash` / `cat`),
+//!   shell operator (`<` / `>` / `|`), unknown flag (`-J`), or
+//!   non-literal `-I` argument flips the decision to `false`. This
+//!   pins S21 (`xargs -I{} rm {} < list`).
+//!
+//! Sub-issue: <https://github.com/Linnanli/xClaw/issues/603> (Phase
+//! 3.2.E.rest Part 1).
+//!
+//! Test matrix follows pairwise(2-way) coverage over:
+//! - flag    ∈ {none, -I {}, -I X, -L 1, -n 1, -n1, -J X, -r}
+//! - target  ∈ {echo, printf, wc, grep, head, tail, ls, rm, mkdir, sh}
+//! - redirect∈ {none, < list, > out, | pipe}
+//!
+//! Cases below intentionally enumerate the boundary rows rather than
+//! the full Cartesian product — each row corresponds to a documented
+//! validator branch.
+
+use dasclaw_bash_validation::is_command_read_only;
+
+// ---------------------------------------------------------------------------
+// Safe targets: each entry in SAFE_TARGET_COMMANDS_FOR_XARGS must allow
+// the simplest "xargs <target>" form.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn req_security_s21_xargs_echo_allowed() {
+    assert!(is_command_read_only("xargs echo"));
+}
+
+#[test]
+fn req_security_s21_xargs_printf_allowed() {
+    assert!(is_command_read_only("xargs printf"));
+}
+
+#[test]
+fn req_security_s21_xargs_wc_allowed() {
+    assert!(is_command_read_only("xargs wc"));
+}
+
+#[test]
+fn req_security_s21_xargs_grep_allowed() {
+    assert!(is_command_read_only("xargs grep"));
+}
+
+#[test]
+fn req_security_s21_xargs_head_allowed() {
+    assert!(is_command_read_only("xargs head"));
+}
+
+#[test]
+fn req_security_s21_xargs_tail_allowed() {
+    assert!(is_command_read_only("xargs tail"));
+}
+
+// ---------------------------------------------------------------------------
+// Unsafe targets: NOT in SAFE_TARGET_COMMANDS_FOR_XARGS → reject.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn req_security_s21_xargs_ls_blocked() {
+    assert!(!is_command_read_only("xargs ls"));
+}
+
+#[test]
+fn req_security_s21_xargs_rm_blocked() {
+    assert!(!is_command_read_only("xargs rm"));
+}
+
+#[test]
+fn req_security_s21_xargs_mkdir_blocked() {
+    assert!(!is_command_read_only("xargs mkdir"));
+}
+
+#[test]
+fn req_security_s21_xargs_sh_blocked() {
+    assert!(!is_command_read_only("xargs sh"));
+}
+
+#[test]
+fn req_security_s21_xargs_bash_blocked() {
+    assert!(!is_command_read_only("xargs bash"));
+}
+
+#[test]
+fn req_security_s21_xargs_cat_blocked() {
+    // `cat` is read-only but reads arbitrary files — NOT in the xargs
+    // safe-target allowlist (UNC-on-Windows attack surface, upstream
+    // L1218 SECURITY comment). xargs cannot dispatch to cat.
+    assert!(!is_command_read_only("xargs cat"));
+}
+
+// ---------------------------------------------------------------------------
+// -I flag interactions (Brace arg type).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn req_security_s21_xargs_dash_i_literal_brace_safe_target_allowed() {
+    assert!(is_command_read_only("xargs -I {} echo"));
+}
+
+#[test]
+fn req_security_s21_xargs_dash_i_literal_brace_unsafe_target_blocked() {
+    // Canonical S21: `xargs -I{} rm {} < list` simplified to the
+    // single-subcommand shape (compound `< list` is rejected
+    // separately by the operator check below).
+    assert!(!is_command_read_only("xargs -I {} rm"));
+}
+
+#[test]
+fn req_security_s21_xargs_dash_i_non_literal_brace_blocked() {
+    // -I expects literal `{}`; any other string is rejected by the
+    // Brace flag-arg validator (upstream `validateFlagArgument`).
+    assert!(!is_command_read_only("xargs -I X echo"));
+}
+
+// ---------------------------------------------------------------------------
+// Other flag shapes.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn req_security_s21_xargs_dash_l_number_safe_target_allowed() {
+    assert!(is_command_read_only("xargs -L 1 echo"));
+}
+
+#[test]
+fn req_security_s21_xargs_dash_n_number_safe_target_allowed() {
+    assert!(is_command_read_only("xargs -n 1 echo"));
+}
+
+#[test]
+fn req_security_s21_xargs_dash_r_safe_target_allowed() {
+    assert!(is_command_read_only("xargs -r echo"));
+}
+
+#[test]
+fn req_security_s21_xargs_unknown_flag_blocked() {
+    // -J is NOT in XARGS_FLAGS — unknown flag → reject regardless
+    // of target safety.
+    assert!(!is_command_read_only("xargs -J X echo"));
+}
+
+#[test]
+fn req_security_s21_xargs_combined_arg_taking_bundle_blocked() {
+    // `-rI` bundles `-r` (no-arg) with `-I` (arg-taking). Bundled
+    // arg-taking flags create a parser differential with GNU getopt
+    // — the validator rejects the whole bundle (existing flag_parser
+    // unit test `req_bash_validation_320_a_rejects_combined_short_with_arg_taking_member`).
+    assert!(!is_command_read_only("xargs -rI echo rm evil"));
+}
+
+// ---------------------------------------------------------------------------
+// Operator interactions at THIS boundary.
+//
+// `is_command_read_only` consumes the flag-parsing dispatcher which
+// tokenises with `shell_words` (no operator model). Operator bypass is
+// guarded at a HIGHER layer:
+//
+// * `crate::validate_read_only` (legacy ValidationResult path used by
+//   `BashValidationHook`) explicitly checks WRITE_REDIRECTIONS.
+// * `command_writes_to_git_internal_paths` uses tree-sitter and catches
+//   redirections into `HEAD` / `objects/` / `refs/` / `hooks/`.
+//
+// The cases below cover only what THIS function can decide: the canonical
+// S21 attack with `< list` is rejected because `rm` is not a safe xargs
+// target (the `<` is incidental). Pipe-bypass is rejected because the
+// first token of the compound is `ls`, not `xargs` — the dispatcher only
+// inspects the leading subcommand. Output-redirect-to-non-git is
+// intentionally NOT pinned here; that path lives at the hook layer and
+// is exercised by hook-level snapshot tests.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn req_security_s21_xargs_input_redirect_to_unsafe_target_blocked() {
+    // Canonical S21: `< list` is incidental; the decisive rejection is
+    // `rm` not being in SAFE_TARGET_COMMANDS_FOR_XARGS.
+    assert!(!is_command_read_only("xargs -I {} rm < list"));
+}
+
+#[test]
+fn req_security_s21_pipe_to_xargs_with_unsafe_target_blocked() {
+    // `ls | xargs rm` — first token is `ls`, not `xargs`; the
+    // dispatcher only inspects the leading subcommand, so the
+    // xargs-decomposition path never fires. The whole compound is
+    // rejected because `ls | xargs rm` does not match any single
+    // allowlist prefix.
+    assert!(!is_command_read_only("ls | xargs rm"));
+}
+
+// ---------------------------------------------------------------------------
+// Expansion / substitution: defense in depth via
+// contains_unquoted_expansion.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn req_security_s21_xargs_dollar_expansion_blocked() {
+    assert!(!is_command_read_only("xargs echo $HOME"));
+}
+
+#[test]
+fn req_security_s21_xargs_glob_expansion_blocked() {
+    assert!(!is_command_read_only("xargs echo *"));
+}

--- a/crates/dasclaw_hooks/src/bash_permission_hook.rs
+++ b/crates/dasclaw_hooks/src/bash_permission_hook.rs
@@ -77,6 +77,9 @@ use dasclaw_bash_permissions::{
     PermissionRule, ToolPermissionContext, check_compound_match, check_exact_match,
     permission_rule_value_to_string, suggestion_for_exact_command,
 };
+use dasclaw_bash_validation::{
+    command_has_any_git, command_writes_to_git_internal_paths, is_unsafe_xargs_invocation,
+};
 use serde_json::Value;
 use x_claw_agent::{RuleAction, RuleSuggestion, SafetyDecision, SafetyError, SafetyHook};
 
@@ -152,6 +155,24 @@ impl SafetyHook for BashPermissionHook {
             }
         };
 
+        // Phase 3.2.E.rest (issue #603): hard-deny sandbox-escape pins
+        // **S21** (`xargs` targeting a non-safe command) and **S22**
+        // (write into `HEAD` / `objects/` / `refs/` / `hooks/` when
+        // the compound also invokes git) BEFORE the rule pipeline.
+        // No user permission rule may legitimately allow these — they
+        // are validator-defeating attacks that bypass the readonly
+        // allowlist or the .git/-relative bare-repo protection.
+        if let Some(reason) = detect_sandbox_escape(command) {
+            return Ok(map_permission_result(
+                tool,
+                command,
+                PermissionResult::Deny {
+                    message: sandbox_escape_message(&reason),
+                    reason,
+                },
+            ));
+        }
+
         // Upstream pipeline (bashPermissions.ts L1663-L1820): exact
         // match wins first (fast path, no AST cost). Only when the
         // engine has no exact opinion do we run the compound /
@@ -212,7 +233,12 @@ fn map_permission_result(tool: &str, command: &str, result: PermissionResult) ->
 /// `"Bash(content)"` rendering of the matching rule's pattern. For
 /// `Other` variants (cap exceeded, empty input, no rule fired) we use
 /// the literal string `"Other"` so audit dashboards have a stable
-/// dimension to filter on.
+/// dimension to filter on. The two sandbox-escape variants
+/// ([`PermissionDecisionReason::FlagNotInAllowlist`] /
+/// [`PermissionDecisionReason::GitInternalPathWrite`], added by Phase
+/// 3.2.E.rest) render as their bare variant name so the
+/// `bash_perm::<rule_id>` audit channel can filter on them
+/// alongside rule-driven blocks.
 fn format_rule_id(reason: &PermissionDecisionReason) -> String {
     match reason {
         PermissionDecisionReason::Rule {
@@ -222,6 +248,8 @@ fn format_rule_id(reason: &PermissionDecisionReason) -> String {
             rule_value.rule_content.as_deref(),
         ),
         PermissionDecisionReason::Other { .. } => "Other".to_string(),
+        PermissionDecisionReason::FlagNotInAllowlist { .. } => "FlagNotInAllowlist".to_string(),
+        PermissionDecisionReason::GitInternalPathWrite { .. } => "GitInternalPathWrite".to_string(),
     }
 }
 
@@ -257,5 +285,64 @@ fn rule_suggestion_from_bash(s: BashRuleSuggestion) -> RuleSuggestion {
         label,
         rule_pattern,
         action,
+    }
+}
+
+/// Sandbox-escape pre-check — runs before the rule pipeline so the
+/// permission engine cannot be coerced into allowing pins **S21** /
+/// **S22** via a user-installed `allow` rule.
+///
+/// Returns `Some(reason)` when the command matches one of the two
+/// validator-defeating patterns documented on
+/// [`PermissionDecisionReason::FlagNotInAllowlist`] /
+/// [`PermissionDecisionReason::GitInternalPathWrite`]:
+///
+/// * **S21** — `xargs` invocation whose target is not in
+///   `SAFE_TARGET_COMMANDS_FOR_XARGS` (delegated to
+///   [`is_unsafe_xargs_invocation`]).
+/// * **S22** — a compound that both contains a git invocation and
+///   writes into one of the four git-internal roots
+///   (`HEAD` / `objects/` / `refs/` / `hooks/`). Both halves of the
+///   conjunction are required (upstream parity, `readOnlyValidation.ts`
+///   L1838-L1842): a bare `echo foo > hooks/x` with no git in the
+///   compound is not the bare-repo masquerade attack and should fall
+///   through to the rule engine.
+///
+/// Precedence: S22 is checked before S21 so the audit log surfaces
+/// the more-specific git-internal reason when both fire (e.g.,
+/// `xargs git commit && echo m > hooks/x`).
+fn detect_sandbox_escape(command: &str) -> Option<PermissionDecisionReason> {
+    if command_has_any_git(command) && command_writes_to_git_internal_paths(command) {
+        return Some(PermissionDecisionReason::GitInternalPathWrite {
+            command: command.to_string(),
+        });
+    }
+    if is_unsafe_xargs_invocation(command) {
+        return Some(PermissionDecisionReason::FlagNotInAllowlist {
+            command: command.to_string(),
+        });
+    }
+    None
+}
+
+/// Renders the user-visible block message for a sandbox-escape reason.
+/// The message text is the audit-log `message` field — kept stable so
+/// SIEM dashboards / snapshot tests can pin on it.
+fn sandbox_escape_message(reason: &PermissionDecisionReason) -> String {
+    match reason {
+        PermissionDecisionReason::FlagNotInAllowlist { command } => format!(
+            "bash sandbox escape S21: `xargs` target / flag is not in the safe allowlist \
+             (command: {command})"
+        ),
+        PermissionDecisionReason::GitInternalPathWrite { command } => format!(
+            "bash sandbox escape S22: command writes into a git-internal path \
+             (HEAD / objects/ / refs/ / hooks/) inside a git-bearing compound \
+             (command: {command})"
+        ),
+        // The other variants are never returned by `detect_sandbox_escape`;
+        // fall back to a generic surface so the function is total.
+        PermissionDecisionReason::Rule { .. } | PermissionDecisionReason::Other { .. } => {
+            "bash sandbox escape".to_string()
+        }
     }
 }

--- a/crates/dasclaw_hooks/tests/bash_sandbox_escape_audit_log.rs
+++ b/crates/dasclaw_hooks/tests/bash_sandbox_escape_audit_log.rs
@@ -1,0 +1,253 @@
+//! Phase 3.2.E.rest (issue #603) — sandbox-escape audit-log contract
+//! pinning for [`BashPermissionHook`].
+//!
+//! Companion to [`bash_permission_audit_log.rs`] (Slice 2.2.h), this
+//! file pins the audit-log shape for the two pre-rule-pipeline
+//! hard-deny reasons added by 3.2.E.rest:
+//!
+//! * SECURITY pin **S21** — `xargs` target / flag not in the safe
+//!   allowlist (renders as `rule_id=FlagNotInAllowlist`).
+//! * SECURITY pin **S22** — write into a git-internal path
+//!   (`HEAD` / `objects/` / `refs/` / `hooks/`) inside a git-bearing
+//!   compound (renders as `rule_id=GitInternalPathWrite`).
+//!
+//! ## Why substring pinning, not `insta`
+//!
+//! The existing audit-log contract in
+//! [`bash_permission_audit_log.rs`] / [`bash_security_audit_log.rs`]
+//! uses `tracing_test::logs_contain` with exact literal substrings.
+//! That is the established convention. Adding `insta` here purely
+//! for two new variants would be patch-style accretion. The PIN
+//! semantics are identical: any rename of an enum variant, audit
+//! event name, or message format flips a hard `assert!` here.
+//!
+//! ## Coverage matrix
+//!
+//! | Pin | Rule context | Command                                    | Expected decision    |
+//! |-----|--------------|--------------------------------------------|----------------------|
+//! | S21 | empty (no rules) | `xargs rm`                              | Block FlagNotInAllowlist |
+//! | S21 | allow rule `xargs:*` matches | `xargs -I {} rm`            | Block FlagNotInAllowlist (rule cannot allow) |
+//! | S21 | empty            | `xargs echo`                            | Allow (safe target)     |
+//! | S22 | empty            | `mkdir -p hooks && echo m > hooks/x && git status` | Block GitInternalPathWrite |
+//! | S22 | allow rule `Bash(*)` matches | same as above                   | Block GitInternalPathWrite (rule cannot allow) |
+//! | S22 | empty            | `echo m > hooks/x` (no git)             | Passthrough (no git in compound) |
+//! | S22 | empty            | `git status && mkdir -p HEAD` (creates HEAD dir) | Block GitInternalPathWrite |
+//!
+//! The "rule cannot allow" pins are the SECURITY core of this slice:
+//! they prove the pre-pipeline pre-check fires regardless of user
+//! rules — no admin / project / user config can re-enable a
+//! sandbox-escape.
+
+use dasclaw_bash_permissions::{PermissionBehavior, PermissionRuleSource, ToolPermissionContext};
+use dasclaw_hooks::BashPermissionHook;
+use serde_json::json;
+use tracing_test::traced_test;
+use x_claw_agent::{SafetyDecision, SafetyHook};
+
+fn empty_ctx() -> ToolPermissionContext {
+    ToolPermissionContext::default()
+}
+
+fn ctx_with(behavior: PermissionBehavior, rule_content: &str) -> ToolPermissionContext {
+    let mut ctx = ToolPermissionContext::default();
+    ctx.add_rule(
+        behavior,
+        PermissionRuleSource::ProjectSettings,
+        rule_content,
+    );
+    ctx
+}
+
+async fn fire(ctx: ToolPermissionContext, tool: &str, command: &str) -> SafetyDecision {
+    let hook = BashPermissionHook::new(ctx);
+    let mut args = json!({ "command": command });
+    hook.before_tool_call(tool, &mut args)
+        .await
+        .expect("hook must not error on a string command")
+}
+
+fn block_reason(decision: &SafetyDecision) -> &str {
+    match decision {
+        SafetyDecision::Block { reason } => reason,
+        other => panic!("expected SafetyDecision::Block, got {other:?}"),
+    }
+}
+
+// =====================================================================
+// S21 — `xargs` target / flag not in safe allowlist
+// =====================================================================
+
+#[tokio::test]
+#[traced_test]
+async fn req_security_603_s21_xargs_unsafe_target_block() {
+    let decision = fire(empty_ctx(), "bash", "xargs rm").await;
+    let reason = block_reason(&decision);
+
+    assert!(
+        reason.contains("FlagNotInAllowlist"),
+        "block reason must surface variant tag; got {reason}"
+    );
+    assert!(
+        reason.contains("xargs rm"),
+        "block reason must echo the offending command; got {reason}"
+    );
+
+    assert!(
+        logs_contain("bash_perm::block"),
+        "audit log must carry `bash_perm::block` event-message tag"
+    );
+    assert!(
+        logs_contain("rule_id=FlagNotInAllowlist"),
+        "audit log must surface `rule_id=FlagNotInAllowlist`"
+    );
+    assert!(
+        logs_contain("bash sandbox escape S21"),
+        "audit `message` field must pin the human-readable S21 tag"
+    );
+}
+
+#[tokio::test]
+#[traced_test]
+async fn req_security_603_s21_xargs_unsafe_target_rule_cannot_allow() {
+    // SECURITY core: even with a permission rule that would normally
+    // allow `xargs ...`, the sandbox-escape pre-check fires first and
+    // blocks. No rule config can re-enable S21.
+    let ctx = ctx_with(PermissionBehavior::Allow, "xargs:*");
+    let decision = fire(ctx, "bash", "xargs -I {} rm").await;
+
+    assert!(
+        matches!(decision, SafetyDecision::Block { .. }),
+        "user allow-rule must NOT bypass S21 hard-deny; got {decision:?}"
+    );
+    assert!(
+        logs_contain("rule_id=FlagNotInAllowlist"),
+        "audit log must surface the sandbox-escape rule_id, not the rule pattern"
+    );
+}
+
+#[tokio::test]
+#[traced_test]
+async fn req_security_603_s21_xargs_safe_target_passes_to_rule_engine() {
+    // Negative pin: `xargs echo` is in the safe allowlist; the
+    // sandbox-escape pre-check must NOT fire, leaving the decision to
+    // the rule engine (which, with no rules, returns Passthrough).
+    let decision = fire(empty_ctx(), "bash", "xargs echo hi").await;
+    assert!(
+        matches!(decision, SafetyDecision::Passthrough),
+        "safe xargs target must fall through to rule engine; got {decision:?}"
+    );
+    assert!(
+        !logs_contain("bash_perm::block"),
+        "no block event must fire for safe xargs invocations"
+    );
+    assert!(
+        !logs_contain("FlagNotInAllowlist"),
+        "FlagNotInAllowlist must not appear for safe xargs invocations"
+    );
+}
+
+// =====================================================================
+// S22 — write into git-internal path inside git-bearing compound
+// =====================================================================
+
+#[tokio::test]
+#[traced_test]
+async fn req_security_603_s22_redirect_into_hooks_block() {
+    // Canonical S22 from `command_writes_to_git_internal_paths` docs:
+    // bare-repo masquerade via `hooks/pre-commit` + `git status`.
+    let cmd = "mkdir -p hooks && echo m > hooks/pre-commit && git status";
+    let decision = fire(empty_ctx(), "bash", cmd).await;
+    let reason = block_reason(&decision);
+
+    assert!(
+        reason.contains("GitInternalPathWrite"),
+        "block reason must surface variant tag; got {reason}"
+    );
+    assert!(
+        reason.contains("hooks/pre-commit") || reason.contains(cmd),
+        "block reason must echo command details; got {reason}"
+    );
+
+    assert!(
+        logs_contain("rule_id=GitInternalPathWrite"),
+        "audit log must surface `rule_id=GitInternalPathWrite`"
+    );
+    assert!(
+        logs_contain("bash sandbox escape S22"),
+        "audit `message` field must pin the human-readable S22 tag"
+    );
+}
+
+#[tokio::test]
+#[traced_test]
+async fn req_security_603_s22_rule_cannot_allow() {
+    // SECURITY core: a wildcard allow rule must not let S22 through.
+    let ctx = ctx_with(PermissionBehavior::Allow, "*");
+    let cmd = "mkdir -p hooks && echo m > hooks/pre-commit && git status";
+    let decision = fire(ctx, "bash", cmd).await;
+
+    assert!(
+        matches!(decision, SafetyDecision::Block { .. }),
+        "wildcard allow-rule must NOT bypass S22 hard-deny; got {decision:?}"
+    );
+    assert!(
+        logs_contain("rule_id=GitInternalPathWrite"),
+        "audit log must surface sandbox-escape rule_id, not the rule pattern"
+    );
+}
+
+#[tokio::test]
+#[traced_test]
+async fn req_security_603_s22_no_git_in_compound_passes_through() {
+    // Negative pin: write into `hooks/` WITHOUT any git invocation in
+    // the compound is not the bare-repo masquerade attack (it's just a
+    // file write to an oddly-named directory). The sandbox-escape
+    // pre-check must NOT fire; the rule engine decides.
+    let decision = fire(empty_ctx(), "bash", "echo m > hooks/pre-commit").await;
+    assert!(
+        matches!(decision, SafetyDecision::Passthrough),
+        "non-git hooks/ write must fall through to rule engine; got {decision:?}"
+    );
+    assert!(
+        !logs_contain("GitInternalPathWrite"),
+        "GitInternalPathWrite must not appear when no git is in the compound"
+    );
+}
+
+#[tokio::test]
+#[traced_test]
+async fn req_security_603_s22_mkdir_head_dir_block() {
+    // Vector-2 surface: `mkdir HEAD` creates a top-level HEAD file/dir
+    // that git will then read as bare-repo HEAD. Compound also
+    // contains a git invocation, so the pre-check fires.
+    let decision = fire(empty_ctx(), "bash", "git status && mkdir -p HEAD").await;
+    let reason = block_reason(&decision);
+    assert!(
+        reason.contains("GitInternalPathWrite"),
+        "mkdir into HEAD inside git-bearing compound must block; got {reason}"
+    );
+}
+
+// =====================================================================
+// Precedence — S22 wins over S21 when both apply
+// =====================================================================
+
+#[tokio::test]
+#[traced_test]
+async fn req_security_603_s22_precedes_s21() {
+    // `xargs git commit` is an unsafe xargs target (`git` not in
+    // SAFE_TARGET_COMMANDS_FOR_XARGS), AND the compound writes to
+    // `hooks/`. The pre-check checks S22 first so the more-specific
+    // git-internal reason wins the audit log.
+    let cmd = "xargs git commit && echo m > hooks/pre-commit";
+    let decision = fire(empty_ctx(), "bash", cmd).await;
+    let reason = block_reason(&decision);
+    assert!(
+        reason.contains("GitInternalPathWrite"),
+        "S22 must take precedence over S21 when both apply; got {reason}"
+    );
+    assert!(
+        !reason.contains("FlagNotInAllowlist"),
+        "S21 reason must not also appear in the same audit line; got {reason}"
+    );
+}


### PR DESCRIPTION
## 背景 / 目标

Phase 3.2.E.rest，bash parity 移植的 E 序列收尾。把 xargs 分解（**S21**）与 git-internal 路径写入（**S22**）两个 sandbox-escape pin 接入 `BashPermissionHook` 的 pre-rule-pipeline 硬拒绝路径，并补上审计日志契约 pin。

E.2（xargs 分解）+ E.3（Hook wiring + DecisionReason widening + snapshot）按 issue #603 显式要求合并到单 PR — 拆分会引入补丁式代码（enum widening 的 match-site 修改与 hook wiring 强耦合）。

Closes #603
Refs #490

## Stacked PR 信息

- **base**: `feat/bash-parity-3.2.E.1-git-internal`（PR #602）
- **不是** `xClaw` —— 本 PR 复用 PR #602 引入的 `command_has_any_git` / `command_writes_to_git_internal_paths` API
- **Merge 顺序**：必须先 merge #602，再 merge 本 PR
- **请先看 #602，再看本 PR**

## Sources read

- `docs/plans/architecture-refactor/adr-113-hook-engine-unification.md` §"3.2.E rest" — Phase 3.2.E.rest 验收清单
- `docs/plans/architecture-refactor/32-execution-plan.md` Phase 3.2.E 行 — 验证步骤
- `decode-claude-code-main/architecture/runtime/readOnlyValidation.ts` L1218-L1232（S21 安全 xargs target 白名单分支）
- 同上 L1376-L1377（`SAFE_TARGET_COMMANDS_FOR_XARGS` 集合定义）
- 同上 L1681-L1745（xargs target-validator pre-check 分支）
- 同上 L1838-L1842（S22 git-internal 路径写入 + git-bearing compound 双条件）
- `crates/dasclaw_hooks/tests/bash_permission_audit_log.rs` L1-100 — 审计日志 pin 测试约定（`tracing_test::traced_test` + `logs_contain`）
- `crates/dasclaw_hooks/src/bash_permission_hook.rs`（被改文件全文）

## 改动范围

8 个文件，+~390 LOC。

**生产代码** (~160 LOC)：
- `crates/dasclaw_bash_permissions/src/types.rs` — `PermissionDecisionReason` 加 2 个 typed variants：
  - `FlagNotInAllowlist { command: String }` （S21）
  - `GitInternalPathWrite { command: String }` （S22）
- `crates/dasclaw_bash_validation/src/readonly/main_entry.rs` — 新增 `pub fn is_unsafe_xargs_invocation(command: &str) -> bool`（`#[must_use]`）
- `crates/dasclaw_bash_validation/src/lib.rs` — re-export
- `crates/dasclaw_hooks/src/bash_permission_hook.rs` — `before_tool_call` 在 rule pipeline 之前插入 `detect_sandbox_escape` 预检；新增 `detect_sandbox_escape` / `sandbox_escape_message` helper；`format_rule_id` 加 2 个 arm

**测试** (~230 LOC)：
- `crates/dasclaw_bash_validation/tests/req_security_xargs_decomposition_tests.rs`（NEW，24 个 PICT pin）
- `crates/dasclaw_hooks/tests/bash_sandbox_escape_audit_log.rs`（NEW，8 个审计日志 pin）
- `crates/dasclaw_bash_permissions/tests/{prefix,compound}_match_test.rs` — 单行 pipe-pattern 把新 variant 折进既有 `None`-arm

## 非目标（What's NOT in this PR）

- ❌ **不修改** PR #602 的 `git_internal.rs`（API 已锁定）
- ❌ **不修改** `static_regex` 基础设施
- ❌ **不重写** xargs 规则解析（既有 `is_command_safe_via_flag_parsing` 已够用）
- ❌ **不引入** `insta` snapshot framework —— 沿用既有 `bash_permission_audit_log.rs` 的 `tracing_test::logs_contain` 约定。理由：为 2 个 variant 引入新框架是补丁式 accretion；子串 pin 对 variant rename / event rename / message rename 有同样的 hard-assert 语义。判断写在新测试文件的 module doc 里。
- ❌ **不修复** `shell_words::split` 不模型化 `>` 操作符的 broader parity gap（属独立 issue scope；redirect-bypass 防线本就在 hook 层 `validate_read_only` + `command_writes_to_git_internal_paths`，本 PR 的 xargs 测试 module doc 已诚实说明这个边界）

## SECURITY 核心（pin 测试覆盖）

| Pin | 场景 | 攻击向量 | 验证 |
|-----|------|----------|------|
| S21 rule-cannot-allow | 用户装了 `xargs:*` allow 规则 | 仍然 Block `xargs -I {} rm` | `req_security_603_s21_xargs_unsafe_target_rule_cannot_allow` |
| S22 rule-cannot-allow | 用户装了 `*` 通配 allow 规则 | 仍然 Block `mkdir -p hooks && echo m > hooks/pre-commit && git status` | `req_security_603_s22_rule_cannot_allow` |
| S22 precedes S21 | 命令同时触发两者 | 审计日志只出 S22 reason | `req_security_603_s22_precedes_s21` |
| S22 scoping 负 pin | 写 `hooks/` 但无 git | Passthrough（不是 bare-repo 攻击） | `req_security_603_s22_no_git_in_compound_passes_through` |
| S21 scoping 负 pin | `xargs echo` 安全 target | Passthrough | `req_security_603_s21_xargs_safe_target_passes_to_rule_engine` |

## 验证

```bash
# 24 个 S21 PICT pin
cargo nextest run -p dasclaw_bash_validation --test req_security_xargs_decomposition_tests
# → 24/24 passed

# 8 个 S21+S22 审计日志 pin
cargo nextest run -p dasclaw_hooks --test bash_sandbox_escape_audit_log
# → 8/8 passed

# 3 个 crate 全集回归
cargo nextest run -p dasclaw_bash_validation -p dasclaw_bash_permissions -p dasclaw_hooks
# → 947/947 passed in 423s

# clippy
cargo clippy --no-deps -p dasclaw_bash_validation -p dasclaw_bash_permissions -p dasclaw_hooks --all-targets -- -D warnings
# → clean

# fmt
cargo fmt -p dasclaw_bash_validation -p dasclaw_bash_permissions -p dasclaw_hooks
# → clean

# no-panics
python3.12 scripts/check_no_panics.py --base origin/xClaw
# → OK: No panic-inducing calls in changed production code.
```

## Skills 自查

- ✅ `code-quality-audit` — 5 项全过（无补丁式、无函数过长、无重复逻辑、无 unwrap/clone 滥用、无重复造轮子）
- ✅ `code-simplifier` — 无简化点；helper 配对粒度合理，测试 helper 抽象适度
- ✅ `code-review-expert` — APPROVE，无 P0/P1；1 项 P2（module doc 里一行过时的 "follow-up PR" 注释，deferred 到 doc cleanup PR 避免 scope creep）

## Cross-cuts

- ADR-114：**类A**（无新增 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量）

## 后续 PR / 下一步

- 该 PR merge 后 Phase 3.2.E 全序列完成
- 可选 follow-up：`shell_words::split` operator-modeling parity（独立 issue，与 S21/S22 解耦）
- 可选 follow-up：`bash_permission_hook.rs:70-72` 过时 module doc cleanup（P2）
