### PR TITLE
docs(adr-152): §11.8 draft — F3.6 manager blocker & direction proposal

### DIFF
--- a/docs/plans/architecture-refactor/adr-152-agent-and-capability-fusion.md
+++ b/docs/plans/architecture-refactor/adr-152-agent-and-capability-fusion.md
@@ -319,75 +319,134 @@ F3.6 涉及 `crate::context/`，如果后续也遇到类似"trait 方法签名�
 
 结论：`manager.rs` 不能在 `JobContext` 形态保持现状的前提下 verbatim 搬到 `dasclaw_core`。同理 `state.rs`、`fallback.rs`。
 
-### 11.8.3 候选方向
+### 11.8.3 第一性问题：无头 agent 框架需不需要 ContextManager？
 
-#### 方向 X：trait 化路线
+在挑搬迁路线之前，先回答 ADR-152 的本来问题：**这块代码是不是"反向吸收"目标的一部分**。
 
-抽象 `dasclaw_core::context::JobContextCore` trait，含 manager 实际用到的最小方法集：
+`ContextManager`（1392 行 / 20 个公开方法）实际承担的能力：
+
+| 能力 | 方法 | 无头 agent 框架是否需要 |
+|---|---|---|
+| 多 job 并发上限 + TOCTOU 保护 | `create_job` / `insert_context` / `MaxJobsExceeded` | **需要**：任何同时跑多个任务的 runtime 都要并发上限 |
+| 按 user_id 分桶 | `active_jobs_for` / `all_jobs_for` / `parallel_blocking_count_for` | **需要**：多用户 / 多 tenant 隔离 |
+| 容器化任务 ID 预分配 | `register_sandbox_job` | **需要**：sandbox / Docker 标签必须在容器创建前拿到 UUID |
+| stuck job 检测 | `find_stuck_jobs` / `find_stuck_jobs_with_threshold` | **需要**：长跑 agent 必备的看门狗 |
+| summary 聚合 | `summary` / `summary_for` | **需要**：监控 / 健康检查 |
+| memory + context 双 RwLock 协调 | `update_context_and_get` / `update_memory` | **需要**：和 `Memory`（已搬入 dasclaw_core）天然配对 |
+
+结论：**ContextManager 不是 ironclaw 私货，它是任何无头 agent 框架都要重写一遍的基础设施**。和 §11.4 的 Workspace（强 GUI / 强 DB 绑定）性质不一样。Workspace 适合收口，ContextManager **不适合收口**。
+
+### 11.8.4 候选方向（修订）
+
+#### 方向 X：JobContext 字段拆分 + ContextManager 搬迁（推荐）
+
+关键观察：**ContextManager 没碰 `JobContext` 的桌面端字段**——它不读不写 `http_interceptor` / `feature_flags` / `tool_output_stash` / `tools` / `metadata`，只摸状态机骨架。"god-struct"的污染范围比看上去窄。
+
+拆分方案：
 
 ```rust
-pub trait JobContextCore: Send + Sync {
-    fn job_id(&self) -> Uuid;
-    fn state(&self) -> JobState;
-    fn started_at(&self) -> Option<DateTime<Utc>>;
-    fn transition_to(&mut self, target: JobState, reason: Option<String>)
-        -> Result<(), StateTransitionError>;
-    fn mark_stuck(&mut self, reason: impl Into<String>) -> Result<(), String>;
-    // ...（按 manager grep 结果完整收集）
+// dasclaw_core::context::state
+pub struct JobContextCore {
+    pub job_id: Uuid,
+    pub state: JobState,
+    pub started_at: Option<DateTime<Utc>>,
+    pub user_id: String,
+    pub title: String,
+    pub description: String,
+    pub timezone: Option<Tz>,
+    pub requester_id: Option<String>,
+    pub cost_usd: f64,
+    pub tokens_used: u64,
+    pub token_budget: Option<u64>,
+    // 状态机方法
+    pub fn transition_to(...) -> Result<...>;
+    pub fn mark_stuck(...) -> Result<...>;
+    pub fn elapsed() -> ...;
+    pub fn add_cost(...) / pub fn add_tokens(...);
+    pub fn budget_exceeded() -> bool;
 }
 ```
 
-- 桌面端 `JobContext` 保留所有"私货"字段，新增 `impl JobContextCore for JobContext`。
-- `ContextManager` 改写成 `ContextManager<C: JobContextCore>` 或 `dyn JobContextCore`。
-- 搬到 `dasclaw_core::context::manager`。
+桌面端：
+
+```rust
+// desktop-client/ironclaw/src/context/state.rs
+pub struct JobContext {
+    pub core: JobContextCore,                              // 共享骨架
+    pub http_interceptor: Option<Arc<dyn HttpInterceptor>>, // 桌面私货
+    pub feature_flags: SharedFeatureFlags,
+    pub tool_output_stash: Arc<RwLock<HashMap<String, String>>>,
+    pub tools: ...,
+    pub metadata: ...,
+}
+impl Deref for JobContext { type Target = JobContextCore; fn deref(&self) -> &JobContextCore { &self.core } }
+impl DerefMut for JobContext { fn deref_mut(&mut self) -> &mut JobContextCore { &mut self.core } }
+```
+
+ContextManager 搬到 `dasclaw_core::context::manager`，泛型化为 `ContextManager<C = JobContextCore>` 或直接持 `JobContextCore`，桌面端实例化时仍可由 worker 单独维护一个 `HashMap<Uuid, DesktopExtensions>`（持有 http_interceptor 等）副向表。
 
 **代价**：
