### PR TITLE
feat(dasclaw_runtime): port job state machine to shared crate (F3.2 phase 2 PR 3 of 6) [#641]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3094,7 +3094,10 @@ dependencies = [
 name = "dasclaw_runtime"
 version = "0.0.0-w6"
 dependencies = [
+ "chrono",
  "dasclaw_tool",
+ "serde",
+ "serde_json",
  "thiserror 1.0.69",
 ]
 

--- a/crates/dasclaw_runtime/Cargo.toml
+++ b/crates/dasclaw_runtime/Cargo.toml
@@ -2,9 +2,14 @@
 name = "dasclaw_runtime"
 version = "0.0.0-w6"
 edition = "2021"
-description = "Runtime (application-layer) building blocks for any dasclaw host: errors that carry the failing tool's identity, future JobContext, etc."
+description = "Runtime (application-layer) building blocks for any dasclaw host: errors that carry the failing tool's identity, job state machine, future JobContext trait extension, etc."
 license = "MIT OR Apache-2.0"
 
 [dependencies]
 dasclaw_tool = { path = "../dasclaw_tool" }
 thiserror = "1"
+serde = { version = "1", features = ["derive"] }
+chrono = { version = "0.4", features = ["serde"] }
+
+[dev-dependencies]
+serde_json = "1"

--- a/crates/dasclaw_runtime/src/job.rs
+++ b/crates/dasclaw_runtime/src/job.rs
@@ -1,0 +1,255 @@
+//! Job state machine — the headless-framework vocabulary for "what is this
+//! job doing right now?".
+//!
+//! Any dasclaw host (desktop GUI, admin-backend, claw-code, CLI, ...) needs
+//! the same finite-state model: a job can be `Pending`, in progress, stuck,
+//! completed, etc. Moving this vocabulary into the shared runtime crate is
+//! step 1 of F3.2 phase 2 PR 3 (#641): later sub-PRs will add a
+//! `JobContextCore` trait that exposes the framework-essential accessors
+//! (job id, workspace, timeout, permission context) and split the current
+//! ironclaw `JobContext` god-struct into "core fields" + GUI/marketplace
+//! trait extension.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+/// Lifecycle state of a job.
+///
+/// State transitions are validated by [`JobState::can_transition_to`]. The
+/// transition graph is conservative: only forward / well-defined edges are
+/// permitted, and `Completed -> Completed` is the single allowed self-loop
+/// (it makes the worker-wrapper / execution-loop race a no-op instead of an
+/// error that would mask a successful completion).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum JobState {
+    /// Job is waiting to be started.
+    Pending,
+    /// Job is currently being worked on.
+    InProgress,
+    /// Job work is complete, awaiting submission.
+    Completed,
+    /// Job has been submitted for review.
+    Submitted,
+    /// Job was accepted/paid.
+    Accepted,
+    /// Job failed and cannot be completed.
+    Failed,
+    /// Job is stuck and needs repair.
+    Stuck,
+    /// Job was cancelled.
+    Cancelled,
+}
+
+impl JobState {
+    /// Check if this state allows transitioning to another state.
+    pub fn can_transition_to(&self, target: JobState) -> bool {
+        use JobState::*;
+
+        // Allow idempotent Completed -> Completed transition.
+        // Both the execution loop and the worker wrapper may race to mark a
+        // job complete; the second call should be a harmless no-op rather
+        // than an error that masks the successful completion.
+        if matches!((self, target), (Completed, Completed)) {
+            return true;
+        }
+
+        matches!(
+            (self, target),
+            // From Pending
+            (Pending, InProgress) | (Pending, Cancelled) |
+            // From InProgress
+            (InProgress, Completed) | (InProgress, Failed) |
+            (InProgress, Stuck) | (InProgress, Cancelled) |
+            // From Completed
+            (Completed, Submitted) | (Completed, Failed) |
+            // From Submitted
+            (Submitted, Accepted) | (Submitted, Failed) |
+            // From Stuck (can recover or fail)
+            (Stuck, InProgress) | (Stuck, Failed) | (Stuck, Cancelled)
+        )
+    }
+
+    /// Check if this is a terminal state.
+    pub fn is_terminal(&self) -> bool {
+        matches!(self, Self::Accepted | Self::Failed | Self::Cancelled)
+    }
+
+    /// Check if the job is active (not terminal).
+    pub fn is_active(&self) -> bool {
+        !self.is_terminal()
+    }
+
+    /// Check if this job consumes a parallel execution slot.
+    ///
+    /// Only jobs in Pending, InProgress, or Stuck states consume execution
+    /// resources and should count toward the parallel job limit. Completed
+    /// and Submitted jobs are in the state machine but are no longer
+    /// actively executing.
+    pub fn is_parallel_blocking(&self) -> bool {
+        matches!(self, Self::Pending | Self::InProgress | Self::Stuck)
+    }
+}
+
+impl std::fmt::Display for JobState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            Self::Pending => "pending",
+            Self::InProgress => "in_progress",
+            Self::Completed => "completed",
+            Self::Submitted => "submitted",
+            Self::Accepted => "accepted",
+            Self::Failed => "failed",
+            Self::Stuck => "stuck",
+            Self::Cancelled => "cancelled",
+        };
+        write!(f, "{s}")
+    }
+}
+
+/// A recorded state transition event in a job's history.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StateTransition {
+    /// Previous state.
+    pub from: JobState,
+    /// New state.
+    pub to: JobState,
+    /// When the transition occurred.
+    pub timestamp: DateTime<Utc>,
+    /// Reason for the transition.
+    pub reason: Option<String>,
+}
+
+/// Error returned when a job exceeds its token budget.
+///
+/// Carries both the consumed total and the configured limit so callers can
+/// emit precise diagnostics (e.g. channel response, audit trail) without
+/// re-deriving the numbers.
+#[derive(Debug, Error)]
+#[error("Token budget exceeded: used {used} of {limit} allowed tokens")]
+pub struct TokenBudgetExceeded {
+    /// Total tokens consumed (including the call that exceeded the budget).
+    pub used: u64,
+    /// Configured token limit for this job.
+    pub limit: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn req_dasclaw_runtime_job_state_transitions_forward_allowed() {
+        assert!(JobState::Pending.can_transition_to(JobState::InProgress));
+        assert!(JobState::InProgress.can_transition_to(JobState::Completed));
+        assert!(JobState::Completed.can_transition_to(JobState::Submitted));
+        assert!(JobState::Submitted.can_transition_to(JobState::Accepted));
+    }
+
+    #[test]
+    fn req_dasclaw_runtime_job_state_transitions_backward_rejected() {
+        assert!(!JobState::Completed.can_transition_to(JobState::Pending));
+        assert!(!JobState::Accepted.can_transition_to(JobState::InProgress));
+        assert!(!JobState::Cancelled.can_transition_to(JobState::Pending));
+    }
+
+    #[test]
+    fn req_dasclaw_runtime_job_state_idempotent_completed_only() {
+        // The single allowed self-loop: Completed -> Completed. Models the
+        // worker-wrapper vs execution-loop race.
+        assert!(JobState::Completed.can_transition_to(JobState::Completed));
+
+        // All other self-loops are forbidden.
+        assert!(!JobState::Pending.can_transition_to(JobState::Pending));
+        assert!(!JobState::InProgress.can_transition_to(JobState::InProgress));
+        assert!(!JobState::Failed.can_transition_to(JobState::Failed));
+        assert!(!JobState::Stuck.can_transition_to(JobState::Stuck));
+        assert!(!JobState::Submitted.can_transition_to(JobState::Submitted));
+        assert!(!JobState::Accepted.can_transition_to(JobState::Accepted));
+        assert!(!JobState::Cancelled.can_transition_to(JobState::Cancelled));
+    }
+
+    #[test]
+    fn req_dasclaw_runtime_job_state_terminal_classification() {
+        assert!(JobState::Accepted.is_terminal());
+        assert!(JobState::Failed.is_terminal());
+        assert!(JobState::Cancelled.is_terminal());
+        // Active states
+        assert!(!JobState::Pending.is_terminal());
+        assert!(!JobState::InProgress.is_terminal());
+        assert!(!JobState::Stuck.is_terminal());
+        assert!(!JobState::Completed.is_terminal());
+        assert!(!JobState::Submitted.is_terminal());
+        // is_active is the strict complement
+        assert!(!JobState::Accepted.is_active());
+        assert!(JobState::Pending.is_active());
+    }
+
+    #[test]
+    fn req_dasclaw_runtime_job_state_parallel_blocking_set() {
+        // These three states reserve a parallel-execution slot.
+        assert!(JobState::Pending.is_parallel_blocking());
+        assert!(JobState::InProgress.is_parallel_blocking());
+        assert!(JobState::Stuck.is_parallel_blocking());
+
+        // Completed/Submitted are still alive but no longer hold a slot;
+        // misclassifying them would deadlock the worker pool.
+        assert!(!JobState::Completed.is_parallel_blocking());
+        assert!(!JobState::Submitted.is_parallel_blocking());
+        assert!(!JobState::Accepted.is_parallel_blocking());
+        assert!(!JobState::Failed.is_parallel_blocking());
+        assert!(!JobState::Cancelled.is_parallel_blocking());
+    }
+
+    #[test]
+    fn req_dasclaw_runtime_job_state_display_lowercase_snake() {
+        // Display output is the on-wire / log format; downstream channels
+        // depend on it. snake_case keeps the rendering consistent with the
+        // serde `rename_all = "snake_case"` directive.
+        assert_eq!(JobState::Pending.to_string(), "pending");
+        assert_eq!(JobState::InProgress.to_string(), "in_progress");
+        assert_eq!(JobState::Stuck.to_string(), "stuck");
+    }
+
+    #[test]
+    fn req_dasclaw_runtime_job_state_serde_round_trip_snake_case() {
+        let json = serde_json::to_string(&JobState::InProgress).expect("serialize");
+        assert_eq!(json, "\"in_progress\"");
+        let back: JobState = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back, JobState::InProgress);
+    }
+
+    #[test]
+    fn req_dasclaw_runtime_state_transition_round_trip() {
+        let t = StateTransition {
+            from: JobState::Pending,
+            to: JobState::InProgress,
+            timestamp: chrono::DateTime::<Utc>::from_timestamp(1_700_000_000, 0).unwrap(),
+            reason: Some("worker picked up".into()),
+        };
+        let json = serde_json::to_string(&t).expect("serialize");
+        // Field names and snake-case state values must survive the round
+        // trip — downstream consumers (web channels, audit log) rely on it.
+        assert!(json.contains("\"from\":\"pending\""));
+        assert!(json.contains("\"to\":\"in_progress\""));
+        assert!(json.contains("worker picked up"));
+        let back: StateTransition = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back.from, JobState::Pending);
+        assert_eq!(back.to, JobState::InProgress);
+        assert_eq!(back.timestamp, t.timestamp);
+        assert_eq!(back.reason.as_deref(), Some("worker picked up"));
+    }
+
+    #[test]
+    fn req_dasclaw_runtime_token_budget_exceeded_display() {
+        let err = TokenBudgetExceeded {
+            used: 12_345,
+            limit: 10_000,
+        };
+        assert_eq!(
+            err.to_string(),
+            "Token budget exceeded: used 12345 of 10000 allowed tokens"
+        );
+    }
+}

