### PR TITLE
feat(fs_tools): port file.rs (read/write/list/apply_patch) per ADR-156 §6.3 F4.6.6-c

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2919,8 +2919,10 @@ name = "dasclaw_fs_tools"
 version = "0.0.0-w6"
 dependencies = [
  "async-trait",
+ "dasclaw_apply_patch",
  "dasclaw_runtime",
  "dasclaw_tool",
+ "dasclaw_workspace_cap",
  "globset",
  "regex",
  "serde_json",

--- a/crates/dasclaw_fs_tools/Cargo.toml
+++ b/crates/dasclaw_fs_tools/Cargo.toml
@@ -2,7 +2,7 @@
 name = "dasclaw_fs_tools"
 version = "0.0.0-w6"
 edition = "2024"
-description = "Filesystem tools (path validation, file guard, code_edit, glob_search, grep_search) extracted from desktop-client/ironclaw per ADR-156 §6.3 F4.6.6-a/-b."
+description = "Filesystem tools (path validation, file guard, code_edit, glob_search, grep_search, file ops, apply_patch) extracted from desktop-client/ironclaw per ADR-156 §6.3 F4.6.6-a/-b/-c."
 license = "Apache-2.0 OR MIT"
 publish = false
 
@@ -19,6 +19,8 @@ tracing = "0.1"
 
 dasclaw_runtime = { path = "../dasclaw_runtime" }
 dasclaw_tool = { path = "../dasclaw_tool" }
+dasclaw_workspace_cap = { path = "../dasclaw_workspace_cap" }
+dasclaw_apply_patch = { path = "../dasclaw_apply_patch" }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/dasclaw_fs_tools/src/file.rs
+++ b/crates/dasclaw_fs_tools/src/file.rs
@@ -10,13 +10,12 @@ use std::path::{Path, PathBuf};
 use async_trait::async_trait;
 use tokio::fs;
 
-use crate::tools::builtin::path_utils::{AccessMode, PathPolicy, validate_path_with_policy};
-use crate::tools::tool::{
-    ApprovalRequirement, Tool, ToolDomain, ToolError, ToolOutput, require_str,
-};
-use crate::workspace::paths as ws_paths;
+use crate::path_utils::{AccessMode, PathPolicy, validate_path_with_policy};
+use dasclaw_runtime::Tool;
+use dasclaw_tool::{ApprovalRequirement, ToolDomain, ToolError, ToolOutput, require_str};
+use dasclaw_workspace_cap::document::paths as ws_paths;
 
-use super::file_guard;
+use crate::file_guard;
 
 /// Well-known workspace filenames that must go through memory_write, not write_file.
 ///
@@ -122,7 +121,7 @@ impl Tool for ReadFileTool {
 
         let start = std::time::Instant::now();
 
-        let effective = super::path_utils::effective_base_dir(self.base_dir.as_deref(), ctx);
+        let effective = crate::path_utils::effective_base_dir(self.base_dir.as_deref(), ctx);
         let path = validate_path_with_policy(
             path_str,
             effective.as_deref(),
@@ -280,7 +279,7 @@ impl Tool for WriteFileTool {
             )));
         }
 
