### PR TITLE
fix(submodule): pin codex-cli-main to Linnanli/xclaw-codex-cli-main fork

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,4 +8,4 @@
 	branch = x-claw
 [submodule "codex-cli-main"]
 	path = codex-cli-main
-	url = https://github.com/openai/codex.git
+	url = https://github.com/Linnanli/xclaw-codex-cli-main.git


### PR DESCRIPTION
## 背景 / 目标

unblock 所有当前 CI——`openai/codex.git` 上游的可达历史里不再包含 `.gitmodules` 中 pin 的 commit `6e838a19fa52f2c30442c5bd2913acd1e6fe4c9d`，导致每一个用 `actions/checkout@v4` 带 `submodules: recursive` 的 job 都失败（21+ jobs in `code_style.yml`，2 in `e2e.yml`）。当前 PR #757、#749、#756 全部因此红。

## 改动范围

- `.gitmodules`: `codex-cli-main` 的 `url` 改为 `https://github.com/Linnanli/xclaw-codex-cli-main.git`（已 fork，commit 已确认可达）
- submodule 的 commit SHA 不变（仍为 `6e838a19...`），所以 ADR-13x verbatim drift baseline **不受影响**

## 非目标 (What's NOT in this PR)

- 不动 submodule pin commit 本身
- 不动任何 ADR-13x drift 脚本或 baseline 文件
- 不改 `claw-code` / `ironclaw` submodule（它们已经在 fork 下，本来就稳定）
- 不动任何 workflow yml

## Cross-cuts

ADR-114：无新增 `.ironclaw` 或 `IRONCLAW_BASE_DIR` 字面量 — 类A。

## 验证

```bash
git submodule sync codex-cli-main
cd codex-cli-main && git fetch origin 6e838a19fa52f2c30442c5bd2913acd1e6fe4c9d
# → * branch  6e838a19...  -> FETCH_HEAD   ✅
```

合并后给 #757 / #749 / #756 各 push 一个空 commit 触发重跑，预期所有 submodule checkout 阶段通过。

## Sources read

- `.gitmodules` (本仓 root) — 确认 `claw-code` / `ironclaw` 都已经走 fork URL 模式，本 PR 跟齐
- failing job log of latest CI run on #756 — 确认错误是 `Direct fetching of that commit failed` 而非凭据问题
- AGENTS.md "Base 分支既有 broken 测试处置规范" — 本 PR 即该规范第 3 条 "互锁的 broken 优先合并到单 PR" 的实际应用（infra-broken 而非测试 broken，但同源问题）

Closes #758