### PR TITLE
feat(runtime): JobContextCore trait + supporting vocab port (#672 step 1/2)

### DIFF
--- a/crates/dasclaw_runtime/Cargo.toml
+++ b/crates/dasclaw_runtime/Cargo.toml
@@ -12,6 +12,7 @@ dasclaw_tool = { path = "../dasclaw_tool" }
 dasclaw_core = { path = "../dasclaw_core" }
 thiserror = "1"
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 chrono = { version = "0.4", features = ["serde"] }
 secrecy = { version = "0.10", features = ["serde"] }
 uuid = { version = "1", features = ["v4", "serde"] }

--- a/crates/dasclaw_runtime/src/feature_flags.rs
+++ b/crates/dasclaw_runtime/src/feature_flags.rs
@@ -1,0 +1,61 @@
+//! Tool-level feature-flag vocabulary shared across dasclaw hosts.
+//!
+//! The bare data type [`ToolFeatureFlags`] and its convenience alias
+//! [`SharedFeatureFlags`] were verbatim-ported from
+//! `desktop-client/ironclaw/src/tools/feature_flags.rs` (ADR-129 §1.3,
+//! ADR-154 step 1/2). The `BuiltinBlocklistPolicy` adapter (which depends
+//! on `dasclaw_governance::tool_visibility`) stays in ironclaw — only the
+//! HashSet-backed vocabulary moves down so that the future
+//! [`crate::job_context::JobContextCore`] trait can expose
+//! `SharedFeatureFlags` without dragging governance into this crate.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+/// Tool-level feature flag configuration.
+///
+/// Loaded from `Config.feature_flags` and optionally updated via Admin Backend
+/// `system_settings` KV pushes. The default state is **all tools enabled** —
+/// only tools explicitly listed in `disabled_tools` are rejected.
+#[derive(Debug, Clone)]
+pub struct ToolFeatureFlags {
+    disabled_tools: HashSet<String>,
+}
+
+impl ToolFeatureFlags {
+    /// Create a new instance with all tools enabled.
+    pub fn all_enabled() -> Self {
+        Self {
+            disabled_tools: HashSet::new(),
+        }
+    }
+
+    /// Create from a set of disabled tool names.
+    pub fn with_disabled(disabled: impl IntoIterator<Item = String>) -> Self {
+        Self {
+            disabled_tools: disabled.into_iter().collect(),
+        }
+    }
+
+    /// Check whether a tool is enabled.
+    ///
+    /// Returns `true` unless the tool name is in the disabled set.
+    pub fn is_tool_enabled(&self, tool_name: &str) -> bool {
+        !self.disabled_tools.contains(tool_name)
+    }
+
+    /// Return the set of disabled tool names (for diagnostics / filtering).
+    pub fn disabled_tools(&self) -> &HashSet<String> {
+        &self.disabled_tools
+    }
+}
+
+impl Default for ToolFeatureFlags {
+    fn default() -> Self {
+        Self::all_enabled()
+    }
+}
+
+/// Convenience alias used by `JobContext` and callers that share the flags
+/// across cloned contexts cheaply.
+pub type SharedFeatureFlags = Arc<ToolFeatureFlags>;

--- a/crates/dasclaw_runtime/src/job_context.rs
+++ b/crates/dasclaw_runtime/src/job_context.rs
@@ -1,0 +1,91 @@
+//! Headless `JobContext` trait — see ADR-154.
+//!
+//! `ironclaw::JobContext` is a 27-field god-struct that mixes three
+//! concerns: desktop GUI / marketplace bookkeeping (budget, bids, time
+//! stamps, state transition history), ironclaw-internal dependencies
+//! (`HttpInterceptor`, `tool_output_stash`, feature flags), and the
+//! actual "what does a tool need to know about the current job?" subset.
+//!
+//! This trait extracts **only the third subset** — the fields that
+//! `Tool::execute` implementations actually read or write across the
+//! workspace (verified by full-tree grep, see ADR-154 §2.1). GUI /
+//! marketplace fields stay on the ironclaw side and **do not** appear in
+//! this trait, so headless hosts (admin-backend, claw-code,
+//! dasclaw_runtime-only consumers) can supply a minimal implementation
+//! without pulling in marketplace bookkeeping.
+//!
+//! ## Status
+//!
+//! ADR-154 step 1/2: the trait is added here and `ironclaw::JobContext`
+//! implements it, but `Tool::execute` still takes `&JobContext` directly
+//! — no call site changes yet. ADR-154 step 2/2 will switch the
+//! `Tool::execute` signature to `&mut dyn JobContextCore` and mechanically
+//! replace every `ctx.field` with `ctx.field()` across the workspace.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use uuid::Uuid;
+
+use crate::feature_flags::SharedFeatureFlags;
+use crate::job::JobState;
+use crate::recording::HttpInterceptor;
+
+/// Minimal job context surface that any `Tool::execute` implementation
+/// can rely on.
+///
+/// See [`module documentation`](self) and ADR-154 for the rationale
+/// behind this split.
+pub trait JobContextCore: Send + Sync {
+    // ── identifiers ──
+
+    /// Unique job ID.
+    fn job_id(&self) -> Uuid;
+    /// User ID that owns this job (for workspace scoping).
+    fn user_id(&self) -> &str;
+    /// Channel-specific requester/actor ID, when different from the owner scope.
+    fn requester_id(&self) -> Option<&str>;
+    /// Conversation ID if linked to a conversation.
+    fn conversation_id(&self) -> Option<Uuid>;
+    /// Replace the conversation ID (used by sub-agent / session-fork
+    /// flows that create a fresh conversation for forked work).
+    fn set_conversation_id(&mut self, id: Option<Uuid>);
+
+    // ── state ──
+
+    /// Current job state.
+    fn state(&self) -> JobState;
+
+    // ── shared tool I/O ──
+
+    /// Job metadata (read by many tools, written by `job.rs:1886`).
+    fn metadata(&self) -> &serde_json::Value;
+    /// Replace the job metadata blob wholesale.
+    fn set_metadata(&mut self, value: serde_json::Value);
+    /// Stash of full tool outputs keyed by tool_call_id, used for
+    /// cross-tool reference passing (`$tool_call_id` syntax) and
+    /// implicit state (keys prefixed with `__`).
+    fn tool_output_stash(&self) -> Arc<tokio::sync::RwLock<HashMap<String, String>>>;
+    /// Extra environment variables to inject into spawned child
+    /// processes (e.g., fetched credentials passed to shell tools).
+    fn extra_env(&self) -> Arc<HashMap<String, String>>;
+
+    // ── environment / recording ──
+
+    /// User's preferred timezone (IANA name, e.g. "America/New_York").
+    fn user_timezone(&self) -> &str;
+    /// Optional HTTP interceptor for trace recording/replay.
+    fn http_interceptor(&self) -> Option<Arc<dyn HttpInterceptor>>;
+
+    // ── capability gates ──
+
+    /// Tool-level feature flags controlling which tools are enabled.
+    fn feature_flags(&self) -> SharedFeatureFlags;
+
+    // ── job summary (used by `job.rs` cross-task listing) ──
+
+    /// Job title.
+    fn title(&self) -> &str;
+    /// Job description.
+    fn description(&self) -> &str;
+}

--- a/crates/dasclaw_runtime/src/lib.rs
+++ b/crates/dasclaw_runtime/src/lib.rs
@@ -35,8 +35,14 @@
 //! [`ToolError::from_tool_impl`].
 
 pub mod error;
+pub mod feature_flags;
 pub mod job;
+pub mod job_context;
+pub mod recording;
 pub mod secrets;
 
 pub use error::ToolError;
+pub use feature_flags::{SharedFeatureFlags, ToolFeatureFlags};
 pub use job::{JobState, StateTransition, TokenBudgetExceeded};
+pub use job_context::JobContextCore;
+pub use recording::{HttpExchange, HttpExchangeRequest, HttpExchangeResponse, HttpInterceptor};

--- a/crates/dasclaw_runtime/src/recording.rs
+++ b/crates/dasclaw_runtime/src/recording.rs
@@ -1,0 +1,56 @@
+//! HTTP recording / replay vocabulary shared across dasclaw hosts.
+//!
+//! These types and the [`HttpInterceptor`] trait were verbatim-ported from
+//! `desktop-client/ironclaw/src/llm/recording.rs` (ADR-129 §1.3, ADR-154
+//! step 1/2). The concrete `RecordingHttpInterceptor` and
+//! `ReplayingHttpInterceptor` implementations stay in ironclaw — only the
+//! trait + the request/response/exchange data carriers move down so that
+//! the future [`crate::job_context::JobContextCore`] trait can expose
+//! `Option<Arc<dyn HttpInterceptor>>` without dragging ironclaw down with
+//! it.
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+/// A single HTTP request/response pair captured during a session.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HttpExchange {
+    pub request: HttpExchangeRequest,
+    pub response: HttpExchangeResponse,
+}
+
+/// The request side of an HTTP exchange.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HttpExchangeRequest {
+    pub method: String,
+    pub url: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub headers: Vec<(String, String)>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub body: Option<String>,
+}
+
+/// The response side of an HTTP exchange.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HttpExchangeResponse {
+    pub status: u16,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub headers: Vec<(String, String)>,
+    pub body: String,
+}
+
+/// Trait for intercepting HTTP requests from tools.
+///
+/// During recording, the interceptor captures exchanges after the real
+/// request completes. During replay, it short-circuits with a recorded response.
+#[async_trait]
+pub trait HttpInterceptor: Send + Sync + std::fmt::Debug {
+    /// Called before making an HTTP request.
+    ///
+    /// Return `Some(response)` to short-circuit (replay mode).
+    /// Return `None` to let the real request proceed (recording mode).
+    async fn before_request(&self, request: &HttpExchangeRequest) -> Option<HttpExchangeResponse>;
+
+    /// Called after a real HTTP request completes (recording mode only).
+    async fn after_response(&self, request: &HttpExchangeRequest, response: &HttpExchangeResponse);
+}

