### PR TITLE
feat(wasm-tools): F4.5.3 — extract 8 wasm sandbox primitives to dasclaw_wasm_tools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2666,6 +2666,7 @@ dependencies = [
  "dasclaw_safety",
  "dasclaw_sandbox",
  "dasclaw_tool",
+ "dasclaw_wasm_tools",
  "dasclaw_workspace_cap",
  "deadpool-postgres",
  "dirs 6.0.0",
@@ -3363,6 +3364,31 @@ version = "0.0.0-w7"
 dependencies = [
  "pretty_assertions",
  "regex-lite",
+]
+
+[[package]]
+name = "dasclaw_wasm_tools"
+version = "0.0.0-w1"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "blake3",
+ "chrono",
+ "dasclaw_runtime",
+ "dasclaw_tool",
+ "deadpool-postgres",
+ "libsql",
+ "secrecy",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-postgres",
+ "tracing",
+ "url",
+ "urlencoding",
+ "uuid",
+ "wasmtime",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,8 @@ members = [
 	"crates/dasclaw_routines",
 	# F4.5 first slice — channel core trait + manager + relay extracted from desktop
 	"crates/dasclaw_channels",
+	# F4.5.3 — wasm sandbox primitives extracted from desktop tools/wasm/
+	"crates/dasclaw_wasm_tools",
 	# W2.6 接线层：组合 sandbox + pty + workspace_cap policy
 	"crates/dasclaw_exec",
 	# W6-C 主仓自实现 LLM provider —— 替代 claw-code-api path-dep（ADR-118 PR-A.0 骨架）

--- a/crates/dasclaw_wasm_tools/Cargo.toml
+++ b/crates/dasclaw_wasm_tools/Cargo.toml
@@ -1,0 +1,43 @@
+[package]
+name = "dasclaw_wasm_tools"
+version = "0.0.0-w1"
+edition = "2024"
+description = "WASM sandbox primitives for tool execution (verbatim port from desktop-client/ironclaw/src/tools/wasm)."
+license = "Apache-2.0 OR MIT"
+publish = false
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+anyhow = "1"
+async-trait = "0.1"
+blake3 = "1"
+chrono = { version = "0.4", features = ["serde"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+thiserror = "2"
+tokio = { version = "1", features = ["sync"] }
+tracing = "0.1"
+url = "2"
+urlencoding = "2"
+uuid = { version = "1", features = ["v4", "v5", "serde"] }
+wasmtime = { version = "28", features = ["component-model"] }
+
+# Workspace crates
+dasclaw_runtime = { path = "../dasclaw_runtime" }
+dasclaw_tool = { path = "../dasclaw_tool" }
+
+# Optional storage backends
+deadpool-postgres = { version = "0.14", optional = true }
+tokio-postgres = { version = "0.7", optional = true }
+libsql = { version = "0.6", optional = true, default-features = false, features = ["core", "replication", "remote", "tls"] }
+
+[features]
+default = []
+postgres = ["dep:deadpool-postgres", "dep:tokio-postgres", "dasclaw_runtime/postgres"]
+libsql = ["dep:libsql", "dasclaw_runtime/libsql"]
+
+[dev-dependencies]
+secrecy = "0.10"
+tokio = { version = "1", features = ["sync", "rt", "macros"] }

--- a/crates/dasclaw_wasm_tools/src/allowlist.rs
+++ b/crates/dasclaw_wasm_tools/src/allowlist.rs
@@ -17,7 +17,7 @@
 
 use std::fmt;
 
-use crate::tools::wasm::capabilities::EndpointPattern;
+use crate::capabilities::EndpointPattern;
 
 /// Result of allowlist validation.
 #[derive(Debug, Clone)]
@@ -255,8 +255,8 @@ fn has_valid_percent_encoding(segment: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use crate::tools::wasm::allowlist::{AllowlistValidator, DenyReason};
-    use crate::tools::wasm::capabilities::EndpointPattern;
+    use crate::allowlist::{AllowlistValidator, DenyReason};
+    use crate::capabilities::EndpointPattern;
 
     fn validator_with_patterns() -> AllowlistValidator {
         AllowlistValidator::new(vec![

--- a/crates/dasclaw_wasm_tools/src/capabilities.rs
+++ b/crates/dasclaw_wasm_tools/src/capabilities.rs
@@ -310,19 +310,19 @@ impl SecretsCapability {
 ///
 /// Type alias for `ToolRateLimitConfig` from the shared rate limiter module.
 /// WASM capabilities use it to configure per-tool HTTP request limits.
-pub use crate::tools::tool::ToolRateLimitConfig as RateLimitConfig;
+pub use dasclaw_tool::ToolRateLimitConfig as RateLimitConfig;
 
 /// Webhook auth/signature capability descriptor.
 ///
 /// Per [ADR-154 §3.5] the struct lives in `dasclaw_tool::WebhookCapability`.
-/// This re-export keeps `crate::tools::wasm::WebhookCapability` working for
+/// This re-export keeps `dasclaw_wasm_tools::WebhookCapability` working for
 /// all existing call sites (including `Capabilities.webhook` and the
 /// `Tool::webhook_capability()` default impl re-export path).
 pub use dasclaw_tool::WebhookCapability;
 
 #[cfg(test)]
 mod tests {
-    use crate::tools::wasm::capabilities::{Capabilities, EndpointPattern, SecretsCapability};
+    use crate::capabilities::{Capabilities, EndpointPattern, SecretsCapability};
 
     #[test]
     fn test_capabilities_default_is_none() {

--- a/crates/dasclaw_wasm_tools/src/capabilities_schema.rs
+++ b/crates/dasclaw_wasm_tools/src/capabilities_schema.rs
@@ -32,7 +32,7 @@ use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 
-use crate::tools::wasm::{
+use crate::{
     Capabilities, EndpointPattern, HttpCapability, RateLimitConfig, SecretsCapability,
     ToolInvokeCapability, WebhookCapability, WorkspaceCapability,
 };
@@ -754,7 +754,7 @@ fn default_tool_setup_field_input_type() -> ToolSetupFieldInputType {
 mod tests {
     use serde_json::json;
 
-    use crate::tools::wasm::capabilities_schema::{CapabilitiesFile, CredentialLocationSchema};
+    use crate::capabilities_schema::{CapabilitiesFile, CredentialLocationSchema};
 
     #[test]
     fn test_parse_minimal() {
@@ -1283,7 +1283,7 @@ mod tests {
         assert!(setup.required_fields[0].restart_required);
         assert_eq!(
             setup.required_fields[0].input_type,
-            crate::tools::wasm::capabilities_schema::ToolSetupFieldInputType::Text
+            crate::capabilities_schema::ToolSetupFieldInputType::Text
         );
         assert_eq!(setup.required_fields[1].name, "selected_model");
     }
@@ -1310,11 +1310,11 @@ mod tests {
         let setup = caps.setup.unwrap();
         assert_eq!(
             setup.required_fields[0].input_type,
-            crate::tools::wasm::capabilities_schema::ToolSetupFieldInputType::Text
+            crate::capabilities_schema::ToolSetupFieldInputType::Text
         );
         assert_eq!(
             setup.required_fields[1].input_type,
-            crate::tools::wasm::capabilities_schema::ToolSetupFieldInputType::Password
+            crate::capabilities_schema::ToolSetupFieldInputType::Password
         );
     }
 

--- a/crates/dasclaw_wasm_tools/src/credential_injector.rs
+++ b/crates/dasclaw_wasm_tools/src/credential_injector.rs
@@ -271,7 +271,7 @@ impl CredentialInjector {
 }
 
 /// Inject a single credential into the result.
-pub(crate) fn inject_credential(
+pub fn inject_credential(
     result: &mut InjectedCredentials,
     location: &CredentialLocation,
     secret: &DecryptedSecret,
@@ -310,7 +310,7 @@ pub(crate) fn inject_credential(
 }
 
 /// Check if a host matches a pattern (supports wildcards).
-pub(crate) fn host_matches_pattern(host: &str, pattern: &str) -> bool {
+pub fn host_matches_pattern(host: &str, pattern: &str) -> bool {
     if pattern == host {
         return true;
     }
@@ -366,17 +366,26 @@ fn base64_encode(input: &[u8]) -> String {
 mod tests {
     use std::collections::HashMap;
 
-    use crate::testing::credentials::{TEST_OPENAI_API_KEY, test_secrets_store};
-    use crate::tools::wasm::credential_injector::{
-        CredentialInjector, base64_encode, host_matches_pattern,
-    };
+    use crate::credential_injector::{CredentialInjector, base64_encode, host_matches_pattern};
     use dasclaw_runtime::secrets::{
         CreateSecretParams, CredentialLocation, CredentialMapping, InMemorySecretsStore,
-        SecretsStore,
+        SecretsCrypto, SecretsStore,
     };
+    use secrecy::SecretString;
+    use std::sync::Arc;
+
+    /// Fake API key used across tests. Mirrors the legacy
+    /// `crate::testing::credentials::TEST_OPENAI_API_KEY` constant.
+    const TEST_OPENAI_API_KEY: &str = "sk-test123";
 
     fn test_store() -> InMemorySecretsStore {
-        test_secrets_store()
+        let crypto = Arc::new(
+            SecretsCrypto::new(SecretString::from(
+                "0123456789abcdef0123456789abcdef".to_string(),
+            ))
+            .unwrap(),
+        );
+        InMemorySecretsStore::new(crypto)
     }
 
     #[test]
@@ -535,7 +544,7 @@ mod tests {
 
     // ── SharedCredentialRegistry tests ─────────────────────────────────
 
-    use crate::tools::wasm::credential_injector::SharedCredentialRegistry;
+    use crate::credential_injector::SharedCredentialRegistry;
 
     #[test]
     fn test_shared_registry_empty() {

--- a/crates/dasclaw_wasm_tools/src/error.rs
+++ b/crates/dasclaw_wasm_tools/src/error.rs
@@ -91,15 +91,15 @@ impl From<std::io::Error> for WasmError {
     }
 }
 
-impl From<WasmError> for crate::tools::ToolError {
+impl From<WasmError> for dasclaw_tool::ToolError {
     fn from(e: WasmError) -> Self {
-        crate::tools::ToolError::Sandbox(e.to_string())
+        dasclaw_tool::ToolError::Sandbox(e.to_string())
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::tools::wasm::error::WasmError;
+    use crate::error::WasmError;
 
     #[test]
     fn test_error_display() {
@@ -117,9 +117,9 @@ mod tests {
     #[test]
     fn test_conversion_to_tool_error() {
         let wasm_err = WasmError::Trapped("test trap".to_string());
-        let tool_err: crate::tools::ToolError = wasm_err.into();
+        let tool_err: dasclaw_tool::ToolError = wasm_err.into();
         match tool_err {
-            crate::tools::ToolError::Sandbox(msg) => {
+            dasclaw_tool::ToolError::Sandbox(msg) => {
                 assert!(msg.contains("test trap"));
             }
             _ => panic!("Expected Sandbox variant"),

--- a/crates/dasclaw_wasm_tools/src/host.rs
+++ b/crates/dasclaw_wasm_tools/src/host.rs
@@ -24,8 +24,8 @@
 
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use crate::tools::wasm::capabilities::Capabilities;
-use crate::tools::wasm::error::WasmError;
+use crate::capabilities::Capabilities;
+use crate::error::WasmError;
 
 /// Maximum log entries per execution (prevents log spam attacks).
 const MAX_LOG_ENTRIES: usize = 1000;
@@ -260,7 +260,7 @@ impl HostState {
             .ok_or_else(|| "HTTP capability not granted".to_string())?;
 
         // Use the allowlist validator
-        use crate::tools::wasm::allowlist::AllowlistValidator;
+        use crate::allowlist::AllowlistValidator;
 
         let validator = AllowlistValidator::new(capability.allowlist.clone());
         let result = validator.validate(url, method);
@@ -381,10 +381,10 @@ fn validate_workspace_path(path: &str) -> Result<(), WasmError> {
 mod tests {
     use std::sync::Arc;
 
-    use crate::tools::wasm::capabilities::{
+    use crate::capabilities::{
         Capabilities, SecretsCapability, WorkspaceCapability, WorkspaceReader,
     };
-    use crate::tools::wasm::host::{
+    use crate::host::{
         HostState, LogLevel, MAX_LOG_ENTRIES, MAX_LOG_MESSAGE_BYTES, validate_workspace_path,
     };
 
@@ -566,7 +566,7 @@ mod tests {
     fn test_http_request_rate_limit() {
         // Create state with HTTP capability enabled
         let capabilities = Capabilities {
-            http: Some(crate::tools::wasm::capabilities::HttpCapability::default()),
+            http: Some(crate::capabilities::HttpCapability::default()),
             ..Default::default()
         };
         let mut state = HostState::new(capabilities);
@@ -584,7 +584,7 @@ mod tests {
     fn test_tool_invoke_rate_limit() {
         // Create state with tool invoke capability enabled
         let capabilities = Capabilities {
-            tool_invoke: Some(crate::tools::wasm::capabilities::ToolInvokeCapability::default()),
+            tool_invoke: Some(crate::capabilities::ToolInvokeCapability::default()),
             ..Default::default()
         };
         let mut state = HostState::new(capabilities);

--- a/crates/dasclaw_wasm_tools/src/lib.rs
+++ b/crates/dasclaw_wasm_tools/src/lib.rs
@@ -1,0 +1,64 @@
+//! WASM sandbox primitives for tool execution.
+//!
+//! This crate hosts the verbatim port of `desktop-client/ironclaw/src/tools/wasm/`
+//! infrastructure modules per [ADR-152 §4.2 addendum] (F4.5.3). The following
+//! files moved here unchanged (only `use` paths and `pub(crate)` visibility were
+//! adjusted per ADR-129 §1.3.1 fork-able boundary):
+//!
+//! - `error` — `WasmError` + `From<WasmError> for dasclaw_tool::ToolError`
+//! - `limits` — wasmtime `ResourceLimiter`, fuel/memory/timeout defaults
+//! - `capabilities` — `Capabilities` descriptor + sub-capabilities
+//! - `capabilities_schema` — YAML schema for `capabilities.yaml`
+//! - `host` — `HostState` for wasmtime store (logs, capabilities)
+//! - `allowlist` — HTTP endpoint allowlist validator
+//! - `storage` — `WasmToolStore` trait + Postgres / libSQL implementations
+//! - `credential_injector` — secret injection into outbound HTTP requests
+//!
+//! The modules `wrapper`, `runtime`, `rate_limiter`, and `loader` remain in
+//! `desktop-client/ironclaw/src/tools/wasm/` because they couple to desktop
+//! oauth helpers, the desktop `ToolRegistry`, or shim into desktop modules
+//! outside `wasm/`. See `tools/wasm/mod.rs` for the re-export shim that keeps
+//! `crate::*` working from the desktop side.
+
+pub mod allowlist;
+pub mod capabilities;
+pub mod capabilities_schema;
+pub mod credential_injector;
+pub mod error;
+pub mod host;
+pub mod limits;
+pub mod storage;
+
+// Core re-exports (mirror of the historical `tools/wasm/mod.rs` block, minus
+// the four modules that stay in the desktop crate).
+pub use error::WasmError;
+pub use host::{HostState, LogEntry, LogLevel};
+pub use limits::{
+    DEFAULT_FUEL_LIMIT, DEFAULT_MEMORY_LIMIT, DEFAULT_TIMEOUT, FuelConfig, ResourceLimits,
+    WasmResourceLimiter,
+};
+
+pub use capabilities::{
+    Capabilities, EndpointPattern, HttpCapability, RateLimitConfig, SecretsCapability,
+    ToolInvokeCapability, WebhookCapability, WorkspaceCapability, WorkspaceReader,
+};
+
+pub use allowlist::{AllowlistResult, AllowlistValidator, DenyReason};
+pub use credential_injector::{
+    CredentialInjector, InjectedCredentials, InjectionError, SharedCredentialRegistry,
+    host_matches_pattern, inject_credential,
+};
+
+#[cfg(feature = "libsql")]
+pub use storage::LibSqlWasmToolStore;
+#[cfg(feature = "postgres")]
+pub use storage::PostgresWasmToolStore;
+pub use storage::{
+    StoreToolParams, StoredCapabilities, StoredWasmTool, StoredWasmToolWithBinary, ToolStatus,
+    TrustLevel, WasmStorageError, WasmToolStore, compute_binary_hash, verify_binary_integrity,
+};
+
+pub use capabilities_schema::{
+    AuthCapabilitySchema, CapabilitiesFile, OAuthConfigSchema, RateLimitSchema,
+    ToolFieldSetupSchema, ToolSetupFieldInputType, ToolSetupSchema, ValidationEndpointSchema,
+};

--- a/crates/dasclaw_wasm_tools/src/limits.rs
+++ b/crates/dasclaw_wasm_tools/src/limits.rs
@@ -195,7 +195,7 @@ impl FuelConfig {
 
 #[cfg(test)]
 mod tests {
-    use crate::tools::wasm::limits::{
+    use crate::limits::{
         DEFAULT_FUEL_LIMIT, DEFAULT_MEMORY_LIMIT, DEFAULT_TIMEOUT, FuelConfig, ResourceLimits,
         WasmResourceLimiter,
     };

--- a/crates/dasclaw_wasm_tools/src/storage.rs
+++ b/crates/dasclaw_wasm_tools/src/storage.rs
@@ -20,7 +20,7 @@ use chrono::{DateTime, Utc};
 use deadpool_postgres::Pool;
 use uuid::Uuid;
 
-use crate::tools::wasm::capabilities::{
+use crate::capabilities::{
     Capabilities, EndpointPattern, HttpCapability, RateLimitConfig, SecretsCapability,
     ToolInvokeCapability,
 };
@@ -1032,9 +1032,7 @@ fn libsql_row_to_tool_at(
 
 #[cfg(test)]
 mod tests {
-    use crate::tools::wasm::storage::{
-        ToolStatus, TrustLevel, compute_binary_hash, verify_binary_integrity,
-    };
+    use crate::storage::{ToolStatus, TrustLevel, compute_binary_hash, verify_binary_integrity};
 
     #[test]
     fn test_compute_hash() {

--- a/desktop-client/ironclaw/Cargo.toml
+++ b/desktop-client/ironclaw/Cargo.toml
@@ -207,6 +207,11 @@ dasclaw_tool = { path = "../../crates/dasclaw_tool" }
 # (F3.2 phase 2 PR 2; ADR-152 §3, #641).
 dasclaw_runtime = { path = "../../crates/dasclaw_runtime" }
 
+# WASM sandbox primitives (allowlist / capabilities / credential injector /
+# host / limits / storage / error). Extracted from desktop tools/wasm/ under
+# ADR-152 F4.5.3.
+dasclaw_wasm_tools = { path = "../../crates/dasclaw_wasm_tools" }
+
 # AWS Bedrock (native Converse API, opt-in via --features bedrock)
 aws-config = { version = "1", features = ["behavior-version-latest"], optional = true }
 aws-sdk-bedrockruntime = { version = "1", optional = true }
@@ -315,8 +320,11 @@ postgres = [
     # Forward our feature flag so the optional postgres deps are pulled in
     # and the `repository` module + `Repository` re-export become available.
     "dasclaw_workspace_cap/postgres",
+    # ADR-152 F4.5.3: forward postgres feature to the new wasm-tools crate so
+    # the `PostgresWasmToolStore` re-export resolves.
+    "dasclaw_wasm_tools/postgres",
 ]
-libsql = ["dep:libsql", "dasclaw_runtime/libsql"]
+libsql = ["dep:libsql", "dasclaw_runtime/libsql", "dasclaw_wasm_tools/libsql"]
 # Opt-in feature for especially heavy integration-test targets that run in a
 # dedicated CI job instead of the default Rust test matrix.
 integration = []

--- a/desktop-client/ironclaw/src/tools/wasm/mod.rs
+++ b/desktop-client/ironclaw/src/tools/wasm/mod.rs
@@ -1,77 +1,11 @@
 //! WASM sandbox for untrusted tool execution.
 //!
-//! This module provides Wasmtime-based sandboxed execution for tools,
-//! following patterns from NEAR blockchain and modern WASM best practices:
-//!
-//! - **Compile once, instantiate fresh**: Tools are validated and compiled
-//!   at registration time. Each execution creates a fresh instance.
-//!
-//! - **Fuel metering**: CPU usage is limited via Wasmtime's fuel system.
-//!
-//! - **Memory limits**: Memory growth is bounded via ResourceLimiter.
-//!
-//! - **Extended host API (V2)**: log, time, workspace, HTTP, tool invoke, secrets
-//!
-//! - **Capability-based security**: Features are opt-in via Capabilities.
-//!
-//! # Architecture (V2)
-//!
-//! ```text
-//! ┌─────────────────────────────────────────────────────────────────────────────┐
-//! │                              WASM Tool Execution                             │
-//! │                                                                              │
-//! │   WASM Tool ──▶ Host Function ──▶ Allowlist ──▶ Credential ──▶ Execute     │
-//! │   (untrusted)   (boundary)        Validator     Injector       Request      │
-//! │                                                                    │        │
-//! │                                                                    ▼        │
-//! │                              ◀────── Leak Detector ◀────── Response        │
-//! │                          (sanitized, no secrets)                            │
-//! └─────────────────────────────────────────────────────────────────────────────┘
-//! ```
-//!
-//! # Security Constraints
-//!
-//! | Threat | Mitigation |
-//! |--------|------------|
-//! | CPU exhaustion | Fuel metering |
-//! | Memory exhaustion | ResourceLimiter, 10MB default |
-//! | Infinite loops | Epoch interruption + tokio timeout |
-//! | Filesystem access | No WASI FS, only host workspace_read |
-//! | Network access | Allowlisted endpoints only |
-//! | Credential exposure | Injection at host boundary only |
-//! | Secret exfiltration | Leak detector scans all outputs |
-//! | Log spam | Max 1000 entries, 4KB per message |
-//! | Path traversal | Validate paths (no `..`, no `/` prefix) |
-//! | Trap recovery | Discard instance, never reuse |
-//! | Side channels | Fresh instance per execution |
-//! | Rate abuse | Per-tool rate limiting |
-//! | WASM tampering | BLAKE3 hash verification on load |
-//! | Direct tool access | Tool aliasing (indirection layer) |
-//!
-//! # Example
-//!
-//! ```ignore
-//! use ironclaw::tools::wasm::{WasmToolRuntime, WasmRuntimeConfig, WasmToolWrapper};
-//! use ironclaw::tools::wasm::Capabilities;
-//! use std::sync::Arc;
-//!
-//! // Create runtime
-//! let runtime = Arc::new(WasmToolRuntime::new(WasmRuntimeConfig::default())?);
-//!
-//! // Prepare a tool from WASM bytes
-//! let wasm_bytes = std::fs::read("my_tool.wasm")?;
-//! let prepared = runtime.prepare("my_tool", &wasm_bytes, None).await?;
-//!
-//! // Create wrapper with HTTP capability
-//! let capabilities = Capabilities::none()
-//!     .with_http(HttpCapability::new(vec![
-//!         EndpointPattern::host("api.openai.com").with_path_prefix("/v1/"),
-//!     ]));
-//! let tool = WasmToolWrapper::new(runtime, prepared, capabilities);
-//!
-//! // Execute (implements Tool trait)
-//! let output = tool.execute(serde_json::json!({"input": "test"}), &ctx).await?;
-//! ```
+//! Most primitives (allowlist, capabilities, capabilities_schema,
+//! credential_injector, error, host, limits, storage) have been moved to the
+//! `dasclaw_wasm_tools` crate under ADR-152 F4.5.3. This module re-exports
+//! them so existing `crate::tools::wasm::*` call sites keep compiling, and
+//! keeps the four still-desktop-coupled modules (loader, rate_limiter,
+//! runtime, wrapper) in place.
 
 /// Host WIT version for tool extensions.
 ///
@@ -82,49 +16,47 @@ pub const WIT_TOOL_VERSION: &str = "0.3.0";
 /// Host WIT version for channel extensions.
 pub const WIT_CHANNEL_VERSION: &str = "0.3.0";
 
-mod allowlist;
-mod capabilities;
-mod capabilities_schema;
-pub(crate) mod credential_injector;
-mod error;
-mod host;
-mod limits;
+// Re-export moved modules so `crate::tools::wasm::<mod>::*` paths still resolve.
+pub use dasclaw_wasm_tools::{
+    allowlist, capabilities, capabilities_schema, credential_injector, error, host, limits, storage,
+};
+
+// Modules still kept in the desktop crate.
 pub(crate) mod loader;
 mod rate_limiter;
 mod runtime;
-pub(crate) mod storage;
 mod wrapper;
 
 // Core types
-pub use error::WasmError;
-pub use host::{HostState, LogEntry, LogLevel};
-pub use limits::{
+pub use dasclaw_wasm_tools::WasmError;
+pub use dasclaw_wasm_tools::{
     DEFAULT_FUEL_LIMIT, DEFAULT_MEMORY_LIMIT, DEFAULT_TIMEOUT, FuelConfig, ResourceLimits,
     WasmResourceLimiter,
 };
+pub use dasclaw_wasm_tools::{HostState, LogEntry, LogLevel};
 pub use runtime::{PreparedModule, WasmRuntimeConfig, WasmToolRuntime, enable_compilation_cache};
 pub use wrapper::{OAuthRefreshConfig, WasmToolWrapper};
 
 // Capabilities (V2)
-pub use capabilities::{
+pub use dasclaw_wasm_tools::{
     Capabilities, EndpointPattern, HttpCapability, RateLimitConfig, SecretsCapability,
     ToolInvokeCapability, WebhookCapability, WorkspaceCapability, WorkspaceReader,
 };
 
 // Security components (V2)
-pub use allowlist::{AllowlistResult, AllowlistValidator, DenyReason};
-pub(crate) use credential_injector::inject_credential;
-pub use credential_injector::{
+pub use dasclaw_wasm_tools::inject_credential;
+pub use dasclaw_wasm_tools::{AllowlistResult, AllowlistValidator, DenyReason};
+pub use dasclaw_wasm_tools::{
     CredentialInjector, InjectedCredentials, InjectionError, SharedCredentialRegistry,
 };
 pub use rate_limiter::{LimitType, RateLimitError, RateLimitResult, RateLimiter};
 
 // Storage (V2)
 #[cfg(feature = "libsql")]
-pub use storage::LibSqlWasmToolStore;
+pub use dasclaw_wasm_tools::LibSqlWasmToolStore;
 #[cfg(feature = "postgres")]
-pub use storage::PostgresWasmToolStore;
-pub use storage::{
+pub use dasclaw_wasm_tools::PostgresWasmToolStore;
+pub use dasclaw_wasm_tools::{
     StoreToolParams, StoredCapabilities, StoredWasmTool, StoredWasmToolWithBinary, ToolStatus,
     TrustLevel, WasmStorageError, WasmToolStore, compute_binary_hash, verify_binary_integrity,
 };
@@ -137,7 +69,7 @@ pub use loader::{
 };
 
 // Capabilities schema (for parsing *.capabilities.json files)
-pub use capabilities_schema::{
+pub use dasclaw_wasm_tools::{
     AuthCapabilitySchema, CapabilitiesFile, OAuthConfigSchema, RateLimitSchema,
     ToolFieldSetupSchema, ToolSetupFieldInputType, ToolSetupSchema, ValidationEndpointSchema,
 };


### PR DESCRIPTION
## 背景 / 目标

ADR-152 §F4.5.3 + 修订 (#739)：把 desktop `tools/wasm/` 中与 desktop 耦合最弱的 8 个文件 **verbatim** 搬迁到独立 crate `dasclaw_wasm_tools`，为 W6 hooks 工程化预清场。

## 改动范围

**新 crate**：`crates/dasclaw_wasm_tools`（version `0.0.0-w1`, `publish = false`），public API 通过 `lib.rs` 镜像原 `tools/wasm/mod.rs` 的 `pub use` 块。

**搬迁 8 文件（verbatim port + use 路径重写）**：
- `error.rs`、`limits.rs`、`capabilities.rs`、`capabilities_schema.rs`
- `host.rs`、`allowlist.rs`、`storage.rs`、`credential_injector.rs`

**desktop shim**：`desktop-client/ironclaw/src/tools/wasm/mod.rs` 改为 re-export 形式，保留 `WIT_TOOL_VERSION` / `WIT_CHANNEL_VERSION` 常量和原 `pub use` 列表，让 `crate::tools::wasm::*` 调用点不变。

**保留在 desktop**：`wrapper.rs` / `runtime.rs` / `rate_limiter.rs` / `loader.rs`（与 desktop tool registry / oauth_defaults / extensions manager 强耦合，F4.5.4 单独切片处理）。

**可见性微调（跨 crate shim 必需）**：
- `credential_injector::inject_credential`: `pub(crate)` → `pub`
- `credential_injector::host_matches_pattern`: `pub(crate)` → `pub`

**Cargo.toml**：
- 工作区 members 增加 `crates/dasclaw_wasm_tools`
- desktop `dasclaw_wasm_tools = { path = "../../crates/dasclaw_wasm_tools" }`
- `postgres` / `libsql` feature 各自 forward 到 `dasclaw_wasm_tools/postgres` / `dasclaw_wasm_tools/libsql`

## 非目标（What is NOT in this PR）

- ❌ 不动业务逻辑（ADR-129 §1.3 verbatim red line；§1.3.1 fork-able boundary 仅允许 use 路径、模块组织、Cargo.toml deps 调整）
- ❌ 不搬 `wrapper.rs` / `runtime.rs` / `rate_limiter.rs` / `loader.rs`（F4.5.4）
- ❌ 不替换 `WebhookCapability`（ADR-154 §3.5 已 verbatim-ported 到 `dasclaw_tool`，本 PR 仅保留行 321 `pub use dasclaw_tool::WebhookCapability` 再导出 shim）
- ❌ 不新增 `.ironclaw` 字面量（Cross-cuts 类A）

## 验证

```
cargo check -p dasclaw_wasm_tools --tests       0 错 0 警
cargo check -p dasclaw --tests                   0 错 0 警
cargo nextest run -p dasclaw_wasm_tools          107/107 PASS
cargo fmt --all                                  干净
python3.12 scripts/check_no_panics.py            干净
cargo clippy --no-deps -p dasclaw_wasm_tools     0 警
```

## Sources read

- `docs/plans/architecture-refactor/adr-152-architecture-redesign.md` §F4.5.3
- PR #739 (ADR-152 F4.5 修订)
- `docs/plans/architecture-refactor/adr-129-verbatim-port-discipline.md` §1.3 / §1.3.1
- `docs/plans/architecture-refactor/adr-154-tool-trait-migration.md` §3.5（确认 `WebhookCapability` 已 verbatim-ported 到 dasclaw_tool）
- 重复模块审查（3 层验证：semantic_search → grep → 文件对照）：
  - `crates/dasclaw_governance/src/allowlist.rs` — 命令前缀治理白名单（与 wasm endpoint allowlist 不同领域）
  - `crates/dasclaw_runtime/src/secrets/` — 凭据存储（与 credential 注入到 HTTP 请求不同关注点）
  - `crates/dasclaw_protocol/.../capabilities.rs` — 协议握手能力（与 wasm 沙箱授权模型不同领域）
  - `crates/dasclaw_runtime/src/storage/` — 通用存储（与 wasm 工具元数据存储不同关注点）

## Cross-cuts

ADR-114：**类A**（无新增 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量；已用 `python3 scripts/check_no_new_ironclaw_literal.py --base origin/xClaw` 自查通过）。

## 后续步骤

- F4.5.4 处理 `wrapper.rs` / `runtime.rs` / `rate_limiter.rs` / `loader.rs`（需先解耦 oauth_defaults / extensions manager / tool registry）

Closes #740