### PR TITLE
feat(net-tools): F4.6.8 phase 3 — web_search 下沉到 dasclaw_net_tools

### DIFF
--- a/crates/dasclaw_net_tools/src/lib.rs
+++ b/crates/dasclaw_net_tools/src/lib.rs
@@ -2,14 +2,16 @@
 //! ADR-156 §6.3 F4.6.8.
 //!
 //! Phase 1: `web_fetch`.
-//! Phase 2 (current): `http` + `html_converter` (the latter is `http`'s
+//! Phase 2: `http` + `html_converter` (the latter is `http`'s
 //!   feature-gated HTML→Markdown helper, sunk together to avoid a stacked PR).
-//! Phase 3 (planned): `web_search`.
+//! Phase 3 (current): `web_search` — DuckDuckGo HTML search, no API key.
 
 mod html_converter;
 mod http;
 mod web_fetch;
+mod web_search;
 
 pub use html_converter::convert_html_to_markdown;
 pub use http::HttpTool;
 pub use web_fetch::WebFetchTool;
+pub use web_search::WebSearchTool;

--- a/crates/dasclaw_net_tools/src/web_search.rs
+++ b/crates/dasclaw_net_tools/src/web_search.rs
@@ -14,7 +14,8 @@ use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 
-use crate::tools::tool::{ApprovalRequirement, Tool, ToolError, ToolOutput, require_str};
+use dasclaw_runtime::Tool;
+use dasclaw_tool::{ApprovalRequirement, ToolError, ToolOutput, require_str};
 
 const USER_AGENT: &str = concat!("IronClaw-WebSearch/", env!("CARGO_PKG_VERSION"),);
 

--- a/desktop-client/ironclaw/src/tools/builtin/mod.rs
+++ b/desktop-client/ironclaw/src/tools/builtin/mod.rs
@@ -10,7 +10,6 @@ pub(crate) mod shell;
 pub use shell::classify_command_risk;
 pub mod skill_tools;
 mod tool_info;
-mod web_search;
 
 // F4.6.6-a/-b/-c (ADR-156 §6.3): `path_utils` + `file_guard` + `code_edit` +
 // `glob_search` + `grep_search` + `file` were extracted to `dasclaw_fs_tools`.
@@ -66,11 +65,10 @@ pub use routine::{
 pub use shell::ShellTool;
 pub use skill_tools::{SkillInstallTool, SkillListTool, SkillRemoveTool, SkillSearchTool};
 pub use tool_info::ToolInfoTool;
-pub use web_search::WebSearchTool;
 
 pub use dasclaw_image_tools::{ImageAnalyzeTool, ImageEditTool, ImageGenerateTool};
 
-// F4.6.8 (phase 1 + 2) — `web_fetch`, `http`, and the `html_converter` helper
-// were extracted to `crates/dasclaw_net_tools` per ADR-156 §6.3. Thin
-// re-exports keep existing call sites compiling unchanged.
-pub use dasclaw_net_tools::{HttpTool, WebFetchTool, convert_html_to_markdown};
+// F4.6.8 (phase 1 + 2 + 3) — `web_fetch`, `http`, `html_converter`, and
+// `web_search` were extracted to `crates/dasclaw_net_tools` per ADR-156 §6.3.
+// Thin re-exports keep existing call sites compiling unchanged.
+pub use dasclaw_net_tools::{HttpTool, WebFetchTool, WebSearchTool, convert_html_to_markdown};


### PR DESCRIPTION
## 背景 / 目标

ADR-156 §6.3 F4.6.8 phase 3（收尾）。把 desktop-client/ironclaw 的 `tools/builtin/web_search.rs`（552 行）verbatim 下沉到 `crates/dasclaw_net_tools`。

Closes #781

## stacked PR 说明

- **base 不是 `xClaw`，而是 `feat/net-tools-http`**（PR #780 phase 2）
- merge 顺序：先 #780，再本 PR
- 请先看 #780，本 PR diff 只看 web_search 移动 + 一个 mod.rs / lib.rs 增量
- phase 2 与 phase 3 共享 `crates/dasclaw_net_tools/Cargo.toml` / `src/lib.rs` / desktop `builtin/mod.rs`，无法平行开 PR

## 改动范围

- git mv `desktop-client/ironclaw/src/tools/builtin/web_search.rs` → `crates/dasclaw_net_tools/src/web_search.rs`
- 改 import：`crate::tools::tool::*` → `dasclaw_runtime::Tool` + `dasclaw_tool::{ApprovalRequirement, ToolError, ToolOutput, require_str}`
- desktop `builtin/mod.rs` 删 `mod web_search` + 旧 re-export，net_tools 联合 re-export 加 `WebSearchTool`
- `crates/dasclaw_net_tools/src/lib.rs` 加 `mod web_search` + `pub use`

## 非目标

- 不改 web_search 业务逻辑（verbatim port）
- 不改 `IRONCLAW_WEB_SEARCH_BASE_URL` env var 名（保留向后兼容，非 ADR-114 红线字面量）

## 验证

```
cargo check -p dasclaw_net_tools --tests --features html-to-markdown   # ✅
cargo check -p dasclaw --tests                                          # ✅
cargo nextest run -p dasclaw_net_tools --features html-to-markdown      # ✅ 71 passed
cargo fmt --all                                                         # ✅
python3.12 scripts/check_no_panics.py --base origin/xClaw               # ✅
python3 scripts/check_blueprint_sync.py                                 # ✅
python3 scripts/check_no_new_ironclaw_literal.py --base origin/xClaw    # ✅
cargo clippy --no-deps -p dasclaw_net_tools --all-targets --features html-to-markdown -- -D warnings  # ✅
```

## Sources read

- AGENTS.md §Rust 开发规范 / §GitHub PR 工作流 / §ADR-114 红线
- docs/plans/architecture-refactor/adr-156-*.md §6.3 F4.6.8
- docs/plans/architecture-refactor/adr-129-*.md §1.3（verbatim port 跳过 code-simplifier）

## Cross-cuts

类A（无新增 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量；`IRONCLAW_WEB_SEARCH_BASE_URL` 是已存在的运行时 env var 名，搬迁未新增）

## 后续

- F4.6.8 收尾，net_tools crate 完成。后续按 ADR-156 §6.3 推进下一族 builtin 下沉。