### PR TITLE
feat(wasm-tools): F4.5.4 port runtime.rs + wrapper.rs + wit to dasclaw_wasm_tools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3372,15 +3372,21 @@ version = "0.0.0-w1"
 dependencies = [
  "anyhow",
  "async-trait",
+ "axum 0.8.8",
  "blake3",
  "chrono",
+ "dasclaw_llm_provider",
  "dasclaw_runtime",
+ "dasclaw_safety",
  "dasclaw_tool",
  "deadpool-postgres",
+ "dirs 6.0.0",
  "libsql",
+ "reqwest 0.12.28",
  "secrecy",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tokio-postgres",
@@ -3389,6 +3395,7 @@ dependencies = [
  "urlencoding",
  "uuid",
  "wasmtime",
+ "wasmtime-wasi",
 ]
 
 [[package]]

--- a/crates/dasclaw_llm_provider/src/provider/oauth_helpers.rs
+++ b/crates/dasclaw_llm_provider/src/provider/oauth_helpers.rs
@@ -351,6 +351,133 @@ pub fn landing_html(provider_name: &str, success: bool) -> String {
     )
 }
 
+// ── Proxy-based token refresh ───────────────────────────────────────────
+
+/// Response from the OAuth token exchange.
+pub struct OAuthTokenResponse {
+    pub access_token: String,
+    pub refresh_token: Option<String>,
+    pub expires_in: Option<u64>,
+    pub token_type: Option<String>,
+    pub scope: Option<String>,
+}
+
+pub struct ProxyRefreshTokenRequest<'a> {
+    pub proxy_url: &'a str,
+    /// OAuth proxy auth token.
+    /// Kept as `gateway_token` for public API compatibility.
+    pub gateway_token: &'a str,
+    pub token_url: &'a str,
+    pub client_id: &'a str,
+    pub client_secret: Option<&'a str>,
+    pub refresh_token: &'a str,
+    pub resource: Option<&'a str>,
+    pub provider: Option<&'a str>,
+}
+
+pub fn oauth_token_response_from_json(
+    token_data: serde_json::Value,
+    access_token_field: &str,
+) -> Result<OAuthTokenResponse, OAuthCallbackError> {
+    let access_token = token_data
+        .get(access_token_field)
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| {
+            let fields: Vec<&str> = token_data
+                .as_object()
+                .map(|o| o.keys().map(|k| k.as_str()).collect())
+                .unwrap_or_default();
+            OAuthCallbackError::Io(format!(
+                "No '{}' field in proxy response (fields present: {:?})",
+                access_token_field, fields
+            ))
+        })?
+        .to_string();
+
+    let refresh_token = token_data
+        .get("refresh_token")
+        .and_then(|v| v.as_str())
+        .map(String::from);
+    let expires_in = token_data.get("expires_in").and_then(|v| v.as_u64());
+
+    Ok(OAuthTokenResponse {
+        access_token,
+        refresh_token,
+        expires_in,
+        token_type: token_data
+            .get("token_type")
+            .and_then(|v| v.as_str())
+            .map(String::from),
+        scope: token_data
+            .get("scope")
+            .and_then(|v| v.as_str())
+            .map(String::from),
+    })
+}
+
+/// Refresh an OAuth access token via the platform's token refresh proxy.
+///
+/// Authenticated via an OAuth proxy auth token (Bearer header). The caller may
+/// either rely on proxy-side secret lookup or forward a `client_secret` when
+/// the provider requires it.
+pub async fn refresh_token_via_proxy(
+    request: ProxyRefreshTokenRequest<'_>,
+) -> Result<OAuthTokenResponse, OAuthCallbackError> {
+    if request.gateway_token.is_empty() {
+        return Err(OAuthCallbackError::Io(
+            "OAuth proxy auth token is required for proxy token refresh".to_string(),
+        ));
+    }
+
+    let refresh_url = format!("{}/oauth/refresh", request.proxy_url.trim_end_matches('/'));
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(15))
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .map_err(|e| OAuthCallbackError::Io(format!("Failed to build HTTP client: {}", e)))?;
+
+    let mut params = vec![
+        ("refresh_token", request.refresh_token.to_string()),
+        ("token_url", request.token_url.to_string()),
+        ("client_id", request.client_id.to_string()),
+    ];
+    if let Some(secret) = request.client_secret {
+        params.push(("client_secret", secret.to_string()));
+    }
+    if let Some(resource) = request.resource {
+        params.push(("resource", resource.to_string()));
+    }
+    if let Some(provider) = request.provider {
+        params.push(("provider", provider.to_string()));
+    }
+
+    let response = client
+        .post(&refresh_url)
+        .bearer_auth(request.gateway_token)
+        .form(&params)
+        .send()
+        .await
+        .map_err(|e| {
+            OAuthCallbackError::Io(format!("Token refresh proxy request failed: {}", e))
+        })?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        return Err(OAuthCallbackError::Io(format!(
+            "Token refresh proxy failed: {} - {}",
+            status, body
+        )));
+    }
+
+    let token_data: serde_json::Value = response
+        .json()
+        .await
+        .map_err(|e| OAuthCallbackError::Io(format!("Failed to parse proxy response: {}", e)))?;
+
+    oauth_token_response_from_json(token_data, "access_token")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/dasclaw_wasm_tools/Cargo.toml
+++ b/crates/dasclaw_wasm_tools/Cargo.toml
@@ -14,18 +14,24 @@ anyhow = "1"
 async-trait = "0.1"
 blake3 = "1"
 chrono = { version = "0.4", features = ["serde"] }
+dirs = "6"
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls-native-roots", "stream"] }
+secrecy = "0.10"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"
-tokio = { version = "1", features = ["sync"] }
+tokio = { version = "1", features = ["sync", "rt"] }
 tracing = "0.1"
 url = "2"
 urlencoding = "2"
 uuid = { version = "1", features = ["v4", "v5", "serde"] }
 wasmtime = { version = "28", features = ["component-model"] }
+wasmtime-wasi = "28"
 
 # Workspace crates
+dasclaw_llm_provider = { path = "../dasclaw_llm_provider" }
 dasclaw_runtime = { path = "../dasclaw_runtime" }
+dasclaw_safety = { path = "../dasclaw_safety" }
 dasclaw_tool = { path = "../dasclaw_tool" }
 
 # Optional storage backends