--- a/crates/dasclaw_runtime/src/lib.rs
+++ b/crates/dasclaw_runtime/src/lib.rs
@@ -1,6 +1,14 @@
 //! Application-layer runtime types shared across dasclaw hosts (ironclaw,
 //! admin-backend, claw-code, ...).
 //!
+//! ## Modules
+//!
+//! - [`error`] — application-layer `ToolError` carrying the failing tool's
+//!   identity (F3.2 phase 2 PR 2).
+//! - [`job`] — pure job state machine (`JobState`, `StateTransition`,
+//!   `TokenBudgetExceeded`); the headless-framework vocabulary for "what is
+//!   this job doing right now?" (F3.2 phase 2 PR 3).
+//!
 //! ## Two-layer `ToolError` model
 //!
 //! There are *two* `ToolError` types in the codebase and that is intentional:
@@ -21,5 +29,7 @@
 //! [`ToolError::from_tool_impl`].
 
 pub mod error;
+pub mod job;
 
 pub use error::ToolError;
+pub use job::{JobState, StateTransition, TokenBudgetExceeded};

--- a/desktop-client/ironclaw/src/context/state.rs
+++ b/desktop-client/ironclaw/src/context/state.rs
@@ -1,4 +1,12 @@
 //! Job state machine.
+//!
+//! The pure state-machine vocabulary (`JobState`, `StateTransition`,
+//! `TokenBudgetExceeded`) lives in [`dasclaw_runtime::job`] as of F3.2
+//! phase 2 PR 3 (#641) — any dasclaw host needs the same model. This file
+//! re-exports those types and keeps the ironclaw-specific `JobContext`
+//! god-struct, which still owns GUI/marketplace fields. The god-struct
+//! split into a `JobContextCore` trait + GUI extension is the follow-up
+//! sub-PR.
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -6,121 +14,13 @@ use std::time::Duration;
 
 use chrono::{DateTime, Utc};
 use rust_decimal::Decimal;
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use uuid::Uuid;
+
+pub use dasclaw_runtime::{JobState, StateTransition, TokenBudgetExceeded};
 
 use crate::llm::recording::HttpInterceptor;
 use crate::tools::feature_flags::{SharedFeatureFlags, ToolFeatureFlags};
