### PR TITLE
chore(ci): use relative submodule URLs to fix Actions checkout auth

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,11 +1,11 @@
 [submodule "ironclaw"]
 	path = desktop-client/ironclaw
-	url = https://github.com/Linnanli/xclaw-ironclaw.git
+	url = ../xclaw-ironclaw.git
 	branch = x-claw-core
 [submodule "claw-code"]
 	path = claw-code
-	url = https://github.com/Linnanli/xclaw-claw-code.git
+	url = ../xclaw-claw-code.git
 	branch = x-claw
 [submodule "codex-cli-main"]
 	path = codex-cli-main
-	url = https://github.com/Linnanli/xclaw-codex-cli-main.git
+	url = ../xclaw-codex-cli-main.git


### PR DESCRIPTION
## 背景 / 目标

PR #761 CI 多个 job 失败，日志显示 `fatal: could not read Username for 'https://github.com'`，根因是 `actions/checkout` 把宿主 `GITHUB_TOKEN` 作为 Basic auth 注入到绝对 https submodule URL，对同 owner 的 public fork 仓库无效，runner 退回 prompt 路径 fatal。

详细诊断见 #762。

## 改动范围

`.gitmodules` 三处 URL：

- `https://github.com/Linnanli/xclaw-ironclaw.git` → `../xclaw-ironclaw.git`
- `https://github.com/Linnanli/xclaw-claw-code.git` → `../xclaw-claw-code.git`
- `https://github.com/Linnanli/xclaw-codex-cli-main.git` → `../xclaw-codex-cli-main.git`

## 非目标 / What's NOT in this PR

- 不改任何 workflow（21 处 `actions/checkout` 全部保持原样）
- 不引入 secrets / PAT
- 不改 submodule branch / 内容 / commit pin
- 不动业务代码

## 验证

本地：
- `git submodule sync` 成功，工作区子模块路径与 commit 保持一致
- `git diff .gitmodules` 只有三行 URL 变更

CI：本 PR 自身将证明改动生效（之前在 PR #761 上 fail 的 Formatting / ADR drift / Code Style 等 job 应在本 PR 全部 pass）。

## Cross-cuts

ADR-114 `.ironclaw` 命名迁移：**不涉及**（只动 `.gitmodules` 内的 fork 仓库 URL，未新增 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量）。

## 后续

合并后 #761 重跑 CI 即可全绿，无需 rebase。

Closes #762