### PR TITLE
docs(skills): add code-review-graph-usage skill + wire into AGENTS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,6 +77,13 @@
 | `adr-compliance-check` | **触及 `crates/dasclaw_*` / `.github/workflows/code_style.yml` / `scripts/check_codex_*_drift.py` / starlark pin / `.ironclaw` 字面量新增或豁免** 的 PR push 前 | 漏掉 verbatim 纯度违规、drift guard 接线缺失、CI roll-up `failure-check` stanza 缺失、PR 描述漏 ADR/Issue cite 等架构纪律问题 |
 | `code-review-expert` | **PR 自审前**（push 之前）、PR 合并前、用户说"review/审查这次改动" | 漏掉 SOLID 违规、安全风险、依赖耦合等高阶问题 |
 
+### 配套查询能力（推荐，不强制）
+
+| Skill | 何时调出 | 作用 |
+|-------|---------|------|
+| `code-review-graph-usage` | **任何"搬迁/拆 crate/改公共类型"PR 开工前**；想查"谁调用了 X""哪些 repo 有相似代码""改动的爆炸半径"时 | 给出本仓 6 个已注册 repo 的查询规范、坑位与回退到 grep 的判定，避免一上来就乱试参数 |
+
+
 **执行顺序（默认管线）**：
 1. 实现完成 → `cargo check -p <touched-crate> --tests` 0 错 0 警（完整 `cargo build` 由 CI 兑现）
 2. `code-quality-audit` 自查（必须）

--- a/skills/code-review-graph-usage/README.md
+++ b/skills/code-review-graph-usage/README.md
@@ -1,0 +1,15 @@
+# code-review-graph-usage
+
+x-claw 仓库已挂 6 个 repo 的代码知识图（code-review-graph MCP）。
+本 skill 给出**在 dasclaw 重构/迁移任务中正确使用图谱的判定流程**，
+踩过的坑都写在 `SKILL.md` 里。
+
+## 何时读它
+
+- 开一个会搬迁公共类型 / 拆 crate / 跨 repo 对照上游的 PR 之前
+- 看到 `code-review-graph` 工具调用报错或返回 0 结果时（先来对一下坑位章节，再决定是回退到 grep 还是修工具）
+- 写 PR "## 工具协助" 段时
+
+## 关键产出
+
+每个搬迁 PR 的描述必须贴"## 工具协助"段。本 skill 第"输出规范"节列出最小内容。

