### PR TITLE
feat(tools): move WebhookCapability POD to dasclaw_tool (#672 step 2c)

### DIFF
--- a/crates/dasclaw_tool/src/lib.rs
+++ b/crates/dasclaw_tool/src/lib.rs
@@ -22,6 +22,7 @@
 pub mod error;
 pub mod params;
 pub mod types;
+pub mod webhook_capability;
 
 pub use error::ToolError;
 pub use params::{redact_params, require_param, require_str, validate_tool_schema};
@@ -29,3 +30,4 @@ pub use types::{
     ApprovalContext, ApprovalRequirement, RiskLevel, ToolDiscoverySummary, ToolDomain, ToolOutput,
     ToolRateLimitConfig, ToolSchema,
 };
+pub use webhook_capability::WebhookCapability;

--- a/crates/dasclaw_tool/src/webhook_capability.rs
+++ b/crates/dasclaw_tool/src/webhook_capability.rs
@@ -1,0 +1,28 @@
+//! Webhook auth/signature capability descriptor (verbatim port from
+//! `desktop-client/ironclaw/src/tools/wasm/capabilities.rs`).
+//!
+//! Per [ADR-154 §3.5], the `WebhookCapability` struct is a pure 7-field POD
+//! (all `Option<String>`) with zero ironclaw dependency, and is moved here
+//! verbatim so that `Tool::webhook_capability()` can stop pointing into the
+//! ironclaw wasm module. The ironclaw side keeps a `pub use` shim so all
+//! existing call sites (including `wasm::capabilities::Capabilities.webhook`)
+//! continue to compile.
+
+/// Webhook auth/signature capability configuration for tools.
+#[derive(Debug, Clone, Default)]
+pub struct WebhookCapability {
+    /// Optional header name for shared-secret validation.
+    pub secret_header: Option<String>,
+    /// Secret name in secrets store for shared-secret validation.
+    pub secret_name: Option<String>,
+    /// Secret name in secrets store containing Ed25519 public key (Discord-style).
+    pub signature_key_secret_name: Option<String>,
+    /// Secret name in secrets store for HMAC-SHA256 signing validation.
+    pub hmac_secret_name: Option<String>,
+    /// Header containing signature (e.g. X-Hub-Signature-256 or X-Slack-Signature).
+    pub hmac_signature_header: Option<String>,
+    /// Optional timestamp header. When present, Slack-style v0 signature is used.
+    pub hmac_timestamp_header: Option<String>,
+    /// Optional signature prefix (default: "sha256=" or "v0=" for timestamped mode).
+    pub hmac_prefix: Option<String>,
+}

--- a/desktop-client/ironclaw/src/tools/tool.rs
+++ b/desktop-client/ironclaw/src/tools/tool.rs
@@ -2,16 +2,15 @@
 //!
 //! Pure-data primitives (`ApprovalRequirement`, `ApprovalContext`,
 //! `RiskLevel`, `ToolDomain`, `ToolOutput`, `ToolSchema`,
-//! `ToolDiscoverySummary`, `ToolRateLimitConfig`) and parameter helpers
-//! (`require_str`, `require_param`, `redact_params`, `validate_tool_schema`)
-//! moved to the shared [`dasclaw_tool`] crate so any dasclaw host
-//! (desktop, CLI, headless, admin backend) can describe and dispatch
-//! tools without depending on this ironclaw crate.
+//! `ToolDiscoverySummary`, `ToolRateLimitConfig`, `WebhookCapability`) and
+//! parameter helpers (`require_str`, `require_param`, `redact_params`,
+//! `validate_tool_schema`) moved to the shared [`dasclaw_tool`] crate so any
+//! dasclaw host (desktop, CLI, headless, admin backend) can describe and
+//! dispatch tools without depending on this ironclaw crate.
 //!
-//! The [`Tool`] trait itself still lives here because it depends on
-//! [`crate::context::JobContext`] and
-//! [`crate::tools::wasm::WebhookCapability`]; decoupling those is
-//! tracked as a follow-up issue.
+//! The [`Tool`] trait itself still lives here because the trait is exercised
+//! by ironclaw-specific tests; the remaining work to physically move it to
+//! `dasclaw_tool` (and the `LspQueryTool` follow-up) is tracked in #672.
 
 use std::time::Duration;
 
@@ -137,7 +136,7 @@ pub trait Tool: Send + Sync {
     ///
     /// When present, `/webhook/tools/{tool}` validates shared secret/signatures
     /// before invoking the tool. Tools should then only handle payload normalization.
-    fn webhook_capability(&self) -> Option<crate::tools::wasm::WebhookCapability> {
+    fn webhook_capability(&self) -> Option<dasclaw_tool::WebhookCapability> {
         None
     }
 

--- a/desktop-client/ironclaw/src/tools/wasm/capabilities.rs
+++ b/desktop-client/ironclaw/src/tools/wasm/capabilities.rs
@@ -312,24 +312,13 @@ impl SecretsCapability {
 /// WASM capabilities use it to configure per-tool HTTP request limits.
 pub use crate::tools::tool::ToolRateLimitConfig as RateLimitConfig;
 
-/// Webhook auth/signature capability configuration for tools.
-#[derive(Debug, Clone, Default)]
-pub struct WebhookCapability {
-    /// Optional header name for shared-secret validation.
-    pub secret_header: Option<String>,
-    /// Secret name in secrets store for shared-secret validation.
-    pub secret_name: Option<String>,
-    /// Secret name in secrets store containing Ed25519 public key (Discord-style).
-    pub signature_key_secret_name: Option<String>,
-    /// Secret name in secrets store for HMAC-SHA256 signing validation.
-    pub hmac_secret_name: Option<String>,
-    /// Header containing signature (e.g. X-Hub-Signature-256 or X-Slack-Signature).
-    pub hmac_signature_header: Option<String>,
-    /// Optional timestamp header. When present, Slack-style v0 signature is used.
-    pub hmac_timestamp_header: Option<String>,
-    /// Optional signature prefix (default: "sha256=" or "v0=" for timestamped mode).
-    pub hmac_prefix: Option<String>,
-}
+/// Webhook auth/signature capability descriptor.
+///
+/// Per [ADR-154 §3.5] the struct lives in `dasclaw_tool::WebhookCapability`.
+/// This re-export keeps `crate::tools::wasm::WebhookCapability` working for
+/// all existing call sites (including `Capabilities.webhook` and the
+/// `Tool::webhook_capability()` default impl re-export path).
+pub use dasclaw_tool::WebhookCapability;
 
 #[cfg(test)]
 mod tests {

--- a/desktop-client/ironclaw/src/tools/wasm/wrapper.rs
+++ b/desktop-client/ironclaw/src/tools/wasm/wrapper.rs
@@ -1218,7 +1218,7 @@ impl Tool for WasmToolWrapper {
         Some(self.prepared.limits.timeout)
     }
 
-    fn webhook_capability(&self) -> Option<crate::tools::wasm::WebhookCapability> {
+    fn webhook_capability(&self) -> Option<dasclaw_tool::WebhookCapability> {
         self.capabilities.webhook.clone()
     }
 }


### PR DESCRIPTION
feat(tools): move WebhookCapability POD to dasclaw_tool (#672 step 2c)

Verbatim-port the 7-field `WebhookCapability` POD struct from
`desktop-client/ironclaw/src/tools/wasm/capabilities.rs` to a new
`crates/dasclaw_tool/src/webhook_capability.rs`, and switch
`Tool::webhook_capability()` + `WasmToolWrapper::webhook_capability()`
to return `Option<dasclaw_tool::WebhookCapability>`. ironclaw side keeps
`pub use dasclaw_tool::WebhookCapability` so every existing call site
(`Capabilities.webhook`, `webhooks/mod.rs` test stubs, capabilities_schema)
keeps compiling unchanged.

Per ADR-154 §3.5 — closes the second of the two #672 blockers (the first,
JobContext coupling, was resolved by #682 step 2b). With both blockers
gone, the next slice (#672 step 3) can physically relocate the `Tool`
trait to `dasclaw_tool`.

## Sources read
- AGENTS.md (Skills 强制使用规范, PR/commit discipline)
- .github/copilot-instructions.md (§3 mandatory pipeline, §4 PR checklist, §6 reuse-before-create)
- docs/plans/architecture-refactor/adr-154-jobcontext-core-trait-split.md (§3.5 WebhookCapability 同步迁移, §4 non-goals)
- desktop-client/ironclaw/src/tools/wasm/capabilities.rs (current struct location, verbatim source)
- desktop-client/ironclaw/src/tools/tool.rs (trait default method)
- desktop-client/ironclaw/src/tools/wasm/wrapper.rs (impl that returns it)
- desktop-client/ironclaw/src/webhooks/mod.rs (test stubs that construct it)

## Verification
```
cargo check -p dasclaw_tool --tests   # OK
cargo check -p dasclaw --tests        # OK (warning-free after removing dead re-export)
cargo fmt --all -- --check            # clean
python3.12 scripts/check_no_panics.py --base origin/xClaw   # OK
cargo clippy --no-deps -p dasclaw_tool --all-targets -- -D warnings   # clean
cargo clippy --no-deps -p dasclaw --all-targets -- -D warnings        # clean (5m12s)
```

Closes #684
Refs #672
Refs #683
