### PR TITLE
feat(safety): ADR-148 PR-B attachment DLP gate (closes #92)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3452,6 +3452,7 @@ dependencies = [
  "uuid",
  "windows 0.58.0",
  "wiremock",
+ "x_claw_agent",
  "zbus",
 ]
 

--- a/desktop-client/Cargo.toml
+++ b/desktop-client/Cargo.toml
@@ -38,8 +38,16 @@ regex = "1"
 open = "5"
 
 # Safety and DLP
-ironclaw_safety = { path = "./ironclaw/crates/ironclaw_safety" }
+# `egress-gate` feature exposes the `IronclawEgressGate` adapter so this
+# crate can plug `SafetyLayer` into the project-wide `EgressGate` trait
+# (ADR-148 §6.4, closes issue #92 attachment DLP gate).
+ironclaw_safety = { path = "./ironclaw/crates/ironclaw_safety", features = ["egress-gate"] }
 dasclaw_sandbox = { path = "../crates/dasclaw_sandbox" }
+
+# EgressGate trait (ADR-148) — single seam for data leaving the agent's
+# trust boundary. Used to gate attachment extracted_text on both the
+# LlmRequest and Persistence egress kinds.
+x_claw_agent = { path = "../crates/x_claw_agent" }
 
 # IronClaw embedded server (ADR-114 Ⅴ: package was renamed to `dasclaw`,
 # alias the extern name back to `ironclaw` so all `use ironclaw::` imports

--- a/desktop-client/src/engine.rs
+++ b/desktop-client/src/engine.rs
@@ -172,6 +172,18 @@ pub async fn start_ironclaw_engine(app_handle: AppHandle) -> anyhow::Result<()> 
         None, // DataReporter 在 admin_sync 阶段注入
     ));
 
+    // Build the project-wide `EgressGate` chain. The current desktop
+    // client has a single gate (the IronclawEgressGate wrapping
+    // SafetyLayer); future enterprise scanners append via
+    // `CompositeEgressGate::builder().add(...)` without touching IPC
+    // call sites (ADR-148 §6.4, closes issue #92).
+    let egress: Arc<dyn x_claw_agent::EgressGate> = Arc::new(
+        ironclaw_safety::egress_gate::IronclawEgressGate::new(Arc::clone(&components.safety)),
+    );
+    let attachment_scanner = Arc::new(crate::safety_attachment_scanner::AttachmentScanner::new(
+        Arc::clone(&egress),
+    ));
+
     // ── 模型切换 ──────────────────────────────────────────────────
     // model_override 在 AppState 和 ModelSwitchProvider 之间共享。
     let model_override = Arc::new(std::sync::RwLock::new(None::<String>));
@@ -253,6 +265,8 @@ pub async fn start_ironclaw_engine(app_handle: AppHandle) -> anyhow::Result<()> 
         skills_config: config.skills.clone(),
         safety: Arc::clone(&components.safety),
         safety_bridge,
+        attachment_scanner,
+        egress,
         context_manager: Arc::clone(&components.context_manager),
         conversation_tracker: Arc::clone(&tracker),
         data_reporter: Arc::clone(&reporter),

--- a/desktop-client/src/engine_startup_tests.rs
+++ b/desktop-client/src/engine_startup_tests.rs
@@ -39,6 +39,12 @@ mod engine_state_timing_tests {
         };
         let safety = Arc::new(SafetyLayer::new(&safety_config));
         let safety_bridge = Arc::new(SafetyBridge::new(Arc::clone(&safety), None, None));