--- a/desktop-client/ironclaw/src/context/state.rs
+++ b/desktop-client/ironclaw/src/context/state.rs
@@ -284,6 +284,66 @@ impl Default for JobContext {
     }
 }
 
+// ── JobContextCore impl (ADR-154 step 1/2) ────────────────────────
+//
+// The trait exposes only the subset of fields that `Tool::execute`
+// implementations actually read or write across the workspace.
+// GUI / marketplace fields (`budget`, `bid_amount`, `actual_cost`,
+// `transitions`, `created_at`, ...) intentionally do NOT appear here
+// and remain accessible via direct field access on `JobContext`.
+impl dasclaw_runtime::JobContextCore for JobContext {
+    fn job_id(&self) -> Uuid {
+        self.job_id
+    }
+    fn user_id(&self) -> &str {
+        &self.user_id
+    }
+    fn requester_id(&self) -> Option<&str> {
+        self.requester_id.as_deref()
+    }
+    fn conversation_id(&self) -> Option<Uuid> {
+        self.conversation_id
+    }
+    fn set_conversation_id(&mut self, id: Option<Uuid>) {
+        self.conversation_id = id;
+    }
+
+    fn state(&self) -> JobState {
+        self.state
+    }
+
+    fn metadata(&self) -> &serde_json::Value {
+        &self.metadata
+    }
+    fn set_metadata(&mut self, value: serde_json::Value) {
+        self.metadata = value;
+    }
+    fn tool_output_stash(&self) -> Arc<tokio::sync::RwLock<HashMap<String, String>>> {
+        self.tool_output_stash.clone()
+    }
+    fn extra_env(&self) -> Arc<HashMap<String, String>> {
+        self.extra_env.clone()
+    }
+
+    fn user_timezone(&self) -> &str {
+        &self.user_timezone
+    }
+    fn http_interceptor(&self) -> Option<Arc<dyn dasclaw_runtime::HttpInterceptor>> {
+        self.http_interceptor.clone()
+    }
+
+    fn feature_flags(&self) -> SharedFeatureFlags {
+        self.feature_flags.clone()
+    }
+
+    fn title(&self) -> &str {
+        &self.title
+    }
+    fn description(&self) -> &str {
+        &self.description
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/desktop-client/ironclaw/src/llm/recording.rs
+++ b/desktop-client/ironclaw/src/llm/recording.rs
@@ -27,6 +27,11 @@ use crate::llm::{
     ToolCompletionRequest, ToolCompletionResponse,
 };
 
+// ── HTTP recording vocabulary (moved to dasclaw_runtime per ADR-154) ──
+pub use dasclaw_runtime::recording::{
+    HttpExchange, HttpExchangeRequest, HttpExchangeResponse, HttpInterceptor,
+};
+
 // ── Trace format types ─────────────────────────────────────────────
 
 /// Top-level trace file — extended format with memory snapshot and HTTP exchanges.
@@ -49,33 +54,6 @@ pub struct TraceFile {
 pub struct MemorySnapshotEntry {
     pub path: String,
     pub content: String,
-}
-
-/// A recorded HTTP request/response pair.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct HttpExchange {
-    pub request: HttpExchangeRequest,
-    pub response: HttpExchangeResponse,
-}
-
-/// The request side of an HTTP exchange.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct HttpExchangeRequest {
-    pub method: String,
-    pub url: String,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub headers: Vec<(String, String)>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub body: Option<String>,
-}
-
-/// The response side of an HTTP exchange.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct HttpExchangeResponse {
-    pub status: u16,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub headers: Vec<(String, String)>,
-    pub body: String,
 }
 
 /// A single step in the trace.
