### PR TITLE
feat(net-tools): F4.6.8 phase 2 — http + html_converter 下沉到 dasclaw_net_tools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2686,7 +2686,6 @@ dependencies = [
  "hex",
  "hkdf",
  "hmac",
- "html-to-markdown-rs",
  "http-body-util",
  "hyper 1.8.1",
  "hyper-util",
@@ -2706,7 +2705,6 @@ dependencies = [
  "pretty_assertions",
  "pty-process",
  "rand 0.8.5",
- "readabilityrs",
  "refinery",
  "regex",
  "reqwest 0.12.28",
@@ -3133,12 +3131,20 @@ name = "dasclaw_net_tools"
 version = "0.0.0-w6"
 dependencies = [
  "async-trait",
+ "bytes",
+ "dasclaw_fs_tools",
  "dasclaw_runtime",
+ "dasclaw_safety",
  "dasclaw_tool",
+ "dasclaw_wasm_tools",
+ "futures",
+ "html-to-markdown-rs",
+ "readabilityrs",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/dasclaw_net_tools/Cargo.toml
+++ b/crates/dasclaw_net_tools/Cargo.toml
@@ -2,7 +2,7 @@
 name = "dasclaw_net_tools"
 version = "0.0.0-w6"
 edition = "2024"
-description = "Network/web LLM tools (web_fetch, …) extracted from desktop-client/ironclaw per ADR-156 §6.3 F4.6.8."
+description = "Network/web LLM tools (web_fetch, http, …) extracted from desktop-client/ironclaw per ADR-156 §6.3 F4.6.8."
 license = "Apache-2.0 OR MIT"
 publish = false
 
@@ -11,12 +11,29 @@ path = "src/lib.rs"
 
 [dependencies]
 async-trait = "0.1"
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls-native-roots"] }
+bytes = "1"
+futures = "0.3"
+reqwest = { version = "0.12", default-features = false, features = ["json", "multipart", "rustls-tls-native-roots", "stream"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+tokio = { version = "1", features = ["fs", "macros", "net", "rt", "time"] }
+tracing = "0.1"
+
+# Optional: HTML-to-Markdown conversion for http tool responses.
+html-to-markdown-rs = { version = "2.3", optional = true }
+readabilityrs = { version = "0.1.2", optional = true }
 
 dasclaw_runtime = { path = "../dasclaw_runtime" }
+dasclaw_safety = { path = "../dasclaw_safety" }
 dasclaw_tool = { path = "../dasclaw_tool" }
+dasclaw_fs_tools = { path = "../dasclaw_fs_tools" }
+dasclaw_wasm_tools = { path = "../dasclaw_wasm_tools" }
+
+[features]
+default = []
+# Mirrors desktop-client/ironclaw `html-to-markdown` feature so http response
+# bodies can be reduced to markdown before being returned to the model.
+html-to-markdown = ["dep:html-to-markdown-rs", "dep:readabilityrs"]
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/crates/dasclaw_net_tools/src/html_converter.rs
+++ b/crates/dasclaw_net_tools/src/html_converter.rs
@@ -3,7 +3,7 @@
 //! Two-stage pipeline: readability (extract article) -> html-to-markdown-rs (convert to md).
 //! When the `html-to-markdown` feature is disabled, passthrough only.
 
-use crate::tools::tool::ToolError;
+use dasclaw_tool::ToolError;
 
 #[cfg(feature = "html-to-markdown")]
 use html_to_markdown_rs::convert;

--- a/crates/dasclaw_net_tools/src/http.rs
+++ b/crates/dasclaw_net_tools/src/http.rs
@@ -9,13 +9,14 @@ use async_trait::async_trait;
 use futures::StreamExt;
 use reqwest::Client;
 
-use crate::safety::LeakDetector;
-use crate::tools::tool::{ApprovalRequirement, Tool, ToolError, ToolOutput, require_str};
-use crate::tools::wasm::{InjectedCredentials, SharedCredentialRegistry, inject_credential};
+use dasclaw_runtime::Tool;
 use dasclaw_runtime::secrets::SecretsStore;
+use dasclaw_safety::LeakDetector;
+use dasclaw_tool::{ApprovalRequirement, ToolError, ToolOutput, require_str};
+use dasclaw_wasm_tools::{InjectedCredentials, SharedCredentialRegistry, inject_credential};
 
 #[cfg(feature = "html-to-markdown")]
-use crate::tools::builtin::convert_html_to_markdown;
+use crate::convert_html_to_markdown;
 
 /// Maximum response body size for text responses (5 MB).
 ///
@@ -94,7 +95,7 @@ fn validate_save_to_path(save_to: &str) -> Result<std::path::PathBuf, ToolError>
     // Validate path BEFORE creating directories to prevent traversal-based
     // directory creation outside /tmp (e.g. `/tmp/../../etc/passwd`).
     let tmp_base = std::path::Path::new("/tmp");
-    let validated = crate::tools::builtin::path_utils::validate_path(save_to, Some(tmp_base))?;
+    let validated = dasclaw_fs_tools::path_utils::validate_path(save_to, Some(tmp_base))?;
     // Only create parent directories for the validated (safe) path
     if let Some(parent) = validated.parent() {
         std::fs::create_dir_all(parent).map_err(|e| {
@@ -586,7 +587,7 @@ impl Tool for HttpTool {
             .map_err(|e| ToolError::NotAuthorized(format!("{}", e)))?;
 
         // Build the interceptor request descriptor for recording/replay
-        let intercept_req = crate::llm::recording::HttpExchangeRequest {
+        let intercept_req = dasclaw_runtime::recording::HttpExchangeRequest {
             method: method_upper,
             url: parsed_url.to_string(),
             headers: headers_vec.clone(),
@@ -813,7 +814,7 @@ impl Tool for HttpTool {
             interceptor
                 .after_response(
                     &intercept_req,
-                    &crate::llm::recording::HttpExchangeResponse {
+                    &dasclaw_runtime::recording::HttpExchangeResponse {
                         status,
                         headers: resp_headers,
                         body: body_text.clone(),
@@ -857,7 +858,7 @@ impl Tool for HttpTool {
     }
 
     fn requires_approval(&self, params: &serde_json::Value) -> ApprovalRequirement {
-        let has_credentials = crate::safety::params_contain_manual_credentials(params)
+        let has_credentials = dasclaw_safety::params_contain_manual_credentials(params)
             || (self.credential_registry.as_ref().is_some_and(|registry| {
                 extract_host_from_params(params)
                     .is_some_and(|host| registry.has_credentials_for_host(&host))
@@ -876,15 +877,21 @@ impl Tool for HttpTool {
         ApprovalRequirement::UnlessAutoApproved
     }
 
-    fn rate_limit_config(&self) -> Option<crate::tools::tool::ToolRateLimitConfig> {
-        Some(crate::tools::tool::ToolRateLimitConfig::new(30, 500))
+    fn rate_limit_config(&self) -> Option<dasclaw_tool::ToolRateLimitConfig> {
+        Some(dasclaw_tool::ToolRateLimitConfig::new(30, 500))
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::testing::credentials::{TEST_OPENAI_API_KEY, test_secrets_store};
+    // Sourced upstream from `dasclaw_wasm_tools::test_credentials` (re-exported
+    // through `desktop-client/ironclaw::testing::credentials` in the original).
+    // `TEST_OPENAI_API_KEY_SHORT` (= "sk-test") is functionally equivalent for
+    // bearer-token approval-gate assertions.
+    use dasclaw_wasm_tools::test_credentials::{
+        TEST_OPENAI_API_KEY_SHORT as TEST_OPENAI_API_KEY, test_secrets_store,
+    };
 
     #[test]
     fn test_http_tool_schema_headers_is_array() {
@@ -1243,8 +1250,8 @@ mod tests {
 
     #[test]
     fn test_host_with_credential_mapping_returns_unless_auto_approved() {
-        use crate::tools::wasm::SharedCredentialRegistry;
         use dasclaw_runtime::secrets::CredentialMapping;
+        use dasclaw_wasm_tools::SharedCredentialRegistry;
 
         let registry = Arc::new(SharedCredentialRegistry::new());
         registry.add_mappings(vec![CredentialMapping::bearer(
@@ -1270,7 +1277,7 @@ mod tests {
 
     #[test]
     fn test_get_host_without_credential_mapping_returns_never() {
-        use crate::tools::wasm::SharedCredentialRegistry;
+        use dasclaw_wasm_tools::SharedCredentialRegistry;
 
         let registry = Arc::new(SharedCredentialRegistry::new());
         // Empty registry - no credential mappings
@@ -1355,7 +1362,7 @@ mod tests {
 
     #[test]
     fn test_requires_approval_with_stringified_http_params() {
-        use crate::tools::wasm::SharedCredentialRegistry;
+        use dasclaw_wasm_tools::SharedCredentialRegistry;
 
         let tool = HttpTool::new().with_credentials(
             Arc::new(SharedCredentialRegistry::new()),
@@ -1425,8 +1432,8 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn requires_approval_multi_thread_no_panic() {
-        use crate::tools::wasm::SharedCredentialRegistry;
         use dasclaw_runtime::secrets::CredentialMapping;
+        use dasclaw_wasm_tools::SharedCredentialRegistry;
 
         // Test with credential registry (uses std::sync::RwLock - should be safe)
         let registry = Arc::new(SharedCredentialRegistry::new());

--- a/crates/dasclaw_net_tools/src/lib.rs
+++ b/crates/dasclaw_net_tools/src/lib.rs
@@ -1,9 +1,15 @@
 //! Network / web LLM tools extracted from `desktop-client/ironclaw` per
 //! ADR-156 §6.3 F4.6.8.
 //!
-//! Phase 1 (current): hosts the `web_fetch` tool only.
-//! Phase 2 (planned): `http`, `web_search`, `html_converter` will be merged here.
+//! Phase 1: `web_fetch`.
+//! Phase 2 (current): `http` + `html_converter` (the latter is `http`'s
+//!   feature-gated HTML→Markdown helper, sunk together to avoid a stacked PR).
+//! Phase 3 (planned): `web_search`.
 
+mod html_converter;
+mod http;
 mod web_fetch;
 
+pub use html_converter::convert_html_to_markdown;
+pub use http::HttpTool;
 pub use web_fetch::WebFetchTool;

--- a/crates/dasclaw_net_tools/src/lib.rs
+++ b/crates/dasclaw_net_tools/src/lib.rs
@@ -2,14 +2,16 @@
 //! ADR-156 §6.3 F4.6.8.
 //!
 //! Phase 1: `web_fetch`.
-//! Phase 2 (current): `http` + `html_converter` (the latter is `http`'s
+//! Phase 2: `http` + `html_converter` (the latter is `http`'s
 //!   feature-gated HTML→Markdown helper, sunk together to avoid a stacked PR).
-//! Phase 3 (planned): `web_search`.
+//! Phase 3 (current): `web_search` — DuckDuckGo HTML search, no API key.
 
 mod html_converter;
 mod http;
 mod web_fetch;
+mod web_search;
 
 pub use html_converter::convert_html_to_markdown;
 pub use http::HttpTool;
 pub use web_fetch::WebFetchTool;
+pub use web_search::WebSearchTool;

--- a/crates/dasclaw_net_tools/src/web_search.rs
+++ b/crates/dasclaw_net_tools/src/web_search.rs
@@ -14,7 +14,8 @@ use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 
-use crate::tools::tool::{ApprovalRequirement, Tool, ToolError, ToolOutput, require_str};
+use dasclaw_runtime::Tool;
+use dasclaw_tool::{ApprovalRequirement, ToolError, ToolOutput, require_str};
 
 const USER_AGENT: &str = concat!("IronClaw-WebSearch/", env!("CARGO_PKG_VERSION"),);
 

--- a/desktop-client/ironclaw/Cargo.toml
+++ b/desktop-client/ironclaw/Cargo.toml
@@ -261,9 +261,9 @@ mime_guess = "2.0.5"
 clap_complete = "4.5.0"
 lru = "0.16.3"
 
-# HTML to Markdown conversion (feature gated)
-html-to-markdown-rs = { version = "2.3", optional = true }
-readabilityrs = { version = "0.1.2", optional = true }
+# HTML to Markdown conversion (feature gated) — moved to `dasclaw_net_tools`
+# per ADR-156 §6.3 F4.6.8 phase 2. The desktop crate forwards its
+# `html-to-markdown` feature to `dasclaw_net_tools/html-to-markdown` below.
 ed25519-dalek = { version = "2.2.0", features = ["std"] }
 hex = "0.4.3"
 
@@ -350,7 +350,7 @@ libsql = ["dep:libsql", "dasclaw_runtime/libsql", "dasclaw_wasm_tools/libsql"]
 # Opt-in feature for especially heavy integration-test targets that run in a
 # dedicated CI job instead of the default Rust test matrix.
 integration = []
-html-to-markdown = ["dep:html-to-markdown-rs", "dep:readabilityrs"]
+html-to-markdown = ["dasclaw_net_tools/html-to-markdown"]
 bedrock = ["dep:aws-config", "dep:aws-sdk-bedrockruntime", "dep:aws-smithy-types"]
 import = ["dep:json5", "libsql"]
 

--- a/desktop-client/ironclaw/src/tools/builtin/mod.rs
+++ b/desktop-client/ironclaw/src/tools/builtin/mod.rs
@@ -1,7 +1,6 @@
 //! Built-in tools that come with the agent.
 
 pub mod extension_tools;
-mod http;
 mod job;
 pub mod lsp;
 pub mod memory;
@@ -53,7 +52,6 @@ pub use extension_tools::{
 pub use file::{ApplyPatchTool, ListDirTool, ReadFileTool, WriteFileTool};
 pub use glob_search::GlobSearchTool;
 pub use grep_search::GrepSearchTool;
-pub use http::HttpTool;
 pub use job::{
     CancelJobTool, CreateJobTool, JobEventsTool, JobPromptTool, JobStatusTool, ListJobsTool,
     PromptQueue, SchedulerSlot,
@@ -69,11 +67,10 @@ pub use shell::ShellTool;
 pub use skill_tools::{SkillInstallTool, SkillListTool, SkillRemoveTool, SkillSearchTool};
 pub use tool_info::ToolInfoTool;
 pub use web_search::WebSearchTool;
-mod html_converter;
 
 pub use dasclaw_image_tools::{ImageAnalyzeTool, ImageEditTool, ImageGenerateTool};
 
-// F4.6.8 (phase 1) — web_fetch was extracted to `crates/dasclaw_net_tools` per
-// ADR-156 §6.3. Thin re-export keeps existing call sites compiling unchanged.
-pub use dasclaw_net_tools::WebFetchTool;
-pub use html_converter::convert_html_to_markdown;
+// F4.6.8 (phase 1 + 2) — `web_fetch`, `http`, and the `html_converter` helper
+// were extracted to `crates/dasclaw_net_tools` per ADR-156 §6.3. Thin
+// re-exports keep existing call sites compiling unchanged.
+pub use dasclaw_net_tools::{HttpTool, WebFetchTool, convert_html_to_markdown};

--- a/desktop-client/ironclaw/src/tools/builtin/mod.rs
+++ b/desktop-client/ironclaw/src/tools/builtin/mod.rs
@@ -10,7 +10,6 @@ pub(crate) mod shell;
 pub use shell::classify_command_risk;
 pub mod skill_tools;
 mod tool_info;
-mod web_search;
 
 // F4.6.6-a/-b/-c (ADR-156 §6.3): `path_utils` + `file_guard` + `code_edit` +
 // `glob_search` + `grep_search` + `file` were extracted to `dasclaw_fs_tools`.
@@ -66,11 +65,10 @@ pub use routine::{
 pub use shell::ShellTool;
 pub use skill_tools::{SkillInstallTool, SkillListTool, SkillRemoveTool, SkillSearchTool};
 pub use tool_info::ToolInfoTool;
-pub use web_search::WebSearchTool;
 
 pub use dasclaw_image_tools::{ImageAnalyzeTool, ImageEditTool, ImageGenerateTool};
 
-// F4.6.8 (phase 1 + 2) — `web_fetch`, `http`, and the `html_converter` helper
-// were extracted to `crates/dasclaw_net_tools` per ADR-156 §6.3. Thin
-// re-exports keep existing call sites compiling unchanged.
-pub use dasclaw_net_tools::{HttpTool, WebFetchTool, convert_html_to_markdown};
+// F4.6.8 (phase 1 + 2 + 3) — `web_fetch`, `http`, `html_converter`, and
+// `web_search` were extracted to `crates/dasclaw_net_tools` per ADR-156 §6.3.
+// Thin re-exports keep existing call sites compiling unchanged.
+pub use dasclaw_net_tools::{HttpTool, WebFetchTool, WebSearchTool, convert_html_to_markdown};


### PR DESCRIPTION
## 背景 / 目标

ADR-156 §6.3 F4.6.8 phase 2。把 desktop-client/ironclaw 的 `tools/builtin/http.rs`（1513 行）和 `tools/builtin/html_converter.rs`（128 行）verbatim 下沉到 `crates/dasclaw_net_tools`。

Closes #779

## 改动范围

- git mv 两文件到 `crates/dasclaw_net_tools/src/`
- 改 import：`crate::tools::tool::*` → `dasclaw_tool::*` / `dasclaw_runtime::*` / `dasclaw_safety::*` / `dasclaw_wasm_tools::*` / `dasclaw_fs_tools::*`
- 测试 fixture：`TEST_OPENAI_API_KEY` → `TEST_OPENAI_API_KEY_SHORT as TEST_OPENAI_API_KEY`（功能等价的 bearer-token 触发器，已加注释）
- net_tools Cargo.toml 加 deps：`bytes`、`tokio`、`dasclaw_fs_tools`
- desktop `builtin/mod.rs` 改 re-export 指向 `dasclaw_net_tools`
- 移除 desktop 的 `html-to-markdown-rs` / `readabilityrs` 直接依赖（转交 net_tools `html-to-markdown` feature）

## 非目标

- 不改 http/html_converter 的业务逻辑（verbatim port）
- 不动 web_search.rs（phase 3 单独 PR）

## 为什么合并到一个 PR

`http.rs` 通过 `#[cfg(feature="html-to-markdown")] use crate::convert_html_to_markdown;` 编译期依赖 html_converter。拆 stacked PR 会强制 review 顺序变成 html_converter → http，没有 review 收益。

## 验证

```
cargo check -p dasclaw_net_tools --tests --features html-to-markdown   # ✅
cargo check -p dasclaw --tests                                          # ✅
cargo nextest run -p dasclaw_net_tools --features html-to-markdown      # ✅ 61 passed
cargo fmt --all                                                         # ✅
python3.12 scripts/check_no_panics.py --base origin/xClaw               # ✅
python3 scripts/check_blueprint_sync.py                                 # ✅
python3 scripts/check_no_new_ironclaw_literal.py --base origin/xClaw    # ✅
cargo clippy --no-deps -p dasclaw_net_tools --all-targets --features html-to-markdown -- -D warnings  # ✅
```

## Sources read

- AGENTS.md §Rust 开发规范 / §GitHub PR 工作流 / §ADR-114 红线
- docs/plans/architecture-refactor/adr-156-*.md §6.3 F4.6.8
- docs/plans/architecture-refactor/adr-129-*.md §1.3（verbatim port 跳过 code-simplifier）

## Cross-cuts

类A（无新增 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量）

## 后续 PR

- F4.6.8 phase 3：web_search.rs（552 行）→ `crates/dasclaw_net_tools/src/web_search.rs`