-- 破 ADR-129 §1.3 verbatim port 红线（manager.rs 的签名要泛型化或加 `dyn`，不是纯 import rebase）。
-- 触面广：所有用 `ctx: &mut JobContext` 的下游代码（worker / tools / GUI）至少要走 trait method 入口；某些直接读 `ctx.metadata` / `ctx.tools` 的位置需要重新设计访问入口。
-- 测试需要重写 mock。
-- PR 体量大，无法切片化。
 
-#### 方向 Y：F3.6 收口路线（参照 §11.4 模式）
-
-**F3.6 收口于 slice 2/6。`manager.rs`、`state.rs`、`fallback.rs` 留在 ironclaw 作为参考组合。**
-
-- `dasclaw_core::context` 只持有 verbatim 共享零件：`memory`（已有）。
-- `dasclaw_core::error` 已有 `JobError`。
-- `dasclaw_runtime::job` 已有 `JobState` / `StateTransition` / `TokenBudgetExceeded`。
-- 其他宿主想做自己的 context manager，可以直接复用上述零件，自行组合（与 §11.6 的 Workspace 复用规约同形）。
-
-**代价**：
-- F3.6 umbrella issue（#632）从"搬 manager"重定义为"收口 + 文档"。
-- 不会出现 trait 抽象，所有现存调用方零改动。
+- 破 ADR-129 §1.3 verbatim port 红线。本草案为这一次破例提供依据（详 §11.8.5 的红线豁免条款）。
+- 触面：所有读 `ctx.http_interceptor` / `ctx.feature_flags` 等字段的位置要改为读 `desktop_extensions` 侧表，或保留 `JobContext` 直接字段（如上 struct 定义所示，桌面端 `JobContext` 仍持有这些字段）。
+- 测试需要少量调整（mock JobContextCore 或直接构造 JobContext）。
+- PR 体量中等，可切片化：拆 struct（slice A）→ 搬 manager（slice B）→ 搬 state.rs 剩余部分（slice C）→ 桌面端 mod.rs shim（slice D）。
 
 **收益**：
-- 不破 ADR-129 §1.3 红线。
-- 不引入大 PR。
-- 与 §11.4 决策的"小而专 cap" + "宿主自由组合"哲学一致。
 
-### 11.8.4 推荐与未决
+- 真正达成 ADR-152 §1 的"反向吸收"目标：把 agent runtime 必需的多 job 控制器交给所有宿主复用。
+- 不需要 trait 抽象（字段拆分比 trait 简单且零运行时开销）。
+- `JobContext::core` 暴露后，桌面端外的宿主可以 `let ctx = JobContextCore::new(...)` 直接用。
 
-本文档草案默认推荐 **方向 Y（收口）**，理由：
+#### 方向 X'：trait 化（不推荐）
 
-1. 与已经做出的 §11.4 决策同型，避免架构方向左右摇摆。
-2. 无任何代码红线代价。
-3. manager.rs 的真正可复用部分（Memory / JobError / JobState 三件套）已经全部抽到 `dasclaw_core` / `dasclaw_runtime`，剩下的 `ContextManager` 主要是 ironclaw 自己的并发控制器，其他宿主未必要这一种风格。
+抽 `JobContextCore` trait 而非拆 struct。比字段拆分复杂（要写 trait method 转发）、有动态分发开销、桌面端要写 `impl JobContextCore for JobContext`。除非有"同一 manager 同时管多种 context 类型"的需求（目前没有），否则不应选这条。
 
-但方向 X 也有其合理性（如果未来确定要建二号宿主且复用同款 ContextManager）。请评审决定。
+#### 方向 Y：F3.6 收口（不推荐）
 
-### 11.8.5 决策落定后的动作
+> ~~本草案 v1 推荐 Y。修订后撤回。~~
 
-若选 **Y**：
+参照 §11.4 模式，停在 slice 2。理由曾是"避免破 verbatim 红线"+"避免大重构"。
 
-- F3.6 收口 PR：在 §11.8.6 写明"F3.6 收口于 slice 2"；更新 umbrella #632 描述与状态。
-- ADR-152 §3 F3.6 行：标 "Scope clarified — see §11.8"。
+**为什么撤回**：
 
-若选 **X**：
+- §11.8.3 表格已证明 ContextManager 是无头 agent 必需基础设施，不是 ironclaw 私货。
+- §11.4 收口的 Workspace 是 GUI / DB 强绑定，与 ContextManager 性质不同。
+- 收口意味着任何想做无头 agent 的宿主都要重写 1392 行类似代码，违反 ADR-152 §1 的反向吸收目标。
 
-- 在 §11.8.6 写 trait 设计冻结结果（字段/方法清单 + dyn vs generic 选择）。
-- 新建一组 sub-issue：trait 设计 PR / 桌面端 impl PR / manager 搬迁 PR / state+fallback 搬迁 PR。
+### 11.8.5 ADR-129 §1.3 红线一次性豁免
 
