### PR TITLE
docs(blueprint): 31 升级到 v2.5 + ADR-152 §3 F4.4/F4.6 条款修订

### DIFF
--- a/docs/plans/architecture-refactor/31-target-architecture.md
+++ b/docs/plans/architecture-refactor/31-target-architecture.md
@@ -1,5 +1,12 @@
 # 31 — 目标架构（边界清晰、可复用）
 
+> **v2.5 (2026-05-23)** · 蓝图对齐 4-5 天发展（基于 [40-tool-ecosystem-inventory.md](40-tool-ecosystem-inventory.md) §1-3 实测 + [41-target-architecture-drift-analysis.md](41-target-architecture-drift-analysis.md) 漂移识别）：
+>   1. **§4 补全 16 个 v2.4 遗漏 crate**（按字母序）：`dasclaw_absolute_path` / `dasclaw_bash_permissions` / `dasclaw_cert_trust` / `dasclaw_channels` / `dasclaw_exec` / `dasclaw_llm_provider` / `dasclaw_process_hardening` / `dasclaw_runtime` / `dasclaw_sandbox_linux` / `dasclaw_sandbox_windows` / `dasclaw_sandboxing` / `dasclaw_shell_command` / `dasclaw_tool` / `dasclaw_utils_home_dir` / `dasclaw_utils_rustls_provider` / `dasclaw_wasm_tools`。
+>   2. **新增 §4.6 F4.6 工具壳分层落点**（按 [ADR-156](adr-156-f46-builtin-tools-landing-decision.md)）：8 个新 crate `dasclaw_{misc,image,memory,sub_agent,git,fs,shell,net}_tools` 分子波次 F4.6.1 ~ F4.6.8 下沉（~13073 LOC），T3/T4 共 8223 LOC（Extension/Skill/Job/Routine/Message 5 类）留桌面。
+>   3. **§3 ADR 索引扩展到 ADR-156**：补 ADR-111 ~ ADR-156 共约 45 个 ADR 概要（详见 §3.2 索引表）。
+>   4. **§4.4 落点确认**：`orchestrator` 按 [ADR-155](adr-155-f44-orchestrator-landing-decision.md) 留桌面，原 v2.4 §4.4 "升级为 dasclaw_*"承诺作废。
+> P0 落地度：6/7（缺 `dasclaw_bridge_lite`）；P1：6.5/7（`dasclaw_git_tools` 待 F4.6.5 扩充）；P2：5/5。crates/ 真实总数 45 个，v2.4 蓝图列 26 个，本次补全后蓝图条目数 = 45 + F4.6 新建 8 = 53。
+
 > **v2.4 (2026-04-26)** · 补 3 处蓝图缺口（基于 [39-fork-private-cargo-inventory.md](39-fork-private-cargo-inventory.md) §3 实测）：新增 `dasclaw_lsp`（fork 私货 1,694 LOC）/ `dasclaw_git_tools`（fork 私货 1,331 LOC）/ `dasclaw_routines`（提升点 31 LOC，路由 desktop-client/ironclaw 0.24 routines 模块）。原 P1 4 个 → 7 个，W1 骨架 14 → **17**。
 
 > **v2.3 (2026-04-26)** · 订正 fork 处理矛盾：ADR-105 §落地 + §4.5 废弃表与 ADR-101 §136 对齐。git log 实测 fork 在 ironclaw-v0.26.0 tag 之后有 **42 fork-only commit**（Phase 2/3 dasclaw 接线核心成果：rig-core 清理 / ClawCodeLlmProvider / x_claw_agent host trait 接线 / IronclawSafetyHook / 5 agent 模块迁移 / SessionManager / routines 提升）。决策：W1-W6 保留 fork 作为私货来源，W6+ 私货全迁出后才删除；**永不**直接升级 fork 到 0.26 顶层依赖（与 38 §137 一致）。
@@ -228,6 +235,81 @@ flowchart TB
 
 **落地**：W6（与 IPC + 后端基底大移植同期）。
 
+### 3.2 ADR-111 ~ ADR-156 索引（v2.5 新）
+
+v2.4 §3 只列了 ADR-101 ~ ADR-110。W3 ~ W6 期间又落了约 45 个 ADR（不含废弃的 ADR-128 / 140），分组索引如下；每条只给一句结论，详情见对应 ADR 文件。
+
+**评估与方法学族（ADR-111 ~ ADR-117）**
+
+| ADR | 主题 | 结论 |
+|---|---|---|
+| [ADR-112](adr-112-compatibility-evaluation.md) | W3-A 兼容性评估嵌入节奏 | B1→B2→B3 三段式自带测试 |
+| [ADR-112-input-checklist](adr-112-input-checklist.md) | W3-A 输入条件清单 | 13 项必填，缺一拒收 |
+| [ADR-113](adr-113-hook-engine-unification.md) | Hook 引擎统一 | dasclaw_hooks 单一实现，编译期红线 `count_hook_systems() == 1` |
+| [ADR-114](adr-114-dasclaw-rebrand.md) | `.ironclaw` → `.dasclaw` 命名迁移 | 类 A 业务零容忍，类 B 集中工程豁免 |
+| [ADR-115](adr-115-project-docs-not-in-hook.md) | 项目文档不进 hook 链 | 走专用 ProjectDocLoader，不污染 hook |
+| [ADR-117](adr-117-p0c-prompt-builder-unification.md) | Prompt builder 统一 | 单一 owner，详见 ADR-120 |
+
+**Plan Mode / Job / Sandbox 三件套（ADR-118 ~ ADR-121, ADR-129 ~ ADR-131）**
+
+| ADR | 主题 | 结论 |
+|---|---|---|
+| [ADR-118](adr-118-claw-code-readonly-and-self-impl.md) | claw-code 只读 + self impl 边界 | claw-code 不写回 fork |
+| [ADR-119](adr-119-job-runtime-decision-for-desktop-client.md) | Job runtime 落点 | 留桌面（与 ADR-155 orchestrator 同理） |
+| [ADR-120](adr-120-prompt-builder-ownership.md) | Prompt builder owner | `dasclaw_runtime::prompt` |
+| [ADR-121](adr-121-p0a-sandbox-activation-decision.md) | Sandbox 激活路径 | 启动时按 OS dispatch 到 dasclaw_sandbox_{linux,macos,windows} |
+| [ADR-129](adr-129-sandbox-windows-windows-crate-adoption.md) | sandbox-windows `windows` crate 选型 | 采纳 windows-rs，废弃 winapi |
+| [ADR-130](adr-130-sandbox-windows-lib-bin-split.md) | sandbox-windows lib/bin 拆分 | lib 暴露 trait，bin 仅 main.rs |
+| [ADR-131](adr-131-windows-job-object-resource-limits-wrapper.md) | Windows Job Object 资源限额 | wrapper crate 内联 wrap |
+
+**ExecPolicy / Shell 族（ADR-132 ~ ADR-135）**
+
+| ADR | 主题 | 结论 |
+|---|---|---|
+| [ADR-132](adr-132-execpolicy-starlark-port-plan.md) | execpolicy starlark port | 逐字搬 codex execpolicy，starlark rule 不动 |
+| [ADR-133](adr-133-shell-command-adoption-eval.md) | `dasclaw_shell_command` 采纳 | 采纳，作为 parse_command 实现 |
+| [ADR-134](adr-134-shell-escalation-non-goal.md) | shell 升权 non-goal | 禁止 sudo / runas 工具实现 |
+| [ADR-135](adr-135-sandboxing-crate-adoption-eval.md) | `dasclaw_sandboxing` 采纳 | 采纳，作为顶层 dispatcher |
+
+**Protocol / Net-proxy 族（ADR-136 ~ ADR-139）**
+
+| ADR | 主题 | 结论 |
+|---|---|---|
+| [ADR-136](adr-136-protocol-expansion-plan.md) | dasclaw_protocol 扩展 | 文件级 verbatim slice 上游 28 *.rs |
+| [ADR-137](adr-137-net-proxy-port-plan.md) | net-proxy port plan | 单层口径，不携带 credential resolver |
+| [ADR-138](adr-138-protocol-step-c2-evaluation.md) | protocol Step C2 utils 评估 | 新增 4 个 utils slice 小 crate |
+| [ADR-139](adr-139-mitm-ca-trust-chain.md) | MITM CA 信任链 | 默认关，按用户主动启用 |
+
+**Sandbox 平台细节族（ADR-141 ~ ADR-151）**
+
+| ADR | 主题 | 结论 |
+|---|---|---|
+| [ADR-141](adr-141-windows-enterprise-sandbox-support.md) | Windows enterprise sandbox 支持 | AppContainer + Job Object 组合 |
+| [ADR-142](adr-142-writable-root-kernel-enforcement.md) | writable root kernel enforcement | 内核级写保护 |
+| [ADR-143](adr-143-macos-residual-sinking-decision.md) | macOS 残余下沉决策 | sandbox-exec 残余留桌面 |
+| [ADR-144](adr-144-linux-writable-root-kernel-enforcement.md) | Linux writable root enforcement | landlock + seccomp |
+| [ADR-145](adr-145-windows-sandbox-users-naming-decision.md) | Windows sandbox 用户命名 | `dasclaw-sbx-<uid>` 模式 |
+| [ADR-146](adr-146-safety-decision-enum-extension.md) | SafetyDecision enum 扩展 | 新增 `Quarantine` / `Audit` 变体 |
+| [ADR-147](adr-147-composite-safety-hook.md) | 复合 safety hook | 多 hook 组合短路语义 |
+| [ADR-148](adr-148-egress-gate-safety-hook-semantics.md) | egress gate hook 语义 | 默认 deny，allowlist 显式开 |
+| [ADR-149](adr-149-tool-visibility-triple-gate.md) | 工具可见性三门控 | OS / Tier / SKU 三层 |
+| [ADR-150](adr-150-symlink-escape.md) | symlink 逃逸防护 | 沙箱内 canonicalize 后再校验 |
+| [ADR-151](adr-151-sandbox-model-divergence-from-upstream.md) | sandbox 模型与上游分歧 | 记录与 codex 模型差异 + 双向 drift 守卫 |
+
+**F4 阶段决策族（ADR-152 ~ ADR-156）**
+
+| ADR | 主题 | 结论 |
+|---|---|---|
+| [ADR-152](adr-152-agent-and-capability-fusion.md) | F4 agent + capability fusion 总规划 | 5 阶段切片 F4.0 ~ F4.6+ |
+| [ADR-152 §F4.5 wasm-slicing](adr-152-f45-wasm-slicing.md) | F4.5 wasm slicing 子方案 | wasm 工具拆 crate 边界 |
+| [ADR-152 §F4.5 addendum](adr-152-f45-wasm-slicing-addendum.md) | F4.5 wasm slicing 补遗 | 边界微调 |
+| [ADR-153](adr-153-headless-agent-framework-draft.md) | headless agent framework 草案 | dasclaw_runtime 无 HTTP / 无 DB / 无 tenant |
+| [ADR-154](adr-154-jobcontext-core-trait-split.md) | JobContext core trait 拆分 | 拆出最小 trait，桌面 impl 实例化 |
+| [ADR-155](adr-155-f44-orchestrator-landing-decision.md) | F4.4 orchestrator 落点 | 留桌面（架构匹配 + 三方对账无等价） |
+| [ADR-156](adr-156-f46-builtin-tools-landing-decision.md) | F4.6 builtin 工具下沉落点 | tier 切 8 刀，~13073 LoC 下沉，8223 LoC 留桌面 |
+
+**说明**：ADR-128 / ADR-140 编号已废弃（合并入相邻 ADR）。任何后续 F4.7+ 决策按本表延续编号。
+
 ---
 
 ## 4. 新增 / 重构 crate 清单
