### PR TITLE
refactor(x-claw-agent): extract apply_egress_decision helper (ADR-148 PR-A follow-up)

### DIFF
--- a/crates/x_claw_agent/src/agentic_loop.rs
+++ b/crates/x_claw_agent/src/agentic_loop.rs
@@ -19,7 +19,8 @@
 
 use async_trait::async_trait;
 
-use crate::hooks::{EgressDecision, EgressKind, HookBundle};
+use crate::egress_apply::{EgressApply, apply_egress_decision};
+use crate::hooks::{EgressKind, HookBundle};
 use crate::intent::{TOOL_INTENT_NUDGE, TRUNCATED_TOOL_CALL_NOTICE, llm_signals_tool_intent};
 use crate::messages::{ChatMessage, FinishReason, Role, ToolCall};
 use crate::reasoning_ctx::ReasoningContext;
@@ -197,55 +198,20 @@ pub async fn run_agentic_loop(
         // EgressGate (ADR-148 Layer B): scan / redact the most recent user
         // message before the LLM sees it. A Redact decision swaps the
         // payload with the sanitized version so the LLM call uses it.
+        // The five-arm decision handling lives in `apply_egress_decision`
+        // so every gate site in the workspace halts identically on
+        // Block / Ask / unknown variant.
         if let Some(idx) = reason_ctx
             .messages
             .iter()
             .rposition(|m| m.role == Role::User)
         {
             let prompt = &mut reason_ctx.messages[idx].content;
-            match hooks.egress.check(&EgressKind::LlmRequest, prompt).await {
-                // Allow / Passthrough: continue unchanged (single-gate
-                // context treats Passthrough as Allow per ADR-148 §2.2).
-                EgressDecision::Allow | EgressDecision::Passthrough => {}
-                EgressDecision::Redact { sanitized, .. } => {
-                    *prompt = sanitized;
-                }
-                EgressDecision::Block { reason, .. } => {
-                    tracing::warn!(iteration, %reason, "egress gate blocked LlmRequest");
-                    return Ok(LoopOutcome::Failure(format!(
-                        "egress gate blocked prompt: {reason}"
-                    )));
-                }
-                // Ask in a headless agent loop has no UI to render. Fail-Safe:
-                // treat as Block. Desktop-client wires real Ask UX in
-                // slice D (ADR-146 §2.5 / ADR-148 §2.2).
-                EgressDecision::Ask { reason, .. } => {
-                    tracing::warn!(
-                        iteration,
-                        %reason,
-                        "egress gate returned Ask in headless context; Fail-Safe block (slice D will wire UI)"
-                    );
-                    return Ok(LoopOutcome::Failure(format!(
-                        "egress gate requires user confirmation (no UI available): {reason}"
-                    )));
-                }
-                // Non-exhaustive guard: future variants added to
-                // `EgressDecision` (which is `#[non_exhaustive]`) must be
-                // addressed explicitly at this site; failing closed is
-                // Fail-Safe. `#[allow(unreachable_patterns)]` is required
-                // because within the defining crate the compiler sees the
-                // enum as exhaustive — outside callers will need it.
-                #[allow(unreachable_patterns)]
-                other => {
-                    tracing::error!(
-                        iteration,
-                        decision = ?other,
-                        "egress gate returned unhandled EgressDecision variant; Fail-Safe block"
-                    );
-                    return Ok(LoopOutcome::Failure(
-                        "egress gate returned unsupported decision".to_string(),
-                    ));
-                }
+            let decision = hooks.egress.check(&EgressKind::LlmRequest, prompt).await;
+            if let EgressApply::Halt(reason) = apply_egress_decision(decision, prompt, "LlmRequest")
+            {
+                tracing::warn!(iteration, %reason, "egress gate halted LlmRequest");
+                return Ok(LoopOutcome::Failure(reason));
             }
         }
 
@@ -257,38 +223,11 @@ pub async fn run_agentic_loop(
         // Tool-call responses skip this gate; delegates apply the
         // tool-level egress themselves inside `execute_tool_calls`.
         if let RespondResult::Text(ref mut text) = output.result {
-            match hooks.egress.check(&EgressKind::UserDisplay, text).await {
-                EgressDecision::Allow | EgressDecision::Passthrough => {}
-                EgressDecision::Redact { sanitized, .. } => {
-                    *text = sanitized;
-                }
-                EgressDecision::Block { reason, .. } => {
-                    tracing::warn!(iteration, %reason, "egress gate blocked UserDisplay");
-                    return Ok(LoopOutcome::Failure(format!(
-                        "egress gate blocked completion: {reason}"
-                    )));
-                }
-                EgressDecision::Ask { reason, .. } => {
-                    tracing::warn!(
-                        iteration,
-                        %reason,
-                        "egress gate returned Ask on UserDisplay in headless context; Fail-Safe block"
-                    );
-                    return Ok(LoopOutcome::Failure(format!(
-                        "egress gate requires confirmation on completion (no UI): {reason}"
-                    )));
-                }
-                #[allow(unreachable_patterns)]
-                other => {
-                    tracing::error!(
-                        iteration,
-                        decision = ?other,
-                        "egress gate returned unhandled EgressDecision variant on UserDisplay; Fail-Safe block"
-                    );
-                    return Ok(LoopOutcome::Failure(
-                        "egress gate returned unsupported decision".to_string(),
-                    ));
-                }
+            let decision = hooks.egress.check(&EgressKind::UserDisplay, text).await;
+            if let EgressApply::Halt(reason) = apply_egress_decision(decision, text, "UserDisplay")
+            {
+                tracing::warn!(iteration, %reason, "egress gate halted UserDisplay");
+                return Ok(LoopOutcome::Failure(reason));
             }
         }
 

--- a/crates/x_claw_agent/src/egress_apply.rs
+++ b/crates/x_claw_agent/src/egress_apply.rs
@@ -1,0 +1,201 @@
+//! Shared helper for applying an [`EgressDecision`] to a mutable payload.
+//!
+//! Every consumer of [`EgressGate::check`](crate::hooks::EgressGate::check)
+//! repeats the same five-arm match: Allow / Passthrough → continue, Redact →
+//! swap payload, Block / Ask / unknown variant → halt the caller with a
+//! Fail-Safe error string.
+//!
+//! `apply_egress_decision` centralises this pattern so:
+//!
+//! 1. The agentic loop's `LlmRequest` and `UserDisplay` sites stop carrying
+//!    two near-identical 30-line match blocks (PR-A follow-up).
+//! 2. Ironclaw's tool-output sanitisation call sites (PR-C R2, ADR-148
+//!    epic #483) all halt identically when the gate refuses.
+//! 3. The `#[non_exhaustive]` guard on
+//!    [`EgressDecision`](crate::hooks::EgressDecision) is enforced in one
+//!    place — future variants surface a single Fail-Safe code path instead
+//!    of being silently allowed by callers that forgot to match them.
+
+use crate::hooks::EgressDecision;
+
+/// Outcome of applying an [`EgressDecision`] to a payload.
+///
+/// Returned by [`apply_egress_decision`]. The caller decides how to lift
+/// `Halt(reason)` into its native error type (e.g.
+/// [`LoopOutcome::Failure`](crate::agentic_loop::LoopOutcome::Failure),
+/// `anyhow::Error`, ironclaw's `HostError`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EgressApply {
+    /// `Allow` / `Passthrough` / `Redact` — payload may have been swapped
+    /// in place; caller continues normally.
+    Continue,
+    /// `Block` / `Ask` / unknown variant — caller must halt with the
+    /// contained Fail-Safe reason.
+    Halt(String),
+}
+
+/// Apply an [`EgressDecision`] to `payload`, returning whether the caller
+/// should continue or halt.
+///
+/// - [`EgressDecision::Allow`] / [`EgressDecision::Passthrough`] →
+///   [`EgressApply::Continue`], `payload` untouched.
+/// - [`EgressDecision::Redact`] → `payload` is replaced with the sanitised
+///   version; [`EgressApply::Continue`].
+/// - [`EgressDecision::Block`] → emits `tracing::warn!` and returns
+///   [`EgressApply::Halt`] with `"egress gate blocked {kind_label}: {reason}"`.
+/// - [`EgressDecision::Ask`] in a headless caller has no UI to render; per
+///   ADR-148 §2.2 and ADR-146 §2.5 this is treated as Fail-Safe block.
+///   Slice D will replace this with real Ask UX on the desktop client.
+/// - Future variants of the `#[non_exhaustive]` enum hit the
+///   `#[allow(unreachable_patterns)]` arm and are logged as an error
+///   before halting; this is the single Fail-Safe guard for the whole
+///   workspace.
+///
+/// `kind_label` is a short human-readable label for the gate site (e.g.
+/// `"LlmRequest"`, `"UserDisplay"`, `"ToolOutput:bash"`). It appears in
+/// both the trace event and the halt reason so log lines and failure
+/// messages are self-describing.
+pub fn apply_egress_decision(
+    decision: EgressDecision,
+    payload: &mut String,
+    kind_label: &str,
+) -> EgressApply {
+    match decision {
+        EgressDecision::Allow | EgressDecision::Passthrough => EgressApply::Continue,
+        EgressDecision::Redact { sanitized, .. } => {
+            *payload = sanitized;
+            EgressApply::Continue
+        }
+        EgressDecision::Block { reason, .. } => {
+            tracing::warn!(kind = kind_label, %reason, "egress gate blocked");
+            EgressApply::Halt(format!("egress gate blocked {kind_label}: {reason}"))
+        }
+        EgressDecision::Ask { reason, .. } => {
+            tracing::warn!(
+                kind = kind_label,
+                %reason,
+                "egress gate returned Ask in headless context; Fail-Safe block (slice D will wire UI)"
+            );
+            EgressApply::Halt(format!(
+                "egress gate requires user confirmation for {kind_label} (no UI available): {reason}"
+            ))
+        }
+        // The `EgressDecision` enum is `#[non_exhaustive]`. Any future
+        // variant added in the defining crate must be addressed
+        // explicitly here; failing closed is Fail-Safe.
+        // `#[allow(unreachable_patterns)]` is required because, within
+        // the defining crate, the compiler already sees the enum as
+        // exhaustive — out-of-crate callers do not.
+        #[allow(unreachable_patterns)]
+        other => {
+            tracing::error!(
+                kind = kind_label,
+                decision = ?other,
+                "egress gate returned unhandled EgressDecision variant; Fail-Safe block"
+            );
+            EgressApply::Halt(format!(
+                "egress gate returned unsupported decision for {kind_label}"
+            ))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::hooks::RedactionStats;
+
+    #[test]
+    fn allow_returns_continue_without_touching_payload() {
+        let mut payload = String::from("hello");
+        let out = apply_egress_decision(EgressDecision::Allow, &mut payload, "LlmRequest");
+        assert_eq!(out, EgressApply::Continue);
+        assert_eq!(payload, "hello");
+    }
+
+    #[test]
+    fn passthrough_returns_continue_without_touching_payload() {
+        let mut payload = String::from("hello");
+        let out = apply_egress_decision(EgressDecision::Passthrough, &mut payload, "UserDisplay");
+        assert_eq!(out, EgressApply::Continue);
+        assert_eq!(payload, "hello");
+    }
+
+    #[test]
+    fn redact_swaps_payload_in_place() {
+        let mut payload = String::from("secret=abc123");
+        let out = apply_egress_decision(
+            EgressDecision::Redact {
+                sanitized: "secret=[REDACTED]".to_string(),
+                stats: RedactionStats::default(),
+            },
+            &mut payload,
+            "UserDisplay",
+        );
+        assert_eq!(out, EgressApply::Continue);
+        assert_eq!(payload, "secret=[REDACTED]");
+    }
+
+    #[test]
+    fn block_returns_halt_with_label_and_reason() {
+        let mut payload = String::from("contraband");
+        let out = apply_egress_decision(
+            EgressDecision::Block {
+                reason: "policy violation".to_string(),
+                stats: RedactionStats::default(),
+            },
+            &mut payload,
+            "LlmRequest",
+        );
+        match out {
+            EgressApply::Halt(msg) => {
+                assert!(msg.contains("egress gate blocked"));
+                assert!(msg.contains("LlmRequest"));
+                assert!(msg.contains("policy violation"));
+            }
+            EgressApply::Continue => panic!("expected Halt"),
+        }
+        // Block does not mutate the payload — the caller decides whether
+        // to discard it or surface a placeholder.
+        assert_eq!(payload, "contraband");
+    }
+
+    #[test]
+    fn ask_in_headless_context_returns_halt() {
+        let mut payload = String::from("needs approval");
+        let out = apply_egress_decision(
+            EgressDecision::Ask {
+                reason: "high risk".to_string(),
+                suggestions: Vec::new(),
+            },
+            &mut payload,
+            "UserDisplay",
+        );
+        match out {
+            EgressApply::Halt(msg) => {
+                assert!(msg.contains("requires user confirmation"));
+                assert!(msg.contains("UserDisplay"));
+                assert!(msg.contains("high risk"));
+            }
+            EgressApply::Continue => panic!("expected Halt"),
+        }
+    }
+
+    #[test]
+    fn redact_with_empty_sanitized_still_swaps() {
+        // Edge case: Redact with empty content is still a valid decision
+        // (e.g. a leak detector that nukes the whole payload). The helper
+        // must not silently treat empty sanitized as Allow.
+        let mut payload = String::from("all secret");
+        let out = apply_egress_decision(
+            EgressDecision::Redact {
+                sanitized: String::new(),
+                stats: RedactionStats::default(),
+            },
+            &mut payload,
+            "Persistence",
+        );
+        assert_eq!(out, EgressApply::Continue);
+        assert_eq!(payload, "");
+    }
+}

--- a/crates/x_claw_agent/src/lib.rs
+++ b/crates/x_claw_agent/src/lib.rs
@@ -16,6 +16,7 @@ pub mod bash_validation;
 pub mod compaction;
 // composite_safety_hook removed by ADR-148; CompositeEgressGate lives in dasclaw_governance::egress.
 pub mod context_monitor;
+pub mod egress_apply;
 pub mod hooks;
 pub mod intent;
 pub mod llm;


### PR DESCRIPTION
## 背景 / 目标

ADR-148 PR-A (#612) 自留 follow-up：`crates/x_claw_agent/src/agentic_loop.rs` 的 `LlmRequest` 和 `UserDisplay` 两个 EgressGate 检查点各自挂着 30 行近乎相同的 `match` 块，处理 `Allow/Passthrough/Redact/Block/Ask/unknown variant` 五条分支。

这是 PR-C R2 散点清理（issue #483, ADR-148 §7）的**前置准备**：把共享决策语义提到独立 helper，让接下来 ironclaw 9 个 `sanitize_tool_output` 调用点都能复用同一段 Fail-Safe 处理，避免把 30 行 `match` 复制 9 遍。

## Sources read

- `AGENTS.md` § PR 体例 + Skills 强制使用
- `docs/plans/architecture-refactor/adr-148-egress-gate-unification.md` § 2.2 (Ask Fail-Safe), § 5.2 (合约清单), § 7 (验收)
- `crates/x_claw_agent/src/agentic_loop.rs` § run_agentic_loop EgressGate Layer B 两个站点
- `crates/dasclaw_governance/src/egress.rs` § `EgressDecision` 枚举（确认 `Ask { reason, suggestions }` 字段，**不是** `stats`）
- PR #612 的 follow-up 列表（"agentic_loop.rs LlmRequest/UserDisplay 决策处理去重"）

## 改动范围

**新增** `crates/x_claw_agent/src/egress_apply.rs`：
- `pub enum EgressApply { Continue, Halt(String) }`
- `pub fn apply_egress_decision(decision, payload, kind_label) -> EgressApply`
  - `Allow` / `Passthrough` → `Continue`，payload 不动
  - `Redact { sanitized, .. }` → in-place 替换 payload，`Continue`
  - `Block` / `Ask` / 未知变体 → 记录 `tracing` 事件，返回 `Halt(reason)`
- 6 个单测：Allow / Passthrough / Redact / Block / Ask / 空 Redact

**改动** `crates/x_claw_agent/src/agentic_loop.rs`：
- `LlmRequest` 站点：30 行 match → 4 行 `apply_egress_decision(...)` + 哨兵
- `UserDisplay` 站点：同上
- 净减 ~50 行重复代码（91 行 → ~40 行）

**改动** `crates/x_claw_agent/src/lib.rs`：注册 `pub mod egress_apply`

## 非目标（What's NOT in this PR）

- ❌ **不**触碰 ironclaw 的 9 个 `sanitize_tool_output` 调用点（PR-C R2 下一个 PR）
- ❌ **不**为 `WorkerDeps` / `AgentDeps` / `RoutineEngineCtx` 添加 `egress` 字段（PR-C R2）
- ❌ **不**做 `no_mutation_in_egress_gate` startup contract test（独立工作项）
- ❌ **不**改变任何对外可观察行为（halt reason 字符串保留 `"egress gate blocked"` 前缀，唯一现有断言不受影响）
- ❌ 不 close #483（R2/R3/R4 仍未完成）

## 行为变化（小且向后兼容）

Halt reason 字符串从分散的 `"egress gate blocked prompt: {reason}"` / `"egress gate blocked completion: {reason}"` 统一为 `"egress gate blocked {kind_label}: {reason}"`（`{kind_label}` 是 `"LlmRequest"` 或 `"UserDisplay"`）。

- `agentic_loop.rs:1002` 的现有断言只检 `contains("egress gate blocked")` —— 通过。
- 全仓 grep 未发现其他对完整 halt 字符串敏感的代码或测试。

## 验证

```
$ cargo nextest run -p x_claw_agent
Summary [26.660s] 246 tests run: 246 passed, 0 skipped

$ python3.12 scripts/check_no_panics.py --base origin/xClaw
OK: No panic-inducing calls in changed production code.

$ cargo fmt --all
(clean)

$ cargo clippy --no-deps -p x_claw_agent --all-targets -- -D warnings
Finished `dev` profile [unoptimized + debuginfo] target(s) in 6.39s
(0 warnings, 0 errors)
```

## 3 层自查

**Layer 1 — code-quality-audit 视角**
- 无 `unwrap` / `expect` / `panic!` 在生产代码
- `#[non_exhaustive]` 守卫保留 `#[allow(unreachable_patterns)]`
- Fail-Safe 语义全部保留（Block / Ask / 未知 → Halt）
- `tracing::warn!` / `tracing::error!` 日志保留

**Layer 2 — code-simplifier 视角**
- `kind_label: &str` 而非 `&'static str`，为下游 ironclaw 9 个站点的动态标签（如 `format!("ToolOutput:{tool_name}")`）留出空间
- 返回专用 `EgressApply` 而非 `Result<(), String>`，命名变体表达 Fail-Safe 语义更清晰
- helper 内部 `warn` 与 loop 外层 `warn` 字段不同（kind vs iteration），保留双日志属合理冗余

**Layer 3 — code-review-expert 视角**
- 行为兼容：现有 `egress_gate_block_on_llm_request_yields_failure` 测试只检 `"egress gate blocked"` 子串 → 通过
- helper 模块独立可测，6 单测覆盖五种决策 + 空 sanitized 边界
- doc 注释解释了为什么 Ask 在 headless 上下文等同 Block（引用 ADR-148 §2.2 / ADR-146 §2.5）
- 为 PR-C R2 的 9 个站点提供了清晰的复用入口

Refs #483