-
-/// Error returned when a job exceeds its token budget.
-#[derive(Debug, thiserror::Error)]
-#[error("Token budget exceeded: used {used} of {limit} allowed tokens")]
-pub struct TokenBudgetExceeded {
-    /// Total tokens consumed (including the call that exceeded the budget).
-    pub used: u64,
-    /// Configured token limit for this job.
-    pub limit: u64,
-}
-
-/// State of a job.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum JobState {
-    /// Job is waiting to be started.
-    Pending,
-    /// Job is currently being worked on.
-    InProgress,
-    /// Job work is complete, awaiting submission.
-    Completed,
-    /// Job has been submitted for review.
-    Submitted,
-    /// Job was accepted/paid.
-    Accepted,
-    /// Job failed and cannot be completed.
-    Failed,
-    /// Job is stuck and needs repair.
-    Stuck,
-    /// Job was cancelled.
-    Cancelled,
-}
-
-impl JobState {
-    /// Check if this state allows transitioning to another state.
-    pub fn can_transition_to(&self, target: JobState) -> bool {
-        use JobState::*;
-
-        // Allow idempotent Completed -> Completed transition.
-        // Both the execution loop and the worker wrapper may race to mark a
-        // job complete; the second call should be a harmless no-op rather
-        // than an error that masks the successful completion.
-        if matches!((self, target), (Completed, Completed)) {
-            return true;
-        }
-
-        matches!(
-            (self, target),
-            // From Pending
-            (Pending, InProgress) | (Pending, Cancelled) |
-            // From InProgress
-            (InProgress, Completed) | (InProgress, Failed) |
-            (InProgress, Stuck) | (InProgress, Cancelled) |
-            // From Completed
-            (Completed, Submitted) | (Completed, Failed) |
-            // From Submitted
-            (Submitted, Accepted) | (Submitted, Failed) |
-            // From Stuck (can recover or fail)
-            (Stuck, InProgress) | (Stuck, Failed) | (Stuck, Cancelled)
-        )
-    }
-
-    /// Check if this is a terminal state.
-    pub fn is_terminal(&self) -> bool {
-        matches!(self, Self::Accepted | Self::Failed | Self::Cancelled)
-    }
-
-    /// Check if the job is active (not terminal).
-    pub fn is_active(&self) -> bool {
-        !self.is_terminal()
-    }
-
-    /// Check if this job consumes a parallel execution slot.
-    ///
-    /// Only jobs in Pending, InProgress, or Stuck states consume execution resources
-    /// and should count toward the parallel job limit. Completed and Submitted jobs
-    /// are in the state machine but are no longer actively executing.
-    pub fn is_parallel_blocking(&self) -> bool {
-        matches!(self, Self::Pending | Self::InProgress | Self::Stuck)
-    }
-}
-
-impl std::fmt::Display for JobState {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let s = match self {
-            Self::Pending => "pending",
-            Self::InProgress => "in_progress",
-            Self::Completed => "completed",
-            Self::Submitted => "submitted",
-            Self::Accepted => "accepted",
-            Self::Failed => "failed",
-            Self::Stuck => "stuck",
-            Self::Cancelled => "cancelled",
-        };
-        write!(f, "{}", s)
-    }
-}
-
-/// A state transition event.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct StateTransition {
-    /// Previous state.
-    pub from: JobState,
-    /// New state.
-    pub to: JobState,
-    /// When the transition occurred.
-    pub timestamp: DateTime<Utc>,
-    /// Reason for the transition.
-    pub reason: Option<String>,
-}
 
 /// Context for a running job.
 #[derive(Debug, Clone, Serialize)]


