### PR TITLE
feat(F2.2): wire BashPermissionHook into ironclaw CompositeEgressGate (closes #626)

### DIFF
--- a/crates/dasclaw_hooks/src/lib.rs
+++ b/crates/dasclaw_hooks/src/lib.rs
@@ -29,6 +29,14 @@ pub mod registry;
 pub use bash_permission_hook::BashPermissionHook;
 pub use bash_validation_hook::{BashValidationHook, DEFAULT_BASH_TOOL_NAMES};
 
+// ADR-152 §3 F2.2 (#626): re-export the rule context type so call sites
+// constructing a `BashPermissionHook` do not need a direct dependency on
+// the `dasclaw_bash_permissions` crate. Real rule ingestion lands in
+// Phase 2.3.
+pub use dasclaw_bash_permissions::{
+    PermissionBehavior, PermissionRuleSource, ToolPermissionContext,
+};
+
 pub use bundled::{
     HookBundleConfig, HookBundleError, HookRegistrationSummary, HookRuleConfig,
     OutboundWebhookConfig, RegexReplacementConfig, register_bundle, register_bundled_hooks,

--- a/desktop-client/ironclaw/src/agent/agentic_loop.rs
+++ b/desktop-client/ironclaw/src/agent/agentic_loop.rs
@@ -30,6 +30,11 @@ pub use dasclaw_core::permissions::PermissionMode;
 // Re-exported so call sites don't have to depend on `dasclaw_workspace_cap`
 // directly.
 pub use dasclaw_workspace_cap::WorkspaceCapability;
+// ADR-152 §3 F2.2 (#626): bash permission rule context is re-exported so
+// call sites construct `BashPermissionHook` rule contexts without taking a
+// direct dependency on the `dasclaw_bash_permissions` crate. Real rule
+// ingestion (from admin-backend / session config) is Phase 2.3.
+pub use dasclaw_hooks::ToolPermissionContext;
 
 use dasclaw_core::traits::HostError;
 
@@ -74,6 +79,40 @@ pub fn hook_bundle_with_safety(
     workspace_cap: std::sync::Arc<WorkspaceCapability>,
     permission_mode: PermissionMode,
 ) -> dasclaw_core::HookBundle {
+    hook_bundle_with_safety_and_permissions(
+        safety,
+        workspace_cap,
+        permission_mode,
+        ToolPermissionContext::default(),
+    )
+}
+
+/// ADR-152 §3 F2.2 (#626) variant of [`hook_bundle_with_safety`] that lets
+/// callers thread a [`ToolPermissionContext`] into the
+/// [`dasclaw_hooks::BashPermissionHook`] step of the egress chain.
+///
+/// Chain order is **bash-validation → bash-permissions → ironclaw-safety**:
+///
+/// 1. [`dasclaw_hooks::BashValidationHook`] — command-string structural /
+///    path-escape validation (security gate, never abstains).
+/// 2. [`dasclaw_hooks::BashPermissionHook`] — Deny/Ask/Allow rule pipeline
+///    over `permission_context`. With the default (empty) context every
+///    decision is `Passthrough`, so this step is a no-op until Phase 2.3
+///    (config ingestion) lands real rules. Inserting it now so the chain
+///    shape is stable and tests can drive the gate end-to-end.
+/// 3. [`ironclaw_safety::egress_gate::IronclawEgressGate`] — generic JSON
+///    validation + leak detection.
+///
+/// Empty-context guarantee: `BashPermissionHook::new(ToolPermissionContext::default())`
+/// returns `Passthrough` for every bash command, so the new step cannot
+/// regress the behaviour of [`hook_bundle_with_safety`] callers that don't
+/// supply rules.
+pub fn hook_bundle_with_safety_and_permissions(
+    safety: std::sync::Arc<crate::safety::SafetyLayer>,
+    workspace_cap: std::sync::Arc<WorkspaceCapability>,
+    permission_mode: PermissionMode,
+    permission_context: ToolPermissionContext,
+) -> dasclaw_core::HookBundle {
     use std::sync::Arc;
     let composite = dasclaw_core::CompositeEgressGate::builder()
         .add(
@@ -82,6 +121,10 @@ pub fn hook_bundle_with_safety(
                 permission_mode,
                 workspace_cap.root().to_path_buf(),
             )),
+        )
+        .add(
+            "bash-permissions",
+            Arc::new(dasclaw_hooks::BashPermissionHook::new(permission_context)),
         )
         .add(
             "ironclaw-safety",
@@ -475,6 +518,121 @@ mod tests {
         assert!(
             matches!(decision, EgressDecision::Block { .. }),
             "cap-rooted secrets bundle must still enforce ReadOnly, got {decision:?}"
+        );
+    }
+
+    // ---- ADR-152 §3 F2.2 (#626): BashPermissionHook wiring ----
+    //
+    // These tests prove the new `bash-permissions` step in the composite
+    // egress chain is reachable end-to-end and honours rule context:
+    //
+    // 1. Empty context: no rule fires → existing safety path is untouched
+    //    (the `req_safety_73_d_*` family above already exercises this
+    //    against `hook_bundle_with_safety` — those tests would have
+    //    regressed if the empty-context Passthrough contract was wrong).
+    // 2. Deny rule fires: a destructive command that bash-validation would
+    //    Allow (under `WorkspaceWrite`) is Blocked because a user-supplied
+    //    Deny rule matches. Proves the new step actually runs.
+    // 3. Ask rule fires: the permission hook surfaces `Ask` so the UI can
+    //    confirm. Distinguishes "hook is wired but only deny works" from
+    //    "hook is wired across all behaviours".
+    //
+    // Full per-behaviour matrix is owned by
+    // `dasclaw_hooks::bash_permission_hook::tests`; ironclaw only tests the
+    // wiring.
+
+    fn ctx_with_rule(
+        behavior: dasclaw_hooks::PermissionBehavior,
+        rule: &str,
+    ) -> ToolPermissionContext {
+        let mut ctx = ToolPermissionContext::default();
+        ctx.add_rule(behavior, dasclaw_hooks::PermissionRuleSource::Session, rule);
+        ctx
+    }
+
+    #[tokio::test]
+    async fn adr152_f22_permission_hook_deny_rule_blocks_bash_command() {
+        use dasclaw_core::{EgressDecision, EgressKind};
+        let ctx = ctx_with_rule(dasclaw_hooks::PermissionBehavior::Deny, "rm:*");
+        let bundle = hook_bundle_with_safety_and_permissions(
+            safety_layer(),
+            test_workspace_cap(),
+            // WorkspaceWrite is the mode under which bash-validation would
+            // Allow `rm -rf /tmp/foo` — so any Block we observe here must
+            // come from the new permission hook step, not the validation
+            // step.
+            PermissionMode::WorkspaceWrite,
+            ctx,
+        );
+        let args = serde_json::json!({ "command": "rm -rf /tmp/adr152_f22" });
+        let decision = bundle
+            .egress
+            .check(
+                &EgressKind::ToolExecution {
+                    tool: "bash".to_string(),
+                },
+                &args.to_string(),
+            )
+            .await;
+        assert!(
+            matches!(decision, EgressDecision::Block { .. }),
+            "Deny rule must block bash command via BashPermissionHook, got {decision:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn adr152_f22_permission_hook_ask_rule_surfaces_ask() {
+        use dasclaw_core::{EgressDecision, EgressKind};
+        let ctx = ctx_with_rule(dasclaw_hooks::PermissionBehavior::Ask, "echo:*");
+        let bundle = hook_bundle_with_safety_and_permissions(
+            safety_layer(),
+            test_workspace_cap(),
+            PermissionMode::WorkspaceWrite,
+            ctx,
+        );
+        // `echo hello` is benign — bash-validation Allows it. Any `Ask`
+        // observed must come from the permission hook.
+        let args = serde_json::json!({ "command": "echo hello" });
+        let decision = bundle
+            .egress
+            .check(
+                &EgressKind::ToolExecution {
+                    tool: "bash".to_string(),
+                },
+                &args.to_string(),
+            )
+            .await;
+        assert!(
+            matches!(decision, EgressDecision::Ask { .. }),
+            "Ask rule must surface EgressDecision::Ask, got {decision:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn adr152_f22_safety_only_helper_uses_empty_permission_context() {
+        use dasclaw_core::{EgressDecision, EgressKind};
+        // `hook_bundle_with_safety` delegates to the permissioned helper
+        // with `ToolPermissionContext::default()`. A benign command under
+        // WorkspaceWrite must Allow — proving the empty context is a true
+        // no-op for the new step (not silently blocking everything).
+        let bundle = hook_bundle_with_safety(
+            safety_layer(),
+            test_workspace_cap(),
+            PermissionMode::WorkspaceWrite,
+        );
+        let args = serde_json::json!({ "command": "echo hello" });
+        let decision = bundle
+            .egress
+            .check(
+                &EgressKind::ToolExecution {
+                    tool: "bash".to_string(),
+                },
+                &args.to_string(),
+            )
+            .await;
+        assert!(
+            matches!(decision, EgressDecision::Allow),
+            "empty permission context must not regress safety-only helper, got {decision:?}"
         );
     }
 }


### PR DESCRIPTION
## Sources read

- [AGENTS.md](AGENTS.md) — 中文规约总入口
- [docs/plans/architecture-refactor/adr-152-...](docs/plans/architecture-refactor/) §3 F2.2（issue #626 body 链接）
- [crates/dasclaw_hooks/src/bash_permission_hook.rs](crates/dasclaw_hooks/src/bash_permission_hook.rs) §模块文档 + Pipeline + "What is NOT in this slice"（确认 `ToolPermissionContext::default()` → 全 `Passthrough` 的空规则不变契约）
- [crates/dasclaw_bash_permissions/src/types.rs](crates/dasclaw_bash_permissions/src/types.rs) §`ToolPermissionContext` + `add_rule` 构造器
- [desktop-client/ironclaw/src/agent/agentic_loop.rs](desktop-client/ironclaw/src/agent/agentic_loop.rs) §`hook_bundle_with_safety` 现有链 `bash-validation → ironclaw-safety`
- [crates/dasclaw_bash_permissions/tests/env_strip_wiring_test.rs](crates/dasclaw_bash_permissions/tests/env_strip_wiring_test.rs) §确认规则字符串语法（`rm:*` 通配 vs 字面 `rm`）

## 背景 / 目标

ADR-152 §3 F2.2 计划把 `dasclaw_bash_permissions` 的规则引擎以 `BashPermissionHook` 形式接入 ironclaw 的 `CompositeEgressGate`。

`crates/dasclaw_hooks/src/bash_permission_hook.rs` 已经把 hook 实现完整落地（包含 S21/S22 沙箱逃逸硬拒、Phase 4.2 sed 严格白名单等），但 ironclaw 端从未把它装到链上 —— 实测 `grep -rn "BashPermissionHook" desktop-client/ironclaw/src/` 为 0 命中。本 PR 只补这一段接线。

## 改动范围

1. `desktop-client/ironclaw/src/agent/agentic_loop.rs`
   - 新增 `hook_bundle_with_safety_and_permissions(safety, workspace_cap, mode, permission_ctx)`，把 `BashPermissionHook::new(permission_ctx)` 作为新的 `"bash-permissions"` 步插入到 `"bash-validation"` 与 `"ironclaw-safety"` 之间（顺序遵循 hook 模块文档 "added **after** BashValidationHook"）。
   - 原 `hook_bundle_with_safety` 改为薄壳，转调新函数并传 `ToolPermissionContext::default()`。空 context 的 `BashPermissionHook` 对所有 bash 命令返回 `Passthrough`，下游 `IronclawEgressGate` 行为不变 —— 既有 5 个 `req_safety_73_d_*` + 2 个 `req_safety_73_e_*` 用例仍然全绿，证明无回归。
   - 重新导出 `ToolPermissionContext` / `PermissionBehavior` / `PermissionRuleSource`，避免上游调用方再额外依赖 `dasclaw_bash_permissions` crate。

2. `crates/dasclaw_hooks/src/lib.rs`
   - 把 `ToolPermissionContext` / `PermissionBehavior` / `PermissionRuleSource` 从 `dasclaw_bash_permissions` 重新导出，配合上一项让 ironclaw 维持只依赖 `dasclaw_hooks` 的现状。

3. 新增 3 个单元测试 `adr152_f22_*`：
   - `permission_hook_deny_rule_blocks_bash_command` —— `WorkspaceWrite` 下 `rm -rf` 本由 bash-validation Allow，加入 `Deny: rm:*` 规则后必须 Block，证明新步骤真正在跑（不是 short-circuit）。
   - `permission_hook_ask_rule_surfaces_ask` —— `echo hello` 本被 Allow，加入 `Ask: echo:*` 规则后须 `EgressDecision::Ask`。
   - `safety_only_helper_uses_empty_permission_context` —— 空规则 + 良性命令仍 Allow，证明默认路径无回归。

## 非目标 (What's NOT in this PR)

- **不**加载真实规则配置：admin-backend / `~/.dasclaw/settings.toml` 的 `ToolPermissionContext` 注入是 Phase 2.3 / F2.3 的工作。当前所有调用点继续传 `ToolPermissionContext::default()`。
- **不**改 dispatcher / worker 调用点签名：它们走的是 `hook_bundle_with_safety` / `hook_bundle_with_safety_and_secrets`，这两个签名一字未动。
- **不**接 desktop Ask UX：`EgressDecision::Ask` 已经能从新通道返回，但前端如何对接 hook ask UI 留给 Phase 2.3。
- **不**触碰 F2.1（#625）：本 PR 只做接线，不动 ironclaw 的 845 行 bash_validator。

## 验证

```bash
# Layer 1 —— check + fmt + no-panic
cargo check -p dasclaw_hooks --tests
cargo check -p dasclaw --tests
cargo fmt --all
python3.12 scripts/check_no_panics.py --base origin/xClaw
# => OK: No panic-inducing calls in changed production code.

# Layer 2 —— 单元测试（新 + 既有回归）
cargo nextest run -p dasclaw --lib \
  -E 'test(adr152_f22) | test(req_safety_73_d) | test(req_safety_73_e)'
# => Summary [2.585s] 10 tests run: 10 passed, 4075 skipped

# Layer 3 —— clippy（仅本次改动的 crate）
cargo clippy --no-deps -p dasclaw_hooks --all-targets -- -D warnings
# => Finished, 0 warnings
```

`dasclaw` 全包 clippy 报 3 处既有问题（`job_runtime.rs` / `dynamic_layer.rs` / `grep_search.rs`），均不在本 PR 改动范围内，留给 workspace clippy 清理的另一个 issue。

Closes #626
