### PR TITLE
feat(runtime): move Tool trait to dasclaw_runtime (#672 step 3, ADR-154 §10 amendment)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3125,6 +3125,7 @@ dependencies = [
  "hkdf",
  "libsql",
  "rand 0.8.5",
+ "rust_decimal",
  "secrecy",
  "secret-service",
  "security-framework 3.7.0",

--- a/crates/dasclaw_runtime/Cargo.toml
+++ b/crates/dasclaw_runtime/Cargo.toml
@@ -11,6 +11,7 @@ dasclaw_tool = { path = "../dasclaw_tool" }
 # `secrets::agent_provider::AgentSecrets` adapter (F3.2 phase 2 PR 4c, #641).
 dasclaw_core = { path = "../dasclaw_core" }
 thiserror = "1"
+rust_decimal = { version = "1", features = ["serde", "serde-with-str", "maths"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 chrono = { version = "0.4", features = ["serde"] }

--- a/crates/dasclaw_runtime/src/lib.rs
+++ b/crates/dasclaw_runtime/src/lib.rs
@@ -40,9 +40,11 @@ pub mod job;
 pub mod job_context;
 pub mod recording;
 pub mod secrets;
+pub mod tool;
 
 pub use error::ToolError;
 pub use feature_flags::{SharedFeatureFlags, ToolFeatureFlags};
 pub use job::{JobState, StateTransition, TokenBudgetExceeded};
 pub use job_context::JobContextCore;
 pub use recording::{HttpExchange, HttpExchangeRequest, HttpExchangeResponse, HttpInterceptor};
+pub use tool::Tool;

--- a/crates/dasclaw_runtime/src/tool.rs
+++ b/crates/dasclaw_runtime/src/tool.rs
@@ -1,0 +1,182 @@
+//! Application-layer `Tool` trait.
+//!
+//! Per [ADR-154 §3.1 amendment](../../../../docs/plans/architecture-refactor/adr-154-jobcontext-core-trait-split.md):
+//! the trait lives in `dasclaw_runtime` rather than `dasclaw_tool` because
+//! the workspace dependency direction is `dasclaw_runtime → dasclaw_tool`
+//! (runtime owns the `ToolError` adapter `from_tool_impl`), not the other
+//! way around. Putting `Tool` here lets `Tool::execute(ctx: &mut dyn
+//! JobContextCore)` reference the `JobContextCore` trait that also lives in
+//! this crate, without introducing a circular dependency.
+//!
+//! ironclaw and other hosts keep a thin `pub use dasclaw_runtime::Tool;`
+//! re-export so existing call sites compile unchanged.
+
+use std::time::Duration;
+
+use async_trait::async_trait;
+use rust_decimal::Decimal;
+
+use dasclaw_tool::{
+    ApprovalRequirement, RiskLevel, ToolDiscoverySummary, ToolDomain, ToolError, ToolOutput,
+    ToolRateLimitConfig, ToolSchema, WebhookCapability,
+};
+
+use crate::job_context::JobContextCore;
+
+/// Trait for tools that the agent can use.
+#[async_trait]
+pub trait Tool: Send + Sync {
+    /// Get the tool name.
+    fn name(&self) -> &str;
+
+    /// Get a description of what the tool does.
+    fn description(&self) -> &str;
+
+    /// Get the JSON Schema for the tool's parameters.
+    fn parameters_schema(&self) -> serde_json::Value;
+
+    /// Execute the tool with the given parameters.
+    async fn execute(
+        &self,
+        params: serde_json::Value,
+        ctx: &mut dyn JobContextCore,
+    ) -> Result<ToolOutput, ToolError>;
+
+    /// Estimate the cost of running this tool with the given parameters.
+    fn estimated_cost(&self, _params: &serde_json::Value) -> Option<Decimal> {
+        None
+    }
+
+    /// Estimate how long this tool will take with the given parameters.
+    fn estimated_duration(&self, _params: &serde_json::Value) -> Option<Duration> {
+        None
+    }
+
+    /// Whether this tool's output needs sanitization.
+    ///
+    /// Returns true for tools that interact with external services,
+    /// where the output might contain malicious content.
+    fn requires_sanitization(&self) -> bool {
+        true
+    }
+
+    /// Risk level for a specific invocation of this tool.
+    ///
+    /// Defaults to `Low` (read-only, safe). Override for tools whose risk
+    /// depends on the parameters — the shell tool classifies commands into
+    /// `Low` / `Medium` / `High` based on the command string.
+    ///
+    /// The worker logs this value with every tool call so operators can audit
+    /// the risk level at which each execution was classified.
+    fn risk_level_for(&self, _params: &serde_json::Value) -> RiskLevel {
+        RiskLevel::Low
+    }
+
+    /// Whether this tool invocation requires user approval.
+    ///
+    /// Returns `Never` by default (most tools run in a sandboxed environment).
+    /// Override to return `UnlessAutoApproved` for tools that need approval
+    /// but can be session-auto-approved, or `Always` for invocations that
+    /// must always prompt (e.g. destructive shell commands, HTTP with auth).
+    fn requires_approval(&self, _params: &serde_json::Value) -> ApprovalRequirement {
+        ApprovalRequirement::Never
+    }
+
+    /// Maximum time this tool is allowed to run before the caller kills it.
+    /// Override for long-running tools like sandbox execution.
+    /// Default: 60 seconds.
+    fn execution_timeout(&self) -> Duration {
+        Duration::from_secs(60)
+    }
+
+    /// Where this tool should execute.
+    ///
+    /// `Orchestrator` tools run in the main agent process (safe, no FS access).
+    /// `Container` tools run inside Docker containers (shell, file ops).
+    ///
+    /// Default: `Orchestrator` (safe for the main process).
+    fn domain(&self) -> ToolDomain {
+        ToolDomain::Orchestrator
+    }
+
+    /// Parameter names whose values must be redacted before logging, hooks, and approvals.
+    ///
+    /// The agent framework replaces these parameter values with `"[REDACTED]"` before:
+    /// - Writing to debug logs
+    /// - Storing in `ActionRecord` (in-memory job history)
+    /// - Recording in `TurnToolCall` (session state)
+    /// - Sending to `BeforeToolCall` hooks
+    /// - Displaying in the approval UI
+    ///
+    /// **The `execute()` method still receives the original, unredacted parameters.**
+    /// Redaction only applies to the observability and audit paths, not execution.
+    ///
+    /// Use this for tools that accept plaintext secrets as parameters (e.g. `secret_save`).
+    fn sensitive_params(&self) -> &[&str] {
+        &[]
+    }
+
+    /// Per-invocation rate limit for this tool.
+    ///
+    /// Return `Some(config)` to throttle how often this tool can be called per user.
+    /// Read-only tools (echo, time, json, file_read, memory_search, etc.) should
+    /// return `None`. Write/external tools (shell, http, file_write, memory_write,
+    /// create_job) should return sensible limits to prevent runaway agents.
+    ///
+    /// Rate limits are per-user, per-tool, and in-memory (reset on restart).
+    /// This is orthogonal to `requires_approval()` — a tool can be both
+    /// approval-gated and rate limited. Rate limit is checked first (cheaper).
+    ///
+    /// Default: `None` (no rate limiting).
+    fn rate_limit_config(&self) -> Option<ToolRateLimitConfig> {
+        None
+    }
+
+    /// Optional host-side webhook verification configuration for this tool.
+    ///
+    /// When present, `/webhook/tools/{tool}` validates shared secret/signatures
+    /// before invoking the tool. Tools should then only handle payload normalization.
+    fn webhook_capability(&self) -> Option<WebhookCapability> {
+        None
+    }
+
+    /// Full parameter schema for discovery and coercion purposes.
+    ///
+    /// Unlike `parameters_schema()` (which may be permissive to keep the tools
+    /// array compact), this returns the complete typed schema. Used by the
+    /// `tool_info` built-in and by WASM parameter coercion.
+    ///
+    /// Default: delegates to `parameters_schema()`.
+    fn discovery_schema(&self) -> serde_json::Value {
+        self.parameters_schema()
+    }
+
+    /// Curated discovery guidance used by `tool_info(detail: "summary")`.
+    ///
+    /// Default: no custom summary; callers may derive a minimal fallback from
+    /// `discovery_schema()`.
+    fn discovery_summary(&self) -> Option<ToolDiscoverySummary> {
+        None
+    }
+
+    /// Get the tool schema for LLM function calling.
+    fn schema(&self) -> ToolSchema {
+        let parameters = self.parameters_schema();
+        let has_discovery_hint =
+            self.discovery_summary().is_some() || self.discovery_schema() != parameters;
+        let description = if has_discovery_hint {
+            format!(
+                "{} (call tool_info(name: \"{}\", detail: \"summary\") for rules/examples or detail: \"schema\" for the full discovery schema)",
+                self.description(),
+                self.name()
+            )
+        } else {
+            self.description().to_string()
+        };
+        ToolSchema {
+            name: self.name().to_string(),
+            description,
+            parameters,
+        }
+    }
+}

--- a/desktop-client/ironclaw/src/tools/tool.rs
+++ b/desktop-client/ironclaw/src/tools/tool.rs
@@ -1,21 +1,19 @@
-//! Tool trait and helpers.
+//! `Tool` trait re-export and ironclaw-side trait conformance tests.
+//!
+//! Per [ADR-154 §3.1 amendment](../../../../../docs/plans/architecture-refactor/adr-154-jobcontext-core-trait-split.md),
+//! the `Tool` trait was physically moved to `dasclaw_runtime` (not
+//! `dasclaw_tool`) because the workspace dep direction is
+//! `dasclaw_runtime → dasclaw_tool`. ironclaw keeps a thin re-export so
+//! every existing path resolves unchanged.
 //!
 //! Pure-data primitives (`ApprovalRequirement`, `ApprovalContext`,
 //! `RiskLevel`, `ToolDomain`, `ToolOutput`, `ToolSchema`,
 //! `ToolDiscoverySummary`, `ToolRateLimitConfig`, `WebhookCapability`) and
 //! parameter helpers (`require_str`, `require_param`, `redact_params`,
-//! `validate_tool_schema`) moved to the shared [`dasclaw_tool`] crate so any
-//! dasclaw host (desktop, CLI, headless, admin backend) can describe and
-//! dispatch tools without depending on this ironclaw crate.
-//!
-//! The [`Tool`] trait itself still lives here because the trait is exercised
-//! by ironclaw-specific tests; the remaining work to physically move it to
-//! `dasclaw_tool` (and the `LspQueryTool` follow-up) is tracked in #672.
+//! `validate_tool_schema`) continue to live in the shared `dasclaw_tool`
+//! crate.
 
-use std::time::Duration;
-
-use async_trait::async_trait;
-use rust_decimal::Decimal;
+pub use dasclaw_runtime::Tool;
 
 pub use dasclaw_tool::{
     ApprovalContext, ApprovalRequirement, RiskLevel, ToolDiscoverySummary, ToolDomain, ToolError,
@@ -23,166 +21,12 @@ pub use dasclaw_tool::{
     validate_tool_schema,
 };
 
-/// Trait for tools that the agent can use.
-#[async_trait]
-pub trait Tool: Send + Sync {
-    /// Get the tool name.
-    fn name(&self) -> &str;
-
-    /// Get a description of what the tool does.
-    fn description(&self) -> &str;
-
-    /// Get the JSON Schema for the tool's parameters.
-    fn parameters_schema(&self) -> serde_json::Value;
-
-    /// Execute the tool with the given parameters.
-    async fn execute(
-        &self,
-        params: serde_json::Value,
-        ctx: &mut dyn dasclaw_runtime::JobContextCore,
-    ) -> Result<ToolOutput, ToolError>;
-
-    /// Estimate the cost of running this tool with the given parameters.
-    fn estimated_cost(&self, _params: &serde_json::Value) -> Option<Decimal> {
-        None
-    }
-
-    /// Estimate how long this tool will take with the given parameters.
-    fn estimated_duration(&self, _params: &serde_json::Value) -> Option<Duration> {
-        None
-    }
-
-    /// Whether this tool's output needs sanitization.
-    ///
-    /// Returns true for tools that interact with external services,
-    /// where the output might contain malicious content.
-    fn requires_sanitization(&self) -> bool {
-        true
-    }
-
-    /// Risk level for a specific invocation of this tool.
-    ///
-    /// Defaults to `Low` (read-only, safe). Override for tools whose risk
-    /// depends on the parameters — the shell tool classifies commands into
-    /// `Low` / `Medium` / `High` based on the command string.
-    ///
-    /// The worker logs this value with every tool call so operators can audit
-    /// the risk level at which each execution was classified.
-    fn risk_level_for(&self, _params: &serde_json::Value) -> RiskLevel {
-        RiskLevel::Low
-    }
-
-    /// Whether this tool invocation requires user approval.
-    ///
-    /// Returns `Never` by default (most tools run in a sandboxed environment).
-    /// Override to return `UnlessAutoApproved` for tools that need approval
-    /// but can be session-auto-approved, or `Always` for invocations that
-    /// must always prompt (e.g. destructive shell commands, HTTP with auth).
-    fn requires_approval(&self, _params: &serde_json::Value) -> ApprovalRequirement {
-        ApprovalRequirement::Never
-    }
-
-    /// Maximum time this tool is allowed to run before the caller kills it.
-    /// Override for long-running tools like sandbox execution.
-    /// Default: 60 seconds.
-    fn execution_timeout(&self) -> Duration {
-        Duration::from_secs(60)
-    }
-
-    /// Where this tool should execute.
-    ///
-    /// `Orchestrator` tools run in the main agent process (safe, no FS access).
-    /// `Container` tools run inside Docker containers (shell, file ops).
-    ///
-    /// Default: `Orchestrator` (safe for the main process).
-    fn domain(&self) -> ToolDomain {
-        ToolDomain::Orchestrator
-    }
-
-    /// Parameter names whose values must be redacted before logging, hooks, and approvals.
-    ///
-    /// The agent framework replaces these parameter values with `"[REDACTED]"` before:
-    /// - Writing to debug logs
-    /// - Storing in `ActionRecord` (in-memory job history)
-    /// - Recording in `TurnToolCall` (session state)
-    /// - Sending to `BeforeToolCall` hooks
-    /// - Displaying in the approval UI
-    ///
-    /// **The `execute()` method still receives the original, unredacted parameters.**
-    /// Redaction only applies to the observability and audit paths, not execution.
-    ///
-    /// Use this for tools that accept plaintext secrets as parameters (e.g. `secret_save`).
-    fn sensitive_params(&self) -> &[&str] {
-        &[]
-    }
-
-    /// Per-invocation rate limit for this tool.
-    ///
-    /// Return `Some(config)` to throttle how often this tool can be called per user.
-    /// Read-only tools (echo, time, json, file_read, memory_search, etc.) should
-    /// return `None`. Write/external tools (shell, http, file_write, memory_write,
-    /// create_job) should return sensible limits to prevent runaway agents.
-    ///
-    /// Rate limits are per-user, per-tool, and in-memory (reset on restart).
-    /// This is orthogonal to `requires_approval()` — a tool can be both
-    /// approval-gated and rate limited. Rate limit is checked first (cheaper).
-    ///
-    /// Default: `None` (no rate limiting).
-    fn rate_limit_config(&self) -> Option<ToolRateLimitConfig> {
-        None
-    }
-
-    /// Optional host-side webhook verification configuration for this tool.
-    ///
-    /// When present, `/webhook/tools/{tool}` validates shared secret/signatures
-    /// before invoking the tool. Tools should then only handle payload normalization.
-    fn webhook_capability(&self) -> Option<dasclaw_tool::WebhookCapability> {
-        None
-    }
-
-    /// Full parameter schema for discovery and coercion purposes.
-    ///
-    /// Unlike `parameters_schema()` (which may be permissive to keep the tools
-    /// array compact), this returns the complete typed schema. Used by the
-    /// `tool_info` built-in and by WASM parameter coercion.
-    ///
-    /// Default: delegates to `parameters_schema()`.
-    fn discovery_schema(&self) -> serde_json::Value {
-        self.parameters_schema()
-    }
-
-    /// Curated discovery guidance used by `tool_info(detail: "summary")`.
-    ///
-    /// Default: no custom summary; callers may derive a minimal fallback from
-    /// `discovery_schema()`.
-    fn discovery_summary(&self) -> Option<ToolDiscoverySummary> {
-        None
-    }
-
-    /// Get the tool schema for LLM function calling.
-    fn schema(&self) -> ToolSchema {
-        let parameters = self.parameters_schema();
-        let has_discovery_hint =
-            self.discovery_summary().is_some() || self.discovery_schema() != parameters;
-        let description = if has_discovery_hint {
-            format!(
-                "{} (call tool_info(name: \"{}\", detail: \"summary\") for rules/examples or detail: \"schema\" for the full discovery schema)",
-                self.description(),
-                self.name()
-            )
-        } else {
-            self.description().to_string()
-        };
-        ToolSchema {
-            name: self.name().to_string(),
-            description,
-            parameters,
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
+    use async_trait::async_trait;
+
     use super::*;
     use crate::context::JobContext;
 

--- a/docs/plans/architecture-refactor/adr-154-jobcontext-core-trait-split.md
+++ b/docs/plans/architecture-refactor/adr-154-jobcontext-core-trait-split.md
@@ -218,3 +218,23 @@ let agent = Agent::builder()
 - PR #671（#670 切片 1/2：tool 辅助类型与 helper 已搬走）
 - issue #672（本 ADR 要解锁的工作）
 - `desktop-client/ironclaw/src/context/state.rs` 第 6–9 行（god-struct 拆分预告）
+
+---
+
+## 10. Amendment（2026-05-21，#672 step 3 实施时发现）
+
+§3.1 原文写：
+> 落点选 `dasclaw_runtime` 而非 `dasclaw_tool`：trait 里包含 `JobState`、`Uuid`、`HttpInterceptor` 等运行时类型，`dasclaw_tool` 应保持依赖轻。**`dasclaw_tool` 已经依赖 `dasclaw_runtime`（见 PR #641 把 `JobState` 搬过去那一步）**，所以 `Tool::execute(ctx: &dyn JobContextCore)` 在 `dasclaw_tool` 里能直接引用。
+
+实际依赖方向**反过来**：`dasclaw_runtime` 依赖 `dasclaw_tool`（runtime 的 `error::ToolError::from_tool_impl(&str, dasclaw_tool::ToolError)` 适配器需要 `dasclaw_tool::ToolError`），而 `dasclaw_tool` **没有**依赖 `dasclaw_runtime`。这是 ADR 写作时对依赖图的事实判断失误。
+
+§8 第 4 步原计划"搬 `Tool` trait 到 `dasclaw_tool`"会立刻造成循环依赖，无法执行。
+
+**修正决定**：`Tool` trait 物理落点改为 `crates/dasclaw_runtime/src/tool.rs`（与 `JobContextCore`、`ToolFeatureFlags`、`HttpInterceptor` 等运行时 trait 同居）。理由：
+
+1. trait 的 `execute(ctx: &mut dyn JobContextCore)` 直接引用同 crate 的 `JobContextCore`，零跨 crate 跳跃。
+2. `dasclaw_tool` 维持"实现层纯数据 + 错误"的定位，依赖图保持单向 `runtime → tool`。
+3. 所有真实工具实现（`WasmToolWrapper`、内置工具）已经 transitively 依赖 `dasclaw_runtime`（通过 `JobContextCore`），落点变更对 host 端注册逻辑零成本。
+4. ironclaw 侧 `desktop-client/ironclaw/src/tools/tool.rs` 改为 `pub use dasclaw_runtime::Tool;` 薄壳，所有 `crate::tools::tool::Tool` 旧路径零修改继续编译。
+
+ADR-152 §3 F3.3 字面写"把 `Tool` trait 与所有内置工具搬到 `dasclaw_tool`"，本 amendment 将其细化为：trait 落 `dasclaw_runtime`、内置工具实现仍按原计划随领域拆到对应 crate（如 `dasclaw_lsp::LspQueryTool` 等）。`dasclaw_tool` 继续承担 trait 的入参/出参/错误/能力描述类型。


### PR DESCRIPTION
feat(runtime): physically move Tool trait to dasclaw_runtime (#672 step 3)

Per ADR-154 §3 + §10 amendment, move the `Tool` trait from
`desktop-client/ironclaw/src/tools/tool.rs` into a new
`crates/dasclaw_runtime/src/tool.rs`. ironclaw side keeps a thin
`pub use dasclaw_runtime::Tool;` re-export, plus the existing
`crate::context::JobContext`-based trait conformance tests.

## Why dasclaw_runtime, not dasclaw_tool

ADR-154 §3.1 originally said the trait should land in `dasclaw_tool`,
based on the assumption that `dasclaw_tool` already depended on
`dasclaw_runtime`. While implementing this slice we found the real
workspace dep direction is the opposite:

- `dasclaw_runtime` depends on `dasclaw_tool` (needs `dasclaw_tool::ToolError`
  for the `from_tool_impl` adapter in `crates/dasclaw_runtime/src/error.rs`).
- `dasclaw_tool` has no dep on `dasclaw_runtime`.

Making `dasclaw_tool` depend on `dasclaw_runtime` would create an
immediate cycle. The clean fix per user direction is to land the trait
in `dasclaw_runtime` next to `JobContextCore` (which `Tool::execute`
already references) and keep `dasclaw_tool` as the lightweight
"implementation-layer types + errors" crate. ADR-154 §10 (new) records
this amendment with full reasoning so future readers see why the trait
sits beside its required vocab.

## Changes

- `crates/dasclaw_runtime/src/tool.rs` (new): verbatim trait body
  including all default methods (`schema`, `risk_level_for`,
  `requires_approval`, `webhook_capability`, etc.). References
  `JobContextCore` via the in-crate path.
- `crates/dasclaw_runtime/src/lib.rs`: `pub mod tool; pub use tool::Tool;`.
- `crates/dasclaw_runtime/Cargo.toml`: add `rust_decimal` (needed by the
  trait's `estimated_cost` default).
- `desktop-client/ironclaw/src/tools/tool.rs`: replace the inline trait
  definition with `pub use dasclaw_runtime::Tool;` plus a module doc
  citing the ADR amendment. The `#[cfg(test)] mod tests { EchoTool }`
  block remains so we keep proving the trait works with ironclaw's
  concrete `JobContext`.
- `docs/plans/architecture-refactor/adr-154-jobcontext-core-trait-split.md`:
  append §10 amendment.

Every existing call site (`crate::tools::tool::Tool`, every `impl Tool
for ...` in `tools/`, the `WasmToolWrapper` impl, `webhooks/mod.rs`
test stubs, every downstream registration in `dasclaw_mcp` and
`dasclaw_lsp`) resolves through the re-export with zero source changes.

## Sources read
- AGENTS.md (Skills 强制使用规范, PR/commit discipline)
- .github/copilot-instructions.md (§3 pipeline, §4 PR checklist, §6 reuse-before-create)
- docs/plans/architecture-refactor/adr-154-jobcontext-core-trait-split.md (§1, §3.1, §3.5, §4, §8, §10 amendment)
- desktop-client/ironclaw/src/tools/tool.rs (trait source)
- crates/dasclaw_runtime/src/lib.rs (target crate layout)
- crates/dasclaw_runtime/src/error.rs (dep direction evidence)
- crates/dasclaw_tool/Cargo.toml + crates/dasclaw_runtime/Cargo.toml (dep direction evidence)

## Verification
```
cargo check -p dasclaw_runtime --tests   # OK
cargo check -p dasclaw --tests           # OK (5m20s)
cargo fmt --all -- --check               # clean
python3.12 scripts/check_no_panics.py --base origin/xClaw   # OK
cargo clippy --no-deps -p dasclaw_runtime --all-targets -- -D warnings   # clean
cargo clippy --no-deps -p dasclaw --all-targets -- -D warnings           # clean (5m57s)
```

Closes #686
Refs #672
Refs #684
