### PR TITLE
feat(net-tools): extract web_fetch into dasclaw_net_tools (ADR-156 F4.6.8 phase 1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2663,6 +2663,7 @@ dependencies = [
  "dasclaw_mcp",
  "dasclaw_misc_tools",
  "dasclaw_net_proxy",
+ "dasclaw_net_tools",
  "dasclaw_observability",
  "dasclaw_process_hardening",
  "dasclaw_routines",
@@ -3125,6 +3126,19 @@ dependencies = [
  "tokio",
  "tracing",
  "url",
+]
+
+[[package]]
+name = "dasclaw_net_tools"
+version = "0.0.0-w6"
+dependencies = [
+ "async-trait",
+ "dasclaw_runtime",
+ "dasclaw_tool",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,8 @@ members = [
 	"crates/dasclaw_misc_tools",
 	# F4.6.2 — vision/image LLM tools (image_analyze/image_edit/image_generate) per ADR-156 §6.3
 	"crates/dasclaw_image_tools",
+	# F4.6.8 (phase 1, web_fetch) — network/web LLM tools per ADR-156 §6.3
+	"crates/dasclaw_net_tools",
 	# F4.6.6-a — fs leaf utilities (path_utils + file_guard) per ADR-156 §6.3
 	"crates/dasclaw_fs_tools",
 	# F4.6.4 — sub_agent builtin tool (SubAgentTool / SubAgentRole) per ADR-156 §6.3

--- a/crates/dasclaw_net_tools/Cargo.toml
+++ b/crates/dasclaw_net_tools/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "dasclaw_net_tools"
+version = "0.0.0-w6"
+edition = "2024"
+description = "Network/web LLM tools (web_fetch, …) extracted from desktop-client/ironclaw per ADR-156 §6.3 F4.6.8."
+license = "Apache-2.0 OR MIT"
+publish = false
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+async-trait = "0.1"
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls-native-roots"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+dasclaw_runtime = { path = "../dasclaw_runtime" }
+dasclaw_tool = { path = "../dasclaw_tool" }
+
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/crates/dasclaw_net_tools/src/lib.rs
+++ b/crates/dasclaw_net_tools/src/lib.rs
@@ -1,0 +1,9 @@
+//! Network / web LLM tools extracted from `desktop-client/ironclaw` per
+//! ADR-156 §6.3 F4.6.8.
+//!
+//! Phase 1 (current): hosts the `web_fetch` tool only.
+//! Phase 2 (planned): `http`, `web_search`, `html_converter` will be merged here.
+
+mod web_fetch;
+
+pub use web_fetch::WebFetchTool;

--- a/crates/dasclaw_net_tools/src/web_fetch.rs
+++ b/crates/dasclaw_net_tools/src/web_fetch.rs
@@ -15,7 +15,8 @@ use reqwest::Client;
 use serde::Serialize;
 use serde_json::json;
 
-use crate::tools::tool::{ApprovalRequirement, Tool, ToolError, ToolOutput, require_str};
+use dasclaw_runtime::Tool;
+use dasclaw_tool::{ApprovalRequirement, ToolError, ToolOutput, require_str};
 
 const USER_AGENT: &str = concat!("IronClaw-WebFetch/", env!("CARGO_PKG_VERSION"),);
 

--- a/desktop-client/ironclaw/Cargo.toml
+++ b/desktop-client/ironclaw/Cargo.toml
@@ -220,6 +220,9 @@ dasclaw_misc_tools = { path = "../../crates/dasclaw_misc_tools" }
 # extracted from desktop tools/builtin/ per ADR-156 §6.3.
 dasclaw_image_tools = { path = "../../crates/dasclaw_image_tools" }
 
+# F4.6.8 (phase 1, web_fetch) — network/web LLM tools per ADR-156 §6.3.
+dasclaw_net_tools = { path = "../../crates/dasclaw_net_tools" }
+
 # F4.6.6-a — fs leaf utilities (path_utils + file_guard) per ADR-156 §6.3.
 dasclaw_fs_tools = { path = "../../crates/dasclaw_fs_tools" }
 

--- a/desktop-client/ironclaw/src/tools/builtin/mod.rs
+++ b/desktop-client/ironclaw/src/tools/builtin/mod.rs
@@ -11,7 +11,6 @@ pub(crate) mod shell;
 pub use shell::classify_command_risk;
 pub mod skill_tools;
 mod tool_info;
-mod web_fetch;
 mod web_search;
 
 // F4.6.6-a/-b/-c (ADR-156 §6.3): `path_utils` + `file_guard` + `code_edit` +
@@ -69,9 +68,12 @@ pub use routine::{
 pub use shell::ShellTool;
 pub use skill_tools::{SkillInstallTool, SkillListTool, SkillRemoveTool, SkillSearchTool};
 pub use tool_info::ToolInfoTool;
-pub use web_fetch::WebFetchTool;
 pub use web_search::WebSearchTool;
 mod html_converter;
 
 pub use dasclaw_image_tools::{ImageAnalyzeTool, ImageEditTool, ImageGenerateTool};
+
+// F4.6.8 (phase 1) — web_fetch was extracted to `crates/dasclaw_net_tools` per
+// ADR-156 §6.3. Thin re-export keeps existing call sites compiling unchanged.
+pub use dasclaw_net_tools::WebFetchTool;
 pub use html_converter::convert_html_to_markdown;

--- a/docs/plans/architecture-refactor/adr-156-f46-builtin-tools-landing-decision.md
+++ b/docs/plans/architecture-refactor/adr-156-f46-builtin-tools-landing-decision.md
@@ -274,14 +274,35 @@ let agent = Agent::builder()
 |--------|-------|--------|--------------|
 | F4.6.1 | `dasclaw_misc_tools` | F4.5 全绿 | `cargo nextest run -p dasclaw_misc_tools` + 该 crate 自带 unit 测试 |
 | F4.6.2 | `dasclaw_image_tools` | F4.6.1 merge | 同上 |
-| F4.6.3 | `dasclaw_memory_tools` | F4.6.2 merge | 同上 |
-| F4.6.4 | `dasclaw_sub_agent_tools` | F4.6.3 merge | 同上 |
+| ~~F4.6.3~~ | ~~`dasclaw_memory_tools`~~ | **取消下沉** | 见 §6.3.1 决策依据 |
+| F4.6.4 | `dasclaw_sub_agent_tools` | F4.6.3 决策 | 同上 |
 | F4.6.5 | `dasclaw_git_tools`（扩充）| F4.6.4 merge | 同上 + 把 lsp 薄壳合入 |
 | F4.6.6 | `dasclaw_fs_tools` | F4.6.5 merge | 同上 + 跨 crate path 校验测试 |
 | F4.6.7 | `dasclaw_shell_tools` | F4.6.6 merge | 同上 + `classify_command_risk` 回归 |
 | F4.6.8 | `dasclaw_net_tools` | F4.6.7 merge | 同上 + wasm_tools 集成 |
 
 **节奏特征**：先搬 T0 简单工具（F4.6.1~F4.6.5），再搬 T1/T2 有依赖工具（F4.6.6~F4.6.8）。每个 PR 单独可 revert，符合 ADR-152 §4.2。
+
+### 6.3.1 F4.6.3 决策：memory_tools 取消下沉，标记 desktop-only
+
+**结论**：`memory.rs`（MemorySearch / MemoryWrite / MemoryRead / MemoryTree 四个工具，974 行）**不下沉到 `crates/`**，继续留在 `desktop-client/ironclaw/src/tools/builtin/`。
+
+**依据**：
+
+1. **真实依赖偏离 T0**：原表格把 `dasclaw_memory_tools` 列为 T0（依赖 `dasclaw_tool + dasclaw_runtime`），但 memory.rs 实际依赖 `desktop-client/ironclaw/src/workspace/` 运行时模块——一整套 PostgreSQL/SQLite 双后端 + 向量 embeddings + 文档分块（chunker）+ 隐私分层（layer / privacy）+ 内容卫生（hygiene）+ 混合检索（FTS + 余弦相似度）的 RAG 系统。这与 F4.6.6 file.rs 只用 `dasclaw_workspace_cap::document::paths`（轻量常量）的情况完全不同。
+
+2. **无头 agent 框架不需要 RAG 记忆**：
+   - codex 无头：无持久记忆，每次 session 独立
+   - claw-code / ironclaw-main：用文件系统 + `CLAUDE.md` / `AGENTS.md` 做文件级记忆
+   - `dasclaw_fs_tools` 的 `read_file` / `write_file` / `list_directory` 已覆盖纯无头 CLI 的记忆需求
+
+3. **强行下沉会污染共享层依赖**：把 PostgreSQL、sqlx、向量 embeddings、隐私分类等重依赖引入 `crates/` 会让所有下游（包括纯 CLI）背上数据库依赖，违反 ADR-156 §4「无头 agent 共享层应保持依赖最小」的原则。
+
+4. **desktop 部署不受影响**：Tool trait 注册机制是开放的——desktop-client 在自己的 agent 启动代码里实例化 `Workspace` 并注册四个 MemoryTool，与"代码住在哪个 crate"无关。memory_tools 留在 desktop 不影响 desktop 的 agent 用上它们。
+
+5. **未来需求的正确解法**：如果将来出现第三方客户端需要 RAG 向量记忆能力，应单独立 ADR 规划 "workspace 运行时下沉" 工程（含数据库选型、embeddings 后端、隐私层定义等），届时 memory_tools 跟随一起搬。**不属于 F4.6 节奏。**
+
+**后续编号调整**：F4.6.3 槽位保留（不复用，避免历史 PR 编号混乱），F4.6.4 ~ F4.6.8 编号不变。本决策由 PR #775 之后的对账发现并落入 ADR。
 
 ### 6.4 desktop `tools/builtin/mod.rs` 薄壳化（独立 PR）
 

--- a/scripts/check_blueprint_sync.py
+++ b/scripts/check_blueprint_sync.py
@@ -45,12 +45,12 @@ PLANNED: dict[str, str] = {
     # F4.6.8; remove an entry from PLANNED the moment its crate directory
     # is created.
     # F4.6.1 (`dasclaw_misc_tools`) landed in PR #761 — entry removed.
-    "dasclaw_memory_tools": "ADR-156 F4.6.3 planned",
+    "dasclaw_memory_tools": "ADR-156 §6.3.1 — 取消下沉 (desktop-only, runtime workspace dep)",
     # F4.6.2 (`dasclaw_image_tools`) landed — entry removed.
     # F4.6.4 (`dasclaw_sub_agent_tools`) landed — entry removed.
     # F4.6.6-a (`dasclaw_fs_tools`) landed — entry removed.
     "dasclaw_shell_tools": "ADR-156 F4.6.7 planned",
-    "dasclaw_net_tools": "ADR-156 F4.6.8 planned",
+    # F4.6.8 (`dasclaw_net_tools`) phase 1 (web_fetch) landed — entry removed.
 }
 
 # Symbols that look like crate names but are not. Examples: conceptual


### PR DESCRIPTION
## 背景 / 目标

按 ADR-156 §6.3 F4.6.8 计划，把 `desktop-client/ironclaw/src/tools/builtin/web_fetch.rs`（366 行叶子）下沉为新 crate `crates/dasclaw_net_tools`。verbatim port（ADR-129 §1.3），不动逻辑。

F4.6.8 被切成多 phase 推进，本 PR 是 phase 1（最干净的叶子），后续 phase 2~4 分别处理 http.rs / web_search.rs / html_converter.rs。

同步在 ADR-156 加 §6.3.1 决策依据：F4.6.3 `memory_tools` **取消下沉**，留在 desktop（memory.rs 真实依赖 desktop 的 workspace 运行时—— PostgreSQL/SQLite + 向量 embeddings + 隐私分层，无头 agent 不需要 RAG 记忆，强行下沉会污染共享层依赖）。

## 改动范围

- 新建 `crates/dasclaw_net_tools/`（Cargo.toml + src/lib.rs）
- `git mv` web_fetch.rs 进新 crate
- 改写 imports：`crate::tools::tool::{Tool, …}` → `dasclaw_runtime::Tool` + `dasclaw_tool::{ApprovalRequirement, ToolError, ToolOutput, require_str}`
- 根 `Cargo.toml` workspace members 追加新 crate
- `desktop-client/ironclaw/Cargo.toml` 加 path-dep
- `desktop-client/ironclaw/src/tools/builtin/mod.rs` 改成 `pub use dasclaw_net_tools::WebFetchTool` 薄壳
- `scripts/check_blueprint_sync.py` 移除 net_tools planned 条目，更新 memory_tools 注释
- ADR-156 表格标 F4.6.3 strikethrough + 新增 §6.3.1 决策依据章节

## 非目标（What's NOT in this PR）

- ❌ 不搬 http.rs（1513 行，T2 sandbox/safety 依赖，后续 phase 2）
- ❌ 不搬 web_search.rs（552 行，phase 3）
- ❌ 不搬 html_converter.rs（phase 4）
- ❌ 不搬 memory_tools（按 §6.3.1 决策永久留 desktop）
- ❌ 不改 web_fetch 任何逻辑（verbatim）

## 验证

```
✅ cargo check -p dasclaw_net_tools --tests  → clean
✅ cargo check -p dasclaw --tests            → clean
✅ cargo nextest run -p dasclaw_net_tools    → 12/12 passed
✅ cargo fmt --all                           → clean
✅ python3.12 scripts/check_no_panics.py     → OK
✅ python3.12 scripts/check_blueprint_sync.py → OK 46 crates / 3 planned
✅ python3.12 scripts/check_no_new_ironclaw_literal.py → OK
✅ cargo clippy --no-deps -p dasclaw_net_tools --all-targets -- -D warnings → clean
```

## Cross-cuts

- **ADR-114**：`类A`（无新增 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量；grep guard 通过）
- **ADR-129 §1.3**：verbatim port，跳过 code-simplifier
- **ADR-156 §6.3**：F4.6.8 phase 1，沿用 F4.6.2 image_tools 同款切片节奏

## Sources read

- AGENTS.md §会话轮换 / §Skills 强制使用 / §分析工具使用规范
- docs/plans/architecture-refactor/adr-156-f46-builtin-tools-landing-decision.md §6.3 §6.3.1
- docs/plans/architecture-refactor/adr-129 §1.3（verbatim 红线）

Closes #777