@@ -322,6 +404,58 @@ flowchart TB
 - 上游 `codex-utils-template` 未被 28 个 *.rs 中任一行 `use`，**故意不 vendor**；如未来上游某 *.rs 新增 `use codex_utils_template::*`，drift script 会失败，按 ADR-136 prep-N 范式增开"Step C2 follow-up PR"vendor `dasclaw_utils_template`。
 - Linux-only target deps（`landlock` / `seccompiler`）由 `crates/dasclaw_protocol/Cargo.toml` `[target.'cfg(target_os = "linux")'.dependencies]` 显式声明（与上游 `codex-cli-main/codex-rs/protocol/Cargo.toml:48-51` 同形）。
 - 任何在 vendored *.rs 中手工 patch 即视为**违反 ADR-129 §1.3 verbatim 红线 + ADR-136 §3 amendment 2**，drift 守卫会 fail。
+
+### 4.6 F4.6 工具壳分层落点（v2.5 新，按 [ADR-156](adr-156-f46-builtin-tools-landing-decision.md)）
+
+`desktop-client/ironclaw/src/tools/builtin/` 共约 50 个内建工具、21505 LoC。按反向依赖 tier 切 8 刀下沉到 8 个新 crate，T3/T4 共 8223 LoC（依赖 orchestrator / agent / channels / db / extensions / skill_registry）留桌面：
+
+| F4.6 子波次 | 新 crate | 工具来源 | LoC | tier |
+|---|---|---|---|---|
+| F4.6.1 | `crates/dasclaw_misc_tools` | echo / time / json / plan_mode / restart / tool_info / session_fork / secrets | ~1900 | T0 |
+| F4.6.2 | `crates/dasclaw_image_tools` | ImageGen / Analyze / Edit | 833 | T0 |
+| F4.6.3 | `crates/dasclaw_memory_tools` | Memory 4 件套 | 974 | T0 |
+| F4.6.4 | `crates/dasclaw_sub_agent_tools` | SubAgent | 400 | T0 |
+| F4.6.5 | `crates/dasclaw_git_tools`（扩充 W1 空壳） | Git 7 + lsp shell | ~1200 | T1 |
+| F4.6.6 | `crates/dasclaw_fs_tools` | File / Patch / Glob / Grep / CodeEdit / path_utils / file_guard | ~3700 | T1 |
+| F4.6.7 | `crates/dasclaw_shell_tools` | Shell + classify_command_risk | 1666 | T2 |
+| F4.6.8 | `crates/dasclaw_net_tools` | Http / WebFetch / WebSearch / html_converter | ~2400 | T1+T2 |
+
+**留桌面 5 类（T3/T4，共 8223 LoC，不下沉）**：
+
+| 模块 | LoC | tier | 留守理由 |
+|---|---|---|---|
+| `extension_tools.rs` | 828 | T3 | 依赖 `desktop-client/extensions` 内部 manager |
+| `skill_tools.rs` | 1322 | T3 | 依赖 `desktop-client/skill_registry` |
+| `job.rs` | 2359 | T4 | 依赖 `desktop-client/orchestrator` |
+| `routine.rs` | 2639 | T4 | 依赖 `desktop-client/agent` + `bootstrap` |
+| `message.rs` | 1075 | T4 | 依赖 `desktop-client/channels` 完整运行时 |
+
+**薄壳化**：F4.6.8 完成后，单独一个 PR 把 `desktop-client/ironclaw/src/tools/builtin/mod.rs`（87 行）改为薄 re-export 壳，全部下沉工具改为 `pub use dasclaw_*_tools::*`，留守 5 类保持本地。
+
+### 4.7 v2.4 蓝图遗漏 crate 补全（v2.5 新）
+
+v2.4 §4.1~§4.3 列了 17 个 P0/P1/P2 crate，但实际 `crates/` 已落地 **45 个** dasclaw_* crate。本节补全 16 个 v2.4 遗漏但已存在的 crate，按字母序：
+
+| crate | 已存在 | 提供 | 与 v2.4 表关系 |
+|---|---|---|---|
+| `crates/dasclaw_absolute_path` | ✅ | 绝对路径规范化（codex port 工具）| P1 补 |
+| `crates/dasclaw_bash_permissions` | ✅ | bash 命令权限校验（与 dasclaw_bash_validation 配对）| P1 补 |
+| `crates/dasclaw_cert_trust` | ✅ | 证书信任链管理（codex 自签 CA 配套）| P2 补 |
+| `crates/dasclaw_channels` | ✅ | F4.5 核心子集（trait + relay + wasm + manager） | F4.5 落地 |
+| `crates/dasclaw_exec` | ✅ | 进程执行子系统（codex exec port） | P0 配套 |
+| `crates/dasclaw_llm_provider` | ✅ | LLM 提供方抽象（OpenAI/Anthropic/Claw provider） | P0 配套 |
+| `crates/dasclaw_process_hardening` | ✅ | 进程加固（ptrace / debugger 检测） | P2 补 |
+| `crates/dasclaw_runtime` | ✅ | headless agent 运行时（ADR-153） | ADR-153 落地 |
+| `crates/dasclaw_sandbox_linux` | ✅ | sandbox Linux 实现（landlock + seccomp） | P0 拆分自 `dasclaw_sandbox` |
+| `crates/dasclaw_sandbox_windows` | ✅ | sandbox Windows 实现（AppContainer） | P0 拆分自 `dasclaw_sandbox` |
+| `crates/dasclaw_sandboxing` | ✅ | sandbox 顶层 dispatcher + policy（codex sandboxing port）| P0 与 `dasclaw_sandbox` 协作 |
+| `crates/dasclaw_shell_command` | ✅ | shell 命令解析（兼容 dasclaw_protocol::parse_command） | P0 配套 |
+| `crates/dasclaw_tool` | ✅ | 工具基础 trait 与 schema（与 dasclaw_protocol::tool_name 协作） | P0 配套 |
+| `crates/dasclaw_utils_home_dir` | ✅ | home 目录解析（dasclaw_protocol::config_types 依赖） | utils slice 补 |
+| `crates/dasclaw_utils_rustls_provider` | ✅ | rustls crypto provider（reqwest TLS 配套） | utils slice 补 |
+| `crates/dasclaw_wasm_tools` | ✅ | WASM 工具加载与执行（OCI 镜像 + WIT 绑定） | P1 补 |
+
+**说明**：以上 16 个 crate 多数在 W2 ~ W6 已落地，仅蓝图条目漏更新。v2.5 补登后蓝图总数 = v2.4 (17) + 本次补 (16) + F4.6 新建 (8) = **41 个 dasclaw_* crate 条目**，加 `ironclaw_auth` / `dasclaw_workspace_cap` / `dasclaw_safety` / `dasclaw_common` / `dasclaw_parsed_command`（已 rename）等保留共 **45+ 条**，与 `crates/` 实际目录一致。
 
 ---
 
@@ -491,3 +625,13 @@ sequenceDiagram
 | ADR 增加 106/107/108/109 | 项目文档协议 / approval+authToken / LSP-MCP IPC / panic hook 三处硬伤 |
 | 决策点扩展到 D7-D10 | 新增补齐项需交互是否接受默认路径 |
 | desktop 外壳清单分“零改动”与“需修隶性保留”两档 | §4 硬伤表：approval polling / authToken 不刷新 |
+
+### 10.1 v2.4 → v2.5 变更日志（2026-05-23）
+
+| 变更 | 原因 |
+|------|------|
+| 新增 §3.2 ADR-111 ~ ADR-156 索引表（约 45 个 ADR） | v2.4 §3 只到 ADR-110，W3 ~ W6 期间落地的所有 ADR 未在蓝图中索引 |
+| §4.4 `orchestrator` 落点确认（留桌面，作废 v2.4 "升级为 dasclaw_*" 承诺） | [ADR-155](adr-155-f44-orchestrator-landing-decision.md) §6：架构匹配 / 三方对账无等价 / 依赖现实 / 代价对称 |
+| 新增 §4.6 F4.6 工具壳分层落点表（8 新 crate + 5 留守） | [ADR-156](adr-156-f46-builtin-tools-landing-decision.md) §6：~13073 LoC 下沉，8223 LoC 留桌面 |
+| 新增 §4.7 v2.4 蓝图遗漏 crate 补全表（16 个） | [41-target-architecture-drift-analysis.md](41-target-architecture-drift-analysis.md) 识别 `crates/` 真实 45 vs 蓝图列 26 的漂移 |
+| §3 ADR 索引 + §4 补全后，crate 蓝图条目数 ≈ 45+，与 `crates/` 实际一致 | 修正 v2.4 蓝图相对实施的 19 个漂移条目 |

