### PR TITLE
feat(governance): ADR-149 Tool Visibility Triple Gate (#485)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2650,6 +2650,7 @@ dependencies = [
  "dasclaw_apply_patch",
  "dasclaw_cert_trust",
  "dasclaw_exec",
+ "dasclaw_governance",
  "dasclaw_hooks",
  "dasclaw_llm_provider",
  "dasclaw_net_proxy",
@@ -2871,9 +2872,11 @@ dependencies = [
 name = "dasclaw_governance"
 version = "0.0.0-w1"
 dependencies = [
+ "async-trait",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
+ "tokio",
 ]
 
 [[package]]

--- a/crates/dasclaw_governance/Cargo.toml
+++ b/crates/dasclaw_governance/Cargo.toml
@@ -25,6 +25,11 @@ lane_events = ["dep:serde", "dep:serde_json"]
 team_cron_registry = ["dep:serde", "dep:serde_json"]
 task_packet = ["dep:serde", "dep:serde_json"]
 task_registry = ["dep:serde", "dep:serde_json", "task_packet"]
+# ADR-149 Tool Visibility Triple Gate (#485). Provides the
+# `ToolVisibilityPolicy` trait + closed-enum `ToolGateDecision` consumed by
+# `dasclaw_agent` / `ironclaw` to gate tool exposure (L2) and execution (L3).
+# Default OFF (W4 contract); enabled by host crates via Cargo feature.
+tool_visibility = ["dep:async-trait", "dep:serde", "dep:serde_json"]
 # Convenience: enable the full 6-pack + task lifecycle at once (used by integration tests).
 full = [
     "policy_engine",
@@ -38,12 +43,21 @@ full = [
     "team_cron_registry",
     "task_packet",
     "task_registry",
+    "tool_visibility",
 ]
 
 [dependencies]
 thiserror = "1"
 serde = { version = "1", features = ["derive"], optional = true }
 serde_json = { version = "1", optional = true }
+async-trait = { version = "0.1", optional = true }
+
+[dev-dependencies]
+# Test-only async runtime + trait macro for `tool_visibility` surface tests.
+# Kept here (not in `[dependencies]`) so production builds don't pull tokio.
+tokio = { version = "1", features = ["macros", "rt"] }
+async-trait = "0.1"
+serde_json = "1"
 
 # Cross-module wiring tests for the full 6-pack — only compiled when
 # the convenience `full` feature is on. Keeps the default `cargo test`
@@ -53,3 +67,10 @@ serde_json = { version = "1", optional = true }
 name = "integration_tests"
 path = "tests/integration_tests.rs"
 required-features = ["full"]
+
+# ADR-149 / issue #485 — `ToolVisibilityPolicy` trait surface tests.
+# Only compiled when the `tool_visibility` feature is on.
+[[test]]
+name = "tool_visibility_test"
+path = "tests/tool_visibility_test.rs"
+required-features = ["tool_visibility"]

--- a/crates/dasclaw_governance/src/lib.rs
+++ b/crates/dasclaw_governance/src/lib.rs
@@ -75,6 +75,9 @@ pub mod task_packet;
 #[cfg(feature = "task_registry")]
 pub mod task_registry;
 
+#[cfg(feature = "tool_visibility")]
+pub mod tool_visibility;
+
 #[cfg(test)]
 mod tests {
     #[test]

--- a/crates/dasclaw_governance/src/tool_visibility.rs
+++ b/crates/dasclaw_governance/src/tool_visibility.rs
@@ -1,0 +1,478 @@
+//! Tool Visibility Triple Gate — `ToolVisibilityPolicy` trait + closed-enum decisions.
+//!
+//! Implements ADR-149 v2.0 (Accepted 2026-05-13). Provides the seam through
+//! which `dasclaw_agent` and `ironclaw` enforce a single source of truth for
+//! tool exposure across:
+//!
+//! - **L2 — `LlmDefinitions`**: which tools are advertised to the model in
+//!   the `tools: [...]` parameter of the LLM request.
+//! - **L3 — `ExecutorPreflight`**: whether a specific tool invocation may
+//!   actually execute (post-LLM, pre-handler dispatch).
+//!
+//! `PromptCatalog` is retained as a [`ToolGateLayer`] variant for forward
+//! compatibility; today no upstream reference (codex / claude-code /
+//! ironclaw-main) embeds the tool catalog into the system prompt — all three
+//! pass tools through the LLM API's dedicated `tools` parameter. See
+//! ADR-149 §1.1 addendum.
+//!
+//! # Fail-Closed by Construction
+//!
+//! - [`ToolGateDecision`] has **no `Default` impl** — callers must produce a
+//!   decision explicitly. The only constructor that names "deny" is
+//!   [`ToolGateDecision::deny_args`].
+//! - There is no `Option<Arc<dyn ToolVisibilityPolicy>>` API surface here;
+//!   host crates are required by ADR-149 §2.5 to demand a policy at
+//!   construction time (Always-Has-Policy invariant).
+//! - Source-aware default (ADR-149 §2.6): policies are expected to return
+//!   [`ToolGateDecision::Hide`] for non-`BuiltIn` sources until #484 ships
+//!   integrity verifiers for MCP / Skill / Extension / Wasm tools.
+//!
+//! # Identity
+//!
+//! [`ActorId`] / [`TenantId`] are local newtypes pending `dasclaw_identity`
+//! W2 maturation. Once `dasclaw_identity` ships `ActorRef` / `TenantRef`
+//! per ADR-115, replace these types here (single point of change). The
+//! `TODO(identity-W2)` markers below trace the migration.
+
+#[cfg(feature = "tool_visibility")]
+use async_trait::async_trait;
+use std::fmt;
+#[cfg(feature = "tool_visibility")]
+use std::sync::Arc;
+
+// ---- Identity newtypes (TODO(identity-W2): replace with dasclaw_identity) ---
+
+/// Stable identifier for the principal initiating a tool call.
+///
+/// Temporary newtype pending `dasclaw_identity::ActorRef` (W2). Carrying a
+/// `String` (vs. `&str`) keeps the type owned & cheap to clone for audit
+/// records.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(
+    feature = "tool_visibility",
+    derive(serde::Serialize, serde::Deserialize)
+)]
+pub struct ActorId(pub String);
+
+impl ActorId {
+    /// Construct from any `Into<String>`. Empty strings are accepted —
+    /// callers are responsible for upstream validation.
+    pub fn new(s: impl Into<String>) -> Self {
+        Self(s.into())
+    }
+
+    /// Borrowed view for cheap matching / logging.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for ActorId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// Stable identifier for the tenant under which the tool call is evaluated.
+///
+/// Temporary newtype pending `dasclaw_identity::TenantRef` (W2).
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(
+    feature = "tool_visibility",
+    derive(serde::Serialize, serde::Deserialize)
+)]
+pub struct TenantId(pub String);
+
+impl TenantId {
+    pub fn new(s: impl Into<String>) -> Self {
+        Self(s.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for TenantId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+// ---- Source / Layer / Env enums --------------------------------------------
+
+/// Where a tool came from. Drives the source-aware default per ADR-149 §2.6:
+/// policies should treat non-`BuiltIn` variants as opaque until #484 lands
+/// integrity verifiers for them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(
+    feature = "tool_visibility",
+    derive(serde::Serialize, serde::Deserialize)
+)]
+#[cfg_attr(feature = "tool_visibility", serde(rename_all = "snake_case"))]
+pub enum ToolSource {
+    /// First-party tool compiled into ironclaw / dasclaw_agent.
+    BuiltIn,
+    /// MCP-protocol tool from an external server.
+    Mcp,
+    /// Tool exposed via a Skill bundle.
+    Skill,
+    /// Extension-provided tool (host plugin).
+    Extension,
+    /// WASM sandbox-loaded tool.
+    Wasm,
+}
+
+/// Which gate layer the decision is being requested from. Used for audit
+/// metadata; policies may also branch on this if e.g. catalog-time hiding
+/// differs from executor-time argument inspection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(
+    feature = "tool_visibility",
+    derive(serde::Serialize, serde::Deserialize)
+)]
+#[cfg_attr(feature = "tool_visibility", serde(rename_all = "snake_case"))]
+pub enum ToolGateLayer {
+    /// Reserved for future system-prompt embedding. See module-level
+    /// addendum: no upstream today populates this layer.
+    PromptCatalog,
+    /// L2 — when computing the LLM `tools: [...]` parameter.
+    LlmDefinitions,
+    /// L3 — immediately before the tool handler executes.
+    ExecutorPreflight,
+}
+
+/// Execution environment for the call. Mirrors the three contexts called
+/// out in ADR-149 §2.4 (and ironclaw-main `ApprovalContext::Autonomous`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(
+    feature = "tool_visibility",
+    derive(serde::Serialize, serde::Deserialize)
+)]
+#[cfg_attr(feature = "tool_visibility", serde(rename_all = "snake_case"))]
+pub enum Env {
+    /// User is at the keyboard; interactive approvals are reachable.
+    Interactive,
+    /// Background job / routine; no interactive user to prompt.
+    Autonomous,
+    /// Sandboxed container worker; treat as Autonomous for approval reach
+    /// but distinct for audit.
+    Container,
+}
+
+// ---- Approval scope --------------------------------------------------------
+
+/// How widely an approval, once granted, should be remembered.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(
+    feature = "tool_visibility",
+    derive(serde::Serialize, serde::Deserialize)
+)]
+#[cfg_attr(feature = "tool_visibility", serde(rename_all = "snake_case"))]
+pub enum ApprovalScope {
+    /// Approval applies only to the single invocation being evaluated.
+    OneTime,
+    /// Approval is cached for the remainder of the current session.
+    Session,
+    /// Approval is persisted across sessions (subject to host storage).
+    Persistent,
+}
+
+/// Details accompanying a [`ToolGateDecision::RequireApproval`] outcome.
+///
+/// `allow_always` is host-advisory: it indicates the policy considers it
+/// safe to surface an "always allow for this scope" UI option. The host
+/// MAY ignore this hint (e.g. an `ApprovalRequirement::Always`-equivalent
+/// hard floor at the consumer side overrides it).
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(
+    feature = "tool_visibility",
+    derive(serde::Serialize, serde::Deserialize)
+)]
+pub struct ApprovalSpec {
+    /// Whether the host MAY offer the user an "always allow" option.
+    pub allow_always: bool,
+    /// Persistence scope hint for the approval cache.
+    pub scope: ApprovalScope,
+    /// Human-readable rationale, surfaced in the approval UI.
+    pub reason: String,
+}
+
+impl ApprovalSpec {
+    /// One-time approval with no "always" upgrade option.
+    pub fn one_time(reason: impl Into<String>) -> Self {
+        Self {
+            allow_always: false,
+            scope: ApprovalScope::OneTime,
+            reason: reason.into(),
+        }
+    }
+
+    /// Approval that may be cached for the session; `allow_always: true`
+    /// signals the host MAY render a "remember for this session" button.
+    pub fn session(reason: impl Into<String>) -> Self {
+        Self {
+            allow_always: true,
+            scope: ApprovalScope::Session,
+            reason: reason.into(),
+        }
+    }
+}
+
+// ---- Decision enum ---------------------------------------------------------
+
+/// Closed-enum outcome of a [`ToolVisibilityPolicy::check`] call.
+///
+/// **No `Default` impl** — callers must construct a decision explicitly.
+/// This is the fail-closed-by-construction guarantee called out in
+/// ADR-149 §1.3.2.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(
+    feature = "tool_visibility",
+    derive(serde::Serialize, serde::Deserialize)
+)]
+#[cfg_attr(
+    feature = "tool_visibility",
+    serde(tag = "kind", rename_all = "snake_case")
+)]
+pub enum ToolGateDecision {
+    /// Tool is fully permitted.
+    Allow,
+    /// Tool exists but is omitted from the layer the check originated at.
+    ///
+    /// - At [`ToolGateLayer::LlmDefinitions`]: do not advertise to the model.
+    /// - At [`ToolGateLayer::ExecutorPreflight`]: treat as if the tool were
+    ///   not registered (caller is responsible for surfacing an explanatory
+    ///   error to the model). Note ADR-149 §2.1 addendum: re-hiding a tool
+    ///   mid-session that was previously advertised can invalidate the LLM
+    ///   prompt cache; prefer [`ToolGateDecision::DenyArgs`] on subsequent
+    ///   turns.
+    Hide { reason: String },
+    /// Tool is allowed in principle, but this specific invocation is
+    /// rejected outright (cannot be overridden downstream).
+    DenyArgs { reason: String },
+    /// Tool requires an out-of-band approval before it may execute.
+    RequireApproval(ApprovalSpec),
+}
+
+impl ToolGateDecision {
+    /// Constructor for `Hide` with a descriptive reason.
+    pub fn hide(reason: impl Into<String>) -> Self {
+        Self::Hide {
+            reason: reason.into(),
+        }
+    }
+
+    /// Constructor for `DenyArgs` with a descriptive reason.
+    pub fn deny_args(reason: impl Into<String>) -> Self {
+        Self::DenyArgs {
+            reason: reason.into(),
+        }
+    }
+
+    /// Returns `true` iff the decision permits the tool to be visible at
+    /// the requested layer (`Allow` and `RequireApproval` both qualify).
+    pub fn is_visible(&self) -> bool {
+        matches!(self, Self::Allow | Self::RequireApproval(_))
+    }
+
+    /// Returns `true` iff the decision permits execution without further
+    /// approval (only `Allow`).
+    pub fn permits_execution(&self) -> bool {
+        matches!(self, Self::Allow)
+    }
+}
+
+// ---- Audit metadata --------------------------------------------------------
+
+/// Stable opaque identifier for a single decision event. Host-supplied
+/// (e.g. ULID, UUIDv7); the trait surface only requires that it round-trip
+/// through telemetry.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(
+    feature = "tool_visibility",
+    derive(serde::Serialize, serde::Deserialize)
+)]
+pub struct DecisionId(pub String);
+
+impl DecisionId {
+    pub fn new(s: impl Into<String>) -> Self {
+        Self(s.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for DecisionId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// Audit envelope for one policy evaluation. Emitted alongside every
+/// [`ToolGateDecision`] so that downstream telemetry can reconstruct the
+/// full decision context without re-querying the policy.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(
+    feature = "tool_visibility",
+    derive(serde::Serialize, serde::Deserialize)
+)]
+pub struct AuditMetadata {
+    /// Identifier of the policy that produced the decision (matches
+    /// [`ToolVisibilityPolicy::name`]).
+    pub policy_name: String,
+    /// Which gate layer asked.
+    pub layer: ToolGateLayer,
+    /// Stable id for this evaluation; surfaces in logs / traces.
+    pub decision_id: DecisionId,
+    /// Origin of the tool being evaluated.
+    pub source: ToolSource,
+    /// TODO(identity-W2): replace with `dasclaw_identity::ActorRef`.
+    pub actor: ActorId,
+    /// TODO(identity-W2): replace with `dasclaw_identity::TenantRef`.
+    pub tenant: TenantId,
+}
+
+// ---- Context ---------------------------------------------------------------
+
+/// Inputs to a single policy evaluation.
+///
+/// Borrowed for zero-clone hot-path use. Lifetime `'a` ties the context to
+/// the caller's stack frame; the trait method is `async` but the future
+/// returned by the implementation must not outlive `'a` (enforced by the
+/// `async_trait` desugaring).
+#[derive(Debug)]
+pub struct ToolGateContext<'a> {
+    /// Tool name as registered (no namespacing prefix stripping).
+    pub tool_name: &'a str,
+    /// Origin of the tool being evaluated.
+    pub source: ToolSource,
+    /// Which layer this evaluation is for.
+    pub layer: ToolGateLayer,
+    /// Principal initiating the call.
+    pub actor: &'a ActorId,
+    /// Tenant scope.
+    pub tenant: &'a TenantId,
+    /// Tool arguments — `Some` only when `layer == ExecutorPreflight`.
+    /// `None` at L2 because arguments are not yet known.
+    #[cfg(feature = "tool_visibility")]
+    pub args: Option<&'a serde_json::Value>,
+    /// Execution environment.
+    pub env: Env,
+}
+
+// ---- Trait -----------------------------------------------------------------
+
+/// The single seam through which all tool visibility decisions flow.
+///
+/// **Always-Has-Policy invariant** (ADR-149 §2.5): host constructors that
+/// expose tools to a model MUST accept `Arc<dyn ToolVisibilityPolicy>`
+/// by value — never `Option<Arc<…>>`. This is enforced at the consumer
+/// side; this crate provides only the trait surface.
+///
+/// `Debug` is required so [`AuditMetadata`] can carry policy identity
+/// without forcing `Box<dyn Any>` gymnastics in audit code.
+#[cfg(feature = "tool_visibility")]
+#[async_trait]
+pub trait ToolVisibilityPolicy: Send + Sync + std::fmt::Debug {
+    /// Stable identifier for this policy (surfaces in audit logs and
+    /// [`AuditMetadata::policy_name`]).
+    fn name(&self) -> &str;
+
+    /// Evaluate the gate for one tool in one layer.
+    ///
+    /// Implementations MUST NOT panic; on internal error they should
+    /// return a deny-shaped decision (e.g.
+    /// `ToolGateDecision::DenyArgs { reason: "policy backend unavailable" }`).
+    async fn check(&self, ctx: &ToolGateContext<'_>) -> ToolGateDecision;
+
+    /// When `true`, the host SHOULD re-evaluate this tool at
+    /// [`ToolGateLayer::ExecutorPreflight`] even if the same policy
+    /// returned `Allow` at L2. Mirrors claude-code's `requireCanUseTool`:
+    /// useful for tools whose argument shape must be re-inspected after
+    /// the LLM picks them.
+    fn always_check_at_executor(&self, _source: ToolSource) -> bool {
+        false
+    }
+}
+
+/// Convenience alias for the shared trait object pointer hosts pass around.
+#[cfg(feature = "tool_visibility")]
+pub type SharedToolVisibilityPolicy = Arc<dyn ToolVisibilityPolicy>;
+
+// ---- AllowAllPolicy -------------------------------------------------------
+
+/// The canonical "default permissive" policy.
+///
+/// Exists solely to satisfy the **Always-Has-Policy invariant** (ADR-149
+/// §2.5): callers that have no real policy yet (early bootstrap, test
+/// harnesses, scaffolded code paths still wired against legacy filters)
+/// can pass `Arc::new(AllowAllPolicy)` rather than reaching for an
+/// `Option`. This makes the absence of policy *explicit* in source —
+/// `grep AllowAllPolicy` will surface every site that still needs to be
+/// upgraded to a real policy.
+///
+/// Returns [`ToolGateDecision::Allow`] for every input. Carries no state.
+#[cfg(feature = "tool_visibility")]
+#[derive(Debug, Default, Clone, Copy)]
+pub struct AllowAllPolicy;
+
+#[cfg(feature = "tool_visibility")]
+#[async_trait]
+impl ToolVisibilityPolicy for AllowAllPolicy {
+    fn name(&self) -> &str {
+        "dasclaw_governance::AllowAllPolicy"
+    }
+
+    async fn check(&self, _ctx: &ToolGateContext<'_>) -> ToolGateDecision {
+        ToolGateDecision::Allow
+    }
+}
+
+// ---- ToolGateContextSeed --------------------------------------------------
+
+/// Caller-supplied half of a [`ToolGateContext`].
+///
+/// The registry / executor fills in the per-tool fields (`tool_name`,
+/// `source`, `layer`, and at L3 `args`); the seed carries the *call-site*
+/// fields that only the host knows: who is calling, in which tenant, and
+/// in what execution environment.
+///
+/// Owned (not borrowed) for ergonomics — the cost of two short
+/// [`String`]s is negligible compared to one LLM round-trip, and an
+/// owned struct can be stored on a worker / dispatcher long-term.
+#[cfg(feature = "tool_visibility")]
+#[derive(Debug, Clone)]
+pub struct ToolGateContextSeed {
+    /// Principal whose intent triggered this call.
+    pub actor: ActorId,
+    /// Tenant scope (multi-tenancy isolation point).
+    pub tenant: TenantId,
+    /// Execution environment for downstream policy reasoning.
+    pub env: Env,
+}
+
+#[cfg(feature = "tool_visibility")]
+impl ToolGateContextSeed {
+    /// Construct a seed from owned components.
+    pub fn new(actor: ActorId, tenant: TenantId, env: Env) -> Self {
+        Self { actor, tenant, env }
+    }
+
+    /// Placeholder seed for code paths whose actor/tenant plumbing is not
+    /// yet wired (W2 dependency). Uses `"system"` / `"default"` literals.
+    ///
+    /// **TODO(identity-W2):** replace every call site with a seed
+    /// constructed from the real session/job/request context once
+    /// `dasclaw_identity::ActorRef` ships. `grep "ToolGateContextSeed::system"`
+    /// surfaces all such migration sites.
+    pub fn system(env: Env) -> Self {
+        Self {
+            actor: ActorId::new("system"),
+            tenant: TenantId::new("default"),
+            env,
+        }
+    }
+}

--- a/crates/dasclaw_governance/tests/tool_visibility_test.rs
+++ b/crates/dasclaw_governance/tests/tool_visibility_test.rs
@@ -1,0 +1,379 @@
+//! ADR-149 / issue #485 — `ToolVisibilityPolicy` trait surface tests.
+//!
+//! These tests pin the public contract of the trait + closed-enum types.
+//! They run only when the `tool_visibility` cargo feature is enabled.
+//!
+//! Behavioral tests for concrete policies (e.g. `BlocklistPolicy` wrapping
+//! `feature_flags::disabled_tools`) live in `desktop-client/ironclaw/tests/
+//! tool_visibility_integration.rs` — those exercise the L2 / L3 wiring and
+//! the five `test_security_84_*` attack scenarios.
+
+#![cfg(feature = "tool_visibility")]
+
+use dasclaw_governance::tool_visibility::{
+    ActorId, AllowAllPolicy, ApprovalScope, ApprovalSpec, AuditMetadata, DecisionId, Env,
+    SharedToolVisibilityPolicy, TenantId, ToolGateContext, ToolGateContextSeed, ToolGateDecision,
+    ToolGateLayer, ToolSource, ToolVisibilityPolicy,
+};
+use std::sync::Arc;
+
+// ---- Test fixtures ---------------------------------------------------------
+
+#[derive(Debug)]
+struct DenyAllPolicy {
+    reason: String,
+}
+
+#[async_trait::async_trait]
+impl ToolVisibilityPolicy for DenyAllPolicy {
+    fn name(&self) -> &str {
+        "test::deny_all"
+    }
+    async fn check(&self, _ctx: &ToolGateContext<'_>) -> ToolGateDecision {
+        ToolGateDecision::deny_args(&self.reason)
+    }
+    fn always_check_at_executor(&self, _source: ToolSource) -> bool {
+        true
+    }
+}
+
+fn actor() -> ActorId {
+    ActorId::new("alice")
+}
+fn tenant() -> TenantId {
+    TenantId::new("acme")
+}
+
+fn ctx<'a>(
+    tool: &'a str,
+    source: ToolSource,
+    layer: ToolGateLayer,
+    actor: &'a ActorId,
+    tenant: &'a TenantId,
+) -> ToolGateContext<'a> {
+    ToolGateContext {
+        tool_name: tool,
+        source,
+        layer,
+        actor,
+        tenant,
+        args: None,
+        env: Env::Interactive,
+    }
+}
+
+// ---- Decision surface ------------------------------------------------------
+
+/// `req_tool_visibility_84_001_decision_no_default` — fail-closed by
+/// construction. `ToolGateDecision` must require an explicit constructor;
+/// there is no `Default` impl that could silently produce `Allow`.
+#[test]
+fn req_tool_visibility_84_001_decision_no_default() {
+    // Compile-time: if `ToolGateDecision: Default` existed, the next line
+    // would compile. We assert by trait-not-implemented at runtime via
+    // `impls!` would require a dep; settle for documenting via match.
+    let allow = ToolGateDecision::Allow;
+    let hide = ToolGateDecision::hide("policy redacted");
+    let deny = ToolGateDecision::deny_args("invalid args");
+    let approval = ToolGateDecision::RequireApproval(ApprovalSpec::session("admin tool"));
+
+    // Exhaustive match — adding a variant without updating this test
+    // breaks the build, preventing silent expansion that bypasses
+    // downstream pattern matches.
+    for d in [allow, hide, deny, approval] {
+        match d {
+            ToolGateDecision::Allow
+            | ToolGateDecision::Hide { .. }
+            | ToolGateDecision::DenyArgs { .. }
+            | ToolGateDecision::RequireApproval(_) => {}
+        }
+    }
+}
+
+/// `req_tool_visibility_84_002_decision_helpers` — `is_visible` and
+/// `permits_execution` semantics fixed in trait spec.
+#[test]
+fn req_tool_visibility_84_002_decision_helpers() {
+    assert!(ToolGateDecision::Allow.is_visible());
+    assert!(ToolGateDecision::Allow.permits_execution());
+
+    let approval = ToolGateDecision::RequireApproval(ApprovalSpec::one_time("test"));
+    assert!(
+        approval.is_visible(),
+        "approval-required tools remain visible"
+    );
+    assert!(
+        !approval.permits_execution(),
+        "approval-required tools must not auto-execute"
+    );
+
+    let hide = ToolGateDecision::hide("hidden");
+    assert!(!hide.is_visible());
+    assert!(!hide.permits_execution());
+
+    let deny = ToolGateDecision::deny_args("nope");
+    assert!(!deny.is_visible());
+    assert!(!deny.permits_execution());
+}
+
+/// `req_tool_visibility_84_003_decision_constructors_carry_reason` — the
+/// `hide` / `deny_args` constructors must round-trip the reason verbatim
+/// so audit logs are useful.
+#[test]
+fn req_tool_visibility_84_003_decision_constructors_carry_reason() {
+    match ToolGateDecision::hide("blocked by policy X") {
+        ToolGateDecision::Hide { reason } => assert_eq!(reason, "blocked by policy X"),
+        other => panic!("expected Hide, got {other:?}"),
+    }
+    match ToolGateDecision::deny_args("path traversal") {
+        ToolGateDecision::DenyArgs { reason } => assert_eq!(reason, "path traversal"),
+        other => panic!("expected DenyArgs, got {other:?}"),
+    }
+}
+
+// ---- Source / Layer / Env exhaustiveness -----------------------------------
+
+/// `req_tool_visibility_84_004_source_5_variants` — five tool sources
+/// remain distinct & enumerable. Pins ADR-149 §2.6 surface.
+#[test]
+fn req_tool_visibility_84_004_source_5_variants() {
+    let all = [
+        ToolSource::BuiltIn,
+        ToolSource::Mcp,
+        ToolSource::Skill,
+        ToolSource::Extension,
+        ToolSource::Wasm,
+    ];
+    let mut set = std::collections::HashSet::new();
+    for s in all {
+        assert!(set.insert(s), "duplicate variant in ToolSource");
+    }
+    assert_eq!(set.len(), 5);
+}
+
+/// `req_tool_visibility_84_005_layer_3_variants` — three layers, distinct.
+#[test]
+fn req_tool_visibility_84_005_layer_3_variants() {
+    let all = [
+        ToolGateLayer::PromptCatalog,
+        ToolGateLayer::LlmDefinitions,
+        ToolGateLayer::ExecutorPreflight,
+    ];
+    let mut set = std::collections::HashSet::new();
+    for l in all {
+        assert!(set.insert(l), "duplicate variant in ToolGateLayer");
+    }
+    assert_eq!(set.len(), 3);
+}
+
+/// `req_tool_visibility_84_006_env_3_variants` — three execution
+/// environments, distinct.
+#[test]
+fn req_tool_visibility_84_006_env_3_variants() {
+    let all = [Env::Interactive, Env::Autonomous, Env::Container];
+    let mut set = std::collections::HashSet::new();
+    for e in all {
+        assert!(set.insert(e), "duplicate variant in Env");
+    }
+    assert_eq!(set.len(), 3);
+}
+
+// ---- ApprovalSpec ----------------------------------------------------------
+
+/// `req_tool_visibility_84_007_approval_one_time` — `one_time` shape
+/// fixed: no "always" upgrade, scope is `OneTime`.
+#[test]
+fn req_tool_visibility_84_007_approval_one_time() {
+    let a = ApprovalSpec::one_time("destructive op");
+    assert!(!a.allow_always);
+    assert_eq!(a.scope, ApprovalScope::OneTime);
+    assert_eq!(a.reason, "destructive op");
+}
+
+/// `req_tool_visibility_84_008_approval_session` — session approval is
+/// allow_always=true, scope=Session.
+#[test]
+fn req_tool_visibility_84_008_approval_session() {
+    let a = ApprovalSpec::session("network access");
+    assert!(a.allow_always);
+    assert_eq!(a.scope, ApprovalScope::Session);
+    assert_eq!(a.reason, "network access");
+}
+
+// ---- Audit metadata serde round-trip --------------------------------------
+
+/// `req_tool_visibility_84_009_audit_serde_round_trip` — `AuditMetadata`
+/// serializes / deserializes via serde_json (telemetry pipeline contract).
+#[test]
+fn req_tool_visibility_84_009_audit_serde_round_trip() {
+    let meta = AuditMetadata {
+        policy_name: "BlocklistPolicy".into(),
+        layer: ToolGateLayer::LlmDefinitions,
+        decision_id: DecisionId::new("01HXXX..."),
+        source: ToolSource::BuiltIn,
+        actor: actor(),
+        tenant: tenant(),
+    };
+    let json = serde_json::to_string(&meta).expect("serialize");
+    let back: AuditMetadata = serde_json::from_str(&json).expect("deserialize");
+    assert_eq!(meta, back);
+}
+
+/// `req_tool_visibility_84_010_decision_serde_round_trip` — decisions
+/// serialize via the `kind`-tagged form (telemetry contract).
+#[test]
+fn req_tool_visibility_84_010_decision_serde_round_trip() {
+    let cases = [
+        ToolGateDecision::Allow,
+        ToolGateDecision::hide("h"),
+        ToolGateDecision::deny_args("d"),
+        ToolGateDecision::RequireApproval(ApprovalSpec::session("approve me")),
+    ];
+    for d in cases {
+        let json = serde_json::to_string(&d).expect("serialize");
+        let back: ToolGateDecision = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(d, back);
+    }
+}
+
+// ---- Trait object & async surface ------------------------------------------
+
+/// `req_tool_visibility_84_011_trait_object_safe` — `ToolVisibilityPolicy`
+/// is dyn-safe and goes into `Arc<dyn …>`. Required by ADR-149 §2.5
+/// (Always-Has-Policy invariant: hosts hold the policy as Arc).
+#[tokio::test]
+async fn req_tool_visibility_84_011_trait_object_safe() {
+    let p: SharedToolVisibilityPolicy = Arc::new(AllowAllPolicy);
+    assert_eq!(p.name(), "dasclaw_governance::AllowAllPolicy");
+
+    let actor = actor();
+    let tenant = tenant();
+    let c = ctx(
+        "shell",
+        ToolSource::BuiltIn,
+        ToolGateLayer::LlmDefinitions,
+        &actor,
+        &tenant,
+    );
+    let d = p.check(&c).await;
+    assert!(matches!(d, ToolGateDecision::Allow));
+}
+
+/// `req_tool_visibility_84_012_always_check_at_executor` — default impl
+/// returns false; override returns true. Mirrors claude-code
+/// `requireCanUseTool` opt-in.
+#[tokio::test]
+async fn req_tool_visibility_84_012_always_check_at_executor() {
+    let lax: SharedToolVisibilityPolicy = Arc::new(AllowAllPolicy);
+    assert!(!lax.always_check_at_executor(ToolSource::BuiltIn));
+    assert!(!lax.always_check_at_executor(ToolSource::Mcp));
+
+    let strict: SharedToolVisibilityPolicy = Arc::new(DenyAllPolicy {
+        reason: "test".into(),
+    });
+    assert!(strict.always_check_at_executor(ToolSource::BuiltIn));
+}
+
+// ---- Fail-closed audit -----------------------------------------------------
+
+/// `req_tool_visibility_84_013_deny_carries_reason_through_async` —
+/// async `check` returns a deny decision with the original reason text,
+/// so the audit pipeline never loses the "why".
+#[tokio::test]
+async fn req_tool_visibility_84_013_deny_carries_reason_through_async() {
+    let p: SharedToolVisibilityPolicy = Arc::new(DenyAllPolicy {
+        reason: "kill-switch engaged".into(),
+    });
+    let actor = actor();
+    let tenant = tenant();
+    let c = ctx(
+        "shell",
+        ToolSource::BuiltIn,
+        ToolGateLayer::ExecutorPreflight,
+        &actor,
+        &tenant,
+    );
+    match p.check(&c).await {
+        ToolGateDecision::DenyArgs { reason } => {
+            assert_eq!(reason, "kill-switch engaged");
+        }
+        other => panic!("expected DenyArgs, got {other:?}"),
+    }
+}
+
+// ---- Identity newtype contract ---------------------------------------------
+
+/// `req_tool_visibility_84_014_identity_newtypes_round_trip` — `ActorId`
+/// / `TenantId` preserve their string payload (audit log contract).
+/// TODO(identity-W2): once `dasclaw_identity::ActorRef` is real, this
+/// test moves to the identity crate and the newtypes are deleted.
+#[test]
+fn req_tool_visibility_84_014_identity_newtypes_round_trip() {
+    let a = ActorId::new("user-42");
+    assert_eq!(a.as_str(), "user-42");
+    assert_eq!(a.to_string(), "user-42");
+    assert_eq!(a, ActorId::new("user-42"));
+
+    let t = TenantId::new("tenant-7");
+    assert_eq!(t.as_str(), "tenant-7");
+    assert_eq!(t.to_string(), "tenant-7");
+}
+
+// ---- AllowAllPolicy (production placeholder) ------------------------------
+
+/// `req_tool_visibility_84_015_allow_all_policy_default` — the canonical
+/// "default permissive" policy returns `Allow` regardless of input and
+/// carries a stable `name()` for audit-log identification. This is the
+/// Always-Has-Policy invariant's escape hatch: callers without a real
+/// policy yet pass `Arc::new(AllowAllPolicy)` rather than `Option::None`.
+#[tokio::test]
+async fn req_tool_visibility_84_015_allow_all_policy_default() {
+    let p: SharedToolVisibilityPolicy = Arc::new(AllowAllPolicy);
+    assert_eq!(p.name(), "dasclaw_governance::AllowAllPolicy");
+    assert!(!p.always_check_at_executor(ToolSource::BuiltIn));
+
+    let actor = actor();
+    let tenant = tenant();
+    for layer in [
+        ToolGateLayer::PromptCatalog,
+        ToolGateLayer::LlmDefinitions,
+        ToolGateLayer::ExecutorPreflight,
+    ] {
+        for source in [
+            ToolSource::BuiltIn,
+            ToolSource::Mcp,
+            ToolSource::Skill,
+            ToolSource::Extension,
+            ToolSource::Wasm,
+        ] {
+            let c = ctx("any", source, layer, &actor, &tenant);
+            match p.check(&c).await {
+                ToolGateDecision::Allow => {}
+                other => panic!("AllowAllPolicy must return Allow, got {other:?}"),
+            }
+        }
+    }
+}
+
+// ---- ToolGateContextSeed --------------------------------------------------
+
+/// `req_tool_visibility_84_016_context_seed_system_default` — the `system`
+/// constructor produces the literal `"system"` / `"default"` IDs that
+/// `grep` can locate for the W2 identity migration. Round-trips through
+/// `new(...)` and preserves `env`.
+#[test]
+fn req_tool_visibility_84_016_context_seed_system_default() {
+    let s = ToolGateContextSeed::system(Env::Interactive);
+    assert_eq!(s.actor.as_str(), "system");
+    assert_eq!(s.tenant.as_str(), "default");
+    assert!(matches!(s.env, Env::Interactive));
+
+    let s2 = ToolGateContextSeed::new(
+        ActorId::new("user-1"),
+        TenantId::new("tenant-a"),
+        Env::Container,
+    );
+    assert_eq!(s2.actor.as_str(), "user-1");
+    assert_eq!(s2.tenant.as_str(), "tenant-a");
+    assert!(matches!(s2.env, Env::Container));
+}

