### PR TITLE
feat(dasclaw_core): extract JobError to dasclaw_core::error (ADR-152 §3 F3.6 slice 2)

### DIFF
--- a/crates/dasclaw_core/src/error.rs
+++ b/crates/dasclaw_core/src/error.rs
@@ -1,0 +1,58 @@
+//! Error types ported from `desktop-client/ironclaw/src/error.rs`.
+//!
+//! Verbatim port per ADR-152 §3 F3.6 slice 2/6 and ADR-129 §1.3. Only
+//! `JobError` lives here for now; other error families remain in the host
+//! crate until their respective slices land. The host's `crate::error::JobError`
+//! is kept as a `pub use` re-export shim, matching the pattern already used by
+//! [`dasclaw_workspace_cap::error::WorkspaceError`] and
+//! [`dasclaw_runtime::ToolError`].
+
+use std::time::Duration;
+
+use uuid::Uuid;
+
+/// Job-related errors.
+#[derive(Debug, thiserror::Error)]
+pub enum JobError {
+    #[error("Job {id} not found")]
+    NotFound { id: Uuid },
+
+    #[error("Job {id} already in state {state}, cannot transition to {target}")]
+    InvalidTransition {
+        id: Uuid,
+        state: String,
+        target: String,
+    },
+
+    #[error("Job {id} failed: {reason}")]
+    Failed { id: Uuid, reason: String },
+
+    #[error("Job {id} stuck for {duration:?}")]
+    Stuck { id: Uuid, duration: Duration },
+
+    #[error("Maximum parallel jobs ({max}) exceeded")]
+    MaxJobsExceeded { max: usize },
+
+    #[error("Job {id} context error: {reason}")]
+    ContextError { id: Uuid, reason: String },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn job_error_display() {
+        let err = JobError::MaxJobsExceeded { max: 5 };
+        let msg = err.to_string();
+        assert!(msg.contains("5"), "Should mention max: {msg}");
+
+        let id = Uuid::new_v4();
+        let err = JobError::NotFound { id };
+        let msg = err.to_string();
+        assert!(
+            msg.contains(&id.to_string()),
+            "Should mention job id: {msg}"
+        );
+    }
+}

--- a/crates/dasclaw_core/src/lib.rs
+++ b/crates/dasclaw_core/src/lib.rs
@@ -18,6 +18,7 @@ pub mod compaction;
 pub mod context;
 pub mod context_monitor;
 pub mod egress_apply;
+pub mod error;
 pub mod hooks;
 pub mod intent;
 pub mod llm;
@@ -39,6 +40,7 @@ pub use bash_validation::{
     CommandIntent, ValidationResult, check_destructive, classify_command, validate_command,
     validate_mode, validate_paths, validate_read_only, validate_sed,
 };