@@ -39,5 +45,7 @@ postgres = ["dep:deadpool-postgres", "dep:tokio-postgres", "dasclaw_runtime/post
 libsql = ["dep:libsql", "dasclaw_runtime/libsql"]
 
 [dev-dependencies]
+axum = "0.8"
 secrecy = "0.10"
-tokio = { version = "1", features = ["sync", "rt", "macros"] }
+tempfile = "3"
+tokio = { version = "1", features = ["sync", "rt", "macros", "net"] }

--- a/crates/dasclaw_wasm_tools/src/lib.rs
+++ b/crates/dasclaw_wasm_tools/src/lib.rs
@@ -1,7 +1,7 @@
 //! WASM sandbox primitives for tool execution.
 //!
 //! This crate hosts the verbatim port of `desktop-client/ironclaw/src/tools/wasm/`
-//! infrastructure modules per [ADR-152 §4.2 addendum] (F4.5.3). The following
+//! infrastructure modules per [ADR-152 §4.2 addendum] (F4.5.3 + F4.5.4). The following
 //! files moved here unchanged (only `use` paths and `pub(crate)` visibility were
 //! adjusted per ADR-129 §1.3.1 fork-able boundary):
 //!
@@ -13,12 +13,15 @@
 //! - `allowlist` — HTTP endpoint allowlist validator
 //! - `storage` — `WasmToolStore` trait + Postgres / libSQL implementations
 //! - `credential_injector` — secret injection into outbound HTTP requests
+//! - `runtime` — `WasmToolRuntime` engine/store lifecycle (F4.5.4)
+//! - `wrapper` — `WasmToolWrapper` Tool impl + WIT bindings (F4.5.4)
+//! - `test_credentials` — shared fixtures consumed by wrapper tests (F4.5.4)
 //!
-//! The modules `wrapper`, `runtime`, `rate_limiter`, and `loader` remain in
-//! `desktop-client/ironclaw/src/tools/wasm/` because they couple to desktop
-//! oauth helpers, the desktop `ToolRegistry`, or shim into desktop modules
-//! outside `wasm/`. See `tools/wasm/mod.rs` for the re-export shim that keeps
-//! `crate::*` working from the desktop side.
+//! The modules `rate_limiter` and `loader` remain in
+//! `desktop-client/ironclaw/src/tools/wasm/` because they couple to the desktop
+//! `ToolRegistry` or shim into desktop modules outside `wasm/`. See
+//! `tools/wasm/mod.rs` for the re-export shim that keeps `crate::*` working from
+//! the desktop side.
 
 pub mod allowlist;
 pub mod capabilities;
@@ -27,16 +30,27 @@ pub mod credential_injector;
 pub mod error;
 pub mod host;
 pub mod limits;
+pub mod runtime;
 pub mod storage;
+pub mod test_credentials;
+pub mod wrapper;
+
+/// WIT interface version exposed to tools (matches `wit/tool.wit`).
+pub const WIT_TOOL_VERSION: &str = "0.3.0";
+
+/// Channel WIT interface version (matches `desktop-client/ironclaw/wit/channel.wit`).
+pub const WIT_CHANNEL_VERSION: &str = "0.3.0";
 
 // Core re-exports (mirror of the historical `tools/wasm/mod.rs` block, minus
-// the four modules that stay in the desktop crate).
+// the two modules that stay in the desktop crate).
 pub use error::WasmError;
 pub use host::{HostState, LogEntry, LogLevel};
 pub use limits::{
     DEFAULT_FUEL_LIMIT, DEFAULT_MEMORY_LIMIT, DEFAULT_TIMEOUT, FuelConfig, ResourceLimits,
     WasmResourceLimiter,
 };
+pub use runtime::{PreparedModule, WasmRuntimeConfig, WasmToolRuntime, enable_compilation_cache};
+pub use wrapper::{OAuthRefreshConfig, WasmToolWrapper};
 
 pub use capabilities::{
     Capabilities, EndpointPattern, HttpCapability, RateLimitConfig, SecretsCapability,

--- a/crates/dasclaw_wasm_tools/src/runtime.rs
+++ b/crates/dasclaw_wasm_tools/src/runtime.rs
@@ -11,8 +11,8 @@ use std::time::Duration;
 use tokio::sync::RwLock;
 use wasmtime::{Config, Engine, OptLevel};
 
-use crate::tools::wasm::error::WasmError;
-use crate::tools::wasm::limits::{FuelConfig, ResourceLimits};
+use crate::error::WasmError;
+use crate::limits::{FuelConfig, ResourceLimits};
 
 /// Default epoch tick interval. Each tick increments the engine's epoch counter,
 /// which causes any store with an expired epoch deadline to trap.
@@ -270,26 +270,23 @@ impl WasmToolRuntime {
             // Briefly instantiate to extract metadata (description + schema)
             // from the tool's exports, analogous to MCP's list_tools().
             let effective_limits = limits.clone().unwrap_or(default_limits.clone());
-            let (description, schema) = crate::tools::wasm::wrapper::extract_wasm_metadata(
-                &engine,
-                &component,
-                &effective_limits,
-            )
-            .unwrap_or_else(|e| {
-                tracing::warn!(
-                    name = %name,
-                    error = %e,
-                    "WASM metadata extraction failed, using fallbacks"
-                );
-                (
-                    "WASM sandboxed tool".to_string(),
-                    serde_json::json!({
-                        "type": "object",
-                        "properties": {},
-                        "additionalProperties": true
-                    }),
-                )
-            });
+            let (description, schema) =
+                crate::wrapper::extract_wasm_metadata(&engine, &component, &effective_limits)
+                    .unwrap_or_else(|e| {
+                        tracing::warn!(
+                            name = %name,
+                            error = %e,
+                            "WASM metadata extraction failed, using fallbacks"
+                        );
+                        (
+                            "WASM sandboxed tool".to_string(),
+                            serde_json::json!({
+                                "type": "object",
+                                "properties": {},
+                                "additionalProperties": true
+                            }),
+                        )
+                    });
 
             Ok::<_, WasmError>(PreparedModule {
                 name: name.clone(),
@@ -352,8 +349,8 @@ impl std::fmt::Debug for WasmToolRuntime {
 
 #[cfg(test)]
 mod tests {
-    use crate::tools::wasm::limits::ResourceLimits;
-    use crate::tools::wasm::runtime::{WasmRuntimeConfig, WasmToolRuntime};
+    use crate::limits::ResourceLimits;
+    use crate::runtime::{WasmRuntimeConfig, WasmToolRuntime};
 
     #[test]
     fn test_runtime_config_default() {
@@ -404,7 +401,7 @@ mod tests {
     /// produce a valid TOML config that wasmtime can load.
     #[test]
     fn test_enable_compilation_cache_with_explicit_dir() {
-        use crate::tools::wasm::runtime::enable_compilation_cache;
+        use crate::runtime::enable_compilation_cache;
 
         let tmp = tempfile::tempdir().expect("failed to create temp dir");
         let cache_dir = tmp.path().join("custom-cache");
@@ -432,7 +429,7 @@ mod tests {
     /// so that their file locks do not conflict. Regression test for #448.
     #[test]
     fn test_enable_compilation_cache_label_isolation() {
-        use crate::tools::wasm::runtime::enable_compilation_cache;
+        use crate::runtime::enable_compilation_cache;
 
         let tmp = tempfile::tempdir().expect("failed to create temp dir");
         let base = tmp.path().join("isolation");

--- a/crates/dasclaw_wasm_tools/src/test_credentials.rs
+++ b/crates/dasclaw_wasm_tools/src/test_credentials.rs
@@ -1,0 +1,57 @@
+//! Centralized fake credential constants for WASM tool tests.
+//!
+//! All values here are intentionally fake. Centralizing them makes security
+//! audits trivial (one file to verify) and eliminates duplication across
+//! the test suite.
+//!
+//! These fixtures were originally defined in
+//! `desktop-client/ironclaw/src/testing/credentials.rs`; the WASM-tool-relevant
+//! subset is hoisted here so that `crates/dasclaw_wasm_tools/src/wrapper.rs`
+//! tests do not depend on the desktop crate. The downstream `testing/credentials`
+//! module re-exports these symbols so existing desktop callers continue to work
+//! unchanged.
+
+use std::sync::Arc;
+
+use secrecy::SecretString;
+
+use dasclaw_runtime::secrets::{InMemorySecretsStore, SecretsCrypto};
+
+/// 32-character key string for `SecretsCrypto::new()` in tests.
+pub const TEST_CRYPTO_KEY: &str = "0123456789abcdef0123456789abcdef";
+
+// ── Google OAuth ─────────────────────────────────────────────────────────
+
+/// Google OAuth access token (standard test).
+pub const TEST_GOOGLE_OAUTH_TOKEN: &str = "ya29.test-token";
+
+/// Google OAuth access token (fresh/non-expired variant).
+pub const TEST_GOOGLE_OAUTH_FRESH: &str = "ya29.fresh-token";
+
+/// Google OAuth access token (legacy/no-expiry variant).
+pub const TEST_GOOGLE_OAUTH_LEGACY: &str = "ya29.legacy-token";
+
+// ── OAuth client credentials ────────────────────────────────────────────
+
+/// OAuth client ID for token refresh tests.
+pub const TEST_OAUTH_CLIENT_ID: &str = "test-client-id";
+
+/// OAuth client secret for token refresh tests.
+pub const TEST_OAUTH_CLIENT_SECRET: &str = "test-client-secret";
+
+// ── Bearer/auth tokens ──────────────────────────────────────────────────
+
+/// Bearer token with suffix (wasm wrapper credential injection).
+pub const TEST_BEARER_TOKEN_123: &str = "test-token-123";
+
+// ── Helpers ──────────────────────────────────────────────────────────────
+
+/// Create an `InMemorySecretsStore` backed by [`TEST_CRYPTO_KEY`].
+///
+/// Replaces the duplicated `test_store()` pattern found across multiple
+/// test modules.
+pub fn test_secrets_store() -> InMemorySecretsStore {
+    let crypto =
+        Arc::new(SecretsCrypto::new(SecretString::from(TEST_CRYPTO_KEY.to_string())).unwrap());
+    InMemorySecretsStore::new(crypto)
+}

--- a/crates/dasclaw_wasm_tools/src/test_credentials.rs
+++ b/crates/dasclaw_wasm_tools/src/test_credentials.rs
@@ -51,8 +51,8 @@ pub const TEST_BEARER_TOKEN_123: &str = "test-token-123";
 /// Replaces the duplicated `test_store()` pattern found across multiple
 /// test modules.
 pub fn test_secrets_store() -> InMemorySecretsStore {
-    // safety: test-only helper with a 32-byte hard-coded key; cannot fail.
-    let crypto =
-        Arc::new(SecretsCrypto::new(SecretString::from(TEST_CRYPTO_KEY.to_string())).unwrap());
+    let crypto = Arc::new(
+        SecretsCrypto::new(SecretString::from(TEST_CRYPTO_KEY.to_string())).unwrap(), // safety: test helper with hard-coded 32-byte key; never fails.
+    );
     InMemorySecretsStore::new(crypto)
 }

--- a/crates/dasclaw_wasm_tools/src/test_credentials.rs
+++ b/crates/dasclaw_wasm_tools/src/test_credentials.rs
@@ -51,6 +51,7 @@ pub const TEST_BEARER_TOKEN_123: &str = "test-token-123";
 /// Replaces the duplicated `test_store()` pattern found across multiple
 /// test modules.
 pub fn test_secrets_store() -> InMemorySecretsStore {
+    // safety: test-only helper with a 32-byte hard-coded key; cannot fail.
     let crypto =
         Arc::new(SecretsCrypto::new(SecretString::from(TEST_CRYPTO_KEY.to_string())).unwrap());
     InMemorySecretsStore::new(crypto)

--- a/crates/dasclaw_wasm_tools/src/wrapper.rs
+++ b/crates/dasclaw_wasm_tools/src/wrapper.rs
@@ -16,18 +16,17 @@ use wasmtime::Store;
 use wasmtime::component::Linker;
 use wasmtime_wasi::{ResourceTable, WasiCtx, WasiCtxBuilder, WasiView};
 
-use crate::llm::recording::{HttpExchangeRequest, HttpExchangeResponse, HttpInterceptor};
-use crate::safety::LeakDetector;
-use crate::tools::tool::{Tool, ToolError, ToolOutput};
-use crate::tools::wasm::capabilities::Capabilities;
-use crate::tools::wasm::credential_injector::{
-    InjectedCredentials, host_matches_pattern, inject_credential,
-};
-use crate::tools::wasm::error::WasmError;
-use crate::tools::wasm::host::{HostState, LogLevel};
-use crate::tools::wasm::limits::{ResourceLimits, WasmResourceLimiter};
-use crate::tools::wasm::runtime::{EPOCH_TICK_INTERVAL, PreparedModule, WasmToolRuntime};
+use crate::capabilities::Capabilities;
+use crate::credential_injector::{InjectedCredentials, host_matches_pattern, inject_credential};
+use crate::error::WasmError;
+use crate::host::{HostState, LogLevel};
+use crate::limits::{ResourceLimits, WasmResourceLimiter};
+use crate::runtime::{EPOCH_TICK_INTERVAL, PreparedModule, WasmToolRuntime};
+use dasclaw_runtime::Tool;
+use dasclaw_runtime::recording::{HttpExchangeRequest, HttpExchangeResponse, HttpInterceptor};
 use dasclaw_runtime::secrets::{DecryptedSecret, SecretsStore};
+use dasclaw_safety::LeakDetector;
+use dasclaw_tool::{ToolError, ToolOutput};
 
 // Generate component model bindings from the WIT file.
 //
@@ -43,7 +42,7 @@ wasmtime::component::bindgen!({
 });
 
 // Alias the export interface types for convenience.
-use crate::cli::oauth_defaults;
+use dasclaw_llm_provider::provider::oauth_helpers as oauth_defaults;
 use exports::near::agent::tool as wit_tool;
 
 /// Configuration needed to refresh an expired OAuth access token.
@@ -934,7 +933,7 @@ impl WasmToolWrapper {
         params: serde_json::Value,
         context_json: Option<String>,
         host_credentials: Vec<ResolvedHostCredential>,
-    ) -> Result<(String, Vec<crate::tools::wasm::host::LogEntry>), WasmError> {
+    ) -> Result<(String, Vec<crate::host::LogEntry>), WasmError> {
         let engine = self.runtime.engine();
         let limits = &self.prepared.limits;
 
@@ -982,7 +981,7 @@ impl WasmToolWrapper {
                         "{msg}. This usually means the extension was compiled against \
                          a different WIT version than the host supports. \
                          Rebuild the extension against the current WIT (host: {}).",
-                        crate::tools::wasm::WIT_TOOL_VERSION
+                        crate::WIT_TOOL_VERSION
                     ))
                 } else {
                     WasmError::InstantiationFailed(msg)
@@ -1103,7 +1102,7 @@ impl Tool for WasmToolWrapper {
     /// a hint to the description directing the LLM to call `tool_info` for the
     /// full parameter schema. This keeps the raw description clean while still
     /// guiding the LLM.
-    fn schema(&self) -> crate::tools::tool::ToolSchema {
+    fn schema(&self) -> dasclaw_tool::ToolSchema {
         let description = if self.schemas.is_advertised_permissive() {
             format!(
                 "{} (call tool_info(name: \"{}\", include_schema: true) for parameter schema)",
@@ -1112,7 +1111,7 @@ impl Tool for WasmToolWrapper {
         } else {
             self.description.clone()
         };
-        crate::tools::tool::ToolSchema {
+        dasclaw_tool::ToolSchema {
             name: self.prepared.name.clone(),
             description,
             parameters: self.schemas.advertised(),
@@ -1819,14 +1818,14 @@ mod tests {
         SecretsStore,
     };
 
-    use crate::testing::credentials::{
+    use crate::capabilities::Capabilities;
+    use crate::runtime::{WasmRuntimeConfig, WasmToolRuntime};
+    use crate::test_credentials::{
         TEST_BEARER_TOKEN_123, TEST_GOOGLE_OAUTH_FRESH, TEST_GOOGLE_OAUTH_LEGACY,
         TEST_GOOGLE_OAUTH_TOKEN, TEST_OAUTH_CLIENT_ID, TEST_OAUTH_CLIENT_SECRET,
         test_secrets_store,
     };
-    use crate::tools::tool::Tool;
-    use crate::tools::wasm::capabilities::Capabilities;
-    use crate::tools::wasm::runtime::{WasmRuntimeConfig, WasmToolRuntime};
+    use dasclaw_runtime::Tool;
 
     struct RecordingSecretsStore {
         inner: InMemorySecretsStore,
@@ -2247,7 +2246,7 @@ mod tests {
 
     #[test]
     fn test_extract_host_from_url() {
-        use crate::tools::wasm::wrapper::extract_host_from_url;
+        use crate::wrapper::extract_host_from_url;
 
         assert_eq!(
             extract_host_from_url("https://www.googleapis.com/calendar/v3/events"),
@@ -2280,7 +2279,7 @@ mod tests {
 
     #[test]
     fn test_inject_host_credentials_bearer() {
-        use crate::tools::wasm::wrapper::{ResolvedHostCredential, StoreData};
+        use crate::wrapper::{ResolvedHostCredential, StoreData};
         use std::collections::HashMap;
 
         let host_credentials = vec![ResolvedHostCredential {
@@ -2322,7 +2321,7 @@ mod tests {
 
     #[test]
     fn test_inject_host_credentials_query_params() {
-        use crate::tools::wasm::wrapper::{ResolvedHostCredential, StoreData};
+        use crate::wrapper::{ResolvedHostCredential, StoreData};
         use std::collections::HashMap;
 
         let host_credentials = vec![ResolvedHostCredential {
@@ -2352,7 +2351,7 @@ mod tests {
 
     #[test]
     fn test_redact_credentials_includes_host_credentials() {
-        use crate::tools::wasm::wrapper::{ResolvedHostCredential, StoreData};
+        use crate::wrapper::{ResolvedHostCredential, StoreData};
         use std::collections::HashMap;
 
         let host_credentials = vec![ResolvedHostCredential {
@@ -2377,7 +2376,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_resolve_host_credentials_no_store() {
-        use crate::tools::wasm::wrapper::resolve_host_credentials;
+        use crate::wrapper::resolve_host_credentials;
 
         let caps = Capabilities::default();
         let result = resolve_host_credentials(&caps, None, "user1", None).await;
@@ -2386,7 +2385,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_resolve_host_credentials_no_http_cap() {
-        use crate::tools::wasm::wrapper::resolve_host_credentials;
+        use crate::wrapper::resolve_host_credentials;
 
         let store = test_secrets_store();
 
@@ -2397,8 +2396,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_resolve_host_credentials_bearer() {
-        use crate::tools::wasm::capabilities::HttpCapability;
-        use crate::tools::wasm::wrapper::resolve_host_credentials;
+        use crate::capabilities::HttpCapability;
+        use crate::wrapper::resolve_host_credentials;
         use dasclaw_runtime::secrets::{
             CreateSecretParams, CredentialLocation, CredentialMapping, SecretsStore,
         };
@@ -2442,8 +2441,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_resolve_host_credentials_owner_scope_bearer() {
-        use crate::tools::wasm::capabilities::HttpCapability;
-        use crate::tools::wasm::wrapper::resolve_host_credentials;
+        use crate::capabilities::HttpCapability;
+        use crate::wrapper::resolve_host_credentials;
         use dasclaw_runtime::secrets::{
             CreateSecretParams, CredentialLocation, CredentialMapping, SecretsStore,
         };
@@ -2487,7 +2486,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_execute_resolves_host_credentials_from_owner_scope_context() {
-        use crate::tools::wasm::capabilities::HttpCapability;
+        use crate::capabilities::HttpCapability;
         use dasclaw_runtime::secrets::{CredentialLocation, CredentialMapping};
 
         let runtime = Arc::new(WasmToolRuntime::new(WasmRuntimeConfig::for_testing()).unwrap());
@@ -2536,8 +2535,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_resolve_host_credentials_missing_secret() {
-        use crate::tools::wasm::capabilities::HttpCapability;
-        use crate::tools::wasm::wrapper::resolve_host_credentials;
+        use crate::capabilities::HttpCapability;
+        use crate::wrapper::resolve_host_credentials;
         use dasclaw_runtime::secrets::{CredentialLocation, CredentialMapping};
 
         let store = test_secrets_store();
@@ -2567,8 +2566,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_resolve_host_credentials_skips_refresh_when_not_expired() {
-        use crate::tools::wasm::capabilities::HttpCapability;
-        use crate::tools::wasm::wrapper::{OAuthRefreshConfig, resolve_host_credentials};
+        use crate::capabilities::HttpCapability;
+        use crate::wrapper::{OAuthRefreshConfig, resolve_host_credentials};
         use dasclaw_runtime::secrets::{
             CreateSecretParams, CredentialLocation, CredentialMapping, SecretsStore,
         };
@@ -2626,8 +2625,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_resolve_host_credentials_skips_refresh_no_config() {
-        use crate::tools::wasm::capabilities::HttpCapability;
-        use crate::tools::wasm::wrapper::resolve_host_credentials;
+        use crate::capabilities::HttpCapability;
+        use crate::wrapper::resolve_host_credentials;
         use dasclaw_runtime::secrets::{
             CreateSecretParams, CredentialLocation, CredentialMapping, SecretsStore,
         };
@@ -2669,8 +2668,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_resolve_host_credentials_skips_refresh_no_expires_at() {
-        use crate::tools::wasm::capabilities::HttpCapability;
-        use crate::tools::wasm::wrapper::{OAuthRefreshConfig, resolve_host_credentials};
+        use crate::capabilities::HttpCapability;
+        use crate::wrapper::{OAuthRefreshConfig, resolve_host_credentials};
         use dasclaw_runtime::secrets::{
             CreateSecretParams, CredentialLocation, CredentialMapping, SecretsStore,
         };
@@ -2727,8 +2726,8 @@ mod tests {
     #[tokio::test]
     async fn test_resolve_host_credentials_refreshes_via_proxy_without_direct_token_url_validation()
     {
-        use crate::tools::wasm::capabilities::HttpCapability;
-        use crate::tools::wasm::wrapper::{OAuthRefreshConfig, resolve_host_credentials};
+        use crate::capabilities::HttpCapability;
+        use crate::wrapper::{OAuthRefreshConfig, resolve_host_credentials};
         use dasclaw_runtime::secrets::{
             CreateSecretParams, CredentialLocation, CredentialMapping, SecretsStore,
         };
@@ -2837,8 +2836,8 @@ mod tests {
     #[tokio::test]
     async fn test_resolve_host_credentials_skips_refresh_token_lookup_without_oauth_proxy_auth_token()
      {
-        use crate::tools::wasm::capabilities::HttpCapability;
-        use crate::tools::wasm::wrapper::{OAuthRefreshConfig, resolve_host_credentials};
+        use crate::capabilities::HttpCapability;
+        use crate::wrapper::{OAuthRefreshConfig, resolve_host_credentials};
         use dasclaw_runtime::secrets::{
             CreateSecretParams, CredentialLocation, CredentialMapping, SecretsStore,
         };
@@ -2904,8 +2903,8 @@ mod tests {
     #[tokio::test]
     async fn test_resolve_host_credentials_skips_refresh_token_lookup_for_invalid_direct_token_url()
     {
-        use crate::tools::wasm::capabilities::HttpCapability;
-        use crate::tools::wasm::wrapper::{OAuthRefreshConfig, resolve_host_credentials};
+        use crate::capabilities::HttpCapability;
+        use crate::wrapper::{OAuthRefreshConfig, resolve_host_credentials};
         use dasclaw_runtime::secrets::{
             CreateSecretParams, CredentialLocation, CredentialMapping, SecretsStore,
         };
@@ -3093,7 +3092,7 @@ mod tests {
     /// tool's own legitimate outbound request.
     #[test]
     fn test_leak_scan_runs_before_credential_injection() {
-        use crate::safety::LeakDetector;
+        use dasclaw_safety::LeakDetector;
 
         // Simulate pre-injection headers: WASM only sees the placeholder, not the real token.
         let raw_headers: Vec<(String, String)> = vec![
@@ -3142,8 +3141,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_resolve_host_credentials_fallback_to_default_user() {
-        use crate::tools::wasm::capabilities::HttpCapability;
-        use crate::tools::wasm::wrapper::resolve_host_credentials;
+        use crate::capabilities::HttpCapability;
+        use crate::wrapper::resolve_host_credentials;
         use dasclaw_runtime::secrets::{CredentialLocation, CredentialMapping, SecretsStore};
 
         let store = test_secrets_store();
@@ -3174,7 +3173,7 @@ mod tests {
             http: Some(HttpCapability {
                 allowlist: vec![],
                 credentials: creds,
-                rate_limit: crate::tools::wasm::capabilities::RateLimitConfig::default(),
+                rate_limit: crate::capabilities::RateLimitConfig::default(),
                 max_request_bytes: 1024 * 1024,
                 max_response_bytes: 10 * 1024 * 1024,
                 timeout: std::time::Duration::from_secs(30),
@@ -3191,7 +3190,7 @@ mod tests {
     }
 
     fn test_capabilities_with_google_oauth() -> Capabilities {
-        use crate::tools::wasm::capabilities::HttpCapability;
+        use crate::capabilities::HttpCapability;
         use dasclaw_runtime::secrets::{CredentialLocation, CredentialMapping};
 
         let mut creds = std::collections::HashMap::new();
@@ -3207,7 +3206,7 @@ mod tests {
             http: Some(HttpCapability {
                 allowlist: vec![],
                 credentials: creds,
-                rate_limit: crate::tools::wasm::capabilities::RateLimitConfig::default(),
+                rate_limit: crate::capabilities::RateLimitConfig::default(),
                 max_request_bytes: 1024 * 1024,
                 max_response_bytes: 10 * 1024 * 1024,
                 timeout: std::time::Duration::from_secs(30),
@@ -3218,7 +3217,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_resolve_host_credentials_prefers_user_specific_over_default() {
-        use crate::tools::wasm::wrapper::resolve_host_credentials;
+        use crate::wrapper::resolve_host_credentials;
         use dasclaw_runtime::secrets::SecretsStore;
 
         let store = test_secrets_store();
@@ -3260,7 +3259,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_resolve_host_credentials_no_fallback_when_already_default() {
-        use crate::tools::wasm::wrapper::resolve_host_credentials;
+        use crate::wrapper::resolve_host_credentials;
         use dasclaw_runtime::secrets::SecretsStore;
 
         let store = test_secrets_store();
@@ -3290,7 +3289,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_resolve_host_credentials_missing_secret_warns() {
-        use crate::tools::wasm::wrapper::resolve_host_credentials;
+        use crate::wrapper::resolve_host_credentials;
 
         let store = test_secrets_store();
 

--- a/crates/dasclaw_wasm_tools/wit/tool.wit
+++ b/crates/dasclaw_wasm_tools/wit/tool.wit
@@ -1,0 +1,152 @@
+package near:agent@0.3.0;
+
+// WASM Tool Sandbox Interface
+//
+// Defines the contract between sandboxed tools and the host runtime.
+// Tools export the `tool` interface; the host provides the `host` interface.
+//
+// Security Model:
+// - WASM tools are untrusted and run in a sandbox
+// - All capabilities are opt-in (default: no access)
+// - Secrets are NEVER exposed to WASM; credentials are injected at host boundary
+// - All outputs are scanned for secret leakage before returning to WASM
+
+/// Host-provided capabilities for sandboxed tools.
+///
+/// These are the only ways a sandboxed tool can interact with the outside world.
+/// The set is intentionally minimal to reduce attack surface.
+interface host {
+    /// Log levels for structured logging.
+    enum log-level {
+        trace,
+        debug,
+        info,
+        warn,
+        error,
+    }
+
+    /// Emit a log message.
+    ///
+    /// Messages are collected and emitted after execution completes.
+    /// Rate-limited to 1000 entries per execution, 4KB per message.
+    log: func(level: log-level, message: string);
+
+    /// Get the current timestamp in milliseconds since Unix epoch.
+    now-millis: func() -> u64;
+
+    /// Read a file from the workspace (if capability granted).
+    ///
+    /// Path must be relative (no leading /) and cannot contain "..".
+    /// Returns None if the file doesn't exist or capability not granted.
+    workspace-read: func(path: string) -> option<string>;
+
+    // ==================== HTTP Capability ====================
+
+    /// Response from an HTTP request.
+    record http-response {
+        /// HTTP status code.
+        status: u16,
+        /// Response headers as JSON object string.
+        headers-json: string,
+        /// Response body bytes.
+        body: list<u8>,
+    }
+
+    /// Make an HTTP request (if capability granted).
+    ///
+    /// Security:
+    /// - Only allowed endpoints (host/path patterns) can be accessed
+    /// - Credentials are injected by the host; WASM never sees them
+    /// - Response is scanned for leaked secrets before returning
+    /// - Rate-limited per tool
+    ///
+    /// Returns Err with error message if:
+    /// - Endpoint not in allowlist
+    /// - Rate limit exceeded
+    /// - Request/response size limit exceeded
+    /// - Network error
+    /// - Timeout
+    /// - Secret leak detected in response
+    ///
+    /// The optional timeout-ms parameter controls the HTTP client timeout
+    /// in milliseconds. Defaults to 30000 (30s) when not provided.
+    /// Capped at the callback timeout to prevent hangs.
+    http-request: func(
+        method: string,
+        url: string,
+        headers-json: string,
+        body: option<list<u8>>,
+        timeout-ms: option<u32>,
+    ) -> result<http-response, string>;
+
+    // ==================== Tool Invocation Capability ====================
+
+    /// Invoke another tool by alias (if capability granted).
+    ///
+    /// Security:
+    /// - WASM calls tools by alias, not real name (indirection layer)
+    /// - Only aliased tools can be invoked
+    /// - Rate-limited per tool
+    /// - Output is scanned for leaked secrets before returning
+    ///
+    /// Returns the tool output as JSON string, or Err with error message.
+    tool-invoke: func(alias: string, params-json: string) -> result<string, string>;
+
+    // ==================== Secrets Capability ====================
+
+    /// Check if a secret exists (if capability granted).
+    ///
+    /// Security:
+    /// - WASM can only check existence, NEVER read values
+    /// - Only allowed secret names can be checked
+    /// - Actual credentials are injected by host during HTTP requests
+    ///
+    /// Returns true if the secret exists and is accessible to this tool.
+    secret-exists: func(name: string) -> bool;
+}
+
+/// Tool interface that sandboxed tools must implement.
+interface tool {
+    /// Request payload for tool execution.
+    record request {
+        /// JSON-encoded parameters matching the tool's schema.
+        params: string,
+        /// Optional JSON-encoded job context for stateful operations.
+        context: option<string>,
+    }
+
+    /// Response from tool execution.
+    record response {
+        /// JSON-encoded output on success.
+        output: option<string>,
+        /// Error message on failure.
+        error: option<string>,
+    }
+
+    /// Execute the tool with the given request.
+    ///
+    /// This is the main entry point. The tool should:
+    /// 1. Parse params as JSON according to its schema
+    /// 2. Perform the operation
+    /// 3. Return a response with either result or error set
+    execute: func(req: request) -> response;
+
+    /// Get the JSON Schema for this tool's parameters.
+    ///
+    /// Must return a valid JSON Schema object describing the expected
+    /// structure of the `params` field in requests.
+    schema: func() -> string;
+
+    /// Get a human-readable description of what this tool does.
+    ///
+    /// Used by the LLM to understand when to invoke the tool.
+    description: func() -> string;
+}
+
+/// World definition for sandboxed tools.
+///
+/// Tools import host capabilities and export the tool interface.
+world sandboxed-tool {
+    import host;
+    export tool;
+}

--- a/desktop-client/ironclaw/src/cli/oauth_defaults.rs
+++ b/desktop-client/ironclaw/src/cli/oauth_defaults.rs
@@ -94,7 +94,9 @@ pub fn hosted_proxy_client_secret(
 // crate-level helpers, preserving the historical zero-arg call surface for
 // in-tree callers.
 pub use crate::llm::oauth_helpers::{
-    OAUTH_CALLBACK_PORT, OAuthCallbackError, is_loopback_host, landing_html, wait_for_callback,
+    OAUTH_CALLBACK_PORT, OAuthCallbackError, OAuthTokenResponse, ProxyRefreshTokenRequest,
+    is_loopback_host, landing_html, oauth_token_response_from_json, refresh_token_via_proxy,
+    wait_for_callback,
 };
 
 /// Read the OAuth callback host from `IRONCLAW_OAUTH_CALLBACK_HOST` (legacy
@@ -122,15 +124,6 @@ pub async fn bind_callback_listener() -> Result<tokio::net::TcpListener, OAuthCa
 }
 
 // ── Shared OAuth flow steps ─────────────────────────────────────────
-
-/// Response from the OAuth token exchange.
-pub struct OAuthTokenResponse {
-    pub access_token: String,
-    pub refresh_token: Option<String>,
-    pub expires_in: Option<u64>,
-    pub token_type: Option<String>,
-    pub scope: Option<String>,
-}
 
 /// Result of building an OAuth 2.0 authorization URL.
 pub struct OAuthUrlResult {
@@ -802,59 +795,6 @@ pub struct ProxyTokenExchangeRequest<'a> {
     pub extra_token_params: &'a HashMap<String, String>,
 }
 
-pub struct ProxyRefreshTokenRequest<'a> {
-    pub proxy_url: &'a str,
-    /// OAuth proxy auth token.
-    /// Kept as `gateway_token` for public API compatibility.
-    pub gateway_token: &'a str,
-    pub token_url: &'a str,
-    pub client_id: &'a str,
-    pub client_secret: Option<&'a str>,
-    pub refresh_token: &'a str,
-    pub resource: Option<&'a str>,
-    pub provider: Option<&'a str>,
-}
-
-fn oauth_token_response_from_json(
-    token_data: serde_json::Value,
-    access_token_field: &str,
-) -> Result<OAuthTokenResponse, OAuthCallbackError> {
-    let access_token = token_data
-        .get(access_token_field)
-        .and_then(|v| v.as_str())
-        .ok_or_else(|| {
-            let fields: Vec<&str> = token_data
-                .as_object()
-                .map(|o| o.keys().map(|k| k.as_str()).collect())
-                .unwrap_or_default();
-            OAuthCallbackError::Io(format!(
-                "No '{}' field in proxy response (fields present: {:?})",
-                access_token_field, fields
-            ))
-        })?
-        .to_string();
-
-    let refresh_token = token_data
-        .get("refresh_token")
-        .and_then(|v| v.as_str())
-        .map(String::from);
-    let expires_in = token_data.get("expires_in").and_then(|v| v.as_u64());
-
-    Ok(OAuthTokenResponse {
-        access_token,
-        refresh_token,
-        expires_in,
-        token_type: token_data
-            .get("token_type")
-            .and_then(|v| v.as_str())
-            .map(String::from),
-        scope: token_data
-            .get("scope")
-            .and_then(|v| v.as_str())
-            .map(String::from),
-    })
-}
-
 /// Exchange an OAuth authorization code via the platform's token exchange proxy.
 ///
 /// Authenticated via an OAuth proxy auth token (Bearer header). The caller may
@@ -920,69 +860,6 @@ pub async fn exchange_via_proxy(
         .await
         .map_err(|e| OAuthCallbackError::Io(format!("Failed to parse proxy response: {}", e)))?;
     oauth_token_response_from_json(token_data, request.access_token_field)
-}
-
-/// Refresh an OAuth access token via the platform's token refresh proxy.
-///
-/// Authenticated via an OAuth proxy auth token (Bearer header). The caller may
-/// either rely on proxy-side secret lookup or forward a `client_secret` when
-/// the provider requires it.
-pub async fn refresh_token_via_proxy(
-    request: ProxyRefreshTokenRequest<'_>,
-) -> Result<OAuthTokenResponse, OAuthCallbackError> {
-    if request.gateway_token.is_empty() {
-        return Err(OAuthCallbackError::Io(
-            "OAuth proxy auth token is required for proxy token refresh".to_string(),
-        ));
-    }
-
-    let refresh_url = format!("{}/oauth/refresh", request.proxy_url.trim_end_matches('/'));
-    let client = reqwest::Client::builder()
-        .timeout(Duration::from_secs(15))
-        .redirect(reqwest::redirect::Policy::none())
-        .build()
-        .map_err(|e| OAuthCallbackError::Io(format!("Failed to build HTTP client: {}", e)))?;
-
-    let mut params = vec![
-        ("refresh_token", request.refresh_token.to_string()),
-        ("token_url", request.token_url.to_string()),
-        ("client_id", request.client_id.to_string()),
-    ];
-    if let Some(secret) = request.client_secret {
-        params.push(("client_secret", secret.to_string()));
-    }
-    if let Some(resource) = request.resource {
-        params.push(("resource", resource.to_string()));
-    }
-    if let Some(provider) = request.provider {
-        params.push(("provider", provider.to_string()));
-    }
-
-    let response = client
-        .post(&refresh_url)
-        .bearer_auth(request.gateway_token)
-        .form(&params)
-        .send()
-        .await
-        .map_err(|e| {
-            OAuthCallbackError::Io(format!("Token refresh proxy request failed: {}", e))
-        })?;
-
-    if !response.status().is_success() {
-        let status = response.status();
-        let body = response.text().await.unwrap_or_default();
-        return Err(OAuthCallbackError::Io(format!(
-            "Token refresh proxy failed: {} - {}",
-            status, body
-        )));
-    }
-
-    let token_data: serde_json::Value = response
-        .json()
-        .await
-        .map_err(|e| OAuthCallbackError::Io(format!("Failed to parse proxy response: {}", e)))?;
-
-    oauth_token_response_from_json(token_data, "access_token")
 }
 
 #[cfg(test)]

--- a/desktop-client/ironclaw/src/testing/credentials.rs
+++ b/desktop-client/ironclaw/src/testing/credentials.rs
@@ -4,16 +4,16 @@
 //! audits trivial (one file to verify) and eliminates duplication across
 //! the test suite.
 
-use std::sync::Arc;
-
-use secrecy::SecretString;
-
-use dasclaw_runtime::secrets::{InMemorySecretsStore, SecretsCrypto};
+// WASM-tool-relevant fixtures live upstream in `dasclaw_wasm_tools::test_credentials`
+// so the moved wrapper.rs tests do not depend on the desktop crate. We re-export
+// them here so existing desktop callers (oauth_defaults, loader, channels, config,
+// orchestrator tests) continue to work unchanged.
+pub use dasclaw_wasm_tools::test_credentials::{
+    TEST_BEARER_TOKEN_123, TEST_CRYPTO_KEY, TEST_GOOGLE_OAUTH_FRESH, TEST_GOOGLE_OAUTH_LEGACY,
+    TEST_GOOGLE_OAUTH_TOKEN, TEST_OAUTH_CLIENT_ID, TEST_OAUTH_CLIENT_SECRET, test_secrets_store,
+};
 
 // ── Encryption keys ──────────────────────────────────────────────────────
-
-/// 32-character key string for `SecretsCrypto::new()` in tests.
-pub const TEST_CRYPTO_KEY: &str = "0123456789abcdef0123456789abcdef";
 
 /// 32+ char key for web gateway `SecretsCrypto` in tests.
 pub const TEST_GATEWAY_CRYPTO_KEY: &str = "test-key-at-least-32-chars-long!!";
@@ -47,15 +47,8 @@ pub const TEST_ANTHROPIC_OAUTH_BASIC: &str = "sk-ant-oat01-basic";
 pub const TEST_ANTHROPIC_OAUTH_NESTED: &str = "sk-ant-oat01-primary-token";
 
 // ── Google OAuth ─────────────────────────────────────────────────────────
-
-/// Google OAuth access token (standard test).
-pub const TEST_GOOGLE_OAUTH_TOKEN: &str = "ya29.test-token";
-
-/// Google OAuth access token (fresh/non-expired variant).
-pub const TEST_GOOGLE_OAUTH_FRESH: &str = "ya29.fresh-token";
-
-/// Google OAuth access token (legacy/no-expiry variant).
-pub const TEST_GOOGLE_OAUTH_LEGACY: &str = "ya29.legacy-token";
+// `TEST_GOOGLE_OAUTH_TOKEN`, `TEST_GOOGLE_OAUTH_FRESH`, `TEST_GOOGLE_OAUTH_LEGACY`
+// are re-exported from `dasclaw_wasm_tools::test_credentials` at the top.
 
 // ── GitHub ───────────────────────────────────────────────────────────────
 
@@ -68,20 +61,16 @@ pub const TEST_GITHUB_TOKEN: &str = "ghp_test123";
 pub const TEST_TELEGRAM_BOT_TOKEN: &str = "telegram-test-bot-token-not-a-real-token";
 
 // ── OAuth client credentials ────────────────────────────────────────────
-
-/// OAuth client ID for token refresh tests.
-pub const TEST_OAUTH_CLIENT_ID: &str = "test-client-id";
-
-/// OAuth client secret for token refresh tests.
-pub const TEST_OAUTH_CLIENT_SECRET: &str = "test-client-secret";
+// `TEST_OAUTH_CLIENT_ID`, `TEST_OAUTH_CLIENT_SECRET` are re-exported from
+// `dasclaw_wasm_tools::test_credentials` at the top.
 
 // ── Bearer/auth tokens ──────────────────────────────────────────────────
 
 /// Generic test bearer token.
 pub const TEST_BEARER_TOKEN: &str = "test-token";
 
-/// Bearer token with suffix (wasm wrapper credential injection).
-pub const TEST_BEARER_TOKEN_123: &str = "test-token-123";
+// `TEST_BEARER_TOKEN_123` is re-exported from `dasclaw_wasm_tools::test_credentials`
+// at the top.
 
 /// Auth token used by web gateway middleware tests.
 pub const TEST_AUTH_SECRET_TOKEN: &str = "secret-token";
@@ -121,14 +110,5 @@ pub const TEST_SECRET_VALUE: &str = "sk-test-12345";
 /// HTTP webhook secret for channel tests.
 pub const TEST_HTTP_SECRET: &str = "test-secret-123";
 
-// ── Helpers ──────────────────────────────────────────────────────────────
-
-/// Create an `InMemorySecretsStore` backed by [`TEST_CRYPTO_KEY`].
-///
-/// Replaces the duplicated `test_store()` pattern found across multiple
-/// test modules.
-pub fn test_secrets_store() -> InMemorySecretsStore {
-    let crypto =
-        Arc::new(SecretsCrypto::new(SecretString::from(TEST_CRYPTO_KEY.to_string())).unwrap());
-    InMemorySecretsStore::new(crypto)
-}
+// `test_secrets_store` is re-exported from `dasclaw_wasm_tools::test_credentials`
+// at the top.

--- a/desktop-client/ironclaw/src/tools/tool.rs
+++ b/desktop-client/ironclaw/src/tools/tool.rs
@@ -17,7 +17,7 @@ pub use dasclaw_runtime::Tool;
 
 pub use dasclaw_tool::{
     ApprovalContext, ApprovalRequirement, RiskLevel, ToolDiscoverySummary, ToolDomain, ToolError,
-    ToolOutput, ToolRateLimitConfig, ToolSchema, redact_params, require_param, require_str,
+    ToolOutput, ToolRateLimitConfig, redact_params, require_param, require_str,
     validate_tool_schema,
 };
 

--- a/desktop-client/ironclaw/src/tools/wasm/mod.rs
+++ b/desktop-client/ironclaw/src/tools/wasm/mod.rs
@@ -1,31 +1,27 @@
 //! WASM sandbox for untrusted tool execution.
 //!
 //! Most primitives (allowlist, capabilities, capabilities_schema,
-//! credential_injector, error, host, limits, storage) have been moved to the
-//! `dasclaw_wasm_tools` crate under ADR-152 F4.5.3. This module re-exports
-//! them so existing `crate::tools::wasm::*` call sites keep compiling, and
-//! keeps the four still-desktop-coupled modules (loader, rate_limiter,
-//! runtime, wrapper) in place.
+//! credential_injector, error, host, limits, storage, runtime, wrapper) have
+//! been moved to the `dasclaw_wasm_tools` crate under ADR-152 F4.5.3 + F4.5.4.
+//! This module re-exports them so existing `crate::tools::wasm::*` call sites
+//! keep compiling, and keeps the two still-desktop-coupled modules (loader,
+//! rate_limiter) in place.
 
 /// Host WIT version for tool extensions.
 ///
 /// Extensions declaring a `wit_version` in their capabilities file are checked
 /// against this at load time: same major, not greater than host.
-pub const WIT_TOOL_VERSION: &str = "0.3.0";
-
-/// Host WIT version for channel extensions.
-pub const WIT_CHANNEL_VERSION: &str = "0.3.0";
+pub use dasclaw_wasm_tools::{WIT_CHANNEL_VERSION, WIT_TOOL_VERSION};
 
 // Re-export moved modules so `crate::tools::wasm::<mod>::*` paths still resolve.
 pub use dasclaw_wasm_tools::{
-    allowlist, capabilities, capabilities_schema, credential_injector, error, host, limits, storage,
+    allowlist, capabilities, capabilities_schema, credential_injector, error, host, limits,
+    runtime, storage, wrapper,
 };
 
 // Modules still kept in the desktop crate.
 pub(crate) mod loader;
 mod rate_limiter;
-mod runtime;
-mod wrapper;
 
 // Core types
 pub use dasclaw_wasm_tools::WasmError;
@@ -34,8 +30,10 @@ pub use dasclaw_wasm_tools::{
     WasmResourceLimiter,
 };
 pub use dasclaw_wasm_tools::{HostState, LogEntry, LogLevel};
-pub use runtime::{PreparedModule, WasmRuntimeConfig, WasmToolRuntime, enable_compilation_cache};
-pub use wrapper::{OAuthRefreshConfig, WasmToolWrapper};
+pub use dasclaw_wasm_tools::{
+    OAuthRefreshConfig, PreparedModule, WasmRuntimeConfig, WasmToolRuntime, WasmToolWrapper,
+    enable_compilation_cache,
+};
 
 // Capabilities (V2)
 pub use dasclaw_wasm_tools::{


### PR DESCRIPTION
## 背景 / 目标

ADR-152 F4.5.4 **Plan A_extended** verbatim port:
- 把 `runtime.rs` + `wrapper.rs` + `wit/tool.wit` 物理迁移到 `crates/dasclaw_wasm_tools/`
- 4 个 OAuth helpers 上提到 `dasclaw_llm_provider::provider::oauth_helpers`
- 7 个测试 fixtures + `test_secrets_store()` 通过新增 `dasclaw_wasm_tools/src/test_credentials.rs` 共享
- desktop 旧路径 (`desktop-client/ironclaw/src/tools/wasm/{runtime,wrapper}.rs`、`cli/oauth_defaults.rs`、`testing/credentials.rs`、`tools/wasm/mod.rs`) 全部转为薄壳 re-export

严格 verbatim:仅做 `use` 路径重写 + 文件搬迁,无任何逻辑/简化(ADR-129 §1.3)。

## 改动范围

```
M  Cargo.lock
M  crates/dasclaw_llm_provider/src/provider/oauth_helpers.rs   (+OAuth 4 helpers)
M  crates/dasclaw_wasm_tools/Cargo.toml                         (+wasmtime-wasi/dirs/reqwest/secrecy 等)
M  crates/dasclaw_wasm_tools/src/lib.rs                         (注册 runtime/wrapper/test_credentials 模块)
A  crates/dasclaw_wasm_tools/src/runtime.rs                     (rename from desktop)
A  crates/dasclaw_wasm_tools/src/wrapper.rs                     (rename from desktop)
A  crates/dasclaw_wasm_tools/src/test_credentials.rs            (新增共享 fixture)
A  crates/dasclaw_wasm_tools/wit/tool.wit                       (copy verbatim)
M  desktop-client/ironclaw/src/cli/oauth_defaults.rs            (薄壳 re-export)
M  desktop-client/ironclaw/src/testing/credentials.rs           (薄壳 re-export)
M  desktop-client/ironclaw/src/tools/tool.rs                    (移除 unused ToolSchema re-export)
M  desktop-client/ironclaw/src/tools/wasm/mod.rs                (薄壳 re-export)
D  desktop-client/ironclaw/src/tools/wasm/runtime.rs            (renamed)
D  desktop-client/ironclaw/src/tools/wasm/wrapper.rs            (renamed)
```

## 非目标 (What's NOT in this PR)

- `loader.rs` + `rate_limiter.rs` **暂留 desktop** — 仍耦合 `ToolRegistry` / cli 启动路径,按 ADR-152 addendum §4.2 规划下一波再切
- 不重命名任何符号、不调整 API、不简化逻辑
- 不动 `.ironclaw` 字面量(类 A,见 Cross-cuts)
- 不动 desktop 业务调用方代码,全部经薄壳透明转发

## 验证

| 命令 | 结果 |
|---|---|
| `cargo check -p dasclaw_wasm_tools --tests` | 0 错 0 警 (1m40s) |
| `cargo check -p dasclaw --tests` | 0 错 0 警 (51s) |
| `cargo nextest run -p dasclaw_wasm_tools` | **160 passed, 0 skipped** (31.9s) |
| `cargo clippy --no-deps -p dasclaw_wasm_tools --all-targets -- -D warnings` | clean (19.7s) |
| `cargo fmt --all` | clean |
| `python3.12 scripts/check_no_panics.py --base origin/xClaw` | OK |
| `python3 scripts/check_no_new_ironclaw_literal.py --base origin/xClaw` | OK |

完整 workspace build / clippy / heavy integration 由 CI 兑现。

## Cross-cuts

**类 A**(无新增 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量,grep guard 通过)

## Sources read

- [docs/plans/architecture-refactor/adr-152-wasm-tools-slicing.md](../docs/plans/architecture-refactor/adr-152-wasm-tools-slicing.md) §4.5.4 Plan A_extended + addendum §4.2
- [docs/plans/architecture-refactor/adr-129-verbatim-port-policy.md](../docs/plans/architecture-refactor/adr-129-verbatim-port-policy.md) §1.3 verbatim 红线 + §1.3.1 fork-able 边界
- [docs/plans/architecture-refactor/adr-114-dasclaw-rebrand.md](../docs/plans/architecture-refactor/adr-114-dasclaw-rebrand.md) §grep guard
- [AGENTS.md](../AGENTS.md) 本地节奏 + Skills 强制使用规范
- 实际打开的源码:`crates/dasclaw_wasm_tools/{Cargo.toml, src/lib.rs, src/runtime.rs, src/wrapper.rs, src/test_credentials.rs, wit/tool.wit}`、`crates/dasclaw_llm_provider/src/provider/oauth_helpers.rs`、`desktop-client/ironclaw/src/{cli/oauth_defaults.rs, testing/credentials.rs, tools/tool.rs, tools/wasm/mod.rs, tools/wasm/loader.rs}`

## 关联 ADR

- ADR-152 (F4.5.4) — 主体
- ADR-129 §1.3 — verbatim 红线
- ADR-114 类 A — 命名空间

## 后续

- F4.5.5: `loader.rs` 在解耦 `ToolRegistry` 后切到 `dasclaw_wasm_tools`
- F4.5.6: `rate_limiter.rs` 同步迁移

Closes #742
