### PR TITLE
feat(safety): ADR-148 PR-C2 R2 sanitize_tool_output cleanup

### DIFF
--- a/desktop-client/ironclaw/src/agent/dispatcher.rs
+++ b/desktop-client/ironclaw/src/agent/dispatcher.rs
@@ -591,17 +591,25 @@ impl<'a> LoopDelegate for ChatDelegate<'a> {
         reason_ctx: &mut ReasoningContext,
     ) -> Result<Option<LoopOutcome>, HostError> {
         // Extract and sanitize the narrative before consuming `content`.
-        let narrative = content
-            .as_deref()
-            .filter(|c| !c.trim().is_empty())
-            .map(|c| {
-                let sanitized = self
-                    .agent
-                    .safety()
-                    .sanitize_tool_output("agent_narrative", c);
-                sanitized.content
-            })
-            .filter(|c| !c.trim().is_empty());
+        // ADR-148 R2: route through the unified Layer-B egress gate
+        // (`UserDisplay` kind) via `safety::egress::sanitize_tool_output_via_egress`
+        // instead of the legacy `SafetyLayer::sanitize_tool_output` path.
+        let narrative = match content.as_deref().filter(|c| !c.trim().is_empty()) {
+            Some(c) => {
+                let sanitized = crate::safety::egress::sanitize_tool_output_via_egress(
+                    self.agent.safety(),
+                    "agent_narrative",
+                    c,
+                )
+                .await;
+                if sanitized.trim().is_empty() {
+                    None
+                } else {
+                    Some(sanitized)
+                }
+            }
+            None => None,
+        };
 
         // Add the assistant message with tool_calls to context.
         // OpenAI protocol requires this before tool-result messages.
@@ -624,23 +632,25 @@ impl<'a> LoopDelegate for ChatDelegate<'a> {
             .await;
 
         // Build per-tool decisions for the reasoning update.
-        // Sanitize each rationale through SafetyLayer (parity with JobDelegate).
-        let decisions: Vec<crate::channels::ToolDecision> = tool_calls
-            .iter()
-            .filter_map(|tc| {
-                tc.reasoning.as_ref().map(|r| {
-                    let sanitized = self
-                        .agent
-                        .safety()
-                        .sanitize_tool_output("tool_rationale", r)
-                        .content;
-                    crate::channels::ToolDecision {
-                        tool_name: tc.name.clone(),
-                        rationale: sanitized,
-                    }
-                })
-            })
-            .collect();
+        // ADR-148 R2: route every tool rationale through the unified
+        // Layer-B egress gate (`UserDisplay` kind). Build sequentially
+        // (`for`) instead of `.filter_map` so each gate call can `.await`.
+        let mut decisions: Vec<crate::channels::ToolDecision> =
+            Vec::with_capacity(tool_calls.len());
+        for tc in tool_calls.iter() {
+            if let Some(r) = tc.reasoning.as_ref() {
+                let sanitized = crate::safety::egress::sanitize_tool_output_via_egress(
+                    self.agent.safety(),
+                    "tool_rationale",
+                    r,
+                )
+                .await;
+                decisions.push(crate::channels::ToolDecision {
+                    tool_name: tc.name.clone(),
+                    rationale: sanitized,
+                });
+            }
+        }
 
         // Emit reasoning update to channels.
         if narrative.is_some() || !decisions.is_empty() {
@@ -669,6 +679,26 @@ impl<'a> LoopDelegate for ChatDelegate<'a> {
                 };
                 redacted_args.push(safe);
             }
+            // ADR-148 R2: pre-sanitise each rationale via the unified
+            // Layer-B egress gate *before* taking the session lock — the
+            // gate is async and the session mutex must not be held across
+            // an `.await` (deadlock risk + Send bounds).
+            let mut sanitized_rationales: Vec<Option<String>> =
+                Vec::with_capacity(tool_calls.len());
+            for tc in &tool_calls {
+                let s = match tc.reasoning.as_ref() {
+                    Some(r) => Some(
+                        crate::safety::egress::sanitize_tool_output_via_egress(
+                            self.agent.safety(),
+                            "tool_rationale",
+                            r,
+                        )
+                        .await,
+                    ),
+                    None => None,
+                };
+                sanitized_rationales.push(s);
+            }
             let mut sess = self.session.lock().await;
             if let Some(thread) = sess.threads.get_mut(&self.thread_id)
                 && let Some(turn) = thread.last_turn_mut()
@@ -677,13 +707,11 @@ impl<'a> LoopDelegate for ChatDelegate<'a> {
                 if turn.narrative.is_none() {
                     turn.narrative = narrative;
                 }
-                for (tc, safe_args) in tool_calls.iter().zip(redacted_args) {
-                    let sanitized_rationale = tc.reasoning.as_ref().map(|r| {
-                        self.agent
-                            .safety()
-                            .sanitize_tool_output("tool_rationale", r)
-                            .content
-                    });
+                for ((tc, safe_args), sanitized_rationale) in tool_calls
+                    .iter()
+                    .zip(redacted_args)
+                    .zip(sanitized_rationales)
+                {
                     turn.record_tool_call_with_reasoning(
                         &tc.name,
                         safe_args,

--- a/desktop-client/ironclaw/src/routines/routine_engine.rs
+++ b/desktop-client/ironclaw/src/routines/routine_engine.rs
@@ -1709,16 +1709,29 @@ async fn execute_lightweight_with_tools(
             for tc in response.tool_calls {
                 let result = execute_routine_tool(ctx, &job_ctx, &allowed_tools, &tc).await;
 
-                // Sanitize and wrap result (including errors)
+                // Sanitize and wrap result (including errors).
+                // ADR-148 R2: route through the unified Layer-B egress gate
+                // (`UserDisplay` kind) via `safety::egress::sanitize_tool_output_via_egress`
+                // instead of the legacy `SafetyLayer::sanitize_tool_output` path.
                 let result_content = match result {
                     Ok(output) => {
-                        let sanitized = ctx.safety.sanitize_tool_output(&tc.name, &output);
-                        ctx.safety.wrap_for_llm(&tc.name, &sanitized.content)
+                        let sanitized = crate::safety::egress::sanitize_tool_output_via_egress(
+                            &ctx.safety,
+                            &tc.name,
+                            &output,
+                        )
+                        .await;
+                        ctx.safety.wrap_for_llm(&tc.name, &sanitized)
                     }
                     Err(e) => {
                         let error_msg = format!("Tool '{}' failed: {}", tc.name, e);
-                        let sanitized = ctx.safety.sanitize_tool_output(&tc.name, &error_msg);
-                        ctx.safety.wrap_for_llm(&tc.name, &sanitized.content)
+                        let sanitized = crate::safety::egress::sanitize_tool_output_via_egress(
+                            &ctx.safety,
+                            &tc.name,
+                            &error_msg,
+                        )
+                        .await;
+                        ctx.safety.wrap_for_llm(&tc.name, &sanitized)
                     }
                 };
 

--- a/desktop-client/ironclaw/src/safety/egress.rs
+++ b/desktop-client/ironclaw/src/safety/egress.rs
@@ -1,0 +1,130 @@
+//! ADR-148 R2 cleanup helper: replace `SafetyLayer::sanitize_tool_output`
+//! call sites with the unified Layer-B [`EgressGate`] using the
+//! [`EgressKind::UserDisplay`] kind.
+//!
+//! ## Why a single helper
+//!
+//! Before this helper, nine call sites across `dispatcher.rs`,
+//! `worker/job.rs`, and `routines/routine_engine.rs` each called
+//! `SafetyLayer::sanitize_tool_output(tool, payload).content`. That bypassed
+//! the ADR-148 Layer-B chain entirely (no leak detector, no audit signal,
+//! no shared rule set with the agentic loop's egress checks).
+//!
+//! Threading a new `egress: Arc<dyn EgressGate>` field through
+//! `AgentDeps` / `WorkerDeps` / `EngineContext` would ripple to ~14
+//! constructors including 8 test mocks — pure plumbing for what is
+//! semantically a single operation: "sanitise this tool output via the
+//! unified Layer-B gate".
+//!
+//! Instead, [`sanitize_tool_output_via_egress`] takes the same
+//! `Arc<SafetyLayer>` the caller already holds, wraps it in an
+//! [`IronclawEgressGate`] (the canonical adapter from `SafetyLayer` to
+//! [`EgressGate`]), runs the gate, and applies the decision via
+//! [`x_claw_agent::egress_apply::apply_egress_decision`] — the same helper
+//! the agentic loop's `LlmRequest`/`UserDisplay` sites use. One Fail-Safe
+//! semantics surface, nine identical call-site rewrites, zero ctor changes.
+//!
+//! ## EgressKind choice — `UserDisplay`, never `ToolExecution`
+//!
+//! All nine sites take **already-executed tool output** (plain text) and
+//! channel it back into either the user-facing UI or the LLM context.
+//! That fits the `UserDisplay` contract (leak detector + scan_and_clean).
+//!
+//! `EgressKind::ToolExecution` would route through
+//! `IronclawEgressGate::validate_tool_params` which JSON-parses the
+//! payload and rejects any non-JSON. Tool outputs are arbitrary text →
+//! parse fails → Fail-Safe `Block` → every tool output dropped.
+//! Catastrophic regression; the helper enforces `UserDisplay` so the
+//! choice cannot be made wrong at a call site.
+//!
+//! ## Fail-Safe on `Block` / `Ask`
+//!
+//! If the gate refuses (Block or, in a headless context, Ask), the
+//! returned string is `"[redacted: <reason>]"` so the LLM / UI does not
+//! see the original payload. The reason is also surfaced through
+//! `tracing::warn!` for audit. This mirrors the agentic loop's behaviour
+//! of halting on Block / Ask but keeps the worker / dispatcher pipelines
+//! flowing (a single redacted line in a tool result is recoverable;
+//! aborting the entire job because one tool's output tripped a leak rule
+//! is not the desired UX here — that is the role of the LlmRequest gate
+//! upstream).
+
+use std::sync::Arc;
+
+use dasclaw_governance::egress::{EgressGate, EgressKind};
+use ironclaw_safety::SafetyLayer;
+use ironclaw_safety::egress_gate::IronclawEgressGate;
+use x_claw_agent::egress_apply::{EgressApply, apply_egress_decision};
+
+/// Run `payload` through the ADR-148 Layer-B egress gate and return the
+/// sanitised string ready to be embedded in LLM context, channel events,
+/// or persisted job records.
+///
+/// On `Allow` / `Passthrough` returns the original payload unchanged. On
+/// `Redact` returns the gate-sanitised payload. On `Block` / `Ask` /
+/// future variants returns `"[redacted: <reason>]"` and logs the
+/// Fail-Safe halt at `WARN`.
+///
+/// `tool_name` is used purely as a tracing label (`ToolOutput:<tool>`);
+/// the gate itself never inspects it.
+pub async fn sanitize_tool_output_via_egress(
+    safety: &Arc<SafetyLayer>,
+    tool_name: &str,
+    payload: &str,
+) -> String {
+    // Cheap wrapper: holds `Arc<SafetyLayer>` only. Constructing per call
+    // avoids ctor-threading 14 construction sites for what is functionally
+    // a method on `SafetyLayer`.
+    let gate = IronclawEgressGate::new(Arc::clone(safety));
+    let mut buf = payload.to_string();
+    let decision = gate.check(&EgressKind::UserDisplay, &buf).await;
+    let label = format!("ToolOutput:{tool_name}");
+    match apply_egress_decision(decision, &mut buf, &label) {
+        EgressApply::Continue => buf,
+        EgressApply::Halt(reason) => {
+            tracing::warn!(
+                tool = tool_name,
+                %reason,
+                "tool output halted by egress gate; substituting [redacted] placeholder"
+            );
+            format!("[redacted: {reason}]")
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ironclaw_safety::SafetyConfig;
+
+    fn make_safety() -> Arc<SafetyLayer> {
+        Arc::new(SafetyLayer::new(&SafetyConfig {
+            max_output_length: 1024,
+            injection_check_enabled: true,
+        }))
+    }
+
+    #[tokio::test]
+    async fn plain_output_passes_through() {
+        let safety = make_safety();
+        let out = sanitize_tool_output_via_egress(&safety, "read_file", "Hello world").await;
+        assert_eq!(out, "Hello world");
+    }
+
+    #[tokio::test]
+    async fn empty_payload_is_preserved() {
+        let safety = make_safety();
+        let out = sanitize_tool_output_via_egress(&safety, "noop_tool", "").await;
+        assert_eq!(out, "");
+    }
+
+    #[tokio::test]
+    async fn unicode_payload_is_preserved_unchanged() {
+        // Regression: leak-detector must not mangle multi-byte boundaries
+        // on a clean payload.
+        let safety = make_safety();
+        let payload = "你好，世界 🌏 — café";
+        let out = sanitize_tool_output_via_egress(&safety, "translate", payload).await;
+        assert_eq!(out, payload);
+    }
+}

--- a/desktop-client/ironclaw/src/safety/mod.rs
+++ b/desktop-client/ironclaw/src/safety/mod.rs
@@ -2,5 +2,12 @@
 //!
 //! This module re-exports everything from the `ironclaw_safety` crate,
 //! keeping `crate::safety::*` imports working throughout the codebase.
+//!
+//! The [`egress`] sub-module provides the ADR-148 R2 helper
+//! [`egress::sanitize_tool_output_via_egress`] that replaces nine legacy
+//! `SafetyLayer::sanitize_tool_output(...).content` call sites with a
+//! single Layer-B gate invocation.
+
+pub mod egress;
 
 pub use ironclaw_safety::*;

--- a/desktop-client/ironclaw/src/worker/job.rs
+++ b/desktop-client/ironclaw/src/worker/job.rs
@@ -733,12 +733,23 @@ Report when the job is complete or if you encounter issues you cannot resolve."#
             }
         }
 
-        // Record action in memory and get the ActionRecord for persistence
+        // Record action in memory and get the ActionRecord for persistence.
+        // ADR-148 R2: route tool output through the unified Layer-B
+        // egress gate (`UserDisplay` kind) via `safety::egress::sanitize_tool_output_via_egress`
+        // instead of the legacy `SafetyLayer::sanitize_tool_output` path.
         let action = match &result {
             Ok(Ok(output)) => {
-                let output_str = serde_json::to_string_pretty(&output.result)
-                    .ok()
-                    .map(|s| deps.safety.sanitize_tool_output(tool_name, &s).content);
+                let output_str = match serde_json::to_string_pretty(&output.result).ok() {
+                    Some(s) => Some(
+                        crate::safety::egress::sanitize_tool_output_via_egress(
+                            &deps.safety,
+                            tool_name,
+                            &s,
+                        )
+                        .await,
+                    ),
+                    None => None,
+                };
                 match deps
                     .context_manager
                     .update_memory(job_id, |mem| {
@@ -858,16 +869,19 @@ Report when the job is complete or if you encounter issues you cannot resolve."#
 
         match result {
             Ok(raw_output) => {
-                let sanitized = self
-                    .deps
-                    .safety
-                    .sanitize_tool_output(&selection.tool_name, &raw_output);
+                // ADR-148 R2: route through unified Layer-B egress gate.
+                let sanitized = crate::safety::egress::sanitize_tool_output_via_egress(
+                    &self.deps.safety,
+                    &selection.tool_name,
+                    &raw_output,
+                )
+                .await;
                 self.log_event(
                     "tool_result",
                     serde_json::json!({
                         "tool_name": selection.tool_name,
                         "success": true,
-                        "output": truncate_for_preview(&sanitized.content, 500),
+                        "output": truncate_for_preview(&sanitized, 500),
                     }),
                 );
                 Ok(())
@@ -1725,37 +1739,38 @@ impl<'a> LoopDelegate for JobDelegate<'a> {
         }
 
         // Emit reasoning event if any tool calls carry reasoning.
-        // Sanitize narrative and per-tool rationale through SafetyLayer
-        // (parity with ChatDelegate in dispatcher.rs).
-        let sanitized_narrative = content
-            .as_deref()
-            .filter(|c| !c.trim().is_empty())
-            .map(|c| {
-                self.worker
-                    .deps
-                    .safety
-                    .sanitize_tool_output("job_narrative", c)
-                    .content
-            })
-            .filter(|c| !c.trim().is_empty())
-            .unwrap_or_default();
-        let decisions: Vec<serde_json::Value> = tool_calls
-            .iter()
-            .filter_map(|tc| {
-                tc.reasoning.as_ref().map(|r| {
-                    let sanitized = self
-                        .worker
-                        .deps
-                        .safety
-                        .sanitize_tool_output("tool_rationale", r)
-                        .content;
-                    serde_json::json!({
-                        "tool_name": tc.name,
-                        "rationale": sanitized,
-                    })
-                })
-            })
-            .collect();
+        // ADR-148 R2: route every narrative / rationale through the unified
+        // Layer-B egress gate (`UserDisplay` kind) via
+        // `safety::egress::sanitize_tool_output_via_egress`. The legacy
+        // `SafetyLayer::sanitize_tool_output` is replaced; build the
+        // `decisions` Vec with a sequential `for` loop so each gate call
+        // can `.await`.
+        let sanitized_narrative = match content.as_deref().filter(|c| !c.trim().is_empty()) {
+            Some(c) => {
+                crate::safety::egress::sanitize_tool_output_via_egress(
+                    &self.worker.deps.safety,
+                    "job_narrative",
+                    c,
+                )
+                .await
+            }
+            None => String::new(),
+        };
+        let mut decisions: Vec<serde_json::Value> = Vec::with_capacity(tool_calls.len());
+        for tc in tool_calls.iter() {
+            if let Some(r) = tc.reasoning.as_ref() {
+                let sanitized = crate::safety::egress::sanitize_tool_output_via_egress(
+                    &self.worker.deps.safety,
+                    "tool_rationale",
+                    r,
+                )
+                .await;
+                decisions.push(serde_json::json!({
+                    "tool_name": tc.name,
+                    "rationale": sanitized,
+                }));
+            }
+        }
         if !decisions.is_empty() {
             self.worker.log_event(
                 "reasoning",


### PR DESCRIPTION
# feat(safety): ADR-148 PR-C2 R2 `sanitize_tool_output` cleanup

> Stacked on **#614** (PR-C1 — already merged into `xClaw`). Base = `xClaw`.

## 背景 / 目标

ADR-148 R2 收尾：将 ironclaw 中 9 处直接调用 `SafetyLayer::sanitize_tool_output(...).content`
的旧路径，统一替换为 Layer-B 出口闸口（`EgressKind::UserDisplay`）。
PR-C1 (#614) 提供了 `x_claw_agent::egress_apply::apply_egress_decision`
helper；本 PR 在 ironclaw 侧新增一个薄包装 helper
`safety::egress::sanitize_tool_output_via_egress`，让 9 个站点拿到同一份
Fail-Safe 语义。

## 改动范围

- **新文件** `desktop-client/ironclaw/src/safety/egress.rs`
  - `pub async fn sanitize_tool_output_via_egress(safety, tool_name, payload) -> String`
  - 内部强制 `EgressKind::UserDisplay`（杜绝调用方误选 `ToolExecution`）
  - 3 个 tokio 单测（plain / empty / unicode）
- **`safety/mod.rs`** 注册 `pub mod egress;`
- **9 个调用站点替换**
  - `agent/dispatcher.rs` × 3（narrative / rationale × 2）
  - `worker/job.rs` × 4（tool output / job rationale / job narrative / process_tool_result）
  - `routines/routine_engine.rs` × 2（success / error 双路径）

## 非目标（What's NOT in this PR）

- **不**为 `AgentDeps` / `WorkerDeps` / `EngineContext` / `RoutineEngine` / `Scheduler`
  增加 `egress: Arc<dyn EgressGate>` 字段（评估发现会波及 ~14 个构造函数 + ~10 个 test mock，
  纯水管代码，无语义收益）。
- **不**改 `IronclawEgressGate` / `SafetyLayer` 的公开 API。
- **不**触碰 ADR-148 R3 / R4 的工作。

## 为什么是 helper 而非"贯穿字段"（关键设计决策）

- 9 处调用的语义完全一致：把工具输出送进 Layer-B Fail-Safe 通道。
- 每处调用都已能拿到 `Arc<SafetyLayer>`；`IronclawEgressGate::new(safety)` 是 Arc clone，开销忽略。
- 贯穿 5 个 struct 字段需要更新 14 个 ctor + 10 个 test mock；helper 方案只需 9 处替换 + 1 个新模块。
- helper 内部硬编码 `EgressKind::UserDisplay`：调用方**不可能选错**。
  `ToolExecution` 会 JSON-parse plain text → Fail-Safe Block → 整个工具输出被吞，是致命回归。

## Sync → async 重写（5 处）

5 处旧站点用 `.map` / `.filter_map` 同步闭包；闸口是 async 的，必须改为顺序 `for` 循环
+ 提前 await。这是 async 契约要求的自然重构，**不是补丁式代码**。

额外，`dispatcher.rs` 第 3 处站点原本在 `self.session.lock().await` 临界区里调用旧
sanitize；重写后把所有 rationale 先 await 完装进 `Vec<Option<String>>`，再拿锁——
持锁跨 `.await` 既违反 Send 又有死锁风险。

## 验证（命令 + 结果）

```bash
cargo check -p dasclaw --tests            # ✅ Finished 2m34s
cargo nextest run -p dasclaw safety::egress  # ✅ 3/3 passed
cargo nextest run -p dasclaw              # ✅ 4599/4599 passed, 22 skipped
cargo fmt --all                           # ✅ clean
python3.12 scripts/check_no_panics.py --base origin/xClaw  # ✅ OK
```

Clippy 在 xClaw 当前基线上对 `config/job_runtime.rs` / `llm/prompt/dynamic_layer.rs` /
`tools/builtin/grep_search.rs` 已有 3 处既存 warning（与本 PR 无关，stash 后验证）。

## Sources read

- `AGENTS.md` §"红线" / §"PR 必填"
- `docs/plans/architecture-refactor/adr-148-egress-gate.md` §R2 cleanup scope
- `crates/dasclaw_governance/src/egress.rs`（`EgressGate` trait / `EgressKind` / `EgressDecision`）
- `desktop-client/ironclaw/crates/ironclaw_safety/src/egress_gate.rs`（`IronclawEgressGate::new` 行为）
- `crates/x_claw_agent/src/egress_apply.rs`（PR-C1 #614 引入的 Fail-Safe helper）
- `desktop-client/ironclaw/src/agent/dispatcher.rs` § record-tool-calls 区块
- `desktop-client/ironclaw/src/worker/job.rs` § execute_tool_inner / process_tool_result_job / execute_tool_calls
- `desktop-client/ironclaw/src/routines/routine_engine.rs` § execute_lightweight_with_tools

## 3 层自查

**Layer 1 — code-quality-audit**
- 无 `unwrap` / `expect` / `panic!` 在生产代码（脚本通过）
- `EgressKind::UserDisplay` 内置在 helper 内，调用方零选择负担
- Fail-Safe 行为：Block / Ask → `[redacted: <reason>]` 占位 + `tracing::warn!` 审计

**Layer 2 — code-simplifier**
- 9 处站点替换为 1 行调用（5 处闭包重写为最小 for 循环）
- 锁外 await：dispatcher 第 3 处把异步 sanitize 提前到 `session.lock()` 之前，避免持锁跨 await
- helper 模块 130 行（含 doc + 3 单测），新增表面积小

**Layer 3 — code-review-expert**
- 行为兼容：`UserDisplay` 路径运行 leak_detector + scan_and_clean，对干净文本透传（unicode 单测验证）
- 复用 PR-C1 已合入的 `apply_egress_decision`：一处定义、九处一致
- `#[non_exhaustive]` 守卫由 `apply_egress_decision` 单点持有，未来 `EgressDecision` 新增变体只需改一处
- 4599 个 ironclaw 测试全绿，无回归

Refs #483

Closes #483