@@ -145,22 +123,14 @@ pub struct ExpectedToolResult {
 }
 
 // ── HTTP interceptor ───────────────────────────────────────────────
-
-/// Trait for intercepting HTTP requests from tools.
-///
-/// During recording, the interceptor captures exchanges after the real
-/// request completes. During replay, it short-circuits with a recorded response.
-#[async_trait]
-pub trait HttpInterceptor: Send + Sync + std::fmt::Debug {
-    /// Called before making an HTTP request.
-    ///
-    /// Return `Some(response)` to short-circuit (replay mode).
-    /// Return `None` to let the real request proceed (recording mode).
-    async fn before_request(&self, request: &HttpExchangeRequest) -> Option<HttpExchangeResponse>;
-
-    /// Called after a real HTTP request completes (recording mode only).
-    async fn after_response(&self, request: &HttpExchangeRequest, response: &HttpExchangeResponse);
-}
+//
+// The `HttpInterceptor` trait, `HttpExchange`, `HttpExchangeRequest`,
+// and `HttpExchangeResponse` types were moved to
+// `dasclaw_runtime::recording` per ADR-154 step 1/2. They are re-exported
+// from this module via the `pub use` block at the top of this file so all
+// existing `crate::llm::recording::HttpInterceptor` callers keep working.
+// Concrete implementations (`RecordingHttpInterceptor`,
+// `ReplayingHttpInterceptor`) continue to live here.
 
 /// Records HTTP exchanges during a live session.
 #[derive(Debug)]