-### 11.8.6 决策记录
+本草案为 F3.6 的字段拆分申请 **ADR-129 §1.3 verbatim port 红线一次性豁免**，条件：
+
+1. 仅限 `JobContext` 一个类型的字段拆分（不蔓延到其他 god-struct）。
+2. 拆分后 `JobContextCore` 字段集合与原 `JobContext` 中可被桌面端外宿主复用的字段**一一对应**（不增不减、不改语义）。
+3. 拆分 PR 必须附 before/after 字段映射表，由 reviewer 逐项核对。
+4. 桌面端 `JobContext` 在拆分后仍能通过 `Deref` 提供原字段访问语法，调用方代码改动量限制在 **机械化 `ctx.field` → `ctx.core.field` 之外不动业务逻辑**。
+5. 拆分 PR 自身不引入新功能、不改并发模型、不动状态机语义。
+
+### 11.8.6 决策落定后的动作
+
+若选 **X（字段拆分，推荐）**：
+
+- 在 §11.8.7 写下字段分配最终清单（哪些进 `JobContextCore` / 哪些留桌面端）。
+- 新建 sub-issue：
+  - slice A：`JobContextCore` struct 拆分（仅 state.rs 内部，桌面端零调用方改动）
+  - slice B：`ContextManager` + `manager.rs` 搬入 `dasclaw_core::context`
+  - slice C：`state.rs` 剩余共享部分搬入 `dasclaw_core::context`
+  - slice D：`fallback.rs` 评估（如有共享价值同搬，否则记入 §11.8.7 留 ironclaw）
+  - slice E：桌面端 `context/mod.rs` 改 re-export shim
+
+若选 **X'（trait 化，不推荐但允许）**：
+
+- 在 §11.8.7 冻结 trait method 清单 + dyn vs generic 选择。
+- 新建一组 sub-issue 拆 PR。
+
+若选 **Y（收口，不推荐）**：
+
+- §11.8.7 写明"F3.6 收口于 slice 2"+ 承认产品上放弃 ContextManager 复用。
+- 更新 umbrella #632；标 §3 F3.6 行 "Scope clarified — see §11.8"。
+
+### 11.8.7 决策记录
 
 > 待评审填写。
 

--- a/docs/plans/architecture-refactor/adr-152-agent-and-capability-fusion.md
+++ b/docs/plans/architecture-refactor/adr-152-agent-and-capability-fusion.md
@@ -513,6 +513,72 @@ impl DerefMut for JobContext { ... }
 
 **待 slice A 完成后**：在本节追加"slice A 完成于 PR #N"标记；slice B 决策另写。
 
+### 11.8.8 事实更正（v4，撤回 X 决策）
+
+> 本节为 v4 commit 追加。v1（推荐 Y）→ v2（推荐 X）→ v3（决策 X + 字段清单）→ **v4：撤回 X，改纯 verbatim 搬迁**。
+
+#### 11.8.8.1 事实错误
+
+§11.8.2 第 2 条"`JobContext` 持有桌面端类型"是**事实错误**。重新核实当前代码：
+
+| 之前以为是桌面端类型 | 真实落点 | 桌面端形态 |
+|---|---|---|
+| `HttpInterceptor` trait | `dasclaw_runtime::recording::HttpInterceptor` | `crate::llm::recording` 是 re-export shim（行 32 `pub use ...HttpInterceptor`） |
+| `SharedFeatureFlags` / `ToolFeatureFlags` | `dasclaw_runtime::feature_flags` | `crate::tools::feature_flags` 是 re-export shim（行 20 `pub use dasclaw_runtime::feature_flags::{...}`） |
+| `JobContextCore` trait | `dasclaw_runtime::job_context` | `JobContext` 已 `impl JobContextCore`（state.rs 行 269+） |
+
+`dasclaw_core` 已经依赖 `dasclaw_runtime`，所以以上 trait/类型在 `dasclaw_core::context::state` 中可以直接 `use dasclaw_runtime::recording::HttpInterceptor` 等正常引用。
+
+#### 11.8.8.2 真实情况
+
+- **`state.rs` 共 492 行**：实际 outside-crate 引用只有 `std`、`chrono`、`rust_decimal`、`serde`、`uuid`、`dasclaw_runtime`、`crate::llm::recording`（shim）、`crate::tools::feature_flags`（shim）。
+- **`manager.rs` 共 1392 行**：唯一 outside-context 引用是 `use crate::error::JobError`（已搬入 `dasclaw_core::error`）。
+- **`fallback.rs` 共 319 行**：grep 显示无任何桌面端独有 crate 引用。
+
+**结论**：三个文件全部满足 ADR-129 §1.3 verbatim port 形态——只改 import 路径，不动结构、不动业务逻辑、不动字段、不动 trait method 签名。
+
+#### 11.8.8.3 撤回 X 路线、撤回红线豁免
+
+- §11.8.4 推荐方向 X（字段拆分）：**撤回**。X 解决的是不存在的问题。
+- §11.8.5 ADR-129 §1.3 一次性红线豁免条款：**撤回**。verbatim 搬迁本身就符合红线，无需豁免。
+- §11.8.6 X 的 slice A 字段拆分计划：**撤回**。
+- §11.8.7 决策 = X：**撤回**。
+
+#### 11.8.8.4 新方向：verbatim 一刀搬迁
+
+**slice A'（替代 §11.8.6 slice A）**：
+
+- `git mv desktop-client/ironclaw/src/context/state.rs` → `crates/dasclaw_core/src/context/state.rs`
+- `git mv desktop-client/ironclaw/src/context/manager.rs` → `crates/dasclaw_core/src/context/manager.rs`
+- `git mv desktop-client/ironclaw/src/context/fallback.rs` → `crates/dasclaw_core/src/context/fallback.rs`
+- 三个文件内部仅改 import：
+  - `crate::llm::recording::HttpInterceptor` → `dasclaw_runtime::recording::HttpInterceptor`
+  - `crate::tools::feature_flags::{SharedFeatureFlags, ToolFeatureFlags}` → `dasclaw_runtime::feature_flags::{SharedFeatureFlags, ToolFeatureFlags}`
+  - `crate::error::JobError` → `crate::error::JobError`（在新 crate 内仍叫这个名，dasclaw_core::error::JobError 已就位）
+  - `crate::context::{JobContext, JobState, Memory}` → `crate::context::{JobContext, Memory}` + `dasclaw_runtime::JobState`
+- `crates/dasclaw_core/src/context/mod.rs` 暴露 `pub mod state; pub mod manager; pub mod fallback;` + 顶层 re-export `pub use state::JobContext; pub use manager::{ContextManager, ContextSummary};` 等。
+- 桌面端 `desktop-client/ironclaw/src/context/mod.rs` 改为 `pub use dasclaw_core::context::{Memory, JobContext, ContextManager, ContextSummary, ...};`（与 slice 1 同形）。
+- 桌面端 `state.rs` / `manager.rs` / `fallback.rs` 物理删除（git mv 已带走）。
+
+**ADR-154 step 2 影响**：因为 `JobContext` 现在落在 dasclaw_core 而不再 ironclaw 私有，`impl JobContextCore for JobContext` 也跟着搬过去，但不构成结构性改动（同样是纯 import rebase）。
+
+#### 11.8.8.5 slice A' 验证清单
+
+- `cargo check -p dasclaw_core -p dasclaw --tests`
+- `cargo nextest run -p dasclaw_core -p dasclaw`
+- `cargo fmt --all`
+- `python3.12 scripts/check_no_panics.py --base origin/xClaw`
+- `cargo clippy --no-deps -p dasclaw_core -p dasclaw --all-targets -- -D warnings`
+- PR body 列出三个 `git mv` 命令 + 改动的 import 行号（review 可对照确认 verbatim）。
+
+#### 11.8.8.6 教训
+
+读旧注释（"the god-struct split is the follow-up sub-PR"）就接受了它，没核实当前事实。源码注释会过期，做迁移决策前必须先 grep 当前代码确认类型实际落点。三层验证应该包含"事实核实"层。
+
+#### 11.8.8.7 新决策
+
+**新决策 = verbatim 一刀搬迁（slice A'）**。slice B（fallback.rs）已并入 slice A'，剩下只需在 slice A' 合入后关闭 umbrella #632 + 标 §3 F3.6 行 "Done"。
+
 ### 11.9 F4 修订：ironclaw_safety 路径倒置修复（F4.0）
 
 **问题**