### PR DESCRIPTION
## 背景 / 目标

F3.2 phase 2 第 3 个 PR(共 6 个)。将 ironclaw 内的纯 Job 状态机词汇迁移到共享的 `dasclaw_runtime` crate,让任何 dasclaw 宿主(桌面 GUI / admin-backend / claw-code / CLI)都能复用同一套有限状态模型,这是"无头 agent 框架"的基础词汇。

Closes #641 (F3.2 phase 2 PR 3 of 6)

**Stacked on #644** (PR 2 引入 `dasclaw_runtime` crate)。先看 #644 再看本 PR;待 #644 合并后本 PR 会自动 rebase 到干净的 `xClaw` 基线。

## 改动范围

新建 `crates/dasclaw_runtime/src/job.rs`:

- `JobState` 枚举(8 个状态)+ `can_transition_to` / `is_terminal` / `is_active` / `is_parallel_blocking` + `Display`
- `StateTransition`(状态转换历史事件)
- `TokenBudgetExceeded`(thiserror 错误类型,带 `used` / `limit` 数值)

`desktop-client/ironclaw/src/context/state.rs` 通过 `pub use dasclaw_runtime::{JobState, StateTransition, TokenBudgetExceeded};` 透明转发,不修改任何调用方。

新增 9 个 `req_dasclaw_runtime_*` 测试。