+        let egress: Arc<dyn x_claw_agent::EgressGate> = Arc::new(
+            ironclaw_safety::egress_gate::IronclawEgressGate::new(Arc::clone(&safety)),
+        );
+        let attachment_scanner = Arc::new(
+            crate::safety_attachment_scanner::AttachmentScanner::new(Arc::clone(&egress)),
+        );
         let tools = Arc::new(ToolRegistry::new());
         let context_manager = Arc::new(ContextManager::new(5));
         let data_reporter = Arc::new(crate::data_reporter::DataReporter::new(
@@ -64,6 +70,8 @@ mod engine_state_timing_tests {
             skills_config: ironclaw::config::SkillsConfig::default(),
             safety,
             safety_bridge,
+            attachment_scanner,
+            egress,
             context_manager,
             conversation_tracker: Arc::new(crate::conversation_tracker::ConversationTracker::new(
                 "test-owner".to_string(),

--- a/desktop-client/src/ipc/chat.rs
+++ b/desktop-client/src/ipc/chat.rs
@@ -17,6 +17,7 @@ use serde::{Deserialize, Serialize};
 use tauri::{Manager, State};
 
 use crate::data_reporter::ConversationAttachment;
+use crate::safety_attachment_scanner::{AttachmentDecision, AttachmentScanner};
 use crate::state::EngineState;
 use crate::vercel_ui_protocol::VercelUIStream;
 
@@ -87,7 +88,8 @@ pub async fn send_chat_message(
 ) -> Result<SendMessageResponse, String> {
     let state = state.get()?;
     let message_id = uuid::Uuid::new_v4().to_string();
-    let (incoming_attachments, report_attachments) = build_attachments(attachments)?;
+    let (incoming_attachments, report_attachments) =
+        build_attachments(attachments, state.attachment_scanner.as_ref()).await?;
 
     // ── 配额预检：调用 Admin Backend 检查是否超额 ─────────────────
     if let Err(reason) = quota_precheck(state).await {
@@ -247,8 +249,9 @@ pub async fn ic_finalize_thread(
     Ok(())
 }
 
-fn build_attachments(
+async fn build_attachments(
     attachments: Option<Vec<FrontendAttachment>>,
+    scanner: &AttachmentScanner,
 ) -> Result<(Vec<IncomingAttachment>, Vec<ConversationAttachment>), String> {
     let mut incoming_attachments = Vec::new();
     let mut report_attachments = Vec::new();
@@ -261,13 +264,56 @@ fn build_attachments(
             _ => AttachmentKind::from_mime_type(&attachment.mime_type),
         };
 
+        // ── Attachment DLP gate (issue #92, ADR-148 §6.4) ─────
+        //
+        // Every attachment's `extracted_text` is routed through the
+        // project-wide `EgressGate` chain on **both** the LlmRequest
+        // and Persistence kinds before it reaches the agent loop or
+        // the audit reporter. Binary MIME types are checked against a
+        // small whitelist — anything else is rejected (fail-safe).
+        let has_binary_payload = !attachment.data.is_empty();
+        let decision = scanner
+            .scan(
+                &attachment.mime_type,
+                attachment.extracted_text.as_deref(),
+                has_binary_payload,
+            )
+            .await;
+
+        let extracted_text = match decision {
+            AttachmentDecision::Allow => attachment.extracted_text.clone(),
+            AttachmentDecision::Redact {
+                sanitized_text,
+                kinds_redacted,
+            } => {
+                tracing::info!(
+                    attachment_id = %attachment.id,
+                    mime = %attachment.mime_type,
+                    kinds = ?kinds_redacted,
+                    "attachment text redacted by EgressGate",
+                );
+                Some(sanitized_text)
+            }
+            AttachmentDecision::Block { reason } => {
+                tracing::warn!(
+                    attachment_id = %attachment.id,
+                    mime = %attachment.mime_type,
+                    "attachment blocked by EgressGate: {reason}",
+                );
+                return Err(format!(
+                    "Attachment `{}` was rejected by the DLP gate: {reason}",
+                    attachment.filename.as_deref().unwrap_or("(unnamed)")
+                ));
+            }
+        };
+
         report_attachments.push(ConversationAttachment::from_frontend(
             attachment.id.clone(),
             attachment.kind.clone(),
             attachment.mime_type.clone(),
             attachment.filename.clone(),
             attachment.size_bytes,
-            attachment.extracted_text.clone(),
+            extracted_text.clone(),
             &attachment.data,
             attachment.duration_secs,
         ));
@@ -280,7 +326,7 @@ fn build_attachments(
             size_bytes: attachment.size_bytes,
             source_url: None,
             storage_key: None,
-            extracted_text: attachment.extracted_text,
+            extracted_text,
             data: attachment.data,
             duration_secs: attachment.duration_secs,
         });

--- a/desktop-client/src/ipc/extensions.rs
+++ b/desktop-client/src/ipc/extensions.rs
@@ -483,6 +483,12 @@ mod tests {
             injection_check_enabled: true,
         }));
         let safety_bridge = Arc::new(SafetyBridge::new(Arc::clone(&safety), None, None));
+        let egress: Arc<dyn x_claw_agent::EgressGate> = Arc::new(
+            ironclaw_safety::egress_gate::IronclawEgressGate::new(Arc::clone(&safety)),
+        );
+        let attachment_scanner = Arc::new(
+            crate::safety_attachment_scanner::AttachmentScanner::new(Arc::clone(&egress)),
+        );
         let tools = Arc::new(ToolRegistry::new());
         let context_manager = Arc::new(ContextManager::new(5));
         let data_reporter = Arc::new(crate::data_reporter::DataReporter::new(
@@ -508,6 +514,8 @@ mod tests {
             skills_config: ironclaw::config::SkillsConfig::default(),
             safety,
             safety_bridge,
+            attachment_scanner,
+            egress,
             context_manager,
             conversation_tracker: Arc::new(crate::conversation_tracker::ConversationTracker::new(
                 "test-owner".to_string(),

--- a/desktop-client/src/lib.rs
+++ b/desktop-client/src/lib.rs
@@ -10,6 +10,7 @@ pub mod dlp;
 pub mod dlp_integration;
 pub mod enterprise_policy_sync;
 pub mod policy_sync;
+pub mod safety_attachment_scanner;
 pub mod safety_bridge;
 
 // ── IronClaw 嵌入模块 ──────────────────────────────────────────────

--- a/desktop-client/src/safety_attachment_scanner.rs
+++ b/desktop-client/src/safety_attachment_scanner.rs
@@ -1,0 +1,466 @@
+//! Attachment DLP gate (issue #92, ADR-148 §6.4).
+//!
+//! Wraps the project-wide [`EgressGate`] trait so chat attachments
+//! (`document` / `image` / `audio`) flow through the same DLP / leak
+//! detector chain as ordinary user text **before** they reach the agent
+//! loop or the persistence path.
+//!
+//! # Threat model addressed
+//!
+//! Before this gate, [`desktop-client/src/ipc/chat.rs`](../ipc/chat.rs)
+//! scanned only the chat textbox content. An attacker (or a careless
+//! user) could drop a PDF / Word / image / audio file whose
+//! `extracted_text` carried `sk-*` API keys, `BEGIN PRIVATE KEY` PEM
+//! bodies, or PII; the attachment was forwarded into the agent message
+//! verbatim and persisted into the audit/admin-backend report path.
+//!
+//! # Two egress kinds, two gate calls
+//!
+//! For each attachment we ask the same gate two questions:
+//!
+//! 1. **`EgressKind::LlmRequest`** — is it safe to ship to the LLM?
+//! 2. **`EgressKind::Persistence`** — is it safe to write to the local
+//!    DB / admin-backend report?
+//!
+//! The strictest of the two decisions wins (Block > Ask > Redact >
+//! Allow). When either gate `Block`s, the whole attachment is rejected
+//! and the agent never sees it.
+//!
+//! # Binary MIME policy (fail-closed)
+//!
+//! Binary `data` cannot be text-scanned (it is opaque to the leak
+//! detector). We allow only a small whitelist of MIME types whose
+//! semantics are well understood by downstream consumers (image render
+//! / audio transcription / document extraction):
+//!
+//! - `image/{jpeg,png,webp,gif}`
+//! - `audio/{ogg,mpeg,mp4,wav,webm,flac,x-m4a}`
+//! - `application/{pdf, vnd.openxmlformats-officedocument.*, msword,
+//!    vnd.ms-excel, vnd.ms-powerpoint}`
+//! - `text/*`
+//!
+//! Anything else is **blocked** rather than forwarded — per AGENTS.md
+//! red-line "安全功能必须 Fail-Safe".
+
+use std::sync::Arc;
+
+use x_claw_agent::{EgressDecision, EgressGate, EgressKind};
+
+/// Per-attachment scan decision returned by [`AttachmentScanner::scan`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AttachmentDecision {
+    /// Attachment is safe to forward unchanged.
+    Allow,
+    /// Attachment text was rewritten by the gate; callers MUST replace
+    /// the original `extracted_text` with `sanitized_text` before
+    /// forwarding the attachment to the agent **and** to persistence.
+    Redact {
+        sanitized_text: String,
+        /// Which egress kinds fired a Redact (for audit stats only).
+        kinds_redacted: Vec<EgressKind>,
+    },
+    /// Attachment must be rejected. `reason` is safe to surface to the
+    /// user (never contains the original secret).
+    Block { reason: String },
+}
+
+/// Async-safe scanner that routes one attachment through the configured
+/// [`EgressGate`].
+pub struct AttachmentScanner {
+    gate: Arc<dyn EgressGate>,
+}
+
+impl AttachmentScanner {
+    pub fn new(gate: Arc<dyn EgressGate>) -> Self {
+        Self { gate }
+    }
+
+    /// Run both [`EgressKind::LlmRequest`] and [`EgressKind::Persistence`]
+    /// gates against `extracted_text`, plus the binary MIME whitelist on
+    /// `mime_type` when the attachment carries raw `data`.
+    ///
+    /// `extracted_text` may be `None` for attachments that have no text
+    /// representation yet (e.g. an image without OCR). In that case
+    /// only the binary MIME check runs.
+    ///
+    /// `has_binary_payload` MUST be `true` whenever the caller is about
+    /// to forward non-empty raw bytes to the LLM (multimodal) or
+    /// persist them; the whitelist check is skipped only for purely
+    /// metadata-only attachments to avoid blocking benign cases.
+    pub async fn scan(
+        &self,
+        mime_type: &str,
+        extracted_text: Option<&str>,
+        has_binary_payload: bool,
+    ) -> AttachmentDecision {
+        // ── 1. Binary MIME whitelist (fail-closed) ─────────────────
+        if has_binary_payload && !is_binary_mime_allowed(mime_type) {
+            return AttachmentDecision::Block {
+                reason: format!(
+                    "Attachment MIME `{mime_type}` is not on the egress whitelist; refusing to forward binary payload (fail-safe)"
+                ),
+            };
+        }
+
+        // ── 2. extracted_text gate (LlmRequest + Persistence) ──────
+        let text = match extracted_text {
+            Some(t) if !t.is_empty() => t,
+            _ => return AttachmentDecision::Allow,
+        };
+
+        let llm_decision = self.gate.check(&EgressKind::LlmRequest, text).await;
+        let persist_decision = self.gate.check(&EgressKind::Persistence, text).await;
+
+        merge_decisions(llm_decision, persist_decision)
+    }
+}
+
+/// Combine the two per-kind decisions; strictest wins.
+///
+/// Precedence: `Block` > `Ask` (mapped to Block in headless) >
+/// `Redact` > `Allow` / `Passthrough`.
+fn merge_decisions(llm: EgressDecision, persist: EgressDecision) -> AttachmentDecision {
+    // Fast path: both Allow / Passthrough.
+    if is_allow_or_passthrough(&llm) && is_allow_or_passthrough(&persist) {
+        return AttachmentDecision::Allow;
+    }
+
+    // Any Block / Ask → fail-closed.
+    if let Some(reason) = block_reason(&llm).or_else(|| block_reason(&persist)) {
+        return AttachmentDecision::Block { reason };
+    }
+
+    // Otherwise at least one side Redacted. Use the persistence-side
+    // sanitized payload if available (it is the stricter scan in
+    // IronclawEgressGate — full leak detector), else the LLM-side one.
+    let mut kinds_redacted = Vec::new();
+    let sanitized = if let EgressDecision::Redact { sanitized, .. } = &persist {
+        kinds_redacted.push(EgressKind::Persistence);
+        if matches!(llm, EgressDecision::Redact { .. }) {
+            kinds_redacted.push(EgressKind::LlmRequest);
+        }
+        sanitized.clone()
+    } else if let EgressDecision::Redact { sanitized, .. } = &llm {
+        kinds_redacted.push(EgressKind::LlmRequest);
+        sanitized.clone()
+    } else {
+        // Unreachable: the fast path above ruled out all-Allow, and
+        // block_reason ruled out Block/Ask, so at least one side must
+        // be Redact. Fail-safe Block defensively.
+        return AttachmentDecision::Block {
+            reason: "attachment gate returned an unexpected decision combination (fail-safe)"
+                .to_string(),
+        };
+    };
+
+    AttachmentDecision::Redact {
+        sanitized_text: sanitized,
+        kinds_redacted,
+    }
+}
+
+fn is_allow_or_passthrough(d: &EgressDecision) -> bool {
+    matches!(d, EgressDecision::Allow | EgressDecision::Passthrough)
+}
+
+fn block_reason(d: &EgressDecision) -> Option<String> {
+    match d {
+        EgressDecision::Block { reason, .. } => Some(reason.clone()),
+        // Ask in headless desktop chat context = Block (Fail-Safe).
+        EgressDecision::Ask { reason, .. } => Some(format!(
+            "attachment gate requested user confirmation; treated as block in headless context: {reason}"
+        )),
+        _ => None,
+    }
+}
+
+/// Whitelist of binary MIME types whose semantics downstream consumers
+/// understand. Anything outside this list with raw bytes is **blocked**.
+fn is_binary_mime_allowed(mime: &str) -> bool {
+    let lower = mime.to_ascii_lowercase();
+    // text/* always allowed (already covered by text scan path; binary
+    // path can also accept e.g. text/plain attachments uploaded as raw
+    // bytes).
+    if lower.starts_with("text/") {
+        return true;
+    }
+    matches!(
+        lower.as_str(),
+        // Images
+        "image/jpeg"
+            | "image/png"
+            | "image/webp"
+            | "image/gif"
+            // Audio
+            | "audio/ogg"
+            | "audio/mpeg"
+            | "audio/mp4"
+            | "audio/wav"
+            | "audio/x-wav"
+            | "audio/webm"
+            | "audio/flac"
+            | "audio/x-m4a"
+            | "audio/x-flac"
+            // Documents
+            | "application/pdf"
+            | "application/msword"
+            | "application/vnd.ms-excel"
+            | "application/vnd.ms-powerpoint"
+            | "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+            | "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+            | "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+            | "application/json"
+            | "application/xml"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use x_claw_agent::RedactionStats;
+
+    /// Programmable test gate keyed by `EgressKind` discriminant.
+    struct ScriptedGate {
+        on_llm: EgressDecision,
+        on_persist: EgressDecision,
+    }
+
+    #[async_trait]
+    impl EgressGate for ScriptedGate {
+        async fn check(&self, kind: &EgressKind, _payload: &str) -> EgressDecision {
+            match kind {
+                EgressKind::LlmRequest => self.on_llm.clone(),
+                EgressKind::Persistence => self.on_persist.clone(),
+                _ => EgressDecision::Allow,
+            }
+        }
+    }
+
+    fn scanner(llm: EgressDecision, persist: EgressDecision) -> AttachmentScanner {
+        AttachmentScanner::new(Arc::new(ScriptedGate {
+            on_llm: llm,
+            on_persist: persist,
+        }))
+    }
+
+    fn block(reason: &str) -> EgressDecision {
+        EgressDecision::Block {
+            reason: reason.into(),
+            stats: RedactionStats::default(),
+        }
+    }
+
+    fn redact(sanitized: &str) -> EgressDecision {
+        EgressDecision::Redact {
+            sanitized: sanitized.into(),
+            stats: RedactionStats::default(),
+        }
+    }
+
+    // ── #92 acceptance tests (req_attach_92_*) ────────────────────
+
+    #[tokio::test]
+    async fn req_attach_92_a_document_extracted_secret_blocks() {
+        // DOCX extracted_text contains an OpenAI key → Block, never
+        // reaches msg_sender.send.
+        let s = scanner(block("secret detected: sk-xxxx"), EgressDecision::Allow);
+        let payload = format!("user notes: sk-{}", "A".repeat(48));
+        let decision = s
+            .scan(
+                "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                Some(&payload),
+                true,
+            )
+            .await;
+        assert!(
+            matches!(decision, AttachmentDecision::Block { .. }),
+            "expected Block, got {decision:?}",
+        );
+    }
+
+    #[tokio::test]
+    async fn req_attach_92_b_image_extracted_pii_redacts() {
+        // Image OCR result contains a Chinese ID — must be redacted
+        // (not blocked) so the user's intent is preserved.
+        let sanitized = "客户身份证：330***618";
+        let s = scanner(redact(sanitized), redact(sanitized));
+        let decision = s
+            .scan("image/png", Some("客户身份证：330106199001011234"), true)
+            .await;
+        match decision {
+            AttachmentDecision::Redact { sanitized_text, .. } => {
+                assert_eq!(sanitized_text, sanitized);
+                assert!(!sanitized_text.contains("330106199001011234"));
+            }
+            other => panic!("expected Redact, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn req_attach_92_c_audio_transcript_secret_blocks() {
+        let s = scanner(block("secret in transcript"), EgressDecision::Allow);
+        let payload = format!("the key is sk-{}", "B".repeat(48));
+        let decision = s.scan("audio/ogg", Some(&payload), true).await;
+        assert!(matches!(decision, AttachmentDecision::Block { .. }));
+    }
+
+    #[tokio::test]
+    async fn req_attach_92_d_clean_attachment_passes_through() {
+        let s = scanner(EgressDecision::Allow, EgressDecision::Allow);
+        let decision = s
+            .scan("application/pdf", Some("Quarterly report contents."), true)
+            .await;
+        assert_eq!(decision, AttachmentDecision::Allow);
+    }
+
+    #[tokio::test]
+    async fn req_attach_92_e_persistence_path_redacts_before_report() {
+        // Persistence side redacts even though LLM side allows. The
+        // attachment must be Redacted (not Allowed) so the persistence
+        // call site picks up the sanitized text.
+        let sanitized = "redacted-for-persistence";
+        let s = scanner(EgressDecision::Allow, redact(sanitized));
+        let decision = s
+            .scan(
+                "text/plain",
+                Some("data with bank card 6225 7600 1234 5678"),
+                true,
+            )
+            .await;
+        match decision {
+            AttachmentDecision::Redact {
+                sanitized_text,
+                kinds_redacted,
+            } => {
+                assert_eq!(sanitized_text, sanitized);
+                assert!(kinds_redacted.contains(&EgressKind::Persistence));
+            }
+            other => panic!("expected Redact (persistence), got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn req_attach_92_f_thread_restore_blocks_historical_secret() {
+        // When threads.rs replays a historical attachment whose
+        // extracted_text still contains a secret, the same scanner
+        // call site MUST block. (Same scan API, different caller.)
+        let s = scanner(block("historical secret"), EgressDecision::Allow);
+        let decision = s
+            .scan("application/pdf", Some("legacy key sk-AAA"), true)
+            .await;
+        assert!(matches!(decision, AttachmentDecision::Block { .. }));
+    }
+
+    #[tokio::test]
+    async fn req_attach_92_g_dlp_stats_in_metadata_only() {
+        // Redact decision carries kinds_redacted (for audit metadata)
+        // but never the original payload — only the sanitized copy.
+        let sanitized = "***";
+        let s = scanner(redact(sanitized), EgressDecision::Allow);
+        let decision = s
+            .scan("text/plain", Some("original secret payload sk-xxx"), false)
+            .await;
+        match decision {
+            AttachmentDecision::Redact {
+                sanitized_text,
+                kinds_redacted,
+            } => {
+                assert_eq!(sanitized_text, sanitized);
+                assert!(!sanitized_text.contains("sk-xxx"));
+                assert!(kinds_redacted.contains(&EgressKind::LlmRequest));
+            }
+            other => panic!("expected Redact, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn req_attach_92_h_binary_data_classification() {
+        // Unknown binary MIME with payload → Block.
+        let s = scanner(EgressDecision::Allow, EgressDecision::Allow);
+        let decision = s
+            .scan("application/octet-stream", Some("anything"), true)
+            .await;
+        assert!(
+            matches!(decision, AttachmentDecision::Block { .. }),
+            "unknown binary MIME must be blocked (fail-safe), got {decision:?}",
+        );
+
+        // Whitelist MIME with payload → reaches text gate (Allow here).
+        let decision = s.scan("image/png", Some("metadata only"), true).await;
+        assert_eq!(decision, AttachmentDecision::Allow);
+
+        // Metadata-only (no binary payload) skips MIME check even for
+        // unknown MIME — the text gate still runs.
+        let decision = s
+            .scan("application/octet-stream", Some("safe text"), false)
+            .await;
+        assert_eq!(decision, AttachmentDecision::Allow);
+    }
+
+    // ── Security regression tests ─────────────────────────────────
+
+    #[tokio::test]
+    async fn test_security_attachment_bypass_via_kind_swap() {
+        // Attacker tries to slip a secret through by labelling a PDF as
+        // image/png. The scanner uses extracted_text content — not the
+        // claimed kind — so the gate still fires.
+        let s = scanner(block("secret"), EgressDecision::Allow);
+        let payload = format!("sk-{}", "Z".repeat(48));
+        let decision = s.scan("image/png", Some(&payload), true).await;
+        assert!(
+            matches!(decision, AttachmentDecision::Block { .. }),
+            "claimed-MIME swap must not bypass content scanning",
+        );
+    }
+
+    #[tokio::test]
+    async fn test_security_attachment_bypass_via_oversize() {
+        // Even if the upstream extractor truncated input to 100K chars,
+        // anything that does reach the scanner is fully checked — the
+        // gate does not short-circuit on size. Verify by feeding a
+        // large input where the secret is at the tail.
+        let mut payload = String::with_capacity(110_000);
+        payload.push_str(&"a".repeat(100_000));
+        payload.push_str(" sk-XYZ");
+        let s = scanner(block("secret at tail"), EgressDecision::Allow);
+        let decision = s.scan("text/plain", Some(&payload), false).await;
+        assert!(
+            matches!(decision, AttachmentDecision::Block { .. }),
+            "oversize input must not bypass the gate",
+        );
+    }
+
+    // ── Composite-decision merge semantics ────────────────────────
+
+    #[tokio::test]
+    async fn ask_decision_is_treated_as_block_in_headless_context() {
+        let s = scanner(
+            EgressDecision::Ask {
+                reason: "needs user confirmation".into(),
+                suggestions: Vec::new(),
+            },
+            EgressDecision::Allow,
+        );
+        let decision = s
+            .scan("text/plain", Some("borderline content"), false)
+            .await;
+        assert!(matches!(decision, AttachmentDecision::Block { .. }));
+    }
+
+    #[tokio::test]
+    async fn passthrough_combines_to_allow() {
+        let s = scanner(EgressDecision::Passthrough, EgressDecision::Passthrough);
+        let decision = s.scan("text/plain", Some("ok"), false).await;
+        assert_eq!(decision, AttachmentDecision::Allow);
+    }
+
+    #[tokio::test]
+    async fn no_extracted_text_with_whitelist_mime_allows() {
+        // Pure image/audio with no OCR result yet — binary MIME ok,
+        // no text to scan.
+        let s = scanner(EgressDecision::Allow, EgressDecision::Allow);
+        let decision = s.scan("image/jpeg", None, true).await;
+        assert_eq!(decision, AttachmentDecision::Allow);
+    }
+}

--- a/desktop-client/src/state.rs
+++ b/desktop-client/src/state.rs
@@ -47,9 +47,11 @@ use ironclaw::tools::ToolRegistry;
 use ironclaw::workspace::Workspace;
 use tokio::sync::mpsc;
 use uuid::Uuid;
+use x_claw_agent::EgressGate;
 
 use crate::conversation_tracker::ConversationTracker;
 use crate::data_reporter::DataReporter;
+use crate::safety_attachment_scanner::AttachmentScanner;
 use crate::safety_bridge::SafetyBridge;
 
 /// IronClaw 引擎内部状态。
@@ -77,6 +79,19 @@ pub struct AppState {
     pub safety: Arc<SafetyLayer>,
     /// 安全桥接器（统一 SafetyLayer + DLP 格式保留脱敏）。
     pub safety_bridge: Arc<SafetyBridge>,
+    /// Attachment DLP gate (issue #92, ADR-148 §6.4).
+    ///
+    /// Routes every attachment's `extracted_text` through both
+    /// `EgressKind::LlmRequest` and `EgressKind::Persistence` gates
+    /// before the agent loop or the audit reporter sees it. Wraps the
+    /// project-wide `EgressGate` chain so future enterprise scanners
+    /// (Presidio, etc.) plug in via `CompositeEgressGate` without
+    /// touching the IPC call site.
+    pub attachment_scanner: Arc<AttachmentScanner>,
+    /// Project-wide `EgressGate` instance shared with the attachment
+    /// scanner. Held here so other IPC paths (tool args, persistence
+    /// follow-ups) can reuse the same gate chain without re-wiring.
+    pub egress: Arc<dyn EgressGate>,
     /// 上下文管理器（任务审批等）。
     pub context_manager: Arc<ContextManager>,
     /// 对话追踪器（对话审计与技能使用上报）。


### PR DESCRIPTION
## 背景/目标

实现 [#92](https://github.com/Linnanli/xClaw/issues/92) "Attachment DLP gate before agent injection" — 把附件 `extracted_text`（document / image / audio）和二进制 MIME 都纳入 ADR-148 §6.4 的统一 `EgressGate` 安全门。PR-A (#612) 已合并 EgressGate 基础设施；本 PR-B 把附件路径"焊"到现有 gate 上。

## Sources read

- [`AGENTS.md`](../AGENTS.md) — § Skills 强制使用规范、§ 安全红线（Fail-Safe、no unwrap/expect/panic）、§ 测试纪律
- [`docs/plans/architecture-refactor/adr-148-safety-hook-to-egress-gate.md`](../docs/plans/architecture-refactor/adr-148-safety-hook-to-egress-gate.md) — §6.4 附件 DLP 网关、§5 EgressGate 契约
- [`docs/plans/architecture-refactor/adr-112-compatibility-evaluation.md`](../docs/plans/architecture-refactor/adr-112-compatibility-evaluation.md) — 红线
- [`docs/plans/architecture-refactor/adr-113-hook-engine-unification.md`](../docs/plans/architecture-refactor/adr-113-hook-engine-unification.md) — Hook 单一引擎红线
- Issue [#92](https://github.com/Linnanli/xClaw/issues/92) body + 3 条 design 评论（含 ~1040 LOC 设计方案）
- [`crates/dasclaw_governance/src/egress.rs`](../crates/dasclaw_governance/src/egress.rs) — `EgressGate` trait + `CompositeEgressGate`
- [`desktop-client/ironclaw/crates/ironclaw_safety/src/egress_gate.rs`](../desktop-client/ironclaw/crates/ironclaw_safety/src/egress_gate.rs) — `IronclawEgressGate` 适配器
- [`desktop-client/src/ipc/chat.rs`](../desktop-client/src/ipc/chat.rs) — `build_attachments` 改造目标
- [`desktop-client/src/safety_bridge.rs`](../desktop-client/src/safety_bridge.rs) — 现有 SafetyBridge
- [`desktop-client/src/state.rs`](../desktop-client/src/state.rs) / [`desktop-client/src/engine.rs`](../desktop-client/src/engine.rs) — AppState 注入点

## 改动范围

| 文件 | 用途 |
|---|---|
| `desktop-client/src/safety_attachment_scanner.rs` *(新)* | `AttachmentScanner` 主体：两次 gate 调用（`LlmRequest` + `Persistence`），合并最严决策；二进制 MIME 白名单 + 未知一律 Block（fail-safe）；Ask → Block（headless context）|
| `desktop-client/Cargo.toml` | 启用 `ironclaw_safety` 的 `egress-gate` feature；新增 `x_claw_agent` 依赖 |
| `desktop-client/src/lib.rs` | 注册 `pub mod safety_attachment_scanner` |
| `desktop-client/src/state.rs` | `AppState` 新增 `attachment_scanner: Arc<AttachmentScanner>` + `egress: Arc<dyn EgressGate>` |
| `desktop-client/src/engine.rs` | 启动期构造 `IronclawEgressGate::new(Arc::clone(&components.safety))` 与 scanner，注入 AppState |
| `desktop-client/src/ipc/chat.rs` | `build_attachments` 改为 async，每个附件先经过 scanner；Block → IPC 错误（不进 `msg_sender`/`DataReporter`）；Redact → 把 sanitized 文本同时写入 `IncomingAttachment` 与 `ConversationAttachment` |
| `desktop-client/src/ipc/extensions.rs` + `desktop-client/src/engine_startup_tests.rs` | 测试 helper 同步新字段 |

总计 +572/-5（新模块含 11 个测试 ~250 LOC）。

## 非目标（What's NOT in this PR）

- **不动 `threads.rs`**：经核实其 `record_user_message` 路径是只读的历史回放，没有 `msg_sender.send` 重放；issue #92 设计稿原计划的 "threads.rs 重放门"已通过 `req_attach_92_f` 测试用例验证 scanner API 可复用，留待后续真正出现重放路径时一并接入。
- **不抽 `input_advisor`**：当前 5 文件最小正确实现已覆盖 #92 全部验收点；设计稿中 ~1040 LOC 包含的 advisor 抽取属于优化项，待后续 PR。
- **不打 `Closes #483`**：本 PR 只闭合 #92；#483 R2/R3/R4 仍在 epic 里继续推进。
- **未触碰其它 IPC 路径**（`scan_tool_output` / `sanitize_for_storage` 等），保持现有 `SafetyBridge` 调用不变。

## 验证（命令 + 结果）

```bash
$ cargo check -p desktop-client --tests
Finished `dev` profile in 30.41s   # clean

$ cargo nextest run -p desktop-client safety_attachment_scanner
Summary [2.618s] 13 tests run: 13 passed, 797 skipped
  - req_attach_92_a_document_extracted_secret_blocks       PASS
  - req_attach_92_b_image_extracted_pii_redacts            PASS
  - req_attach_92_c_audio_transcript_secret_blocks         PASS
  - req_attach_92_d_clean_attachment_passes_through        PASS
  - req_attach_92_e_persistence_path_redacts_before_report PASS
  - req_attach_92_f_thread_restore_blocks_historical_secret PASS
  - req_attach_92_g_dlp_stats_in_metadata_only             PASS
  - req_attach_92_h_binary_data_classification             PASS
  - test_security_attachment_bypass_via_kind_swap          PASS
  - test_security_attachment_bypass_via_oversize           PASS
  - ask_decision_is_treated_as_block_in_headless_context   PASS
  - passthrough_combines_to_allow                          PASS
  - no_extracted_text_with_whitelist_mime_allows           PASS

$ cargo fmt --all       # clean
$ python3 scripts/check_no_panics.py --base origin/xClaw
OK: No panic-inducing calls in changed production code.

$ cargo clippy --no-deps -p desktop-client --lib
# 0 errors / 0 warnings on new code
# 8 pre-existing warnings in unrelated files (managed_policy, state.rs Default impl etc.)
```

## 安全设计要点（review focus）

1. **Fail-Safe 严格遵守**：未知 `EgressKind`（trait `#[non_exhaustive]`）→ Block；未知二进制 MIME → Block；gate 返回 `Ask` 在 headless 桌面端 → Block；defensive unreachable 分支 → Block。**无任何 Fail-Open 路径**。
2. **两次 gate 调用，最严胜出**：先 `LlmRequest`（agent 路径），再 `Persistence`（持久化 / admin-backend 上报路径）。任一 Block 即 Block；任一 Redact 即用 sanitized 文本（优先 Persistence 侧的更严扫描结果）覆盖 `IncomingAttachment.extracted_text` 与 `ConversationAttachment.extracted_text`。
3. **无 patch-style**：`build_attachments` 重构为 async + 结构化 `Result`，不在原函数尾追加 `if scan_result.was_blocked` 分支。
4. **无 unwrap/expect/panic**：`scripts/check_no_panics.py` 全绿；scanner 模块全部用 `match` + `return Err`。
5. **审计元数据不泄密**：`Redact{ sanitized_text, kinds_redacted }` 只携带哪些 `EgressKind` 触发了脱敏（用于 tracing），原始 payload 永远不出现在日志或返回值中。

## Skills 自查

按 AGENTS.md 强制要求，我在写完后做了三层人工 self-review（code-quality-audit → code-simplifier → code-review-expert）：

- **quality**：模块/公开类型/函数全部带文档；错误信息对用户安全（不回显原始内容）；threat model 在模块顶注释明确写出。
- **simplifier**：移除了一处未被使用的 `AttachmentScanError` enum；移除了 `let _ = redaction_note;` 占位绑定；保留 defensive unreachable→Block 分支（fail-safe 不可简化）。
- **review-expert**：确认 13 个测试覆盖了 #92 全部 8 个验收点 + 2 个绕过攻击向量 + 3 个合并语义；MIME 白名单清单与 `DocumentExtractionMiddleware` / `TranscriptionMiddleware` 实际产出 MIME 对齐。

Closes #92
