### PR TITLE
feat(dasclaw_misc_tools): F4.6.1b verbatim port of secrets_tools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3044,6 +3044,7 @@ dependencies = [
  "chrono-tz",
  "dasclaw_runtime",
  "dasclaw_tool",
+ "dasclaw_wasm_tools",
  "dasclaw_workspace_cap",
  "serde_json",
  "tokio",

--- a/crates/dasclaw_misc_tools/Cargo.toml
+++ b/crates/dasclaw_misc_tools/Cargo.toml
@@ -2,7 +2,7 @@
 name = "dasclaw_misc_tools"
 version = "0.0.0-w6"
 edition = "2024"
-description = "Miscellaneous builtin tools (echo, time, json, plan_mode, restart, session_fork) extracted from desktop-client/ironclaw per ADR-156 §6.3 F4.6.1."
+description = "Miscellaneous builtin tools (echo, time, json, plan_mode, restart, secrets_tools, session_fork) extracted from desktop-client/ironclaw per ADR-156 §6.3 F4.6.1 / F4.6.1b."
 license = "Apache-2.0 OR MIT"
 publish = false
 
@@ -24,3 +24,4 @@ dasclaw_workspace_cap = { path = "../dasclaw_workspace_cap", version = "0.1.0" }
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }
 uuid = { version = "1", features = ["v4"] }
+dasclaw_wasm_tools = { path = "../dasclaw_wasm_tools" }

--- a/crates/dasclaw_misc_tools/src/lib.rs
+++ b/crates/dasclaw_misc_tools/src/lib.rs
@@ -8,18 +8,20 @@
 //! `dasclaw_tool::{...}` to follow the workspace dependency direction
 //! (ADR-154 §3.1 amendment).
 //!
-//! Not in this PR (deferred to F4.6.1b):
-//! - `secrets_tools.rs` — its `#[cfg(test)] mod tests` depends on
-//!   `crate::testing::credentials::{TEST_OPENAI_API_KEY_SHORT,
-//!   test_secrets_store}`, a desktop-internal fixture that requires a
-//!   separate `pub(crate) testing` exposure decision.
+//! Not in this PR (deferred to a later wave):
 //! - `tool_info.rs` — depends on `crate::tools::registry::ToolRegistry`
 //!   which still lives in desktop and will be sunk in a later wave.
+//!
+//! F4.6.1b landed `secrets_tools.rs` (SecretListTool / SecretDeleteTool) —
+//! its test fixture (`TEST_OPENAI_API_KEY_SHORT`, `test_secrets_store`) is
+//! now imported from `dasclaw_wasm_tools::test_credentials` instead of the
+//! desktop-internal `crate::testing::credentials` module.
 
 mod echo;
 mod json;
 mod plan_mode;
 mod restart;
+mod secrets_tools;
 mod session_fork;
 mod time;
 
@@ -27,5 +29,6 @@ pub use echo::EchoTool;
 pub use json::JsonTool;
 pub use plan_mode::PlanModeTool;
 pub use restart::RestartTool;
+pub use secrets_tools::{SecretDeleteTool, SecretListTool};
 pub use session_fork::SessionForkTool;
 pub use time::TimeTool;

--- a/crates/dasclaw_misc_tools/src/secrets_tools.rs
+++ b/crates/dasclaw_misc_tools/src/secrets_tools.rs
@@ -15,8 +15,9 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 
-use crate::tools::tool::{ApprovalRequirement, Tool, ToolError, ToolOutput, require_str};
+use dasclaw_runtime::Tool;
 use dasclaw_runtime::secrets::SecretsStore;
+use dasclaw_tool::{ApprovalRequirement, ToolError, ToolOutput, require_str};
 
 // ── secret_list ──────────────────────────────────────────────────────────────
 