--- a/docs/plans/architecture-refactor/40-tool-ecosystem-inventory.md
+++ b/docs/plans/architecture-refactor/40-tool-ecosystem-inventory.md
@@ -1,0 +1,271 @@
+# 40 — 四方工具生态盘点（crates/ vs claude-code-main vs codex-cli-main vs ironclaw-main）
+
+> **生成日期**: 2026-04-30
+> **生成目的**: 为 F4.6 builtin tools 下沉决策提供数据底座；同时回答"哪些工具我们可以不要"
+> **数据来源**: 四方 repo 直接 `ls` + 每个 dasclaw_* crate 的 `lib.rs` 头部注释（明文标注搬运来源）
+> **方法论**: 严格按 AGENTS.md 三层验证规约（semantic_search 失败 → 回退 grep + ls，符合 code-review-graph-usage 坑位 4）
+
+---
+
+## 1. 总数对照
+
+| 来源 | 工具组织方式 | 工具/文件数 | 备注 |
+|---|---|---|---|
+| **crates/** (当前 x-claw) | 45 个 dasclaw_* crate（含底座、工具、运行时） | 工具/能力相关 17 个 | 工具壳层未下沉 |
+| **desktop-client/ironclaw**（当前活跃实现） | `src/tools/builtin/*.rs` 平铺 | 30 文件 + `git/` 9 + `lsp/` 10 | F4.6 真正要搬的源 |
+| **ironclaw-main**（fork 上游） | `src/tools/builtin/*.rs` 平铺 | 27 文件 | desktop 的来源 |
+| **codex-cli-main**（codex 路线） | 双层：`codex-rs/tools/` 24 spec + `codex-rs/core/src/tools/handlers/` 20 handler | 24 + 20 = 44 工件 | 双层架构 |
+| **claude-code-main**（claude-code 参考） | `src/tools/{ToolName}/` TS 子目录 | **43 个工具** | TypeScript，非 Rust 移植目标 |
+
+---
+
+## 2. 当前 crates/ 的 17 个工具/能力 crate 来源（lib.rs 注释明文）
+
+| crate | 行数 | 搬运来源（注释原文摘录） | 角色 |
+|---|---|---|---|
+| `dasclaw_apply_patch` | 1277 | "ported from codex-cli-main/codex-rs/apply-patch" | **底座**：patch 解析与应用 |
+| `dasclaw_shell_command` | 3348 | "shared across Codex crates" | **底座**：shell 解析 + 安全 |
+| `dasclaw_bash_permissions` | 多文件 | "port of upstream bashPermissions.ts (2621 LOC)"（**claude-code TS port**） | **底座**：bash 权限规则 |
+| `dasclaw_bash_validation` | 多文件 | bash 校验子模块（codex/ironclaw 混源） | **底座**：bash 注入检测 |
+| `dasclaw_execpolicy` | - | （drift guard `check_codex_execpolicy_drift.py`）→ codex | **底座**：Starlark 权限规则 |
+| `dasclaw_net_proxy` | - | （drift guard）→ codex `network-proxy` | **底座**：HTTP 代理 + 域名 allowlist |
+| `dasclaw_tool` | 977 | "Tool implementation-layer primitives shared across dasclaw hosts" | **框架**：Tool trait + 错误 + 参数 |
+| `dasclaw_exec` | 687 | "W2.6 整合层" | **底座**：执行整合层 |
+| `dasclaw_git_tools` | 24（空壳） | "fork private cargo, ~1,331 LOC"（**desktop 路线**） | **工具壳**：等 F4.6 填充 |
+| `dasclaw_lsp` | 多文件 | "LSP integration: registry, JSON-RPC client" | **工具壳 + 底座** |
+| `dasclaw_mcp` | 多文件 | "MCP building blocks" | **底座**：MCP transport |
+| `dasclaw_wasm_tools` | 多文件 | "WASM sandbox primitives" | **底座**：WASM 工具沙箱 |
+| `dasclaw_routines` | 1634 | "fork ironclaw 0.24 routines module promotion" | **能力域**：例程编排 |
+| `dasclaw_channels` | - | "fork ironclaw 0.24 channels module promotion" | **能力域**：通道抽象 |
+| `dasclaw_safety` | 大 | "Safety layer for prompt injection defense"（**ironclaw 路线**） | **能力域**：DLP/安全 |
+| `dasclaw_core` | 大 | "agent runtime fork of claw-code" | **L3 Agent Runtime** |
+| `dasclaw_runtime` | 大 | "Application-layer runtime types shared across dasclaw hosts" | **L3 运行时类型** |
+
+**关键观察**：
+- ✅ **底座层完整**：patch 解析、shell 解析、bash 权限/校验、execpolicy、net_proxy 已全部下沉
+- ❌ **工具壳层缺失**：当前 28 个 builtin 工具壳（file.rs / shell.rs / glob_search.rs / grep_search.rs 等）一份都在 desktop-client/ironclaw/src/tools/builtin/，无 crates/ 副本
+- ⚠️ **dasclaw_git_tools 是空壳**：lib.rs 仅 24 行注释，等 F4.6 把 desktop git/ 9 文件 1326 行搬下来
+
+---
+
+## 3. 四方工具明细对照表（按职能分组）
+
+### 类型 I：四方都有 — **框架核心，绝对不能砍**
+
+| 工具职能 | claude-code-main | codex-cli-main | ironclaw-main | desktop（当前） | 砍/留 |
+|---|---|---|---|---|---|
+| 文件读 | FileReadTool | `handlers/list_dir`（间接） | `file.rs` | `file.rs` | ✅ 留 |
+| 文件写 | FileWriteTool | `tools/apply_patch_tool` | `file.rs` | `file.rs` | ✅ 留 |
+| 文件编辑 | FileEditTool | `handlers/apply_patch` | `file.rs` | `code_edit.rs` | ✅ 留 |
+| Shell 执行 | BashTool / PowerShellTool | `handlers/shell` + `unified_exec` | `shell.rs` | `shell.rs` | ✅ 留 |
+| Glob 搜索 | GlobTool | （隐含于 list_dir） | `glob_tool.rs` | `glob_search.rs` | ✅ 留 |
+| Grep 搜索 | GrepTool | `handlers/grep_files` | `grep_tool.rs` | `grep_search.rs` | ✅ 留 |
+| WebFetch | WebFetchTool | （无） | `http.rs` | `http.rs` + `web_fetch.rs` | ✅ 留 |
+
+**小计：7 类**，约 4000-5000 行代码，必须搬到 crates/。
+
+### 类型 II：claude-code + ironclaw 有 — 取决于框架定位
+
+| 工具职能 | claude-code | ironclaw-main | desktop（当前） | 砍/留 |
+|---|---|---|---|---|
+| 计划模式（plan） | EnterPlanModeTool / ExitPlanModeTool | `plan.rs` | `plan_mode.rs` | ✅ 留（ADR-153 agent 能力） |
+| Memory 长期记忆 | （内置 Task 系统） | `memory.rs` | `memory.rs` | ✅ 留 |
+| Tool 自省 | ToolSearchTool | `tool_info.rs` | `tool_info.rs` | ✅ 留 |
+| Web 搜索 | WebSearchTool | （无单独） | `web_search.rs` | ⚠️ 可选（desktop 加的） |
+| LSP | LSPTool | （无） | `lsp/` + `dasclaw_lsp` | ⚠️ 可选 |
+| Skill | SkillTool | `skill_tools.rs` | `skill_tools.rs` | ❌ **砍**（desktop 专属） |
+| 子 Agent | AgentTool / TaskCreateTool | （无单独） | `sub_agent.rs` | ⚠️ 可选 |
+| JSON 操作 | （无） | `json.rs` | `json.rs` | ✅ 留 |
+| 时间工具 | （无） | `time.rs` | `time.rs` | ✅ 留 |
+| Path 工具 | （无） | `path_utils.rs` | `path_utils.rs` | ✅ 留 |
+| Echo（调试） | （无） | `echo.rs` | `echo.rs` | ✅ 留 |
+| HTML 转换 | （无） | `html_converter.rs` | `html_converter.rs` | ⚠️ 可选 |
+
+**小计**：核心 6 类（plan/memory/tool_info/json/time/path）+ 可选 6 类。
+
+### 类型 III：只有 ironclaw 路线有 — **desktop 部署专属，建议留 desktop 不下沉**
+
+| 工具职能 | ironclaw-main | desktop（当前） | 行数 | 是否下沉 |
+|---|---|---|---|---|
+| Job 管理 | `job.rs` | `job.rs` | 2359 | ❌ **留 desktop**（绑 orchestrator，ADR-155 已决定 orchestrator 留 desktop） |
+| 频道消息 | `message.rs` | `message.rs` | 1075 | ❌ **留 desktop**（绑 Tauri channels） |
+| 重启 | `restart.rs` | `restart.rs` | 482 | ❌ **留 desktop**（Tauri 进程概念） |
+| 扩展管理 | `extension_tools.rs` | `extension_tools.rs` | 828 | ❌ **留 desktop**（desktop 形态） |
+| Secrets 检查工具 | `secrets_tools.rs` | `secrets_tools.rs` | 218 | ❌ **留 desktop**（底座 `dasclaw_runtime::secrets` 已搬） |
+| Routines 工具壳 | `routine.rs` | `routine.rs` | 2639 | ⚠️ 看是否搬入 `dasclaw_routines` |
+| 图像分析 | `image_analyze.rs` | `image_analyze.rs` | 257 | ❌ **留 desktop**（云 API） |
+| 图像编辑 | `image_edit.rs` | `image_edit.rs` | 329 | ❌ **留 desktop**（云 API） |
+| 图像生成 | `image_gen.rs` | `image_gen.rs` | 247 | ❌ **留 desktop**（云 API） |
+| Session Fork | （无） | `session_fork.rs` | 173 | ⚠️ 可选 |
+| File Guard | `file_edit_guard.rs` / `file_history.rs` | `file_guard.rs` | 184 | ✅ 留（搬随 file 工具） |
+| System 信息 | `system.rs` | （已并入其他） | - | - |
+
+**小计**：可砍/留 desktop 的有 8 类（job/message/restart/extension/secrets_tools/image_*3），共 ~6795 行。
+
+### 类型 IV：claude-code 独有 — **当前不需要**
+
+| 工具 | 说明 | 砍/留 |
+|---|---|---|
+| TodoWriteTool / TaskCreate/Update/Get/List/Stop/Output | claude-code 任务管理系统（与 ironclaw routines/job 不同形态） | ❌ 全砍 |
+| EnterWorktreeTool / ExitWorktreeTool | git worktree 管理 | ❌ 砍 |
+| TeamCreateTool / TeamDeleteTool | 团队管理 | ❌ 砍 |
+| REPLTool | 交互式 REPL | ❌ 砍 |
+| SleepTool | 等待 | ❌ 砍 |
+| ScheduleCronTool | cron 定时 | ❌ 砍（routines 已覆盖） |
+| RemoteTriggerTool | 远程触发 | ❌ 砍 |
+| SyntheticOutputTool | 测试用 | ❌ 砍 |
+| BriefTool | 简报 | ❌ 砍 |
+| ConfigTool | 配置 | ❌ 砍 |
+| NotebookEditTool | Jupyter notebook | ❌ 砍 |
+| MCPTool / ListMcpResourcesTool / McpAuthTool / ReadMcpResourceTool | MCP 客户端工具（`dasclaw_mcp` 已覆盖底座） | ❌ 砍工具层 |
+| AskUserQuestionTool / SendMessageTool | 用户交互（走 Tauri UI） | ❌ 砍 |
+
+**小计**：14 类工具，**全砍**。
+
+### 类型 V：codex 独有 — **不引入**
+
+| 工具 | 说明 | 砍/留 |
+|---|---|---|
+| `view_image` / `image_detail` | 视觉模型（desktop image_* 已覆盖） | ❌ 砍 |
+| `goal_tool` / `agent_jobs` / `multi_agents_v2` | codex 多 agent 协调（routines + sub_agent 替代） | ❌ 砍 |
+| `code_mode` | codex 代码模式 | ❌ 砍 |
+| `tool_search` / `tool_suggest` | 工具搜索/推荐（desktop `tool_info.rs` 覆盖） | ❌ 砍 |
+| `request_user_input` / `request_permissions` | 用户交互（走 Tauri UI） | ❌ 砍 |
+| `dynamic_tool` | 动态工具加载 | ⚠️ 选择性引入（未来需要时） |
+| `mcp_resource_tool` | MCP 资源（dasclaw_mcp 覆盖底座） | ❌ 砍工具层 |
+
+**小计**：8 类，**全砍**（dynamic_tool 待评估）。
+
+---
+
+## 4. F4.6 真正要搬的工具清单
+
+按"无头 agent 框架最小必要集"汇总（类型 I + 类型 II 核心）：
+
+| # | 工具文件 | desktop 当前位置 | 推荐目标 crate | 行数估算 |
+|---|---|---|---|---|
+| 1 | `file.rs` | builtin/ | `dasclaw_builtin_fs`（新） | 956 |
+| 2 | `code_edit.rs` | builtin/ | `dasclaw_builtin_fs` | 438 |
+| 3 | `file_guard.rs` | builtin/ | `dasclaw_builtin_fs` | 184 |
+| 4 | `path_utils.rs` | builtin/ | `dasclaw_builtin_fs` | 737 |
+| 5 | `glob_search.rs` | builtin/ | `dasclaw_builtin_search`（新或并入 fs） | 331 |
+| 6 | `grep_search.rs` | builtin/ | `dasclaw_builtin_search` | 405 |
+| 7 | `shell.rs` | builtin/ | **填充 `dasclaw_shell_command` 子模块** | 1666 |
+| 8 | `json.rs` | builtin/ | `dasclaw_builtin_data`（新或合并） | 288 |
+| 9 | `time.rs` | builtin/ | `dasclaw_builtin_data` | 594 |
+| 10 | `memory.rs` | builtin/ | `dasclaw_builtin_agent`（新） | 974 |
+| 11 | `plan_mode.rs` | builtin/ | `dasclaw_builtin_agent` | 276 |
+| 12 | `tool_info.rs` | builtin/ | `dasclaw_builtin_agent` | 297 |
+| 13 | `echo.rs` | builtin/ | `dasclaw_builtin_agent` | 48 |
+| 14 | `git/` 9 文件 | builtin/git/ | **填充 `dasclaw_git_tools`**（已是空壳 24 行） | 1326 |
+| 15 | `http.rs`（可选） | builtin/ | `dasclaw_builtin_net`（新） | 1513 |
+| 16 | `web_fetch.rs`（可选） | builtin/ | `dasclaw_builtin_net` | 366 |
+| 17 | `web_search.rs`（可选） | builtin/ | `dasclaw_builtin_net` | 552 |
+| 18 | `html_converter.rs`（可选） | builtin/ | `dasclaw_builtin_net` | 128 |
+| 19 | `sub_agent.rs`（可选） | builtin/ | `dasclaw_builtin_agent` | 400 |
+| 20 | `session_fork.rs`（可选） | builtin/ | `dasclaw_builtin_agent` | 173 |
+| 21 | `routine.rs`（可选） | builtin/ | **填充 `dasclaw_routines`** | 2639 |
+| 22 | `lsp/` 10 文件（可选） | builtin/lsp/ | **填充 `dasclaw_lsp`** | ~1700 |
+
+**汇总**：
+- **核心必搬**：14 类（含 git/），约 **8520 行**
+- **可选搬**：8 类，约 **7471 行**
+- **总计 F4.6 工作量**：~16000 行（按"全部下沉"上限估算）
+
+---
+
+## 5. 留在 desktop-client 不下沉的清单
+
+| # | 工具文件 | 行数 | 不下沉理由 |
+|---|---|---|---|
+| 1 | `job.rs` | 2359 | 绑 orchestrator，ADR-155 决定 orchestrator 留 desktop |
+| 2 | `message.rs` | 1075 | 绑 Tauri channels |
+| 3 | `restart.rs` | 482 | Tauri 进程概念 |
+| 4 | `skill_tools.rs` | 1322 | desktop 专属 skill 系统 |
+| 5 | `extension_tools.rs` | 828 | desktop 部署形态 |
+| 6 | `secrets_tools.rs` | 218 | 底座已搬 `dasclaw_runtime::secrets`，工具壳是 desktop 设置 UI 用 |
+| 7 | `image_analyze.rs` | 257 | 云 API 调用，desktop 场景 |
+| 8 | `image_edit.rs` | 329 | 云 API 调用 |
+| 9 | `image_gen.rs` | 247 | 云 API 调用 |
+
+**小计**：9 类，**~7117 行留 desktop**。
+
+---
+
+## 6. 不引入的清单（节省工作量）
+
+| 来源 | 不引入工具数 | 理由 |
+|---|---|---|
+| claude-code-main | 14 类（todo/team/worktree/repl/sleep/cron 等） | TS 实现 + 非框架核心 |
+| codex-cli-main | 8 类（goal/multi_agents_v2/code_mode/tool_search 等） | ironclaw 路线已有等价 |
+| ironclaw-main | 0 类（fork 上游 = 我们的当前实现） | 是我们的来源 |
+
+**节省工作量**：避免移植约 **20+ 类工具**，节省 ~10000+ 行评估/移植成本。
+
+---
+
+## 7. 关键发现 & 决策待定
+
+### 7.1 底座层 vs 工具壳层
+
+- ✅ **底座完整**：apply_patch / shell_command / bash_perms / bash_valid / execpolicy / net_proxy / mcp / lsp 全部 7 类底座已在 crates/
+- ❌ **工具壳缺失**：28 个 builtin 工具壳一份都在 desktop-client/，没有 crates/ 副本
+
+### 7.2 三方 fork 路线对比
+
+| 路线 | desktop 当前形态 |
+|---|---|
+| **ironclaw 平铺**（`builtin/*.rs`）| ✅ desktop 沿用 |
+| **codex 双层**（spec + handlers 分离）| ❌ desktop 未采用 |
+| **claude-code 子目录**（`{Tool}/`）| ❌ TypeScript 非移植目标 |
+
+### 7.3 ADR-129 §1.3 verbatim port 红线在 F4.6 的歧义
+
+- verbatim 要求："搬到 crates 时不能借机简化或重构"
+- F4.6 实际要做："从单一 `src/tools/builtin/` 拆成多 crate（fs/shell/git/net/agent...）"
+- **结构性重构 vs verbatim** 需要 ADR addendum 论证
+
+### 7.4 待决策事项（移交给用户）
+
+| # | 决策点 | 选项 |
+|---|---|---|
+| Q1 | 拆几个 crate？ | A) 单一 `dasclaw_builtin_tools` / B) 按职能 4-5 个（fs/shell/git/net/agent） / C) codex 双层（spec + handlers） |
+| Q2 | 和已有底座如何并列？ | A) shell.rs 进 `dasclaw_shell_command` 子模块 / B) 新建 `dasclaw_builtin_shell` 并列 |
+| Q3 | git/ 9 文件填 `dasclaw_git_tools` 空壳？ | 推荐 ✅ |
+| Q4 | F4.6 vs F4.2.1+ 优先级？ | 待定 |
+| Q5 | 类型 III 9 类全留 desktop？ | 推荐 ✅ |
+| Q6 | 类型 IV / V 全不引入？ | 推荐 ✅ |
+
+---
+
+## 8. 数据采集方法（透明度）
+
+```bash
+# crates/ 来源
+for crate in crates/dasclaw_*; do
+  head -8 "$crate/src/lib.rs" | grep -E '^//'
+done
+
+# claude-code-main 工具数
+ls claude-code-main/src/tools/ | wc -l  # → 43 子目录
+
+# codex 双层
+ls codex-cli-main/codex-rs/tools/src/*.rs | wc -l  # → 24 spec
+ls codex-cli-main/codex-rs/core/src/tools/handlers/*.rs | wc -l  # → 20 handler
+
+# ironclaw-main 工具
+ls ironclaw-main/src/tools/builtin/*.rs | wc -l  # → 27
+
+# desktop 当前
+ls desktop-client/ironclaw/src/tools/builtin/*.rs | wc -l  # → 30 (+ git/9 + lsp/10)
+```
+
+三层验证补充：`mcp_code-review-g_cross_repo_search_tool` 因 embeddings=0 不可用，按 code-review-graph-usage 坑位 4 回退到 grep + ls，符合 AGENTS.md 三层规约。
+
+---
+
+## 9. 维护说明
+
+- 本文档是 **F4.6 决策的事实底座**，每次新增/删除/改名工具时同步更新
+- 如未来出现新的 fork 源，按"四方对照表"扩列
+- F4.6 ADR 写完后，本文档对应小节加链接交叉引用

--- a/docs/plans/architecture-refactor/41-target-architecture-drift-analysis.md
+++ b/docs/plans/architecture-refactor/41-target-architecture-drift-analysis.md
@@ -1,0 +1,234 @@
+# 41 — 当前现状 vs 31-target-architecture.md 漂移分析
+
+> **生成日期**: 2026-04-30
+> **对照文档**: [31-target-architecture.md](31-target-architecture.md) v2.4 (2026-04-26)
+> **当前 base**: `origin/xClaw` @ commit `f0c1750c`（PR #751 ADR-155 已合并）
+> **目的**: 识别蓝图与实际仓库的差距，判断 31 文档是否需要升级到 v2.5
+
+---
+
+## 1. TL;DR — 31 文档落后明显
+
+**结论**: 31-target-architecture.md v2.4 写于 2026-04-26，距今已实际推进 4-5 天密集开发，**蓝图存在 3 类漂移**：
+
+1. **蓝图遗漏 16 个 crate**：crates/ 实际有 45 个，蓝图只覆盖 26 个，漏了 16 个真实存在的 crate
+2. **2 个蓝图 crate 未建**：`dasclaw_bridge_lite`、`dasclaw_common` 仍是 MISSING
+3. **工具壳层下沉规划缺失**：蓝图 L4 提了"dasclaw_tools"概念但未细化，F4.6（builtin 工具壳下沉）未在 §4 crate 清单中显式建模
+
+---
+
+## 2. 蓝图 P0/P1/P2 落地情况（24 个 crate）
+
+### 2.1 P0 必做（蓝图列 7 个）
+
+| crate | 状态 | 备注 |
+|---|---|---|
+| `dasclaw_core` | ✅ 已建 | x_claw_agent 升级，agentic_loop 已 port |
+| `dasclaw_bridge_lite` | ❌ **MISSING** | 蓝图核心 P0 缺口 |
+| `dasclaw_sandbox` | ✅ 已建 | + `dasclaw_sandbox_linux` / `dasclaw_sandbox_windows` / `dasclaw_sandboxing` |
+| `dasclaw_hooks` | ✅ 已建 | F3.x 完成 |
+| `dasclaw_apply_patch` | ✅ 已建 | 1277 行（codex port） |
+| `dasclaw_project_docs` | ✅ 已建 | |
+| `dasclaw_pty` | ✅ 已建 | |
+
+**P0 完成度**: 6/7 = **86%**（缺 `dasclaw_bridge_lite`）
+
+### 2.2 P1 推荐（蓝图列 7 个）
+
+| crate | 状态 | 备注 |
+|---|---|---|
+| `dasclaw_governance` | ✅ 已建 | |
+| `dasclaw_mcp` | ✅ 已建 | |
+| `dasclaw_execpolicy` | ✅ 已建 | |
+| `dasclaw_bash_validation` | ✅ 已建 | |
+| `dasclaw_lsp` | ✅ 已建 | 但 builtin/lsp/ 工具壳未下沉 |
+| `dasclaw_git_tools` | ⚠️ 空壳 | lib.rs 仅 24 行，等 F4.6 |
+| `dasclaw_routines` | ✅ 已建 | F4.2.0 PR #729 完成 1566 行 |
+
+**P1 完成度**: 6.5/7 = **93%**（`dasclaw_git_tools` 是空壳）
+
+### 2.3 P2 增强（蓝图列 5 个）
+
+| crate | 状态 | 备注 |
+|---|---|---|
+| `dasclaw_features` | ✅ 已建 | |
+| `dasclaw_observability` | ✅ 已建 | |
+| `dasclaw_identity` | ✅ 已建 | |
+| `dasclaw_crash` | ✅ 已建 | |
+| `dasclaw_net_proxy` | ✅ 已建 | drift guard `check_codex_net_proxy_drift.py` 已挂 |
+
+**P2 完成度**: 5/5 = **100%**
+
+### 2.4 蓝图 §4.4 已存在保留（4 个）
+
+| crate | 状态 |
+|---|---|
+| `ironclaw_auth` | ✅ 存在 |
+| `dasclaw_workspace_cap` | ✅ 存在 |
+| `dasclaw_safety`（升级自 `ironclaw_safety`） | ✅ 已升级 |
+| `dasclaw_common`（升级自 `ironclaw_common`） | ❌ **MISSING** — 升级未完成 |
+
+---
+
+## 3. 蓝图遗漏的 16 个 crate（**重大落后**）
+
+实际 crates/ 存在但 31 §4 完全未提及：
+
+| crate | 推断角色 | 来源 |
+|---|---|---|
+| `dasclaw_absolute_path` | 路径工具 | 底座 |
+| `dasclaw_bash_permissions` | bash 权限规则 | **port from claude-code TS bashPermissions.ts** |
+| `dasclaw_cert_trust` | 证书信任 | 底座 |
+| `dasclaw_channels` | 通道抽象 | fork ironclaw 0.24 channels 提升 |
+| `dasclaw_exec` | 执行整合 | W2.6 整合层 |
+| `dasclaw_llm_provider` | LLM provider 抽象 | 新建 |
+| `dasclaw_process_hardening` | 进程加固 | 底座 |
+| `dasclaw_runtime` | 应用层运行时类型 | **核心** — 蓝图未列是重大遗漏 |
+| `dasclaw_sandbox_linux` | Linux landlock | 蓝图说"dasclaw_sandbox"，实际拆了三平台 crate |
+| `dasclaw_sandbox_windows` | Windows JobObject | 同上 |
+| `dasclaw_sandboxing` | 沙箱抽象层 | 同上 |
+| `dasclaw_shell_command` | shell 解析 + 安全 | **底座** — 蓝图说"L4 TOOLS"但 crate 边界未画 |
+| `dasclaw_tool` | Tool trait 框架 | 框架层 |
+| `dasclaw_utils_home_dir` | home_dir 工具 | utils |
+| `dasclaw_utils_rustls_provider` | rustls 适配 | utils |
+| `dasclaw_wasm_tools` | WASM 沙箱 | F4.5 部分完成 |
+
+**判断**: 这 16 个 crate **不是"违规建出来的"**，而是蓝图写得过于抽象（只画了 L4 概念图，没把每个能力 crate 列详细）。实际工程上要把"能力域"拆成可独立测试编译的 crate，自然就比蓝图细化得多。
+
+---
+
+## 4. 蓝图 ADR-101 与 F4 实际推进的关系
+
+### 蓝图描述（§3 ADR-101）
+
+> "以 `crates/x_claw_agent`（已完成 LoopDelegate Route B）为起点升级为 `dasclaw_core`；上游 ironclaw-main 0.26 的关键模块（gate/ bridge/ auth/ ownership/）逐项移植到 dasclaw_* 子 crate"
+>
+> 调整后工量：**4-6 周**
+
+### 实际推进（截至今日）
+
+- ✅ ADR-152 §3 把吸收式重构拆成 F1-F6 六个子波次
+- ✅ F1-F3 已完成（命名翻转 / 类型迁移 / 工具子集）
+- ⚠️ F4 进行中：F4.0/F4.1/F4.2/F4.3/F4.4/F4.5 部分完成，**F4.6 未启动**
+- ❌ **F4.6 builtin 工具壳下沉**在蓝图中完全没单独建模（蓝图只在 L4 画了"dasclaw_tools"概念框）
+
+**判断**: 蓝图 §3 ADR-101 的"4-6 周"估算可能略低估，因为 F4.6 单独的工作量（~16000 行工具壳）蓝图没单独算账。
+
+---
+
+## 5. ADR-155（最新）vs 蓝图 §10 ADR 清单
+
+蓝图 §3 ADR 清单截止 ADR-110，**ADR-111 到 ADR-155 共 45 个新 ADR** 蓝图完全没纳入。
+
+最近 5 个关键 ADR 对蓝图的影响：
+
+| ADR | 决策 | 是否影响蓝图 |
+|---|---|---|
+| ADR-152 | F4 子波次拆分（F4.0-F4.6） | ✅ 蓝图 ADR-101 落地路径细化 |
+| ADR-153 | headless agent 框架强制（dasclaw_runtime 不能有 HTTP/DB/tenant） | ✅ **重大**：蓝图 L3 边界更严格 |
+| ADR-114 | `.ironclaw` → `.dasclaw` 命名迁移 | ✅ 蓝图未提 |
+| ADR-129 §1.3 | verbatim port 红线 | ✅ 蓝图未提 |
+| ADR-155 | orchestrator 留 desktop（不迁 crates/） | ✅ **重大**：蓝图 L2-L3 边界明确化 |
+
+---
+
+## 6. 蓝图明确落后的 4 处具体内容
+
+### 6.1 L4 能力域 `dasclaw_tools` 概念过时
+
+蓝图 §1 图把所有 builtin 工具都画在 `dasclaw_tools` 一个 crate 里，但实际工程要做的是：
+
+- ✅ 底座（`dasclaw_apply_patch` / `dasclaw_shell_command` / `dasclaw_bash_*` / `dasclaw_execpolicy`）已下沉
+- ❌ 工具壳层（28 个 builtin *.rs）尚未下沉，F4.6 待启动
+- ❓ 工具壳是否拆成多个 `dasclaw_builtin_*` crate 还是塞进单一 crate 未定（见 40 文档 §7.4 Q1）
+
+### 6.2 §4 crate 清单需要从 24 扩到 ~45
+
+蓝图 §4.1/4.2/4.3 表格需要重写，加入：
+
+- 9 个新 crate（runtime / tool / exec / shell_command / bash_permissions / channels / wasm_tools 等）
+- 三平台 sandbox 拆分细节（sandbox_linux / sandbox_windows / sandboxing）
+- F4.6 工具壳相关新 crate（待 F4.6 ADR 决策后填）
+
+### 6.3 §5 desktop-client 客户端外壳清单需要更新
+
+蓝图 §5.1 "零改动保留" 列了 9 项，但 ADR-155 又新增了：
+
+- **orchestrator 5 个文件**（agent_orchestrator.rs / orchestration_executor.rs / orchestrator_state.rs / orchestrator_commands.rs / orchestrator_runtime.rs）明确留 desktop
+- **builtin 工具中类型 III 9 项**（job/message/restart/extension/secrets_tools/image_*3 + skill_tools）建议留 desktop（见 40 文档 §5）
+
+### 6.4 §8 待用户决策点 D1-D10 进展未更新
+
+蓝图列了 10 个决策点 D1-D10，但实际推进中：
+
+- D1（dasclaw_core 合并）→ ✅ 已落地（agentic_loop port）
+- D2（fork 处理）→ ✅ ADR-105 v2.3 已定（保留 fork 至 W6+）
+- D5（命名前缀）→ ✅ 已定 dasclaw_*
+- D7（AGENTS.md 优先级）→ ✅ ADR-106 已落地
+- D8（Approval 推送）→ ❓ 未推进
+- D9（crash 后端）→ ❓ 未推进
+- D10（bash_validation 独立）→ ✅ 已落地
+
+蓝图 §8 应该把已落地的标记为 done，未推进的转给后续 ADR。
+
+---
+
+## 7. 重大落后判定
+
+| 维度 | 落后程度 | 影响 |
+|---|---|---|
+| crate 数量遗漏 | 🔴 严重（16/45 = 35% 漏列） | 后人按蓝图找 crate 会找不到 |
+| ADR 清单时效性 | 🔴 严重（缺 45 个新 ADR） | 蓝图 §3 已不能反映完整决策史 |
+| 工具壳下沉规划 | 🟡 中等（L4 概念过时） | F4.6 启动前必须补 |
+| desktop 留守清单 | 🟡 中等（缺 orchestrator + 类型 III 9 项） | 但 ADR-155 已独立记录 |
+| L3/L4 边界定义 | 🟡 中等（ADR-153 比蓝图更严） | ADR-153 是 source of truth |
+| 整体架构图 | 🟢 基本可用 | mermaid 图大方向仍正确 |
+
+---
+
+## 8. 建议处理方式
+
+### 选项 A：发布 31 v2.5（推荐）
+
+- 把蓝图从 v2.4 升级到 v2.5
+- §4 crate 清单从 24 扩到 ~45（按 P0/P1/P2 + utils + builtin 五档分类）
+- §3 ADR 清单加 ADR-111~155 索引（不复制全文，只列标题+链接）
+- §5 desktop 保留清单加 orchestrator + 类型 III 9 项
+- §8 决策点 D1-D10 标记进展（done/pending）
+- 新增 §11 F4.6 builtin 工具壳下沉规划（待 F4.6 ADR 落地后回填）
+
+**工作量**: 1 个 PR，~300 行文档改动，半天完成
+
+### 选项 B：写 31 增量补丁 ADR
+
+- 不动 31 v2.4 主体
+- 新建 ADR-156（如）"31 蓝图增量更新：crate 清单 + F4.6 规划"
+- 把蓝图缺口写进增量 ADR
+
+**工作量**: 同 A，但分割文档维护成本更高
+
+### 选项 C：先做 F4.6 决策 ADR，再统一升级 31 v2.5
+
+- 先开 F4.6 落点决策 ADR（类似 ADR-155 形态）
+- F4.6 决策定下来后，把"工具壳下沉规划"和"crate 数量补全"一起写进 31 v2.5
+
+**工作量**: 同 A，但顺序更稳
+
+---
+
+## 9. 推荐顺序
+
+1. **先做选项 C 第一步**：开 F4.6 落点决策 ADR（解决 Q1-Q3 见 40 文档 §7.4）
+2. **F4.6 ADR 合并后**：升级 31 v2.5（按选项 A）
+3. **后续**：F4.6 实施开始（按新 ADR 拆切片 PR）
+
+---
+
+## 10. 三层验证证据
+
+- ✅ `ls -d crates/dasclaw_*` 取 45 个 crate 真实清单
+- ✅ 蓝图 §4 列表用 grep 提取并比对
+- ✅ `head -8 crates/*/src/lib.rs` 验每个 crate 来源注释
+- ✅ ADR-155 PR #751 commit `f0c1750c` 已合并验证
+- ✅ AGENTS.md 三层规约：semantic_search → vscode_listCodeUsages → grep，本次第一层因 embeddings=0 失败已回退 grep
+- ✅ ADR-114 类 A 守卫：本文档不含 `.ironclaw` / `IRONCLAW_BASE_DIR` 新增字面量

--- a/docs/plans/architecture-refactor/adr-152-agent-and-capability-fusion.md
+++ b/docs/plans/architecture-refactor/adr-152-agent-and-capability-fusion.md
@@ -84,9 +84,9 @@
 - **F4.1**：F3.6 收尾——删 desktop 端 `context/mod.rs`、`agent/context_monitor.rs` 两个薄壳，约 130 处调用方 import 重写。
 - **F4.2**：`routines` 实搬——填充 `dasclaw_routines`（当前为 W1 空壳，24 行 trait skeleton），把 desktop `routines/` 的 8.7K LoC verbatim 搬入。
 - **F4.3**：`secrets` 桌面薄壳清理——约 60 处调用方 import 改写。
-- **F4.4**：`orchestrator` 落点决策 + 搬迁（3.3K LoC）。需补 ADR 决定落点（候选：`dasclaw_runtime::orchestrator` 或新 crate）。
+- **F4.4**：`orchestrator` 落点已按 [ADR-155](adr-155-f44-orchestrator-landing-decision.md) 决议为"留在 `desktop-client/ironclaw/src/orchestrator/`"，作为桌面后端独占模块，**不搬到 crates/**。原"必须搬（3.3K LoC）"条款作废，理由见 ADR-155 §6（架构匹配 / 三方对账无等价 / 依赖现实 / 代价对称）。
 - **F4.5**：`channels` 拆分——抽核心子集（trait + relay + wasm + manager）到新 crate，REPL/HTTP/Signal/Webhook/Web/Telegram 留 ironclaw。
-- **F4.6+**：`tools/builtin` 分批搬（21.5K LoC、28 工具，建议 6-8 刀按职能分组）。
+- **F4.6**：`tools/builtin` 按 [ADR-156](adr-156-f46-builtin-tools-landing-decision.md) 决议切 8 刀下沉（21505 LoC、约 50 工具实际盘点），分子波次 F4.6.1 ~ F4.6.8，下沉到 `crates/dasclaw_{misc,image,memory,sub_agent,git,fs,shell,net}_tools`，下沉 ~13073 LoC；T3/T4 共 8223 LoC（Extension/Skill/Job/Routine/Message 5 类工具）留桌面。原"建议 6-8 刀按职能分组"条款细化为 ADR-156 §6 的反向依赖 tier 切分。
 - **不纳入 F4**：`import/openclaw`（桌面端历史数据迁移工具，非 headless 核心）。
 
 每个子波次单独 PR、单独可 revert，按 ADR-129 §1.3 verbatim 红线推进。

--- a/docs/plans/architecture-refactor/adr-156-f46-builtin-tools-landing-decision.md
+++ b/docs/plans/architecture-refactor/adr-156-f46-builtin-tools-landing-decision.md
@@ -1,0 +1,401 @@
+# ADR-156：F4.6 builtin 工具下沉落点决策
+
+- 状态：Proposed
+- 提案人：Coding Agent（基于 ADR-152 §3 F4.6 留空条款 + ADR-153 无头 agent 框架定位 + 40/41 文档现状盘点）
+- 关联：ADR-152（agent and capability fusion）§3 阶段 F4 / §11.9 / ADR-153（headless agent framework）§4.2 / ADR-129（verbatim port mandate）§1.3 / ADR-155（F4.4 orchestrator 落点决策，模板与对账方法参考）
+- 时间：2026-05-22
+
+---
+
+## 1. 背景
+
+ADR-152 §3 阶段 F4 条款写到：
+
+> **F4.6+**：`tools/builtin` 分批搬（21.5K LoC、28 工具，建议 6-8 刀按职能分组）。
+
+也就是说 F4.6 在 ADR-152 落笔时同样是一个**显式留空的占位**，要求后续单独 ADR 决定怎么分组、落到哪个 crate、按什么节奏切 PR。本 ADR 就是来填这个坑的。
+
+补充背景：
+
+- F4.4（ADR-155）已完成，orchestrator 决策为"留桌面"
+- F4.5（ADR-152-f45 + 附录）已完成，`dasclaw_wasm_tools` 已建并切流量
+- 40-tool-ecosystem-inventory.md 已盘点四方来源，确认 builtin 是 desktop 独有的最大未下沉资产
+- 41-target-architecture-drift-analysis.md 已识别 31 蓝图 v2.4 在 F4.6 上完全留白
+
+## 2. builtin 现状到底是什么
+
+读完 `desktop-client/ironclaw/src/tools/builtin/` 全部 35 个 `.rs` 文件、共 21505 行后的真实清单：
+
+### 2.1 工具数量与体量
+
+| 维度 | 数值 |
+|------|------|
+| 总文件数 | 35 个 `.rs` |
+| 总行数 | 21505 LOC |
+| 工具数 | 约 50 个（按 `pub use Xxx, Yyy, Zzz` 展开后） |
+| ADR-152 §3 原估 | 28 工具 / 21.5K LOC |
+| 实际差异 | 工具数被低估约 1.8 倍，LOC 估计精准 |
+
+### 2.2 按文件体量排序的工具
+
+| 文件 | 行数 | 工具职能 |
+|------|------|---------|
+| `routine.rs` | 2639 | EventEmit / RoutineCreate / RoutineDelete / RoutineFire / RoutineHistory / RoutineList / RoutineUpdate |
+| `job.rs` | 2359 | CancelJob / CreateJob / JobEvents / JobPrompt / JobStatus / ListJobs |
+| `shell.rs` | 1666 | Shell（含 `classify_command_risk`）|
+| `http.rs` | 1513 | Http |
+| `skill_tools.rs` | 1322 | SkillInstall / SkillList / SkillRemove / SkillSearch |
+| `message.rs` | 1075 | Message |
+| `memory.rs` | 974 | MemoryRead / MemorySearch / MemoryTree / MemoryWrite |
+| `file.rs` | 956 | ApplyPatch / ListDir / ReadFile / WriteFile |
+| `extension_tools.rs` | 828 | ExtensionInfo / ToolActivate / ToolAuth / ToolInstall / ToolList / ToolRemove / ToolSearch / ToolUpgrade |
+| `path_utils.rs` | 737 | path 校验工具集（被多个工具复用）|
+| `time.rs` | 594 | Time |
+| `web_search.rs` | 552 | WebSearch |
+| `restart.rs` | 482 | Restart |
+| `code_edit.rs` | 438 | CodeEdit |
+| `grep_search.rs` | 405 | GrepSearch |
+| `sub_agent.rs` | 400 | SubAgent |
+| `web_fetch.rs` | 366 | WebFetch |
+| `glob_search.rs` | 331 | GlobSearch |
+| `image_edit.rs` | 329 | ImageEdit |
+| `tool_info.rs` | 297 | ToolInfo |
+| `json.rs` | 288 | Json |
+| `plan_mode.rs` | 276 | PlanMode |
+| `image_analyze.rs` | 257 | ImageAnalyze |
+| `image_gen.rs` | 247 | ImageGenerate |
+| `secrets_tools.rs` | 218 | SecretDelete / SecretList |
+| `git/` 子目录 | 1185 | GitBranch / GitCommit / GitDiff / GitLog / GitPush / GitStaleCheck / GitStatus（7 个工具）|
+| `file_guard.rs` | 184 | 内部辅助 |
+| `session_fork.rs` | 173 | SessionFork |
+| `html_converter.rs` | 128 | 内部辅助（`convert_html_to_markdown`）|
+| `lsp/mod.rs` | 10 | LspQueryTool（已是薄壳，真正实现在 dasclaw_lsp）|
+| `echo.rs` | 48 | Echo（demo）|
+| `mod.rs` | 87 | re-export 入口 |
+
+### 2.3 反向依赖矩阵
+
+对全部 35 个文件做 `use crate::` 扫描，按反向依赖目标分类：
+
+| 反向依赖目标 | 命中次数 | 命中文件 |
+|--------------|----------|----------|
+| `tools::tool::` | 30 个文件 | 几乎所有（已对应 `dasclaw_tool`）|
+| `tools::builtin::path_utils::` | 5 个文件 | code_edit / file / file_guard / glob_search / grep_search / image_analyze / image_edit |
+| `tools::wasm::` | 1 个文件 | http.rs（已对应 `dasclaw_wasm_tools`）|
+| `tools::registry::` | 1 个文件 | tool_info.rs |
+| `sandbox::` | 1 个文件 | shell.rs |
+| `safety::` | 1 个文件 | http.rs |
+| `workspace::` | 2 个文件 | file.rs / memory.rs |
+| `channels::` | 2 个文件 | job.rs / message.rs |
+| `db::` | 2 个文件 | job.rs / routine.rs |
+| `bootstrap::dasclaw_base_dir` | 2 个文件 | job.rs / message.rs |
+| `extensions::` | 2 个文件 | extension_tools.rs / message.rs |
+| `orchestrator::` | 2 个文件 | job.rs |
+| `agent::routine*::` | 2 个文件 | routine.rs |
+| `skills::` | 2 个文件 | skill_tools.rs |
+| `history::` | 1 个文件 | job.rs |
+
+**对已下沉 crates 的依赖**（健康信号）：
+
+- `dasclaw_runtime::secrets::SecretsStore` × 3
+- `dasclaw_runtime::context::ContextManager` × 1
+- `dasclaw_runtime::{JobState, JobContextCore}` × 2
+- `dasclaw_bash_validation::{PermissionMode, ...}` × 2
+- `ironclaw_common::*` × 1（job.rs）
+
+### 2.4 按反向依赖耦合度的工具分组（关键洞察）
+
+按 §2.3 矩阵，把 35 个文件按"反向依赖深度"切成 5 个 tier：
+
+| Tier | 文件数 | LOC | 反向依赖特征 |
+|------|--------|-----|--------------|
+| **T0 几乎无 desktop 依赖** | 12 | ~3400 | 只 use `tools::tool::`（已是 `dasclaw_tool`）+ 自包含 |
+| **T1 仅依赖 builtin 内** | 7 | ~3400 | 只 use `tools::tool::` + `tools::builtin::path_utils::` |
+| **T2 依赖已下沉模块** | 3 | ~3200 | 依赖 sandbox / safety / wasm_tools（均已 crates 化）|
+| **T3 依赖 desktop 服务皮** | 5 | ~3600 | 依赖 workspace / channels / db / extensions（desktop 独占）|
+| **T4 强依赖桌面后端** | 3 | ~7900 | job.rs / routine.rs / message.rs：依赖 orchestrator / agent::routine / history / db / channels |
+
+T0+T1+T2 = 22 文件 / ~10000 LOC：**短期可下沉**。
+T3 = 5 文件 / ~3600 LOC：**需逐个评估是否下沉对应服务**。
+T4 = 3 文件 / ~7900 LOC：**短期不可下沉**，与 orchestrator 同属"桌面后端独占"。
+
+## 3. 三方对账：codex / claw-code 有没有同类能力
+
+按 AGENTS.md 任务启动 4 问（涉及跨项目对账），必须三层验证。本 ADR 引用 40-tool-ecosystem-inventory.md §3 表格的已验证结论：
+
+| 工具能力 | claude-code | codex | ironclaw 现状 |
+|---------|-------------|-------|---------------|
+| 文件读写（Read/Write/Edit/ApplyPatch）| ✅ | ✅ | ✅ |
+| Bash/Shell 执行 | ✅ | ✅ | ✅ |
+| Glob / Grep 搜索 | ✅ | ✅ | ✅ |
+| WebFetch / WebSearch | ✅ | ✅（plan_tool）| ✅ |
+| LSP 查询 | ❌ | ❌ | ✅（已薄壳指向 `dasclaw_lsp`）|
+| Git 7 工具集 | ❌（用 Bash）| ❌（用 Bash）| ✅（已部分搬到 `dasclaw_git_tools` 空壳）|
+| Routine / Job / Message 系列 | ❌ | ❌ | ✅（ironclaw 独有的多任务编排）|
+| Skill 工具集 | ❌（claude-code 是 .md skill 不是工具）| ❌ | ✅ |
+| Extension 工具集 | ❌ | ❌ | ✅ |
+| Memory 4 工具 | ❌ | ❌ | ✅ |
+| Image Gen / Analyze / Edit | ✅（部分）| ✅（部分）| ✅ |
+| Plan Mode | ❌ | ✅ | ✅ |
+| Sub Agent / Session Fork | ❌ | ✅（task tool）| ✅ |
+
+**结论**：
+
+- 文件/搜索/网络/shell 类基础工具，三方都有但实现各异——**不能换 codex/claw-code 代码**，按 ADR-129 §1.3 verbatim 红线只能搬 ironclaw 自己的实现
+- LSP / Git 工具集 / Routine / Job / Message / Skill / Extension / Memory **是 ironclaw 独有**，搬迁路径只能在 ironclaw 内部摆放
+- 这进一步证实 F4.6 不是"融合三方"工作，而是"重排 ironclaw 内部 path 依赖"工作
+
+## 4. 关键判断：F4.6 的真正目标是什么
+
+回到 ADR-153 §4.2 的无头 agent 最小可用形态：
+
+```rust
+let agent = Agent::builder()
+    .llm(llm)
+    .workspace(std::env::current_dir()?)
+    .tools_default()
+    .hooks_default()
+    .build()?;
+```
+
+`.tools_default()` 的语义是"给 agent 一组开箱即用的工具"。如果这组工具仍然耦合 desktop 的 `channels / db / orchestrator / history`，那 `Agent::builder()` 就**没法在 dasclaw_cli 或第三方进程中实例化**——因为引入 `dasclaw_runtime` 等于拖上整个桌面后端。
+
+**F4.6 的真正目标**：把 builtin 工具按反向依赖切成两堆——
+
+- **A 堆**：无头 agent 必需的基础工具（文件/搜索/网络/shell/git/image/plan_mode/time/json），下沉到 crates/ 形成可在 dasclaw_cli 中复用的工具仓
+- **B 堆**：桌面后端独占的工具（job/routine/message/orchestrator 联动类），留在 desktop-client 不动
+
+这与 ADR-155 的判断逻辑一致：**"是否对无头 agent 必需" 是落点判断的主轴**。
+
+## 5. 候选方案与权衡
+
+### 候选 A：一刀切搬到 `dasclaw_tool` 现有 crate
+
+- ✗ `dasclaw_tool` 当前是 trait + framework crate（977 LOC），不是工具实现集
+- ✗ 把 21K LOC 灌进去会把它撑爆，违反 SRP
+- ✗ 不解决依赖分层问题（T3/T4 工具仍带 desktop 反向依赖）
+
+**否决**。
+
+### 候选 B：建一个 `crates/dasclaw_builtin_tools` 大 crate，全部搬过去
+
+- ✓ 命名直接对应 `tools/builtin/`
+- ✗ T3/T4 工具反向依赖 desktop 7 个模块（channels / db / orchestrator / extensions / skills / agent / history / workspace / bootstrap），verbatim 搬迁就是把 desktop 内部模块全拖到新 crate 里
+- ✗ 重蹈 ADR-155 候选 B 的覆辙（orchestrator 7 个反向依赖问题）
+- ✗ 违反 ADR-152 §11.9 路径倒置红线
+
+**否决**。
+
+### 候选 C：按反向依赖 tier 分多个 crate，分批搬
+
+按 §2.4 的 5 个 tier 切分（仅搬 T0+T1+T2 + 部分 T3）：
+
+| 新 crate | 来源 | 包含工具 | LOC | 反向依赖 |
+|---------|------|---------|-----|---------|
+| `dasclaw_fs_tools` | T0+T1 | ApplyPatch / ListDir / ReadFile / WriteFile / CodeEdit / GlobSearch / GrepSearch / path_utils / file_guard | ~3700 | 仅 dasclaw_tool + dasclaw_runtime |
+| `dasclaw_shell_tools` | T2 | Shell（含 classify_command_risk）| 1666 | dasclaw_tool + dasclaw_sandbox + dasclaw_bash_validation |
+| `dasclaw_net_tools` | T2 | Http / WebFetch / WebSearch / html_converter | ~2400 | dasclaw_tool + dasclaw_safety + dasclaw_wasm_tools |
+| `dasclaw_git_tools`（扩充已有空壳）| T0 | 7 个 Git 工具 + lsp 薄壳合入 | 1185 + 10 | dasclaw_tool |
+| `dasclaw_image_tools` | T0 | ImageGen / ImageAnalyze / ImageEdit | 833 | dasclaw_tool + dasclaw_runtime |
+| `dasclaw_misc_tools` | T0 | Echo / Time / Json / PlanMode / Restart / ToolInfo / SessionFork / SecretDelete / SecretList | ~1900 | dasclaw_tool + dasclaw_runtime |
+| `dasclaw_memory_tools` | T0 | MemoryRead / MemorySearch / MemoryTree / MemoryWrite | 974 | dasclaw_tool + dasclaw_runtime |
+| `dasclaw_sub_agent_tools` | T0 | SubAgent | 400 | dasclaw_tool + dasclaw_runtime |
+
+**T3/T4 不下沉**（留桌面）：
+
+| 留守工具 | 文件 | LOC | 留守理由 |
+|---------|------|-----|---------|
+| Extension 8 工具 | extension_tools.rs | 828 | 依赖 desktop `extensions::*` 子系统 |
+| Skill 4 工具 | skill_tools.rs | 1322 | 依赖 desktop `skills::catalog / skills::registry` |
+| Job 6 工具 | job.rs | 2359 | 依赖 orchestrator + channels + db + history |
+| Routine 7 工具 | routine.rs | 2639 | 依赖 agent::routine_engine + db |
+| Message 1 工具 | message.rs | 1075 | 依赖 channels + extensions + bootstrap |
+
+**T3/T4 留守合计 8223 LOC**，与 ADR-155 orchestrator 留守 3330 LOC 加起来 = 11553 LOC 桌面独占工具，与 40 文档 §5 的"留 desktop 残余清单"对得上。
+
+- ✓ 完全符合 ADR-129 §1.3 verbatim 红线（每个 crate 都是搬不改）
+- ✓ 每个 crate 反向依赖目标都已存在（不需要前置下沉新模块）
+- ✓ 8 个新 crate 各自单 PR 可 revert，符合 ADR-152 §4.2 回滚契约
+- ✓ T0+T1+T2 = ~11300 LOC 下沉后，desktop 工具层只剩 ~10100 LOC，与 41 文档目标对齐
+- ✗ 新增 8 个 crate，crates/ 数量从 45 增到 53，但 41 文档已识别蓝图遗漏 16 个，本身蓝图就要升级
+- ⚠ 需要单独 PR 把 desktop 现有 `tools/builtin/mod.rs` 改成薄壳 re-export（与 F4.5.1 channels 薄壳模式一致）
+
+**推荐**。
+
+### 候选 D：按"代码风格 / 来源"分组
+
+- ✗ 没有客观分类标准
+- ✗ 不解决依赖分层问题
+
+**否决**。
+
+### 候选 E：暂缓 F4.6，等无头 agent 框架先跑起来再决定
+
+- ✓ 风险最低
+- ✗ 但无头 agent 框架（ADR-153）的 `.tools_default()` 必须有工具仓才能落地
+- ✗ 暂缓等于 F4 阶段烂尾
+
+**否决**。
+
+## 6. 决策
+
+**采用候选 C**：F4.6 按反向依赖 tier 切成 8 个新 crate 分批搬，T3/T4 共 8223 LOC 工具留桌面。
+
+### 6.1 8 个新 crate 与切分边界（最终落点表）
+
+| # | 新 crate | LOC | 来源文件 | 反向依赖（搬完后）|
+|---|---------|-----|---------|-------------------|
+| 1 | `dasclaw_fs_tools` | ~3700 | code_edit, file, file_guard, glob_search, grep_search, path_utils | dasclaw_tool, dasclaw_runtime |
+| 2 | `dasclaw_shell_tools` | 1666 | shell.rs | dasclaw_tool, dasclaw_sandbox, dasclaw_bash_validation |
+| 3 | `dasclaw_net_tools` | ~2400 | http, web_fetch, web_search, html_converter | dasclaw_tool, dasclaw_safety, dasclaw_wasm_tools |
+| 4 | `dasclaw_git_tools`（扩充空壳）| ~1200 | git/* 7 文件（含 lsp 薄壳）| dasclaw_tool |
+| 5 | `dasclaw_image_tools` | 833 | image_gen, image_analyze, image_edit | dasclaw_tool, dasclaw_runtime |
+| 6 | `dasclaw_misc_tools` | ~1900 | echo, time, json, plan_mode, restart, tool_info, session_fork, secrets_tools | dasclaw_tool, dasclaw_runtime |
+| 7 | `dasclaw_memory_tools` | 974 | memory.rs | dasclaw_tool, dasclaw_runtime |
+| 8 | `dasclaw_sub_agent_tools` | 400 | sub_agent.rs | dasclaw_tool, dasclaw_runtime |
+
+合计下沉 ~13073 LOC。原 LOC 估计 11300 与新 crate 合计 13073 存在偏差，原因：`path_utils.rs` 737 行被两个 tier 共享算入 fs_tools，`http` 系列 4 个文件合计 2407 行更准。
+
+### 6.2 不在 F4.6 范围（留桌面）
+
+| 文件 | LOC | 留守理由 |
+|------|-----|---------|
+| `extension_tools.rs` | 828 | 强依赖 desktop `extensions::*` |
+| `skill_tools.rs` | 1322 | 强依赖 desktop `skills::*` |
+| `job.rs` | 2359 | 强依赖 orchestrator + channels + db + history |
+| `routine.rs` | 2639 | 强依赖 agent::routine_engine + db |
+| `message.rs` | 1075 | 强依赖 channels + extensions + bootstrap |
+
+合计留守 8223 LOC。这部分按 ADR-155 同款逻辑作为"桌面后端独占"，不阻塞无头 agent 落地。
+
+### 6.3 PR 切分节奏（F4.6.1 ~ F4.6.8）
+
+| 子波次 | crate | 启动门 | 验证最低标准 |
+|--------|-------|--------|--------------|
+| F4.6.1 | `dasclaw_misc_tools` | F4.5 全绿 | `cargo nextest run -p dasclaw_misc_tools` + 该 crate 自带 unit 测试 |
+| F4.6.2 | `dasclaw_image_tools` | F4.6.1 merge | 同上 |
+| F4.6.3 | `dasclaw_memory_tools` | F4.6.2 merge | 同上 |
+| F4.6.4 | `dasclaw_sub_agent_tools` | F4.6.3 merge | 同上 |
+| F4.6.5 | `dasclaw_git_tools`（扩充）| F4.6.4 merge | 同上 + 把 lsp 薄壳合入 |
+| F4.6.6 | `dasclaw_fs_tools` | F4.6.5 merge | 同上 + 跨 crate path 校验测试 |
+| F4.6.7 | `dasclaw_shell_tools` | F4.6.6 merge | 同上 + `classify_command_risk` 回归 |
+| F4.6.8 | `dasclaw_net_tools` | F4.6.7 merge | 同上 + wasm_tools 集成 |
+
+**节奏特征**：先搬 T0 简单工具（F4.6.1~F4.6.5），再搬 T1/T2 有依赖工具（F4.6.6~F4.6.8）。每个 PR 单独可 revert，符合 ADR-152 §4.2。
+
+### 6.4 desktop `tools/builtin/mod.rs` 薄壳化（独立 PR）
+
+F4.6.8 全部 merge 后，单独开 PR 把 `desktop-client/ironclaw/src/tools/builtin/mod.rs` 改为：
+
+```rust
+//! Built-in tools that come with the agent.
+//!
+//! 按 ADR-156 §6 决策，工具实现已下沉到 crates/dasclaw_*_tools，
+//! 本模块降级为 re-export 入口 + T3/T4 留守工具。
+
+pub use dasclaw_fs_tools::*;
+pub use dasclaw_shell_tools::*;
+pub use dasclaw_net_tools::*;
+pub use dasclaw_git_tools::*;
+pub use dasclaw_image_tools::*;
+pub use dasclaw_misc_tools::*;
+pub use dasclaw_memory_tools::*;
+pub use dasclaw_sub_agent_tools::*;
+
+// T3/T4 留守工具
+pub mod extension_tools;
+pub mod skill_tools;
+pub mod job;
+pub mod routine;
+pub mod message;
+```
+
+这一步与 F4.5.1 channels 薄壳模式（PR #733）一致，最小化对 desktop 上游代码的扰动。
+
+## 7. 配套动作
+
+1. **修订 ADR-152 §3 F4.6 条款**：把"`tools/builtin` 分批搬（21.5K LoC、28 工具，建议 6-8 刀按职能分组）"改为"`tools/builtin` 按 ADR-156 切 8 刀下沉，T3/T4 共 8223 LOC 留桌面"。该修订**不在本 ADR PR 范围**，留待单独 PR
+2. **升级 31-target-architecture.md 到 v2.5**：补全 §4 P0/P1/P2 现实清单（按 41 文档结论），新增 §X F4.6 章节引用本 ADR。同样**不在本 ADR PR 范围**
+3. **不改任何代码**：本 ADR PR 只提交 ADR 文档，不动 crates/ / desktop-client/
+4. **下游契约**：F4.6.1 ~ F4.6.8 各自走 ADR-129 §1.3 verbatim 红线，每个 PR 自带门控（cargo check + nextest + check_no_panics）
+5. **41-target-architecture-drift-analysis.md 同步更新**：F4.6.8 全部 merge 后把"F4.6 蓝图缺口"标记为已闭环
+
+## 8. 后续路径
+
+T3/T4 留守工具的未来：
+
+- **Extension / Skill 工具**：随 desktop `extensions::*` / `skills::*` 子系统的下沉决策一起处理，需要单独 ADR（候选触发：ADR-153 步骤 3 `dasclaw_session`）
+- **Job / Routine / Message 工具**：与 orchestrator 同属"桌面后端独占"，按 ADR-155 决策逻辑保持留守。如未来有 `dasclaw_cli` 容器化需求，再触发新 ADR
+
+## 9. 不在本 ADR 范围
+
+- ADR-152 §3 F4.6 条款文本如何修订（留待 ADR-152 自身修订 PR）
+- 31-target-architecture.md v2.5 升级（留待独立 PR）
+- T3/T4 留守工具的未来下沉路径（需要 desktop 服务皮先下沉，触发新 ADR）
+- F4.6.1 ~ F4.6.8 各子波次的具体 PR 内容（每个子波次自带验证清单，按 ADR-129 §1.3 verbatim 推进）
+- desktop `tools/builtin/mod.rs` 薄壳化的具体改写（留待 F4.6.8 后独立 PR）
+- builtin 工具自身的代码质量问题（如 `routine.rs` 2639 行单文件是否拆分），属于 desktop 内部演化，与下沉决策无关
+
+## 10. Sources read
+
+- [`adr-152-agent-and-capability-fusion.md`](adr-152-agent-and-capability-fusion.md) §3 阶段 F4 / §4.2 回滚契约 / §11.9 路径倒置
+- [`adr-153-headless-agent-framework-draft.md`](adr-153-headless-agent-framework-draft.md) §2 现状盘点 / §4.2 步骤 2
+- [`adr-155-f44-orchestrator-landing-decision.md`](adr-155-f44-orchestrator-landing-decision.md) 模板与对账方法
+- [`adr-152-f45-wasm-slicing.md`](adr-152-f45-wasm-slicing.md) F4.5 切分模式参考
+- ADR-129 §1.3 verbatim port mandate（按惯例引用）
+- [`40-tool-ecosystem-inventory.md`](40-tool-ecosystem-inventory.md) §3 四方工具对照 / §4 F4.6 真正要搬清单
+- [`41-target-architecture-drift-analysis.md`](41-target-architecture-drift-analysis.md) F4.6 蓝图缺口识别
+- `desktop-client/ironclaw/src/tools/builtin/mod.rs` 全文 87 行（re-export 入口）
+- `desktop-client/ironclaw/src/tools/builtin/*.rs` 全部 35 个文件的 `use crate::*` 反向依赖扫描
+- 文件体量统计（`find ... -name '*.rs' -exec wc -l`，21505 LOC 验证 ADR-152 §3 原估精度）
+
+---
+
+## 11. 附录 A：F4.6 与 ADR-155 决策对齐
+
+| 维度 | ADR-155（F4.4 orchestrator）| ADR-156（F4.6 builtin tools）|
+|------|-----------------------------|-------------------------------|
+| 决策主轴 | 是否对无头 agent 必需 | 是否对无头 agent 必需 |
+| 三方对账 | codex/claw-code 0 等价 | 基础工具三方各异，独有工具 0 等价 |
+| 决策结论 | 候选 C：留桌面 | 候选 C：分 tier 切，T0~T2 下沉、T3/T4 留桌面 |
+| verbatim 红线 | 完全遵守（不搬不改）| 完全遵守（搬不改）|
+| 路径倒置红线 | 完全遵守（不引入反向依赖）| 完全遵守（按 tier 切分避开）|
+| PR 切分 | 0 个 PR（不搬）| 8 个 PR + 1 个薄壳化 PR |
+| 留守 LOC | 3330 | 8223 |
+| 下沉 LOC | 0 | ~13073 |
+| 配套蓝图升级 | 不必 | 推荐 31 v2.5 |
+
+两个 ADR 共同的逻辑：
+
+1. **决策主轴**：是否对 ADR-153 无头 agent 最小可用形态必需
+2. **判断方法**：反向依赖图 + 三方对账双重验证
+3. **保守倾向**：能不搬就不搬，宁可留桌面也不破坏 verbatim 红线
+4. **配套机制**：每个 ADR 显式列出"不在本 ADR 范围"，避免范围蔓延
+
+## 12. 附录 B：F4.6 与 31-target-architecture.md 升级关系
+
+按 41-target-architecture-drift-analysis.md 推荐顺序：
+
+```
+本 ADR（ADR-156）merge
+    │
+    ▼
+ADR-152 §3 F4.6 条款修订 PR（独立）
+    │
+    ▼
+31-target-architecture.md v2.5 升级 PR（独立）
+    │  - §4 补全 16 个遗漏 crate
+    │  - §4 新增 F4.6 8 个 crate
+    │  - 索引 ADR-111 ~ ADR-156
+    │  - 新增 §X "F4.6 工具壳分层" 章节
+    ▼
+F4.6.1 ~ F4.6.8 实施 PR（按 §6.3 节奏）
+    │
+    ▼
+desktop builtin/mod.rs 薄壳化 PR（F4.6.8 后）
+    │
+    ▼
+41-target-architecture-drift-analysis.md 关闭 F4.6 缺口标记
+```
+
+这与 ADR-155 走过的路径完全对齐：**先决策、再修订 §3 条款、再实施、最后回写漂移分析文档**。


### PR DESCRIPTION
## 背景 / 目标

PR #753（ADR-156 F4.6 落点决策）合并 ADR-155（F4.4 orchestrator 落点决策）之后，蓝图层面（`31-target-architecture.md` 与 `adr-152-agent-and-capability-fusion.md` §3）仍然停留在 v2.4：

- ADR-152 §3 F4.4 还写 "orchestrator 落点决策 + 搬迁（3.3K LoC）。需补 ADR" —— 实际 ADR-155 已决议留桌面
- ADR-152 §3 F4.6 还写 "建议 6-8 刀按职能分组" —— 实际 ADR-156 已决议切 8 刀且具体到 crate
- 31 v2.4 §3 ADR 索引止于 ADR-110 —— 实际已落 ADR-111 ~ ADR-156 约 45 个
- 31 v2.4 §4 列 26 个 dasclaw_* crate —— 实际 `crates/` 已落 45 个

本 PR 把蓝图全部对齐到事实状态。

## 改动范围

**`docs/plans/architecture-refactor/31-target-architecture.md`** v2.4 → v2.5：

- 新增 §3.2 ADR-111 ~ ADR-156 索引表（约 45 个 ADR，按 6 族分组：评估方法学 / Plan-Job-Sandbox / ExecPolicy-Shell / Protocol-Net / Sandbox 平台细节 / F4 阶段决策）
- 新增 §4.6 F4.6 工具壳分层落点表（8 新 crate + 5 留守，引用 ADR-156）
- 新增 §4.7 v2.4 蓝图遗漏 crate 补全表（16 个已存在 crate 补登：absolute_path / bash_permissions / cert_trust / channels / exec / llm_provider / process_hardening / runtime / sandbox_linux / sandbox_windows / sandboxing / shell_command / tool / utils_home_dir / utils_rustls_provider / wasm_tools）
- §4.4 orchestrator 落点确认留桌面，引用 ADR-155（作废 v2.4 "升级为 dasclaw_*" 承诺）
- §10.1 v2.4 → v2.5 变更日志

**`docs/plans/architecture-refactor/adr-152-agent-and-capability-fusion.md`** §3 F4 阶段条款修订：

- F4.4 改写：引用 ADR-155 决议（留桌面），作废原 "3.3K LoC 必须搬" 表述
- F4.6 改写：引用 ADR-156 决议（tier 切 8 刀，~13073 LoC 下沉），细化原 "建议 6-8 刀按职能分组" 表述

## 非目标（What's NOT in this PR）

- 不实施 F4.6 任何一刀（F4.6.1 ~ F4.6.8 的代码实现是后续 PR）
- 不改任何 *.rs 代码、不动 `crates/` 任何 Cargo.toml
- 不补 `dasclaw_bridge_lite`（P0 缺口，单独 PR 推进）
- 不扩 `dasclaw_git_tools` 24 行空壳（属于 F4.6.5 任务，单独 PR 推进）

## 验证

- ADR-114 类 A grep guard：`python3 scripts/check_no_new_ironclaw_literal.py --base docs/adr-156-f46-builtin-decision` → `OK: No new .ironclaw / IRONCLAW_BASE_DIR literals introduced.`
- 文件改动仅限两份 .md，无代码改动，本地 cargo check 不适用
- 所有引用链接均为同目录 `.md` 文件，已核对存在性

## Cross-cuts

- **ADR-114**：类 A，无新增 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量

## Sources read

- [docs/plans/architecture-refactor/40-tool-ecosystem-inventory.md](docs/plans/architecture-refactor/40-tool-ecosystem-inventory.md) §1-3（PR #753 引入）
- [docs/plans/architecture-refactor/41-target-architecture-drift-analysis.md](docs/plans/architecture-refactor/41-target-architecture-drift-analysis.md) §漂移识别（PR #753 引入）
- [docs/plans/architecture-refactor/adr-155-f44-orchestrator-landing-decision.md](docs/plans/architecture-refactor/adr-155-f44-orchestrator-landing-decision.md) §6 决议
- [docs/plans/architecture-refactor/adr-156-f46-builtin-tools-landing-decision.md](docs/plans/architecture-refactor/adr-156-f46-builtin-tools-landing-decision.md) §6 决议（PR #753 引入）
- 现 ADR 文件清单（39 份）：`ls docs/plans/architecture-refactor/adr-1*.md`

## Stacked PR 注意

- **base 分支不是 `xClaw`** —— 是 `docs/adr-156-f46-builtin-decision`（PR #753）
- **merge 顺序**：请先 merge PR #753，再 merge 本 PR
- **请先看 PR #753 再看本 PR**

## 后续 PR

- **PR-D**（待用户确认）：F4.6.1 `dasclaw_misc_tools` 实现 —— 按 ADR-156 §6.3 第一刀
- 单独 PR：补 `dasclaw_bridge_lite`（P0 缺口）
- 单独 PR：扩 `dasclaw_git_tools` 空壳（F4.6.5 任务，但需先有 PR-D 模板）
