### PR TITLE
feat(dasclaw_cli): ADR-153 §4.4 step 4 — headless agent CLI skeleton

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2853,6 +2853,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "dasclaw_cli"
+version = "0.0.0-w6"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "clap",
+ "dasclaw_core",
+ "dasclaw_runtime",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "dasclaw_core"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,9 @@ members = [
 	"crates/dasclaw_sandbox_linux",
 	# W8 ADR-139 §4.5 PR1 — MITM CA trust-chain manager (dasclaw original, not verbatim)
 	"crates/dasclaw_cert_trust",
+	# ADR-153 §4.4 step 4 — headless agent CLI (proof that dasclaw_runtime::Agent
+	# runs without desktop: no Tauri, no DB, no HTTP server)
+	"crates/dasclaw_cli",
 	"desktop-client/ironclaw",
 	"desktop-client/ironclaw/crates/ironclaw_common",
 	"crates/dasclaw_safety",

--- a/crates/dasclaw_cli/Cargo.toml
+++ b/crates/dasclaw_cli/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "dasclaw_cli"
+version = "0.0.0-w6"
+edition = "2024"
+description = "Headless agent CLI binary (ADR-153 §4.4 step 4). Demonstrates dasclaw_runtime::Agent::builder() end-to-end without desktop dependencies (no Tauri, no database, no HTTP server)."
+license = "MIT OR Apache-2.0"
+
+[[bin]]
+name = "dasclaw-cli"
+path = "src/main.rs"
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+dasclaw_runtime = { path = "../dasclaw_runtime" }
+dasclaw_core = { path = "../dasclaw_core" }
+anyhow = "1"
+clap = { version = "4", features = ["derive"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "io-std", "io-util"] }
+async-trait = "0.1"
+thiserror = "1"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "test-util"] }

--- a/crates/dasclaw_cli/src/lib.rs
+++ b/crates/dasclaw_cli/src/lib.rs
@@ -89,7 +89,13 @@ impl EchoResponder {
 
     /// Number of times [`AgentResponder::respond`] has been called.
     pub fn call_count(&self) -> usize {
-        *self.call_count.lock().expect("call_count mutex poisoned")
+        // Mutex poisoning here only happens if a previous holder panicked.
+        // The counter has no invariants to protect, so recovering the inner
+        // value is safe and lets us stay panic-free in production code.
+        *self
+            .call_count
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
     }
 }
 