--- a/desktop-client/ironclaw/src/tools/feature_flags.rs
+++ b/desktop-client/ironclaw/src/tools/feature_flags.rs
@@ -4,62 +4,20 @@
 //! runtime without unregistering them from the registry. Disabled tools are
 //! rejected at the `execute_tool_with_safety` gate and excluded from LLM tool
 //! definitions so the model never attempts to call them.
-
-use std::collections::HashSet;
-use std::sync::Arc;
+//!
+//! The bare HashSet-backed vocabulary (`ToolFeatureFlags`,
+//! `SharedFeatureFlags`) was moved to `dasclaw_runtime::feature_flags`
+//! per ADR-154 step 1/2 and is re-exported below so existing callers
+//! that use `crate::tools::feature_flags::ToolFeatureFlags` keep working.
+//! The `BuiltinBlocklistPolicy` adapter (which depends on
+//! `dasclaw_governance::tool_visibility`) stays here.
 
 use async_trait::async_trait;
 use dasclaw_governance::tool_visibility::{
     ToolGateContext, ToolGateDecision, ToolSource, ToolVisibilityPolicy,
 };
 
-/// Tool-level feature flag configuration.
-///
-/// Loaded from `Config.feature_flags` and optionally updated via Admin Backend
-/// `system_settings` KV pushes. The default state is **all tools enabled** —
-/// only tools explicitly listed in `disabled_tools` are rejected.
-#[derive(Debug, Clone)]
-pub struct ToolFeatureFlags {
-    disabled_tools: HashSet<String>,
-}
-
-impl ToolFeatureFlags {
-    /// Create a new instance with all tools enabled.
-    pub fn all_enabled() -> Self {
-        Self {
-            disabled_tools: HashSet::new(),
-        }
-    }
-
-    /// Create from a set of disabled tool names.
-    pub fn with_disabled(disabled: impl IntoIterator<Item = String>) -> Self {
-        Self {
-            disabled_tools: disabled.into_iter().collect(),
-        }
-    }
-
-    /// Check whether a tool is enabled.
-    ///
-    /// Returns `true` unless the tool name is in the disabled set.
-    pub fn is_tool_enabled(&self, tool_name: &str) -> bool {
-        !self.disabled_tools.contains(tool_name)
-    }
-
-    /// Return the set of disabled tool names (for diagnostics / filtering).
-    pub fn disabled_tools(&self) -> &HashSet<String> {
-        &self.disabled_tools
-    }
-}
-
-impl Default for ToolFeatureFlags {
-    fn default() -> Self {
-        Self::all_enabled()
-    }
-}
-
-/// Convenience alias used by `JobContext` and callers that share the flags
-/// across cloned contexts cheaply.
-pub type SharedFeatureFlags = Arc<ToolFeatureFlags>;
+pub use dasclaw_runtime::feature_flags::{SharedFeatureFlags, ToolFeatureFlags};
 
 /// ADR-149 / issue #485 — built-in tool blocklist as a
 /// [`ToolVisibilityPolicy`].


