### PR TITLE
fix(ci): check_no_panics.py 区分 Rust 生命周期与 char 字面量 (#657)

### DIFF
--- a/scripts/check_no_panics.py
+++ b/scripts/check_no_panics.py
@@ -141,9 +141,33 @@ def sanitize_line(line: str, state: LexerState) -> str:
             i += 1
             continue
         if ch == "'":
-            # This can misclassify lifetimes like `'a` as char literals. That only
-            # risks false negatives by masking later code on the same line.
-            state.in_char = True
+            # Distinguish a char literal from a Rust lifetime annotation.
+            #
+            # The previous version always entered char-literal mode on any `'`,
+            # which meant a lifetime such as `&'a str` or `Foo<'_>` would open
+            # an `in_char` state that only closed on the *next* `'` — often
+            # many lines later (e.g. an English apostrophe inside a comment
+            # like `doesn't`). Everything in between was sanitised to spaces,
+            # silently masking `#[cfg(test)]` / `mod tests {` and producing
+            # false-positive panic violations on test-only `assert!` calls.
+            #
+            # Grammar: a Rust char literal is either `'\<escape>...'` or
+            # `'<single-char>'`. A lifetime is `'` followed by an identifier
+            # character (or `_`) without an immediate closing `'`. We use a
+            # bounded look-ahead — no token scan — so we never advance past
+            # the closing quote when it really is a char literal.
+            if nxt == "\\":
+                # Escaped char literal, e.g. `'\n'`, `'\''`, `'\u{1F600}'`.
+                state.in_char = True
+                i += 1
+                continue
+            if i + 2 < len(chars) and chars[i + 2] == "'":
+                # Single-char literal, e.g. `'a'` or `'!'`.
+                state.in_char = True
+                i += 1
+                continue
+            # Treat as a lifetime: skip just the apostrophe and keep scanning
+            # normal code on the rest of the line.
             i += 1
             continue
 
@@ -420,6 +444,47 @@ class CheckNoPanicsTests(unittest.TestCase):
         self.assertFalse(is_test_only_file(pathlib.Path("src/lib.rs")))
         self.assertFalse(is_test_only_file(pathlib.Path("src/seatbelt.rs")))
         self.assertFalse(is_test_only_file(pathlib.Path("src/notests.rs")))
+
+    def test_lifetime_annotation_does_not_swallow_following_lines(self) -> None:
+        # Regression for #657: an `&'a str` lifetime used to open the lexer's
+        # `in_char` state and mask the rest of the file until the next `'`,
+        # so `#[cfg(test)] mod tests { ... }` would never be recognised and
+        # test-only `assert!` calls were flagged as production panics.
+        lines = [
+            "pub enum EffectiveTransport<'a> {\n",
+            "    Stdio { args: &'a [String] },\n",
+            "    Unix { socket_path: &'a str },\n",
+            "}\n",
+            "\n",
+            "#[cfg(test)]\n",
+            "mod tests {\n",
+            "    #[test]\n",
+            "    fn t() {\n",
+            "        assert!(true);\n",
+            "    }\n",
+            "}\n",
+        ]
+
+        contexts = line_test_contexts(lines)
+
+        # The assert! sits inside `mod tests` and must be marked test-context.
+        self.assertTrue(contexts[9], f"contexts={contexts}")
+
+    def test_real_char_literals_still_mask_string_content(self) -> None:
+        # Char literals are still recognised so that e.g. an `assert!`-shaped
+        # token sitting inside `'!'` would not flag — though in practice the
+        # PANIC_PATTERN already requires `!` adjacency. Cover both forms.
+        lines = [
+            "fn f() {\n",
+            "    let c: char = 'a';\n",
+            "    let n: char = '\\n';\n",
+            "    let u: char = '\\u{1F600}';\n",
+            "}\n",
+        ]
+
+        # Should run without panicking and leave context = False (no test).
+        contexts = line_test_contexts(lines)
+        self.assertFalse(any(contexts))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
fix(ci): check_no_panics.py 区分 Rust 生命周期与 char 字面量 (#657)

## 背景 / 目标

`scripts/check_no_panics.py` 的 `sanitize_line` 看到任意 `'` 就进入 `in_char`
状态，并一直保留到下一个 `'`。当源码出现 Rust 生命周期标注（`&'a str` /
`<'a>` / `'_`），开头那个 `'` 后没有立刻闭合，词法器会把后续所有字符当成
char 字面量"吞掉"，直到下一行某处出现 `'`（例如注释里的英文撇号
`doesn't`）才退出。

落到 PR #653 (`feat/f3.2-phase2-pr5a-dasclaw-mcp-config-#641`):
- `crates/dasclaw_mcp/src/config.rs` 第 502/506/510 行多个 `'a` lifetime 反复
  入栈，最后一次开在 510 行，直到 709 行才被关掉。
- 期间 515 行 `#[cfg(test)] mod tests {` 被完全脱字成空白，test 上下文识别
  不到，`block_stack` 没把 test-context 入栈。
- 711 行 `assert!(!config.requires_auth());` 误报为生产 panic。
- 同一波 CI 里 `Code Style (fmt + clippy + deny)` 的聚合 bash 第 4 位是上面
  这个 panic check，所以两条红同根。

脚本里其实自己留了 known-limitation 注释（line 144），但实际效果跨行，不是
只在同一行。

## 改动范围

只动 `scripts/check_no_panics.py`：

1. `sanitize_line` 在遇到 `'` 时做最小程度的前瞻区分：
   - `'\…'`（转义 char 字面量）→ 进入 `in_char`
   - `'<x>'`（单字节 char 字面量）→ 进入 `in_char`
   - 其它一律视作生命周期，仅跳过 `'`，不进入 char 状态
2. 加两条 unittest：
   - `test_lifetime_annotation_does_not_swallow_following_lines`：覆盖
     `EffectiveTransport<'a>` / `&'a [String]` / `&'a str` + `#[cfg(test)]
     mod tests` + `assert!` 这条 #657 回归现场，断言 `assert!` 行被识别为
     test-context。
   - `test_real_char_literals_still_mask_string_content`：覆盖 `'a'` /
     `'\n'` / `'\u{1F600}'` 三种合法 char 字面量仍能被处理掉。

## 非目标

- 不动 `dasclaw_mcp/src/config.rs` 本身。
- 不批量给现有 lifetime 文件加 `// safety: ...` 抑制（那是补丁式做法，被
  AGENTS.md §2 明确禁止）。
- 不动 workflow / 其它 drift guard。

## 验证

```bash
python3.12 scripts/check_no_panics.py --self-test
# Ran 7 tests in 0.001s
# OK

# 在 PR #653 分支上跑改后脚本：
git checkout feat/f3.2-phase2-pr5a-dasclaw-mcp-config-#641
python3.12 /tmp/patched.py --base origin/xClaw
# OK: No panic-inducing calls in changed production code.
```

修复合入 xClaw 后，PR #653、#654（PR 5a/5b 栈）的 panic check 与 code style
聚合检查在重新 push / rerun 时都会转绿。

## 3 层自查

- 质量：前瞻只看后 2 个字符，没有 token 扫描，匹配 Rust 词法；增量 ~30 行
  代码 + 2 个 unittest。
- 简化：单点修复，不抽工具函数、不改其它逻辑。
- 安全：本次修改只让"原本被误吞的代码"重新可见，没有放松任何 panic 检测；
  唯一假设是 Rust 不存在合法的、以 `\` 开头但不进入 char 模式的 token —— 这
  与语法一致。

## Sources read

- `AGENTS.md` §2（不要补丁式代码）、§3（必跑管线）、§5（TDD）
- `scripts/check_no_panics.py` §sanitize_line / §line_test_contexts / §
  CheckNoPanicsTests
- failing CI run https://github.com/Linnanli/xClaw/actions/runs/26101100541
  jobs 76752098526（panic check）+ 76754851671（code style aggregator）
- `crates/dasclaw_mcp/src/config.rs` lines 500–720（lifetime + mod tests 现场）
- Rust reference §Tokens §3.5 char literal grammar

Closes #657
