### PR TITLE
feat(dasclaw_tool): port tool-impl ToolError to shared crate (F3.2 phase 2 PR 1, #641)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2659,6 +2659,7 @@ dependencies = [
  "dasclaw_net_proxy",
  "dasclaw_process_hardening",
  "dasclaw_sandbox",
+ "dasclaw_tool",
  "dasclaw_workspace_cap",
  "deadpool-postgres",
  "dirs 6.0.0",
@@ -3203,6 +3204,13 @@ dependencies = [
  "tree-sitter-bash",
  "url",
  "which 8.0.2",
+]
+
+[[package]]
+name = "dasclaw_tool"
+version = "0.0.0-w6"
+dependencies = [
+ "thiserror 1.0.69",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,8 @@ members = [
 	"crates/dasclaw_mcp",
 	"crates/dasclaw_execpolicy",
 	"crates/dasclaw_features",
+	# F3.2 phase 2 PR 1 — tool implementation-layer error type (see #641)
+	"crates/dasclaw_tool",
 	"crates/dasclaw_observability",
 	"crates/dasclaw_identity",
 	"crates/dasclaw_crash",

--- a/crates/dasclaw_tool/Cargo.toml
+++ b/crates/dasclaw_tool/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "dasclaw_tool"
+version = "0.0.0-w6"
+edition = "2021"
+description = "Tool implementation layer building blocks: errors, output, and shared types used by any dasclaw host."
+license = "MIT OR Apache-2.0"
+
+[dependencies]
+thiserror = "1"

--- a/crates/dasclaw_tool/src/error.rs
+++ b/crates/dasclaw_tool/src/error.rs
@@ -1,0 +1,87 @@
+//! Tool implementation-layer error type.
+//!
+//! Returned by an individual tool's `execute()` method. The error does not
+//! carry the tool's name on purpose: the dispatcher that invoked the tool
+//! attaches the identity when it converts this into the outer application
+//! error (see future `dasclaw_runtime::ToolError`).
+
+use std::time::Duration;
+
+use thiserror::Error;
+
+/// Error type for tool execution.
+///
+/// Variants intentionally use tuple-style payloads to keep tools' error
+/// construction terse. The wrapping application error converts these into
+/// rich struct-style variants that include the failing tool's identity.
+#[derive(Debug, Error)]
+pub enum ToolError {
+    #[error("Invalid parameters: {0}")]
+    InvalidParameters(String),
+
+    #[error("Execution failed: {0}")]
+    ExecutionFailed(String),
+
+    #[error("Timeout after {0:?}")]
+    Timeout(Duration),
+
+    #[error("Not authorized: {0}")]
+    NotAuthorized(String),
+
+    #[error("Rate limited, retry after {0:?}")]
+    RateLimited(Option<Duration>),
+
+    #[error("External service error: {0}")]
+    ExternalService(String),
+
+    #[error("Sandbox error: {0}")]
+    Sandbox(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn req_dasclaw_tool_error_display_invalid_parameters() {
+        let err = ToolError::InvalidParameters("missing name".into());
+        assert_eq!(err.to_string(), "Invalid parameters: missing name");
+    }
+
+    #[test]
+    fn req_dasclaw_tool_error_display_timeout() {
+        let err = ToolError::Timeout(Duration::from_secs(5));
+        assert_eq!(err.to_string(), "Timeout after 5s");
+    }
+
+    #[test]
+    fn req_dasclaw_tool_error_display_rate_limited_some() {
+        let err = ToolError::RateLimited(Some(Duration::from_millis(250)));
+        assert_eq!(err.to_string(), "Rate limited, retry after Some(250ms)");
+    }
+
+    #[test]
+    fn req_dasclaw_tool_error_display_rate_limited_none() {
+        let err = ToolError::RateLimited(None);
+        assert_eq!(err.to_string(), "Rate limited, retry after None");
+    }
+
+    #[test]
+    fn req_dasclaw_tool_error_variants_distinct() {
+        let variants = [
+            ToolError::InvalidParameters("a".into()),
+            ToolError::ExecutionFailed("b".into()),
+            ToolError::NotAuthorized("c".into()),
+            ToolError::ExternalService("d".into()),
+            ToolError::Sandbox("e".into()),
+        ];
+        // Every variant's Display output must include its tag so dispatcher
+        // logs can distinguish them without pattern matching on Debug.
+        let messages: Vec<String> = variants.iter().map(|e| e.to_string()).collect();
+        assert!(messages[0].contains("Invalid parameters"));
+        assert!(messages[1].contains("Execution failed"));
+        assert!(messages[2].contains("Not authorized"));
+        assert!(messages[3].contains("External service error"));
+        assert!(messages[4].contains("Sandbox error"));
+    }
+}

--- a/crates/dasclaw_tool/src/lib.rs
+++ b/crates/dasclaw_tool/src/lib.rs
@@ -1,0 +1,15 @@
+//! Tool implementation-layer primitives shared across dasclaw hosts.
+//!
+//! This crate hosts the **inner** error type that an individual tool's
+//! implementation returns. The outer "application layer" error (which adds
+//! the failing tool's identity to the wire) lives in a separate crate and
+//! is constructed by the dispatcher when a tool error bubbles up.
+//!
+//! The two-layer split mirrors the design in `ironclaw-main`:
+//! `src/tools/tool.rs::ToolError` (this crate) carries no tool name;
+//! `src/error.rs::ToolError` (future `dasclaw_runtime`) attaches the name
+//! at the call boundary.
+
+pub mod error;
+
+pub use error::ToolError;

--- a/desktop-client/ironclaw/Cargo.toml
+++ b/desktop-client/ironclaw/Cargo.toml
@@ -190,6 +190,9 @@ dasclaw_llm_provider = { path = "../../crates/dasclaw_llm_provider" }
 # MCP wire types + typed server-name allowlist (F3.2 phase 1; ADR-152 §3).
 dasclaw_mcp = { path = "../../crates/dasclaw_mcp" }
 
+# Tool implementation-layer error type (F3.2 phase 2 PR 1; ADR-152 §3, #641).
+dasclaw_tool = { path = "../../crates/dasclaw_tool" }
+
 # AWS Bedrock (native Converse API, opt-in via --features bedrock)
 aws-config = { version = "1", features = ["behavior-version-latest"], optional = true }
 aws-sdk-bedrockruntime = { version = "1", optional = true }

--- a/desktop-client/ironclaw/src/tools/tool.rs
+++ b/desktop-client/ironclaw/src/tools/tool.rs
@@ -6,7 +6,6 @@ use std::time::Duration;
 use async_trait::async_trait;
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
-use thiserror::Error;
 
 use crate::context::JobContext;
 
@@ -153,29 +152,16 @@ pub enum ToolDomain {
 }
 
 /// Error type for tool execution.
-#[derive(Debug, Error)]
-pub enum ToolError {
-    #[error("Invalid parameters: {0}")]
-    InvalidParameters(String),
-
-    #[error("Execution failed: {0}")]
-    ExecutionFailed(String),
-
-    #[error("Timeout after {0:?}")]
-    Timeout(Duration),
-
-    #[error("Not authorized: {0}")]
-    NotAuthorized(String),
-
-    #[error("Rate limited, retry after {0:?}")]
-    RateLimited(Option<Duration>),
-
-    #[error("External service error: {0}")]
-    ExternalService(String),
-
-    #[error("Sandbox error: {0}")]
-    Sandbox(String),
-}
+///
+/// Re-exported from [`dasclaw_tool`] (F3.2 phase 2 PR 1, #641). The
+/// implementation now lives in the shared `crates/dasclaw_tool` crate so
+/// that any dasclaw host (desktop, CLI, headless service, admin backend)
+/// can construct and propagate the same inner error without depending on
+/// the ironclaw desktop crate. The struct-shape outer error in
+/// `crate::error::ToolError` (which adds the failing tool's identity)
+/// still lives in ironclaw for now and will move to `dasclaw_runtime`
+/// in PR 2.
+pub use dasclaw_tool::ToolError;
 
 /// Output from a tool execution.
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
## 背景 / 目标

把"工具实现层"的 `ToolError`（不带工具名、由具体工具的 `execute()` 返回的内层错误）从
`desktop-client/ironclaw/src/tools/tool.rs` 搬到新 crate `crates/dasclaw_tool`，让任何宿主
（桌面 GUI / CLI / 无头服务 / admin backend）都能复用同一份内层错误，**不再依赖 ironclaw 桌面 crate**。

这是 #641 (F3.2 phase 2) 的 PR 1，承接 #640 已合并的 phase 1。

## 设计依据

调研发现 ironclaw 里有**两份** `ToolError`，并且 `ironclaw-main` 上游也是两份。证据：
`ironclaw-main/src/tools/builder/core.rs:42` 使用 `use crate::error::ToolError as AgentToolError;` 别名 —
两份是**有意的两层模型**，不是历史欠债：

| 层 | 文件 | 形态 | 含工具名? | 本 PR 处理 |
|---|---|---|---|---|
| 工具实现层 | `src/tools/tool.rs::ToolError` | tuple-style | 否 | **本 PR 搬到 `dasclaw_tool`** |
| 应用层 | `src/error.rs::ToolError` | struct-style | 是 | PR 2 搬到 `dasclaw_runtime` + `From<dasclaw_tool::ToolError>` |

## 改动范围

- **新 crate** `crates/dasclaw_tool/`（v0.0.0-w6）
  - `src/error.rs`：纯定义，5 个 `req_dasclaw_tool_error_*` 单元测试覆盖 Display + 变体区分
  - `src/lib.rs`：crate 文档说明两层模型 + `pub use`
- **workspace `Cargo.toml`**：加入新成员
- **`desktop-client/ironclaw/Cargo.toml`**：依赖 `dasclaw_tool`
- **`desktop-client/ironclaw/src/tools/tool.rs`**：把原 `pub enum ToolError {...}`（19 行）替换成
  `pub use dasclaw_tool::ToolError;`（1 行），并移除不再用到的 `use thiserror::Error;`。
  20+ 处 `use crate::tools::tool::ToolError;` 调用方零改动，源码兼容（与 phase 1 `dasclaw_mcp` shim 同模式）。

## 非目标（What's NOT in this PR）

- 不动 `src/error.rs::ToolError`（应用层错误）— 留给 PR 2
- 不加 `From<dasclaw_tool::ToolError> for crate::error::ToolError` — 留给 PR 2
- 不合并两份 `ToolError`（是有意设计，证据见上）
- 不抽 `JobContext` / `SecretsStore` / MCP `auth.rs` `config.rs` — 分别留给 PR 3 / 4 / 5 / 6

## 验证

```
cargo check -p dasclaw_tool --tests   → Finished
cargo nextest run -p dasclaw_tool     → 5/5 pass
cargo check -p dasclaw --tests        → Finished (5m40s)
cargo nextest run -p dasclaw --lib    → 3525/3525 pass, 3 skipped (1004s)
cargo fmt --all                       → clean
python3.12 scripts/check_no_panics.py --base origin/xClaw
                                      → OK: No panic-inducing calls in changed production code.
cargo clippy --no-deps -p dasclaw_tool --all-targets -- -D warnings
                                      → Finished, no warnings
```

## 工具协助

| 工具 | 调用 | 结论 |
|---|---|---|
| `code-review-graph callers_of tool.rs::ToolError` | 0 results | 提示 graph 对该符号有冲突或未编入；fallback 到 grep |
| `grep_search use crate::tools::tool::(\{...ToolError\|ToolError)` | 20+ matches | 全部为 `use` 语句，无 impl 块；shim 策略安全 |
| `grep_search impl.*for ToolError\|impl ToolError\|From.*ToolError`（在 `tools/tool.rs` 内） | 0 matches | 该文件内无 impl，直接替换为 `pub use` 即可 |
| 对比 ironclaw-main | `use ... as AgentToolError` 模式存在 | **两层 ToolError 是有意设计**，重塑预案为"分头搬"而非"合并" |

## Sources read

- [`AGENTS.md`](AGENTS.md) §强制阅读 / §测试纪律 / §复用优先 / §Skills 强制使用
- [`.github/copilot-instructions.md`](.github/copilot-instructions.md) §1-§7
- [`docs/plans/architecture-refactor/31-target-architecture.md`](docs/plans/architecture-refactor/31-target-architecture.md) §L4 能力域、§dasclaw_* crate inventory
- [`docs/plans/architecture-refactor/32-execution-plan.md`](docs/plans/architecture-refactor/32-execution-plan.md) §W5 MCP wave 上下文
- [`docs/plans/architecture-refactor/adr-112-compatibility-evaluation.md`](docs/plans/architecture-refactor/adr-112-compatibility-evaluation.md) §非破坏性迁移 — 本 PR 的 shim 策略与之一致
- [`ironclaw-main/src/tools/builder/core.rs`](ironclaw-main/src/tools/builder/core.rs#L42) §别名 `as AgentToolError`（关键证据）
- [`ironclaw-main/src/tools/tool.rs`](ironclaw-main/src/tools/tool.rs#L206) §`ToolError` 上游形态对照
- [`desktop-client/ironclaw/src/tools/tool.rs`](desktop-client/ironclaw/src/tools/tool.rs) §修改前后对比

Closes #641 (F3.2 phase 2 PR 1 of 6). Refs #628, #640.