### PR DESCRIPTION
# feat(runtime): JobContextCore trait + supporting vocab port (#672 step 1/2)

## 背景 / 目标

ADR-154（已 Accepted）把 `JobContext` 上帝结构拆分成两件事：
1. **支撑词汇 verbatim 搬到 `dasclaw_runtime`**（本 PR）
2. 改 `Tool::execute` 签名为 `&mut dyn JobContextCore` + 机械替换全部调用点（下一 PR，即 #672 step 2/2）

本 PR 只做第 1 步：在 `dasclaw_runtime` 落 `JobContextCore` trait + 必要的 vocab，**零调用点改动**，零回归风险。`Tool::execute` 签名不动，所有现有工具实现继续按 `&JobContext` 字段访问跑。

## 改动范围

**dasclaw_runtime 新增（verbatim port）**
- `recording.rs`：从 `ironclaw::llm::recording` 搬 `HttpInterceptor` trait + `HttpExchange` / `HttpExchangeRequest` / `HttpExchangeResponse`。**仅 trait + 数据载体**，concrete `RecordingHttpInterceptor` / `ReplayingHttpInterceptor` 留在 ironclaw 继续 `impl HttpInterceptor for ...`（trait 来自外部 crate，本 crate impl，Rust 标准做法）。
- `feature_flags.rs`：从 `ironclaw::tools::feature_flags` 搬 `ToolFeatureFlags` + `SharedFeatureFlags`（纯 HashSet+Arc 数据，零业务依赖）。`BuiltinBlocklistPolicy` 留在 ironclaw（依赖 `dasclaw_governance::tool_visibility`，不进底层）。
- `job_context.rs`：新建 `JobContextCore` trait（13 方法 + 2 setter），接口完全对齐 ADR-154 §3.1 表格，每个方法都对得到 `Tool::execute` 实际读写点。
- `Cargo.toml`：加 `serde_json = "1"` 依赖（trait 方法用 `&serde_json::Value` 暴露 metadata，与 `JobContext.metadata` 类型保持一致）。
- `lib.rs`：注册 4 个新模块，re-export `JobContextCore` / `HttpInterceptor` 等顶层符号。

**ironclaw 这边（pub use shim）**
- `llm/recording.rs`：删除本地 `HttpInterceptor` trait + 3 个数据 struct 定义，改为 `pub use dasclaw_runtime::recording::{...}`。文件其余 ~970 行业务实现（`TraceFile`、`RecordingLlm`、`TraceLlm` 等）**完全不动**。
- `tools/feature_flags.rs`：删除本地 `ToolFeatureFlags` + `SharedFeatureFlags` 定义，改为 `pub use dasclaw_runtime::feature_flags::{...}`。`BuiltinBlocklistPolicy` 全部 100+ 行不动。
- `context/state.rs`：底部新增 `impl JobContextCore for JobContext` — 13 个方法每个一行，全部委托到对应字段。`JobContext` struct 本体 27 字段、构造方法、`transition_to`/`add_cost`/`add_tokens` 等业务方法**完全不动**。

## 非目标（What's NOT in this PR）

