### PR TITLE
fix(deny): ignore RUSTSEC-2026-0149 (wasmtime-wasi path_open TRUNCATE)

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -43,6 +43,7 @@ ignore = [
     "RUSTSEC-2026-0095",
     "RUSTSEC-2026-0096",
     "RUSTSEC-2026-0104",
+    "RUSTSEC-2026-0149",  # wasmtime-wasi GHSA-2r75-cxrj-cmph (path_open TRUNCATE bypasses FilePerms::WRITE)
 
     # rsa crate Marvin Attack timing sidechannel (RUSTSEC-2023-0071) — pulled
     # in by jsonwebtoken 10.x's `rust_crypto` backend. ironclaw_auth ONLY uses


### PR DESCRIPTION
## 背景 / 目标

cargo-deny 在 PR #733 上失败，错误源自 RustSec 数据库**新公布**的 RUSTSEC-2026-0149（wasmtime-wasi `path_open` TRUNCATE 旁路 `FilePerms::WRITE`）。

`wasmtime-wasi 28.0.1` 是 xClaw 既有的间接依赖（验证：`git show origin/xClaw:Cargo.lock | grep wasmtime-wasi` 返回 28.0.1）。`deny.toml` 已维护一组 Wasmtime cluster ignore，本 PR 在该 cluster 末尾追加 RUSTSEC-2026-0149，注释风格保持一致。

## 改动范围

- `deny.toml` `[advisories].ignore` 列表新增一行 `"RUSTSEC-2026-0149"` + 单行注释（GHSA-2r75-cxrj-cmph）。

## 非目标（What's NOT in this PR）

- 不升 wasmtime / wasmtime-wasi 版本（涉及 channels/wasm + tools/wasm 调用链；按 ADR-152 F4.5.2 wasm 切片处理）。
- 不修改任何 Rust 源码或 Cargo.lock。
- 不调整 deny.toml 既有规则（multiple-versions / wildcards / licenses / sources 全部保持原样）。

## 验证

```bash
cargo deny check advisories
# → advisories ok （新 advisory 已 ignore；其它既有 ignore 行为不变）

python3.12 scripts/check_no_panics.py --base origin/xClaw
# → OK: No panic-inducing calls in changed production code.
```

## 关联

- Closes #734
- 解锁 #733（F4.5 channels 第一刀）的 cargo-deny CI
- 后续 F4.5.2 wasm 切片完成 wasmtime bump 时，本 ignore 与 cluster 其它条目一并清理

## Sources read

- `AGENTS.md` §"3 必跑的本地管线"、§"4 PR 必填项"
- `.github/copilot-instructions.md` §"红线"、§"PR 必填项"
- `deny.toml` 全文（确认追加位置和注释风格与上下文一致）
- `docs/plans/architecture-refactor/adr-152-f45-wasm-slicing.md`（计划在 #733 合并后写；引用 ADR-152 §3 F4.5）
- `docs/plans/architecture-refactor/adr-129-verbatim-port-discipline.md` §1.3（确认本 PR 仅改 deny 配置，不触代码搬迁规则）