@@ -158,9 +159,9 @@ mod tests {
     use std::sync::Arc;
 
     use super::*;
-    use crate::testing::credentials::{TEST_OPENAI_API_KEY_SHORT, test_secrets_store};
     use dasclaw_runtime::context::JobContext;
     use dasclaw_runtime::secrets::CreateSecretParams;
+    use dasclaw_wasm_tools::test_credentials::{TEST_OPENAI_API_KEY_SHORT, test_secrets_store};
 
     fn test_store() -> Arc<dasclaw_runtime::secrets::InMemorySecretsStore> {
         Arc::new(test_secrets_store())

--- a/crates/dasclaw_wasm_tools/src/test_credentials.rs
+++ b/crates/dasclaw_wasm_tools/src/test_credentials.rs
@@ -44,6 +44,18 @@ pub const TEST_OAUTH_CLIENT_SECRET: &str = "test-client-secret";
 /// Bearer token with suffix (wasm wrapper credential injection).
 pub const TEST_BEARER_TOKEN_123: &str = "test-token-123";
 
+// ── OpenAI-style API keys ───────────────────────────────────────────────
+
+/// Short OpenAI-style key for secrets store accessibility tests.
+///
+/// Hoisted from `desktop-client/ironclaw/src/testing/credentials.rs` to
+/// support F4.6.1b: `dasclaw_misc_tools::secrets_tools` tests now consume
+/// this constant directly so the misc-tools crate no longer depends on
+/// the desktop crate. The downstream `testing/credentials` module
+/// re-exports this symbol so existing desktop callers continue to work
+/// unchanged.
+pub const TEST_OPENAI_API_KEY_SHORT: &str = "sk-test";
+
 // ── Helpers ──────────────────────────────────────────────────────────────
 
 /// Create an `InMemorySecretsStore` backed by [`TEST_CRYPTO_KEY`].

--- a/desktop-client/ironclaw/src/testing/credentials.rs
+++ b/desktop-client/ironclaw/src/testing/credentials.rs
@@ -10,7 +10,8 @@
 // orchestrator tests) continue to work unchanged.
 pub use dasclaw_wasm_tools::test_credentials::{
     TEST_BEARER_TOKEN_123, TEST_CRYPTO_KEY, TEST_GOOGLE_OAUTH_FRESH, TEST_GOOGLE_OAUTH_LEGACY,
-    TEST_GOOGLE_OAUTH_TOKEN, TEST_OAUTH_CLIENT_ID, TEST_OAUTH_CLIENT_SECRET, test_secrets_store,
+    TEST_GOOGLE_OAUTH_TOKEN, TEST_OAUTH_CLIENT_ID, TEST_OAUTH_CLIENT_SECRET,
+    TEST_OPENAI_API_KEY_SHORT, test_secrets_store,
 };
 
 // ── Encryption keys ──────────────────────────────────────────────────────
@@ -25,9 +26,6 @@ pub const TEST_OPENAI_API_KEY: &str = "sk-test123";
 
 /// OpenAI API key with longer format (config round-trip tests).
 pub const TEST_OPENAI_API_KEY_LONG: &str = "sk-test-key-1234567890";
-
-/// Short OpenAI-style key for secrets store accessibility tests.
-pub const TEST_OPENAI_API_KEY_SHORT: &str = "sk-test";
 
 /// OpenAI API key used in embeddings config issue-129 test.
 pub const TEST_OPENAI_API_KEY_ISSUE_129: &str = "sk-test-key-for-issue-129";

--- a/desktop-client/ironclaw/src/tools/builtin/mod.rs
+++ b/desktop-client/ironclaw/src/tools/builtin/mod.rs
@@ -14,7 +14,6 @@ pub mod memory;
 mod message;
 pub mod path_utils;
 pub mod routine;
-pub mod secrets_tools;
 pub(crate) mod shell;
 pub use shell::classify_command_risk;
 pub mod skill_tools;
@@ -24,11 +23,13 @@ mod web_fetch;
 mod web_search;
 
 // F4.6.1 — echo/time/json/plan_mode/restart/session_fork were extracted to
-// `crates/dasclaw_misc_tools` per ADR-156 §6.3. The thin re-export below
-// keeps every existing `crate::tools::builtin::EchoTool` (etc.) call site
-// compiling unchanged.
+// `crates/dasclaw_misc_tools` per ADR-156 §6.3. F4.6.1b added
+// secrets_tools (SecretListTool / SecretDeleteTool) into the same crate.
+// The thin re-export below keeps every existing
+// `crate::tools::builtin::EchoTool` (etc.) call site compiling unchanged.
 pub use dasclaw_misc_tools::{
-    EchoTool, JsonTool, PlanModeTool, RestartTool, SessionForkTool, TimeTool,
+    EchoTool, JsonTool, PlanModeTool, RestartTool, SecretDeleteTool, SecretListTool,
+    SessionForkTool, TimeTool,
 };
 
 pub use code_edit::CodeEditTool;
@@ -55,7 +56,6 @@ pub use routine::{
     EventEmitTool, RoutineCreateTool, RoutineDeleteTool, RoutineFireTool, RoutineHistoryTool,
     RoutineListTool, RoutineUpdateTool,
 };
-pub use secrets_tools::{SecretDeleteTool, SecretListTool};
 pub use shell::ShellTool;
 pub use skill_tools::{SkillInstallTool, SkillListTool, SkillRemoveTool, SkillSearchTool};
 pub use sub_agent::{SubAgentRole, SubAgentTool};

--- a/desktop-client/ironclaw/src/tools/tool.rs
+++ b/desktop-client/ironclaw/src/tools/tool.rs
@@ -9,7 +9,7 @@
 //! Pure-data primitives (`ApprovalRequirement`, `ApprovalContext`,
 //! `RiskLevel`, `ToolDomain`, `ToolOutput`, `ToolSchema`,
 //! `ToolDiscoverySummary`, `ToolRateLimitConfig`, `WebhookCapability`) and
-//! parameter helpers (`require_str`, `require_param`, `redact_params`,
+//! parameter helpers (`require_str`, `redact_params`,
 //! `validate_tool_schema`) continue to live in the shared `dasclaw_tool`
 //! crate.
 
@@ -17,8 +17,7 @@ pub use dasclaw_runtime::Tool;
 
 pub use dasclaw_tool::{
     ApprovalContext, ApprovalRequirement, RiskLevel, ToolDiscoverySummary, ToolDomain, ToolError,
-    ToolOutput, ToolRateLimitConfig, redact_params, require_param, require_str,
-    validate_tool_schema,
+    ToolOutput, ToolRateLimitConfig, redact_params, require_str, validate_tool_schema,
 };
 
 #[cfg(test)]


### PR DESCRIPTION
## 背景 / 目标

完成 PR #761 (F4.6.1) 延后的最后一步：把 `secrets_tools.rs` (SecretListTool + SecretDeleteTool) verbatim port 到已有的 `dasclaw_misc_tools` crate —— 这是 ADR-156 §6 表格中给 `secrets_tools` 指派的归宿。**不新建 crate**，因为 ADR-156 §6.3 的 F4.6.5 是 `dasclaw_git_tools` 扩展、不是 secrets。

## 改动范围

- **fixture hoist**：`TEST_OPENAI_API_KEY_SHORT` 从 desktop `testing/credentials.rs` 提升到 `crates/dasclaw_wasm_tools/src/test_credentials.rs`（与 `test_secrets_store` / `TEST_CRYPTO_KEY` 同位）；desktop 通过 re-export 保持对外签名不变
- **verbatim port**：`secrets_tools.rs` 218 行 → `crates/dasclaw_misc_tools/src/secrets_tools.rs`，git rename **96% similarity**（仅 5 行 imports 改动）
- **lib.rs**：新增 `mod secrets_tools;` + `pub use secrets_tools::{SecretDeleteTool, SecretListTool};`，更新 deferred-work 注释（tool_info 仍延后，依赖 ToolRegistry 下沉）
- **Cargo.toml**：dev-dep 加 `dasclaw_wasm_tools`
- **desktop builtin/mod.rs**：删 `pub mod secrets_tools;` 与本地 re-export，把 `SecretDeleteTool / SecretListTool` 合并进现有 `pub use dasclaw_misc_tools::{...}` 行
- **desktop tools/tool.rs**：顺手删 `require_param` re-export（secrets_tools 是 desktop 中唯一使用者，删后 dead）

## 非目标 (What's NOT in this PR)

- ❌ 不下沉 `tool_info.rs`（仍依赖 desktop `ToolRegistry`，留给 registry 下沉的 wave）
- ❌ 不改 `SecretsStore` trait 或 `InMemorySecretsStore` 实现
- ❌ 不动 secret CRUD 之外的工具

## 验证

| 步骤 | 结果 |
|---|---|
| `cargo check -p dasclaw_misc_tools --tests` | 0E 0W |
| `cargo nextest run -p dasclaw_misc_tools` | **47/47 pass** (45 + secret_list + secret_delete) |
| `cargo check -p dasclaw --tests` | 0E 0W |
| `cargo fmt --all` | clean |
| `python3.12 scripts/check_no_panics.py --base origin/xClaw` | clean |
| `cargo clippy --no-deps -p dasclaw_misc_tools --all-targets -- -D warnings` | clean |

## 三层审查

- ✅ **code-quality-audit**：无补丁式代码、无函数 > 50 行新增、verbatim port 与 F4.6.1 完全同模式
- ⏭️ **code-simplifier**：跳过（ADR-129 §1.3 verbatim port 禁止任何简化）
- ✅ **code-review-expert (self)**：依赖方向 desktop → dasclaw_misc_tools → dasclaw_runtime/tool，dev-dep dasclaw_wasm_tools 仅 test 用不污染 production 图；fixture hoist 安全（已通过 re-export 保持向后兼容）

## Cross-cuts

- **ADR-114**：不涉及（无 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量新增）
- **ADR-129 §1.3**：file body byte-for-byte 一致（git rename 96% similarity 作证）
- **ADR-156 §6**：完成 `dasclaw_misc_tools` 在 §6 表格中应有的 7 个工具中的最后 1 个（剩 `tool_info` 待 registry 下沉）

Closes #764