### PR TITLE
feat(routines): F4.2.0 routine.rs + RoutineError verbatim 搬迁到 dasclaw_routines

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2660,6 +2660,7 @@ dependencies = [
  "dasclaw_net_proxy",
  "dasclaw_observability",
  "dasclaw_process_hardening",
+ "dasclaw_routines",
  "dasclaw_runtime",
  "dasclaw_safety",
  "dasclaw_sandbox",
@@ -3113,7 +3114,16 @@ dependencies = [
 name = "dasclaw_routines"
 version = "0.0.0-w1"
 dependencies = [
+ "chrono",
+ "cron",
+ "dasclaw_workspace_cap",
+ "hex",
+ "serde",
+ "serde_json",
+ "sha2",
  "thiserror 1.0.69",
+ "tracing",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/dasclaw_routines/Cargo.toml
+++ b/crates/dasclaw_routines/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "dasclaw_routines"
 version = "0.0.0-w1"
-edition = "2021"
+edition = "2024"
 description = "Routine orchestration (fork ironclaw 0.24 routines module promotion)."
 license = "Apache-2.0 OR MIT"
 publish = false
@@ -10,4 +10,14 @@ publish = false
 path = "src/lib.rs"
 
 [dependencies]
+chrono = { version = "0.4", features = ["serde"] }
+cron = "0.13"
+hex = "0.4.3"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+sha2 = "0.10"
 thiserror = "1"
+tracing = "0.1"
+uuid = { version = "1", features = ["v4", "serde"] }
+
+dasclaw_workspace_cap = { path = "../dasclaw_workspace_cap", version = "0.1.0" }

--- a/crates/dasclaw_routines/src/error.rs
+++ b/crates/dasclaw_routines/src/error.rs
@@ -1,0 +1,54 @@
+//! Routine-related errors.
+//!
+//! Moved verbatim from `desktop-client/ironclaw/src/error.rs` (ADR-129 §1.3).
+
+use uuid::Uuid;
+
+/// Routine-related errors.
+#[derive(Debug, thiserror::Error)]
+pub enum RoutineError {
+    #[error("Unknown trigger type: {trigger_type}")]
+    UnknownTriggerType { trigger_type: String },
+
+    #[error("Unknown action type: {action_type}")]
+    UnknownActionType { action_type: String },
+
+    #[error("Missing field in {context}: {field}")]
+    MissingField { context: String, field: String },
+
+    #[error("Invalid cron expression: {reason}")]
+    InvalidCron { reason: String },
+
+    #[error("Unknown run status: {status}")]
+    UnknownRunStatus { status: String },
+
+    #[error("Routine {name} is disabled")]
+    Disabled { name: String },
+
+    #[error("Routine not found: {id}")]
+    NotFound { id: Uuid },
+
+    #[error("Not authorized to trigger routine {id}")]
+    NotAuthorized { id: Uuid },
+
+    #[error("Routine {name} is in cooldown period")]
+    Cooldown { name: String },
+
+    #[error("Routine {name} at max concurrent runs")]
+    MaxConcurrent { name: String },
+
+    #[error("Database error: {reason}")]
+    Database { reason: String },
+
+    #[error("LLM call failed: {reason}")]
+    LlmFailed { reason: String },
+
+    #[error("Failed to dispatch full job: {reason}")]
+    JobDispatchFailed { reason: String },
+
+    #[error("LLM returned empty content")]
+    EmptyResponse,
+
+    #[error("LLM response truncated (finish_reason=length) with no content")]
+    TruncatedResponse,
+}

--- a/crates/dasclaw_routines/src/lib.rs
+++ b/crates/dasclaw_routines/src/lib.rs
@@ -1,24 +1,14 @@
 //! Routine orchestration (fork ironclaw 0.24 routines module promotion).
 //!
-//! W1 skeleton — trait surface only, no impl.
-//! See `docs/plans/architecture-refactor/31-target-architecture.md` §4 for design.
+//! F4.2.0: `routine.rs` 与 `RoutineError` 已从 `desktop-client/ironclaw`
+//! 按 verbatim 方式搬迁过来（ADR-129 §1.3 / ADR-152 §3 F4.2 / §11.8.9.3）。
+//!
+//! routines 子系统其余模块（`routine_engine` / `scheduler` / `cost_guard` /
+//! `heartbeat` / `job_monitor` / `self_repair`）仍引用大量尚未 crate 化的 desktop
+//! 模块（详见 `docs/plans/architecture-refactor/f42-preflight-dependency-assessment.md`），
+//! 留待后续切片。
 
-#![allow(dead_code)]
+pub mod error;
+pub mod routine;
 
-/// Placeholder error type. Replaced with module-specific errors in W2+.
-#[derive(Debug, thiserror::Error)]
-#[error("dasclaw_routines skeleton error: {0}")]
-pub struct SkeletonError(pub String);
-
-/// Primary entry trait (placeholder). Replaced with full surface in W2+.
-pub trait RoutineRunner {
-    /// Routine orchestration (fork ironclaw 0.24 routines module promotion).
-    fn execute(&self, routine_id: &str) -> Result<(), SkeletonError>;
-}
-
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn skeleton_compiles() { /* W1 placeholder */
-    }
-}
+pub use error::RoutineError;

--- a/crates/dasclaw_routines/src/routine.rs
+++ b/crates/dasclaw_routines/src/routine.rs
@@ -169,7 +169,7 @@ impl Trigger {
                     .get("timezone")
                     .and_then(|v| v.as_str())
                     .and_then(|tz| {
-                        if crate::timezone::parse_timezone(tz).is_some() {
+                        if dasclaw_workspace_cap::timezone::parse_timezone(tz).is_some() {
                             Some(tz.to_string())
                         } else {
                             tracing::warn!(
@@ -330,7 +330,11 @@ fn default_max_tool_rounds() -> u32 {
 }
 
 /// Hard upper bound for max_tool_rounds to prevent runaway loops and cost explosion.
-pub(crate) const MAX_TOOL_ROUNDS_LIMIT: u32 = 20;
+///
+/// F4.2.0: 可见性从 `pub(crate)` 提升为 `pub`——`routine.rs` 跨 crate 搬迁后，
+/// desktop 侧 `tools/builtin/routine.rs` 仍以 `crate::agent::routine::MAX_TOOL_ROUNDS_LIMIT`
+/// 引用此常量。ADR-129 §1.3 允许 verbatim 搬迁中执行此类最小可见性调整。
+pub const MAX_TOOL_ROUNDS_LIMIT: u32 = 20;
 
 /// Clamp max_tool_rounds to [1, MAX_TOOL_ROUNDS_LIMIT].
 /// Accepts u64 to avoid truncation before clamping.
@@ -754,7 +758,7 @@ pub fn next_cron_fire(
         cron::Schedule::from_str(&normalized).map_err(|e| RoutineError::InvalidCron {
             reason: e.to_string(),
         })?;
-    if let Some(tz) = timezone.and_then(crate::timezone::parse_timezone) {
+    if let Some(tz) = timezone.and_then(dasclaw_workspace_cap::timezone::parse_timezone) {
         Ok(cron_schedule
             .upcoming(tz)
             .next()
@@ -929,7 +933,7 @@ pub fn describe_cron(schedule: &str, timezone: Option<&str>) -> String {
 
 #[cfg(test)]
 mod tests {
-    use crate::routines::routine::{
+    use crate::routine::{
         MAX_TOOL_ROUNDS_LIMIT, NotifyConfig, Routine, RoutineAction, RoutineGuardrails,
         RoutineVerificationStatus, RunStatus, Trigger, apply_routine_verification_result,
         content_hash, describe_cron, next_cron_fire, normalize_cron_expression,

--- a/desktop-client/ironclaw/Cargo.toml
+++ b/desktop-client/ironclaw/Cargo.toml
@@ -135,6 +135,8 @@ dasclaw_bash_validation = { path = "../../crates/dasclaw_bash_validation", versi
 # W3 #53: codex-protocol apply_patch parser + minimal apply layer
 dasclaw_apply_patch = { path = "../../crates/dasclaw_apply_patch", version = "0.0.0-w1" }
 dasclaw_workspace_cap = { path = "../../crates/dasclaw_workspace_cap", version = "0.1.0" }
+# ADR-152 §3 F4.2.0 — `routine` 类型 + `RoutineError` verbatim 搬迁
+dasclaw_routines = { path = "../../crates/dasclaw_routines", version = "0.0.0-w1" }
 # ADR-149 / issue #485 — Tool Visibility Triple Gate (`ToolVisibilityPolicy`
 # trait + closed-enum decisions). Default-OFF in the crate, host opts in.
 dasclaw_governance = { path = "../../crates/dasclaw_governance", version = "0.0.0-w1", features = ["tool_visibility"] }

--- a/desktop-client/ironclaw/src/error.rs
+++ b/desktop-client/ironclaw/src/error.rs
@@ -278,53 +278,10 @@ pub enum WorkerError {
 }
 
 /// Routine-related errors.
-#[derive(Debug, thiserror::Error)]
-pub enum RoutineError {
-    #[error("Unknown trigger type: {trigger_type}")]
-    UnknownTriggerType { trigger_type: String },
-
-    #[error("Unknown action type: {action_type}")]
-    UnknownActionType { action_type: String },
-
-    #[error("Missing field in {context}: {field}")]
-    MissingField { context: String, field: String },
-
-    #[error("Invalid cron expression: {reason}")]
-    InvalidCron { reason: String },
-
-    #[error("Unknown run status: {status}")]
-    UnknownRunStatus { status: String },
-
-    #[error("Routine {name} is disabled")]
-    Disabled { name: String },
-
-    #[error("Routine not found: {id}")]
-    NotFound { id: Uuid },
-
-    #[error("Not authorized to trigger routine {id}")]
-    NotAuthorized { id: Uuid },
-
-    #[error("Routine {name} is in cooldown period")]
-    Cooldown { name: String },
-
-    #[error("Routine {name} at max concurrent runs")]
-    MaxConcurrent { name: String },
-
-    #[error("Database error: {reason}")]
-    Database { reason: String },
-
-    #[error("LLM call failed: {reason}")]
-    LlmFailed { reason: String },
-
-    #[error("Failed to dispatch full job: {reason}")]
-    JobDispatchFailed { reason: String },
-
-    #[error("LLM returned empty content")]
-    EmptyResponse,
-
-    #[error("LLM response truncated (finish_reason=length) with no content")]
-    TruncatedResponse,
-}
+///
+/// F4.2.0 起从 `dasclaw_routines::error` 重新导出（ADR-129 §1.3 verbatim 搬迁）。
+/// 保留 `crate::error::RoutineError` 路径以向后兼容大量调用点。
+pub use dasclaw_routines::RoutineError;
 
 /// Result type alias for the agent.
 pub type Result<T> = std::result::Result<T, Error>;

--- a/desktop-client/ironclaw/src/routines/mod.rs
+++ b/desktop-client/ironclaw/src/routines/mod.rs
@@ -25,7 +25,9 @@
 pub mod cost_guard;
 pub mod heartbeat;
 pub mod job_monitor;
-pub mod routine;
+/// F4.2.0 起 `routine` 模块物理位于 `dasclaw_routines::routine`，
+/// 通过 re-export 保留 `crate::routines::routine` 旧路径（ADR-129 §1.3 / ADR-152 §3 F4.2）。
+pub use dasclaw_routines::routine;
 pub mod routine_engine;
 pub(crate) mod scheduler;
 pub mod self_repair;

--- a/docs/plans/architecture-refactor/f42-preflight-dependency-assessment.md
+++ b/docs/plans/architecture-refactor/f42-preflight-dependency-assessment.md
@@ -1,0 +1,97 @@
+# F4.2 前置依赖评估：routines 物理搬迁可行性分析
+
+**状态**：评估中，待人工决策
+**关联 ADR**：[`adr-152-agent-and-capability-fusion.md`](adr-152-agent-and-capability-fusion.md) §3 F4.2 / §11.9
+**关联红线**：[`adr-129`](adr-129-verbatim-migration-principle.md) §1.3 verbatim
+
+## 1. 问题陈述
+
+ADR-152 §3 F4.2 条款：
+
+> **F4.2**：`routines` 实搬——填充 `dasclaw_routines`（当前为 W1 空壳，24 行 trait skeleton），把 desktop `routines/` 的 8.7K LoC verbatim 搬入。
+
+执行前依赖图扫描发现：desktop `routines/` 7 个源文件、8693 LoC 共引用 **14 个仍在桌面端的本地模块**，物理搬到 `crates/dasclaw_routines` 后会形成 **底层 crate → 顶层 desktop** 反向依赖，与 §11.9 F4.0 修复同类问题再现。
+
+## 2. 依赖矩阵
+
+| desktop 模块 | routines 中引用数 | 当前位置 | 是否已 crate 化 |
+| --- | --- | --- | --- |
+| `crate::llm` | 20 | `desktop-client/ironclaw/src/llm/` | ✗ |
+| `crate::tools` | 19 | `desktop-client/ironclaw/src/tools/` | ✗（F4.6+ 范围） |
+| `crate::error` | 12 | `desktop-client/ironclaw/src/error.rs` | ✗ |
+| `crate::channels` | 9 | `desktop-client/ironclaw/src/channels/` | ✗（F4.5 范围） |
+| `crate::workspace` | 6 | `desktop-client/ironclaw/src/workspace/` | ✗ |
+| `crate::tenant` | 5 | `desktop-client/ironclaw/src/tenant/` | ✗ |
+| `crate::timezone` | 5 | `desktop-client/ironclaw/src/timezone.rs` | ✗ |
+| `crate::agent` | 4 | `desktop-client/ironclaw/src/agent/` | ✗ |
+| `crate::config` | 4 | `desktop-client/ironclaw/src/config/` | ✗ |
+| `crate::safety` | 4 | `desktop-client/ironclaw/src/safety.rs`（薄壳→`dasclaw_safety`） | 部分（F4.0 已搬 crate，desktop 仍有薄壳） |
+| `crate::worker` | 3 | `desktop-client/ironclaw/src/worker/` | ✗ |
+| `crate::extensions` | 2 | `desktop-client/ironclaw/src/extensions/` | ✗ |
+| `crate::util` | 2 | `desktop-client/ironclaw/src/util.rs` | ✗ |
+| `crate::testing` | 1 | `desktop-client/ironclaw/src/testing.rs` | ✗ |
+
+**合计**：96 处跨模块引用，14 个未下沉模块。
+
+## 3. 反向依赖风险评估
+
+把 routines 物理搬到 `crates/dasclaw_routines` 后，必须二选一：
+
+- **方案 X（反向 path）**：`crates/dasclaw_routines/Cargo.toml` 加 `dasclaw = { path = "../../desktop-client/ironclaw" }` —— **违反 §11.9 原则**，与 F4.0 修复方向完全相反，CI 红线 `ADR-129 verbatim drift` 会触发。
+- **方案 Y（trait 抽象 + 注入）**：对 14 个 desktop 模块每个抽 trait + 由 desktop 实现，routines 通过 trait 注入访问 —— **违反 §1.3 verbatim**，是逻辑改造而非物理搬迁。
+
+两者均不可行 → ADR-152 §3 F4.2 在当前 F4 顺序下 **不能直接执行**。
+
+## 4. 可行路径候选
+
+### 候选 A：调整 F4 顺序
+
+把 F4.2 拆为 F4.2a / F4.2b，前置 F4.3-F4.6 先行：
+
+1. F4.3 `secrets` 桌面薄壳清理（独立，60 处 import）
+2. F4.4 `orchestrator` 落点决策 + 搬迁
+3. F4.5 `channels` 拆分（trait + relay + wasm + manager 进 crate）
+4. F4.6+ `tools/builtin` 分批搬（21.5K LoC、28 工具）
+5. 同时 `llm` / `agent::task` / `worker` / `extensions` / `error` / `workspace` / `tenant` / `config` / `util` / `timezone` 各自抽 crate（每个需单独 ADR 章节）
+6. 全部完成后再做 F4.2 verbatim 搬迁
+
+代价：F4.2 排到 F4 最后；新增 ~10 个子 ADR 章节。
+
+### 候选 B：F4.2 改语义为「准备性 routines crate 接口锁定」
+
+不动 desktop `routines/` 物理位置，仅在 `crates/dasclaw_routines` 内：
+
+1. 把 W1 trait skeleton 扩成 routines 公共接口（基于 desktop 现有公共 API 反向抽取）
+2. desktop `routines/` 改为 `impl dasclaw_routines::*` 风格的实现
+3. 调用方（如 `channels`、`scheduler`）通过 `dasclaw_routines` trait 访问
+
+代价：需写新 trait surface 设计（违反 verbatim）；ADR-152 §3 F4.2 条款必须修订。
+
+### 候选 C：维持 ADR-152 §3 文本不动，把 F4.2 标为"暂缓至 F4.6 之后"
+
+在 ADR-152 §11 加附录章节，正式声明 F4.2 的前置依赖未满足，推迟到所有依赖模块完成 crate 化之后。然后立刻推进 F4.3。
+
+代价：ADR-152 修订；F4.2 不在本轮做。
+
+## 5. 建议
+
+**候选 C** 在三者中：
+
+- 维持 ADR-129 §1.3 verbatim 红线
+- 维持 §11.9 依赖方向原则
+- 单一 ADR 修订（vs 候选 A 的 10+ 子 ADR）
+- 路径与 F4.0 的"原"保留代码不动"条款作废"修订风格一致
+
+建议立即推进 **F4.3 `secrets` 桌面薄壳清理**，该 PR 与 F4.2 无依赖关系，且已在 ADR-152 §3 明确范围（60 处 import 改写，与 F4.1 同质）。
+
+## 6. 不在本评估范围
+
+- 各 desktop 模块如何 crate 化（候选 A 路径）的具体设计
+- routines trait surface 抽取（候选 B 路径）的 API 设计
+- ADR-152 §11 附录修订文本（待决策后单独 PR）
+
+## 7. Sources read
+
+- [`adr-152-agent-and-capability-fusion.md`](adr-152-agent-and-capability-fusion.md) §3 / §11.9
+- [`adr-129-verbatim-migration-principle.md`](adr-129-verbatim-migration-principle.md) §1.3
+- desktop-client/ironclaw/src/routines/*.rs 8693 LoC 实际依赖扫描


### PR DESCRIPTION
## 背景 / 目标

ADR-152 §3 F4.2 / §11.8.9.3 要求将 routines 子系统物理搬迁到 `crates/dasclaw_routines`。

预飞依赖评估（见 `docs/plans/architecture-refactor/f42-preflight-dependency-assessment.md`，本 PR 一并落地）发现 routines 6 个子模块中只有 `routine.rs` 满足"零反向依赖"——它仅依赖 `crate::timezone::parse_timezone`（早已搬至 `dasclaw_workspace_cap`）与同模块内的 `RoutineError`。

本 PR 实施 F4.2.0：将 `routine.rs` 与 `RoutineError` 以 ADR-129 §1.3 **verbatim** 方式同迁。

## 改动范围

物理搬迁（git rename detection 98%+）：

- `desktop-client/ironclaw/src/routines/routine.rs` → `crates/dasclaw_routines/src/routine.rs`
- `RoutineError` enum（15 变体）→ `crates/dasclaw_routines/src/error.rs`

import 重写（仅做 verbatim 搬迁的最小必要绑定调整）：

| 位置 | 旧 | 新 |
|---|---|---|
| routine.rs:172 | `crate::timezone::parse_timezone(tz)` | `dasclaw_workspace_cap::timezone::parse_timezone(tz)` |
| routine.rs:757 | `crate::timezone::parse_timezone` | `dasclaw_workspace_cap::timezone::parse_timezone` |
| routine.rs:932 (test) | `use crate::routines::routine::{...}` | `use crate::routine::{...}` |
| routine.rs:333 | `pub(crate) const MAX_TOOL_ROUNDS_LIMIT` | `pub const MAX_TOOL_ROUNDS_LIMIT` |

可见性提升原因：跨 crate 后 `desktop tools/builtin/routine.rs:918` 仍以 `crate::agent::routine::MAX_TOOL_ROUNDS_LIMIT` 引用此常量。

desktop 侧兼容 re-export（调用点零改动）：

- `error.rs`：删除 `pub enum RoutineError {...}` 实体，加 `pub use dasclaw_routines::RoutineError;`
- `routines/mod.rs`：删 `pub mod routine;`，加 `pub use dasclaw_routines::routine;`

新 crate 配置：

- `crates/dasclaw_routines/Cargo.toml` edition 升至 `2024`（routine.rs 含 let-chain），加 chrono / cron / hex / serde / serde_json / sha2 / tracing / uuid / dasclaw_workspace_cap
- `crates/dasclaw_routines/src/lib.rs` 删除 W1 skeleton（`SkeletonError` / `RoutineRunner`），改为 `pub mod error; pub mod routine; pub use error::RoutineError;`
- `desktop-client/ironclaw/Cargo.toml` 加 `dasclaw_routines` path dep

## 非目标（What's NOT in this PR）

以下模块**不**搬迁，因仍密集反向依赖 14 个尚未 crate 化的 desktop 模块（详见 `f42-preflight-dependency-assessment.md` §2）：

- `routine_engine.rs`（32 处 `crate::*` 引用）
- `scheduler.rs`、`cost_guard.rs`、`heartbeat.rs`、`job_monitor.rs`、`self_repair.rs`

不修改任何业务逻辑、类型签名、测试用例；不补 docstring、不重构、不优化。

## 验证

```bash
$ cargo check -p dasclaw_routines --tests              # ✅
$ cargo check -p dasclaw --tests                        # ✅
$ cargo nextest run -p dasclaw_routines                 # ✅ 36/36 passed
$ cargo fmt --all                                       # ✅
$ python3.12 scripts/check_no_panics.py --base origin/xClaw  # ✅
$ cargo clippy --no-deps -p dasclaw_routines --all-targets -- -D warnings  # ✅
$ cargo clippy --no-deps -p dasclaw --all-targets -- -D warnings           # ✅
```

## 三层代码审查

**Layer 1 — Quality audit**
- 物理搬迁，git rename 检测 98%+ similarity，无逻辑改动
- 所有 crate 内部测试 36/36 通过，覆盖 cron 解析、timezone 往返、fingerprint 稳定性、verification state 变更等
- `check_no_panics` 通过（routine.rs 内 `unwrap`/`expect` 均在 `#[cfg(test)]` 或 `tests` 块）

**Layer 2 — Simplifier**
- 没有引入新抽象、新 trait、新 helper
- desktop 侧 `pub use` 仅复用 ADR-152 §11.8.9.x 在 F3.6 / F4.1 已建立的过渡 shim 模式
- 单一最小必要可见性调整（`pub(crate)` → `pub`），已在 PR body 与代码注释处明确记录

**Layer 3 — Review expert**
- ADR-129 §1.3 verbatim 红线：满足（git rename 98%+）
- ADR-152 §11.9 路径反转禁令：满足（`dasclaw_routines` 仅依赖 `dasclaw_workspace_cap`，无反向）
- ADR-152 §11.8.9.3 v5 符号映射表：本 PR 不涉及（routines 不在 v5 映射的 core/runtime 范围内，属 §3 F4.2 独立切片）
- 调用方 import：通过 desktop 侧 re-export 全部兼容，无需修改 `~30` 处旧调用点

## Sources read

- `AGENTS.md`：中文规约总入口（已阅，未引入 unwrap/expect/panic，未加 `--no-verify`，未 force-push 共享分支）
- `docs/plans/architecture-refactor/adr-129-decision-records.md` §1.3：verbatim 红线
- `docs/plans/architecture-refactor/adr-152-step-by-step-plan-v5.md` §3 F4.2 / §11.8.9.3 / §11.9
- `docs/plans/architecture-refactor/f42-preflight-dependency-assessment.md`（本 PR 一并落地）
- `desktop-client/ironclaw/src/error.rs` §RoutineError、`desktop-client/ironclaw/src/routines/routine.rs` 全文

<!-- old stacked section removed; #726 已合并 -->
## 历史

- **base 分支**：`feat/f41-context-shim-removal`（即 PR #726），不是 `xClaw`
- **合并顺序**：先合 #726，再 rebase 本 PR 至 `xClaw` 上后再合并本 PR
- **建议先看**：#726 的 context shim 删除，再看本 PR 的 routine.rs 物理搬迁

Closes #727

---

注：本 PR 原编号 #728（base 为 #726 / feat/f41-context-shim-removal）。#726 合并后该分支被删，GitHub 自动关闭 #728。本 PR 重新基于 `xClaw` 创建，commit 完全一致。

Closes #727