### PR TITLE
feat(workspace-cap): extract sanitization helpers to dasclaw_workspace_cap (slice 7/N preparatory)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3324,6 +3324,7 @@ dependencies = [
  "chrono",
  "dasclaw_llm_provider",
  "deadpool-postgres",
+ "ironclaw_safety",
  "lru",
  "pgvector",
  "postgres-types",

--- a/crates/dasclaw_workspace_cap/Cargo.toml
+++ b/crates/dasclaw_workspace_cap/Cargo.toml
@@ -41,6 +41,10 @@ tracing = "0.1"
 # from the llm provider crate (no behavior change vs ironclaw).
 dasclaw_llm_provider = { path = "../dasclaw_llm_provider" }
 
+# Prompt-injection scanner (slice 7 preparatory: sanitization helpers used by
+# Workspace write paths). Mirrors the dep already used by dasclaw_llm_provider.
+ironclaw_safety = { path = "../../desktop-client/ironclaw/crates/ironclaw_safety" }
+
 # PostgreSQL persistence (slice 5/N: repository). Optional, gated by `postgres`
 # feature so default builds stay dependency-light. Mirrors ironclaw's existing
 # `postgres` feature set (see desktop-client/ironclaw/Cargo.toml).

--- a/crates/dasclaw_workspace_cap/src/lib.rs
+++ b/crates/dasclaw_workspace_cap/src/lib.rs
@@ -52,6 +52,7 @@ pub mod embeddings;
 pub mod layer;
 pub mod policy;
 pub mod privacy;
+pub mod sanitization;
 pub mod search;
 
 pub mod error;

--- a/crates/dasclaw_workspace_cap/src/sanitization.rs
+++ b/crates/dasclaw_workspace_cap/src/sanitization.rs
@@ -1,0 +1,71 @@
+//! Prompt-injection scanning helpers for system-prompt-injected workspace files.
+//!
+//! Extracted verbatim from `ironclaw::workspace::mod` (ADR-152 §3 F3.4 slice 7
+//! preparatory). See issue #674 / #704.
+//!
+//! Writes to any file listed in [`SYSTEM_PROMPT_FILES`] are scanned for
+//! prompt-injection patterns; high-severity hits are rejected, lower-severity
+//! ones are logged.
+
+use ironclaw_safety::{Sanitizer, Severity};
+
+use crate::document::paths;
+use crate::error::WorkspaceError;
+
+/// Files injected into the system prompt. Writes to these are scanned for
+/// prompt injection patterns and rejected if high-severity matches are found.
+pub const SYSTEM_PROMPT_FILES: &[&str] = &[
+    paths::SOUL,
+    paths::AGENTS,
+    paths::USER,
+    paths::IDENTITY,
+    paths::MEMORY,
+    paths::TOOLS,
+    paths::HEARTBEAT,
+    paths::BOOTSTRAP,
+    paths::ASSISTANT_DIRECTIVES,
+    paths::PROFILE,
+];
+
+/// Returns true if `path` (already normalized) is a system-prompt-injected file.
+pub fn is_system_prompt_file(path: &str) -> bool {
+    SYSTEM_PROMPT_FILES
+        .iter()
+        .any(|p| path.eq_ignore_ascii_case(p))
+}
+
+/// Shared sanitizer instance — avoids rebuilding Aho-Corasick + regexes on every write.
+static SANITIZER: std::sync::LazyLock<Sanitizer> = std::sync::LazyLock::new(Sanitizer::new);
+
+/// Scan content for prompt injection. Returns `Err` if high-severity patterns
+/// are detected, otherwise logs warnings and returns `Ok(())`.
+pub fn reject_if_injected(path: &str, content: &str) -> Result<(), WorkspaceError> {
+    let sanitizer = &*SANITIZER;
+    let warnings = sanitizer.detect(content);
+    let dominated = warnings.iter().any(|w| w.severity >= Severity::High);
+    if dominated {
+        let descriptions: Vec<&str> = warnings
+            .iter()
+            .filter(|w| w.severity >= Severity::High)
+            .map(|w| w.description.as_str())
+            .collect();
+        tracing::warn!(
+            target: "ironclaw::safety",
+            file = %path,
+            "workspace write rejected: prompt injection detected ({})",
+            descriptions.join("; "),
+        );
+        return Err(WorkspaceError::InjectionRejected {
+            path: path.to_string(),
+            reason: descriptions.join("; "),
+        });
+    }
+    for w in &warnings {
+        tracing::warn!(
+            target: "ironclaw::safety",
+            file = %path, severity = ?w.severity, pattern = %w.pattern,
+            "workspace write warning: {}", w.description,
+        );
+    }
+    Ok(())
+}

--- a/desktop-client/ironclaw/src/workspace/mod.rs
+++ b/desktop-client/ironclaw/src/workspace/mod.rs
@@ -84,65 +84,7 @@ use deadpool_postgres::Pool;
 use uuid::Uuid;
 
 use crate::error::WorkspaceError;
-use crate::safety::{Sanitizer, Severity};
-
-/// Files injected into the system prompt. Writes to these are scanned for
-/// prompt injection patterns and rejected if high-severity matches are found.
-const SYSTEM_PROMPT_FILES: &[&str] = &[
-    paths::SOUL,
-    paths::AGENTS,
-    paths::USER,
-    paths::IDENTITY,
-    paths::MEMORY,
-    paths::TOOLS,
-    paths::HEARTBEAT,
-    paths::BOOTSTRAP,
-    paths::ASSISTANT_DIRECTIVES,
-    paths::PROFILE,
-];
-
-/// Returns true if `path` (already normalized) is a system-prompt-injected file.
-fn is_system_prompt_file(path: &str) -> bool {
-    SYSTEM_PROMPT_FILES
-        .iter()
-        .any(|p| path.eq_ignore_ascii_case(p))
-}
-
-/// Shared sanitizer instance — avoids rebuilding Aho-Corasick + regexes on every write.
-static SANITIZER: std::sync::LazyLock<Sanitizer> = std::sync::LazyLock::new(Sanitizer::new);
-
-/// Scan content for prompt injection. Returns `Err` if high-severity patterns
-/// are detected, otherwise logs warnings and returns `Ok(())`.
-fn reject_if_injected(path: &str, content: &str) -> Result<(), WorkspaceError> {
-    let sanitizer = &*SANITIZER;
-    let warnings = sanitizer.detect(content);
-    let dominated = warnings.iter().any(|w| w.severity >= Severity::High);
-    if dominated {
-        let descriptions: Vec<&str> = warnings
-            .iter()
-            .filter(|w| w.severity >= Severity::High)
-            .map(|w| w.description.as_str())
-            .collect();
-        tracing::warn!(
-            target: "ironclaw::safety",
-            file = %path,
-            "workspace write rejected: prompt injection detected ({})",
-            descriptions.join("; "),
-        );
-        return Err(WorkspaceError::InjectionRejected {
-            path: path.to_string(),
-            reason: descriptions.join("; "),
-        });
-    }
-    for w in &warnings {
-        tracing::warn!(
-            target: "ironclaw::safety",
-            file = %path, severity = ?w.severity, pattern = %w.pattern,
-            "workspace write warning: {}", w.description,
-        );
-    }
-    Ok(())
-}
+use dasclaw_workspace_cap::sanitization::{is_system_prompt_file, reject_if_injected};
 
 /// Internal storage abstraction for Workspace.
 ///


### PR DESCRIPTION
## Sources read

- `AGENTS.md` § 强制阅读顺序 / 红线 / 本地管线 / PR 必填项 / 测试纪律
- `docs/plans/architecture-refactor/adr-152-...md` § 3 F3.4
- `docs/plans/architecture-refactor/adr-129-...md` § 1.3
- `docs/plans/architecture-refactor/adr-114-...md` § class A redline（确认不新增 `.ironclaw` 字面量；`ironclaw_safety` 是 crate 名，已存在）
- Issue #674；issue #704（本 slice）

## 背景 / 目标

延续 #674 (ADR-152 §3 F3.4)。`desktop-client/ironclaw/src/workspace/` 只剩 `mod.rs` (2172 行，含 `Workspace`) 和 `hygiene.rs` (689 行) 两个真实模块未搬。直接 git mv `mod.rs` 不可能：`Workspace` 同时耦合 `crate::safety::{Sanitizer, Severity}`、`crate::config::WorkspaceSearchConfig`、`crate::bootstrap::dasclaw_base_dir`，而 `hygiene` 又依赖 `Workspace`。

本 slice 做**最小、可独立验证的预备解耦**：把 `mod.rs` 顶部那一组与 `Workspace` 类型无关的**纯函数注入防御助手**搬进 cap crate。这一刀完全不动 `Workspace`，但为后续整体搬迁清掉一个直接依赖。

## 改动范围

### 新文件 `crates/dasclaw_workspace_cap/src/sanitization.rs`

verbatim 复制自 `desktop-client/ironclaw/src/workspace/mod.rs` (原 lines 86–145) 的四个定义：

- `pub const SYSTEM_PROMPT_FILES: &[&str]`（10 个 `paths::*` 引用，paths 已在 cap）
- `pub fn is_system_prompt_file(path: &str) -> bool`
- `static SANITIZER: LazyLock<Sanitizer>`（保持私有）
- `pub fn reject_if_injected(path: &str, content: &str) -> Result<(), WorkspaceError>`

签名、函数体、tracing target `"ironclaw::safety"`、日志字符串保持逐字不变。只调整 import 路径：

- `crate::error::WorkspaceError` → `crate::error::WorkspaceError`（同名，cap crate 内部路径）
- `crate::safety::{Sanitizer, Severity}` → `ironclaw_safety::{Sanitizer, Severity}`
- `paths::*` → `crate::document::paths::*`

### `crates/dasclaw_workspace_cap/Cargo.toml`

新增 `ironclaw_safety = { path = "../../desktop-client/ironclaw/crates/ironclaw_safety" }`。路径与 `dasclaw_llm_provider/Cargo.toml` 现有用法一致。不启用 `egress-gate` feature（cap crate 用不到），默认 feature 集即可。

### `crates/dasclaw_workspace_cap/src/lib.rs`

新增 `pub mod sanitization;`，与 `policy` / `privacy` / `search` 同列。

### `desktop-client/ironclaw/src/workspace/mod.rs`

- 删除 line 87 `use crate::safety::{Sanitizer, Severity};`
- 删除 lines 89–145 的四个定义及其文档
- 在同位置加 `use dasclaw_workspace_cap::sanitization::{is_system_prompt_file, reject_if_injected};`

`is_system_prompt_file` / `reject_if_injected` 在 mod.rs 内的 5 处调用点（lines 710 / 736 / 752 / 1982 / 1987）自动 resolve，路径无需改。

## 非目标（What's NOT in this PR）

- 不动 `Workspace` 结构体、`WorkspaceStorage` 枚举、`impl Workspace` 任何方法
- 不动 `hygiene.rs`
- 不改 `ironclaw_safety` crate / `Sanitizer` / `Severity` 任何代码
- 不动 `WorkspaceSearchConfig` 或 `bootstrap::dasclaw_base_dir`（后续 slice）
- 不改 mod.rs 其他 2100 行的任何函数体
- 不改公开 API surface（cap crate 新增 `sanitization` 模块，扩展非破坏）

## 验证（命令 + 结果）

```bash
cargo check -p dasclaw_workspace_cap --tests                    # OK (1m09s)
cargo check -p dasclaw_workspace_cap --tests --features postgres  # OK (16.85s)
cargo nextest run -p dasclaw_workspace_cap                      # 132/132 passed
cargo nextest run -p dasclaw_workspace_cap --features postgres  # 132/132 passed
cargo check -p dasclaw --tests                                  # OK (8m29s)
cargo check -p dasclaw --tests --no-default-features            # OK (3.09s)
cargo fmt --all                                                 # clean
python3.12 scripts/check_no_panics.py --base origin/xClaw       # OK
cargo clippy --no-deps -p dasclaw_workspace_cap --all-targets -- -D warnings           # clean (15.61s)
cargo clippy --no-deps -p dasclaw_workspace_cap --all-targets --features postgres -- -D warnings  # clean (15.05s)
```

`cargo clippy --no-deps -p dasclaw` 由 CI Clippy(default) job 兜底（per `AGENTS.md` "完整 workspace clippy 本地不要跑"）。

## 三层代码审查自检

- grep_search `reject_if_injected|is_system_prompt_file|SYSTEM_PROMPT_FILES|SANITIZER`：搬迁后定义只在 cap crate 的 `sanitization.rs`，ironclaw 侧只剩调用点 5 处 + 1 处 import。无重复定义。
- 比对原 mod.rs lines 89–145 与新 `sanitization.rs`：函数体逐字一致，包含 `target: "ironclaw::safety"` 字符串、`workspace write rejected: prompt injection detected ({})` 日志、`WorkspaceError::InjectionRejected` 分支返回。
- rg / file_search 复核：cap crate 现有 `pub mod` 列表只新增 `sanitization` 一项；`ironclaw_safety` 已在 workspace deny.toml 白名单内（无新增）。

Closes #704
Refs #674
