### PR TITLE
F4.6.6-b: dasclaw_fs_tools — verbatim port code_edit + glob_search + grep_search (middle tier, stacked on #771)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2917,11 +2917,14 @@ dependencies = [
 name = "dasclaw_fs_tools"
 version = "0.0.0-w6"
 dependencies = [
+ "async-trait",
  "dasclaw_runtime",
  "dasclaw_tool",
  "globset",
+ "regex",
  "serde_json",
  "tempfile",
+ "tokio",
  "tracing",
 ]
 

--- a/crates/dasclaw_fs_tools/Cargo.toml
+++ b/crates/dasclaw_fs_tools/Cargo.toml
@@ -2,7 +2,7 @@
 name = "dasclaw_fs_tools"
 version = "0.0.0-w6"
 edition = "2024"
-description = "Filesystem path validation + file guard primitives (leaf layer) extracted from desktop-client/ironclaw per ADR-156 §6.3 F4.6.6-a."
+description = "Filesystem tools (path validation, file guard, code_edit, glob_search, grep_search) extracted from desktop-client/ironclaw per ADR-156 §6.3 F4.6.6-a/-b."
 license = "Apache-2.0 OR MIT"
 publish = false
 
@@ -10,12 +10,16 @@ publish = false
 path = "src/lib.rs"
 
 [dependencies]
+async-trait = "0.1"
 globset = "0.4"
+regex = "1"
+serde_json = "1"
+tokio = { version = "1", features = ["fs", "rt", "macros"] }
 tracing = "0.1"
 
 dasclaw_runtime = { path = "../dasclaw_runtime" }
 dasclaw_tool = { path = "../dasclaw_tool" }
 
 [dev-dependencies]
-serde_json = "1"
 tempfile = "3"
+tokio = { version = "1", features = ["fs", "rt", "macros", "rt-multi-thread"] }

--- a/crates/dasclaw_fs_tools/src/code_edit.rs
+++ b/crates/dasclaw_fs_tools/src/code_edit.rs
@@ -14,12 +14,10 @@ use std::path::PathBuf;
 use async_trait::async_trait;
 use tokio::fs;
 
-use crate::tools::builtin::path_utils::{AccessMode, PathPolicy, validate_path_with_policy};
-use crate::tools::tool::{
-    ApprovalRequirement, Tool, ToolDomain, ToolError, ToolOutput, require_str,
-};
-
-use super::file_guard;
+use crate::file_guard;
+use crate::path_utils::{AccessMode, PathPolicy, validate_path_with_policy};
+use dasclaw_runtime::Tool;
+use dasclaw_tool::{ApprovalRequirement, ToolDomain, ToolError, ToolOutput, require_str};
 
 /// Maximum file size for editing (10MB).
 const MAX_EDIT_SIZE: u64 = 10 * 1024 * 1024;
@@ -176,8 +174,8 @@ impl Tool for CodeEditTool {
         ToolDomain::Container
     }
 
-    fn rate_limit_config(&self) -> Option<crate::tools::tool::ToolRateLimitConfig> {
-        Some(crate::tools::tool::ToolRateLimitConfig::new(20, 200))
+    fn rate_limit_config(&self) -> Option<dasclaw_tool::ToolRateLimitConfig> {
+        Some(dasclaw_tool::ToolRateLimitConfig::new(20, 200))
     }
 }
 

--- a/crates/dasclaw_fs_tools/src/glob_search.rs
+++ b/crates/dasclaw_fs_tools/src/glob_search.rs
@@ -8,10 +8,9 @@ use std::path::{Path, PathBuf};
 
 use async_trait::async_trait;
 
-use crate::tools::builtin::path_utils::validate_path;
-use crate::tools::tool::{
-    ApprovalRequirement, Tool, ToolDomain, ToolError, ToolOutput, require_str,
-};
+use crate::path_utils::validate_path;
+use dasclaw_runtime::Tool;
+use dasclaw_tool::{ApprovalRequirement, ToolDomain, ToolError, ToolOutput, require_str};
 
 /// Maximum results returned by default.
 const DEFAULT_MAX_RESULTS: usize = 100;

--- a/crates/dasclaw_fs_tools/src/grep_search.rs
+++ b/crates/dasclaw_fs_tools/src/grep_search.rs
@@ -9,11 +9,10 @@ use std::path::{Path, PathBuf};
 
 use async_trait::async_trait;
 
-use crate::tools::builtin::file_guard;
-use crate::tools::builtin::path_utils::validate_path;
-use crate::tools::tool::{
-    ApprovalRequirement, Tool, ToolDomain, ToolError, ToolOutput, require_str,
-};
+use crate::file_guard;
+use crate::path_utils::validate_path;
+use dasclaw_runtime::Tool;
+use dasclaw_tool::{ApprovalRequirement, ToolDomain, ToolError, ToolOutput, require_str};
 
 /// Maximum number of results returned by default.
 const DEFAULT_MAX_RESULTS: usize = 50;

--- a/crates/dasclaw_fs_tools/src/lib.rs
+++ b/crates/dasclaw_fs_tools/src/lib.rs
@@ -1,8 +1,13 @@
-//! `dasclaw_fs_tools` — filesystem path validation + file guard primitives.
+//! `dasclaw_fs_tools` — filesystem tools (path validation, guards, code/file search).
 //!
-//! Verbatim port of the leaf layer of `desktop-client/ironclaw/src/tools/builtin/`
-//! filesystem tooling per ADR-156 §6.3 F4.6.6-a. Higher-tier consumers
-//! (`code_edit`, `glob_search`, `grep_search`, `file`) follow in F4.6.6-b/-c.
+//! Verbatim port of `desktop-client/ironclaw/src/tools/builtin/` filesystem
+//! tooling per ADR-156 §6.3.
+//!
+//! - F4.6.6-a (leaf): `path_utils`, `file_guard`.
+//! - F4.6.6-b (middle): `code_edit`, `glob_search`, `grep_search` — built on
+//!   top of the leaf layer; expose `Tool` implementations consumed by the
+//!   desktop tool registry.
+//! - F4.6.6-c (heavy): `file` — pending workspace::paths extraction.
 //!
 //! # Modules
 //!
@@ -10,6 +15,13 @@
 //!   glob allow/deny, `PathPolicy`, `effective_base_dir`).
 //! - [`file_guard`] — symlink-escape, binary-file, size, line-ending guards
 //!   layered on top of [`path_utils::validate_path`].
+//! - [`code_edit`] — single-point-replacement editor with count verification
+//!   and unified-diff preview.
+//! - [`glob_search`] — `find`-like file path matching via glob patterns.
+//! - [`grep_search`] — `grep`-like regex content search with optional context.
 
+pub mod code_edit;
 pub mod file_guard;
+pub mod glob_search;
+pub mod grep_search;
 pub mod path_utils;

--- a/desktop-client/ironclaw/src/tools/builtin/mod.rs
+++ b/desktop-client/ironclaw/src/tools/builtin/mod.rs
@@ -1,11 +1,8 @@
 //! Built-in tools that come with the agent.
 
-mod code_edit;
 pub mod extension_tools;
 mod file;
 pub mod git;
-mod glob_search;
-mod grep_search;
 mod http;
 mod job;
 pub mod lsp;
@@ -21,14 +18,15 @@ mod tool_info;
 mod web_fetch;
 mod web_search;
 
-// F4.6.6-a (ADR-156 §6.3): `path_utils` + `file_guard` extracted to
-// `dasclaw_fs_tools`. Re-exported at the original module paths so the
-// 13 in-tree consumers (`tools::builtin::path_utils::*` /
-// `tools::builtin::file_guard::*`) and external `tests/parity_gate_*`
-// imports keep working without changes. Subsequent F4.6.6-b/-c will
-// migrate the higher-tier fs tools (file/code_edit/glob/grep) onto this
-// base.
-pub use dasclaw_fs_tools::{file_guard, path_utils};
+// F4.6.6-a/-b (ADR-156 §6.3): `path_utils` + `file_guard` + `code_edit` +
+// `glob_search` + `grep_search` were extracted to `dasclaw_fs_tools`.
+// Re-exported at the original module paths so existing in-tree consumers
+// (`tools::builtin::path_utils::*` / `tools::builtin::file_guard::*` /
+// `tools::builtin::code_edit::*` / `tools::builtin::glob_search::*` /
+// `tools::builtin::grep_search::*`) and external `tests/parity_gate_*`
+// imports keep working without changes. F4.6.6-c will migrate `file`
+// once `workspace::paths` extraction is decided.
+pub use dasclaw_fs_tools::{code_edit, file_guard, glob_search, grep_search, path_utils};
 
 // F4.6.1 — echo/time/json/plan_mode/restart/session_fork were extracted to
 // `crates/dasclaw_misc_tools` per ADR-156 §6.3. The thin re-export below


### PR DESCRIPTION
**Stacked on #771** — base branch is `feat/f466a-fs-tools-leaf` (NOT `xClaw`). Please merge #771 first, then this PR.

## 背景

ADR-156 §6.3 wave 8 F4.6.6 中层切片：在 #771 引入的 `dasclaw_fs_tools` 上继续下沉
`code_edit` / `glob_search` / `grep_search` 三个高阶 tool。verbatim port
（ADR-129 §1.3），相似度 93–98%，仅改 use 行 + 1 处 ToolRateLimitConfig 全限定路径。

## 改动范围

| 文件 | 类型 | 备注 |
|---|---|---|
| `crates/dasclaw_fs_tools/Cargo.toml` | M | 加 `async-trait` / `regex` / `serde_json` / `tokio` (fs/rt/macros) |
| `crates/dasclaw_fs_tools/src/lib.rs` | M | 注册 3 个新模块 + 更新 doc |
| `crates/dasclaw_fs_tools/src/code_edit.rs` | R | git mv（相似度 97%）|
| `crates/dasclaw_fs_tools/src/glob_search.rs` | R | git mv（98%）|
| `crates/dasclaw_fs_tools/src/grep_search.rs` | R | git mv（98%）|
| `desktop-client/ironclaw/src/tools/builtin/mod.rs` | M | 移除 `mod code_edit/glob_search/grep_search;`，扩展 `pub use dasclaw_fs_tools::{code_edit, file_guard, glob_search, grep_search, path_utils};` |

零消费者改动：所有 `pub use code_edit::CodeEditTool;` / `glob_search::GlobSearchTool;` /
`grep_search::GrepSearchTool;` 透过模块级 re-export 继续解析成功。

## 非目标（What's NOT in this PR）

- ❌ F4.6.6-c：`file.rs` (956 LOC) — 需先解决 `workspace::document::paths`
  常量（HEARTBEAT/MEMORY/IDENTITY/SOUL/AGENTS/USER/README）的提取策略
- ❌ 任何 logic 改动：本 PR 只做 verbatim port + 路径接线
- ❌ 给 `dasclaw_fs_tools` 加 `pub use` 顶层 re-export（保持 `crate::module::Item` 调用风格不变）

## 验证

```
cargo check -p dasclaw_fs_tools --tests        ✓
cargo nextest run -p dasclaw_fs_tools           ✓ 62/62 pass
cargo check -p dasclaw --tests                  ✓ (只剩 pre-existing require_param 警告)
cargo fmt --all                                  ✓
scripts/check_no_panics.py --base origin/xClaw  ✓
scripts/check_blueprint_sync.py                  ✓
cargo clippy --no-deps -p dasclaw_fs_tools --all-targets -- -D warnings ✓
```

## 复用检查（前置必做）

- code-review-graph `ironclaw` + `xclaw-core` 已增量重建（`Incremental: 9 files updated`）
- `mcp_code-review-g_cross_repo_search_tool`：`code edit apply patch file content modification` / `glob search files pattern walk` 在 5 repo 零命中
- `ls crates/` 仅有 `dasclaw_apply_patch`（codex apply_patch 解析器；与 desktop CodeEditTool 单点字符串替换工具是两个独立 surface，desktop ApplyPatchTool 早已依赖 `dasclaw_apply_patch`）
- 结论：无重复造轮子风险

## Cross-cuts

- ADR-114：**类A**（无新增 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量）
- ADR-129 §1.3 verbatim discipline：✓ similarity 97/98/98
- ADR-156 §6.3 wave 8 F4.6.6-b
- code-simplifier：SKIPPED（verbatim 纪律）

## 后续 PR / 下一步

- F4.6.6-c：`file.rs` 搬迁 — 需要单开 ADR 子节决定 `workspace::paths` 处置（提取到新 crate vs 行内常量 vs 参数注入）

Closes #770（与 #771 共同闭环 F4.6.6-a/-b；F4.6.6-c 单独开新 issue）
