### PR TITLE
feat(lsp): move LspQueryTool into dasclaw_lsp (#688)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2972,6 +2972,8 @@ dependencies = [
 name = "dasclaw_lsp"
 version = "0.0.0-w1"
 dependencies = [
+ "async-trait",
+ "dasclaw_runtime",
  "dasclaw_tool",
  "serde",
  "serde_json",

--- a/crates/dasclaw_lsp/Cargo.toml
+++ b/crates/dasclaw_lsp/Cargo.toml
@@ -10,7 +10,9 @@ publish = false
 path = "src/lib.rs"
 
 [dependencies]
+dasclaw_runtime = { path = "../dasclaw_runtime" }
 dasclaw_tool = { path = "../dasclaw_tool" }
+async-trait = "0.1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["full"] }

--- a/crates/dasclaw_lsp/src/lib.rs
+++ b/crates/dasclaw_lsp/src/lib.rs
@@ -1,9 +1,9 @@
-//! LSP integration: registry, JSON-RPC client, protocol & server mapping.
+//! LSP integration: registry, JSON-RPC client, protocol & server mapping,
+//! plus the host-facing `LspQueryTool`.
 //!
-//! Verbatim port from `desktop-client/ironclaw/src/tools/builtin/lsp/` per
-//! F3.3 (#629). The host-side `LspQueryTool` (the [`Tool`]-trait wiring)
-//! remains in `ironclaw::tools::builtin::lsp` until the [`Tool`] trait moves
-//! into `dasclaw_tool` in a follow-up issue.
+//! Core types verbatim-ported from `desktop-client/ironclaw/src/tools/builtin/lsp/`
+//! per ADR-152 §3 F3.3. The `LspQueryTool` joined them under issue #688 once
+//! the `Tool` trait moved to `dasclaw_runtime` (PR #687 / ADR-154 §10).
 //!
 //! ```text
 //! LspRegistry (host-owned)
@@ -11,15 +11,15 @@
 //!     ├─ idle timeout → auto shutdown
 //!     └─ Admin whitelist filtering
 //! ```
-//!
-//! [`Tool`]: https://github.com/Linnanli/x-claw — see `crate::tools::tool::Tool` in the ironclaw crate
 
 mod client;
 pub(crate) mod protocol;
 mod registry;
 mod server_config;
+mod tool;
 
 pub use client::{LspClient, path_to_uri};
 pub use protocol::LspAction;
 pub use registry::LspRegistry;
 pub use server_config::{LspServerConfig, LspServerMapping};
+pub use tool::LspQueryTool;

--- a/crates/dasclaw_lsp/src/tool.rs
+++ b/crates/dasclaw_lsp/src/tool.rs
@@ -2,6 +2,11 @@
 //!
 //! The LLM calls this with an `action`, `file_path`, and optional `position`
 //! to perform code intelligence queries.
+//!
+//! Verbatim-moved from `desktop-client/ironclaw/src/tools/builtin/lsp/tool.rs`
+//! per ADR-152 §3 F3.3 (tracking issue #688). ironclaw retains a
+//! `pub use dasclaw_lsp::LspQueryTool;` shim so existing registration paths
+//! continue to resolve.
 
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -9,9 +14,10 @@ use std::time::Instant;
 
 use async_trait::async_trait;
 
-use dasclaw_lsp::{LspAction, LspClient, LspRegistry, path_to_uri};
+use dasclaw_runtime::{JobContextCore, Tool};
+use dasclaw_tool::{ApprovalRequirement, RiskLevel, ToolDomain, ToolError, ToolOutput};
 
-use crate::tools::tool::{ApprovalRequirement, RiskLevel, Tool, ToolDomain, ToolError, ToolOutput};
+use crate::{LspAction, LspClient, LspRegistry, path_to_uri};
 
 /// LSP code intelligence tool.
 ///
@@ -81,7 +87,7 @@ impl Tool for LspQueryTool {
     async fn execute(
         &self,
         params: serde_json::Value,
-        ctx: &mut dyn dasclaw_runtime::JobContextCore,
+        ctx: &mut dyn JobContextCore,
     ) -> Result<ToolOutput, ToolError> {
         let start = Instant::now();
 
@@ -211,18 +217,20 @@ async fn dispatch_action(
             let result = lsp
                 .request(
                     "textDocument/definition",
-                    position_params(file_uri, line, col),
+                    serde_json::Value::Object(position_params(file_uri, line, col)),
                 )
                 .await?;
             Ok(format_locations(&result))
         }
         LspAction::FindReferences => {
             let mut p = position_params(file_uri, line, col);
-            p.as_object_mut().expect("object").insert(
+            p.insert(
                 "context".into(),
                 serde_json::json!({"includeDeclaration": true}),
             );
-            let result = lsp.request("textDocument/references", p).await?;
+            let result = lsp
+                .request("textDocument/references", serde_json::Value::Object(p))
+                .await?;
             Ok(format_locations(&result))
         }
         LspAction::Diagnostics => {
@@ -245,7 +253,10 @@ async fn dispatch_action(
         }
         LspAction::Hover => {
             let result = lsp
-                .request("textDocument/hover", position_params(file_uri, line, col))
+                .request(
+                    "textDocument/hover",
+                    serde_json::Value::Object(position_params(file_uri, line, col)),
+                )
                 .await?;
             Ok(format_hover(&result))
         }
@@ -268,17 +279,17 @@ async fn dispatch_action(
                     ToolError::InvalidParameters("'new_name' is required for rename".into())
                 })?;
             let mut p = position_params(file_uri, line, col);
-            p.as_object_mut()
-                .expect("object")
-                .insert("newName".into(), serde_json::Value::String(new_name.into()));
-            let result = lsp.request("textDocument/rename", p).await?;
+            p.insert("newName".into(), serde_json::Value::String(new_name.into()));
+            let result = lsp
+                .request("textDocument/rename", serde_json::Value::Object(p))
+                .await?;
             Ok(format_workspace_edit(&result))
         }
         LspAction::Completions => {
             let result = lsp
                 .request(
                     "textDocument/completion",
-                    position_params(file_uri, line, col),
+                    serde_json::Value::Object(position_params(file_uri, line, col)),
                 )
                 .await?;
             Ok(format_completions(&result))
@@ -287,14 +298,24 @@ async fn dispatch_action(
 }
 
 /// Build a `TextDocumentPositionParams` JSON value.
-fn position_params(uri: &str, line: Option<u32>, col: Option<u32>) -> serde_json::Value {
-    serde_json::json!({
+fn position_params(
+    uri: &str,
+    line: Option<u32>,
+    col: Option<u32>,
+) -> serde_json::Map<String, serde_json::Value> {
+    let value = serde_json::json!({
         "textDocument": { "uri": uri },
         "position": {
             "line": line.unwrap_or(0),
             "character": col.unwrap_or(0)
         }
-    })
+    });
+    match value {
+        serde_json::Value::Object(map) => map,
+        // Unreachable: the literal above is always an object. Construct an
+        // empty map defensively rather than panicking.
+        _ => serde_json::Map::new(),
+    }
 }
 
 // ---- Formatting helpers ----
@@ -528,7 +549,7 @@ fn symbol_kind_name(kind: u64) -> &'static str {
 }
 
 /// Resolve the workspace root from the job context or fall back to CWD.
-fn resolve_workspace_root(ctx: &dyn dasclaw_runtime::JobContextCore) -> PathBuf {
+fn resolve_workspace_root(ctx: &dyn JobContextCore) -> PathBuf {
     ctx.metadata()
         .get("workspace_root")
         .and_then(|v| v.as_str())

--- a/desktop-client/ironclaw/src/tools/builtin/lsp/mod.rs
+++ b/desktop-client/ironclaw/src/tools/builtin/lsp/mod.rs
@@ -1,13 +1,10 @@
 //! LSP integration host wiring.
 //!
-//! Core LSP types (registry, JSON-RPC client, protocol, server config) live
-//! in [`dasclaw_lsp`] after F3.3 (#629). The host-side [`LspQueryTool`]
-//! (impl [`crate::tools::tool::Tool`]) stays here until the `Tool` trait
-//! moves into `dasclaw_tool` in a follow-up issue.
+//! Both the core LSP types (registry, JSON-RPC client, protocol, server
+//! config) and the host-facing [`LspQueryTool`] now live in [`dasclaw_lsp`]
+//! (ADR-152 §3 F3.3, issue #688). This module is a thin re-export so every
+//! existing `crate::tools::builtin::lsp::*` path keeps resolving.
 
 pub use dasclaw_lsp::{
-    LspAction, LspClient, LspRegistry, LspServerConfig, LspServerMapping, path_to_uri,
+    LspAction, LspClient, LspQueryTool, LspRegistry, LspServerConfig, LspServerMapping, path_to_uri,
 };
-
-mod tool;
-pub use tool::LspQueryTool;


### PR DESCRIPTION
feat(lsp): move LspQueryTool into dasclaw_lsp (ADR-152 §3 F3.3 closeout)

## 背景 / 目标

ADR-152 §3 F3.3 要求 LSP 整套（registry / client / protocol / server_config + `LspQueryTool`）落在 `crates/dasclaw_lsp`。
PR #629 先把核心 4 件移过来，但 `LspQueryTool` 因为依赖 `Tool` trait（当时还在 ironclaw 里），只能暂留 `ironclaw::tools::builtin::lsp::tool`。
PR #687（issue #686）把 `Tool` trait 落到了 `dasclaw_runtime`（ADR-154 §10），现在可以把 `LspQueryTool` 物理迁回 `dasclaw_lsp`，正式收口 F3.3。

Closes #688
Refs #672, #686, #687

## 改动范围

- `git mv desktop-client/ironclaw/src/tools/builtin/lsp/tool.rs → crates/dasclaw_lsp/src/tool.rs`（保留 git 历史，ADR-129 verbatim）
- `crates/dasclaw_lsp/Cargo.toml`：新增 `dasclaw_runtime`、`async-trait` 依赖
- `crates/dasclaw_lsp/src/tool.rs`：仅改 use 路径
  - `use crate::tools::tool::{...}` → `use dasclaw_runtime::{JobContextCore, Tool}; use dasclaw_tool::{ApprovalRequirement, RiskLevel, ToolDomain, ToolError, ToolOutput};`
  - `use dasclaw_lsp::{...}` → `use crate::{...}`（已是 crate 内）
  - 函数体未改动
- `crates/dasclaw_lsp/src/lib.rs`：`mod tool;` + `pub use tool::LspQueryTool;`，更新模块注释
- `desktop-client/ironclaw/src/tools/builtin/lsp/mod.rs`：缩减为单条 `pub use dasclaw_lsp::{... LspQueryTool ...};` 再导出，保持 `crate::tools::builtin::lsp::LspQueryTool` 路径不变
- **附带根因修复**（非补丁）：`position_params()` 改返回 `serde_json::Map`，调用点直接 `.insert()`，移除两处 `.as_object_mut().expect("object")` 隐患。这是真正的类型修正——helper 本来就只构造 object，把返回类型对齐到 `Map` 比每次 dispatch 时再断言更稳。

## 非目标 (What's NOT in this PR)

- 不改 `LspQueryTool` 行为、签名、参数 schema、test 断言
- 不改 LSP 协议层（`client.rs` / `protocol.rs` / `registry.rs` / `server_config.rs`）
- 不动 ironclaw 注册逻辑：`tools/registry.rs:834-835` 经由 `builtin::lsp::*` 再导出继续解析
- 不删 ironclaw `tools/builtin/lsp/mod.rs`（保留 shim 是为了 `crate::tools::builtin::lsp::LspRegistry::new()` 等现有调用路径不动）
- 不再有 ADR 修订（ADR-154 §10 已在 #687 落地）

## 验证

```bash
cargo check -p dasclaw_lsp --tests            # Finished in 9.76s
cargo check -p dasclaw --tests                # Finished in 5m 19s
cargo nextest run -p dasclaw_lsp              # 37 passed, 0 failed
cargo fmt --all
python3.12 scripts/check_no_panics.py --base origin/xClaw
# → OK: No panic-inducing calls in changed production code.
cargo clippy --no-deps -p dasclaw_lsp --all-targets -- -D warnings  # clean
cargo clippy --no-deps -p dasclaw --all-targets -- -D warnings      # clean (6m 00s)
```

`dasclaw` 的 `multiple build targets` 警告与本 PR 无关，是预先存在的 bin 配置。

## Sources read

- AGENTS.md §强制阅读顺序、§红线、§本地管线、§PR 必填项
- docs/plans/architecture-refactor/adr-152-decision-routing-extraction.md §3 F3.3（本 PR 收口的 deliverable）
- docs/plans/architecture-refactor/adr-154-jobcontext-core-trait-split.md §10（PR #687 写入的 Tool trait 归属修正）
- docs/plans/architecture-refactor/adr-129-verbatim-port-baseline.md（git mv 保留历史的依据）
- crates/dasclaw_lsp/src/lib.rs（确认原 module 注释里"trait 移走后再迁 LspQueryTool"的承诺）
- crates/dasclaw_runtime/src/{lib.rs,tool.rs}（确认 `Tool` + `JobContextCore` 公开 re-export）
- crates/dasclaw_tool/src/lib.rs（确认 `ApprovalRequirement / RiskLevel / ToolDomain / ToolError / ToolOutput` 公开）
- desktop-client/ironclaw/src/tools/registry.rs:27, 834-835（call sites 经再导出路径继续生效）
- desktop-client/ironclaw/src/tools/builtin/mod.rs:51（`pub use lsp::LspQueryTool;` 继续解析）