@@ -102,7 +108,12 @@ impl Default for EchoResponder {
 #[async_trait]
 impl AgentResponder for EchoResponder {
     async fn respond(&self, ctx: &mut ReasoningContext) -> Result<RespondOutput, HostError> {
-        *self.call_count.lock().expect("call_count mutex poisoned") += 1;
+        // See call_count(): a poisoned mutex around a plain counter has no
+        // invariants to protect, so recover instead of panicking.
+        *self
+            .call_count
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) += 1;
         let last_user_text = ctx
             .messages
             .iter()

--- a/crates/dasclaw_cli/src/lib.rs
+++ b/crates/dasclaw_cli/src/lib.rs
@@ -1,0 +1,120 @@
+//! `dasclaw_cli` — headless agent CLI (ADR-153 §4.4 step 4).
+//!
+//! This crate is the proof-point that [`dasclaw_runtime::Agent`] runs
+//! without any desktop dependency: no Tauri, no database, no channels, no
+//! HTTP server. The binary in `src/main.rs` takes a prompt on argv or
+//! stdin and prints the agent's reply on stdout.
+//!
+//! ## Scope of this skeleton (step 4, slice 1)
+//!
+//! - [`run`] — pure async function. Takes any
+//!   [`dasclaw_runtime::AgentResponder`] plus system / user prompts and
+//!   returns the agent's text reply. Does no I/O.
+//! - [`EchoResponder`] — deterministic built-in
+//!   [`AgentResponder`] that replies with `echo: <last user content>`. It
+//!   exists solely to let the binary and integration tests demonstrate
+//!   end-to-end wire-up without a real LLM key.
+//!
+//! ## Out of scope (deliberately not in this slice)
+//!
+//! - Real LLM provider wiring (would expose
+//!   `dasclaw_llm_provider` config surface; lands in a follow-up PR once
+//!   provider selection mechanism is settled).
+//! - Tool execution wiring ([`dasclaw_runtime::ToolExecutor`]). Same
+//!   reason.
+//! - Streaming / interactive REPL. The first slice is request-response.
+
+use std::sync::Mutex;
+
+use async_trait::async_trait;
+use dasclaw_core::messages::{FinishReason, Role};
+use dasclaw_core::reasoning_ctx::ReasoningContext;
+use dasclaw_core::response_types::{RespondOutput, RespondResult, ResponseMetadata, TokenUsage};
+use dasclaw_core::traits::HostError;
+use dasclaw_runtime::{Agent, AgentError, AgentResponder};
+
+/// Errors surfaced by the CLI library layer.
+#[derive(Debug, thiserror::Error)]
+pub enum CliError {
+    /// Agent loop returned an error.
+    #[error("agent error: {0}")]
+    Agent(#[from] AgentError),
+
+    /// Builder rejected the configuration (e.g. missing responder).
+    #[error("agent builder error: {0}")]
+    Build(String),
+}
+
+/// Build an [`Agent`] from `responder` + `system_prompt` and run it once
+/// against `user_prompt`, returning the text reply.
+///
+/// Single library entry point used by both the binary in `src/main.rs`
+/// and integration tests under `tests/`. Keeping the I/O (stdin / stdout
+/// / argv) out of this function is what lets the integration tests
+/// assert behaviour without spawning subprocesses.
+pub async fn run<R>(
+    responder: R,
+    system_prompt: &str,
+    user_prompt: &str,
+) -> Result<String, CliError>
+where
+    R: AgentResponder + 'static,
+{
+    let agent: Agent = Agent::builder()
+        .responder(responder)
+        .system_prompt(system_prompt)
+        .build()
+        .map_err(|e| CliError::Build(e.to_string()))?;
+    let reply = agent.run(user_prompt).await?;
+    Ok(reply)
+}
+
+/// Deterministic [`AgentResponder`] that replies `echo: <last user
+/// content>`.
+///
+/// Intended for smoke-testing the headless wiring without an LLM key.
+/// Production callers should plug in a real [`AgentResponder`] (e.g.
+/// [`dasclaw_runtime::LlmProviderResponder`]).
+pub struct EchoResponder {
+    call_count: Mutex<usize>,
+}
+
+impl EchoResponder {
+    /// Create a new echo responder.
+    pub fn new() -> Self {
+        Self {
+            call_count: Mutex::new(0),
+        }
+    }
+
+    /// Number of times [`AgentResponder::respond`] has been called.
+    pub fn call_count(&self) -> usize {
+        *self.call_count.lock().expect("call_count mutex poisoned")
+    }
+}
+
+impl Default for EchoResponder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl AgentResponder for EchoResponder {
+    async fn respond(&self, ctx: &mut ReasoningContext) -> Result<RespondOutput, HostError> {
+        *self.call_count.lock().expect("call_count mutex poisoned") += 1;
+        let last_user_text = ctx
+            .messages
+            .iter()
+            .rev()
+            .find(|m| matches!(m.role, Role::User))
+            .map(|m| m.content.clone())
+            .unwrap_or_default();
+        Ok(RespondOutput {
+            result: RespondResult::Text(format!("echo: {last_user_text}")),
+            usage: TokenUsage::default(),
+            finish_reason: FinishReason::Stop,
+            metadata: ResponseMetadata::default(),
+        })
+    }
+}

--- a/crates/dasclaw_cli/src/main.rs
+++ b/crates/dasclaw_cli/src/main.rs
@@ -1,0 +1,69 @@
+//! Headless `dasclaw` CLI binary (ADR-153 §4.4 step 4).
+//!
+//! Thin wrapper around [`dasclaw_cli::run`]. Parses argv with `clap`,
+//! initialises `tracing`, acquires the prompt (from `--prompt` or stdin),
+//! invokes the agent, prints the reply, and maps errors to exit codes.
+//!
+//! For programmatic use, depend on the `dasclaw_cli` library directly.
+
+use std::io::{self, Read};
+use std::process::ExitCode;
+
+use anyhow::{Context, Result};
+use clap::Parser;
+use dasclaw_cli::{EchoResponder, run};
+
+/// Headless dasclaw agent CLI.
+///
+/// Runs a single prompt through a `dasclaw_runtime::Agent` and prints the
+/// reply. The default responder is a deterministic echo for smoke
+/// testing — wire a real LLM responder in once provider selection lands.
+#[derive(Debug, Parser)]
+#[command(name = "dasclaw-cli", version, about, long_about = None)]
+struct Cli {
+    /// User prompt. When omitted, the prompt is read from stdin.
+    #[arg(short, long)]
+    prompt: Option<String>,
+
+    /// System prompt prepended to the conversation.
+    #[arg(short, long, default_value = "You are dasclaw, a headless agent.")]
+    system: String,
+}
+
+#[tokio::main]
+async fn main() -> ExitCode {
+    if let Err(err) = real_main().await {
+        eprintln!("dasclaw: {err:#}");
+        return ExitCode::from(1);
+    }
+    ExitCode::SUCCESS
+}
+
+async fn real_main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("warn")),
+        )
+        .with_writer(io::stderr)
+        .try_init()
+        .ok();
+
+    let cli = Cli::parse();
+    let prompt = match cli.prompt {
+        Some(p) => p,
+        None => read_stdin_prompt().context("reading prompt from stdin")?,
+    };
+
+    let reply = run(EchoResponder::new(), &cli.system, prompt.trim())
+        .await
+        .context("agent run failed")?;
+    println!("{reply}");
+    Ok(())
+}
+
+fn read_stdin_prompt() -> io::Result<String> {
+    let mut buf = String::new();
+    io::stdin().read_to_string(&mut buf)?;
+    Ok(buf)
+}

