### PR TITLE
feat(runtime): extend JobContextCore with created_at/transition_to/set_user_timezone (#672 step 2a)

### DIFF
--- a/crates/dasclaw_runtime/src/job_context.rs
+++ b/crates/dasclaw_runtime/src/job_context.rs
@@ -55,6 +55,20 @@ pub trait JobContextCore: Send + Sync {
 
     /// Current job state.
     fn state(&self) -> JobState;
+    /// Wall-clock time the job was created.
+    ///
+    /// `job.rs` lists active jobs across users and emits each job's
+    /// creation timestamp in RFC 3339, so `JobContextCore` must
+    /// expose this read-only.
+    fn created_at(&self) -> chrono::DateTime<chrono::Utc>;
+    /// Transition to a new lifecycle state, recording the transition
+    /// in the implementor's history and updating internal timestamps.
+    ///
+    /// Returns `Err(reason)` when the transition is illegal under the
+    /// implementor's state machine. `job.rs`, the sub-agent tool, and
+    /// the session-fork tool all drive job transitions through this
+    /// method, so it must remain on the trait surface.
+    fn transition_to(&mut self, new_state: JobState, reason: Option<String>) -> Result<(), String>;
 
     // ── shared tool I/O ──
 
@@ -74,6 +88,9 @@ pub trait JobContextCore: Send + Sync {
 
     /// User's preferred timezone (IANA name, e.g. "America/New_York").
     fn user_timezone(&self) -> &str;
+    /// Replace the user's preferred timezone — used by tests and by
+    /// hosts that rewrite the timezone mid-job after a profile update.
+    fn set_user_timezone(&mut self, timezone: String);
     /// Optional HTTP interceptor for trace recording/replay.
     fn http_interceptor(&self) -> Option<Arc<dyn HttpInterceptor>>;
 

--- a/desktop-client/ironclaw/src/context/state.rs
+++ b/desktop-client/ironclaw/src/context/state.rs
@@ -284,13 +284,14 @@ impl Default for JobContext {
     }
 }
 
-// ── JobContextCore impl (ADR-154 step 1/2) ────────────────────────
+// ── JobContextCore impl (ADR-154 step 2a) ────────────────────────
 //
 // The trait exposes only the subset of fields that `Tool::execute`
 // implementations actually read or write across the workspace.
 // GUI / marketplace fields (`budget`, `bid_amount`, `actual_cost`,
-// `transitions`, `created_at`, ...) intentionally do NOT appear here
-// and remain accessible via direct field access on `JobContext`.
+// `transitions`, ...) intentionally do NOT appear here and remain
+// accessible via direct field access on `JobContext`. `created_at`
+// is exposed because `job.rs` emits it when listing jobs across users.
 impl dasclaw_runtime::JobContextCore for JobContext {
     fn job_id(&self) -> Uuid {
         self.job_id
@@ -311,6 +312,12 @@ impl dasclaw_runtime::JobContextCore for JobContext {
     fn state(&self) -> JobState {
         self.state
     }
+    fn created_at(&self) -> chrono::DateTime<chrono::Utc> {
+        self.created_at
+    }
+    fn transition_to(&mut self, new_state: JobState, reason: Option<String>) -> Result<(), String> {
+        JobContext::transition_to(self, new_state, reason)
+    }
 
     fn metadata(&self) -> &serde_json::Value {
         &self.metadata
@@ -327,6 +334,9 @@ impl dasclaw_runtime::JobContextCore for JobContext {
 
     fn user_timezone(&self) -> &str {
         &self.user_timezone
+    }
+    fn set_user_timezone(&mut self, timezone: String) {
+        self.user_timezone = timezone;
     }
     fn http_interceptor(&self) -> Option<Arc<dyn dasclaw_runtime::HttpInterceptor>> {
         self.http_interceptor.clone()


### PR DESCRIPTION
## 背景 / 目标

ADR-154 step 2/2 的实施前置：扫描所有 `Tool::execute` impl 里的 `ctx.xxx` 访问形态后，发现 `JobContextCore` trait 当前 15 个方法**仍未覆盖**以下三类用法：

| 用法 | 出现位置 |
|---|---|
| `ctx.transition_to(state, reason)` | `tools/builtin/job.rs` 10+ 处、`sub_agent.rs`、`session_fork.rs`、单元测试 |
| `ctx.created_at` （读 → RFC3339） | `tools/builtin/job.rs` 列 active jobs |
| `ctx.user_timezone = ...` （写） | `tools/builtin/time.rs` 测试 |

若 step 2/2 直接改 `Tool::execute(_, ctx: &mut dyn JobContextCore)`，这些访问点全部编译失败。本 PR 是 ADR-154 step 2 的拆分：**step 2a 只扩 trait，不动签名**；step 2b 再统一改签名 + 机械替换。

## 改动范围

- `crates/dasclaw_runtime/src/job_context.rs`：`JobContextCore` 新增三个方法，注释解释每个方法被哪些 tool 实际使用。
  - `fn created_at(&self) -> chrono::DateTime<chrono::Utc>;`
  - `fn transition_to(&mut self, new_state: JobState, reason: Option<String>) -> Result<(), String>;`
  - `fn set_user_timezone(&mut self, timezone: String);`
- `desktop-client/ironclaw/src/context/state.rs`：`impl JobContextCore for JobContext` 补齐三个委托；更新 impl 头注释（把 `created_at` 从「不在 trait」改为「在 trait，因 `job.rs` 列举跨用户作业时使用」）。
- 无新 crate 依赖（`chrono` 已在 `dasclaw_runtime/Cargo.toml`；`JobState` 已在 `dasclaw_runtime::job`；`transition_to` 返回 `Result<(), String>`，无新错误类型）。

## 非目标（What's NOT in this PR）

- 不改 `Tool::execute` 签名。
- 不动任何 `Tool` impl、不动任何 `ctx.field` 调用点（留给 step 2b）。
- 不挪 `Tool` trait body 或 `LspQueryTool` 物理位置（留给后续 ADR-154 工作）。
- 不引入 `JobStateError` 强类型（保留 `Result<(), String>` 与 `JobContext::transition_to` 现状对齐）。

## 验证（命令 + 结果）

| 命令 | 结果 |
|---|---|
| `cargo check -p dasclaw_runtime --tests` | OK (2.69s) |
| `cargo check -p dasclaw --tests` | OK (1m13s) |
| `cargo nextest run -p dasclaw_runtime` | 87 passed, 0 skipped |
| `cargo fmt --all` | clean |
| `python3.12 scripts/check_no_panics.py --base origin/xClaw` | OK — no new panics |
| `python3.12 scripts/check_no_new_ironclaw_literal.py --base origin/xClaw` | OK |
| `cargo clippy --no-deps -p dasclaw_runtime --all-targets -- -D warnings` | clean |

完整 dasclaw workspace nextest / Heavy Integration 按 .github/copilot-instructions.md §3 由 CI 兜底。

## Cross-cuts

- **ADR-113**：未触及 `HookEngine` 路径。
- **ADR-129 §1.3**：本 PR 是 trait 表面扩展而非 verbatim port，不适用 verbatim 基线；新增方法的命名/返回类型与 `JobContext` 现有内联实现 1:1 对齐（`transition_to` 签名字段同源、`created_at` 类型同源、`set_user_timezone` 字段写入语义同源）。
- **ADR-114**：未引入 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量（脚本通过）。
- **ADR-154**：trait 表面定稿 — 完成 step 2a 后，下一步 step 2b 即可 sed 全树 `ctx.field` → `ctx.field()`。

## Sources read

- `AGENTS.md` §「中文规约总入口」「Skills 强制使用规范」（已阅）
- `.github/copilot-instructions.md` §1 强制阅读顺序 / §2 红线 / §3 本地管线 / §4 PR 必填 / §5 测试纪律
- `docs/plans/architecture-refactor/adr-154-jobcontext-core-trait-split.md` §2.1 trait 表面定稿表 / §3.1 step 2 计划
- `docs/plans/architecture-refactor/adr-129-verbatim-port-baseline.md` §1.3（确认本 PR 为扩展而非搬迁，不适用 verbatim 基线）
- `crates/dasclaw_runtime/src/job_context.rs` 当前 trait 全文
- `desktop-client/ironclaw/src/context/state.rs` lines 160-345（`transition_to` 实现 + 现有 `impl JobContextCore`）
- `crates/dasclaw_runtime/src/job.rs` lines 1-80（`JobState` 定义）
- 全树 grep `ctx\.[a-z_]+` over `desktop-client/ironclaw/src/tools/builtin/**`（106 条命中，逐条分类用以决定 trait 表面）

## 3-层审查自查

- **code-quality-audit**
  - trait 新增方法均带 doc 注释，明确"被哪些 tool 用"，避免 trait 表面无依据膨胀。
  - 无新 `unwrap()` / `expect()` / `panic!()` — 红线脚本通过。
  - `transition_to` 返回类型严格对齐 `JobContext::transition_to`，无类型语义漂移。
- **code-simplifier**：本 PR 不适用 verbatim 基线，但保持极简 — 每个方法只一行委托，不引入 helper、不重排既有字段顺序。
- **code-review-expert**
  - 接口完整性：扫描 `tools/builtin/**` 106 处 `ctx.xxx` 访问后定稿，trait 扩展后 `Tool::execute` impl 所需 0 缺口。
  - 风险：本 PR 零调用点改动 → 零回归。三个新方法仅扩展 trait，已有 `impl JobContextCore` 实例（ironclaw `JobContext`）补齐委托后旧调用路径完全保留。
  - 与 ADR-113 / ADR-114 / ADR-129 / ADR-154 一致性：见 Cross-cuts。
  - 后续 step 2b 风险窗口已缩小：仅剩机械替换 `ctx.field` → `ctx.field()`。

Closes #679 (tracking issue for #672 step 2a)

Refs #672 (本 PR = step 2a；下一 PR = step 2b：改 `Tool::execute` 签名 + 机械替换所有调用点)
