### PR TITLE
feat(image-tools): F4.6.2 verbatim port image_analyze/edit/gen to dasclaw_image_tools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2657,6 +2657,7 @@ dependencies = [
  "dasclaw_git_tools",
  "dasclaw_governance",
  "dasclaw_hooks",
+ "dasclaw_image_tools",
  "dasclaw_llm_provider",
  "dasclaw_lsp",
  "dasclaw_mcp",
@@ -2980,6 +2981,25 @@ name = "dasclaw_identity"
 version = "0.0.0-w1"
 dependencies = [
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "dasclaw_image_tools"
+version = "0.0.0-w6"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "dasclaw_fs_tools",
+ "dasclaw_runtime",
+ "dasclaw_tool",
+ "mime_guess",
+ "reqwest 0.12.28",
+ "secrecy",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,8 @@ members = [
 	"crates/dasclaw_wasm_tools",
 	# F4.6.1 — misc builtin tools (echo/time/json/plan_mode/restart/session_fork) per ADR-156 §6.3
 	"crates/dasclaw_misc_tools",
+	# F4.6.2 — vision/image LLM tools (image_analyze/image_edit/image_generate) per ADR-156 §6.3
+	"crates/dasclaw_image_tools",
 	# F4.6.6-a — fs leaf utilities (path_utils + file_guard) per ADR-156 §6.3
 	"crates/dasclaw_fs_tools",
 	# F4.6.4 — sub_agent builtin tool (SubAgentTool / SubAgentRole) per ADR-156 §6.3

--- a/crates/dasclaw_image_tools/Cargo.toml
+++ b/crates/dasclaw_image_tools/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "dasclaw_image_tools"
+version = "0.0.0-w6"
+edition = "2024"
+description = "Vision/image LLM tools (image_analyze, image_edit, image_generate) extracted from desktop-client/ironclaw per ADR-156 §6.3 F4.6.2."
+license = "Apache-2.0 OR MIT"
+publish = false
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+async-trait = "0.1"
+base64 = "0.22"
+mime_guess = "2.0"
+secrecy = { version = "0.10", features = ["serde"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tokio = { version = "1", features = ["fs", "rt", "macros"] }
+tracing = "0.1"
+reqwest = { version = "0.12", default-features = false, features = ["json", "multipart", "rustls-tls-native-roots", "stream"] }
+
+dasclaw_runtime = { path = "../dasclaw_runtime" }
+dasclaw_tool = { path = "../dasclaw_tool" }
+dasclaw_fs_tools = { path = "../dasclaw_fs_tools" }
+
+[dev-dependencies]
+tempfile = "3"
+tokio = { version = "1", features = ["fs", "rt", "macros", "rt-multi-thread"] }

--- a/crates/dasclaw_image_tools/src/image_analyze.rs
+++ b/crates/dasclaw_image_tools/src/image_analyze.rs
@@ -6,8 +6,9 @@ use async_trait::async_trait;
 use base64::Engine;
 use secrecy::{ExposeSecret, SecretString};
 
-use crate::tools::builtin::path_utils::validate_path;
-use crate::tools::tool::{Tool, ToolError, ToolOutput};
+use dasclaw_fs_tools::path_utils::validate_path;
+use dasclaw_runtime::Tool;
+use dasclaw_tool::{ToolError, ToolOutput};
 
 /// Tool for analyzing images using a vision-capable model.
 pub struct ImageAnalyzeTool {
@@ -113,7 +114,8 @@ impl Tool for ImageAnalyzeTool {
             .unwrap_or("Describe this image in detail.");
 
         // Read binary image bytes directly from filesystem
-        let effective = super::path_utils::effective_base_dir(self.base_dir.as_deref(), ctx);
+        let effective =
+            dasclaw_fs_tools::path_utils::effective_base_dir(self.base_dir.as_deref(), ctx);
         let image_bytes = self
             .read_image_bytes(image_path, effective.as_deref())
             .await?;
@@ -123,7 +125,7 @@ impl Tool for ImageAnalyzeTool {
             ));
         }
 
-        let media_type = super::media_type_from_path(image_path);
+        let media_type = crate::media_type_from_path(image_path);
         let b64 = base64::engine::general_purpose::STANDARD.encode(&image_bytes);
         let data_url = format!("data:{media_type};base64,{b64}");
 
@@ -185,9 +187,9 @@ impl Tool for ImageAnalyzeTool {
 
 #[cfg(test)]
 mod tests {
-    use super::super::media_type_from_path;
     use super::*;
-    use crate::tools::tool::ApprovalRequirement;
+    use crate::media_type_from_path;
+    use dasclaw_tool::ApprovalRequirement;
     use tempfile::TempDir;
 
     #[test]

--- a/crates/dasclaw_image_tools/src/image_edit.rs
+++ b/crates/dasclaw_image_tools/src/image_edit.rs
@@ -5,8 +5,9 @@ use std::path::PathBuf;
 use async_trait::async_trait;
 use secrecy::{ExposeSecret, SecretString};
 
-use crate::tools::builtin::path_utils::validate_path;
-use crate::tools::tool::{Tool, ToolError, ToolOutput};
+use dasclaw_fs_tools::path_utils::validate_path;
+use dasclaw_runtime::Tool;
+use dasclaw_tool::{ToolError, ToolOutput};
 
 /// Tool for editing images using an AI image editing API.
 pub struct ImageEditTool {
@@ -120,7 +121,8 @@ impl Tool for ImageEditTool {
         }
 
         // Read binary image bytes directly from filesystem
-        let effective = super::path_utils::effective_base_dir(self.base_dir.as_deref(), ctx);
+        let effective =
+            dasclaw_fs_tools::path_utils::effective_base_dir(self.base_dir.as_deref(), ctx);
         let image_bytes = self
             .read_image_bytes(image_path, effective.as_deref())
             .await?;
@@ -130,7 +132,7 @@ impl Tool for ImageEditTool {
             ));
         }
 
-        let media_type = super::media_type_from_path(image_path);
+        let media_type = crate::media_type_from_path(image_path);
 
         // Use multipart form for image edit API
         let url = format!(
@@ -268,7 +270,7 @@ impl ImageEditTool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tools::tool::ApprovalRequirement;
+    use dasclaw_tool::ApprovalRequirement;
     use tempfile::TempDir;
 
     #[test]

--- a/crates/dasclaw_image_tools/src/image_gen.rs
+++ b/crates/dasclaw_image_tools/src/image_gen.rs
@@ -4,7 +4,8 @@ use async_trait::async_trait;
 use secrecy::{ExposeSecret, SecretString};
 use serde::{Deserialize, Serialize};
 
-use crate::tools::{Tool, ToolError, ToolOutput};
+use dasclaw_runtime::Tool;
+use dasclaw_tool::{ToolError, ToolOutput};
 
 /// Tool for generating images using FLUX or compatible image generation APIs.
 pub struct ImageGenerateTool {
@@ -180,8 +181,8 @@ impl Tool for ImageGenerateTool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tools::tool::ApprovalRequirement;
     use dasclaw_runtime::context::JobContext;
+    use dasclaw_tool::ApprovalRequirement;
 
     #[test]
     fn test_tool_metadata() {

--- a/crates/dasclaw_image_tools/src/lib.rs
+++ b/crates/dasclaw_image_tools/src/lib.rs
@@ -1,0 +1,28 @@
+//! `dasclaw_image_tools` — vision / image LLM tools.
+//!
+//! Verbatim port of `desktop-client/ironclaw/src/tools/builtin/image_*` per
+//! ADR-156 §6.3 F4.6.2.
+//!
+//! # Modules
+//!
+//! - [`image_analyze`] — analyze an image via a vision-capable LLM.
+//! - [`image_edit`] — edit an image via image edit API.
+//! - [`image_gen`] — generate an image via image generation API.
+
+pub mod image_analyze;
+pub mod image_edit;
+pub mod image_gen;
+
+pub use image_analyze::ImageAnalyzeTool;
+pub use image_edit::ImageEditTool;
+pub use image_gen::ImageGenerateTool;
+
+/// Detect image media type from file extension via `mime_guess`.
+/// Falls back to `image/jpeg` for unrecognized or non-image extensions.
+pub(crate) fn media_type_from_path(path: &str) -> String {
+    mime_guess::from_path(path)
+        .first_raw()
+        .filter(|m| m.starts_with("image/"))
+        .unwrap_or("image/jpeg")
+        .to_string()
+}

--- a/desktop-client/ironclaw/Cargo.toml
+++ b/desktop-client/ironclaw/Cargo.toml
@@ -216,6 +216,10 @@ dasclaw_wasm_tools = { path = "../../crates/dasclaw_wasm_tools" }
 # extracted from desktop tools/builtin/ per ADR-156 §6.3.
 dasclaw_misc_tools = { path = "../../crates/dasclaw_misc_tools" }
 
+# F4.6.2 — vision/image LLM tools (image_analyze/image_edit/image_generate)
+# extracted from desktop tools/builtin/ per ADR-156 §6.3.
+dasclaw_image_tools = { path = "../../crates/dasclaw_image_tools" }
+
 # F4.6.6-a — fs leaf utilities (path_utils + file_guard) per ADR-156 §6.3.
 dasclaw_fs_tools = { path = "../../crates/dasclaw_fs_tools" }
 

--- a/desktop-client/ironclaw/src/tools/builtin/mod.rs
+++ b/desktop-client/ironclaw/src/tools/builtin/mod.rs
@@ -72,21 +72,6 @@ pub use tool_info::ToolInfoTool;
 pub use web_fetch::WebFetchTool;
 pub use web_search::WebSearchTool;
 mod html_converter;
-pub mod image_analyze;
-pub mod image_edit;
-pub mod image_gen;
 
+pub use dasclaw_image_tools::{ImageAnalyzeTool, ImageEditTool, ImageGenerateTool};
 pub use html_converter::convert_html_to_markdown;
-pub use image_analyze::ImageAnalyzeTool;
-pub use image_edit::ImageEditTool;
-pub use image_gen::ImageGenerateTool;
-
-/// Detect image media type from file extension via `mime_guess`.
-/// Falls back to `image/jpeg` for unrecognized or non-image extensions.
-pub(crate) fn media_type_from_path(path: &str) -> String {
-    mime_guess::from_path(path)
-        .first_raw()
-        .filter(|m| m.starts_with("image/"))
-        .unwrap_or("image/jpeg")
-        .to_string()
-}

--- a/scripts/check_blueprint_sync.py
+++ b/scripts/check_blueprint_sync.py
@@ -45,8 +45,8 @@ PLANNED: dict[str, str] = {
     # F4.6.8; remove an entry from PLANNED the moment its crate directory
     # is created.
     # F4.6.1 (`dasclaw_misc_tools`) landed in PR #761 — entry removed.
-    "dasclaw_image_tools": "ADR-156 F4.6.2 planned",
     "dasclaw_memory_tools": "ADR-156 F4.6.3 planned",
+    # F4.6.2 (`dasclaw_image_tools`) landed — entry removed.
     # F4.6.4 (`dasclaw_sub_agent_tools`) landed — entry removed.
     # F4.6.6-a (`dasclaw_fs_tools`) landed — entry removed.
     "dasclaw_shell_tools": "ADR-156 F4.6.7 planned",


### PR DESCRIPTION
## 背景 / 目标

按 [ADR-156 §6.3 F4.6.2](docs/plans/architecture-refactor/adr-156-w6-implementation-plan.md) 完成视觉/图像类 LLM 工具的搬迁。将 `image_analyze`、`image_edit`、`image_generate` 三个工具从 `desktop-client/ironclaw/src/tools/builtin/` 抽到独立 crate `dasclaw_image_tools`，让后续 TUI/CLI/MCP 表面都可以复用同一份实现。

属于 verbatim port（[ADR-129 §1.3](docs/plans/architecture-refactor/adr-129-verbatim-port-principle.md)），不做任何逻辑改动。

## 改动范围

- 新建 crate `crates/dasclaw_image_tools`（lib only, version `0.0.0-w6`）
- `git mv` 三个工具源文件到新 crate `src/`
- 把 desktop builtin/mod.rs 里的 `media_type_from_path` 辅助函数迁到新 crate `lib.rs`（保持 `pub(crate)` 可见性）
- `desktop-client/ironclaw/src/tools/builtin/mod.rs` 改为单行 `pub use` 重导出，保留 `crate::tools::builtin::ImageEditTool` 等消费路径不变
- 根 `Cargo.toml` workspace members 增加 `crates/dasclaw_image_tools`
- `desktop-client/ironclaw/Cargo.toml` 增加 path 依赖
- `scripts/check_blueprint_sync.py` 的 planned-list 移除 `dasclaw_image_tools` 条目

## 非目标（What's NOT in this PR）

- 不修改任何 image 工具的运行时行为
- 不动 `dasclaw_utils_image`（这是低层 base64 编码器，与本 PR 的视觉工具无重叠）
- 不涉及 F4.6.3 (memory_tools) / F4.6.7 (shell_tools) / F4.6.8 (net_tools)，留给后续 PR

## 验证

```bash
cargo check -p dasclaw_image_tools --tests          # ✅
cargo check -p dasclaw --tests                       # ✅ (desktop 消费方)
cargo nextest run -p dasclaw_image_tools             # ✅ 11 passed
cargo fmt --all                                      # ✅
python3.12 scripts/check_no_panics.py --base origin/xClaw   # ✅
cargo clippy --no-deps -p dasclaw_image_tools --all-targets -- -D warnings  # ✅
```

11 个单元测试覆盖：path traversal 拒绝、sandbox 外绝对路径拒绝、媒体类型识别、metadata、size/prompt 校验、`requires_approval` 返回 Never。

## Cross-cuts

**ADR-114**：类A — 本 PR 未新增 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量。

## 后续 PR

- F4.6.3 `dasclaw_memory_tools`（叶子，~974 行）
- F4.6.7 `dasclaw_shell_tools`（重量级，~1666 行）
- F4.6.8 `dasclaw_net_tools`


Closes #776