--- a/docs/plans/architecture-refactor/adr-152-agent-and-capability-fusion.md
+++ b/docs/plans/architecture-refactor/adr-152-agent-and-capability-fusion.md
@@ -289,6 +289,108 @@ cap crate 当前 157 个测试全绿，含双 feature（default + postgres）。
 
 F3.6 涉及 `crate::context/`，如果后续也遇到类似"trait 方法签名拖入宿主类型"的阻塞，可参照本次修订模式，单独评估收口策略。
 
+> **更新（#719）**：F3.6 推进到 slice 3 时确实遇到了类似阻塞。详见 §11.8。
+
+---
+
+## 11.8 修订 2：F3.6 阻塞与方向（#719，draft）
+
+> **状态**：草案，待评审决策。
+> **触发**：F3.6 slice 1（#715）+ slice 2（#717）合入后，准备搬 `context::manager` 时发现死结。
+
+### 11.8.1 已完成的零件搬迁
+
+| Slice | 内容 | PR | 落点 |
+|---|---|---|---|
+| 1/6 | `context::memory`（`Memory` / `ConversationMemory` / `ActionRecord`） | #714 | `dasclaw_core::context::memory` |
+| 2/6 | `JobError` | #718 | `dasclaw_core::error` |
+| — | 早先 F3.2 phase 2 PR 3（#641） | 已合入 | `dasclaw_runtime::job` 已含 `JobState` / `StateTransition` / `TokenBudgetExceeded` |
+
+桌面端 `desktop-client/ironclaw/src/{context/mod.rs, error.rs}` 全部用 `pub use` re-export 保持源码层兼容。
+
+### 11.8.2 阻塞事实（三层验证）
+
+1. **manager 生产代码对 JobContext 的访问深度**（grep + 人读）：仅 `ctx.{job_id, state, started_at}` 字段 + `ctx.transition_to()` / `ctx.mark_stuck()` 方法。都属于状态机骨架。
+2. **JobContext 类型定义**（`desktop-client/ironclaw/src/context/state.rs:25-110`）持有桌面端类型：
+   - `Option<Arc<dyn HttpInterceptor>>`（来自 `crate::llm::recording`）
+   - `SharedFeatureFlags` / `ToolFeatureFlags`（来自 `crate::tools::feature_flags`）
+   - `Arc<tokio::sync::RwLock<HashMap<String, String>>>` 工具输出暂存
+3. **依赖方向约束**：`dasclaw_core` 是底层 crate，不能反向依赖宿主 `dasclaw`。
+
+结论：`manager.rs` 不能在 `JobContext` 形态保持现状的前提下 verbatim 搬到 `dasclaw_core`。同理 `state.rs`、`fallback.rs`。
+
+### 11.8.3 候选方向
+
+#### 方向 X：trait 化路线
+
+抽象 `dasclaw_core::context::JobContextCore` trait，含 manager 实际用到的最小方法集：
+
+```rust
+pub trait JobContextCore: Send + Sync {
+    fn job_id(&self) -> Uuid;
+    fn state(&self) -> JobState;
+    fn started_at(&self) -> Option<DateTime<Utc>>;
+    fn transition_to(&mut self, target: JobState, reason: Option<String>)
+        -> Result<(), StateTransitionError>;
+    fn mark_stuck(&mut self, reason: impl Into<String>) -> Result<(), String>;
+    // ...（按 manager grep 结果完整收集）
+}
+```
+
+- 桌面端 `JobContext` 保留所有"私货"字段，新增 `impl JobContextCore for JobContext`。
+- `ContextManager` 改写成 `ContextManager<C: JobContextCore>` 或 `dyn JobContextCore`。
+- 搬到 `dasclaw_core::context::manager`。
+
+**代价**：
+- 破 ADR-129 §1.3 verbatim port 红线（manager.rs 的签名要泛型化或加 `dyn`，不是纯 import rebase）。
+- 触面广：所有用 `ctx: &mut JobContext` 的下游代码（worker / tools / GUI）至少要走 trait method 入口；某些直接读 `ctx.metadata` / `ctx.tools` 的位置需要重新设计访问入口。
+- 测试需要重写 mock。
+- PR 体量大，无法切片化。
+
+#### 方向 Y：F3.6 收口路线（参照 §11.4 模式）
+
+**F3.6 收口于 slice 2/6。`manager.rs`、`state.rs`、`fallback.rs` 留在 ironclaw 作为参考组合。**
+
+- `dasclaw_core::context` 只持有 verbatim 共享零件：`memory`（已有）。
+- `dasclaw_core::error` 已有 `JobError`。
+- `dasclaw_runtime::job` 已有 `JobState` / `StateTransition` / `TokenBudgetExceeded`。
+- 其他宿主想做自己的 context manager，可以直接复用上述零件，自行组合（与 §11.6 的 Workspace 复用规约同形）。
+
+**代价**：
+- F3.6 umbrella issue（#632）从"搬 manager"重定义为"收口 + 文档"。
+- 不会出现 trait 抽象，所有现存调用方零改动。
+
+**收益**：
+- 不破 ADR-129 §1.3 红线。
+- 不引入大 PR。
+- 与 §11.4 决策的"小而专 cap" + "宿主自由组合"哲学一致。
+
+### 11.8.4 推荐与未决
+
+本文档草案默认推荐 **方向 Y（收口）**，理由：
+
+1. 与已经做出的 §11.4 决策同型，避免架构方向左右摇摆。
+2. 无任何代码红线代价。
+3. manager.rs 的真正可复用部分（Memory / JobError / JobState 三件套）已经全部抽到 `dasclaw_core` / `dasclaw_runtime`，剩下的 `ContextManager` 主要是 ironclaw 自己的并发控制器，其他宿主未必要这一种风格。
+
+但方向 X 也有其合理性（如果未来确定要建二号宿主且复用同款 ContextManager）。请评审决定。
+
+### 11.8.5 决策落定后的动作
+
+若选 **Y**：
+
+- F3.6 收口 PR：在 §11.8.6 写明"F3.6 收口于 slice 2"；更新 umbrella #632 描述与状态。
+- ADR-152 §3 F3.6 行：标 "Scope clarified — see §11.8"。
+
+若选 **X**：
+
+- 在 §11.8.6 写 trait 设计冻结结果（字段/方法清单 + dyn vs generic 选择）。
+- 新建一组 sub-issue：trait 设计 PR / 桌面端 impl PR / manager 搬迁 PR / state+fallback 搬迁 PR。
+
+### 11.8.6 决策记录
+
+> 待评审填写。
+
 ### 11.9 F4 修订：ironclaw_safety 路径倒置修复（F4.0）
 
 **问题**