+pub use error::JobError;
 pub use hooks::{
     ApprovalError, ApprovalGate, ApprovalOutcome, ApprovalRequest, AutoApproveGate,
     CompositeEgressGate, CompositeEgressGateBuilder, DenyAllGate, EgressDecision, EgressGate,

--- a/desktop-client/ironclaw/src/error.rs
+++ b/desktop-client/ironclaw/src/error.rs
@@ -1,7 +1,5 @@
 //! Error types for IronClaw.
 
-use std::time::Duration;
-
 use uuid::Uuid;
 
 /// Top-level error type for the agent.
@@ -174,30 +172,12 @@ pub enum SafetyError {
 }
 
 /// Job-related errors.
-#[derive(Debug, thiserror::Error)]
-pub enum JobError {
-    #[error("Job {id} not found")]
-    NotFound { id: Uuid },
-
-    #[error("Job {id} already in state {state}, cannot transition to {target}")]
-    InvalidTransition {
-        id: Uuid,
-        state: String,
-        target: String,
-    },
-
-    #[error("Job {id} failed: {reason}")]
-    Failed { id: Uuid, reason: String },
-
-    #[error("Job {id} stuck for {duration:?}")]
-    Stuck { id: Uuid, duration: Duration },
-
-    #[error("Maximum parallel jobs ({max}) exceeded")]
-    MaxJobsExceeded { max: usize },
-
-    #[error("Job {id} context error: {reason}")]
-    ContextError { id: Uuid, reason: String },
-}
+///
+/// Re-export shim. Definition lives in [`dasclaw_core::error::JobError`]
+/// per ADR-152 §3 F3.6 slice 2 (#717). Kept here so existing
+/// `crate::error::JobError` call sites and the top-level `Error::Job(#[from] _)`
+/// conversion keep working.
+pub use dasclaw_core::JobError;
 
 /// Estimation errors.
 #[derive(Debug, thiserror::Error)]
@@ -406,21 +386,6 @@ mod tests {
         assert!(
             msg.contains("invalid token"),
             "Should mention reason: {msg}"
-        );
-    }
-
-    #[test]
-    fn job_error_display() {
-        let err = JobError::MaxJobsExceeded { max: 5 };
-        let msg = err.to_string();
-        assert!(msg.contains("5"), "Should mention max: {msg}");
-
-        let id = Uuid::new_v4();
-        let err = JobError::NotFound { id };
-        let msg = err.to_string();
-        assert!(
-            msg.contains(&id.to_string()),
-            "Should mention job id: {msg}"
         );
     }
 


### PR DESCRIPTION
## 背景 / 目标

为 F3.6 后续切片（特别是 `context::manager` 搬迁）铺路，把 `JobError` 从 `desktop-client/ironclaw/src/error.rs` 抽到新建的 `dasclaw_core::error` 模块。沿用既有 re-export shim 模式（参考 `WorkspaceError` → `dasclaw_workspace_cap::error`、`ToolError` → `dasclaw_runtime::ToolError`）。

## 改动范围

- **新建** `crates/dasclaw_core/src/error.rs`：`JobError` enum + `job_error_display` 单测，byte-for-byte 复制原定义。
- `crates/dasclaw_core/src/lib.rs`：增 `pub mod error;` 与 `pub use error::JobError;`。
- `desktop-client/ironclaw/src/error.rs`：删除本地 `JobError` 定义和重复的 `job_error_display` 测试，改为 `pub use dasclaw_core::JobError;` re-export shim。删除随之 unused 的 `use std::time::Duration;`。
- 顶层 `Error::Job(#[from] JobError)` 不动 —— 类型同一，`#[from]` 仍生效。

## 非目标（What's NOT in this PR）

- **不搬** `context::manager` / `state` / `fallback`（后续切片）
- **不动** `Error` 顶层 enum 的其它 variants
- **不动** `WorkspaceError` / `ToolError` / `LlmError` 等其它已经独立的错误类型
- **不简化 / 不重命名**（ADR-129 §1.3 verbatim port 红线）

## 验证（命令 + 结果）

```text
cargo check -p dasclaw_core --tests              ✅ clean (3.40s)
cargo check -p dasclaw --tests                   ✅ clean (1m56s)
cargo nextest run -p dasclaw_core -p dasclaw \
  -E 'test(job_error_display) | test(top_level_error_from_conversions)'
  → 2/2 pass
  → PASS dasclaw_core::error::tests::job_error_display
  → PASS dasclaw::error::tests::top_level_error_from_conversions
cargo fmt --all                                  ✅ clean
python3.12 scripts/check_no_panics.py --base origin/xClaw   ✅ clean
cargo clippy --no-deps -p dasclaw_core --all-targets -- -D warnings   ✅ clean (7.30s)
```

## 三层审查

- **code-quality-audit**：无补丁式代码、无新增 unwrap/expect/panic、无重复逻辑；新文件只含 enum + 单测；host 端仅删定义改 shim。
- **code-simplifier**：**跳过**（ADR-129 §1.3 verbatim port 红线）。
- **adr-compliance-check**：ADR-152 §3 F3.6 直接对应；ADR-129 §1.3 字面/字段/derive/error message 完全一致；ADR-114 类 A（无新 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量）；无 panic 红线。
- **code-review-expert**：re-export 链与 `WorkspaceError` / `ToolError` 同形；下游源码零改动；`#[from]` 受 `top_level_error_from_conversions` 测试守护。

Closes #717
Refs #632 (ADR-152 §3 F3.6 umbrella — stays open until all 6 slices land)