### PR TITLE
feat(dasclaw_runtime): F3.6 slice A'' — verbatim move context::{state,manager,fallback}

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3139,6 +3139,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tokio-postgres",
+ "tracing",
  "uuid",
  "windows 0.58.0",
 ]

--- a/crates/dasclaw_runtime/Cargo.toml
+++ b/crates/dasclaw_runtime/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "dasclaw_runtime"
 version = "0.0.0-w6"
-edition = "2021"
+edition = "2024"
 description = "Runtime (application-layer) building blocks for any dasclaw host: errors that carry the failing tool's identity, job state machine, future JobContext trait extension, etc."
 license = "MIT OR Apache-2.0"
 
@@ -19,6 +19,7 @@ secrecy = { version = "0.10", features = ["serde"] }
 uuid = { version = "1", features = ["v4", "serde"] }
 async-trait = "0.1"
 tokio = { version = "1", features = ["sync"] }
+tracing = "0.1"
 aes-gcm = "0.10"
 hkdf = "0.12"
 sha2 = "0.10"

--- a/crates/dasclaw_runtime/src/context/fallback.rs
+++ b/crates/dasclaw_runtime/src/context/fallback.rs
@@ -10,8 +10,8 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::context::Memory;
 use crate::context::state::JobContext;
+use dasclaw_core::context::memory::Memory;
 
 /// Structured summary of a failed or stuck job.
 ///
