### PR TITLE
F4.6.6-a: dasclaw_fs_tools — verbatim port path_utils + file_guard (leaf layer)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2653,6 +2653,7 @@ dependencies = [
  "dasclaw_channels",
  "dasclaw_core",
  "dasclaw_exec",
+ "dasclaw_fs_tools",
  "dasclaw_governance",
  "dasclaw_hooks",
  "dasclaw_llm_provider",
@@ -2910,6 +2911,18 @@ name = "dasclaw_features"
 version = "0.0.0-w1"
 dependencies = [
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "dasclaw_fs_tools"
+version = "0.0.0-w6"
+dependencies = [
+ "dasclaw_runtime",
+ "dasclaw_tool",
+ "globset",
+ "serde_json",
+ "tempfile",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,8 @@ members = [
 	"crates/dasclaw_wasm_tools",
 	# F4.6.1 — misc builtin tools (echo/time/json/plan_mode/restart/session_fork) per ADR-156 §6.3
 	"crates/dasclaw_misc_tools",
+	# F4.6.6-a — fs leaf utilities (path_utils + file_guard) per ADR-156 §6.3
+	"crates/dasclaw_fs_tools",
 	# W2.6 接线层：组合 sandbox + pty + workspace_cap policy
 	"crates/dasclaw_exec",
 	# W6-C 主仓自实现 LLM provider —— 替代 claw-code-api path-dep（ADR-118 PR-A.0 骨架）

--- a/crates/dasclaw_fs_tools/Cargo.toml
+++ b/crates/dasclaw_fs_tools/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "dasclaw_fs_tools"
+version = "0.0.0-w6"
+edition = "2024"
+description = "Filesystem path validation + file guard primitives (leaf layer) extracted from desktop-client/ironclaw per ADR-156 §6.3 F4.6.6-a."
+license = "Apache-2.0 OR MIT"
+publish = false
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+globset = "0.4"
+tracing = "0.1"
+
+dasclaw_runtime = { path = "../dasclaw_runtime" }
+dasclaw_tool = { path = "../dasclaw_tool" }
+
+[dev-dependencies]
+serde_json = "1"
+tempfile = "3"

--- a/crates/dasclaw_fs_tools/src/file_guard.rs
+++ b/crates/dasclaw_fs_tools/src/file_guard.rs
@@ -8,8 +8,8 @@
 
 use std::path::{Path, PathBuf};
 
-use crate::tools::builtin::path_utils::validate_path;
-use crate::tools::tool::ToolError;
+use crate::path_utils::validate_path;
+use dasclaw_tool::ToolError;
 
 /// Default maximum file size: 10 MB.
 const DEFAULT_MAX_FILE_SIZE: u64 = 10 * 1024 * 1024;

--- a/crates/dasclaw_fs_tools/src/lib.rs
+++ b/crates/dasclaw_fs_tools/src/lib.rs
@@ -1,0 +1,15 @@
+//! `dasclaw_fs_tools` — filesystem path validation + file guard primitives.
+//!
+//! Verbatim port of the leaf layer of `desktop-client/ironclaw/src/tools/builtin/`
+//! filesystem tooling per ADR-156 §6.3 F4.6.6-a. Higher-tier consumers
+//! (`code_edit`, `glob_search`, `grep_search`, `file`) follow in F4.6.6-b/-c.
+//!
+//! # Modules
+//!
+//! - [`path_utils`] — secure path validation (directory traversal defence,
+//!   glob allow/deny, `PathPolicy`, `effective_base_dir`).
+//! - [`file_guard`] — symlink-escape, binary-file, size, line-ending guards
+//!   layered on top of [`path_utils::validate_path`].
+
+pub mod file_guard;
+pub mod path_utils;

--- a/crates/dasclaw_fs_tools/src/path_utils.rs
+++ b/crates/dasclaw_fs_tools/src/path_utils.rs
@@ -7,7 +7,7 @@ use std::path::{Path, PathBuf};
 
 use globset::{Glob, GlobSet, GlobSetBuilder};
 
-use crate::tools::tool::ToolError;
+use dasclaw_tool::ToolError;
 
 /// Resolve the effective base directory for file operations.
 ///

--- a/desktop-client/ironclaw/Cargo.toml
+++ b/desktop-client/ironclaw/Cargo.toml
@@ -216,6 +216,9 @@ dasclaw_wasm_tools = { path = "../../crates/dasclaw_wasm_tools" }
 # extracted from desktop tools/builtin/ per ADR-156 §6.3.
 dasclaw_misc_tools = { path = "../../crates/dasclaw_misc_tools" }
 
+# F4.6.6-a — fs leaf utilities (path_utils + file_guard) per ADR-156 §6.3.
+dasclaw_fs_tools = { path = "../../crates/dasclaw_fs_tools" }
+
 # AWS Bedrock (native Converse API, opt-in via --features bedrock)
 aws-config = { version = "1", features = ["behavior-version-latest"], optional = true }
 aws-sdk-bedrockruntime = { version = "1", optional = true }

--- a/desktop-client/ironclaw/src/tools/builtin/mod.rs
+++ b/desktop-client/ironclaw/src/tools/builtin/mod.rs
@@ -3,7 +3,6 @@
 mod code_edit;
 pub mod extension_tools;
 mod file;
-pub mod file_guard;
 pub mod git;
 mod glob_search;
 mod grep_search;
@@ -12,7 +11,6 @@ mod job;
 pub mod lsp;
 pub mod memory;
 mod message;
-pub mod path_utils;
 pub mod routine;
 pub mod secrets_tools;
 pub(crate) mod shell;
@@ -22,6 +20,15 @@ pub mod sub_agent;
 mod tool_info;
 mod web_fetch;
 mod web_search;
+
+// F4.6.6-a (ADR-156 §6.3): `path_utils` + `file_guard` extracted to
+// `dasclaw_fs_tools`. Re-exported at the original module paths so the
+// 13 in-tree consumers (`tools::builtin::path_utils::*` /
+// `tools::builtin::file_guard::*`) and external `tests/parity_gate_*`
+// imports keep working without changes. Subsequent F4.6.6-b/-c will
+// migrate the higher-tier fs tools (file/code_edit/glob/grep) onto this
+// base.
+pub use dasclaw_fs_tools::{file_guard, path_utils};
 
 // F4.6.1 — echo/time/json/plan_mode/restart/session_fork were extracted to
 // `crates/dasclaw_misc_tools` per ADR-156 §6.3. The thin re-export below

--- a/scripts/check_blueprint_sync.py
+++ b/scripts/check_blueprint_sync.py
@@ -48,7 +48,6 @@ PLANNED: dict[str, str] = {
     "dasclaw_image_tools": "ADR-156 F4.6.2 planned",
     "dasclaw_memory_tools": "ADR-156 F4.6.3 planned",
     "dasclaw_sub_agent_tools": "ADR-156 F4.6.4 planned",
-    "dasclaw_fs_tools": "ADR-156 F4.6.6 planned",
     "dasclaw_shell_tools": "ADR-156 F4.6.7 planned",
     "dasclaw_net_tools": "ADR-156 F4.6.8 planned",
 }


### PR DESCRIPTION
Closes #770

## 背景

ADR-156 §6.3 wave 8 子任务 F4.6.6 = 把 desktop builtin 的文件系统类工具下沉到新 crate `dasclaw_fs_tools`，
完整范围 ~3051 LOC（`file.rs` + `code_edit.rs` + `glob_search.rs` + `grep_search.rs` + `path_utils.rs` + `file_guard.rs`）。

经 code-review-graph + 直接代码扫描确认两个事实，导致**单 PR 一次性 verbatim 搬全部 6 个文件不可行**：

1. `file.rs:17` 依赖 `crate::workspace::paths`（实际是 `crate::workspace::document::paths`），是 desktop 私有基础设施（含 `HEARTBEAT`/`MEMORY`/`IDENTITY`/`SOUL`/`AGENTS`/`USER`/`README` 常量集合），verbatim port 无法直接拷贝。
2. `path_utils.rs` 是基础叶子（5 个文件 + 13 个消费者共用 path 校验），必须**先下沉**再处理上层工具。

按 AGENTS.md "PR 小而完整" + ADR-129 §1.3 verbatim 纪律，把 F4.6.6 切成 stacked 子任务，本 issue 跟踪 **F4.6.6-a 叶子层**。

## 范围（F4.6.6-a）

新建 `crates/dasclaw_fs_tools/` 并 verbatim 下沉 2 个叶子文件：

| 文件 | LOC | 内部依赖 |
| --- | ---: | --- |
| `path_utils.rs` | 737 | 仅 `tools::tool::ToolError` |
| `file_guard.rs` | 184 | 仅 `path_utils::validate_path` + `tools::tool::ToolError` |
| **合计** | **921** | — |

机械改动（不算 verbatim 违规）：
- 每文件 1 行 `use crate::tools::tool::ToolError;` → `use dasclaw_tool::ToolError;`
- `file_guard.rs` 内 `use crate::tools::builtin::path_utils::validate_path;` → `use crate::path_utils::validate_path;`（crate-internal 路径）

desktop `tools/builtin/mod.rs` 改为 `pub use dasclaw_fs_tools::{path_utils, file_guard};` 模块级 re-export，
保留对外路径 `tools::builtin::path_utils::X` / `tools::builtin::file_guard::X`，使 13 个消费者文件**完全不需要改动**（最小 churn）。

## 非目标（Not in this PR）

- ⛔ `file.rs`（含 `ApplyPatchTool`/`ListDirTool`/`ReadFileTool`/`WriteFileTool`）— 留给 F4.6.6-c，需先处理 `workspace::paths` 抽取
- ⛔ `code_edit.rs` / `glob_search.rs` / `grep_search.rs` — 留给 F4.6.6-b（依赖本 PR 落地 `dasclaw_fs_tools::{path_utils, file_guard}`）
- ⛔ 不抽 `path_utils` 内的 `validate_path` 公共 API 重构（verbatim 纪律）
- ⛔ 不动消费者文件的 `use` 路径

## 关联 ADR

- ADR-156 §6.3 wave 8 — F4.6.6 总范围
- ADR-129 §1.3 — verbatim port（file body 字节级一致）
- ADR-154 §3.1 — desktop → crates 单向依赖

## Cross-cuts

- ADR-114：**不涉及**（无新增 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量）

## 验证

```bash
cargo check -p dasclaw_fs_tools --tests       # 0E0W
cargo nextest run -p dasclaw_fs_tools
cargo check -p dasclaw --tests                # 0E0W（包名 dasclaw，非 ironclaw）
cargo fmt --all
python3.12 scripts/check_no_panics.py --base origin/xClaw
python3.12 scripts/check_blueprint_sync.py
cargo clippy --no-deps -p dasclaw_fs_tools --all-targets -- -D warnings
```

## 后续

- F4.6.6-b：搬 `code_edit.rs` + `glob_search.rs` + `grep_search.rs`（依赖本 PR）
- F4.6.6-c：搬 `file.rs`，并处理 `workspace::paths` 抽取策略（可能把常量集合也下沉成 `dasclaw_workspace_paths` 或入参化）