### PR TITLE
feat(workspace-cap): extract WorkspaceSearchConfig data struct to dasclaw_workspace_cap (slice 8/N preparatory)

### DIFF
--- a/crates/dasclaw_workspace_cap/src/config.rs
+++ b/crates/dasclaw_workspace_cap/src/config.rs
@@ -1,0 +1,42 @@
+//! Workspace search configuration data.
+//!
+//! This module hosts the data structure that callers (typically the host
+//! process's configuration layer) resolve from environment variables or
+//! settings. The runtime [`crate::search::SearchConfig`] is constructed
+//! from these fields by `Workspace::with_search_config`.
+//!
+//! Environment-variable resolution (`resolve()`) lives in the host crate
+//! (`ironclaw::config::search`) because it depends on host-specific
+//! helpers and error types; this crate only owns the pure data shape.
+
+use crate::search::FusionStrategy;
+
+/// Workspace search configuration resolved from environment variables.
+#[derive(Debug, Clone)]
+pub struct WorkspaceSearchConfig {
+    /// Fusion strategy: "rrf" or "weighted".
+    pub fusion_strategy: FusionStrategy,
+    /// RRF constant k (default 60).
+    pub rrf_k: u32,
+    /// FTS weight for fusion.
+    ///
+    /// [`Default`] uses 0.5. When the configuration is resolved, per-strategy
+    /// defaults are applied: 0.5 (RRF) or 0.3 (weighted).
+    pub fts_weight: f32,
+    /// Vector weight for fusion.
+    ///
+    /// [`Default`] uses 0.5. When the configuration is resolved, per-strategy
+    /// defaults are applied: 0.5 (RRF) or 0.7 (weighted).
+    pub vector_weight: f32,
+}
+
+impl Default for WorkspaceSearchConfig {
+    fn default() -> Self {
+        Self {
+            fusion_strategy: FusionStrategy::default(),
+            rrf_k: 60,
+            fts_weight: 0.5,
+            vector_weight: 0.5,
+        }
+    }
+}

--- a/crates/dasclaw_workspace_cap/src/lib.rs
+++ b/crates/dasclaw_workspace_cap/src/lib.rs
@@ -46,6 +46,7 @@
 //! ```
 
 pub mod chunker;
+pub mod config;
 pub mod document;
 pub mod embedding_cache;
 pub mod embeddings;