--- a/skills/code-review-graph-usage/SKILL.md
+++ b/skills/code-review-graph-usage/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: code-review-graph-usage
+description: "x-claw 仓库已挂载 code-review-graph MCP（6 个 repo 跨仓代码知识图）。本 skill 给出在重构/迁移工作中正确使用它的判定流程、常见坑位、以及什么时候回退到 grep。"
+---
+
+# code-review-graph 使用规范（x-claw 专版）
+
+## 这个工具是干什么的
+
+把代码用 Tree-sitter 解析成"节点+边"的图谱，存进 SQLite：
+
+- **节点**：File / Class（含 enum/struct）/ Function / Test
+- **边**：CALLS（函数调用）、CONTAINS（文件包含）、IMPORTS_FROM（模块依赖）、INHERITS、REFERENCES、TESTED_BY
+
+适合回答："改了这个函数会影响哪些地方？"、"这个 trait 被谁实现？"、"两个 repo 哪些代码长得像？"
+
+不适合直接回答："这个枚举被哪些文件用了？"（详见下文坑位 1）。
+
+## 本仓已注册的 6 个 repo
+
+| alias | 路径 | 用途 |
+|---|---|---|
+| `ironclaw` | `desktop-client/ironclaw/` | 桌面端主体（默认 repo） |
+| `xclaw-core` | `crates/` | 所有 `dasclaw_*` 共享 crate |
+| `ironclaw-main` | `ironclaw-main/` | 上游对照，迁移取舍证据来源 |
+| `codex-cli` | `codex-cli-main/` | OpenAI codex 上游，verbatim port 的对照 |
+| `claw-code` | `claw-code/` | claw-code 实现参考 |
+| `claude-code` | `claude-code-main/` | Anthropic claude-code 实现参考 |
+
+**默认 repo 是 ironclaw**（由 `.vscode/mcp.json` 里 `--repo` 指定）。绝大多数 MCP 工具调用都只看默认 repo。
+
+## 什么时候应该用它（重构工作流）
+
+每个有"搬迁"或"修改公共类型"性质的 PR，开工前先用图谱做：
+
+1. **找调用方**：要搬一个 `pub fn` 之前，先 `query_graph_tool(pattern=callers_of, target=<函数名>)`
+2. **估爆炸半径**：改动落盘后跑 `get_impact_radius_tool()` 看 blast radius
+3. **找上游对照**：要决定"该不该合并某个分裂"时，用 `cross_repo_search_tool` 对照 `ironclaw-main` / `codex-cli` 看上游怎么处理
+4. **审查上下文**：开 PR 前可用 `get_review_context_tool` 拉源码片段附在 PR 描述里
+
+把这些产出贴进 PR 描述的"## 工具协助"段（PR #642 是范例）。
+
+## 标准操作顺序（每次新会话第一次用之前）
+
+```text
+# 1. 看图谱状态
+mcp_code-review-g_list_graph_stats_tool()
+  → 看 last_updated 是不是今天；不是就刷新
+
+# 2. 刷新默认 repo（ironclaw）
+mcp_code-review-g_build_or_update_graph_tool()
+  → 跑增量更新
+
+# 3. 想刷新其他 repo（MCP 工具不接 repo 参数）—— 走 CLI
+cd <repo 路径>
+/Users/nallylin/.local/bin/code-review-graph update
+
+# 4. 看当前 git 改动的影响范围
+mcp_code-review-g_get_impact_radius_tool()
+mcp_code-review-g_detect_changes_tool()
+```
+
+## 选用模式的判定表
+
+| 想知道什么 | 用哪个工具/pattern | 备注 |
+|---|---|---|
+| 谁调用了某个**函数** | `query_graph_tool(pattern=callers_of, target=<函数 qualified_name 或简名>)` | 简名会得到 ambiguous + 候选列表，挑一个再查 |
+| 某个**函数**调用了谁 | `query_graph_tool(pattern=callees_of, target=...)` | 同上 |
+| 谁导入了某个**文件/模块** | `query_graph_tool(pattern=importers_of, target=<文件简名如 tools/tool.rs>)` | **绝对路径会返回 0；用简名拿 ambiguous + 候选** |
+| 某个**类/枚举**被哪些地方用 | **fallback 到 `grep_search`** | 见下方坑位 1 |
+| 某个 trait 被谁实现 | `query_graph_tool(pattern=inheritors_of, target=...)` | 仅 INHERITS 边 |
+| 某个执行流被哪些代码触发 | `get_flow_tool` / `list_flows_tool` | |
+| 跨 repo 找相似代码 | `cross_repo_search_tool` | 不限默认 repo |
+| 改动后的代码风险评估 | `get_impact_radius_tool()` + `detect_changes_tool()` | 不接参数，自动读 git diff |
+| PR 评审证据包 | `get_review_context_tool` | 输出可直接贴 PR |
+
+## 常见坑位（实战发现）
+
+### 坑位 1：`callers_of <Class>` 永远返回 0
+
+**原因**：图里的 `CALLS` 边只指向 **Function**，不指向 Class/Enum/Struct。
+
+**对策**：要查"谁用了某个枚举类型"，**回退到 `grep_search`**，搜 `use <模块路径>::<类型名>` 或 `<类型名>::`。这是 PR #642 工具协助表里采用的方法。
+
+### 坑位 2：`importers_of` 用绝对路径返回 0
+
+**对策**：传短路径（如 `tools/tool.rs`），拿到 ambiguous 候选列表后人肉挑 File 节点。
+
+### 坑位 3：MCP 工具不接 `repo` / `alias` / `repo_path` 参数
+
+报错样式：`unexpected_keyword_argument`。
+
+**对策**：跨 repo 操作走 CLI（`/Users/nallylin/.local/bin/code-review-graph register|build|update`）；跨 repo 查询用 `cross_repo_search_tool`。
+
+### 坑位 4：`semantic_search_nodes_tool` 找不到东西
+
+**原因**：`list_graph_stats` 里 `Embeddings: 0 nodes embedded`，向量没生成。
+
+**修复尝试**：`/Users/nallylin/.local/share/code-review-graph-venv/bin/pip install sentence-transformers`。**本仓当前装失败（依赖冲突）**，所以这条路暂时不能走，改用关键字版 `query_graph_tool` 即可。
+
+### 坑位 5：图谱过期
+
+**症状**：`detect_changes_tool` 返回"7 个改动文件，0 个改动函数"——节点没在图里。
+
+**修复**：调 `build_or_update_graph_tool()` 增量刷一遍。本仓上次因 `tools/tool.rs` 改动后忘刷，就出现这个症状。
+
+### 坑位 6：默认 repo 之外的 repo "看起来不存在"
+
+例如：在默认 repo=`ironclaw` 时查 `crates/dasclaw_tool/` 里的符号，会找不到。
+
+**对策**：那些节点在 `xclaw-core` repo 里，要用 `cross_repo_search_tool` 跨过去。
+
+## 输出规范
+
+在 PR 描述里贴"## 工具协助"段时，至少包含：
+
+- 用了哪些 pattern 和 target
+- 关键查询返回了什么（数量、是否 ambiguous、关键候选）
+- 哪些查询触发了坑位，回退到了什么方法
+- `get_impact_radius` 的 blast radius 数字
+
+让 reviewer 不用重新跑一遍分析。
+
+## 自检清单（开始一个新的搬迁 PR 之前）
+
+- [ ] `list_graph_stats_tool` 看默认 repo 的 last_updated 是不是当天
+- [ ] 必要时 `build_or_update_graph_tool` 刷新
+- [ ] 跨 repo 任务先用 CLI 把相关 repo `update` 一遍
+- [ ] 想查类型用方时，直接用 grep，不浪费时间在 `callers_of` 上
+- [ ] PR 描述里准备好"## 工具协助"段
+
+## 关联
+
+- 工具来源：`.vscode/mcp.json` 第 41-44 行 stdio server 配置
+- 二进制：`/Users/nallylin/.local/bin/code-review-graph`
+- venv：`/Users/nallylin/.local/share/code-review-graph-venv/`
+- 推荐配合：`code-review-expert`（语义评审）、`adr-compliance-check`（红线检查）、`code-quality-audit`（工艺审查）