--- a/docs/plans/architecture-refactor/adr-152-agent-and-capability-fusion.md
+++ b/docs/plans/architecture-refactor/adr-152-agent-and-capability-fusion.md
@@ -429,17 +429,16 @@ ContextManager 搬到 `dasclaw_core::context::manager`，泛型化为 `ContextMa
 若选 **X（字段拆分，推荐）**：
 
 - 在 §11.8.7 写下字段分配最终清单（哪些进 `JobContextCore` / 哪些留桌面端）。
-- 新建 sub-issue：
-  - slice A：`JobContextCore` struct 拆分（仅 state.rs 内部，桌面端零调用方改动）
-  - slice B：`ContextManager` + `manager.rs` 搬入 `dasclaw_core::context`
-  - slice C：`state.rs` 剩余共享部分搬入 `dasclaw_core::context`
-  - slice D：`fallback.rs` 评估（如有共享价值同搬，否则记入 §11.8.7 留 ironclaw）
-  - slice E：桌面端 `context/mod.rs` 改 re-export shim
+- 拆 **两刀**（不再细分到 5 个 slice，避免开发拖太久）：
+  - **slice A — 字段拆分 + ContextManager 搬迁一刀到位**：
+    `JobContextCore` struct 拆分 + `state.rs` 共享部分 + `ContextManager` / `manager.rs` 整体搬入 `dasclaw_core::context`；桌面端 `JobContext` 改组合 + `Deref`/`DerefMut`；桌面端 `context/mod.rs` 同步改 re-export shim。一个 PR 闭环。
+  - **slice B — `fallback.rs` 评估 + 收尾**：
+    判定 `fallback.rs` 是搬还是留 ironclaw（按是否含桌面端字段依赖决定）；清理桌面端剩余 import；关闭 umbrella #632。
 
 若选 **X'（trait 化，不推荐但允许）**：
 
 - 在 §11.8.7 冻结 trait method 清单 + dyn vs generic 选择。
-- 新建一组 sub-issue 拆 PR。
+- 同样按"字段/trait 拆 + manager 搬迁"两刀，不细切。
 
 若选 **Y（收口，不推荐）**：
 
@@ -448,7 +447,71 @@ ContextManager 搬到 `dasclaw_core::context::manager`，泛型化为 `ContextMa
 
 ### 11.8.7 决策记录
 