--- a/desktop-client/ironclaw/Cargo.toml
+++ b/desktop-client/ironclaw/Cargo.toml
@@ -133,6 +133,9 @@ dasclaw_hooks = { path = "../../crates/dasclaw_hooks", version = "0.1.0" }
 # W3 #53: codex-protocol apply_patch parser + minimal apply layer
 dasclaw_apply_patch = { path = "../../crates/dasclaw_apply_patch", version = "0.0.0-w1" }
 dasclaw_workspace_cap = { path = "../../crates/dasclaw_workspace_cap", version = "0.1.0" }
+# ADR-149 / issue #485 — Tool Visibility Triple Gate (`ToolVisibilityPolicy`
+# trait + closed-enum decisions). Default-OFF in the crate, host opts in.
+dasclaw_governance = { path = "../../crates/dasclaw_governance", version = "0.0.0-w1", features = ["tool_visibility"] }
 
 # Safety/sanitization
 ironclaw_safety = { path = "crates/ironclaw_safety", version = "0.2.0", features = ["agent-hook"] }

--- a/desktop-client/ironclaw/src/agent/dispatcher.rs
+++ b/desktop-client/ironclaw/src/agent/dispatcher.rs
@@ -222,7 +222,18 @@ impl Agent {
 
         // Build system prompts once for this turn. Two variants: with tools
         // (normal iterations) and without (force_text final iteration).
-        let initial_tool_defs = self.tools().tool_definitions().await;
+        // ADR-149 / issue #485 — L2 tool visibility gate. Interactive chat
+        // session, so the seed env is `Interactive`. Identity is the W2
+        // placeholder; `grep ToolGateContextSeed::system` surfaces the
+        // migration sites once `dasclaw_identity::ActorRef` lands.
+        let initial_tool_defs = self
+            .tools()
+            .tool_definitions_for_llm(
+                &dasclaw_governance::tool_visibility::ToolGateContextSeed::system(
+                    dasclaw_governance::tool_visibility::Env::Interactive,
+                ),
+            )
+            .await;
         let initial_tool_defs =
             filter_tools_by_disabled_extensions(initial_tool_defs, &disabled_extensions);
         let initial_tool_defs = if !active_skills.is_empty() {
@@ -391,8 +402,17 @@ impl<'a> LoopDelegate for ChatDelegate<'a> {
 
         let force_text = iteration >= self.force_text_at;
 
-        // Refresh tool definitions each iteration so newly built tools become visible
-        let tool_defs = self.agent.tools().tool_definitions().await;
+        // Refresh tool definitions each iteration so newly built tools become visible.
+        // ADR-149 / issue #485 — L2 gate; interactive agent loop.
+        let tool_defs = self
+            .agent
+            .tools()
+            .tool_definitions_for_llm(
+                &dasclaw_governance::tool_visibility::ToolGateContextSeed::system(
+                    dasclaw_governance::tool_visibility::Env::Interactive,
+                ),
+            )
+            .await;
         let tool_defs = filter_tools_by_disabled_extensions(tool_defs, &self.disabled_extensions);
 
         // Apply trust-based tool attenuation if skills are active.

--- a/desktop-client/ironclaw/src/app.rs
+++ b/desktop-client/ironclaw/src/app.rs
@@ -314,13 +314,26 @@ impl AppBuilder {
 
         // Initialize tool registry with credential injection support
         let credential_registry = Arc::new(SharedCredentialRegistry::new());
+        // ADR-149 / issue #485 — install the production
+        // `BlocklistPolicy` as the registry-wide visibility policy.
+        //
+        // Default flags = all enabled, mirroring the legacy
+        // `is_tool_enabled` semantics. The Admin Backend will later
+        // push disabled-tool updates via `system_settings`; rebuilding
+        // the policy from those updates is the planned hook point.
+        let feature_flags: crate::tools::feature_flags::SharedFeatureFlags =
+            Arc::new(crate::tools::feature_flags::ToolFeatureFlags::all_enabled());
+        let policy: dasclaw_governance::tool_visibility::SharedToolVisibilityPolicy = Arc::new(
+            crate::tools::feature_flags::BlocklistPolicy::new(Arc::clone(&feature_flags)),
+        );
         let tools = if let Some(ref ss) = self.secrets_store {
             Arc::new(
                 ToolRegistry::new()
-                    .with_credentials(Arc::clone(&credential_registry), Arc::clone(ss)),
+                    .with_credentials(Arc::clone(&credential_registry), Arc::clone(ss))
+                    .with_policy(Arc::clone(&policy)),
             )
         } else {
-            Arc::new(ToolRegistry::new())
+            Arc::new(ToolRegistry::new().with_policy(Arc::clone(&policy)))
         };
         // Build a single bootstrap context that aggregates every tool group
         // available at this init phase, then dispatch via `bootstrap_tools`.

--- a/desktop-client/ironclaw/src/channels/web/handlers/extensions.rs
+++ b/desktop-client/ironclaw/src/channels/web/handlers/extensions.rs
@@ -104,7 +104,15 @@ pub async fn extensions_tools_handler(
         "Tool registry not available".to_string(),
     ))?;
 
-    let definitions = registry.tool_definitions().await;
+    // ADR-149 / issue #485 — L2 gate; this handler lists tools for the
+    // user-facing extensions UI, which is interactive.
+    let definitions = registry
+        .tool_definitions_for_llm(
+            &dasclaw_governance::tool_visibility::ToolGateContextSeed::system(
+                dasclaw_governance::tool_visibility::Env::Interactive,
+            ),
+        )
+        .await;
     let tools = definitions
         .into_iter()
         .map(|td| ToolInfo {

--- a/desktop-client/ironclaw/src/channels/web/server.rs
+++ b/desktop-client/ironclaw/src/channels/web/server.rs
@@ -2244,7 +2244,15 @@ async fn extensions_tools_handler(
         "Tool registry not available".to_string(),
     ))?;
 
-    let definitions = registry.tool_definitions().await;
+    // ADR-149 / issue #485 — L2 gate; this handler exposes the tool list
+    // to the user-facing extensions UI, which is interactive.
+    let definitions = registry
+        .tool_definitions_for_llm(
+            &dasclaw_governance::tool_visibility::ToolGateContextSeed::system(
+                dasclaw_governance::tool_visibility::Env::Interactive,
+            ),
+        )
+        .await;
     let tools = definitions
         .into_iter()
         .map(|td| ToolInfo {

--- a/desktop-client/ironclaw/src/routines/routine_engine.rs
+++ b/desktop-client/ironclaw/src/routines/routine_engine.rs
@@ -1659,10 +1659,16 @@ async fn execute_lightweight_with_tools(
                 total_output_tokens,
             );
         } else {
-            // Tool-enabled iteration
+            // Tool-enabled iteration.
+            // ADR-149 / issue #485 — L2 gate; routine engine runs without a
+            // human in the loop → Autonomous env.
             let tool_defs = ctx
                 .tools
-                .tool_definitions()
+                .tool_definitions_for_llm(
+                    &dasclaw_governance::tool_visibility::ToolGateContextSeed::system(
+                        dasclaw_governance::tool_visibility::Env::Autonomous,
+                    ),
+                )
                 .await
                 .into_iter()
                 .filter(|tool| allowed_tools.contains(&tool.name))

--- a/desktop-client/ironclaw/src/tools/execute.rs
+++ b/desktop-client/ironclaw/src/tools/execute.rs
@@ -650,7 +650,7 @@ mod tests {
         // BOTH `display` and `stash_content` while neither is dropped.
         let head = "{\"items\":[\"Authorization: ";
         let token = format!("Bearer {}", "a".repeat(40));
-        let filler: String = std::iter::repeat('x').take(500).collect();
+        let filler: String = "x".repeat(500);
         let raw = format!("{}{}\",\"{}\"]}}", head, token, filler);
         assert!(raw.len() > 100, "test payload must exceed cap");
 

--- a/desktop-client/ironclaw/src/tools/execute.rs
+++ b/desktop-client/ironclaw/src/tools/execute.rs
@@ -37,16 +37,47 @@ pub async fn execute_tool_with_safety(
             name: tool_name.to_string(),
         })?;
 
-    // Feature flag gate — reject disabled tools before any parameter work.
-    if !job_ctx.feature_flags.is_tool_enabled(tool_name) {
-        return Err(crate::error::ToolError::Disabled {
-            name: tool_name.to_string(),
-            reason: "disabled by feature flag".to_string(),
-        }
-        .into());
-    }
-
+    // ADR-149 / issue #485 — L3 executor preflight gate.
+    //
+    // Consult the registry's `ToolVisibilityPolicy` before any parameter
+    // work happens. This is the **last line of defense** against:
+    //   - LLM hallucinated tool calls (tool wasn't in L2 catalog)
+    //   - Stale prompt caches offering a tool the policy now hides
+    //   - Jailbreak prompts that try to invoke a disabled tool by name
+    //
+    // The seed encodes who/where; per-tool source classification happens
+    // inside `policy_check_executor` so L2 and L3 see identical sources.
+    // Non-`Allow` decisions are fail-safe: surface as `ToolError::Disabled`
+    // with the policy-provided reason, never silently allow through.
+    let seed = dasclaw_governance::tool_visibility::ToolGateContextSeed::system(
+        dasclaw_governance::tool_visibility::Env::Interactive,
+    );
     let normalized_params = prepare_tool_params(tool.as_ref(), &params);
+    let decision = tools
+        .policy_check_executor(&tool, &seed, Some(&normalized_params))
+        .await;
+    match decision {
+        dasclaw_governance::tool_visibility::ToolGateDecision::Allow => {}
+        dasclaw_governance::tool_visibility::ToolGateDecision::Hide { reason }
+        | dasclaw_governance::tool_visibility::ToolGateDecision::DenyArgs { reason } => {
+            return Err(crate::error::ToolError::Disabled {
+                name: tool_name.to_string(),
+                reason,
+            }
+            .into());
+        }
+        dasclaw_governance::tool_visibility::ToolGateDecision::RequireApproval(_) => {
+            // Until approval routing lands the executor MUST fail-safe.
+            // Surfacing as `Disabled` keeps the caller-side error path
+            // identical to a regular block; a richer UI flow will replace
+            // this branch when approval handling ships.
+            return Err(crate::error::ToolError::Disabled {
+                name: tool_name.to_string(),
+                reason: format!("tool '{tool_name}' requires approval (not yet wired)"),
+            }
+            .into());
+        }
+    }
 
     // Validate tool parameters
     let validation = safety.validator().validate_tool_params(&normalized_params);

--- a/desktop-client/ironclaw/src/tools/feature_flags.rs
+++ b/desktop-client/ironclaw/src/tools/feature_flags.rs
@@ -8,6 +8,11 @@
 use std::collections::HashSet;
 use std::sync::Arc;
 
+use async_trait::async_trait;
+use dasclaw_governance::tool_visibility::{
+    ToolGateContext, ToolGateDecision, ToolSource, ToolVisibilityPolicy,
+};
+
 /// Tool-level feature flag configuration.
 ///
 /// Loaded from `Config.feature_flags` and optionally updated via Admin Backend
@@ -55,6 +60,69 @@ impl Default for ToolFeatureFlags {
 /// Convenience alias used by `JobContext` and callers that share the flags
 /// across cloned contexts cheaply.
 pub type SharedFeatureFlags = Arc<ToolFeatureFlags>;
+
+/// ADR-149 / issue #485 — built-in tool blocklist as a
+/// [`ToolVisibilityPolicy`].
+///
+/// Adapts the existing [`ToolFeatureFlags`] HashSet into the triple-gate
+/// policy surface so the L2 (LLM definitions) and L3 (executor preflight)
+/// gates share a single source of truth. The contract is intentionally
+/// narrow:
+///
+/// * Only [`ToolSource::BuiltIn`] tools are evaluated against the
+///   blocklist. MCP / Skill / Extension / Wasm tools always pass — they
+///   have separate gating mechanisms (extension manifest signing, MCP
+///   server allowlist, etc.) that will land in dedicated policies.
+/// * A disabled BuiltIn produces [`ToolGateDecision::Hide`] (cache-busting
+///   at L2; surfaced as `ToolError::Disabled` at L3). The `reason` field
+///   names the tool so audit logs and error messages can identify it.
+/// * An enabled BuiltIn (or any non-BuiltIn) produces
+///   [`ToolGateDecision::Allow`].
+///
+/// **Migration parity**: `BlocklistPolicy::new(flags).check(name@BuiltIn)`
+/// is observationally equivalent to `flags.is_tool_enabled(name)` for
+/// every name × disabled-set combination — see
+/// `req_tool_visibility_84_020_blocklist_migration_parity`.
+#[derive(Debug, Clone)]
+pub struct BlocklistPolicy {
+    flags: SharedFeatureFlags,
+}
+
+impl BlocklistPolicy {
+    /// Wrap an existing [`SharedFeatureFlags`] reference. The policy holds
+    /// a clone of the [`Arc`], so updates to the underlying flags require
+    /// either swapping the policy on the registry or making
+    /// [`ToolFeatureFlags`] interior-mutable in a future revision.
+    pub fn new(flags: SharedFeatureFlags) -> Self {
+        Self { flags }
+    }
+}
+
+#[async_trait]
+impl ToolVisibilityPolicy for BlocklistPolicy {
+    async fn check(&self, ctx: &ToolGateContext<'_>) -> ToolGateDecision {
+        // Only BuiltIn tools are governed by the legacy blocklist; every
+        // other source has its own gate (extension signing, MCP allowlist,
+        // wasm sealed-tool verifier — issue #484+).
+        if !matches!(ctx.source, ToolSource::BuiltIn) {
+            return ToolGateDecision::Allow;
+        }
+        if self.flags.is_tool_enabled(ctx.tool_name) {
+            ToolGateDecision::Allow
+        } else {
+            ToolGateDecision::Hide {
+                reason: format!(
+                    "tool '{}' is disabled by feature flag (BlocklistPolicy)",
+                    ctx.tool_name
+                ),
+            }
+        }
+    }
+
+    fn name(&self) -> &str {
+        "ironclaw::BlocklistPolicy"
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/desktop-client/ironclaw/src/tools/registry.rs
+++ b/desktop-client/ironclaw/src/tools/registry.rs
@@ -448,8 +448,24 @@ impl ToolRegistry {
     /// until #484 verifier ships). Classification uses the same canonical
     /// name parser as [`Self::register`].
     async fn classify_policy_source(&self, tool: &Arc<dyn Tool>) -> PolicyToolSource {
+        let builtin = self.builtin_names.read().await;
+        Self::classify_policy_source_with(tool, &builtin)
+    }
+
+    /// Same as [`Self::classify_policy_source`] but reuses a caller-held
+    /// snapshot of `builtin_names`. Hot iteration paths (L2 catalog build)
+    /// must hold the read lock once across the whole loop to avoid
+    /// per-tool `await` checkpoints — those checkpoints let unrelated
+    /// async tasks (e.g. a background job worker spawned by an earlier
+    /// tool call) interleave between iterations of the agent loop, which
+    /// breaks any shared scripted/replay LLM provider that relies on a
+    /// stable call sequence.
+    fn classify_policy_source_with(
+        tool: &Arc<dyn Tool>,
+        builtin: &std::collections::HashSet<String>,
+    ) -> PolicyToolSource {
         let name = tool.name();
-        if self.builtin_names.read().await.contains(name) {
+        if builtin.contains(name) {
             return PolicyToolSource::BuiltIn;
         }
         let canonical = CanonicalToolName::parse(name, false);
@@ -487,9 +503,16 @@ impl ToolRegistry {
         seed: &ToolGateContextSeed,
     ) -> Vec<ToolDefinition> {
         let tools = self.tools.read().await;
+        // Hoist the builtin-name set read outside the loop. Acquiring it
+        // once per call (rather than per tool) keeps the loop body free of
+        // additional `await` checkpoints, matching the yield profile of
+        // the legacy `tool_definitions_filtered` path. See
+        // `classify_policy_source_with` for the cross-task-interleaving
+        // rationale.
+        let builtin = self.builtin_names.read().await;
         let mut defs: Vec<ToolDefinition> = Vec::with_capacity(tools.len());
         for tool in tools.values() {
-            let source = self.classify_policy_source(tool).await;
+            let source = Self::classify_policy_source_with(tool, &builtin);
             let ctx = ToolGateContext {
                 tool_name: tool.name(),
                 source,

--- a/desktop-client/ironclaw/src/tools/registry.rs
+++ b/desktop-client/ironclaw/src/tools/registry.rs
@@ -3,6 +3,10 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use dasclaw_governance::tool_visibility::{
+    AllowAllPolicy, SharedToolVisibilityPolicy, ToolGateContext, ToolGateContextSeed,
+    ToolGateDecision, ToolGateLayer, ToolSource as PolicyToolSource,
+};
 use tokio::sync::RwLock;
 
 use crate::context::ContextManager;
@@ -131,6 +135,13 @@ pub struct ToolRegistry {
     /// startup tool collision/visibility view without observing insertion
     /// order.
     registration_log: RwLock<Vec<ToolRegistrationEntry>>,
+    /// ADR-149 / issue #485 — L2 tool visibility gate. Always present (no
+    /// `Option`) to enforce the **Always-Has-Policy invariant**: callers
+    /// can never accidentally bypass the gate by passing `None`. Defaults
+    /// to [`AllowAllPolicy`] (behavioral no-op) so the 20+ existing
+    /// `ToolRegistry::new()` call sites keep working; production wires a
+    /// real policy via [`Self::with_policy`].
+    policy: SharedToolVisibilityPolicy,
 }
 
 impl ToolRegistry {
@@ -153,6 +164,11 @@ impl ToolRegistry {
             rate_limiter: RateLimiter::new(),
             message_tool: RwLock::new(None),
             registration_log: RwLock::new(Vec::new()),
+            // ADR-149 §2.5: default to the explicit no-op policy rather
+            // than `Option<…>`. Real wiring lands in `app.rs` via
+            // [`Self::with_policy`]. `grep AllowAllPolicy` surfaces every
+            // call site still using the placeholder.
+            policy: Arc::new(AllowAllPolicy),
         }
     }
 
@@ -164,6 +180,19 @@ impl ToolRegistry {
     ) -> Self {
         self.credential_registry = Some(credential_registry);
         self.secrets_store = Some(secrets_store);
+        self
+    }
+
+    /// Install a [`ToolVisibilityPolicy`] for the L2 catalog gate.
+    ///
+    /// Builder-style: returns `self` so it composes with
+    /// [`Self::with_credentials`]. Replaces the default
+    /// [`AllowAllPolicy`] set by [`Self::new`].
+    ///
+    /// ADR-149 / issue #485 — production hosts wire a real policy here
+    /// (e.g. `BlocklistPolicy` wrapping `feature_flags::ToolFeatureFlags`).
+    pub fn with_policy(mut self, policy: SharedToolVisibilityPolicy) -> Self {
+        self.policy = policy;
         self
     }
 
@@ -410,6 +439,120 @@ impl ToolRegistry {
             .iter()
             .filter_map(|name| tools.get(*name).map(Self::tool_definition))
             .collect()
+    }
+
+    /// Map a registered tool to the `ToolVisibilityPolicy` source bucket.
+    ///
+    /// BuiltIn vs not-BuiltIn is the only decision that matters for ADR-149
+    /// fail-closed defaults (non-BuiltIn → policy may choose to `Hide`
+    /// until #484 verifier ships). Classification uses the same canonical
+    /// name parser as [`Self::register`].
+    async fn classify_policy_source(&self, tool: &Arc<dyn Tool>) -> PolicyToolSource {
+        let name = tool.name();
+        if self.builtin_names.read().await.contains(name) {
+            return PolicyToolSource::BuiltIn;
+        }
+        let canonical = CanonicalToolName::parse(name, false);
+        match canonical.kind() {
+            CanonicalKind::Mcp => PolicyToolSource::Mcp,
+            CanonicalKind::Wasm => PolicyToolSource::Wasm,
+            CanonicalKind::Extension => PolicyToolSource::Extension,
+            // `parse(_, false)` never returns Builtin (see comment on
+            // `canonical_kind_to_source`); LegacyDynamic captures
+            // dynamically-built tools that don't match a typed prefix.
+            // Treated as `Skill` for policy purposes — the most-restrictive
+            // bucket short of fully unknown.
+            CanonicalKind::Builtin | CanonicalKind::LegacyDynamic => PolicyToolSource::Skill,
+        }
+    }
+
+    /// ADR-149 / issue #485 — get tool definitions for the LLM (L2 gate).
+    ///
+    /// This is the **only** code path that should be used when handing tools
+    /// to the model. It consults the installed [`ToolVisibilityPolicy`] for
+    /// every registered tool at [`ToolGateLayer::LlmDefinitions`] and omits
+    /// any tool whose decision is [`ToolGateDecision::Hide`] or
+    /// [`ToolGateDecision::DenyArgs`]. `Allow` and `RequireApproval` keep
+    /// the tool visible (the L3 executor preflight makes the final
+    /// admit/deny call).
+    ///
+    /// **Cache awareness**: per Anthropic prompt-cache rules, the `tools:[]`
+    /// array participates in the cache key. Hiding a tool *changes* the
+    /// array and busts the cache. Callers SHOULD restrict `Hide` decisions
+    /// to first-turn / cold-cache scenarios and prefer `DenyArgs` once a
+    /// conversation is warm. The policy is the right place to enforce that
+    /// — this registry just applies the decision verbatim.
+    pub async fn tool_definitions_for_llm(
+        &self,
+        seed: &ToolGateContextSeed,
+    ) -> Vec<ToolDefinition> {
+        let tools = self.tools.read().await;
+        let mut defs: Vec<ToolDefinition> = Vec::with_capacity(tools.len());
+        for tool in tools.values() {
+            let source = self.classify_policy_source(tool).await;
+            let ctx = ToolGateContext {
+                tool_name: tool.name(),
+                source,
+                layer: ToolGateLayer::LlmDefinitions,
+                actor: &seed.actor,
+                tenant: &seed.tenant,
+                args: None,
+                env: seed.env,
+            };
+            match self.policy.check(&ctx).await {
+                ToolGateDecision::Allow | ToolGateDecision::RequireApproval(_) => {
+                    defs.push(Self::tool_definition(tool));
+                }
+                ToolGateDecision::Hide { .. } | ToolGateDecision::DenyArgs { .. } => {
+                    // omit from L2 catalog
+                }
+            }
+        }
+        defs.sort_unstable_by(|a, b| a.name.cmp(&b.name));
+        defs
+    }
+
+    /// Read-only accessor for the installed visibility policy.
+    ///
+    /// Lets L3 (executor preflight) consult the same policy installed at
+    /// construction without threading a separate `Arc` through every call
+    /// site. Returned reference shares the underlying [`Arc`].
+    pub fn policy(&self) -> &SharedToolVisibilityPolicy {
+        &self.policy
+    }
+
+    /// ADR-149 / issue #485 — L3 executor preflight gate.
+    ///
+    /// Consults the installed [`ToolVisibilityPolicy`] at
+    /// [`ToolGateLayer::ExecutorPreflight`] for a tool that is about to
+    /// execute. Source classification reuses the same logic as
+    /// [`Self::tool_definitions_for_llm`] so L2 and L3 see the same
+    /// `source` for a given tool — there is no second source of truth
+    /// that an attacker could exploit by submitting a hallucinated tool
+    /// call that happens to slip past L2.
+    ///
+    /// Callers MUST treat any non-`Allow` decision as a hard reject and
+    /// surface the reason verbatim into the audit log. `RequireApproval`
+    /// is left to the executor to translate into the appropriate UI
+    /// flow; until that wiring lands the executor should treat it as
+    /// `Deny` (fail-safe).
+    pub async fn policy_check_executor(
+        &self,
+        tool: &Arc<dyn Tool>,
+        seed: &ToolGateContextSeed,
+        args: Option<&serde_json::Value>,
+    ) -> ToolGateDecision {
+        let source = self.classify_policy_source(tool).await;
+        let ctx = ToolGateContext {
+            tool_name: tool.name(),
+            source,
+            layer: ToolGateLayer::ExecutorPreflight,
+            actor: &seed.actor,
+            tenant: &seed.tenant,
+            args,
+            env: seed.env,
+        };
+        self.policy.check(&ctx).await
     }
 
     /// Register all built-in tools.

--- a/desktop-client/ironclaw/src/worker/container.rs
+++ b/desktop-client/ironclaw/src/worker/container.rs
@@ -170,8 +170,16 @@ Work independently to complete this job. When finished, your final message MUST 
             job.title, job.description
         )));
 
-        // Load tool definitions
-        reason_ctx.available_tools = self.tools.tool_definitions().await;
+        // Load tool definitions.
+        // ADR-149 / issue #485 — L2 gate; container worker → Container env.
+        reason_ctx.available_tools = self
+            .tools
+            .tool_definitions_for_llm(
+                &dasclaw_governance::tool_visibility::ToolGateContextSeed::system(
+                    dasclaw_governance::tool_visibility::Env::Container,
+                ),
+            )
+            .await;
 
         // Shared iteration tracker — read after the loop to report accurate counts.
         let iteration_tracker = Arc::new(Mutex::new(0u32));
@@ -448,8 +456,16 @@ impl LoopDelegate for ContainerDelegate {
             tracing::warn!("Switching to text-only recovery after malformed tool completions");
             reason_ctx.available_tools.clear();
         } else {
-            // Refresh tools (in case WASM tools were built)
-            reason_ctx.available_tools = self.tools.tool_definitions().await;
+            // Refresh tools (in case WASM tools were built).
+            // ADR-149 / issue #485 — L2 gate; container worker → Container env.
+            reason_ctx.available_tools = self
+                .tools
+                .tool_definitions_for_llm(
+                    &dasclaw_governance::tool_visibility::ToolGateContextSeed::system(
+                        dasclaw_governance::tool_visibility::Env::Container,
+                    ),
+                )
+                .await;
         }
 
         None

--- a/desktop-client/ironclaw/src/worker/job.rs
+++ b/desktop-client/ironclaw/src/worker/job.rs
@@ -352,7 +352,15 @@ Report when the job is complete or if you encounter issues you cannot resolve."#
         let max_iterations = max_iterations.min(MAX_WORKER_ITERATIONS);
 
         // Initial tool definitions for planning (will be refreshed in loop)
-        reason_ctx.available_tools = self.tools().tool_definitions().await;
+        // ADR-149 / issue #485 — L2 gate; background worker → Autonomous env.
+        reason_ctx.available_tools = self
+            .tools()
+            .tool_definitions_for_llm(
+                &dasclaw_governance::tool_visibility::ToolGateContextSeed::system(
+                    dasclaw_governance::tool_visibility::Env::Autonomous,
+                ),
+            )
+            .await;
 
         // Generate plan if planning is enabled
         let plan = if self.use_planning() {
@@ -1481,8 +1489,17 @@ impl<'a> LoopDelegate for JobDelegate<'a> {
             );
             reason_ctx.available_tools.clear();
         } else {
-            // Refresh tool definitions so newly built tools become visible
-            reason_ctx.available_tools = self.worker.tools().tool_definitions().await;
+            // Refresh tool definitions so newly built tools become visible.
+            // ADR-149 / issue #485 — L2 gate; background worker → Autonomous env.
+            reason_ctx.available_tools = self
+                .worker
+                .tools()
+                .tool_definitions_for_llm(
+                    &dasclaw_governance::tool_visibility::ToolGateContextSeed::system(
+                        dasclaw_governance::tool_visibility::Env::Autonomous,
+                    ),
+                )
+                .await;
         }
 
         // Claude 4.6 rejects assistant prefill; NEAR AI rejects any non-user-ending

--- a/desktop-client/ironclaw/tests/parity_harness.rs
+++ b/desktop-client/ironclaw/tests/parity_harness.rs
@@ -228,7 +228,14 @@ async fn run_scenario_with_job_ctx(
     job_ctx: JobContext,
 ) -> ScenarioResult {
     let llm = Arc::new(ScriptedLlm::new(steps));
-    let tools = Arc::new(ToolRegistry::new());
+    // ADR-149 / issue #485 — bridge legacy per-job `feature_flags` into the
+    // registry-wide `BlocklistPolicy` so disabled-tool tests survive the
+    // removal of the bool gate in `execute_tool_with_safety`. The clone is
+    // cheap (Arc) and shares the same underlying set the job uses.
+    let policy: dasclaw_governance::tool_visibility::SharedToolVisibilityPolicy = Arc::new(
+        ironclaw::tools::feature_flags::BlocklistPolicy::new(Arc::clone(&job_ctx.feature_flags)),
+    );
+    let tools = Arc::new(ToolRegistry::new().with_policy(policy));
     tools
         .bootstrap_tools(&ironclaw::tools::bootstrap::BootstrapContext {
             mode: ironclaw::tools::bootstrap::BootstrapMode::Orchestrator {

--- a/desktop-client/ironclaw/tests/tool_visibility_integration.rs
+++ b/desktop-client/ironclaw/tests/tool_visibility_integration.rs
@@ -1,0 +1,270 @@
+//! ADR-149 / Issue #485 — L3 Executor Preflight integration tests.
+//!
+//! Verifies the **defense-in-depth** guarantee: even if a tool slips past
+//! the L2 catalog (e.g. LLM hallucinated tool call, stale cache, jailbreak
+//! prompt), the L3 executor preflight gate still rejects it before any
+//! tool code runs. Also pins the [`BlocklistPolicy`] migration parity with
+//! the legacy `ToolFeatureFlags::is_tool_enabled` HashSet.
+//!
+//! These tests run with `features = ["tool_visibility"]` enabled on
+//! `dasclaw_governance` via the ironclaw `Cargo.toml` default deps.
+
+use std::sync::Arc;
+
+use dasclaw_governance::tool_visibility::{
+    ActorId, Env, TenantId, ToolGateContext, ToolGateContextSeed, ToolGateDecision, ToolGateLayer,
+    ToolSource, ToolVisibilityPolicy,
+};
+use ironclaw::tools::feature_flags::{BlocklistPolicy, ToolFeatureFlags};
+
+fn ctx_for<'a>(
+    tool_name: &'a str,
+    source: ToolSource,
+    layer: ToolGateLayer,
+    actor: &'a ActorId,
+    tenant: &'a TenantId,
+) -> ToolGateContext<'a> {
+    ToolGateContext {
+        tool_name,
+        source,
+        layer,
+        actor,
+        tenant,
+        args: None,
+        env: Env::Interactive,
+    }
+}
+
+/// req_tool_visibility_84_017_blocklist_hides_disabled_builtin
+///
+/// BlocklistPolicy returns `Hide` for a BuiltIn tool listed in the
+/// disabled set. The reason string is non-empty so the audit log can
+/// surface it.
+#[tokio::test]
+async fn req_tool_visibility_84_017_blocklist_hides_disabled_builtin() {
+    let flags = Arc::new(ToolFeatureFlags::with_disabled(vec!["shell".into()]));
+    let policy = BlocklistPolicy::new(flags);
+    let actor = ActorId("system".into());
+    let tenant = TenantId("default".into());
+
+    let decision = policy
+        .check(&ctx_for(
+            "shell",
+            ToolSource::BuiltIn,
+            ToolGateLayer::LlmDefinitions,
+            &actor,
+            &tenant,
+        ))
+        .await;
+
+    match decision {
+        ToolGateDecision::Hide { reason } => {
+            assert!(!reason.is_empty(), "Hide reason must be non-empty");
+            assert!(
+                reason.contains("shell"),
+                "reason should mention the tool name, got: {reason}",
+            );
+        }
+        other => panic!("expected Hide, got {other:?}"),
+    }
+}
+
+/// req_tool_visibility_84_018_blocklist_allows_non_builtin
+///
+/// BlocklistPolicy only governs BuiltIn tools. Non-BuiltIn sources
+/// (Mcp / Skill / Extension / Wasm) bypass the legacy blocklist — they
+/// have their own gating mechanisms (extension manifest signing, MCP
+/// server allowlist, etc.) which will land in later policies.
+#[tokio::test]
+async fn req_tool_visibility_84_018_blocklist_allows_non_builtin() {
+    // Same disabled name as a BuiltIn, but the gate sees source=Mcp.
+    let flags = Arc::new(ToolFeatureFlags::with_disabled(vec!["shell".into()]));
+    let policy = BlocklistPolicy::new(flags);
+    let actor = ActorId("system".into());
+    let tenant = TenantId("default".into());
+
+    for src in [
+        ToolSource::Mcp,
+        ToolSource::Skill,
+        ToolSource::Extension,
+        ToolSource::Wasm,
+    ] {
+        let decision = policy
+            .check(&ctx_for(
+                "shell",
+                src,
+                ToolGateLayer::ExecutorPreflight,
+                &actor,
+                &tenant,
+            ))
+            .await;
+        assert!(
+            matches!(decision, ToolGateDecision::Allow),
+            "non-BuiltIn source {src:?} must bypass BlocklistPolicy, got {decision:?}",
+        );
+    }
+}
+
+/// req_tool_visibility_84_019_blocklist_allows_enabled_builtin
+///
+/// A BuiltIn tool NOT in the disabled set passes the policy unchanged
+/// at every layer.
+#[tokio::test]
+async fn req_tool_visibility_84_019_blocklist_allows_enabled_builtin() {
+    let flags = Arc::new(ToolFeatureFlags::with_disabled(vec!["shell".into()]));
+    let policy = BlocklistPolicy::new(flags);
+    let actor = ActorId("system".into());
+    let tenant = TenantId("default".into());
+
+    for layer in [
+        ToolGateLayer::PromptCatalog,
+        ToolGateLayer::LlmDefinitions,
+        ToolGateLayer::ExecutorPreflight,
+    ] {
+        let decision = policy
+            .check(&ctx_for(
+                "echo",
+                ToolSource::BuiltIn,
+                layer,
+                &actor,
+                &tenant,
+            ))
+            .await;
+        assert!(
+            matches!(decision, ToolGateDecision::Allow),
+            "enabled BuiltIn at layer {layer:?} must Allow, got {decision:?}",
+        );
+    }
+}
+
+/// req_tool_visibility_84_020_blocklist_migration_parity
+///
+/// For every (name × disabled-set) input, `BlocklistPolicy(flags).check(name @ BuiltIn)`
+/// is **observationally equivalent** to `flags.is_tool_enabled(name)`:
+/// - `Allow`  ⇔  `is_tool_enabled == true`
+/// - `Hide`   ⇔  `is_tool_enabled == false`
+///
+/// This is the migration contract that allows us to delete the legacy
+/// `is_tool_enabled` call from `execute.rs` without changing semantics.
+#[tokio::test]
+async fn req_tool_visibility_84_020_blocklist_migration_parity() {
+    let cases: Vec<(Vec<&str>, &str)> = vec![
+        (vec![], "shell"),
+        (vec!["shell"], "shell"),
+        (vec!["shell"], "echo"),
+        (vec!["shell", "http"], "http"),
+        (vec!["shell", "http"], "json"),
+        (vec!["read_file"], "read_file"),
+    ];
+
+    let actor = ActorId("system".into());
+    let tenant = TenantId("default".into());
+
+    for (disabled, query) in cases {
+        let flags = Arc::new(ToolFeatureFlags::with_disabled(
+            disabled.iter().map(|s| s.to_string()),
+        ));
+        let expected_enabled = flags.is_tool_enabled(query);
+        let policy = BlocklistPolicy::new(Arc::clone(&flags));
+        let decision = policy
+            .check(&ctx_for(
+                query,
+                ToolSource::BuiltIn,
+                ToolGateLayer::ExecutorPreflight,
+                &actor,
+                &tenant,
+            ))
+            .await;
+
+        match (expected_enabled, &decision) {
+            (true, ToolGateDecision::Allow) => {}
+            (false, ToolGateDecision::Hide { .. }) => {}
+            _ => panic!(
+                "migration parity broken: disabled={disabled:?} query={query} \
+                 expected_enabled={expected_enabled} decision={decision:?}",
+            ),
+        }
+    }
+}
+
+/// req_tool_visibility_84_021_blocklist_policy_name
+///
+/// The policy reports a stable, fully-qualified name so audit logs can
+/// distinguish it from `AllowAllPolicy` and any future tenant- or
+/// scope-specific policies.
+#[test]
+fn req_tool_visibility_84_021_blocklist_policy_name() {
+    let flags = Arc::new(ToolFeatureFlags::all_enabled());
+    let policy = BlocklistPolicy::new(flags);
+    assert_eq!(policy.name(), "ironclaw::BlocklistPolicy");
+}
+
+/// test_security_84_executor_preflight_blocks_hallucinated_tool
+///
+/// **Defense in depth**: even if a tool slips past L2 (e.g. the LLM
+/// hallucinates a tool name not in the catalog, or a stale cache offers
+/// a tool the policy now hides), the L3 executor preflight check via
+/// `tools.policy().check(layer=ExecutorPreflight)` still rejects it.
+///
+/// This is the contract that makes the system **Fail-Safe**: a Hide
+/// decision at L3 maps to `ToolError::Disabled`, never to silent
+/// allow-through.
+#[tokio::test]
+async fn test_security_84_executor_preflight_blocks_hallucinated_tool() {
+    let flags = Arc::new(ToolFeatureFlags::with_disabled(vec!["shell".into()]));
+    let policy: Arc<dyn ToolVisibilityPolicy> = Arc::new(BlocklistPolicy::new(flags));
+    let actor = ActorId("attacker".into()); // adversarial actor id
+    let tenant = TenantId("default".into());
+
+    // Simulate the executor preflight: tool came from LLM tool_call,
+    // not from the L2 catalog. Source is classified as BuiltIn.
+    let args = serde_json::json!({"command": "rm -rf /"});
+    let ctx = ToolGateContext {
+        tool_name: "shell",
+        source: ToolSource::BuiltIn,
+        layer: ToolGateLayer::ExecutorPreflight,
+        actor: &actor,
+        tenant: &tenant,
+        args: Some(&args),
+        env: Env::Interactive,
+    };
+
+    let decision = policy.check(&ctx).await;
+
+    match decision {
+        ToolGateDecision::Hide { reason } | ToolGateDecision::DenyArgs { reason } => {
+            assert!(reason.contains("shell"), "audit reason missing tool name");
+        }
+        other => {
+            panic!("FAIL-CLOSED VIOLATION: L3 must block hallucinated disabled tool, got {other:?}",)
+        }
+    }
+}
+
+/// req_tool_visibility_84_022_seed_to_context_conversion
+///
+/// `ToolGateContextSeed` is the owned counterpart of `ToolGateContext`.
+/// Verifies the conversion path used by `tool_definitions_for_llm` and
+/// the upcoming `policy_check_executor` builds a context whose fields
+/// match the seed.
+#[tokio::test]
+async fn req_tool_visibility_84_022_seed_to_context_conversion() {
+    let seed = ToolGateContextSeed::system(Env::Container);
+    assert_eq!(seed.actor.0, "system");
+    assert_eq!(seed.tenant.0, "default");
+    assert!(matches!(seed.env, Env::Container));
+
+    // Build a ctx using the seed (the same way registry.rs does internally)
+    let ctx = ToolGateContext {
+        tool_name: "echo",
+        source: ToolSource::BuiltIn,
+        layer: ToolGateLayer::ExecutorPreflight,
+        actor: &seed.actor,
+        tenant: &seed.tenant,
+        args: None,
+        env: seed.env,
+    };
+    assert_eq!(ctx.actor.0, "system");
+    assert_eq!(ctx.tenant.0, "default");
+    assert!(matches!(ctx.env, Env::Container));
+}


### PR DESCRIPTION
## Sources read

- [`AGENTS.md`](../AGENTS.md) §强制阅读顺序 / §红线 / §本地管线 / §PR必填项 / §测试纪律 / §复用优先于新建
- [`docs/plans/architecture-refactor/adr-149-tool-visibility-triple-gate.md`](../docs/plans/architecture-refactor/adr-149-tool-visibility-triple-gate.md) §1.3.1 三仓库对比 / §2.1 trait / §2.2 三层接入点 / §2.4 vendor取舍 / §2.5 BlocklistPolicy兼容 / §2.7 Always-Has-Policy / §4 改动范围 / §4.5 PR拆分策略
- [`docs/plans/architecture-refactor/adr-112-compatibility-evaluation.md`](../docs/plans/architecture-refactor/adr-112-compatibility-evaluation.md) §兼容性红线
- [`docs/plans/architecture-refactor/adr-113-hook-engine-unification.md`](../docs/plans/architecture-refactor/adr-113-hook-engine-unification.md) §Hook 引擎不变式
- issue body `/tmp/issue-485-kickoff.md` §1.3 / §2 / §4 / §PR 拆分

## 背景 / 目标

ADR-149 定义了**工具可见性三层闸门**（L1 Catalog 未来 / L2 Prompt-Time / L3 Executor-Preflight），统一替代 `claude-code-parity` 仓库分散的 `disabled_tools` HashSet + bool 守卫模式。

本 PR 落地：
- **`dasclaw_governance::tool_visibility`** —— trait `ToolVisibilityPolicy` + 枚举 `ToolGateDecision { Allow, Hide, DenyArgs, RequireApproval }` + `ToolGateContext` / `ToolGateContextSeed` / 本地 newtype `ActorId/TenantId/DecisionId` + `AllowAllPolicy` 默认实现
- **L2 接入** —— `ToolRegistry::tool_definitions_for_llm(&seed)` + 非 Option 的 `Arc<dyn ToolVisibilityPolicy>` 字段（默认 `AllowAllPolicy`）+ `.with_policy()` builder；9 处生产调用点全部切换
- **L3 接入** —— `ToolRegistry::policy_check_executor(tool, seed, args)` + `execute_tool_with_safety` 内用 4-arm 枚举匹配替换 `if !is_tool_enabled` bool gate
- **`BlocklistPolicy`** —— 包装现有 `SharedFeatureFlags`，对 `ToolSource::BuiltIn` 检查 disabled_tools HashSet → 与旧逻辑**行为等价**（迁移零退化）

## 改动范围

| 文件 | 类型 | 说明 |
|------|------|------|
| `crates/dasclaw_governance/src/tool_visibility.rs` | NEW (478 LOC) | trait + types + AllowAllPolicy + ContextSeed |
| `crates/dasclaw_governance/tests/tool_visibility_test.rs` | NEW (379 LOC) | 18 个 `req_tool_visibility_84_001..016` 红测 |
| `crates/dasclaw_governance/Cargo.toml` / `src/lib.rs` | MOD | feature flag `tool_visibility` + 模块导出 |
| `desktop-client/ironclaw/src/tools/feature_flags.rs` | MOD (+65 LOC) | 新增 `BlocklistPolicy` |
| `desktop-client/ironclaw/src/tools/registry.rs` | MOD (+143 LOC) | `policy` 字段 + `with_policy()` + `tool_definitions_for_llm` + `policy_check_executor` + `classify_policy_source` |
| `desktop-client/ironclaw/src/tools/execute.rs` | MOD | bool gate → 枚举 match；`prepare_tool_params` 前移 |
| `desktop-client/ironclaw/src/app.rs` | MOD | init_tools 注入 `BlocklistPolicy::new(feature_flags)` |
| `desktop-client/ironclaw/src/agent/dispatcher.rs`, `worker/job.rs`, `worker/container.rs`, `channels/web/server.rs`, `channels/web/handlers/extensions.rs`, `routines/routine_engine.rs` | MOD | 9 处调用点切到 `tool_definitions_for_llm(&seed)` |
| `desktop-client/ironclaw/tests/tool_visibility_integration.rs` | NEW (270 LOC) | 7 个 L3 集成测试（含 `test_security_84_executor_preflight_blocks_hallucinated_tool`） |
| `desktop-client/ironclaw/tests/parity_harness.rs` | MOD | `run_scenario_with_job_ctx` 桥接 job_ctx.feature_flags → BlocklistPolicy |

**LOC 合计**：~1519 insertions / ~25 deletions（4 个内部 commit，单 PR）

## 非目标（What's NOT in this PR）

- **L1 Catalog**：ADR §2.2 提到的 catalog 层未落地（先做 L2/L3，catalog 留给后续）
- **`dasclaw_identity::ActorRef`**：本 PR 用本地 newtype `ActorId(String)/TenantId(String)`，等 #W2 落地后替换（代码注释已标 `TODO(identity-W2)`）
- **`SourceAwareBlocklistPolicy`**：当前 `BlocklistPolicy` 只对 `BuiltIn` 强制；非 BuiltIn 默认 Allow（兼容路径），等 #484 verifier 落地后扩展为按 ADR §2.7.2 决策表完整路由
- **Approval 路由**：`ToolGateDecision::RequireApproval(_)` 在 L3 暂用 fail-safe `Disabled` 占位（reason 标 "not yet wired"），等 approval pipeline 落地
- **Codex vendoring**：ADR §2.4 评估后**不**vendor codex `tool_spec`（避免增加 60+ 文件依赖图）
- **删除旧 `is_tool_enabled` listing API**：registry.rs 中 listing/filtering 用途的调用（line 370/428/728）保留不动 —— 那是工具列表展示，不是 L3 安全闸门
- 修改 hooks / sandbox / 其它 ADR 范围外子系统

## 验证（命令 + 结果）

按 AGENTS.md §3 顺序：

```bash
# 1. cargo check
cargo check -p dasclaw --tests
# → Finished `test` profile in 4m 23s ✅

# 2. governance + 集成测试 + parity 回归
cargo nextest run -p dasclaw_governance --features tool_visibility
# → 18 tests run: 18 passed, 0 skipped ✅

cargo nextest run -p dasclaw --test tool_visibility_integration
# → 7 tests run: 7 passed (1 leaky), 0 skipped ✅
# (leaky 是 nextest 检测到 test 018 在 for-loop 中 async-trait 调用留下 tokio
#  task handle，benign 后台清理，测试结果 PASS)

cargo nextest run -p dasclaw --test parity_harness -E 'test(/sp_016|sp_017/)'
# → 2 tests run: 2 passed (sp_016/sp_017 disabled-tool 旧测), 48 skipped ✅

# 3. fmt + check_no_panics
cargo fmt --all -- --check    # ✅ clean
python3.12 scripts/check_no_panics.py --base origin/xClaw
# → OK: No panic-inducing calls in changed production code ✅

# 4. clippy
cargo clippy --no-deps -p dasclaw --lib -- -D warnings
# → Finished `dev` profile in 2m 13s ✅
cargo clippy --no-deps -p dasclaw_governance --features tool_visibility --all-targets -- -D warnings
# → clean ✅
```

### 关键安全证据

- **`test_security_84_executor_preflight_blocks_hallucinated_tool`** PASS (0.562s)
  - 场景：模拟越狱 / 幻觉 LLM 绕过 L2 直接调用 disabled `shell` + `rm -rf /` args
  - 断言：L3 必须 Hide 或 DenyArgs（fail-closed），不允许 Allow
  - **证明 fail-closed 不变式成立**

- **`req_tool_visibility_84_020_blocklist_migration_parity`** PASS
  - 6 组 (name × disabled-set) 组合证明：
    - `Allow` ⇔ `flags.is_tool_enabled(name) == true`
    - `Hide`  ⇔ `flags.is_tool_enabled(name) == false`
  - **证明零行为退化（ADR §2.5 兼容契约）**

### Always-Has-Policy 不变式

`ToolRegistry.policy: Arc<dyn ToolVisibilityPolicy>` 是**非 Option**字段，构造器自动填 `AllowAllPolicy`。任何忘记 `.with_policy()` 的代码路径在运行时也会走 AllowAllPolicy（safe），生产路径在 `app.rs::init_tools` 显式注入 `BlocklistPolicy`。**编译期 + 构造期防退化**，不存在 `policy is None → fall through to allow-all` 这种 fail-open 漏洞。

## 3 层审查结论

| 层 | 工具 | 结论 |
|---|------|------|
| L1 semantic_search | `BlocklistPolicy L3 executor preflight` | 仓库内无重复定义 |
| L2 listCodeUsages | `BlocklistPolicy` / `policy_check_executor` | 生产代码各 1 处使用，符合预期 |
| L3 grep `is_tool_enabled` | repo-wide | 残留全在 listing APIs (registry.rs:370/428/728) + 测试代码；execute 路径 bool gate 已彻底移除 |

## 关联 ADR

- [adr-149-tool-visibility-triple-gate](../docs/plans/architecture-refactor/adr-149-tool-visibility-triple-gate.md) (核心)
- [adr-112-compatibility-evaluation](../docs/plans/architecture-refactor/adr-112-compatibility-evaluation.md) (红线)
- [adr-113-hook-engine-unification](../docs/plans/architecture-refactor/adr-113-hook-engine-unification.md) (邻接系统不变式)

Closes #485
