### PR TITLE
docs(skills): sync upstream code-review-graph 7 skills into code-review-graph-usage [#648]

### DIFF
--- a/skills/code-review-graph-usage/SKILL.md
+++ b/skills/code-review-graph-usage/SKILL.md
@@ -129,9 +129,169 @@ mcp_code-review-g_detect_changes_tool()
 - [ ] 想查类型用方时，直接用 grep，不浪费时间在 `callers_of` 上
 - [ ] PR 描述里准备好"## 工具协助"段
 
+## Token-Efficiency 规则（来自上游 skill）
+
+上游 `tirth8205/code-review-graph` 的 7 个官方 skill 都在 footer 强调同一组限额，本仓采用：
+
+- **任何 graph 工具调用之前，先调一次 `get_minimal_context(task="<这一轮任务的一句话描述>")`**。
+  服务端会按任务返回最小必要节点集，省下来回探查的 token。
+- 所有 graph 工具能传 `detail_level` 的，默认填 `"minimal"`；只有 minimal 信息不够再升 `"standard"`。
+- **每一轮 review / debug / refactor 任务的预算上限：≤5 次 graph 工具调用、≤800 输出 token**。
+  超出时停下来切换策略（grep / 读源文件 / 跨 repo），不要在同一 pattern 上反复打。
+
+## 上游 7 个标准工作流（recipes）
+
+下面把上游 `skills/<name>/SKILL.md` 的步骤序列翻译成本仓可直接套用的脚本。每条都假设你已经
+按"标准操作顺序"做完图谱 last_updated 校验。
+
+### Recipe A — build-graph（首次或长时间未刷）
+
+```text
+1. list_graph_stats_tool()              # 看 last_updated；若 null → full rebuild
+2. build_or_update_graph_tool(full_rebuild=True)   # 仅首次
+   或 build_or_update_graph_tool()                 # 增量
+3. list_graph_stats_tool()              # 复验：files / nodes / edges / languages
+```
+
+何时用：第一次接 repo、做了大重构 / 切大分支、`detect_changes` 报"0 个改动函数"
+（即坑位 5）后。其他时间 hooks 自己会跑。
+
+### Recipe B — explore-codebase（陌生区域摸底）
+
+```text
+1. get_minimal_context(task="explore <module/feature>")
+2. list_graph_stats_tool()              # 总览
+3. get_architecture_overview_tool()     # 社区/模块拓扑
+4. list_communities_tool() → get_community_tool(<community_id>)
+5. semantic_search_nodes_tool(<key term>)            # 嵌入可用时
+   或 query_graph_tool(pattern="children_of", target=<file>)  # 嵌入不可用时
+6. query_graph_tool(pattern="callers_of|callees_of|imports_of", target=...)
+```
+
+何时用：开始研究一个你不熟的子系统(e.g. mcp / sandbox / setup) 之前。
+**先广后窄**（stats → arch → community → node）。
+
+### Recipe C — refactor-safely（重命名 / 找 dead code）
+
+```text
+1. get_minimal_context(task="refactor <symbol>")
+2. refactor_tool(mode="suggest")        # 社区驱动的拆分建议
+3. refactor_tool(mode="dead_code")      # 找未引用代码
+4. refactor_tool(mode="rename", from=<old>, to=<new>)
+                                        # 只 preview，不落盘；返回 refactor_id 和 edit list
+5. apply_refactor_tool(refactor_id=...) # 确认 edit list OK 后再应用
+6. detect_changes_tool() + get_impact_radius_tool()   # 复验
+```
+
+**关键安全闸**：rename 必须先 preview 看完整 edit list 再 apply，不直接落盘；
+大重构前用 `get_affected_flows_tool` 确认没碰到关键执行路径。
+
+### Recipe D — debug-issue（追故障）
+
+```text
+1. get_minimal_context(task="debug <symptom>")
+2. semantic_search_nodes_tool(<error message / fn name>)   # 嵌入可用时
+3. query_graph_tool(pattern="callers_of"|"callees_of", target=<可疑函数>)
+4. get_flow_tool(<entry point>)         # 完整执行路径
+5. detect_changes_tool()                # 最近 commits 有没有改这块
+6. get_impact_radius_tool()             # 评估波及面
+```
+
+**经验**：新 bug 90% 是最近 commits 引入的，先看 `detect_changes` 再看 flow。
+
+### Recipe E — review-delta（"提交以来"的快速增量评审）
+
+```text
+1. build_or_update_graph_tool()         # 先刷
+2. get_review_context_tool()            # 自动读 git diff → 返回:
+                                        #   - 改动文件
+                                        #   - impacted_nodes / impacted_files (blast radius)
+                                        #   - 源码片段
+                                        #   - 评审提示(测试缺口、宽影响、继承变更)
+3. 对每个 impacted_node:
+   - 看片段 → 找 bug / style
+   - query_graph_tool(pattern="tests_for", target=<func>)   # 测试覆盖
+4. 标出无测试的改动 + 高影响 caller
+```
+
+**优势**：只发 changed + 2-hop 邻居进上下文,token 比全 repo 评审低 5–10 倍。
+
+### Recipe F — review-changes（带风险评分的全面评审）
+
+```text
+1. detect_changes_tool()                # 风险评分（high / medium / low）
+2. get_affected_flows_tool()            # 影响的执行路径
+3. 对每个 high-risk 函数:
+     query_graph_tool(pattern="tests_for", target=<func>)
+4. get_impact_radius_tool()
+5. 按风险等级汇报:
+     - 改了什么 / 为什么要紧
+     - 测试覆盖状态
+     - 改进建议
+     - 合并建议（merge / hold / revert）
+```
+
+### Recipe G — review-pr（PR / branch 整体评审,贴进 PR 描述）
+
+```text
+1. 确定 PR/branch:  git diff main...<branch>
+2. build_or_update_graph_tool(base="main")
+3. get_review_context_tool(base="main")          # 返回所有 commits 改动总和
+4. get_impact_radius_tool(base="main")           # PR 整体 blast radius
+5. 逐文件深挖（高 impact 优先）:
+     - 读完整源码（含本 PR 之外的上下文）
+     - query_graph_tool(pattern="callers_of", target=<高风险函数>)
+     - query_graph_tool(pattern="tests_for", target=<func>)
+     - 检查公共 API 是否有破坏性变更
+6. 按下面模板出报告:
+```
+
+PR 评审输出模板（可直接贴 PR 评论 / "## 工具协助"段）：
+
+```text
+## PR Review: <title>
+
+### Summary
+<1–3 句概览>
+
+### Risk Assessment
+- Overall risk: Low / Medium / High
+- Blast radius: X files, Y functions impacted
+- Test coverage: N changed functions covered / M total
+
+### File-by-File Review
+#### <file_path>
+- Changes: <一句话>
+- Impact: <谁依赖它>
+- Issues: <bug / style / 顾虑>
+
+### Missing Tests
+- <function_name> in <file> — 未覆盖
+
+### Recommendations
+1. <可执行的具体建议>
+2. <可执行的具体建议>
+```
+
+**大 PR 建议**：先看 impact 最高（最多 dependent）的文件;用 `semantic_search_nodes`
+找可能漏改的相关代码;确认 rename/move 的函数所有 caller 都更新了。
+
+## 选 Recipe 的速查
+
+| 场景 | Recipe |
+|---|---|
+| 第一次接仓 / 图过期 | A (build-graph) |
+| "我要搞懂这块代码" | B (explore-codebase) |
+| "我要改名 / 删死代码" | C (refactor-safely) |
+| "用户报了个 bug,我要追源头" | D (debug-issue) |
+| "刚改完代码自查一下" | E (review-delta) |
+| "整段功能合并前最后过一遍" | F (review-changes) |
+| "开 PR 之前出评审报告" | G (review-pr) |
+
 ## 关联
 
 - 工具来源：`.vscode/mcp.json` 第 41-44 行 stdio server 配置
 - 二进制：`/Users/nallylin/.local/bin/code-review-graph`
 - venv：`/Users/nallylin/.local/share/code-review-graph-venv/`
+- 上游 7 个 skill 原文：`github.com/tirth8205/code-review-graph/tree/main/skills/{build-graph,debug-issue,explore-codebase,refactor-safely,review-changes,review-delta,review-pr}/SKILL.md`
 - 推荐配合：`code-review-expert`（语义评审）、`adr-compliance-check`（红线检查）、`code-quality-audit`（工艺审查）


### PR DESCRIPTION
Closes #648.
docs(skills): sync upstream code-review-graph 7 skills into code-review-graph-usage

## 背景

用户在上一轮指出上游 `tirth8205/code-review-graph` 在 `skills/` 目录下维护了 7 个
官方提示词(build-graph / debug-issue / explore-codebase / refactor-safely /
review-changes / review-delta / review-pr),它们以 Claude Code 的"目录 + SKILL.md"
格式提供。

本仓已有 `skills/code-review-graph-usage/SKILL.md`(spec-kit 单文件格式),里面已经
覆盖了我们仓库踩过的 6 个坑、跨 6 个 repo 的 alias、本地常用查询表。直接把上游
7 份 .md 复制进来会重复且格式不兼容,所以本 PR 把上游里**我们之前没记录**的部分
蒸馏成两块新内容,追加到现有 SKILL.md 末尾,而不是新建文件。

## 改动范围

`skills/code-review-graph-usage/SKILL.md`(+160 行,纯追加):

1. **Token-Efficiency 规则**:上游 7 个 skill footer 都强调的限额
   - 任何 graph 工具前先调 `get_minimal_context(task=...)`
   - 默认 `detail_level="minimal"`,minimal 不够再升 standard
   - 每轮任务预算 ≤5 次调用 / ≤800 token,超出就换策略

2. **7 个工作流脚手架(Recipe A–G)**:把上游每个 skill 翻译成本仓可直接套用的
   命令序列
   - A (build-graph): 首次或长时间未刷
   - B (explore-codebase): 陌生区域摸底,**先广后窄**
   - C (refactor-safely): 重命名 / 找 dead code,**preview-then-apply 安全闸**
   - D (debug-issue): 追故障,**先看 detect_changes 再看 flow**
   - E (review-delta): "提交以来"的快速增量评审
   - F (review-changes): 带风险评分的全面评审
   - G (review-pr): PR 整体评审 + 输出报告模板(可直接贴 PR 评论)

3. **Recipe 速查表**:7 行场景 → recipe 映射,便于秒选

## 非目标

- **不复制上游原文**:格式不兼容(目录+多文件 vs 我们 spec-kit 单文件),且我们已经
  有更具针对性的"6 个坑位"实战内容
- **不动 `manifest.json` / `README.md`**:它们不需要改
- **不新增 skill 目录**:用户明确要求 "sync 到现有 code-review-graph-usage"

## 关联

- 上游 7 个 SKILL.md:
  `github.com/tirth8205/code-review-graph/tree/main/skills/<name>/SKILL.md`
- 本仓 MCP 配置:`.vscode/mcp.json` 第 41-44 行

## 验证

文档改动,无代码闸门需要跑。手动通读追加段落:
- 没有覆盖原有 6 个坑位 / alias 表 / 自检清单
- 新追加的命令名称与 `mcp_code-review-g_*` 实际工具名一致
- Recipe 速查表覆盖所有 7 个上游 skill

## Sources read

- 现有 `skills/code-review-graph-usage/SKILL.md`(避免重复)
- 上游 7 份 `SKILL.md`(通过 GitHub API + raw.githubusercontent 拉取)
- `AGENTS.md` Skills 强制使用规范段(docs PR 也算 PR,要 Closes / 工具协助)