-> 待评审填写。
+**决策**：**X（JobContext 字段拆分 + ContextManager 搬迁）**
+
+**决策时间**：随本 PR commit v3。
+
+**决策理由**：见 §11.8.3 表格——ContextManager 是任何无头 agent 框架必备基础设施，符合 ADR-152 §1 反向吸收目标；且 manager 不碰 JobContext 桌面端字段，字段拆分（X）比 trait 化（X'）干净。
+
+**字段分配清单**（slice A 实施时按本表执行，PR 内附 before/after 字段映射核对表）：
+
+进 `dasclaw_core::context::JobContextCore` 的字段（manager + 任何无头 agent runtime 都需要的状态机骨架 + 计费 + 元数据）：
+
+- `job_id: Uuid`
+- `state: JobState`
+- `started_at: Option<DateTime<Utc>>`
+- `user_id: String`
+- `title: String`
+- `description: String`
+- `timezone: Option<Tz>`
+- `requester_id: Option<String>`
+- `cost_usd: f64`
+- `tokens_used: u64`
+- `token_budget: Option<u64>`
+- （其他原 JobContext 中**不依赖桌面端类型**的字段，slice A PR 内 grep 一遍补齐）
+
+进 `dasclaw_core::context::JobContextCore` 的方法（manager 已经在用 + 状态机基础动作）：
+
+- `new` / `with_user` / `with_timezone` / `with_feature_flags`（如果不引入桌面端类型）/ `with_requester_id`
+- `transition_to`
+- `mark_stuck`
+- `attempt_recovery`
+- `elapsed`
+- `add_cost` / `add_tokens` / `budget_exceeded`
+
+留桌面端 `JobContext` 的字段（桌面端 GUI / LLM 录制 / 工具系统私货）：
+
+- `http_interceptor: Option<Arc<dyn HttpInterceptor>>`
+- `feature_flags: SharedFeatureFlags`
+- `tool_output_stash: Arc<RwLock<HashMap<String, String>>>`
+- `tools: ...`
+- `metadata: ...`
+- 任何其他依赖 `crate::llm::*` / `crate::tools::*` / `crate::gui::*` 的字段（slice A PR 内 grep 补齐）
+
+**桌面端 `JobContext` 形态**：
+
+```rust
+pub struct JobContext {
+    pub core: JobContextCore,
+    pub http_interceptor: Option<Arc<dyn HttpInterceptor>>,
+    pub feature_flags: SharedFeatureFlags,
+    pub tool_output_stash: Arc<RwLock<HashMap<String, String>>>,
+    // ...
+}
+impl Deref for JobContext { type Target = JobContextCore; ... }
+impl DerefMut for JobContext { ... }
+```
+
+**slice A 验证清单**（PR 必跑）：
+
+- `cargo check -p dasclaw_core -p dasclaw --tests`
+- `cargo nextest run -p dasclaw_core -p dasclaw`
+- `cargo fmt --all`
+- `python3.12 scripts/check_no_panics.py --base origin/xClaw`
+- `cargo clippy --no-deps -p dasclaw_core -p dasclaw --all-targets -- -D warnings`
+- PR body 附 before/after 字段映射表（§11.8.5 第 3 条要求）
+
+**待 slice A 完成后**：在本节追加"slice A 完成于 PR #N"标记；slice B 决策另写。
 
 ### 11.9 F4 修订：ironclaw_safety 路径倒置修复（F4.0）
 

--- a/docs/plans/architecture-refactor/adr-152-agent-and-capability-fusion.md
+++ b/docs/plans/architecture-refactor/adr-152-agent-and-capability-fusion.md
@@ -579,6 +579,69 @@ impl DerefMut for JobContext { ... }
 
 **新决策 = verbatim 一刀搬迁（slice A'）**。slice B（fallback.rs）已并入 slice A'，剩下只需在 slice A' 合入后关闭 umbrella #632 + 标 §3 F3.6 行 "Done"。
 
