### PR TITLE
feat(dasclaw_misc_tools): F4.6.1 verbatim port of 6 builtin misc tools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2658,6 +2658,7 @@ dependencies = [
  "dasclaw_llm_provider",
  "dasclaw_lsp",
  "dasclaw_mcp",
+ "dasclaw_misc_tools",
  "dasclaw_net_proxy",
  "dasclaw_observability",
  "dasclaw_process_hardening",
@@ -3031,6 +3032,22 @@ dependencies = [
  "tracing",
  "url",
  "urlencoding",
+ "uuid",
+]
+
+[[package]]
+name = "dasclaw_misc_tools"
+version = "0.0.0-w6"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "chrono-tz",
+ "dasclaw_runtime",
+ "dasclaw_tool",
+ "dasclaw_workspace_cap",
+ "serde_json",
+ "tokio",
+ "tracing",
  "uuid",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,8 @@ members = [
 	"crates/dasclaw_channels",
 	# F4.5.3 — wasm sandbox primitives extracted from desktop tools/wasm/
 	"crates/dasclaw_wasm_tools",
+	# F4.6.1 — misc builtin tools (echo/time/json/plan_mode/restart/session_fork) per ADR-156 §6.3
+	"crates/dasclaw_misc_tools",
 	# W2.6 接线层：组合 sandbox + pty + workspace_cap policy
 	"crates/dasclaw_exec",
 	# W6-C 主仓自实现 LLM provider —— 替代 claw-code-api path-dep（ADR-118 PR-A.0 骨架）

--- a/crates/dasclaw_misc_tools/Cargo.toml
+++ b/crates/dasclaw_misc_tools/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "dasclaw_misc_tools"
+version = "0.0.0-w6"
+edition = "2024"
+description = "Miscellaneous builtin tools (echo, time, json, plan_mode, restart, session_fork) extracted from desktop-client/ironclaw per ADR-156 §6.3 F4.6.1."
+license = "Apache-2.0 OR MIT"
+publish = false
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+async-trait = "0.1"
+chrono = { version = "0.4", features = ["serde"] }
+chrono-tz = "0.10"
+serde_json = "1"
+tokio = { version = "1", features = ["time", "rt"] }
+tracing = "0.1"
+
+dasclaw_runtime = { path = "../dasclaw_runtime" }
+dasclaw_tool = { path = "../dasclaw_tool" }
+dasclaw_workspace_cap = { path = "../dasclaw_workspace_cap", version = "0.1.0" }
+
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }
+uuid = { version = "1", features = ["v4"] }

--- a/crates/dasclaw_misc_tools/src/echo.rs
+++ b/crates/dasclaw_misc_tools/src/echo.rs
@@ -2,7 +2,8 @@
 
 use async_trait::async_trait;
 
-use crate::tools::tool::{Tool, ToolError, ToolOutput, require_str};
+use dasclaw_runtime::Tool;
+use dasclaw_tool::{ToolError, ToolOutput, require_str};
 
 /// Simple echo tool for testing.
 pub struct EchoTool;

--- a/crates/dasclaw_misc_tools/src/json.rs
+++ b/crates/dasclaw_misc_tools/src/json.rs
@@ -2,7 +2,8 @@
 
 use async_trait::async_trait;
 
-use crate::tools::tool::{Tool, ToolError, ToolOutput, require_param, require_str};
+use dasclaw_runtime::Tool;
+use dasclaw_tool::{ToolError, ToolOutput, require_param, require_str};
 
 /// Tool for JSON manipulation (parse, query, transform).
 pub struct JsonTool;

--- a/crates/dasclaw_misc_tools/src/lib.rs
+++ b/crates/dasclaw_misc_tools/src/lib.rs
@@ -1,0 +1,31 @@
+//! F4.6.1 — Miscellaneous builtin tools extracted from
+//! `desktop-client/ironclaw/src/tools/builtin/` per
+//! [ADR-156 §6.3](../../../docs/plans/architecture-refactor/adr-156-f46-builtin-tools-landing-decision.md).
+//!
+//! Verbatim port (ADR-129 §1.3): file bodies are byte-for-byte copies of the
+//! desktop sources, with only the `use` line rewritten from
+//! `crate::tools::tool::{...}` to `dasclaw_runtime::Tool` +
+//! `dasclaw_tool::{...}` to follow the workspace dependency direction
+//! (ADR-154 §3.1 amendment).
+//!
+//! Not in this PR (deferred to F4.6.1b):
+//! - `secrets_tools.rs` — its `#[cfg(test)] mod tests` depends on
+//!   `crate::testing::credentials::{TEST_OPENAI_API_KEY_SHORT,
+//!   test_secrets_store}`, a desktop-internal fixture that requires a
+//!   separate `pub(crate) testing` exposure decision.
+//! - `tool_info.rs` — depends on `crate::tools::registry::ToolRegistry`
+//!   which still lives in desktop and will be sunk in a later wave.
+
+mod echo;
+mod json;
+mod plan_mode;
+mod restart;
+mod session_fork;
+mod time;
+
+pub use echo::EchoTool;
+pub use json::JsonTool;
+pub use plan_mode::PlanModeTool;
+pub use restart::RestartTool;
+pub use session_fork::SessionForkTool;
+pub use time::TimeTool;

--- a/crates/dasclaw_misc_tools/src/plan_mode.rs
+++ b/crates/dasclaw_misc_tools/src/plan_mode.rs
@@ -9,7 +9,8 @@ use std::time::Duration;
 use async_trait::async_trait;
 use serde_json::json;
 
-use crate::tools::tool::{ApprovalRequirement, Tool, ToolDomain, ToolError, ToolOutput};
+use dasclaw_runtime::Tool;
+use dasclaw_tool::{ApprovalRequirement, ToolDomain, ToolError, ToolOutput};
 
 /// Tool for toggling plan mode on a thread.
 ///

--- a/crates/dasclaw_misc_tools/src/restart.rs
+++ b/crates/dasclaw_misc_tools/src/restart.rs
@@ -27,7 +27,13 @@ use async_trait::async_trait;
 use std::time::Duration;
 
 #[allow(unused_imports)]
-use crate::tools::tool::{ApprovalRequirement, Tool, ToolError, ToolOutput};
+use dasclaw_runtime::Tool;
+// `ApprovalRequirement` is referenced only by the `#[cfg(test)]` module below
+// (assertions on `tool.approval_requirement()`). Keep it on the top-level use
+// line to preserve the verbatim shape of the original desktop port; suppress
+// the lib-build unused-imports warning explicitly.
+#[allow(unused_imports)]
+use dasclaw_tool::{ApprovalRequirement, ToolError, ToolOutput};
 
 /// Tool for triggering a graceful process restart via exit code 0.
 ///

--- a/crates/dasclaw_misc_tools/src/session_fork.rs
+++ b/crates/dasclaw_misc_tools/src/session_fork.rs
@@ -9,7 +9,8 @@ use std::time::Duration;
 use async_trait::async_trait;
 use serde_json::json;
 
-use crate::tools::tool::{ApprovalRequirement, Tool, ToolDomain, ToolError, ToolOutput};
+use dasclaw_runtime::Tool;
+use dasclaw_tool::{ApprovalRequirement, ToolDomain, ToolError, ToolOutput};
 
 /// Tool for forking a conversation thread at a specific turn.
 ///

--- a/crates/dasclaw_misc_tools/src/time.rs
+++ b/crates/dasclaw_misc_tools/src/time.rs
@@ -4,7 +4,8 @@ use async_trait::async_trait;
 use chrono::{DateTime, LocalResult, NaiveDate, NaiveDateTime, TimeZone, Utc};
 use chrono_tz::Tz;
 
-use crate::tools::tool::{Tool, ToolError, ToolOutput};
+use dasclaw_runtime::Tool;
+use dasclaw_tool::{ToolError, ToolOutput};
 
 /// Tool for getting current time and date operations.
 pub struct TimeTool;
@@ -271,7 +272,7 @@ fn context_timezone(
     // Primary: use the dedicated user_timezone field from JobContext
     if ctx.user_timezone() != "UTC"
         && !ctx.user_timezone().is_empty()
-        && let Some(tz) = crate::timezone::parse_timezone(ctx.user_timezone())
+        && let Some(tz) = dasclaw_workspace_cap::timezone::parse_timezone(ctx.user_timezone())
     {
         return Ok(Some((tz, tz.to_string())));
     }

--- a/desktop-client/ironclaw/Cargo.toml
+++ b/desktop-client/ironclaw/Cargo.toml
@@ -212,6 +212,10 @@ dasclaw_runtime = { path = "../../crates/dasclaw_runtime" }
 # ADR-152 F4.5.3.
 dasclaw_wasm_tools = { path = "../../crates/dasclaw_wasm_tools" }
 
+# F4.6.1 — misc builtin tools (echo/time/json/plan_mode/restart/session_fork)
+# extracted from desktop tools/builtin/ per ADR-156 §6.3.
+dasclaw_misc_tools = { path = "../../crates/dasclaw_misc_tools" }
+
 # AWS Bedrock (native Converse API, opt-in via --features bedrock)
 aws-config = { version = "1", features = ["behavior-version-latest"], optional = true }
 aws-sdk-bedrockruntime = { version = "1", optional = true }

--- a/desktop-client/ironclaw/src/tools/builtin/mod.rs
+++ b/desktop-client/ironclaw/src/tools/builtin/mod.rs
@@ -1,7 +1,6 @@
 //! Built-in tools that come with the agent.
 
 mod code_edit;
-mod echo;
 pub mod extension_tools;
 mod file;
 pub mod file_guard;
@@ -10,27 +9,29 @@ mod glob_search;
 mod grep_search;
 mod http;
 mod job;
-mod json;
 pub mod lsp;
 pub mod memory;
 mod message;
 pub mod path_utils;
-mod plan_mode;
-mod restart;
 pub mod routine;
 pub mod secrets_tools;
-mod session_fork;
 pub(crate) mod shell;
 pub use shell::classify_command_risk;
 pub mod skill_tools;
 pub mod sub_agent;
-mod time;
 mod tool_info;
 mod web_fetch;
 mod web_search;
 
+// F4.6.1 — echo/time/json/plan_mode/restart/session_fork were extracted to
+// `crates/dasclaw_misc_tools` per ADR-156 §6.3. The thin re-export below
+// keeps every existing `crate::tools::builtin::EchoTool` (etc.) call site
+// compiling unchanged.
+pub use dasclaw_misc_tools::{
+    EchoTool, JsonTool, PlanModeTool, RestartTool, SessionForkTool, TimeTool,
+};
+
 pub use code_edit::CodeEditTool;
-pub use echo::EchoTool;
 pub use extension_tools::{
     ExtensionInfoTool, ToolActivateTool, ToolAuthTool, ToolInstallTool, ToolListTool,
     ToolRemoveTool, ToolSearchTool, ToolUpgradeTool,
@@ -47,22 +48,17 @@ pub use job::{
     CancelJobTool, CreateJobTool, JobEventsTool, JobPromptTool, JobStatusTool, ListJobsTool,
     PromptQueue, SchedulerSlot,
 };
-pub use json::JsonTool;
 pub use lsp::LspQueryTool;
 pub use memory::{MemoryReadTool, MemorySearchTool, MemoryTreeTool, MemoryWriteTool};
 pub use message::MessageTool;
-pub use plan_mode::PlanModeTool;
-pub use restart::RestartTool;
 pub use routine::{
     EventEmitTool, RoutineCreateTool, RoutineDeleteTool, RoutineFireTool, RoutineHistoryTool,
     RoutineListTool, RoutineUpdateTool,
 };
 pub use secrets_tools::{SecretDeleteTool, SecretListTool};
-pub use session_fork::SessionForkTool;
 pub use shell::ShellTool;
 pub use skill_tools::{SkillInstallTool, SkillListTool, SkillRemoveTool, SkillSearchTool};
 pub use sub_agent::{SubAgentRole, SubAgentTool};
-pub use time::TimeTool;
 pub use tool_info::ToolInfoTool;
 pub use web_fetch::WebFetchTool;
 pub use web_search::WebSearchTool;

--- a/scripts/check_blueprint_sync.py
+++ b/scripts/check_blueprint_sync.py
@@ -44,7 +44,7 @@ PLANNED: dict[str, str] = {
     # F4.6 工具壳分层 (ADR-156). Eight new crates land in waves F4.6.1 ~
     # F4.6.8; remove an entry from PLANNED the moment its crate directory
     # is created.
-    "dasclaw_misc_tools": "ADR-156 F4.6.1 planned",
+    # F4.6.1 (`dasclaw_misc_tools`) landed in PR #761 — entry removed.
     "dasclaw_image_tools": "ADR-156 F4.6.2 planned",
     "dasclaw_memory_tools": "ADR-156 F4.6.3 planned",
     "dasclaw_sub_agent_tools": "ADR-156 F4.6.4 planned",


### PR DESCRIPTION
## 背景 / 目标

按 [ADR-156 §6.3](../blob/xClaw/docs/plans/architecture-refactor/adr-156-builtin-tools-extraction.md) F4.6.1，把 desktop-client/ironclaw 中 6 个无外部依赖的 builtin tools 下沉到独立 crate `dasclaw_misc_tools`，便于服务端 / CLI 复用，并减小 desktop crate 的 LOC。

## 改动范围

- 新建 `crates/dasclaw_misc_tools/`（lib crate，~1700 LOC verbatim copy + 31 行 lib.rs）
- 移植 6 个文件：`echo.rs` / `time.rs` / `json.rs` / `plan_mode.rs` / `restart.rs` / `session_fork.rs`
- 删除 desktop 同名原文件（git 自动识别为 rename，93-99% 相似度）
- `desktop-client/ironclaw/src/tools/builtin/mod.rs` 改用 `pub use dasclaw_misc_tools::{...}` 单点 re-export
- `Cargo.toml` workspace members + `desktop-client/ironclaw/Cargo.toml` 加 path dep

### Verbatim 例外（ADR-129 §1.3 允许的 relocation 改写）

1. **所有文件**：`use crate::tools::tool::{Tool, ...}` → 拆为 `use dasclaw_runtime::Tool;` + `use dasclaw_tool::{...}`（ADR-154 §3.1 amendment：Tool trait 在 dasclaw_runtime）
2. **`time.rs:275`**：`crate::timezone::parse_timezone(...)` → `dasclaw_workspace_cap::timezone::parse_timezone(...)`（desktop `src/timezone.rs` 本就是同模块的 re-export shim，ADR-152 F3.4）
3. **`restart.rs:31`**：顶层 use 加 `#[allow(unused_imports)]` + 行内注释。`ApprovalRequirement` 仅 `#[cfg(test)]` 引用，保留 verbatim use 行形状，独立 lib crate 必须显式抑制 unused warning。

## 非目标（What's NOT in this PR）

- ❌ **`secrets_tools.rs`** — 测试模块依赖 desktop 内部的 `crate::testing::credentials::{TEST_OPENAI_API_KEY_SHORT, test_secrets_store}` fixture，无法 verbatim port。**推迟到 F4.6.1b 跟进**，需先决定 fixture 是抽到 `dasclaw_testkit` 还是改 mock。
- ❌ **`tool_info.rs`** — 依赖 `ToolRegistry` sink，后续 wave 处理。
- ❌ 不动任何 call site：`crate::tools::builtin::EchoTool` 等导入路径完全不变。

## 验证

```
$ cargo check -p dasclaw_misc_tools --tests
Finished `dev` profile in 2.78s (0E 0W)

$ cargo nextest run -p dasclaw_misc_tools
Summary [11.899s] 45 tests run: 45 passed, 0 skipped

$ cargo check -p dasclaw --tests
Finished `dev` profile in 5m 01s (仅 1 项 desktop 遗留 unused warning，非本PR 引入)

$ cargo clippy --no-deps -p dasclaw_misc_tools --all-targets -- -D warnings
Finished `dev` profile in 16.97s (0E 0W)

$ cargo fmt --all && python3.12 scripts/check_no_panics.py --base origin/xClaw
OK: No panic-inducing calls in changed production code.
```

## ADR 关联

- ADR-156 §6.3 — F4.6 拆分计划
- ADR-129 §1.3 — verbatim port 纪律（跳过 code-simplifier）
- ADR-154 §3.1 amendment — Tool trait 位置
- ADR-152 F3.4 — timezone 下沉

## Cross-cuts

类A — 本 PR 未新增 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量。

## Sources read

- `docs/plans/architecture-refactor/adr-156-builtin-tools-extraction.md` §6.3 F4.6.1
- `docs/plans/architecture-refactor/adr-129-verbatim-port-rule.md` §1.3
- `docs/plans/architecture-refactor/adr-154-runtime-tool-trait-amendment.md` §3.1
- `docs/plans/architecture-refactor/adr-152-workspace-cap-extraction.md` §3 F3.4
- `crates/dasclaw_runtime/src/tool.rs`（Tool trait 定义位置）
- `crates/dasclaw_tool/src/types.rs`（辅助类型）
- `desktop-client/ironclaw/src/timezone.rs`（确认 re-export shim 结构）

Closes #760