--- a/skills/code-review-graph-usage/manifest.json
+++ b/skills/code-review-graph-usage/manifest.json
@@ -1,0 +1,6 @@
+{
+  "version": "1.0.0",
+  "name": "code-review-graph-usage",
+  "description": "x-claw 多 repo 代码知识图的使用规范：什么时候调 code-review-graph、调哪个 patten、6 个已注册 repo 的范围、图谱刷新与跨 repo 查询、常见坑位与回退到 grep 的判定。",
+  "author": "nallylin"
+}


### PR DESCRIPTION
## 背景 / 目标

本仓 `.vscode/mcp.json` 早已挂了 `code-review-graph` MCP，且注册了 6 个 repo 的代码知识图谱（ironclaw / xclaw-core / ironclaw-main / codex-cli / claw-code / claude-code）。但在最近一次搬迁 PR（#642）中我踩了一系列"工具能调通但拿不到想要的结果"的坑，几乎每一次都要现场摸索一遍。

把这套使用规范固化成 skill，让后续重构 PR（#641 PR 2~6 和后面的 phase）开工前就能照着判定，不浪费时间。

## 改动范围

- **新 skill** `skills/code-review-graph-usage/`
  - `manifest.json`：标准元数据
  - `SKILL.md`：6 个 repo 范围、操作顺序、模式选用判定表、**6 个实战坑位**、输出规范、自检清单
  - `README.md`：何时读、关键产出
- **`AGENTS.md`**：在四个强制 skill 块之后新增一个"配套查询能力（推荐，不强制）"子表，把这个 skill 列进去并指明触发时机

## 设计要点

1. **不破坏现有四强制 skill 闸门**：这个 skill 是**推荐**而非强制，避免把没图谱的小 PR 也卡住。
2. **坑位章节是实战产出**：每条都有具体场景和回退方案，例如：
   - `callers_of <Class>` 永远 0 → 回退到 `grep_search`（CALLS 边只指向 Function）
   - `importers_of <绝对路径>` 返回 0 → 用短路径拿 ambiguous 候选
   - MCP 工具不接 `repo` 参数 → 跨 repo 走 CLI
   - 嵌入未生成时 `semantic_search_nodes` 拿不到结果（venv 装 `sentence-transformers` 失败，暂用关键字版）
   - 图谱过期症状：`detect_changes` 报"N 个文件 / 0 函数"
3. **输出规范**：每个搬迁 PR 必须有"## 工具协助"段，PR #642 是范例。

## 非目标（What's NOT in this PR）

- 不修复 sentence-transformers 安装问题（venv 依赖冲突，单独排查）
- 不改 `.vscode/mcp.json` 默认 repo 配置
- 不把 skill 列入强制管线（避免阻塞 typo/docs-only PR）
- 不动 code-review-graph CLI 本身

## 验证

文档/skill-only 改动。

```
git diff --stat origin/xClaw...HEAD → 4 files changed:
  AGENTS.md                                       (+ 6 lines, 配套查询能力子表)
  skills/code-review-graph-usage/README.md        (新文件)
  skills/code-review-graph-usage/SKILL.md         (新文件)
  skills/code-review-graph-usage/manifest.json    (新文件)

cargo fmt --all                       → N/A（无 Rust 改动）
scripts/check_no_panics.py            → N/A
```

## Sources read

- [`AGENTS.md`](AGENTS.md) §Skills 强制使用规范 — 确认四 skill 闸门规则，决定本 skill 作为"推荐"而非"强制"
- [`.github/copilot-instructions.md`](.github/copilot-instructions.md) §3 必跑的本地管线 / §4 PR 必填项
- [`skills/adr-compliance-check/SKILL.md`](skills/adr-compliance-check/SKILL.md) §1-40 — 对照 skill 文件结构与 manifest 格式
- [`skills/adr-compliance-check/manifest.json`](skills/adr-compliance-check/manifest.json) — manifest 字段对照
- `.vscode/mcp.json` 第 41-44 行 — 确认 code-review-graph stdio server 配置和默认 repo
- 实战证据：PR #642 工具协助段（同会话产出）— 6 个坑位都是搬迁 `tools/tool.rs::ToolError` 时踩到的

Closes #641 (auxiliary skill landed alongside F3.2 phase 2 PR 1; maintainer please re-open #641 after merge — more PRs follow). Refs #642.