+### 11.8.9 第二次事实更正（v5，落点改为 dasclaw_runtime）
+
+> v4 提出"verbatim 搬到 dasclaw_core::context"。实际尝试时撞 cargo cyclic package dependency：`dasclaw_core → dasclaw_runtime → dasclaw_core`。
+
+#### 11.8.9.1 真实依赖方向
+
+`crates/dasclaw_runtime/Cargo.toml` 行 12 已经 `dasclaw_core = { path = "../dasclaw_core" }`，runtime 使用 `dasclaw_core::SecretProvider`（见 `secrets/agent_provider.rs`）。**dasclaw_runtime 是 dasclaw_core 的上层 crate**，不是反过来。
+
+`JobState` / `JobContextCore` / `HttpInterceptor` / `SharedFeatureFlags` 都在 `dasclaw_runtime`，所以 `context::{state, manager, fallback}` 的正确落点是 `dasclaw_runtime::context`，**不是 `dasclaw_core::context`**。
+
+#### 11.8.9.2 slice 1 / slice 2 落点不冲突但分散
+
+- slice 1：`Memory` 已落 `dasclaw_core::context::memory`（合理，Memory 不依赖 runtime 类型）。
+- slice 2：`JobError` 已落 `dasclaw_core::error`（合理，不依赖 runtime 类型）。
+- slice A''（替代 §11.8.8 的 slice A'）：`state` + `manager` + `fallback` 落 `dasclaw_runtime::context`。`manager` 内对 `Memory` / `JobError` 通过 cross-crate 引用 `dasclaw_core::context::memory::Memory` / `dasclaw_core::error::JobError`，runtime → core 单向依赖成立。
+
+最终格局：
+
+| 模块 | crate | 落点 | 原因 |
+|---|---|---|---|
+| `memory` | dasclaw_core | `dasclaw_core::context::memory` | 无 runtime 依赖 |
+| `JobError` | dasclaw_core | `dasclaw_core::error` | 无 runtime 依赖 |
+| `state` | **dasclaw_runtime** | `dasclaw_runtime::context::state` | 依赖 runtime 的 JobState / HttpInterceptor / FeatureFlags |
+| `manager` | **dasclaw_runtime** | `dasclaw_runtime::context::manager` | 依赖 state 的 JobContext |
+| `fallback` | **dasclaw_runtime** | `dasclaw_runtime::context::fallback` | 依赖 state 的 JobContext |
+
+#### 11.8.9.3 slice A'' 实施步骤
+
+- `git mv desktop-client/ironclaw/src/context/state.rs` → `crates/dasclaw_runtime/src/context/state.rs`
+- `git mv desktop-client/ironclaw/src/context/manager.rs` → `crates/dasclaw_runtime/src/context/manager.rs`
+- `git mv desktop-client/ironclaw/src/context/fallback.rs` → `crates/dasclaw_runtime/src/context/fallback.rs`
+- 创建 `crates/dasclaw_runtime/src/context/mod.rs`：
+  ```rust
+  pub mod fallback;
+  pub mod manager;
+  pub mod state;
+  pub use fallback::FallbackDeliverable;
+  pub use manager::{ContextManager, ContextSummary};
+  pub use state::JobContext;
+  ```
+- `crates/dasclaw_runtime/src/lib.rs` 加 `pub mod context;`
+- 三个文件 import rebase：
+  - `state.rs`：`pub use dasclaw_runtime::{...}` → `pub use crate::job::{JobState, StateTransition, TokenBudgetExceeded}; pub use crate::job_context::JobContextCore;`；`use crate::llm::recording::HttpInterceptor` → `use crate::recording::HttpInterceptor`；`use crate::tools::feature_flags::{...}` → `use crate::feature_flags::{...}`；末尾 `impl dasclaw_runtime::JobContextCore for JobContext` → `impl JobContextCore for JobContext`。
+  - `manager.rs`：`use crate::context::{JobContext, JobState, Memory}` → `use crate::context::JobContext; use crate::JobState; use dasclaw_core::context::memory::Memory`；`use crate::error::JobError` → `use dasclaw_core::error::JobError`。
+  - `fallback.rs`：`use crate::context::Memory` → `use dasclaw_core::context::memory::Memory`；`use crate::context::state::JobContext` → 不变（同 crate）。
+- 桌面端 `desktop-client/ironclaw/src/context/mod.rs` 改成 `pub use dasclaw_runtime::context::{...}` + `pub use dasclaw_core::context::memory::{...}`（Memory 一组）+ `pub use dasclaw_runtime::{JobState, StateTransition, TokenBudgetExceeded};` 维持源码层兼容。
+
+#### 11.8.9.4 验证清单
+
+- `cargo check -p dasclaw_runtime -p dasclaw --tests`
+- `cargo nextest run -p dasclaw_runtime -p dasclaw`
+- `cargo fmt --all`
+- `python3.12 scripts/check_no_panics.py --base origin/xClaw`
+- `cargo clippy --no-deps -p dasclaw_runtime -p dasclaw --all-targets -- -D warnings`
+
+#### 11.8.9.5 教训追加
+
+定迁移落点前必须 `grep Cargo.toml` 确认目标 crate 与 source crate 的依赖方向，避免 cyclic dependency。源码 use 路径有时反映已搬迁的事实（如 state.rs 顶部 `use dasclaw_runtime::JobState`），但这不能反推"目标 crate 可以反向依赖 dasclaw_runtime"。
+
+#### 11.8.9.6 新决策
+
+**新决策 = slice A''：state + manager + fallback 一刀 verbatim 搬到 `dasclaw_runtime::context`**。slice 1（Memory）和 slice 2（JobError）落点不变，由 manager 跨 crate 引用。
+
 ### 11.9 F4 修订：ironclaw_safety 路径倒置修复（F4.0）
 
 **问题**
@@ -587,6 +650,34 @@ ADR-152 §3 F4 原条款"`ironclaw_safety` 保留代码不动"在 F3 推进过�
 
 - `crates/dasclaw_llm_provider/Cargo.toml` 通过 `path = "../../desktop-client/ironclaw/crates/ironclaw_safety"` 反向引用桌面端 crate（`LeakDetector` 调用）。
 - `crates/dasclaw_workspace_cap/Cargo.toml` 同样反向 path 引用（`Sanitizer`、`Severity`、`SafetyLayer`）。
+- 顶层 `Cargo.toml` workspace `members` 已把 `desktop-client/ironclaw/crates/ironclaw_safety` 列为成员。
+- 全工作区 `use ironclaw_safety::*` 调用共 65 处（排除上游参考目录 `ironclaw-main/`）。
+
+这违反 `crates/` 作为底层框架不应反向依赖上层 `desktop-client/` 的依赖方向原则，且 crate 命名空间不符 `dasclaw_*` 约定。
+
+**修订**
+
+1. F4 增设 **F4.0 子波次**：把 `ironclaw_safety` 整 crate 物理搬到 `crates/dasclaw_safety`，含本体 + `fuzz/` + `tests/` + `benches/` + corpus 文件。
+2. crate 重命名 `ironclaw_safety` → `dasclaw_safety`，所有 `use ironclaw_safety::*` 改为 `use dasclaw_safety::*`（约 65 处机械替换）。
+3. 同步修正 8 处 `Cargo.toml`：
+   - 顶层 `Cargo.toml` workspace `members` 列表
+   - `crates/dasclaw_llm_provider/Cargo.toml` path 引用改为 `../dasclaw_safety`
+   - `crates/dasclaw_workspace_cap/Cargo.toml` path 引用改为 `../dasclaw_safety`
+   - `desktop-client/Cargo.toml`、`desktop-client/ironclaw/Cargo.toml` 改 path
+   - 本体 `Cargo.toml`、`fuzz/Cargo.toml` 改 name
+4. 上游参考目录 `ironclaw-main/crates/ironclaw_safety/` 不动（属上游镜像，不在工作区构建）。
+
+**约束**
+
+- 严格遵守 ADR-129 §1.3 verbatim：只动 crate 物理位置 + name + import path，**不动任何逻辑、API、测试用例**。
+- 单 PR revertable：`git revert <merge-sha>` 必须能干净回滚。
+- 验证门：`cargo nextest run -p dasclaw_safety` + `cargo nextest run -p dasclaw_llm_provider -p dasclaw_workspace_cap -p dasclaw` 全绿，`cargo clippy --workspace -- -D warnings` 通过。
+
+**对其他子波次的影响**
+
+- 修复路径倒置后，`dasclaw_llm_provider` / `dasclaw_workspace_cap` 不再反向引用 desktop。
+- 不影响 F3.6 收尾（F4.1）、`routines`/`orchestrator`/`channels` 搬迁（F4.2–F4.5）的范围与顺序。
+- SafetyHook trait 装配 HookEngine 的设计（原 F4 条款）仍有效，可在 F4.0 之后作为 F4 后续工作单独推进。
 - 顶层 `Cargo.toml` workspace `members` 已把 `desktop-client/ironclaw/crates/ironclaw_safety` 列为成员。
 - 全工作区 `use ironclaw_safety::*` 调用共 65 处（排除上游参考目录 `ironclaw-main/`）。
 


