### PR TITLE
fix(ci): 在 xClaw fork 关闭 Code Coverage 的 WASM 依赖 job (#655)

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -42,6 +42,15 @@ permissions:
 jobs:
   coverage:
     name: Coverage (${{ matrix.name }})
+    # disabled in xClaw fork: this job's "Build WASM channels" step calls
+    # ./scripts/build-wasm-extensions.sh inherited from ironclaw, which is not
+    # present at the xClaw workspace root (the script only exists under
+    # desktop-client/ironclaw/scripts/ and ironclaw-main/scripts/). The
+    # channels-src/ WIT extensions are not active in this fork, so the
+    # coverage matrix would always exit 127 at that step. Mirrors the same
+    # `if: false` guard already applied in test.yml (wasm-wit-compat,
+    # bench-compile). Re-enable when WASM channels return to xClaw.
+    if: false
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -129,6 +138,10 @@ jobs:
 
   e2e-coverage:
     name: E2E Coverage
+    # disabled in xClaw fork: same reason as the `coverage` job above —
+    # ./scripts/build-wasm-extensions.sh is not present at the xClaw
+    # workspace root, so the "Build WASM channels" step would exit 127.
+    if: false
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:


### PR DESCRIPTION
fix(ci): 在 xClaw fork 关闭 Code Coverage 的 WASM 依赖 job (#655)

## 背景 / 目标

xClaw 分支每次 push 都让 `Code Coverage` workflow 红：

- `Coverage (all-features) / (default) / (libsql-only)` 与 `E2E Coverage` 这
  四个 job 都在 "Build WASM channels" 那一步退出 127。
- 错误信息：`./scripts/build-wasm-extensions.sh: No such file or directory`。

`./scripts/build-wasm-extensions.sh` 只存在于
`desktop-client/ironclaw/scripts/` 和 `ironclaw-main/scripts/` 下，xClaw 仓库
根 `scripts/` 没有这个脚本（fork 没有保留 channels-src/WIT 扩展构建）。
`test.yml` 早就把同样依赖此脚本的 `wasm-wit-compat`、`bench-compile` 两个 job
用 `if: false` + "disabled in xClaw fork ..." 注释关掉了；`coverage.yml` 漏改
了一处。

## 改动范围

- `.github/workflows/coverage.yml`：
  - `coverage` 矩阵 job 与 `e2e-coverage` job 各加 `if: false` + 解释注释，
    完全沿用 `test.yml` 已有的写法（保留 job 定义，方便未来恢复 WASM channels
    时去掉 `if: false` 直接复活）。

## 非目标 (What's NOT in this PR)

- 不把 `build-wasm-extensions.sh` 复制到 xClaw 根，也不重新引入 WASM 通道构建
  ——属于 fork 战略问题，超出本 PR。
- 不删除 workflow 文件本身。
- 不动 `desktop-client/ironclaw/.github/workflows/coverage.yml` 这份 vendor
  副本。

## 验证（命令 + 结果）

```bash
/tmp/venv-yaml/bin/python -c "import yaml; d=yaml.safe_load(open('.github/workflows/coverage.yml')); print('coverage.if=',d['jobs']['coverage'].get('if')); print('e2e-coverage.if=',d['jobs']['e2e-coverage'].get('if'))"
# coverage.if= False
# e2e-coverage.if= False
```

GitHub Actions 解析 `if: false` 时会在调度阶段直接跳过 job（不会拉 service
container、不会执行任何 step），与 `test.yml` 同一份 fork-drift 处理一致。

## 3 层自查

- 质量：最小化修改，沿用 `test.yml` 的 `if: false` + "disabled in xClaw fork
  ..." 写法，不引入新约定。
- 简化：保留 job 定义而不是删除，方便未来恢复 WASM channels 时去掉 guard 直
  接复活，符合本仓库现有约定。
- 安全：`if: false` 在 job 调度阶段就短路，不会启动 postgres service
  container、不会执行任何 step；这条 workflow 也不是合并必需检查（之前红
  了几十次也没拦住合并），关闭后不会绕过任何强制门禁。

## Sources read

- `AGENTS.md` §1、§3（红线）、§4（PR 必填）
- `.github/workflows/test.yml`（lines 232–254：`wasm-wit-compat` 与
  `bench-compile` 的 `if: false` 写法）
- `.github/workflows/coverage.yml`（修改前后）
- failing run https://github.com/Linnanli/xClaw/actions/runs/26101061338 的
  `E2E Coverage` 与 `Coverage (libsql-only)` 失败 step 日志

Closes #655