@@ -109,7 +109,7 @@ impl FallbackDeliverable {
 
 /// Truncate a string to at most `max_len` bytes on a char boundary.
 fn truncate_str(s: &str, max_len: usize) -> &str {
-    &s[..crate::util::floor_char_boundary(s, max_len)]
+    &s[..super::util::floor_char_boundary(s, max_len)]
 }
 
 #[cfg(test)]

--- a/crates/dasclaw_runtime/src/context/manager.rs
+++ b/crates/dasclaw_runtime/src/context/manager.rs
@@ -6,8 +6,10 @@ use std::time::Duration;
 use tokio::sync::RwLock;
 use uuid::Uuid;
 
-use crate::context::{JobContext, JobState, Memory};
-use crate::error::JobError;
+use crate::JobState;
+use crate::context::JobContext;
+use dasclaw_core::context::memory::Memory;
+use dasclaw_core::error::JobError;
 
 /// Manages contexts for multiple concurrent jobs.
 pub struct ContextManager {
@@ -655,7 +657,7 @@ mod tests {
         // Update memory by adding a message
         manager
             .update_memory(job_id, |m| {
-                m.add_message(crate::llm::ChatMessage::user("hello from test"));
+                m.add_message(dasclaw_core::ChatMessage::user("hello from test"));
             })
             .await
             .unwrap();

--- a/crates/dasclaw_runtime/src/context/mod.rs
+++ b/crates/dasclaw_runtime/src/context/mod.rs
@@ -1,0 +1,20 @@
+//! Per-job context: state machine, manager, fallback delivery.
+//!
+//! ADR-152 §3 F3.6 slice A'' (per §11.8.9): `state`, `manager`, `fallback`
+//! verbatim moved from `desktop-client/ironclaw/src/context/` into
+//! `dasclaw_runtime::context`. `Memory` and `JobError` remain in
+//! `dasclaw_core` and are referenced cross-crate.
+
+pub mod fallback;
+pub mod manager;
+pub mod state;
+mod util;
+
+pub use fallback::FallbackDeliverable;
+pub use manager::{ContextManager, ContextSummary};
+pub use state::JobContext;
+
+// verbatim 兼容 re-export：搬迁前 manager.rs 内测试使用 `crate::context::JobState`
+// / `crate::context::Memory` 全路径。让旧路径仍可用。
+pub use crate::JobState;
+pub use dasclaw_core::context::memory::Memory;

--- a/crates/dasclaw_runtime/src/context/state.rs
+++ b/crates/dasclaw_runtime/src/context/state.rs
@@ -17,10 +17,11 @@ use rust_decimal::Decimal;
 use serde::Serialize;
 use uuid::Uuid;
 
-pub use dasclaw_runtime::{JobState, StateTransition, TokenBudgetExceeded};
+pub use crate::job::{JobState, StateTransition, TokenBudgetExceeded};
 
-use crate::llm::recording::HttpInterceptor;
-use crate::tools::feature_flags::{SharedFeatureFlags, ToolFeatureFlags};
+use crate::feature_flags::{SharedFeatureFlags, ToolFeatureFlags};
+use crate::job_context::JobContextCore;
+use crate::recording::HttpInterceptor;
 
 /// Context for a running job.
 #[derive(Debug, Clone, Serialize)]
@@ -292,7 +293,7 @@ impl Default for JobContext {
 // `transitions`, ...) intentionally do NOT appear here and remain
 // accessible via direct field access on `JobContext`. `created_at`
 // is exposed because `job.rs` emits it when listing jobs across users.
-impl dasclaw_runtime::JobContextCore for JobContext {
+impl JobContextCore for JobContext {
     fn job_id(&self) -> Uuid {
         self.job_id
     }
@@ -338,7 +339,7 @@ impl dasclaw_runtime::JobContextCore for JobContext {
     fn set_user_timezone(&mut self, timezone: String) {
         self.user_timezone = timezone;
     }
-    fn http_interceptor(&self) -> Option<Arc<dyn dasclaw_runtime::HttpInterceptor>> {
+    fn http_interceptor(&self) -> Option<Arc<dyn HttpInterceptor>> {
         self.http_interceptor.clone()
     }
 

--- a/crates/dasclaw_runtime/src/context/util.rs
+++ b/crates/dasclaw_runtime/src/context/util.rs
@@ -1,0 +1,17 @@
+//! Small utility helpers used by `context` (and only by `context`).
+//!
+//! `floor_char_boundary` is a verbatim port of the same helper in
+//! `desktop-client/ironclaw/src/util.rs` (UTF-8 boundary polyfill for the
+//! nightly-only `str::floor_char_boundary`). Duplicated here to keep slice A''
+//! self-contained — the desktop copy stays in place for callers there.
+
+pub(crate) fn floor_char_boundary(s: &str, pos: usize) -> usize {
+    if pos >= s.len() {
+        return s.len();
+    }
+    let mut i = pos;
+    while i > 0 && !s.is_char_boundary(i) {
+        i -= 1;
+    }
+    i
+}

--- a/crates/dasclaw_runtime/src/error.rs
+++ b/crates/dasclaw_runtime/src/error.rs
@@ -7,6 +7,10 @@ use std::time::Duration;
 
 use thiserror::Error;
 
+// ADR-152 §3 F3.6 slice A'' verbatim 兼容 re-export：搬过来的 `manager.rs`
+// 测试代码使用 `crate::error::JobError` 全路径。
+pub use dasclaw_core::error::JobError;
+
 /// Error returned by the tool dispatcher to the rest of the application.
 ///
 /// Every variant that originates from a specific tool carries that tool's

--- a/crates/dasclaw_runtime/src/lib.rs
+++ b/crates/dasclaw_runtime/src/lib.rs
@@ -34,6 +34,7 @@
 //! Instead, callers must attach the name explicitly at the boundary using
 //! [`ToolError::from_tool_impl`].
 
+pub mod context;
 pub mod error;
 pub mod feature_flags;
 pub mod job;

--- a/crates/dasclaw_runtime/src/secrets/crypto.rs
+++ b/crates/dasclaw_runtime/src/secrets/crypto.rs
@@ -14,8 +14,8 @@
 //! have the same plaintext, they'll have different ciphertexts.
 
 use aes_gcm::{
-    aead::{Aead, AeadCore, OsRng},
     Aes256Gcm, KeyInit, Nonce,
+    aead::{Aead, AeadCore, OsRng},
 };
 use hkdf::Hkdf;
 use secrecy::{ExposeSecret, SecretString};

--- a/crates/dasclaw_runtime/src/secrets/keychain.rs
+++ b/crates/dasclaw_runtime/src/secrets/keychain.rs
@@ -84,8 +84,8 @@ impl KeychainConfig {
 
 /// Generate a random 32-byte master key.
 pub fn generate_master_key() -> Vec<u8> {
-    use rand::rngs::OsRng;
     use rand::RngCore;
+    use rand::rngs::OsRng;
     let mut key = vec![0u8; 32];
     OsRng.fill_bytes(&mut key);
     key
@@ -304,12 +304,12 @@ mod platform {
     use std::ffi::c_void;
     use std::slice;
 
-    use windows::core::{PCWSTR, PWSTR};
     use windows::Win32::Foundation::{ERROR_NOT_FOUND, FILETIME};
     use windows::Win32::Security::Credentials::{
-        CredDeleteW, CredFree, CredReadW, CredWriteW, CREDENTIALW, CRED_FLAGS,
-        CRED_PERSIST_LOCAL_MACHINE, CRED_TYPE_GENERIC,
+        CRED_FLAGS, CRED_PERSIST_LOCAL_MACHINE, CRED_TYPE_GENERIC, CREDENTIALW, CredDeleteW,
+        CredFree, CredReadW, CredWriteW,
     };
+    use windows::core::{PCWSTR, PWSTR};
 
     use super::*;
 

--- a/crates/dasclaw_runtime/src/secrets/store.rs
+++ b/crates/dasclaw_runtime/src/secrets/store.rs
@@ -193,10 +193,11 @@ mod tests {
             .await
             .unwrap();
         assert!(!s.is_accessible("u1", "k", &[]).await.unwrap());
-        assert!(s
-            .is_accessible("u1", "k", &["k".to_string()])
-            .await
-            .unwrap());
+        assert!(
+            s.is_accessible("u1", "k", &["k".to_string()])
+                .await
+                .unwrap()
+        );
     }
 
     #[tokio::test]

--- a/crates/dasclaw_runtime/src/secrets/store_in_memory.rs
+++ b/crates/dasclaw_runtime/src/secrets/store_in_memory.rs
@@ -79,10 +79,10 @@ impl SecretsStore for InMemorySecretsStore {
             .cloned()
             .ok_or_else(|| SecretError::NotFound(name.clone()))?;
 
-        if let Some(expires_at) = secret.expires_at {
-            if expires_at < Utc::now() {
-                return Err(SecretError::Expired);
-            }
+        if let Some(expires_at) = secret.expires_at
+            && expires_at < Utc::now()
+        {
+            return Err(SecretError::Expired);
         }
 
         Ok(secret)
@@ -148,10 +148,10 @@ impl SecretsStore for InMemorySecretsStore {
             if pattern_lower == secret_name_lower {
                 return Ok(true);
             }
-            if let Some(prefix) = pattern_lower.strip_suffix('*') {
-                if secret_name_lower.starts_with(prefix) {
-                    return Ok(true);
-                }
+            if let Some(prefix) = pattern_lower.strip_suffix('*')
+                && secret_name_lower.starts_with(prefix)
+            {
+                return Ok(true);
             }
         }
         Ok(false)
@@ -254,10 +254,11 @@ mod tests {
     async fn req_dasclaw_runtime_secrets_store_in_memory_security_is_accessible_exact() {
         let s = store();
         s.create("u", params("github_token", "v")).await.unwrap();
-        assert!(s
-            .is_accessible("u", "github_token", &["github_token".to_string()])
-            .await
-            .unwrap());
+        assert!(
+            s.is_accessible("u", "github_token", &["github_token".to_string()])
+                .await
+                .unwrap()
+        );
     }
 
     #[tokio::test]
@@ -265,15 +266,17 @@ mod tests {
         let s = store();
         s.create("u", params("github_token", "v")).await.unwrap();
         // Wildcard `github_*` permits `github_token`
-        assert!(s
-            .is_accessible("u", "github_token", &["github_*".to_string()])
-            .await
-            .unwrap());
+        assert!(
+            s.is_accessible("u", "github_token", &["github_*".to_string()])
+                .await
+                .unwrap()
+        );
         // But a stricter `slack_*` rule must not match
-        assert!(!s
-            .is_accessible("u", "github_token", &["slack_*".to_string()])
-            .await
-            .unwrap());
+        assert!(
+            !s.is_accessible("u", "github_token", &["slack_*".to_string()])
+                .await
+                .unwrap()
+        );
     }
 
     #[tokio::test]
@@ -283,9 +286,10 @@ mod tests {
         // otherwise a tool could "pre-declare" access and later trigger
         // a write to obtain the secret.
         let s = store();
-        assert!(!s
-            .is_accessible("u", "ghost", &["*".to_string()])
-            .await
-            .unwrap());
+        assert!(
+            !s.is_accessible("u", "ghost", &["*".to_string()])
+                .await
+                .unwrap()
+        );
     }
 }

--- a/desktop-client/ironclaw/src/context/mod.rs
+++ b/desktop-client/ironclaw/src/context/mod.rs
@@ -1,19 +1,12 @@
-//! Per-job context isolation and state management.
+//! Per-job context: re-export shim.
 //!
-//! Each job runs with its own isolated context that includes:
-//! - Conversation history
-//! - Action history
-//! - State machine
-//! - Resource tracking
+//! ADR-152 §3 F3.6 (slice 1 / slice 2 / slice A''): `Memory` + `JobError`
+//! live in `dasclaw_core`; `state` + `manager` + `fallback` live in
+//! `dasclaw_runtime::context`. This shim keeps existing `crate::context::*`
+//! call sites source-compatible.
 
-pub mod fallback;
-mod manager;
-mod state;
-
-pub use fallback::FallbackDeliverable;
-pub use manager::ContextManager;
-// ADR-152 §3 F3.6 slice 1: `memory` was moved into `dasclaw_core::context::memory`.
-// Re-export keeps existing `crate::context::{ActionRecord, ConversationMemory, Memory}`
-// call sites (e.g. `worker::job`) source-compatible.
 pub use dasclaw_core::context::memory::{ActionRecord, ConversationMemory, Memory};
-pub use state::{JobContext, JobState, StateTransition, TokenBudgetExceeded};
+pub use dasclaw_runtime::context::{
+    ContextManager, ContextSummary, FallbackDeliverable, JobContext,
+};
+pub use dasclaw_runtime::{JobState, StateTransition, TokenBudgetExceeded};


### PR DESCRIPTION
## 背景 / 目标

ADR-152 §3 F3.6 = context 模块统一收口。
依据 §11.8.9（落点修正条款：从 dasclaw_core 改到 dasclaw_runtime，避免循环依赖）+ ADR-129 §1.3（原样搬迁红线：只允许 import rebase）。

本 PR 把 `desktop-client/ironclaw/src/context/{state,manager,fallback}.rs` 原样搬到 `crates/dasclaw_runtime/src/context/`，桌面端保留薄壳 re-export。

## 改动范围

- 三个 `git mv` 进 `crates/dasclaw_runtime/src/context/`：state.rs / manager.rs / fallback.rs（git 检测为 rename，相似度 98–99%）
- 新增 `crates/dasclaw_runtime/src/context/mod.rs`：`pub use` 三个子模块 + 兼容 re-export（`JobState`、`Memory`）
- 新增 `crates/dasclaw_runtime/src/context/util.rs`：slice-scoped 私有 `floor_char_boundary` 副本，避免拉入桌面端 util.rs 的 llm 相关 helper
- `crates/dasclaw_runtime/src/lib.rs`：注册 `pub mod context`
- `crates/dasclaw_runtime/src/error.rs`：增加 `pub use dasclaw_core::error::JobError` —— manager.rs 测试使用 `crate::error::JobError`
- `desktop-client/ironclaw/src/context/mod.rs`：精简为 12 行 re-export

附带必需变更（在 PR body 显式标注，避免被当作 scope creep）：

- `crates/dasclaw_runtime/Cargo.toml` edition 2021 → 2024：manager.rs 286-287 行使用 let-chain `&& let Some(...)`，必须 2024
- `crates/dasclaw_runtime/Cargo.toml` 新增 `tracing` 依赖（manager.rs 内部使用）
- `crates/dasclaw_runtime/src/secrets/store_in_memory.rs`：edition 2024 启用后 `collapsible_if` 在两处嵌套 if-let 上报错（pre-existing 代码），按 clippy 提示折叠为 let-chain 形式
- `crates/dasclaw_runtime/src/secrets/{crypto,keychain,store}.rs`：cargo fmt 在 edition 2024 下重排 imports

## 非目标 / What's NOT in this PR

- 不做 god-struct 拆分（ADR-154 step 2a 已完成）
- 不调整 API、不重写逻辑、不增删测试用例
- 不动 `dasclaw_core` 内的 memory 模块
- 不做后续的 `desktop` 内调用方改写（保留薄壳 re-export，调用方走 `dasclaw::context::*` 不变）

## 验证

```
cargo check -p dasclaw_runtime --tests     ✅
cargo check -p dasclaw --tests             ✅ (4m59s)
cargo nextest run -p dasclaw_runtime       ✅ 143/143
cargo nextest run -p dasclaw               ✅ 3564 passed, 22 skipped
cargo fmt --all                            ✅
python3.12 scripts/check_no_panics.py --base origin/xClaw  ✅
cargo clippy --no-deps -p dasclaw_runtime --all-targets -- -D warnings  ✅
cargo clippy --no-deps -p dasclaw --all-targets -- -D warnings          ✅
```

## 三层审查（自查）

依 ADR-129 §1.3 原样搬迁红线，本 PR 跳过 code-simplifier（不允许重构）。

- **code-quality-audit**：所有 import rebase 都是机械替换（`crate::*` → `dasclaw_core::*` / `dasclaw_runtime::*`），无逻辑改动；新增 util.rs 是 verbatim 复制 + slice-scoped 文档说明；error.rs / context/mod.rs 的 re-export 是兼容层、可在后续 slice 移除
- **adr-compliance-check**：
  - ADR-152 §11.8.9 落点 = `crates/dasclaw_runtime/src/context/` ✅
  - ADR-129 §1.3 verbatim：仅 import 路径变更 + 兼容 re-export，无 API/逻辑/测试改动 ✅
  - 附带 edition 2024 + tracing 依赖已在 §11.8.9.4 checklist 中预登记
- **code-review-expert**：
  - 桌面端薄壳保留 `dasclaw::context::*` 公开路径，下游调用方零改动
  - tests 全绿（runtime 143、desktop 3564）
  - clippy `-D warnings` 双 crate 通过
  - 无 `unwrap()/expect()/panic!()` 新增（check_no_panics 通过）

## Sources read

- [AGENTS.md](../AGENTS.md) §会话轮换、§Skills 强制使用规范、§原样搬迁
- [docs/plans/architecture-refactor/adr-152-agent-and-capability-fusion.md](../docs/plans/architecture-refactor/adr-152-agent-and-capability-fusion.md) §3 F3.6、§11.8.8、§11.8.9（落点修正）
- [docs/plans/architecture-refactor/adr-129-headless-agent-architecture.md](../docs/plans/architecture-refactor/adr-129-headless-agent-architecture.md) §1.3 原样搬迁红线
- [docs/plans/architecture-refactor/adr-154-context-state-split.md](../docs/plans/architecture-refactor/adr-154-context-state-split.md) step 2a god-struct 拆分（已完成，本 PR 不重做）
- [crates/dasclaw_runtime/src/lib.rs](../crates/dasclaw_runtime/src/lib.rs)、[crates/dasclaw_runtime/Cargo.toml](../crates/dasclaw_runtime/Cargo.toml) 既有模块和依赖
- [desktop-client/ironclaw/src/context/mod.rs](../desktop-client/ironclaw/src/context/mod.rs) 原 context 入口

Refs #720 #719
Closes #632