--- a/crates/dasclaw_cli/tests/end_to_end.rs
+++ b/crates/dasclaw_cli/tests/end_to_end.rs
@@ -1,0 +1,21 @@
+//! End-to-end smoke test for ADR-153 §4.4 step 4: prove that
+//! `dasclaw_runtime::Agent` runs headlessly (no desktop) via the
+//! `dasclaw_cli` library entry point with the built-in fake responder.
+
+use dasclaw_cli::{EchoResponder, run};
+
+#[tokio::test]
+async fn echo_responder_round_trip() {
+    let reply = run(EchoResponder::new(), "system prompt", "hello world")
+        .await
+        .expect("agent run should succeed");
+
+    assert!(
+        reply.starts_with("echo:"),
+        "expected echo prefix, got: {reply:?}"
+    );
+    assert!(
+        reply.contains("hello world"),
+        "expected reply to echo prompt, got: {reply:?}"
+    );
+}

--- a/docs/plans/architecture-refactor/31-target-architecture.md
+++ b/docs/plans/architecture-refactor/31-target-architecture.md
@@ -5,6 +5,7 @@
 >   2. **F4.6.3 `dasclaw_memory_tools` 取消下沉**：按 [ADR-156 §6.3.1](adr-156-f46-builtin-tools-landing-decision.md) 决定，`memory` 模块依赖 `runtime` workspace crate（mtime / 大小 / 路径治理），强行下沉会绕过 ADR-153 边界，故 `memory` 留 desktop（与 §4.6 "留桌面 5 类"合并为 6 类：memory / extension / skill / job / routine / message）。
 >   3. **§4.6 薄壳化已完成**：`desktop-client/ironclaw/src/tools/builtin/mod.rs` 已转为 wildcard re-export 入口（PR #792），同时为下沉 crate 留 `pub mod` 仅限留守 6 类；shim `shell.rs` / `lsp/mod.rs` 已删。
 >   4. **crate 总数**：47（v2.5 写作时 45，新增 `dasclaw_misc_tools` 等本期产物）；`scripts/check_blueprint_sync.py` 自检为 `47 crates on disk / 2 planned`（剩 `dasclaw_bridge_lite` + `dasclaw_memory_tools` 处于 PLANNED 状态，后者按 ADR-156 §6.3.1 永久搁置）。
