### PR TITLE
docs(adr): mark ADR-153 / ADR-154 as Accepted per user decision in PR #675

### DIFF
--- a/docs/plans/architecture-refactor/adr-153-headless-agent-framework-draft.md
+++ b/docs/plans/architecture-refactor/adr-153-headless-agent-framework-draft.md
@@ -1,6 +1,6 @@
 # ADR-153（草稿）：把 x-claw 演化成一个无头 agent 框架
 
-- 状态：Draft（讨论中，尚未拍板）
+- 状态：Accepted（2026-05-20，用户在 PR #675 反馈中拍板）
 - 提案人：Coding Agent（基于 ADR-152 F2 系列交付的观察）
 - 关联：ADR-152（agent and capability fusion）、ADR-129（verbatim port mandate）
 - 时间：2026-05-18

--- a/docs/plans/architecture-refactor/adr-154-jobcontext-core-trait-split.md
+++ b/docs/plans/architecture-refactor/adr-154-jobcontext-core-trait-split.md
@@ -1,8 +1,8 @@
-# ADR-154（草稿）：把 `JobContext` 上帝结构体拆成 `JobContextCore` trait + ironclaw GUI 扩展
+# ADR-154：把 `JobContext` 上帝结构体拆成 `JobContextCore` trait + ironclaw GUI 扩展
 
-- 状态：Draft（讨论中，尚未拍板）
+- 状态：Accepted（2026-05-20，用户在 PR #675 反馈中拍板）
 - 提案人：Coding Agent（受用户授权，基于 #672 阻塞分析）
-- 关联：ADR-152（agent and capability fusion）、ADR-153 草稿（无头 agent 框架）、ADR-129（verbatim port mandate）
+- 关联：ADR-152（agent and capability fusion）、ADR-153（无头 agent 框架）、ADR-129（verbatim port mandate）
 - 关联 issue：#672（解 `JobContext` / `WebhookCapability` 耦合后把 `Tool` trait + `LspQueryTool` 搬到 `dasclaw_tool`）
 - 时间：2026-05-20
 


### PR DESCRIPTION
## 背景

用户在 PR #675 的 mcp-feedback 中明确拍板「ADR-154、ADR-153 接受」，本 PR 把两份 ADR 的状态从 Draft 改为 Accepted。

## 改动范围

- adr-153 第 3 行：状态 Draft → Accepted（2026-05-20）
- adr-154 第 1 行：标题去掉「（草稿）」
- adr-154 第 3 行：状态 Draft → Accepted
- adr-154 第 4 行：关联里把「ADR-153 草稿」改成「ADR-153」

## 非目标

不改任何 ADR 正文内容；不动文件名（adr-153-headless-agent-framework-draft.md 后缀保留，避免破坏既有引用）；无代码改动。

## 验证

```
python3.12 scripts/check_no_panics.py --base origin/xClaw  # OK
python3 scripts/check_no_new_ironclaw_literal.py --base origin/xClaw  # OK
```

## Sources read

- PR #675 mcp-feedback 用户回复（拍板原文）
- docs/plans/architecture-refactor/adr-153-headless-agent-framework-draft.md（确认仅状态行需改）
- docs/plans/architecture-refactor/adr-154-jobcontext-core-trait-split.md（标题/状态/关联三处需改）

Refs #672 (ADR-154 Accepted 是 #672 实现 PR 的开工前提)