-        let effective = super::path_utils::effective_base_dir(self.base_dir.as_deref(), ctx);
+        let effective = crate::path_utils::effective_base_dir(self.base_dir.as_deref(), ctx);
         let path = validate_path_with_policy(
             path_str,
             effective.as_deref(),
@@ -321,8 +320,8 @@ impl Tool for WriteFileTool {
         ToolDomain::Container
     }
 
-    fn rate_limit_config(&self) -> Option<crate::tools::tool::ToolRateLimitConfig> {
-        Some(crate::tools::tool::ToolRateLimitConfig::new(20, 200))
+    fn rate_limit_config(&self) -> Option<dasclaw_tool::ToolRateLimitConfig> {
+        Some(dasclaw_tool::ToolRateLimitConfig::new(20, 200))
     }
 }
 
@@ -400,7 +399,7 @@ impl Tool for ListDirTool {
 
         let start = std::time::Instant::now();
 
-        let effective = super::path_utils::effective_base_dir(self.base_dir.as_deref(), ctx);
+        let effective = crate::path_utils::effective_base_dir(self.base_dir.as_deref(), ctx);
         let path = validate_path_with_policy(
             path_str,
             effective.as_deref(),
@@ -614,7 +613,7 @@ impl Tool for ApplyPatchTool {
         let args = dasclaw_apply_patch::parse_patch(input)
             .map_err(|e| ToolError::ExecutionFailed(format!("invalid patch: {e}")))?;
 
-        let effective = super::path_utils::effective_base_dir(self.base_dir.as_deref(), ctx);
+        let effective = crate::path_utils::effective_base_dir(self.base_dir.as_deref(), ctx);
 
         // Validate every destination path through the configured policy *before*
         // touching the filesystem; the apply layer then enforces base_dir again
@@ -662,15 +661,15 @@ impl Tool for ApplyPatchTool {
         ToolDomain::Container
     }
 
-    fn rate_limit_config(&self) -> Option<crate::tools::tool::ToolRateLimitConfig> {
-        Some(crate::tools::tool::ToolRateLimitConfig::new(20, 200))
+    fn rate_limit_config(&self) -> Option<dasclaw_tool::ToolRateLimitConfig> {
+        Some(dasclaw_tool::ToolRateLimitConfig::new(20, 200))
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tools::builtin::path_utils::{normalize_lexical, validate_path};
+    use crate::path_utils::{normalize_lexical, validate_path};
     use dasclaw_runtime::context::JobContext;
     use tempfile::TempDir;
 

--- a/crates/dasclaw_fs_tools/src/lib.rs
+++ b/crates/dasclaw_fs_tools/src/lib.rs
@@ -7,7 +7,10 @@
 //! - F4.6.6-b (middle): `code_edit`, `glob_search`, `grep_search` — built on
 //!   top of the leaf layer; expose `Tool` implementations consumed by the
 //!   desktop tool registry.
-//! - F4.6.6-c (heavy): `file` — pending workspace::paths extraction.
+//! - F4.6.6-c (heavy): `file` — `ReadFileTool` / `WriteFileTool` /
+//!   `ListDirTool` / `ApplyPatchTool` built on top of the leaf layer plus
+//!   `dasclaw_workspace_cap::document::paths` for well-known memory filenames
+//!   and `dasclaw_apply_patch` for envelope parsing.
 //!
 //! # Modules
 //!
@@ -19,8 +22,10 @@
 //!   and unified-diff preview.
 //! - [`glob_search`] — `find`-like file path matching via glob patterns.
 //! - [`grep_search`] — `grep`-like regex content search with optional context.
+//! - [`file`] — `read_file` / `write_file` / `list_dir` / `apply_patch` tools.
 
 pub mod code_edit;
+pub mod file;
 pub mod file_guard;
 pub mod glob_search;
 pub mod grep_search;

--- a/desktop-client/ironclaw/src/tools/builtin/mod.rs
+++ b/desktop-client/ironclaw/src/tools/builtin/mod.rs
@@ -1,7 +1,6 @@
 //! Built-in tools that come with the agent.
 
 pub mod extension_tools;
-mod file;
 mod http;
 mod job;
 pub mod lsp;
@@ -16,15 +15,14 @@ mod tool_info;
 mod web_fetch;
 mod web_search;
 
-// F4.6.6-a/-b (ADR-156 §6.3): `path_utils` + `file_guard` + `code_edit` +
-// `glob_search` + `grep_search` were extracted to `dasclaw_fs_tools`.
+// F4.6.6-a/-b/-c (ADR-156 §6.3): `path_utils` + `file_guard` + `code_edit` +
+// `glob_search` + `grep_search` + `file` were extracted to `dasclaw_fs_tools`.
 // Re-exported at the original module paths so existing in-tree consumers
 // (`tools::builtin::path_utils::*` / `tools::builtin::file_guard::*` /
 // `tools::builtin::code_edit::*` / `tools::builtin::glob_search::*` /
-// `tools::builtin::grep_search::*`) and external `tests/parity_gate_*`
-// imports keep working without changes. F4.6.6-c will migrate `file`
-// once `workspace::paths` extraction is decided.
-pub use dasclaw_fs_tools::{code_edit, file_guard, glob_search, grep_search, path_utils};
+// `tools::builtin::grep_search::*` / `tools::builtin::file::*`) and external
+// `tests/parity_gate_*` imports keep working without changes.
+pub use dasclaw_fs_tools::{code_edit, file, file_guard, glob_search, grep_search, path_utils};
 
 // F4.6.1 — echo/time/json/plan_mode/restart/session_fork were extracted to
 // `crates/dasclaw_misc_tools` per ADR-156 §6.3. F4.6.1b added


### PR DESCRIPTION
## 背景 / 目标

F4.6.6 三段切片的最后一片：把 `desktop-client/ironclaw/src/tools/builtin/file.rs`（956 LOC，4 个 Tool 实现）按 ADR-156 §6.3 verbatim 迁到 `crates/dasclaw_fs_tools`。

**Stacked PR 顺序**：先看 #771 (F4.6.6-a) → #772 (F4.6.6-b) → 本 PR (F4.6.6-c)。本 PR base 是 `feat/f466b-fs-tools-middle`，不是 `xClaw`。

事前担心的 `workspace::paths` blocker，实际只是 `dasclaw_workspace_cap::document::paths` 的 thin re-export（desktop `workspace/document.rs` 已经是 `pub use dasclaw_workspace_cap::document::*;`）。直接换 import 路径即可，**无需新建 crate，无需 ADR 修订**。

## 改动范围

- `git mv` `desktop-client/ironclaw/src/tools/builtin/file.rs` → `crates/dasclaw_fs_tools/src/file.rs`（R097 = 97% 相似度，符合 ADR-129 §1.3 verbatim 阈值）
- file.rs use 行改写（机械替换）：
  - `crate::tools::builtin::path_utils::*` → `crate::path_utils::*`
  - `crate::tools::tool::{Tool, ApprovalRequirement, ToolDomain, ToolError, ToolOutput, require_str}` → `dasclaw_runtime::Tool` + `dasclaw_tool::{...}`
  - `crate::workspace::paths` → `dasclaw_workspace_cap::document::paths`
  - `super::file_guard` → `crate::file_guard`
  - `super::path_utils::effective_base_dir` → `crate::path_utils::effective_base_dir`（4 处）
  - `crate::tools::tool::ToolRateLimitConfig::new(20, 200)` → `dasclaw_tool::ToolRateLimitConfig::new(20, 200)`（2 处，与 F4.6.6-b code_edit.rs 修复同模式）
- `crates/dasclaw_fs_tools/Cargo.toml`: 新增 `dasclaw_workspace_cap` + `dasclaw_apply_patch` 两个 path deps
- `crates/dasclaw_fs_tools/src/lib.rs`: 注册 `pub mod file;` + 更新模块文档
- `desktop-client/ironclaw/src/tools/builtin/mod.rs`: 删除 `mod file;`，把 `file` 加入统一 re-export 行，保留 `pub use file::{ApplyPatchTool, ListDirTool, ReadFileTool, WriteFileTool};` 不变

## 非目标 (What's NOT in this PR)

- 不做任何业务逻辑修改（verbatim port）
- 不重构 `Tool` trait / ABI（沿用 -a/-b 已建立的 `dasclaw_runtime::Tool` 边界）
- 不动 `workspace::paths` 的源头定义（`dasclaw_workspace_cap::document::paths`）
- 不抽 `workspace::document` 的其它部分到独立 crate（本 PR 只做 import 重定向）
- 不做下游 consumer 的批量 import 改写（通过 `builtin/mod.rs` 的 re-export 保持零改动）

## 验证（命令 + 结果）

```bash
cargo check -p dasclaw_fs_tools --tests            # 0 errors
cargo nextest run -p dasclaw_fs_tools              # 73 passed, 0 failed
cargo check -p dasclaw --tests                     # 0 errors (pre-existing require_param 警告非本 PR 引入)
cargo fmt --all                                    # clean
python3.12 scripts/check_no_panics.py --base origin/xClaw   # OK: No panic-inducing calls
python3.12 scripts/check_blueprint_sync.py         # OK: 43 crates on disk, blueprint consistent
cargo clippy --no-deps -p dasclaw_fs_tools --all-targets -- -D warnings   # clean
```

## 3 层审查

- **code-quality-audit**：5/5 通过（verbatim 无新增结构）
- **code-simplifier**：按 ADR-129 §1.3 verbatim port 跳过
- **code-review-expert**：依赖方向符合 ADR-154 §3.1（`dasclaw_fs_tools → dasclaw_runtime/dasclaw_tool/dasclaw_workspace_cap/dasclaw_apply_patch`，无反向）；ABI 一致性与 -a/-b 完全对齐

## ADR 红线

- **ADR-114 类 A**：无 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量新增
- **ADR-129 §1.3 verbatim**：97% 相似度，远超 ≥90% 阈值
- **ADR-154 §3.1 依赖方向**：合规
- **ADR-156 §6.3 F4.6.6-c**：本 PR 直接对应该 task

## Cross-cuts

不涉及（类 A）

## 后续

- F4.6.6 三段切片本 PR 合并后即完成；fs_tools crate 内容定稿
- 后续 wave 8 工作按 ADR-156 §6.3 推进其他 F4.6.x 任务

Closes #769

⚠️ **请先 merge #771 → #772 → 本 PR**