+>   5. **ADR-153 §4.4 step 4 落点**：新增 `crates/dasclaw_cli`（headless agent CLI，骨架 + EchoResponder 端到端 demo），证明 `dasclaw_runtime::Agent` 在零 desktop 依赖（无 Tauri / 无 DB / 无 HTTP server）下可独立运行；真实 LLM provider 与 tool executor 接线留待 ADR-153 后续 slice。
 > 本次升级是状态同步性质，不改架构决策，不重画 §1 总览图。原 v2.5 内容保留（§4.6 表格仅增"PR / 状态"列覆盖）。
 
 > **v2.5 (2026-05-23)** · 蓝图对齐 4-5 天发展（基于 [40-tool-ecosystem-inventory.md](40-tool-ecosystem-inventory.md) §1-3 实测 + [41-target-architecture-drift-analysis.md](41-target-architecture-drift-analysis.md) 漂移识别）：


### PR DESCRIPTION
## 背景 / 目标

ADR-153 §4.4 step 4 要求一个 headless 二进制，证明 `dasclaw_runtime::Agent` 不依赖 desktop 即可端到端跑通。本 PR 新增 `crates/dasclaw_cli` 作为首个 desktop-free 调用方，由 CI 守住 ADR-153 边界（runtime 不准长出 Tauri / DB / HTTP server 依赖）。

## 改动范围

- 新增 `crates/dasclaw_cli/`
  - `Cargo.toml` — 仅依赖 `dasclaw_runtime` + `dasclaw_core` + clap + tokio + tracing
  - `src/lib.rs` — `pub async fn run` 库入口 + `EchoResponder`（deterministic `AgentResponder`，回 `echo: <last user>`）
  - `src/main.rs` — bin `dasclaw-cli`，clap argv / stdin → `run` → stdout
  - `tests/end_to_end.rs` — round-trip `builder → run → reply` 集成测试
- 根 `Cargo.toml` workspace members 追加 `crates/dasclaw_cli`
- `docs/plans/architecture-refactor/31-target-architecture.md` v2.6 banner 增加第 5 条，记录本 crate 落点

## 非目标（What's NOT in this PR）

- ❌ 不接真实 LLM provider（待 provider 选型 ADR 落地后单独 PR）
- ❌ 不接 `dasclaw_runtime::ToolExecutor`（同上）
- ❌ 不做 streaming / 交互式 REPL，首切片只跑 request-response
- ❌ 不动 desktop / runtime / 其他 crate 的任何已有代码（纯增量）

## 验证

```
cargo check -p dasclaw_cli --tests           ✅ Finished
cargo nextest run -p dasclaw_cli              ✅ 1 passed
cargo clippy --no-deps -p dasclaw_cli --all-targets -- -D warnings   ✅ Finished
python3.12 scripts/check_no_panics.py --base origin/xClaw            ✅ OK
python3.12 scripts/check_no_new_ironclaw_literal.py --base origin/xClaw  ✅ OK
python3.12 scripts/check_blueprint_sync.py                            ✅ 48 crates on disk, 2 planned
```

## Sources read

- `docs/plans/architecture-refactor/adr-153-headless-agent-framework-draft.md` §4.4 (step 4 headless CLI 证明点)
- `docs/plans/architecture-refactor/31-target-architecture.md` v2.6 banner + §4.6
- `crates/dasclaw_runtime/src/agent.rs` (Agent / AgentBuilder / AgentResponder 完整签名 + ScriptedResponder 测试范例)
- `crates/dasclaw_runtime/src/lib.rs` (导出列表)
- `crates/dasclaw_runtime/Cargo.toml` (workspace dep 风格)
- `crates/dasclaw_core/src/messages.rs` (ChatMessage / Role / FinishReason 实际形状)
- `crates/dasclaw_core/src/reasoning_ctx.rs` (ReasoningContext.messages 公有字段)
- `crates/dasclaw_core/src/response_types.rs` (RespondOutput / RespondResult / TokenUsage / ResponseMetadata)
- `AGENTS.md` §测试纪律 / §复用优先于新建
- `.github/copilot-instructions.md` §3 本地管线 / §6 复用优先

Closes #799