### PR TITLE
feat(dasclaw_runtime): port app-layer ToolError to shared crate (F3.2 phase 2 PR 2 of 6) [#641]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2658,6 +2658,7 @@ dependencies = [
  "dasclaw_mcp",
  "dasclaw_net_proxy",
  "dasclaw_process_hardening",
+ "dasclaw_runtime",
  "dasclaw_sandbox",
  "dasclaw_tool",
  "dasclaw_workspace_cap",
@@ -3086,6 +3087,14 @@ dependencies = [
 name = "dasclaw_routines"
 version = "0.0.0-w1"
 dependencies = [
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "dasclaw_runtime"
+version = "0.0.0-w6"
+dependencies = [
+ "dasclaw_tool",
  "thiserror 1.0.69",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,8 @@ members = [
 	"crates/dasclaw_features",
 	# F3.2 phase 2 PR 1 — tool implementation-layer error type (see #641)
 	"crates/dasclaw_tool",
+	# F3.2 phase 2 PR 2 — application-layer error type + future JobContext (see #641)
+	"crates/dasclaw_runtime",
 	"crates/dasclaw_observability",
 	"crates/dasclaw_identity",
 	"crates/dasclaw_crash",

--- a/crates/dasclaw_runtime/Cargo.toml
+++ b/crates/dasclaw_runtime/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "dasclaw_runtime"
+version = "0.0.0-w6"
+edition = "2021"
+description = "Runtime (application-layer) building blocks for any dasclaw host: errors that carry the failing tool's identity, future JobContext, etc."
+license = "MIT OR Apache-2.0"
+
+[dependencies]
+dasclaw_tool = { path = "../dasclaw_tool" }
+thiserror = "1"

--- a/crates/dasclaw_runtime/src/error.rs
+++ b/crates/dasclaw_runtime/src/error.rs
@@ -1,0 +1,243 @@
+//! Application-layer tool error type.
+//!
+//! See the crate-level docs for why this is separate from
+//! [`dasclaw_tool::ToolError`].
+
+use std::time::Duration;
+
+use thiserror::Error;
+
+/// Error returned by the tool dispatcher to the rest of the application.
+///
+/// Every variant that originates from a specific tool carries that tool's
+/// `name` so logs, traces and user-facing channel responses can attribute
+/// the failure correctly. The single tuple variant `BuilderFailed` describes
+/// failures of the tool **builder** subsystem (which is not itself a tool)
+/// and therefore has no tool name.
+#[derive(Debug, Error)]
+pub enum ToolError {
+    #[error("Tool {name} not found")]
+    NotFound { name: String },
+
+    #[error("Tool {name} execution failed: {reason}")]
+    ExecutionFailed { name: String, reason: String },
+
+    #[error("Tool {name} timed out after {timeout:?}")]
+    Timeout { name: String, timeout: Duration },
+
+    #[error("Invalid parameters for tool {name}: {reason}")]
+    InvalidParameters { name: String, reason: String },
+
+    #[error("Tool {name} is disabled: {reason}")]
+    Disabled { name: String, reason: String },
+
+    #[error("Sandbox error for tool {name}: {reason}")]
+    Sandbox { name: String, reason: String },
+
+    #[error("Tool {name} requires authentication")]
+    AuthRequired { name: String },
+
+    #[error("Tool {name} is not available for autonomous execution: {reason}")]
+    AutonomousUnavailable { name: String, reason: String },
+
+    #[error("Tool {name} is rate limited, retry after {retry_after:?}")]
+    RateLimited {
+        name: String,
+        retry_after: Option<Duration>,
+    },
+
+    #[error("Tool builder failed: {0}")]
+    BuilderFailed(String),
+}
+
+impl ToolError {
+    /// Convert a tool implementation-layer error
+    /// ([`dasclaw_tool::ToolError`]) into the application-layer error by
+    /// attaching the failing tool's name.
+    ///
+    /// This is the *only* supported way to lift the inner error: a blanket
+    /// `From<dasclaw_tool::ToolError>` is intentionally not provided, because
+    /// it would have to fabricate a placeholder name and silently lose the
+    /// real identity at the conversion boundary.
+    ///
+    /// # Mapping
+    ///
+    /// | Inner variant                  | Outer variant                                                   |
+    /// |--------------------------------|-----------------------------------------------------------------|
+    /// | `InvalidParameters(reason)`    | `InvalidParameters { name, reason }`                            |
+    /// | `ExecutionFailed(reason)`      | `ExecutionFailed { name, reason }`                              |
+    /// | `Timeout(d)`                   | `Timeout { name, timeout: d }`                                  |
+    /// | `NotAuthorized(reason)`        | `ExecutionFailed { name, reason: "not authorized: {reason}" }`  |
+    /// | `RateLimited(retry_after)`     | `RateLimited { name, retry_after }`                             |
+    /// | `ExternalService(reason)`      | `ExecutionFailed { name, reason: "external service: {reason}" }`|
+    /// | `Sandbox(reason)`              | `Sandbox { name, reason }`                                      |
+    ///
+    /// `NotAuthorized` is routed to `ExecutionFailed` (not `AuthRequired`)
+    /// because the runtime variant `AuthRequired { name }` carries no reason
+    /// field; folding the reason into `ExecutionFailed` preserves the
+    /// originating message instead of dropping it.
+    pub fn from_tool_impl(name: impl Into<String>, err: dasclaw_tool::ToolError) -> Self {
+        let name = name.into();
+        match err {
+            dasclaw_tool::ToolError::InvalidParameters(reason) => {
+                ToolError::InvalidParameters { name, reason }
+            }
+            dasclaw_tool::ToolError::ExecutionFailed(reason) => {
+                ToolError::ExecutionFailed { name, reason }
+            }
+            dasclaw_tool::ToolError::Timeout(timeout) => ToolError::Timeout { name, timeout },
+            dasclaw_tool::ToolError::NotAuthorized(reason) => ToolError::ExecutionFailed {
+                name,
+                reason: format!("not authorized: {reason}"),
+            },
+            dasclaw_tool::ToolError::RateLimited(retry_after) => {
+                ToolError::RateLimited { name, retry_after }
+            }
+            dasclaw_tool::ToolError::ExternalService(reason) => ToolError::ExecutionFailed {
+                name,
+                reason: format!("external service: {reason}"),
+            },
+            dasclaw_tool::ToolError::Sandbox(reason) => ToolError::Sandbox { name, reason },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn req_dasclaw_runtime_error_display_not_found() {
+        let err = ToolError::NotFound {
+            name: "fs.read".into(),
+        };
+        assert_eq!(err.to_string(), "Tool fs.read not found");
+    }
+
+    #[test]
+    fn req_dasclaw_runtime_error_display_execution_failed() {
+        let err = ToolError::ExecutionFailed {
+            name: "fs.read".into(),
+            reason: "permission denied".into(),
+        };
+        assert_eq!(
+            err.to_string(),
+            "Tool fs.read execution failed: permission denied"
+        );
+    }
+
+    #[test]
+    fn req_dasclaw_runtime_error_display_builder_failed() {
+        let err = ToolError::BuilderFailed("LLM unreachable".into());
+        assert_eq!(err.to_string(), "Tool builder failed: LLM unreachable");
+    }
+
+    #[test]
+    fn req_dasclaw_runtime_error_from_tool_impl_invalid_parameters() {
+        let inner = dasclaw_tool::ToolError::InvalidParameters("missing path".into());
+        let outer = ToolError::from_tool_impl("fs.read", inner);
+        match outer {
+            ToolError::InvalidParameters { name, reason } => {
+                assert_eq!(name, "fs.read");
+                assert_eq!(reason, "missing path");
+            }
+            other => panic!("unexpected variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn req_dasclaw_runtime_error_from_tool_impl_timeout_preserves_duration() {
+        let inner = dasclaw_tool::ToolError::Timeout(Duration::from_secs(7));
+        let outer = ToolError::from_tool_impl("net.fetch", inner);
+        match outer {
+            ToolError::Timeout { name, timeout } => {
+                assert_eq!(name, "net.fetch");
+                assert_eq!(timeout, Duration::from_secs(7));
+            }
+            other => panic!("unexpected variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn req_dasclaw_runtime_error_from_tool_impl_rate_limited_preserves_retry_after() {
+        let inner = dasclaw_tool::ToolError::RateLimited(Some(Duration::from_millis(500)));
+        let outer = ToolError::from_tool_impl("net.fetch", inner);
+        match outer {
+            ToolError::RateLimited { name, retry_after } => {
+                assert_eq!(name, "net.fetch");
+                assert_eq!(retry_after, Some(Duration::from_millis(500)));
+            }
+            other => panic!("unexpected variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn req_dasclaw_runtime_error_from_tool_impl_not_authorized_routes_to_execution_failed() {
+        // NotAuthorized must NOT silently become AuthRequired (which would
+        // drop the reason). It is routed to ExecutionFailed so the message
+        // survives the boundary crossing.
+        let inner = dasclaw_tool::ToolError::NotAuthorized("missing scope: read".into());
+        let outer = ToolError::from_tool_impl("net.fetch", inner);
+        match outer {
+            ToolError::ExecutionFailed { name, reason } => {
+                assert_eq!(name, "net.fetch");
+                assert!(
+                    reason.contains("not authorized"),
+                    "reason should be tagged: {reason}"
+                );
+                assert!(
+                    reason.contains("missing scope: read"),
+                    "original reason must be preserved: {reason}"
+                );
+            }
+            other => panic!("unexpected variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn req_dasclaw_runtime_error_from_tool_impl_external_service_preserves_reason() {
+        let inner = dasclaw_tool::ToolError::ExternalService("503 from upstream".into());
+        let outer = ToolError::from_tool_impl("net.fetch", inner);
+        match outer {
+            ToolError::ExecutionFailed { name, reason } => {
+                assert_eq!(name, "net.fetch");
+                assert!(reason.contains("external service"));
+                assert!(reason.contains("503 from upstream"));
+            }
+            other => panic!("unexpected variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn req_dasclaw_runtime_error_from_tool_impl_sandbox_passthrough() {
+        let inner = dasclaw_tool::ToolError::Sandbox("seccomp denied openat".into());
+        let outer = ToolError::from_tool_impl("fs.read", inner);
+        match outer {
+            ToolError::Sandbox { name, reason } => {
+                assert_eq!(name, "fs.read");
+                assert_eq!(reason, "seccomp denied openat");
+            }
+            other => panic!("unexpected variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn req_dasclaw_runtime_error_security_explicit_name_required() {
+        // Defence-in-depth: the *only* way to lift a tool-impl error into the
+        // app layer is `from_tool_impl(name, err)`, which forces the caller
+        // to pass a name. There is no `Default` impl and no blanket
+        // `From<dasclaw_tool::ToolError>` impl. Adding either would let the
+        // tool name silently fall back to "<unknown>" — a fail-open that
+        // would break attribution in logs / channel responses.
+        //
+        // This test pins the *happy path* of the explicit constructor;
+        // accidental introduction of a no-name fallback would be caught by
+        // reviewers via the absence of these impls in the public API.
+        let inner = dasclaw_tool::ToolError::Sandbox("guard".into());
+        let outer = ToolError::from_tool_impl("explicit", inner);
+        assert!(
+            outer.to_string().contains("explicit"),
+            "tool name must appear in Display output: {outer}"
+        );
+    }
+}

--- a/crates/dasclaw_runtime/src/lib.rs
+++ b/crates/dasclaw_runtime/src/lib.rs
@@ -1,0 +1,25 @@
+//! Application-layer runtime types shared across dasclaw hosts (ironclaw,
+//! admin-backend, claw-code, ...).
+//!
+//! ## Two-layer `ToolError` model
+//!
+//! There are *two* `ToolError` types in the codebase and that is intentional:
+//!
+//! - [`dasclaw_tool::ToolError`] is the **tool implementation layer** error.
+//!   It is what an individual tool's `execute()` returns. It carries no tool
+//!   name — the tool does not need to repeat its own identity.
+//! - [`ToolError`] (this crate) is the **application / dispatcher layer**
+//!   error. The dispatcher knows *which* tool failed, so every variant here
+//!   carries the failing tool's `name` (and any additional runtime context
+//!   such as `retry_after` for rate limiting).
+//!
+//! The conversion from the implementation layer to the application layer is
+//! intentionally **not** a blanket [`From`] impl: a free `From` could not
+//! supply the tool name and would silently fall back to `"<unknown>"` — a
+//! fail-open behaviour incompatible with the security stance of x-claw.
+//! Instead, callers must attach the name explicitly at the boundary using
+//! [`ToolError::from_tool_impl`].
+
+pub mod error;
+
+pub use error::ToolError;

--- a/desktop-client/ironclaw/Cargo.toml
+++ b/desktop-client/ironclaw/Cargo.toml
@@ -193,6 +193,10 @@ dasclaw_mcp = { path = "../../crates/dasclaw_mcp" }
 # Tool implementation-layer error type (F3.2 phase 2 PR 1; ADR-152 §3, #641).
 dasclaw_tool = { path = "../../crates/dasclaw_tool" }
 
+# Application-layer error type + future shared runtime context
+# (F3.2 phase 2 PR 2; ADR-152 §3, #641).
+dasclaw_runtime = { path = "../../crates/dasclaw_runtime" }
+
 # AWS Bedrock (native Converse API, opt-in via --features bedrock)
 aws-config = { version = "1", features = ["behavior-version-latest"], optional = true }
 aws-sdk-bedrockruntime = { version = "1", optional = true }

--- a/desktop-client/ironclaw/src/error.rs
+++ b/desktop-client/ironclaw/src/error.rs
@@ -144,42 +144,15 @@ pub enum ChannelError {
 // LlmError lives in src/llm/error.rs; re-exported here for backward compatibility.
 pub use crate::llm::error::LlmError;
 
-/// Tool execution errors.
-#[derive(Debug, thiserror::Error)]
-pub enum ToolError {
-    #[error("Tool {name} not found")]
-    NotFound { name: String },
-
-    #[error("Tool {name} execution failed: {reason}")]
-    ExecutionFailed { name: String, reason: String },
-
-    #[error("Tool {name} timed out after {timeout:?}")]
-    Timeout { name: String, timeout: Duration },
-
-    #[error("Invalid parameters for tool {name}: {reason}")]
-    InvalidParameters { name: String, reason: String },
-
-    #[error("Tool {name} is disabled: {reason}")]
-    Disabled { name: String, reason: String },
-
-    #[error("Sandbox error for tool {name}: {reason}")]
-    Sandbox { name: String, reason: String },
-
-    #[error("Tool {name} requires authentication")]
-    AuthRequired { name: String },
-
-    #[error("Tool {name} is not available for autonomous execution: {reason}")]
-    AutonomousUnavailable { name: String, reason: String },
-
-    #[error("Tool {name} is rate limited, retry after {retry_after:?}")]
-    RateLimited {
-        name: String,
-        retry_after: Option<Duration>,
-    },
-
-    #[error("Tool builder failed: {0}")]
-    BuilderFailed(String),
-}
+/// Tool execution errors (application layer — carries the failing tool's
+/// identity).
+///
+/// Moved to [`dasclaw_runtime::ToolError`] as part of F3.2 phase 2 PR 2
+/// (#641). Re-exported here so existing `crate::error::ToolError` call sites
+/// keep working. The complementary tool-implementation-layer error lives in
+/// [`dasclaw_tool::ToolError`] (no tool name); cross over with
+/// [`dasclaw_runtime::ToolError::from_tool_impl`].
+pub use dasclaw_runtime::ToolError;
 
 /// Safety/sanitization errors.
 #[derive(Debug, thiserror::Error)]


### PR DESCRIPTION
## 背景 / 目标

F3.2 phase 2 PR 2 / 共 6 个 PR 的第 2 个（PR 1 是 #642，已合）。

把 `desktop-client/ironclaw/src/error.rs::ToolError`（应用层，10 变体，struct-style 带 `name` 字段）搬到新 crate `crates/dasclaw_runtime/`。ironclaw 端通过 `pub use dasclaw_runtime::ToolError;` 做 re-export shim，约 22 处 `crate::error::ToolError::*` 调用零改动继续工作。

新增 `ToolError::from_tool_impl(name, dasclaw_tool::ToolError)` 作为两层 ToolError 模型之间**唯一**的转换入口：

- `dasclaw_tool::ToolError`（PR 1 已落） — 工具实现层，不带工具名
- `dasclaw_runtime::ToolError`（本 PR） — 应用 / 调度层，每个变体都带 `name`

## 改动范围

| 文件 | 改动 |
|---|---|
| `crates/dasclaw_runtime/Cargo.toml` | 新建 — v0.0.0-w6，依赖 `dasclaw_tool` + `thiserror` |
| `crates/dasclaw_runtime/src/lib.rs` | 新建 — crate 级文档解释两层模型 + 为什么不提供 `From` |
| `crates/dasclaw_runtime/src/error.rs` | 新建 — `ToolError` 枚举（10 变体）+ `from_tool_impl` + 10 个 `req_dasclaw_runtime_error_*` 测试 |
| `Cargo.toml`（workspace） | 在 `dasclaw_tool` 之后加 `crates/dasclaw_runtime` |
| `desktop-client/ironclaw/Cargo.toml` | 加 `dasclaw_runtime = { path = "../../crates/dasclaw_runtime" }` |
| `desktop-client/ironclaw/src/error.rs` | 把 38 行的 `ToolError` 枚举替换成单行 `pub use dasclaw_runtime::ToolError;` + 文档 |

## 设计决策：为什么不提供 `impl From<dasclaw_tool::ToolError>`

`From` 是一元 trait，但应用层的每个变体都需要 `name`（工具实现层故意不带）。如果硬写 `From`，只能用占位符 `"<unknown>"` 兜底 —— 这是**fail-open**：日志、channel response、审计 trace 都会丢失真正的工具身份，违背 x-claw 的安全姿态。

替代方案是显式构造器 `ToolError::from_tool_impl(name, err)`，强制调用方在边界（dispatcher）把工具名传进来。这是 ironclaw-main 上游用 `use crate::error::ToolError as AgentToolError;` 别名共存两份 ToolError 的同源思路。

## 变体映射（保留所有 reason 信息）

| 内层（`dasclaw_tool`） | 外层（`dasclaw_runtime`） |
|---|---|
| `InvalidParameters(reason)` | `InvalidParameters { name, reason }` |
| `ExecutionFailed(reason)` | `ExecutionFailed { name, reason }` |
| `Timeout(d)` | `Timeout { name, timeout: d }` |
| `NotAuthorized(reason)` | `ExecutionFailed { name, reason: "not authorized: {reason}" }` |
| `RateLimited(retry_after)` | `RateLimited { name, retry_after }` |
| `ExternalService(reason)` | `ExecutionFailed { name, reason: "external service: {reason}" }` |
| `Sandbox(reason)` | `Sandbox { name, reason }` |

`NotAuthorized` 路由到 `ExecutionFailed` 而不是 `AuthRequired`，是因为运行时层的 `AuthRequired { name }` 没有 reason 字段；折进 `ExecutionFailed` 才能保住原始消息，加 `"not authorized: "` 前缀做 tag。

## 非目标 / What's NOT in this PR

- 不动 `Error` enum 本身（顶层 `Error::Tool(#[from] ToolError)` 继续通过 re-export 解析）
- 不动 22 处现有调用方（pre-existing `crate::error::ToolError::NotFound { name }` 等仍然工作）
- 不动 PR 1 的 `dasclaw_tool::ToolError`（变体集合保持不变）
- 不搬 `JobContext`（留给 PR 3）
- 不搬 `SecretsStore`（留给 PR 4）
- 不接 HookRegistry / EgressGate（ADR-113 / ADR-148，留给 F3.4 / F4）

## 验证

```bash
cargo check -p dasclaw_runtime --tests             # OK (3.4s)
cargo nextest run -p dasclaw_runtime               # 10/10 pass
cargo check -p dasclaw --tests                     # OK (5m38s)
cargo nextest run -p dasclaw --lib                 # 3525/3525 pass, 3 skipped
cargo fmt --all                                    # clean
cargo clippy --no-deps -p dasclaw_runtime          # 无 warning
python3.12 scripts/check_no_panics.py              # OK
python3.12 scripts/check_no_new_ironclaw_literal.py # OK
```

测试用例（`req_dasclaw_runtime_error_*`）：
1. `display_not_found` — Display 输出格式
2. `display_execution_failed`
3. `display_builder_failed`
4. `from_tool_impl_invalid_parameters` — 边界转换基本路径
5. `from_tool_impl_timeout_preserves_duration` — Duration 不丢
6. `from_tool_impl_rate_limited_preserves_retry_after` — `Option<Duration>` 不丢
7. `from_tool_impl_not_authorized_routes_to_execution_failed` — reason 不丢，tag 正确
8. `from_tool_impl_external_service_preserves_reason` — reason 不丢，tag 正确
9. `from_tool_impl_sandbox_passthrough` — Sandbox 直通
10. `security_explicit_name_required` — fail-safe 守门测试

## 工具协助

| 调用 | 用途 / 产出 |
|---|---|
| `grep_search "error::ToolError\|crate::error::ToolError"` | 找到 22 处调用方分布在 `tools/execute.rs`（10）、`routines/scheduler.rs`（3）、`routines/self_repair.rs`（3）、`channels/channel.rs`（2）、`tools/builder/core.rs`（4）、`tools/autonomy.rs`（2）— 全部走 `crate::error::ToolError::*` 路径，shim 一行 `pub use` 即可覆盖 |
| `read_file tools/builder/core.rs:30-120` | 确认 `AgentToolError` 别名模式 + 同时使用 `ToolError::ExecutionFailed(format!())`（工具实现层）和 `AgentToolError::BuilderFailed(format!())`（应用层），双层 boundary 已经在 codebase 里形成事实 |
| `read_file dasclaw_tool/src/error.rs` | 7 变体清单，对照新设计的映射表 |

发现：`tools/builder/core.rs` 同一文件同时引用两层 ToolError，这进一步证实双层模型是上游 ironclaw-main 的既有设计，不是历史欠债。

## 关联

- 父 issue：#641（F3.2 phase 2，6 个 PR）
- 前置 PR：#640（phase 1 已合），#642（phase 2 PR 1 已合，落 `dasclaw_tool`）
- 相关 ADR：ADR-152 §F3.2，ADR-112（非破坏性迁移）
- 计划文档：`docs/plans/architecture-refactor/31-target-architecture.md` §L4，`32-execution-plan.md` §W5

Closes #641 (F3.2 phase 2 PR 2 of 6; maintainer please re-open #641 after merge — 4 more PRs follow). Refs #628, #640, #642.
