### PR TITLE
feat(net-tools): F4.6.8 phase 3 — sink HttpTool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3132,14 +3132,20 @@ name = "dasclaw_net_tools"
 version = "0.0.0-w6"
 dependencies = [
  "async-trait",
+ "bytes",
+ "dasclaw_fs_tools",
  "dasclaw_runtime",
+ "dasclaw_safety",
  "dasclaw_tool",
+ "dasclaw_wasm_tools",
+ "futures",
  "html-to-markdown-rs",
  "readabilityrs",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/dasclaw_net_tools/Cargo.toml
+++ b/crates/dasclaw_net_tools/Cargo.toml
@@ -11,12 +11,19 @@ path = "src/lib.rs"
 
 [dependencies]
 async-trait = "0.1"
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls-native-roots"] }
+bytes = "1"
+futures = "0.3"
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls-native-roots", "stream"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+tokio = { version = "1", features = ["net", "fs", "io-util"] }
+tracing = "0.1"
 
+dasclaw_fs_tools = { path = "../dasclaw_fs_tools" }
 dasclaw_runtime = { path = "../dasclaw_runtime" }
+dasclaw_safety = { path = "../dasclaw_safety" }
 dasclaw_tool = { path = "../dasclaw_tool" }
+dasclaw_wasm_tools = { path = "../dasclaw_wasm_tools" }
 
 # Optional readability + HTML→markdown pipeline used by `html_converter`
 # (gated behind the `html-to-markdown` feature so headless builds stay slim).

--- a/crates/dasclaw_net_tools/src/http.rs
+++ b/crates/dasclaw_net_tools/src/http.rs
@@ -1247,8 +1247,8 @@ mod tests {
 
     #[test]
     fn test_host_with_credential_mapping_returns_unless_auto_approved() {
-        use dasclaw_wasm_tools::SharedCredentialRegistry;
         use dasclaw_runtime::secrets::CredentialMapping;
+        use dasclaw_wasm_tools::SharedCredentialRegistry;
 
         let registry = Arc::new(SharedCredentialRegistry::new());
         registry.add_mappings(vec![CredentialMapping::bearer(
@@ -1429,8 +1429,8 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn requires_approval_multi_thread_no_panic() {
-        use dasclaw_wasm_tools::SharedCredentialRegistry;
         use dasclaw_runtime::secrets::CredentialMapping;
+        use dasclaw_wasm_tools::SharedCredentialRegistry;
 
         // Test with credential registry (uses std::sync::RwLock - should be safe)
         let registry = Arc::new(SharedCredentialRegistry::new());

--- a/crates/dasclaw_net_tools/src/http.rs
+++ b/crates/dasclaw_net_tools/src/http.rs
@@ -9,13 +9,14 @@ use async_trait::async_trait;
 use futures::StreamExt;
 use reqwest::Client;
 
-use crate::safety::LeakDetector;
-use crate::tools::tool::{ApprovalRequirement, Tool, ToolError, ToolOutput, require_str};
-use crate::tools::wasm::{InjectedCredentials, SharedCredentialRegistry, inject_credential};
+use dasclaw_runtime::Tool;
 use dasclaw_runtime::secrets::SecretsStore;
+use dasclaw_safety::LeakDetector;
+use dasclaw_tool::{ApprovalRequirement, ToolError, ToolOutput, require_str};
+use dasclaw_wasm_tools::{InjectedCredentials, SharedCredentialRegistry, inject_credential};
 
 #[cfg(feature = "html-to-markdown")]
-use crate::tools::builtin::convert_html_to_markdown;
+use crate::convert_html_to_markdown;
 
 /// Maximum response body size for text responses (5 MB).
 ///
@@ -94,7 +95,7 @@ fn validate_save_to_path(save_to: &str) -> Result<std::path::PathBuf, ToolError>
     // Validate path BEFORE creating directories to prevent traversal-based
     // directory creation outside /tmp (e.g. `/tmp/../../etc/passwd`).
     let tmp_base = std::path::Path::new("/tmp");
-    let validated = crate::tools::builtin::path_utils::validate_path(save_to, Some(tmp_base))?;
+    let validated = dasclaw_fs_tools::path_utils::validate_path(save_to, Some(tmp_base))?;
     // Only create parent directories for the validated (safe) path
     if let Some(parent) = validated.parent() {
         std::fs::create_dir_all(parent).map_err(|e| {
@@ -586,7 +587,7 @@ impl Tool for HttpTool {
             .map_err(|e| ToolError::NotAuthorized(format!("{}", e)))?;
 
         // Build the interceptor request descriptor for recording/replay
-        let intercept_req = crate::llm::recording::HttpExchangeRequest {
+        let intercept_req = dasclaw_runtime::recording::HttpExchangeRequest {
             method: method_upper,
             url: parsed_url.to_string(),
             headers: headers_vec.clone(),
@@ -813,7 +814,7 @@ impl Tool for HttpTool {
             interceptor
                 .after_response(
                     &intercept_req,
-                    &crate::llm::recording::HttpExchangeResponse {
+                    &dasclaw_runtime::recording::HttpExchangeResponse {
                         status,
                         headers: resp_headers,
                         body: body_text.clone(),
@@ -857,7 +858,7 @@ impl Tool for HttpTool {
     }
 
     fn requires_approval(&self, params: &serde_json::Value) -> ApprovalRequirement {
-        let has_credentials = crate::safety::params_contain_manual_credentials(params)
+        let has_credentials = dasclaw_safety::params_contain_manual_credentials(params)
             || (self.credential_registry.as_ref().is_some_and(|registry| {
                 extract_host_from_params(params)
                     .is_some_and(|host| registry.has_credentials_for_host(&host))
@@ -876,15 +877,18 @@ impl Tool for HttpTool {
         ApprovalRequirement::UnlessAutoApproved
     }
 
-    fn rate_limit_config(&self) -> Option<crate::tools::tool::ToolRateLimitConfig> {
-        Some(crate::tools::tool::ToolRateLimitConfig::new(30, 500))
+    fn rate_limit_config(&self) -> Option<dasclaw_tool::ToolRateLimitConfig> {
+        Some(dasclaw_tool::ToolRateLimitConfig::new(30, 500))
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::testing::credentials::{TEST_OPENAI_API_KEY, test_secrets_store};
+    use dasclaw_wasm_tools::test_credentials::test_secrets_store;
+
+    // Local test fixture mirroring desktop `crate::testing::credentials::TEST_OPENAI_API_KEY`.
+    const TEST_OPENAI_API_KEY: &str = "sk-test123";
 
     #[test]
     fn test_http_tool_schema_headers_is_array() {
@@ -1243,7 +1247,7 @@ mod tests {
 
     #[test]
     fn test_host_with_credential_mapping_returns_unless_auto_approved() {
-        use crate::tools::wasm::SharedCredentialRegistry;
+        use dasclaw_wasm_tools::SharedCredentialRegistry;
         use dasclaw_runtime::secrets::CredentialMapping;
 
         let registry = Arc::new(SharedCredentialRegistry::new());
@@ -1270,7 +1274,7 @@ mod tests {
 
     #[test]
     fn test_get_host_without_credential_mapping_returns_never() {
-        use crate::tools::wasm::SharedCredentialRegistry;
+        use dasclaw_wasm_tools::SharedCredentialRegistry;
 
         let registry = Arc::new(SharedCredentialRegistry::new());
         // Empty registry - no credential mappings
@@ -1355,7 +1359,7 @@ mod tests {
 
     #[test]
     fn test_requires_approval_with_stringified_http_params() {
-        use crate::tools::wasm::SharedCredentialRegistry;
+        use dasclaw_wasm_tools::SharedCredentialRegistry;
 
         let tool = HttpTool::new().with_credentials(
             Arc::new(SharedCredentialRegistry::new()),
@@ -1425,7 +1429,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn requires_approval_multi_thread_no_panic() {
-        use crate::tools::wasm::SharedCredentialRegistry;
+        use dasclaw_wasm_tools::SharedCredentialRegistry;
         use dasclaw_runtime::secrets::CredentialMapping;
 
         // Test with credential registry (uses std::sync::RwLock - should be safe)

--- a/crates/dasclaw_net_tools/src/lib.rs
+++ b/crates/dasclaw_net_tools/src/lib.rs
@@ -5,15 +5,20 @@
 //! - `web_fetch`  — fetch a URL, convert to readable text, answer a prompt.
 //! - `web_search` — DuckDuckGo HTML search, no API key (F4.6.8 phase 2).
 //! - `html_converter::convert_html_to_markdown` — shared helper used by
-//!   web_fetch and the desktop `HttpTool` (F4.6.8 phase 2).
+//!   web_fetch and `HttpTool` (F4.6.8 phase 2).
+//! - `http`       — general-purpose HTTPS request tool with credential
+//!   injection via `dasclaw_wasm_tools::SharedCredentialRegistry`
+//!   (F4.6.8 phase 3).
 //!
-//! `http` (the general-purpose HTTP request tool) remains in desktop-client
-//! pending a follow-up phase — it has deeper coupling to credential storage.
+//! F4.6.8 is closed with phase 3; `dasclaw_net_tools` now hosts all four
+//! files originally listed in ADR-156 §6.1.
 
 pub mod html_converter;
+mod http;
 mod web_fetch;
 mod web_search;
 
 pub use html_converter::convert_html_to_markdown;
+pub use http::HttpTool;
 pub use web_fetch::WebFetchTool;
 pub use web_search::WebSearchTool;

--- a/desktop-client/ironclaw/src/tools/builtin/mod.rs
+++ b/desktop-client/ironclaw/src/tools/builtin/mod.rs
@@ -1,7 +1,6 @@
 //! Built-in tools that come with the agent.
 
 pub mod extension_tools;
-mod http;
 mod job;
 pub mod lsp;
 pub mod memory;
@@ -52,7 +51,6 @@ pub use extension_tools::{
 pub use file::{ApplyPatchTool, ListDirTool, ReadFileTool, WriteFileTool};
 pub use glob_search::GlobSearchTool;
 pub use grep_search::GrepSearchTool;
-pub use http::HttpTool;
 pub use job::{
     CancelJobTool, CreateJobTool, JobEventsTool, JobPromptTool, JobStatusTool, ListJobsTool,
     PromptQueue, SchedulerSlot,
@@ -70,9 +68,8 @@ pub use tool_info::ToolInfoTool;
 
 pub use dasclaw_image_tools::{ImageAnalyzeTool, ImageEditTool, ImageGenerateTool};
 
-// F4.6.8 (phase 1) — web_fetch was extracted to `crates/dasclaw_net_tools` per
-// ADR-156 §6.3. Thin re-export keeps existing call sites compiling unchanged.
-// F4.6.8 (phase 2) — web_search + html_converter::convert_html_to_markdown were
-// also extracted into `dasclaw_net_tools`. ToolInfoTool stays in desktop because
-// it reflects on `Weak<ToolRegistry>`, which lives here.
-pub use dasclaw_net_tools::{WebFetchTool, WebSearchTool, convert_html_to_markdown};
+// F4.6.8 — web_fetch (phase 1), web_search + html_converter (phase 2), and
+// HttpTool (phase 3) all live in `crates/dasclaw_net_tools` per ADR-156 §6.3.
+// Thin re-exports keep existing call sites compiling unchanged. ToolInfoTool
+// stays in desktop because it reflects on `Weak<ToolRegistry>`, which lives here.
+pub use dasclaw_net_tools::{HttpTool, WebFetchTool, WebSearchTool, convert_html_to_markdown};

--- a/scripts/check_blueprint_sync.py
+++ b/scripts/check_blueprint_sync.py
@@ -49,8 +49,8 @@ PLANNED: dict[str, str] = {
     # F4.6.2 (`dasclaw_image_tools`) landed — entry removed.
     # F4.6.4 (`dasclaw_sub_agent_tools`) landed — entry removed.
     # F4.6.6-a (`dasclaw_fs_tools`) landed — entry removed.
-    # F4.6.7 (`dasclaw_shell_tools`) phase 1 landed — entry removed.
-    # F4.6.8 (`dasclaw_net_tools`) phase 1 (web_fetch) landed — entry removed.
+    # F4.6.7 (`dasclaw_shell_tools`) landed — entry removed.
+    # F4.6.8 (`dasclaw_net_tools`) landed (phases 1/2/3) — entry removed.
 }
 
 # Symbols that look like crate names but are not. Examples: conceptual


### PR DESCRIPTION
## 依赖（stacked PR）
- Base: `feat/net-tools-phase2`（**不是** `xClaw`）
- 请**先合 #788**（F4.6.8 phase 2）再看本 PR
- Merge 顺序：#788 → 本 PR

## Sources read
- `docs/plans/architecture-refactor/adr-156-w6-package-refactor.md` §6.1 反向依赖表 + §6.3 F4.6.8（net_tools 目标清单 = http + web_fetch + web_search + html_converter）
- `docs/plans/architecture-refactor/adr-129-w3-w8-discipline.md` §1.3 verbatim port discipline
- `docs/plans/architecture-refactor/adr-114-dasclaw-rebrand.md`（Cross-cuts 类 A 判定）
- `docs/plans/architecture-refactor/adr-153-headless-agent-framework.md`（无头 agent 需要 HTTP 工具能力）

## 背景 / 目标
F4.6.8 phase 1/2 已把 `web_fetch`、`web_search`、`html_converter` 搬到 `dasclaw_net_tools`。本 PR 完成 phase 3：把 `HttpTool`（通用 HTTPS 请求工具，含凭据注入 + 泄漏检测 + exchange 记录）也搬到该 crate，从而把 ADR-156 §6.3 F4.6.8 列出的 4 个文件全部下沉到共享 crate。

完成后 `dasclaw_net_tools` 成为无头 agent 框架可直接复用的 HTTP/Web 工具盒，桌面端只保留薄 re-export。

## 改动范围
- `crates/dasclaw_net_tools/src/http.rs`（新增，1513 行，git 检测为 97% rename）
- `crates/dasclaw_net_tools/src/lib.rs`：注册 `mod http;` + `pub use http::HttpTool;`，更新模块级文档收口 F4.6.8
- `crates/dasclaw_net_tools/Cargo.toml`：新增 `futures` / `bytes` / `tokio`（net/fs/io-util）/ `tracing` + path deps `dasclaw_fs_tools` / `dasclaw_safety` / `dasclaw_wasm_tools`；`reqwest` 加 `stream` feature
- `desktop-client/ironclaw/src/tools/builtin/http.rs`：删除
- `desktop-client/ironclaw/src/tools/builtin/mod.rs`：移除 `mod http;` 与 `pub use http::HttpTool;`，把 `HttpTool` 加入 `dasclaw_net_tools` re-export

## 非目标
- 不改 `HttpTool` 行为 / 公共 API / 测试断言（verbatim port，ADR-129 §1.3）
- 不动 ADR-156 §6.2 留守列表中的 T3/T4 文件
- 不涉及 reqwest TLS backend 切换

## 验证
\`\`\`bash
cargo check -p dasclaw_net_tools --tests                 # ✅
cargo nextest run -p dasclaw_net_tools                   # ✅ 70 passed (lib 24→70 with HttpTool tests)
cargo check -p dasclaw --tests                           # ✅
cargo clippy --no-deps -p dasclaw_net_tools --all-targets --features html-to-markdown -- -D warnings  # ✅
python3.12 scripts/check_no_panics.py --base origin/xClaw  # ✅ OK
\`\`\`

## Cross-cuts
类 A — 无新增 \`.ironclaw\` / \`IRONCLAW_BASE_DIR\` 字面量

## 后续
- F4.6.8 收官 → 推进 ADR-156 §6.3 剩余 family

Closes #789