--- a/desktop-client/ironclaw/src/config/mod.rs
+++ b/desktop-client/ironclaw/src/config/mod.rs
@@ -379,7 +379,7 @@ impl Config {
             claude_code: ClaudeCodeConfig::resolve(settings)?,
             skills: SkillsConfig::resolve()?,
             transcription: TranscriptionConfig::resolve(settings)?,
-            search: WorkspaceSearchConfig::resolve()?,
+            search: search::resolve()?,
             workspace,
             observability: crate::observability::ObservabilityConfig {
                 backend: std::env::var("OBSERVABILITY_BACKEND").unwrap_or_else(|_| "none".into()),

--- a/desktop-client/ironclaw/src/config/search.rs
+++ b/desktop-client/ironclaw/src/config/search.rs
@@ -1,92 +1,66 @@
 use crate::config::helpers::{optional_env, parse_optional_env};
 use crate::error::ConfigError;
-use crate::workspace::FusionStrategy;
+use dasclaw_workspace_cap::search::FusionStrategy;
 
-/// Workspace search configuration resolved from environment variables.
-#[derive(Debug, Clone)]
-pub struct WorkspaceSearchConfig {
-    /// Fusion strategy: "rrf" or "weighted".
-    pub fusion_strategy: FusionStrategy,
-    /// RRF constant k (default 60).
-    pub rrf_k: u32,
-    /// FTS weight for fusion.
-    ///
-    /// [`Default`] uses 0.5. When the configuration is resolved, per-strategy
-    /// defaults are applied: 0.5 (RRF) or 0.3 (weighted).
-    pub fts_weight: f32,
-    /// Vector weight for fusion.
-    ///
-    /// [`Default`] uses 0.5. When the configuration is resolved, per-strategy
-    /// defaults are applied: 0.5 (RRF) or 0.7 (weighted).
-    pub vector_weight: f32,
-}
+pub use dasclaw_workspace_cap::config::WorkspaceSearchConfig;
 
-impl Default for WorkspaceSearchConfig {
-    fn default() -> Self {
-        Self {
-            fusion_strategy: FusionStrategy::default(),
-            rrf_k: 60,
-            fts_weight: 0.5,
-            vector_weight: 0.5,
-        }
+/// Resolve [`WorkspaceSearchConfig`] from environment variables.
+///
+/// Environment-variable IO lives in this host-side module; the pure data
+/// shape lives in `dasclaw_workspace_cap::config`.
+pub(crate) fn resolve() -> Result<WorkspaceSearchConfig, ConfigError> {
+    let fusion_strategy = match optional_env("SEARCH_FUSION_STRATEGY")? {
+        Some(s) => match s.to_lowercase().as_str() {
+            "rrf" => FusionStrategy::Rrf,
+            "weighted" => FusionStrategy::WeightedScore,
+            other => {
+                return Err(ConfigError::InvalidValue {
+                    key: "SEARCH_FUSION_STRATEGY".to_string(),
+                    message: format!("must be 'rrf' or 'weighted', got '{other}'"),
+                });
+            }
+        },
+        None => FusionStrategy::default(),
+    };
+
+    let rrf_k = parse_optional_env("SEARCH_RRF_K", 60u32)?;
+
+    // Per-strategy weight defaults: RRF uses 0.5/0.5, weighted uses 0.3/0.7 (vector-biased).
+    let (default_fts, default_vec) = match fusion_strategy {
+        FusionStrategy::Rrf => (0.5f32, 0.5f32),
+        FusionStrategy::WeightedScore => (0.3f32, 0.7f32),
+    };
+    let fts_weight = parse_optional_env("SEARCH_FTS_WEIGHT", default_fts)?;
+    let vector_weight = parse_optional_env("SEARCH_VECTOR_WEIGHT", default_vec)?;
+
+    if !fts_weight.is_finite() || fts_weight < 0.0 {
+        return Err(ConfigError::InvalidValue {
+            key: "SEARCH_FTS_WEIGHT".to_string(),
+            message: "must be a finite, non-negative float".to_string(),
+        });
     }
-}
-
-impl WorkspaceSearchConfig {
-    pub(crate) fn resolve() -> Result<Self, ConfigError> {
-        let fusion_strategy = match optional_env("SEARCH_FUSION_STRATEGY")? {
-            Some(s) => match s.to_lowercase().as_str() {
-                "rrf" => FusionStrategy::Rrf,
-                "weighted" => FusionStrategy::WeightedScore,
-                other => {
-                    return Err(ConfigError::InvalidValue {
-                        key: "SEARCH_FUSION_STRATEGY".to_string(),
-                        message: format!("must be 'rrf' or 'weighted', got '{other}'"),
-                    });
-                }
-            },
-            None => FusionStrategy::default(),
-        };
-
-        let rrf_k = parse_optional_env("SEARCH_RRF_K", 60u32)?;
-
-        // Per-strategy weight defaults: RRF uses 0.5/0.5, weighted uses 0.3/0.7 (vector-biased).
-        let (default_fts, default_vec) = match fusion_strategy {
-            FusionStrategy::Rrf => (0.5f32, 0.5f32),
-            FusionStrategy::WeightedScore => (0.3f32, 0.7f32),
-        };
-        let fts_weight = parse_optional_env("SEARCH_FTS_WEIGHT", default_fts)?;
-        let vector_weight = parse_optional_env("SEARCH_VECTOR_WEIGHT", default_vec)?;
-
-        if !fts_weight.is_finite() || fts_weight < 0.0 {
-            return Err(ConfigError::InvalidValue {
-                key: "SEARCH_FTS_WEIGHT".to_string(),
-                message: "must be a finite, non-negative float".to_string(),
-            });
-        }
-        if !vector_weight.is_finite() || vector_weight < 0.0 {
-            return Err(ConfigError::InvalidValue {
-                key: "SEARCH_VECTOR_WEIGHT".to_string(),
-                message: "must be a finite, non-negative float".to_string(),
-            });
-        }
-        if matches!(fusion_strategy, FusionStrategy::WeightedScore)
-            && fts_weight == 0.0
-            && vector_weight == 0.0
-        {
-            return Err(ConfigError::InvalidValue {
-                key: "SEARCH_FTS_WEIGHT/SEARCH_VECTOR_WEIGHT".to_string(),
-                message: "weighted fusion requires at least one non-zero weight".to_string(),
-            });
-        }
-
-        Ok(Self {
-            fusion_strategy,
-            rrf_k,
-            fts_weight,
-            vector_weight,
-        })
+    if !vector_weight.is_finite() || vector_weight < 0.0 {
+        return Err(ConfigError::InvalidValue {
+            key: "SEARCH_VECTOR_WEIGHT".to_string(),
+            message: "must be a finite, non-negative float".to_string(),
+        });
     }
+    if matches!(fusion_strategy, FusionStrategy::WeightedScore)
+        && fts_weight == 0.0
+        && vector_weight == 0.0
+    {
+        return Err(ConfigError::InvalidValue {
+            key: "SEARCH_FTS_WEIGHT/SEARCH_VECTOR_WEIGHT".to_string(),
+            message: "weighted fusion requires at least one non-zero weight".to_string(),
+        });
+    }
+
+    Ok(WorkspaceSearchConfig {
+        fusion_strategy,
+        rrf_k,
+        fts_weight,
+        vector_weight,
+    })
 }
 
 #[cfg(test)]
@@ -109,7 +83,7 @@ mod tests {
         let _guard = lock_env();
         clear_search_env();
 
-        let config = WorkspaceSearchConfig::resolve().expect("should resolve");
+        let config = resolve().expect("should resolve");
         assert_eq!(config.fusion_strategy, FusionStrategy::Rrf);
         assert_eq!(config.rrf_k, 60);
         assert!((config.fts_weight - 0.5).abs() < 0.001);
@@ -129,7 +103,7 @@ mod tests {
             std::env::set_var("SEARCH_VECTOR_WEIGHT", "0.1");
         }
 
-        let config = WorkspaceSearchConfig::resolve().expect("should resolve");
+        let config = resolve().expect("should resolve");
         assert_eq!(config.fusion_strategy, FusionStrategy::WeightedScore);
         assert_eq!(config.rrf_k, 30);
         assert!((config.fts_weight - 0.9).abs() < 0.001);
@@ -148,7 +122,7 @@ mod tests {
             std::env::set_var("SEARCH_FUSION_STRATEGY", "bm25");
         }
 
-        let result = WorkspaceSearchConfig::resolve();
+        let result = resolve();
         assert!(result.is_err());
 
         clear_search_env();
@@ -164,7 +138,7 @@ mod tests {
             std::env::set_var("SEARCH_FUSION_STRATEGY", "weighted");
         }
 
-        let config = WorkspaceSearchConfig::resolve().expect("should resolve");
+        let config = resolve().expect("should resolve");
         assert_eq!(config.fusion_strategy, FusionStrategy::WeightedScore);
         // Weighted mode should default to 0.3 FTS / 0.7 vector
         assert!((config.fts_weight - 0.3).abs() < 0.001);
@@ -185,7 +159,7 @@ mod tests {
             std::env::set_var("SEARCH_VECTOR_WEIGHT", "0.0");
         }
 
-        let result = WorkspaceSearchConfig::resolve();
+        let result = resolve();
         assert!(result.is_err());
 
         clear_search_env();
@@ -203,7 +177,7 @@ mod tests {
         }
 
         // RRF ignores weights, so both=0 is fine
-        let config = WorkspaceSearchConfig::resolve().expect("should resolve");
+        let config = resolve().expect("should resolve");
         assert_eq!(config.fusion_strategy, FusionStrategy::Rrf);
 
         clear_search_env();

--- a/desktop-client/ironclaw/src/workspace/mod.rs
+++ b/desktop-client/ironclaw/src/workspace/mod.rs
@@ -461,7 +461,10 @@ impl Workspace {
     }
 
     /// Set the default search configuration from workspace search config.
-    pub fn with_search_config(mut self, config: &crate::config::WorkspaceSearchConfig) -> Self {
+    pub fn with_search_config(
+        mut self,
+        config: &dasclaw_workspace_cap::config::WorkspaceSearchConfig,
+    ) -> Self {
         self.search_defaults = SearchConfig::default()
             .with_fusion_strategy(config.fusion_strategy)
             .with_rrf_k(config.rrf_k)


### PR DESCRIPTION
## Sources read

- `AGENTS.md` § 强制阅读顺序 / 红线 / 本地管线 / PR 必填项
- `docs/plans/architecture-refactor/adr-152-...md` § 3 F3.4
- `docs/plans/architecture-refactor/adr-129-...md` § 1.3
- Issue #674；issue #706

## 背景 / 目标

延续 #674 (ADR-152 §3 F3.4)。Slice 7 (#705, 028b63b0) 把 `crate::safety::*` 直接依赖从 `Workspace` 移走后，`Workspace` 还剩两个对 ironclaw 内部模块的直接依赖：

1. `crate::config::WorkspaceSearchConfig` — `with_search_config` 参数类型
2. `crate::bootstrap::dasclaw_base_dir` — `Default for Workspace`

本 PR 处理第 1 项。把 `WorkspaceSearchConfig` 数据结构搬进 cap crate，让 `with_search_config` 直接引用 `dasclaw_workspace_cap::config::WorkspaceSearchConfig`，`Workspace` 与 ironclaw `config` 模块完全脱钩。

## 改动范围

### 新文件 `crates/dasclaw_workspace_cap/src/config.rs`

verbatim 移植 `desktop-client/ironclaw/src/config/search.rs` lines 5–33（字段 + Default）：
- `pub struct WorkspaceSearchConfig { fusion_strategy, rrf_k, fts_weight, vector_weight }`
- `impl Default`：60 / 0.5 / 0.5 / `FusionStrategy::default()`
- 字段顺序、doc comments 完全一致
- `FusionStrategy` 引用改为 `crate::search::FusionStrategy`（cap 内）

### `crates/dasclaw_workspace_cap/src/lib.rs`

新增 `pub mod config;`（位于 `chunker` 后、`document` 前，保持字母序）。

### `desktop-client/ironclaw/src/config/search.rs`

- 删除本地 struct 定义 + `impl Default` + `impl WorkspaceSearchConfig {` 包裹
- 新增 `pub use dasclaw_workspace_cap::config::WorkspaceSearchConfig;` —— `crate::config::WorkspaceSearchConfig` 路径继续有效
- `use crate::workspace::FusionStrategy;` → `use dasclaw_workspace_cap::search::FusionStrategy;`（resolve 函数与 tests 共用）
- `pub(crate) fn resolve(&Self) -> Result<Self, ConfigError>` （inherent impl）→ `pub(crate) fn resolve() -> Result<WorkspaceSearchConfig, ConfigError>`（同模块自由函数，Rust 孤儿规则要求）。函数体逐字保留：fusion_strategy match / rrf_k / per-strategy 默认 / 边界校验（finite、非负、weighted 双零拒绝）全部不变
- 6 处 `WorkspaceSearchConfig::resolve()` → `resolve()` （5 处在 mod tests 内，1 处即定义本身）

### `desktop-client/ironclaw/src/config/mod.rs`

第 382 行：`search: WorkspaceSearchConfig::resolve()?,` → `search: search::resolve()?,`。`pub use self::search::WorkspaceSearchConfig;` 保留（重导出 cap 类型）。

### `desktop-client/ironclaw/src/workspace/mod.rs`

第 464 行 `with_search_config` 参数类型：
`&crate::config::WorkspaceSearchConfig` → `&dasclaw_workspace_cap::config::WorkspaceSearchConfig`。函数体不变（仍只读 4 个字段链给 `SearchConfig`）。

## 非目标（What's NOT in this PR）

- 不动 `WorkspaceConfig` 顶层结构
- 不搬环境变量读取逻辑（`optional_env`/`parse_optional_env`/`ConfigError` 仍在 ironclaw 配置层）
- 不动 `bootstrap::dasclaw_base_dir`（slice 9 候选）
- 不搬 `Workspace` 本体（后续 slice）
- 不搬 `hygiene.rs`
- 不改 cap 或 ironclaw 公开 API 数据语义；调用方 `crate::config::WorkspaceSearchConfig` 路径仍 work

## 验证（命令 + 结果）

```bash
cargo check -p dasclaw_workspace_cap --tests                                   # OK 2.20s
cargo check -p dasclaw_workspace_cap --tests --features postgres               # OK 2.48s
cargo nextest run -p dasclaw_workspace_cap                                     # 132/132 passed (3.386s)
cargo nextest run -p dasclaw_workspace_cap --features postgres                 # 132/132 passed (3.712s)
cargo check -p dasclaw --tests --no-default-features                           # OK 3m40s
cargo fmt --all                                                                # clean
python3.12 scripts/check_no_panics.py --base origin/xClaw                      # OK
cargo clippy --no-deps -p dasclaw_workspace_cap --all-targets -- -D warnings                       # clean 6.53s
cargo clippy --no-deps -p dasclaw_workspace_cap --all-targets --features postgres -- -D warnings   # clean 5.36s
```

完整 dasclaw default-features check + workspace clippy 留给 CI（per AGENTS.md §3）。

## 三层代码审查自检

- semantic_search 已在前序 slice 完成。
- grep_search `WorkspaceSearchConfig` 全仓：cap 持有结构定义 (config.rs)，ironclaw 持有 `pub use` 重导出 + `resolve()` 自由函数；call sites 不变（channels/web/server.rs:231 / 241、tests/multi_tenant.rs 4 处仍通过 `crate::config::WorkspaceSearchConfig` 路径，由重导出兜底）。无重复定义。
- grep_search `WorkspaceSearchConfig::resolve` 全仓：0 hit（已全部改成 `resolve()` 自由函数调用），唯一 `fn resolve()` 定义在 `config/search.rs`。
- 比对原 mod.rs lines 5–33 与新 cap config.rs：字段名/顺序/类型/Default 数值/doc comments 完全一致。

Closes #706
Refs #674
