### PR TITLE
feat(dasclaw_sub_agent_tools): F4.6.4 verbatim port of sub_agent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2668,6 +2668,7 @@ dependencies = [
  "dasclaw_runtime",
  "dasclaw_safety",
  "dasclaw_sandbox",
+ "dasclaw_sub_agent_tools",
  "dasclaw_tool",
  "dasclaw_wasm_tools",
  "dasclaw_workspace_cap",
@@ -3348,6 +3349,19 @@ dependencies = [
  "tree-sitter-bash",
  "url",
  "which 8.0.2",
+]
+
+[[package]]
+name = "dasclaw_sub_agent_tools"
+version = "0.0.0-w6"
+dependencies = [
+ "async-trait",
+ "dasclaw_runtime",
+ "dasclaw_tool",
+ "serde",
+ "serde_json",
+ "tokio",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,8 @@ members = [
 	"crates/dasclaw_misc_tools",
 	# F4.6.6-a — fs leaf utilities (path_utils + file_guard) per ADR-156 §6.3
 	"crates/dasclaw_fs_tools",
+	# F4.6.4 — sub_agent builtin tool (SubAgentTool / SubAgentRole) per ADR-156 §6.3
+	"crates/dasclaw_sub_agent_tools",
 	# W2.6 接线层：组合 sandbox + pty + workspace_cap policy
 	"crates/dasclaw_exec",
 	# W6-C 主仓自实现 LLM provider —— 替代 claw-code-api path-dep（ADR-118 PR-A.0 骨架）

--- a/crates/dasclaw_sub_agent_tools/Cargo.toml
+++ b/crates/dasclaw_sub_agent_tools/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "dasclaw_sub_agent_tools"
+version = "0.0.0-w6"
+edition = "2024"
+description = "Sub-agent builtin tool (SubAgentTool / SubAgentRole) extracted from desktop-client/ironclaw per ADR-156 §6.3 F4.6.4."
+license = "Apache-2.0 OR MIT"
+publish = false
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+async-trait = "0.1"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tokio = { version = "1", features = ["time", "rt"] }
+
+dasclaw_runtime = { path = "../dasclaw_runtime" }
+dasclaw_tool = { path = "../dasclaw_tool" }
+
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }
+uuid = { version = "1", features = ["v4"] }

--- a/crates/dasclaw_sub_agent_tools/src/lib.rs
+++ b/crates/dasclaw_sub_agent_tools/src/lib.rs
@@ -1,0 +1,13 @@
+//! F4.6.4 — Sub-agent builtin tool extracted from
+//! `desktop-client/ironclaw/src/tools/builtin/` per
+//! [ADR-156 §6.3](../../../docs/plans/architecture-refactor/adr-156-f46-builtin-tools-landing-decision.md).
+//!
+//! Verbatim port (ADR-129 §1.3): the file body is a byte-for-byte copy of
+//! the desktop source, with only the `use` line rewritten from
+//! `crate::tools::tool::{...}` to `dasclaw_runtime::Tool` +
+//! `dasclaw_tool::{...}` to follow the workspace dependency direction
+//! (ADR-154 §3.1 amendment).
+
+mod sub_agent;
+
+pub use sub_agent::{SubAgentRole, SubAgentTool};

--- a/crates/dasclaw_sub_agent_tools/src/sub_agent.rs
+++ b/crates/dasclaw_sub_agent_tools/src/sub_agent.rs
@@ -14,7 +14,8 @@ use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 
-use crate::tools::tool::{ApprovalRequirement, RiskLevel, Tool, ToolDomain, ToolError, ToolOutput};
+use dasclaw_runtime::Tool;
+use dasclaw_tool::{ApprovalRequirement, RiskLevel, ToolDomain, ToolError, ToolOutput};
 
 /// Role a sub-agent can assume — determines its tool whitelist.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/desktop-client/ironclaw/Cargo.toml
+++ b/desktop-client/ironclaw/Cargo.toml
@@ -223,6 +223,10 @@ dasclaw_fs_tools = { path = "../../crates/dasclaw_fs_tools" }
 # from desktop tools/builtin/git/ per ADR-156 §6.3.
 dasclaw_git_tools = { path = "../../crates/dasclaw_git_tools" }
 
+# F4.6.4 — sub_agent builtin tool (SubAgentTool / SubAgentRole)
+# extracted from desktop tools/builtin/ per ADR-156 §6.3.
+dasclaw_sub_agent_tools = { path = "../../crates/dasclaw_sub_agent_tools" }
+
 # AWS Bedrock (native Converse API, opt-in via --features bedrock)
 aws-config = { version = "1", features = ["behavior-version-latest"], optional = true }
 aws-sdk-bedrockruntime = { version = "1", optional = true }

--- a/desktop-client/ironclaw/src/orchestrator/job_manager.rs
+++ b/desktop-client/ironclaw/src/orchestrator/job_manager.rs
@@ -32,7 +32,7 @@ pub enum JobMode {
     /// Lightweight sub-agent with restricted tool access and depth limit.
     SubAgent {
         /// Role determining the tool whitelist.
-        role: crate::tools::builtin::sub_agent::SubAgentRole,
+        role: crate::tools::builtin::SubAgentRole,
         /// Explicit tool whitelist (overrides role defaults if non-empty).
         tool_whitelist: Vec<String>,
         /// Maximum turns before the sub-agent must return a summary.

--- a/desktop-client/ironclaw/src/tools/builtin/mod.rs
+++ b/desktop-client/ironclaw/src/tools/builtin/mod.rs
@@ -11,7 +11,6 @@ pub mod routine;
 pub(crate) mod shell;
 pub use shell::classify_command_risk;
 pub mod skill_tools;
-pub mod sub_agent;
 mod tool_info;
 mod web_fetch;
 mod web_search;
@@ -44,6 +43,11 @@ pub use dasclaw_git_tools::{
     GitStatusTool,
 };
 
+// F4.6.4 — SubAgentTool / SubAgentRole were extracted to
+// `crates/dasclaw_sub_agent_tools` per ADR-156 §6.3. Thin re-export keeps
+// existing call sites compiling unchanged.
+pub use dasclaw_sub_agent_tools::{SubAgentRole, SubAgentTool};
+
 pub use code_edit::CodeEditTool;
 pub use extension_tools::{
     ExtensionInfoTool, ToolActivateTool, ToolAuthTool, ToolInstallTool, ToolListTool,
@@ -66,7 +70,6 @@ pub use routine::{
 };
 pub use shell::ShellTool;
 pub use skill_tools::{SkillInstallTool, SkillListTool, SkillRemoveTool, SkillSearchTool};
-pub use sub_agent::{SubAgentRole, SubAgentTool};
 pub use tool_info::ToolInfoTool;
 pub use web_fetch::WebFetchTool;
 pub use web_search::WebSearchTool;

--- a/desktop-client/ironclaw/tests/parity_gate_p2.rs
+++ b/desktop-client/ironclaw/tests/parity_gate_p2.rs
@@ -11,7 +11,7 @@
 
 use dasclaw_runtime::context::JobContext;
 use ironclaw::agent::session::{PendingPlan, PlanStep, Session, Thread, ThreadState};
-use ironclaw::tools::builtin::sub_agent::SubAgentRole;
+use ironclaw::tools::builtin::SubAgentRole;
 use ironclaw::tools::builtin::{PlanModeTool, SessionForkTool, SubAgentTool};
 use ironclaw::tools::{ApprovalRequirement, RiskLevel, Tool};
 

--- a/scripts/check_blueprint_sync.py
+++ b/scripts/check_blueprint_sync.py
@@ -47,7 +47,8 @@ PLANNED: dict[str, str] = {
     # F4.6.1 (`dasclaw_misc_tools`) landed in PR #761 — entry removed.
     "dasclaw_image_tools": "ADR-156 F4.6.2 planned",
     "dasclaw_memory_tools": "ADR-156 F4.6.3 planned",
-    "dasclaw_sub_agent_tools": "ADR-156 F4.6.4 planned",
+    # F4.6.4 (`dasclaw_sub_agent_tools`) landed — entry removed.
+    # F4.6.6-a (`dasclaw_fs_tools`) landed — entry removed.
     "dasclaw_shell_tools": "ADR-156 F4.6.7 planned",
     "dasclaw_net_tools": "ADR-156 F4.6.8 planned",
 }


### PR DESCRIPTION
## 背景 / 目标

ADR-156 §6.3 F4.6.4：把 `desktop-client/ironclaw/src/tools/builtin/sub_agent.rs` (400 行, `SubAgentTool` + `SubAgentRole`) verbatim port 到新 crate `dasclaw_sub_agent_tools`。

Verbatim port 遵循 ADR-129 §1.3：sub_agent.rs body byte-for-byte 不动，只改 `use crate::tools::tool::{...}` → `dasclaw_runtime::Tool` + `dasclaw_tool::{...}`（ADR-154 §3.1 依赖方向）。git rename detected at **99%** similarity（仅一行 use 改动）。

## 为什么先做 F4.6.4 而非 F4.6.2 / F4.6.3

调研结果：
- **F4.6.2 image_tools** 依赖 `crate::tools::builtin::path_utils::validate_path`（737 行尚未下沉，ADR-156 §6.3 计划随 F4.6.6 一起下沉）→ 暂阻塞
- **F4.6.3 memory_tools** 依赖 `crate::workspace::{Workspace, paths}` 跨模块依赖 → 暂阻塞
- **F4.6.4 sub_agent** 仅依赖 `crate::tools::tool::{...}` + serde/async_trait/std → 完全干净

为保持 F4.6 节奏稳定，先做 F4.6.4。F4.6.2 / F4.6.3 等 path_utils / workspace 下沉决定明确后回头处理。

## 改动范围

- `crates/dasclaw_sub_agent_tools/` 新建（Cargo.toml + src/lib.rs + git-mv sub_agent.rs）
- workspace `Cargo.toml`: 加 member
- `desktop-client/ironclaw/Cargo.toml`: 加 path 依赖
- 桌面 `tools/builtin/mod.rs`: 删 `pub mod sub_agent;` + 本地 re-export，加 `pub use dasclaw_sub_agent_tools::{SubAgentRole, SubAgentTool}`
- 调用点路径更新：`orchestrator/job_manager.rs` + `tests/parity_gate_p2.rs` 从 `builtin::sub_agent::X` → `builtin::X`
- `scripts/check_blueprint_sync.py`: 从 PLANNED dict 移除 dasclaw_sub_agent_tools（已 LANDED）

## 非目标（What's NOT in this PR）

- 不下沉 path_utils（留给 F4.6.6 fs_tools）
- 不下沉 `crate::workspace::{Workspace, paths}`（留给后续 wave）
- 不动 F4.6.2 image_tools / F4.6.3 memory_tools
- 不改 tool_info.rs（仍依赖 `ToolRegistry`，留给后续 wave）
- 不改 SubAgentTool 语义、ApprovalRequirement、RiskLevel、ToolDomain

## 验证

- `cargo check -p dasclaw_sub_agent_tools --tests`: **0E 0W**
- `cargo nextest run -p dasclaw_sub_agent_tools`: **11/11 pass**
- `cargo check -p dasclaw --tests`: clean（pre-existing `require_param` warning 来自 xClaw，与本 PR 无关）
- `cargo fmt --all`: clean
- `python3.12 scripts/check_no_panics.py --base origin/xClaw`: clean
- `python3.12 scripts/check_blueprint_sync.py`: **OK 43 crates / 6 planned**
- `cargo clippy --no-deps -p dasclaw_sub_agent_tools --all-targets -- -D warnings`: clean

## 三层审查

- code-quality-audit: ✅ 无补丁式代码 / 无 unwrap / lib 公共面收敛到 `SubAgentRole, SubAgentTool` / 依赖最小
- code-simplifier: **SKIPPED**（verbatim port discipline per ADR-129 §1.3）
- code-review-expert: ✅ SOLID / 无新增安全面 / dep 方向正确 / 11 tests 覆盖失败路径（depth limit / missing role / empty goal）

## Cross-cuts

**不涉及 ADR-114** —— 无新增 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量。

## 后续

- F4.6.2 image / F4.6.3 memory：待 path_utils 与 workspace 下沉策略确定后再开
- F4.6.5 git_tools / F4.6.7 shell_tools / F4.6.8 net_tools：待评估

Closes #766