### PR TITLE
feat(dasclaw_core): move context::memory into dasclaw_core (ADR-152 §3 F3.6 slice 1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2831,6 +2831,7 @@ dependencies = [
  "dasclaw_governance",
  "dasclaw_project_docs",
  "ironclaw_common",
+ "rust_decimal",
  "serde",
  "serde_json",
  "tempfile",

--- a/crates/dasclaw_core/Cargo.toml
+++ b/crates/dasclaw_core/Cargo.toml
@@ -26,6 +26,8 @@ tracing = "0.1"
 # session / undo / task 依赖
 chrono = { version = "0.4", features = ["serde"] }
 uuid = { version = "1", features = ["v4", "v5", "serde"] }
+# context::memory 依赖 (ADR-152 §3 F3.6 slice 1, ActionRecord.cost / Memory.total_cost)
+rust_decimal = { version = "1", features = ["serde"] }
 # session 的 truncate_preview helper
 ironclaw_common = { path = "../../desktop-client/ironclaw/crates/ironclaw_common", version = "0.1.0" }
 # session_manager 需要 RwLock/Mutex/spawn (fire-and-forget hooks)

--- a/crates/dasclaw_core/src/context/memory.rs
+++ b/crates/dasclaw_core/src/context/memory.rs
@@ -7,7 +7,7 @@ use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::llm::ChatMessage;
+use crate::messages::ChatMessage;
 
 /// A record of an action taken during job execution.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -121,7 +121,7 @@ impl ConversationMemory {
         // Trim old messages if needed (keeping system message if present)
         while self.messages.len() > self.max_messages {
             // Don't remove system messages
-            if self.messages.first().map(|m| m.role) == Some(crate::llm::Role::System) {
+            if self.messages.first().map(|m| m.role) == Some(crate::messages::Role::System) {
                 if self.messages.len() > 1 {
                     self.messages.remove(1);
                 } else {
@@ -416,7 +416,7 @@ mod tests {
 
         assert_eq!(mem.len(), 3); // safety: test
         // System message must survive
-        assert_eq!(mem.messages()[0].role, crate::llm::Role::System); // safety: test
+        assert_eq!(mem.messages()[0].role, crate::messages::Role::System); // safety: test
         assert_eq!(mem.messages()[0].content, "You are helpful"); // safety: test
         // Oldest non-system message (msg1) should be gone
         assert_eq!(mem.messages()[1].content, "msg2"); // safety: test
@@ -432,7 +432,7 @@ mod tests {
         mem.add(ChatMessage::user("b"));
 
         assert_eq!(mem.len(), 2); // safety: test
-        assert_eq!(mem.messages()[0].role, crate::llm::Role::System); // safety: test
+        assert_eq!(mem.messages()[0].role, crate::messages::Role::System); // safety: test
         assert_eq!(mem.messages()[1].content, "b"); // safety: test
     }
 

--- a/crates/dasclaw_core/src/context/mod.rs
+++ b/crates/dasclaw_core/src/context/mod.rs
@@ -1,0 +1,14 @@
+//! Per-job context isolation and state management.
+//!
+//! Verbatim port from `desktop-client/ironclaw/src/context/` per ADR-152 §3
+//! F3.6. Slice 1 of this port brings in [`memory`]; subsequent slices will
+//! add `fallback`, `state`, and `manager`. See ADR-152 §3 F3.6 row and §11.7
+//! for the boundary analysis.
+//!
+//! Modules are re-exported from this crate root via
+//! `dasclaw_core::context::memory::*` so host code only needs a thin
+//! `pub use dasclaw_core::context::memory::*;` shim to consume them.
+
+pub mod memory;
+
+pub use memory::{ActionRecord, ConversationMemory, Memory};

--- a/crates/dasclaw_core/src/lib.rs
+++ b/crates/dasclaw_core/src/lib.rs
@@ -15,6 +15,7 @@ pub mod agentic_loop;
 pub mod bash_validation;
 pub mod compaction;
 // composite_safety_hook removed by ADR-148; CompositeEgressGate lives in dasclaw_governance::egress.
+pub mod context;
 pub mod context_monitor;
 pub mod egress_apply;
 pub mod hooks;

--- a/desktop-client/ironclaw/src/context/fallback.rs
+++ b/desktop-client/ironclaw/src/context/fallback.rs
@@ -10,7 +10,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::context::memory::Memory;
+use crate::context::Memory;
 use crate::context::state::JobContext;
 
 /// Structured summary of a failed or stuck job.
@@ -115,7 +115,7 @@ fn truncate_str(s: &str, max_len: usize) -> &str {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::context::memory::Memory;
+    use crate::context::Memory;
     use crate::context::state::JobContext;
     use chrono::{Duration, Utc};
     use rust_decimal::Decimal;

--- a/desktop-client/ironclaw/src/context/mod.rs
+++ b/desktop-client/ironclaw/src/context/mod.rs
@@ -8,10 +8,12 @@
 
 pub mod fallback;
 mod manager;
-mod memory;
 mod state;
 
 pub use fallback::FallbackDeliverable;
 pub use manager::ContextManager;
-pub use memory::{ActionRecord, ConversationMemory, Memory};
+// ADR-152 §3 F3.6 slice 1: `memory` was moved into `dasclaw_core::context::memory`.
+// Re-export keeps existing `crate::context::{ActionRecord, ConversationMemory, Memory}`
+// call sites (e.g. `worker::job`) source-compatible.
+pub use dasclaw_core::context::memory::{ActionRecord, ConversationMemory, Memory};
 pub use state::{JobContext, JobState, StateTransition, TokenBudgetExceeded};


### PR DESCRIPTION
## 背景 / 目标

ADR-152 §3 F3.6 第一个切片（共 6 个）。把 `desktop-client/ironclaw/src/context/memory.rs` verbatim 搬到 `dasclaw_core::context::memory`。它是 `context/` 家族里唯一一个**没有任何同级依赖**的文件，只需要把 `crate::llm::{ChatMessage,Role}` 这一处 host 引用 rebase 到 `crate::messages::{ChatMessage,Role}`（两个类型已经在 dasclaw_core 里）。

## 改动范围

- `git mv desktop-client/ironclaw/src/context/memory.rs → crates/dasclaw_core/src/context/memory.rs`（git 识别为 98% rename）
- `crates/dasclaw_core/Cargo.toml`：新增 `rust_decimal = { version = "1", features = ["serde"] }`（`ActionRecord.cost` / `Memory.total_cost` 需要）
- `crates/dasclaw_core/src/lib.rs`：注册 `pub mod context;`
- `crates/dasclaw_core/src/context/mod.rs`：新增，re-export `memory::{ActionRecord, ConversationMemory, Memory}`
- `desktop-client/ironclaw/src/context/mod.rs`：去掉 `mod memory;`，把三个名字通过 `pub use dasclaw_core::context::memory::{...};` 拉回来。host 现有的 `crate::context::Memory` 调用点（`worker::job.rs` 等）源码层零改动。
- `desktop-client/ironclaw/src/context/fallback.rs`：把同级 import `crate::context::memory::Memory` 改为父 re-export `crate::context::Memory`（原 `memory` 子模块已不在 host）。
- 在 dasclaw_core 内文件唯一的逻辑性 edit 是 4 处 `crate::llm::*` → `crate::messages::*` 路径替换。

## Verbatim-port 合规（ADR-129 §1.3）

唯一的修改是 import 路径 rebase；零逻辑改动、零命名改动、零文档改动、零测试改动。

## 非目标（What's NOT in this PR）

- 不动 `fallback.rs` / `manager.rs` / `state.rs` / `context/mod.rs` 的本体搬迁
- 不动 `JobError` 抽离（slice 2 候选）
- 不动 `JobContext` god-struct 拆分（ADR-152 §11.7 follow-up，本 PR 不触及）

## 验证（本地）

| 命令 | 结果 |
|---|---|
| `cargo check -p dasclaw_core --tests` | clean |
| `cargo check -p dasclaw --tests` | clean |
| `cargo nextest run -p dasclaw_core` (memory 测试) | **21/21 pass** |
| `cargo fmt --all` | clean |
| `python3.12 scripts/check_no_panics.py --base origin/xClaw` | clean |
| `cargo clippy --no-deps -p dasclaw_core --all-targets -- -D warnings` | clean |

完整 `cargo build` / workspace clippy / 全套 nextest 由 CI 兜底。

## Cross-cuts

ADR-114（`.ironclaw` → `.dasclaw` 命名迁移）：**类 A**（diff 无新增 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量）。

## 后续 PR

- F3.6 slice 2：`JobError` 抽到 `dasclaw_core::error`，然后搬 `manager.rs`（同时消费 Memory + JobError）
- `state.rs` / `fallback.rs`：等 `JobContext` god-struct 拆分完才能搬（ADR-152 §11.7）

## 三层审查

- code-quality-audit：无补丁式代码、无新增 unwrap/clone、未拆函数、未新增逻辑
- code-simplifier：**跳过**（ADR-129 §1.3 verbatim port）
- adr-compliance-check：ADR-152 §3 F3.6 直接对应；ADR-129 §1.3 verbatim 合规；ADR-114 类 A 合规；无 panic 红线
- code-review-expert：re-export 链验证通过（worker::job 源码层无感知）；21/21 单测搬迁后全绿；降耦合而非引入新耦合

Closes #715 (slice 1 sub-issue)
Refs #632 (ADR-152 §3 F3.6 umbrella — stays open until all 6 slices land)