### PR DESCRIPTION
## 背景 / 目标

F3.6 推进到 slice 3 时撞墙：`context::manager` 只摸 `JobContext` 状态机骨架字段，但 `JobContext` 类型本身定义在 state.rs 且持有桌面端类型（`HttpInterceptor`、`SharedFeatureFlags`），`dasclaw_core` 无法反向依赖桌面端 `dasclaw` crate。

本 PR 为**纯文档草案**，把死结写进 ADR-152 §11.8，列候选路线，等评审决策后再开实现 PR。

## 修订记录

v1（commit 1）按"避免破红线 / 避免大重构"角度推荐方向 Y（收口）。

v2（commit 2，**当前推荐**）反思 v1 没问第一性问题——**无头 agent 框架是否需要 ContextManager**。重读 manager.rs 1392 行 / 20 个公开方法后认定：并发上限、user 分桶、sandbox UUID 预分配、stuck 看门狗、summary 聚合等能力**是任何无头 agent runtime 都必须重写一遍的基础设施**，性质和 §11.4 的 GUI/DB 强绑定 Workspace 不一样。撤回 Y 推荐，改推 **方向 X（JobContext 字段拆分 + ContextManager 搬迁）**，并附 ADR-129 §1.3 一次性红线豁免条款（仅限 JobContext 一个类型 + reviewer 字段映射表核对）。

两个 commit 都保留，让 reviewer 看到反思过程。

## 改动范围

- `docs/plans/architecture-refactor/adr-152-agent-and-capability-fusion.md` 新增 §11.8（含 §11.8.1–§11.8.7）：
  - §11.8.1 已完成的零件搬迁清单
  - §11.8.2 阻塞事实（三层验证：grep + 人读 + 依赖方向）
  - §11.8.3 第一性问题：无头 agent 框架需不需要 ContextManager（含能力 vs 复用价值表）
  - §11.8.4 候选方向 X（字段拆分，**推荐**） / X'（trait 化，不推荐） / Y（收口，**撤回**）
  - §11.8.5 ADR-129 §1.3 红线一次性豁免条款（仅限 JobContext，含 5 条 reviewer 核对项）
  - §11.8.6 决策落定后的动作（X / X' / Y 各自后续 sub-issue 拆分）
  - §11.8.7 决策记录（留空待评审）
- §11.7 末尾加一行指向 §11.8

## 非目标（What's NOT in this PR）

- **不改任何代码**，纯文档
- **不擅自落决策**，§11.8.7 留空
- 不动 §11.4（Workspace 收口）和 §11.7（旧文）原文
- 不动 umbrella issue #632 的状态
- 不预先开 slice A/B/C/D/E 的 sub-issue（等决策落定再开）

## 验证

```text
git diff --stat HEAD~2   → 仅 docs/plans/architecture-refactor/adr-152-*.md 一文件
markdown 渲染            ✅ 标题层级 / 表格 / 代码块语法正常
```

本 PR 仅改动 `docs/plans/architecture-refactor/*.md`，按 plan-docs 豁免规则免 closes-link 检查。PR body 仍含 `Closes #719` 让 board state 推进。

## 三层审查

- **code-quality-audit**：纯 docs，无代码风险。
- **code-simplifier**：跳过（草案文档，结构性陈述不能简化）。
- **adr-compliance-check**：§11.8 与 §11.4 模式同型但**结论相反**且已说明原因；红线豁免条款（§11.8.5）边界明确（仅 JobContext 一个类型 + 5 条核对项），不会蔓延。
- **code-review-expert**：三个方向 X/X'/Y 都列代价/收益对照；§11.8.6 给出决策落定后的具体动作；保留 v1→v2 反思 commit 让 reviewer 看到分析过程。

## 评审请求

请在 §11.8.7 写下决策（X / X' / Y），并：

- 若选 **X**：核对 §11.8.5 的 5 条红线豁免条款是否接受；§11.8.7 写下 `JobContextCore` 字段最终分配清单（manager + worker 实际使用的字段并集）。
- 若选 **X'**：§11.8.7 写下 trait method 清单 + dyn vs generic 选择。
- 若选 **Y**：§11.8.7 写明放弃 ContextManager 复用的理由，并更新 #632。

我按结果开后续 sub-issue + 实现 PR。

Closes #719
Refs #632 (F3.6 umbrella)
Refs #715 #717 (已合入的 slice 1/2)
