### PR TITLE
feat(hooks): Phase 4.2 wire sed strict allowlist into BashPermissionHook

### DIFF
--- a/crates/dasclaw_hooks/src/bash_permission_hook.rs
+++ b/crates/dasclaw_hooks/src/bash_permission_hook.rs
@@ -70,6 +70,30 @@
 //!   admin-backend / settings files) is Phase 2.3 too. For now callers
 //!   construct the context directly and pass it in at hook
 //!   construction time.
+//!
+//! # Phase 4.2 strict sed allowlist (opt-in)
+//!
+//! Issue #607 / Phase 4.2 of [Issue #490][issue-490]. After PR #606 landed
+//! the upstream-parity strict sed allowlist function
+//! [`dasclaw_bash_validation::sed_command_is_allowed_by_allowlist`], the
+//! hook can optionally use it to **upgrade** a rule-pipeline
+//! `Passthrough` or `Ask` outcome to `Allow` when the command matches
+//! the upstream Pattern 1 (line print with `-n`) or Pattern 2 (single
+//! substitution) constraints. Enable via
+//! [`BashPermissionHook::with_sed_strict_allowlist`]; default off.
+//!
+//! Invariants (pinned by `tests/bash_permission_sed_strict_allowlist.rs`):
+//!
+//! - **Never downgrades**: `Block` / `Allow` are passed through
+//!   untouched. Deny remains sovereign (PR #557 precedence).
+//! - **Only upgrades** `Passthrough` and `Ask` decisions, so the strict
+//!   mode cannot accidentally short-circuit a hook earlier in the chain
+//!   that wanted to Block.
+//! - **Non-sed → no-op**: the allowlist function returns `false` for
+//!   anything that is not a single `sed` simple command, so non-sed
+//!   inputs fall through unchanged.
+//! - Upgrades emit a `tracing::info!` event `bash_perm::allow_sed_strict_upgrade`
+//!   with `tool` + `rule_id="SedAllowlist"` for SIEM dashboards.
 
 use async_trait::async_trait;
 use dasclaw_bash_permissions::{
@@ -79,6 +103,7 @@ use dasclaw_bash_permissions::{
 };
 use dasclaw_bash_validation::{
     command_has_any_git, command_writes_to_git_internal_paths, is_unsafe_xargs_invocation,
+    sed_command_is_allowed_by_allowlist,
 };
 use serde_json::Value;
 use x_claw_agent::{RuleAction, RuleSuggestion, SafetyDecision, SafetyError, SafetyHook};
@@ -92,6 +117,19 @@ use crate::bash_validation_hook::DEFAULT_BASH_TOOL_NAMES;
 pub struct BashPermissionHook {
     context: ToolPermissionContext,
     bash_tool_names: Vec<String>,
+    /// `Some` enables the Phase 4.2 strict sed allowlist upgrade. The
+    /// inner `bool` mirrors upstream `acceptEdits` → when `true`,
+    /// `sed -i` / file-write substitutions are also pre-approved.
+    /// `None` (default) keeps the pre-4.2 behavior.
+    sed_strict_allowlist: Option<SedStrictMode>,
+}
+
+/// Strict sed allowlist configuration for [`BashPermissionHook`]. See
+/// the Phase 4.2 section of the module-level documentation for the
+/// contract.
+#[derive(Debug, Clone, Copy)]
+struct SedStrictMode {
+    allow_file_writes: bool,
 }
 
 impl BashPermissionHook {
@@ -107,7 +145,25 @@ impl BashPermissionHook {
                 .iter()
                 .map(|s| (*s).to_string())
                 .collect(),
+            sed_strict_allowlist: None,
         }
+    }
+
+    /// Enable the Phase 4.2 strict sed allowlist upgrade.
+    ///
+    /// When enabled, after the rule pipeline returns `Passthrough` or
+    /// `Ask`, the hook checks whether the command matches the strict
+    /// upstream sed allowlist (Pattern 1 line print with `-n` or
+    /// Pattern 2 single substitution); if so, the decision is upgraded
+    /// to `Allow`. `Block` and `Allow` are never modified.
+    ///
+    /// `allow_file_writes` mirrors upstream `acceptEdits` mode: when
+    /// `true`, `sed -i ...` and trailing file arguments are tolerated.
+    /// Set to `false` in read-only contexts.
+    #[must_use]
+    pub fn with_sed_strict_allowlist(mut self, allow_file_writes: bool) -> Self {
+        self.sed_strict_allowlist = Some(SedStrictMode { allow_file_writes });
+        self
     }
 
     /// Override the bash tool-name allowlist.
@@ -124,6 +180,54 @@ impl BashPermissionHook {
     /// Returns `true` if `tool` should be treated as a bash invocation.
     fn is_bash_tool(&self, tool: &str) -> bool {
         self.bash_tool_names.iter().any(|n| n == tool)
+    }
+
+    /// Phase 4.2 strict sed allowlist upgrade.
+    ///
+    /// Returns `decision` unchanged unless **all** of the following hold:
+    ///
+    /// 1. Strict mode was enabled via
+    ///    [`Self::with_sed_strict_allowlist`].
+    /// 2. `decision` is `Passthrough` or `Ask` (the only two
+    ///    rule-pipeline outcomes the issue contract allows upgrading).
+    /// 3. [`sed_command_is_allowed_by_allowlist`] returns `true` for
+    ///    the command, i.e. it is a single `sed` invocation matching
+    ///    upstream Pattern 1 or Pattern 2 and denylist-clean.
+    ///
+    /// On upgrade, emits `tracing::info!("bash_perm::allow_sed_strict_upgrade", ...)`
+    /// with `tool` + `rule_id="SedAllowlist"` so SIEM can pin a stable
+    /// channel separate from `bash_perm::block` / `bash_perm::ask`.
+    fn maybe_upgrade_sed_strict_allowlist(
+        &self,
+        tool: &str,
+        command: &str,
+        decision: SafetyDecision,
+    ) -> SafetyDecision {
+        let Some(mode) = self.sed_strict_allowlist else {
+            return decision;
+        };
+
+        // Only Passthrough / Ask are upgrade candidates. Block / Allow
+        // pass through untouched — strict mode never downgrades a Deny
+        // and never re-logs an existing Allow.
+        if !matches!(
+            decision,
+            SafetyDecision::Passthrough | SafetyDecision::Ask { .. }
+        ) {
+            return decision;
+        }
+
+        if !sed_command_is_allowed_by_allowlist(command, mode.allow_file_writes) {
+            return decision;
+        }
+
+        tracing::info!(
+            tool,
+            rule_id = "SedAllowlist",
+            allow_file_writes = mode.allow_file_writes,
+            "bash_perm::allow_sed_strict_upgrade"
+        );
+        SafetyDecision::Allow
     }
 }
 
@@ -182,7 +286,8 @@ impl SafetyHook for BashPermissionHook {
             decided => decided,
         };
 
-        Ok(map_permission_result(tool, command, result))
+        let decision = map_permission_result(tool, command, result);
+        Ok(self.maybe_upgrade_sed_strict_allowlist(tool, command, decision))
     }
 
     async fn after_tool_output(

--- a/crates/dasclaw_hooks/tests/bash_permission_sed_strict_allowlist.rs
+++ b/crates/dasclaw_hooks/tests/bash_permission_sed_strict_allowlist.rs
@@ -1,0 +1,211 @@
+//! Slice 4.2 — `BashPermissionHook` strict sed allowlist upgrade.
+//!
+//! Tracker: issue #607. Tests follow the `req_perm_490_4_2_*` family.
+//!
+//! Contract (matches issue #607 and ADR-151 sandbox-model context):
+//!
+//! - Opt-in via [`BashPermissionHook::with_sed_strict_allowlist`]. Default
+//!   off → existing behavior preserved (backward-compat for downstream
+//!   users that have not yet enabled strict mode).
+//! - When the rule pipeline returns `Passthrough` or `Ask` AND the command
+//!   matches the upstream-parity strict sed allowlist (single sed call,
+//!   either Pattern 1 line-print with `-n`, or Pattern 2 single
+//!   substitution), the decision is upgraded to `Allow`.
+//! - `Block` and `Allow` decisions from the rule pipeline are **never**
+//!   touched — strict mode only upgrades, never downgrades. This keeps
+//!   Deny rules sovereign (matches PR #557's "Deny > Allow" precedence)
+//!   and avoids redundant re-checks on already-Allow paths.
+//! - Non-sed commands fall through unchanged (the allowlist function
+//!   returns `false` for them, so no upgrade fires).
+//! - Audit log: upgrades emit `tracing::info!` with event message
+//!   `bash_perm::allow_sed_strict_upgrade`, structured fields
+//!   `tool` + `rule_id="SedAllowlist"`.
+
+use dasclaw_bash_permissions::{PermissionBehavior, PermissionRuleSource, ToolPermissionContext};
+use dasclaw_hooks::BashPermissionHook;
+use serde_json::json;
+use tracing_test::traced_test;
+use x_claw_agent::{SafetyDecision, SafetyHook};
+
+fn empty_ctx() -> ToolPermissionContext {
+    ToolPermissionContext::default()
+}
+
+fn ctx_with(behavior: PermissionBehavior, rule_content: &str) -> ToolPermissionContext {
+    let mut ctx = ToolPermissionContext::default();
+    ctx.add_rule(
+        behavior,
+        PermissionRuleSource::ProjectSettings,
+        rule_content,
+    );
+    ctx
+}
+
+async fn fire_with_hook(hook: BashPermissionHook, command: &str) -> SafetyDecision {
+    let mut args = json!({ "command": command });
+    hook.before_tool_call("bash", &mut args)
+        .await
+        .expect("hook must not error on string command")
+}
+
+// --- 01: default (strict off) preserves existing behavior --------------
+
+#[tokio::test]
+async fn req_perm_490_4_2_01_strict_off_default_does_not_upgrade_passthrough() {
+    // No rule + no strict mode → existing Passthrough behavior wins.
+    // This pins backward-compatibility: enabling Phase 4.2 must be a
+    // deliberate opt-in, never an implicit behavioral change.
+    let hook = BashPermissionHook::new(empty_ctx());
+    let decision = fire_with_hook(hook, "sed 's/old/new/g'").await;
+    assert_eq!(
+        decision,
+        SafetyDecision::Passthrough,
+        "strict mode off → safe sed stays Passthrough; got {decision:?}"
+    );
+}
+
+// --- 02: strict on, pattern 2 stdin substitution → Allow ---------------
+
+#[tokio::test]
+async fn req_perm_490_4_2_02_strict_on_safe_substitution_stdin_upgrades_passthrough() {
+    let hook = BashPermissionHook::new(empty_ctx()).with_sed_strict_allowlist(false);
+    let decision = fire_with_hook(hook, "sed 's/old/new/g'").await;
+    assert_eq!(
+        decision,
+        SafetyDecision::Allow,
+        "strict on + allowlist-clean substitution → Allow; got {decision:?}"
+    );
+}
+
+// --- 03: strict on, pattern 1 line print → Allow ----------------------
+
+#[tokio::test]
+async fn req_perm_490_4_2_03_strict_on_line_print_with_dash_n_upgrades_passthrough() {
+    let hook = BashPermissionHook::new(empty_ctx()).with_sed_strict_allowlist(false);
+    let decision = fire_with_hook(hook, "sed -n '1,10p' file.txt").await;
+    assert_eq!(
+        decision,
+        SafetyDecision::Allow,
+        "strict on + `sed -n` line print → Allow; got {decision:?}"
+    );
+}
+
+// --- 04: strict on upgrades Ask, not just Passthrough -----------------
+
+#[tokio::test]
+async fn req_perm_490_4_2_04_strict_on_upgrades_ask_to_allow_when_safe() {
+    // Ask rule on `sed:*` would normally surface as Ask. Strict allowlist
+    // pre-approves the safe pattern so the user is not prompted for
+    // known-safe operations.
+    let ctx = ctx_with(PermissionBehavior::Ask, "sed:*");
+    let hook = BashPermissionHook::new(ctx).with_sed_strict_allowlist(false);
+    let decision = fire_with_hook(hook, "sed 's/foo/bar/'").await;
+    assert_eq!(
+        decision,
+        SafetyDecision::Allow,
+        "strict on + Ask rule + safe pattern → upgrade Ask to Allow; got {decision:?}"
+    );
+}
+
+// --- 05: strict on does NOT downgrade Block ---------------------------
+
+#[tokio::test]
+async fn req_perm_490_4_2_05_strict_on_must_not_override_deny() {
+    // Even if the command is allowlist-clean, a Deny rule must win.
+    // Strict mode only upgrades; it never downgrades. This pins the
+    // "Deny is sovereign" invariant from PR #557.
+    let ctx = ctx_with(PermissionBehavior::Deny, "sed:*");
+    let hook = BashPermissionHook::new(ctx).with_sed_strict_allowlist(false);
+    let decision = fire_with_hook(hook, "sed 's/old/new/'").await;
+    assert!(
+        matches!(decision, SafetyDecision::Block { .. }),
+        "strict on must not override Deny rule; got {decision:?}"
+    );
+}
+
+// --- 06: strict on with allow_file_writes lets `-i` through -----------
+
+#[tokio::test]
+async fn req_perm_490_4_2_06_strict_on_allow_writes_upgrades_in_place_edit() {
+    let hook = BashPermissionHook::new(empty_ctx()).with_sed_strict_allowlist(true);
+    let decision = fire_with_hook(hook, "sed -i 's/old/new/g' file.txt").await;
+    assert_eq!(
+        decision,
+        SafetyDecision::Allow,
+        "strict on + allow_file_writes → `-i` substitution → Allow; got {decision:?}"
+    );
+}
+
+// --- 07: strict on with allow_file_writes=false rejects `-i` ----------
+
+#[tokio::test]
+async fn req_perm_490_4_2_07_strict_on_strict_writes_keeps_in_place_passthrough() {
+    let hook = BashPermissionHook::new(empty_ctx()).with_sed_strict_allowlist(false);
+    let decision = fire_with_hook(hook, "sed -i 's/old/new/g' file.txt").await;
+    assert_eq!(
+        decision,
+        SafetyDecision::Passthrough,
+        "strict on + allow_file_writes=false + `-i` → no upgrade; got {decision:?}"
+    );
+}
+
+// --- 08: strict on does not affect non-sed commands -------------------
+
+#[tokio::test]
+async fn req_perm_490_4_2_08_strict_on_does_not_touch_non_sed_commands() {
+    // The allowlist returns false for non-sed → no upgrade. This guards
+    // against accidental "Allow" leakage if the allowlist function is
+    // ever changed to be more permissive for non-sed input.
+    let hook = BashPermissionHook::new(empty_ctx()).with_sed_strict_allowlist(false);
+    let decision = fire_with_hook(hook, "ls -la").await;
+    assert_eq!(
+        decision,
+        SafetyDecision::Passthrough,
+        "strict on must not upgrade non-sed commands; got {decision:?}"
+    );
+}
+
+// --- 09: strict on does NOT upgrade allowlist-rejected sed ------------
+
+#[tokio::test]
+async fn req_perm_490_4_2_09_strict_on_keeps_passthrough_for_unsafe_sed() {
+    // Multiple `-e` expressions → not in upstream Pattern 1 or 2 → allowlist returns false.
+    let hook = BashPermissionHook::new(empty_ctx()).with_sed_strict_allowlist(false);
+    let decision = fire_with_hook(hook, "sed -e 's/x/y/' -e 's/a/b/'").await;
+    assert_eq!(
+        decision,
+        SafetyDecision::Passthrough,
+        "strict on + multi-`-e` not in allowlist → no upgrade; got {decision:?}"
+    );
+}
+
+// --- 10: audit log emitted on upgrade ---------------------------------
+
+#[tokio::test]
+#[traced_test]
+async fn req_perm_490_4_2_10_strict_upgrade_emits_audit_log() {
+    let hook = BashPermissionHook::new(empty_ctx()).with_sed_strict_allowlist(false);
+    let decision = fire_with_hook(hook, "sed 's/old/new/g'").await;
+    assert_eq!(decision, SafetyDecision::Allow);
+    assert!(
+        logs_contain("bash_perm::allow_sed_strict_upgrade"),
+        "strict mode upgrade must emit `bash_perm::allow_sed_strict_upgrade` audit event"
+    );
+    assert!(
+        logs_contain("SedAllowlist"),
+        "audit event must carry `rule_id=SedAllowlist` for SIEM filtering"
+    );
+}
+
+// --- 11: strict on does NOT touch existing Allow (idempotent) ---------
+
+#[tokio::test]
+async fn req_perm_490_4_2_11_strict_on_does_not_re_log_existing_allow() {
+    // If a rule already returned Allow, we must not re-process the
+    // command — that would emit a misleading audit event and waste
+    // tokenization work. Allow stays Allow with no extra side effects.
+    let ctx = ctx_with(PermissionBehavior::Allow, "sed:*");
+    let hook = BashPermissionHook::new(ctx).with_sed_strict_allowlist(false);
+    let decision = fire_with_hook(hook, "sed 's/old/new/'").await;
+    assert_eq!(decision, SafetyDecision::Allow);
+}


### PR DESCRIPTION
Closes #607

## 背景与目标

实现 issue #607 — 把 `dasclaw_bash_validation::sed_command_is_allowed_by_allowlist`（PR #606 / Phase 4.1 落地）接入 `BashPermissionHook`，作为 **opt-in** 严格白名单升级层。

当严格模式启用时，rule pipeline 返回 `Passthrough` / `Ask` 且命令匹配上游 Pattern 1（带 `-n` 行打印）或 Pattern 2（单 substitution）→ 升级为 `Allow`。

## 改动范围

### 1. [crates/dasclaw_hooks/src/bash_permission_hook.rs](crates/dasclaw_hooks/src/bash_permission_hook.rs)

- 新增结构字段 `sed_strict_allowlist: Option<SedStrictMode>`（默认 `None`，向后兼容）
- 新增 builder `with_sed_strict_allowlist(allow_file_writes: bool) -> Self`
- 新增私有方法 `maybe_upgrade_sed_strict_allowlist(...)`，挂在 `before_tool_call` 尾部
- 模块文档新增 Phase 4.2 章节，列明 4 条不变式

### 2. [crates/dasclaw_hooks/tests/bash_permission_sed_strict_allowlist.rs](crates/dasclaw_hooks/tests/bash_permission_sed_strict_allowlist.rs) (NEW)

- 11 个红测 `req_perm_490_4_2_01..11`，TDD 流程
- 覆盖：默认 off / 安全 Pattern 1+2 / Ask 升级 / Deny 不降级 / `-i` flag / 非 sed 命令 / 多 `-e` 不在白名单 / audit log 落盘 / 已有 Allow 不二次处理

## 非目标（What's NOT in this PR）

- ❌ 不动 `validate_sed`（denylist-only 语义稳定）
- ❌ 不动 `BashValidationHook`（与 permission 层职责分离）
- ❌ 不实现 Phase 2.3 Desktop Ask UX（#608）
- ❌ 不做生产接线（Phase 2.3 admin-backend 配置面会决定何时启用）
- ❌ 不引入 `PermissionMode` 变体或硬切（保持 opt-in，最小侵入）

## 设计要点

### 不变式（红测固化）

1. **Never downgrades**：`Block` / `Allow` 直接 pass-through
2. **Only upgrades** `Passthrough` 和 `Ask`，保证不抢先 short-circuit 上游 chain hook 想 Block 的场景
3. **非 sed 命令 no-op**：`sed_command_is_allowed_by_allowlist` 对非 sed 返回 false
4. **Deny is sovereign**（PR #557 precedence）：strict 模式不能绕过 Deny

### 审计日志契约

- 事件消息：`bash_perm::allow_sed_strict_upgrade`
- 字段：`tool` + `rule_id="SedAllowlist"` + `allow_file_writes`
- SIEM 上独立频道（与 `bash_perm::block` / `bash_perm::ask` 区分）

## 验证

```bash
cargo nextest run -p dasclaw_hooks --test bash_permission_sed_strict_allowlist
# → 11/11 pass

cargo nextest run -p dasclaw_hooks
# → 129/129 pass

cargo clippy --no-deps -p dasclaw_hooks --all-targets -- -D warnings
# → clean

cargo fmt --all
# → clean

python3.12 scripts/check_no_panics.py --base origin/xClaw
# → OK
```

## Sources read

- `AGENTS.md` §"3 层代码审查"、§"必跑本地管线"
- issue #607（本 PR 关闭对象）
- [`crates/dasclaw_hooks/src/bash_permission_hook.rs`](crates/dasclaw_hooks/src/bash_permission_hook.rs#L1-L200) 现有实现 + 文档头
- [`crates/dasclaw_bash_validation/src/sed.rs`](crates/dasclaw_bash_validation/src/sed.rs#L85-L130)（`sed_command_is_allowed_by_allowlist` 签名 + 语义）
- [`crates/dasclaw_bash_validation/src/sed.rs`](crates/dasclaw_bash_validation/src/sed.rs#L930-L975)（既有 allowlist 红测，参考样例）
- [`crates/dasclaw_hooks/tests/bash_permission_hook.rs`](crates/dasclaw_hooks/tests/bash_permission_hook.rs#L1-L120)（test scaffold 参考）
- ADR-146 (SafetyDecision 枚举扩展)、ADR-147 (CompositeSafetyHook)
- PR #606（Phase 4.1 sed AST）、PR #557（Phase 2.2.f 接入 CompositeSafetyHook）

## 3 层代码审查

- ✅ semantic 等价：检索 `BashPermissionHook` builder 风格，沿用现有 `with_tool_names` 模式，命名/可选语义一致
- ✅ 引用点等价：`grep_search "BashPermissionHook::new"` → 19 处全部为测试，无生产 caller 受影响（新字段默认 `None`）
- ✅ 仓库 rg 等价：`sed_command_is_allowed_by_allowlist` 仅在 sed.rs 测试 + 本 hook 引用，无重复实现

非补丁式：所有改动为「新增字段 + 新增 builder + 新增私有方法 + 在 `before_tool_call` 尾部单点 delegation」，无 if 分支堆叠、无逻辑复制、无 flag 切换大块代码。

## Refs

- 父 epic: #490 (closed completed)
- ADR-151（上游分歧 — sandbox 模型，与本 PR 范围正交）
- 关联 follow-up：#608 Desktop Ask UX 落地后可考虑把 strict 模式默认 on