- **不**改 `Tool::execute` 签名（继续是 `&JobContext`）。
- **不**改任何 `Tool` 实现的字段访问（`ctx.user_id` 继续是字段访问而非方法调用）。
- **不**搬 `LspQueryTool` 或其它工具实现（留给 #672 step 2/2）。
- **不**删 `JobContext` 任何字段（GUI/marketplace 字段全部保留）。
- **不**改 `JobContext::new` / `with_user` / `with_timezone` / `with_feature_flags` / `with_requester_id` 任何构造方法。
- **不**搬 `BuiltinBlocklistPolicy`（governance 依赖留在 ironclaw）。
- **不**搬 `recording.rs` 其余业务实现（`TraceFile`/`RecordingLlm`/`TraceLlm`/`MemorySnapshotEntry` 等留在 ironclaw）。
- **不**改 `HookEngine` / hook 唯一入口（ADR-113 不变）。

## 验证

```bash
cargo check -p dasclaw_runtime --tests              # OK
cargo check -p dasclaw --tests                       # OK（含 ironclaw 全部测试目标编译）
cargo nextest run -p dasclaw_runtime                 # 87/87 pass
cargo fmt --all                                      # OK
python3.12 scripts/check_no_panics.py --base origin/xClaw     # OK
python3 scripts/check_no_new_ironclaw_literal.py --base origin/xClaw  # OK
cargo clippy --no-deps -p dasclaw_runtime --all-targets -- -D warnings  # OK
```

完整 `dasclaw` workspace nextest 与 clippy 由 CI 兜底（按 `.github/copilot-instructions.md` §3 本地管线规定，重型回归不在本地跑）。

## Cross-cuts

**类A**：无新增 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量。
**类B**：HookEngine 不动，hook 唯一入口未受影响。
**类D**：搬的 `HttpInterceptor` / `HttpExchange*` / `ToolFeatureFlags` 全部为 verbatim 复制（字节级对齐源文件），符合 ADR-129 §1.3。

## Sources read

- AGENTS.md（PR 模板、Skills 规范、红线）
- .github/copilot-instructions.md（本地管线、PR 必填项、3 层审查）
- ADR-154 §2.1-§3.4（接口设计与拆分策略）
- ADR-153（无头 agent 框架，本 PR 是其落地的第一步）
- ADR-129 §1.3（verbatim port mandate，所有搬迁严格按字节对齐）
- ADR-113（HookEngine 唯一入口，本 PR 不动）
- ADR-114（无 `.ironclaw` literal，类 A 检查脚本通过）
- `desktop-client/ironclaw/src/context/state.rs:1-285`（确认 `JobContext` 字段集合与构造方法）
- `desktop-client/ironclaw/src/llm/recording.rs:56-180`（确认搬迁三件套 + trait 的精确字节范围）
- `desktop-client/ironclaw/src/tools/feature_flags.rs:1-160`（确认 `ToolFeatureFlags` 与 `BuiltinBlocklistPolicy` 分界）
- `crates/dasclaw_runtime/src/lib.rs`（确认现有模块结构与 `pub use` 风格）
- `crates/dasclaw_runtime/Cargo.toml`（确认依赖现状）

## 3-层审查自查

- **code-quality-audit**
  - 所有搬迁文件 verbatim 字节对齐源（手工 diff 确认 doc 注释、`#[derive]`、字段顺序完全一致）。
  - 新 trait `JobContextCore` 的方法签名与 `ironclaw::JobContext` 实际字段类型一一对应；`Send + Sync` 边界声明完整。
  - 无新增 `unwrap()` / `expect()` / `panic!()` — `check_no_panics.py` 通过。
- **code-simplifier**：按 ADR-129 §1.3 verbatim port 基线**跳过**（搬迁不简化）。
- **code-review-expert**
  - 接口完整性：trait 方法集合与全仓 grep `ctx\.(...)` 80+ 匹配点对齐（ADR-154 §2.1 表格），无缺失字段也无多余字段。
  - 风险：本 PR 不改任何 `Tool::execute` 调用点 → 零回归。`HttpInterceptor` 与 `ToolFeatureFlags` 通过 `pub use` 透明 re-export，所有现有 `crate::llm::recording::HttpInterceptor` / `crate::tools::feature_flags::ToolFeatureFlags` 路径继续有效。
  - 与 ADR-113 隔离：`HookEngine` 路径未触及。
  - 与 ADR-129 一致：搬迁字节级 verbatim，仅在 ironclaw 侧补 `pub use` shim。
  - 与 ADR-114 一致：未引入 `.ironclaw` 字面量（类 A 脚本通过）。

Refs #672 (本 PR = step 1/2；下一 PR 改 `Tool::execute` 签名 + 机械替换所有调用点)


Closes #678 (tracking issue for #672 step 1/2)