## 非目标

- `JobContext` god-struct 本体未拆分,留给 sub-PR 3b。
- 不动 `JobContext::transition_to` / `add_tokens`(留在 ironclaw,通过 re-export 工作)。
- 不动 `skills/registry.rs::SkillRegistryError::TokenBudgetExceeded`(同名不同语义)。
- 不引入新的 trait / 抽象层。

## 验证

```
cargo check -p dasclaw_runtime --tests              OK
cargo nextest run -p dasclaw_runtime                19/19 passed
cargo check -p dasclaw --tests                      OK
cargo fmt --all                                     OK
cargo clippy --no-deps -p dasclaw_runtime --all-targets -- -D warnings  OK
python3.12 scripts/check_no_panics.py --base origin/xClaw                OK
python3.12 scripts/check_no_new_ironclaw_literal.py --base origin/xClaw --head HEAD  OK
```

## Sources read

- `AGENTS.md` § 中文规约 / Skills 强制使用规范 / 红线
- `.github/copilot-instructions.md` § 1–7
- `#641` issue body § F3.2 phase 2 六个 PR 拆分清单
- `desktop-client/ironclaw/src/context/state.rs` § 全文(1-440 行)
- `desktop-client/ironclaw/src/context/mod.rs` § L17 re-export
- `crates/dasclaw_runtime/src/lib.rs` § PR 2 docs
- `skills/code-review-graph-usage/SKILL.md` § Pitfall #1

## 工具协助

- `mcp_code-review-g_build_or_update_graph_tool` 刷新图(增量 no-op)
- `mcp_code-review-g_query_graph_tool callers_of JobContext` → ambiguous,复现了 skill Pitfall #1(CALLS 边只指向 Function 节点)
- `mcp_code-review-g_get_impact_radius_tool` 返回 0 节点(Class 节点未覆盖,符合 skill 说明)
- Fallback 到 `grep_search`:`TokenBudgetExceeded` 6 处 / `StateTransition` 5 处 / `JobState` 50+ 处
- 3 层自审:`code-quality-audit` 无 unwrap/panic 入生产 / `code-simplifier` re-export shim 是最小集 / `code-review-expert` API 表面小且聚焦,`Copy` 行为与原始一致,snake_case serde + Display 防止 wire format 漂移
