### PR TITLE
feat(dasclaw_cli): wire real LLM provider (ADR-153 §4.4 step 5)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2860,11 +2860,15 @@ dependencies = [
  "async-trait",
  "clap",
  "dasclaw_core",
+ "dasclaw_llm_provider",
  "dasclaw_runtime",
+ "secrecy",
+ "serde_json",
  "thiserror 1.0.69",
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "wiremock",
 ]
 
 [[package]]

--- a/crates/dasclaw_cli/Cargo.toml
+++ b/crates/dasclaw_cli/Cargo.toml
@@ -15,8 +15,10 @@ path = "src/lib.rs"
 [dependencies]
 dasclaw_runtime = { path = "../dasclaw_runtime" }
 dasclaw_core = { path = "../dasclaw_core" }
+dasclaw_llm_provider = { path = "../dasclaw_llm_provider" }
 anyhow = "1"
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive", "env"] }
+secrecy = "0.10"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "io-std", "io-util"] }
 async-trait = "0.1"
 thiserror = "1"
@@ -25,3 +27,5 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "test-util"] }
+wiremock = "0.6"
+serde_json = "1"

--- a/crates/dasclaw_cli/src/lib.rs
+++ b/crates/dasclaw_cli/src/lib.rs
@@ -17,12 +17,14 @@
 //!
 //! ## Out of scope (deliberately not in this slice)
 //!
-//! - Real LLM provider wiring (would expose
-//!   `dasclaw_llm_provider` config surface; lands in a follow-up PR once
-//!   provider selection mechanism is settled).
-//! - Tool execution wiring ([`dasclaw_runtime::ToolExecutor`]). Same
-//!   reason.
+//! - Tool execution wiring ([`dasclaw_runtime::ToolExecutor`]).
 //! - Streaming / interactive REPL. The first slice is request-response.
+//!
+//! ## Real LLM provider wiring
+//!
+//! See [`provider`] for the [`ProviderArgs`](provider::ProviderArgs) →
+//! [`LlmProviderResponder`](dasclaw_runtime::LlmProviderResponder)
+//! factory used by the binary's non-echo mode (ADR-153 §4.4 step 5).
 
 use std::sync::Mutex;
 
@@ -32,6 +34,8 @@ use dasclaw_core::reasoning_ctx::ReasoningContext;
 use dasclaw_core::response_types::{RespondOutput, RespondResult, ResponseMetadata, TokenUsage};
 use dasclaw_core::traits::HostError;
 use dasclaw_runtime::{Agent, AgentError, AgentResponder};
+
+pub mod provider;
 
 /// Errors surfaced by the CLI library layer.
 #[derive(Debug, thiserror::Error)]

--- a/crates/dasclaw_cli/src/main.rs
+++ b/crates/dasclaw_cli/src/main.rs
@@ -1,33 +1,51 @@
-//! Headless `dasclaw` CLI binary (ADR-153 §4.4 step 4).
+//! Headless `dasclaw` CLI binary (ADR-153 §4.4 steps 4 + 5).
 //!
-//! Thin wrapper around [`dasclaw_cli::run`]. Parses argv with `clap`,
-//! initialises `tracing`, acquires the prompt (from `--prompt` or stdin),
-//! invokes the agent, prints the reply, and maps errors to exit codes.
+//! Thin wrapper around [`dasclaw_cli::run`]. Two subcommands:
 //!
-//! For programmatic use, depend on the `dasclaw_cli` library directly.
+//! - `echo` — built-in deterministic responder, no LLM key needed.
+//!   Default smoke driver inherited from the step-4 skeleton.
+//! - `run` — wires a real `dasclaw_llm_provider`-backed responder via
+//!   [`dasclaw_cli::provider::ProviderArgs`] (step 5). Honours
+//!   `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `DASCLAW_API_KEY`.
+//!
+//! Both subcommands accept `--prompt` or read the user prompt from stdin
+//! and share `--system` for the system message.
 
 use std::io::{self, Read};
 use std::process::ExitCode;
 
 use anyhow::{Context, Result};
-use clap::Parser;
+use clap::{Parser, Subcommand};
+use dasclaw_cli::provider::{ProviderArgs, build_responder};
 use dasclaw_cli::{EchoResponder, run};
 
+const DEFAULT_SYSTEM: &str = "You are dasclaw, a headless agent.";
+
 /// Headless dasclaw agent CLI.
-///
-/// Runs a single prompt through a `dasclaw_runtime::Agent` and prints the
-/// reply. The default responder is a deterministic echo for smoke
-/// testing — wire a real LLM responder in once provider selection lands.
 #[derive(Debug, Parser)]
 #[command(name = "dasclaw-cli", version, about, long_about = None)]
 struct Cli {
+    #[command(subcommand)]
+    command: Option<Command>,
+
     /// User prompt. When omitted, the prompt is read from stdin.
-    #[arg(short, long)]
+    #[arg(short, long, global = true)]
     prompt: Option<String>,
 
     /// System prompt prepended to the conversation.
-    #[arg(short, long, default_value = "You are dasclaw, a headless agent.")]
+    #[arg(short, long, default_value = DEFAULT_SYSTEM, global = true)]
     system: String,
+}
+
+#[derive(Debug, Subcommand)]
+enum Command {
+    /// Run the deterministic built-in echo responder (no LLM, no network).
+    Echo,
+    /// Run a real LLM-backed responder via `dasclaw_llm_provider`.
+    Run {
+        #[command(flatten)]
+        provider: ProviderArgs,
+    },
 }
 
 #[tokio::main]
@@ -40,6 +58,31 @@ async fn main() -> ExitCode {
 }
 
 async fn real_main() -> Result<()> {
+    init_tracing();
+
+    let cli = Cli::parse();
+    let prompt = match cli.prompt.as_deref() {
+        Some(p) => p.to_string(),
+        None => read_stdin_prompt().context("reading prompt from stdin")?,
+    };
+    let prompt = prompt.trim();
+
+    let reply = match cli.command.unwrap_or(Command::Echo) {
+        Command::Echo => run(EchoResponder::new(), &cli.system, prompt)
+            .await
+            .context("echo agent run failed")?,
+        Command::Run { provider } => {
+            let responder = build_responder(&provider).context("building LLM responder")?;
+            run(responder, &cli.system, prompt)
+                .await
+                .context("LLM agent run failed")?
+        }
+    };
+    println!("{reply}");
+    Ok(())
+}
+
+fn init_tracing() {
     tracing_subscriber::fmt()
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()
@@ -48,18 +91,6 @@ async fn real_main() -> Result<()> {
         .with_writer(io::stderr)
         .try_init()
         .ok();
-
-    let cli = Cli::parse();
-    let prompt = match cli.prompt {
-        Some(p) => p,
-        None => read_stdin_prompt().context("reading prompt from stdin")?,
-    };
-
-    let reply = run(EchoResponder::new(), &cli.system, prompt.trim())
-        .await
-        .context("agent run failed")?;
-    println!("{reply}");
-    Ok(())
 }
 
 fn read_stdin_prompt() -> io::Result<String> {

--- a/crates/dasclaw_cli/src/provider.rs
+++ b/crates/dasclaw_cli/src/provider.rs
@@ -1,0 +1,287 @@
+//! CLI-side wiring from argv/env → [`dasclaw_runtime::LlmProviderResponder`].
+//!
+//! ADR-153 §4.4 step 5 follow-up to the step-4 skeleton: prove that
+//! [`dasclaw_runtime::Agent`] drives a real provider end-to-end without
+//! any desktop dependency. This module exposes:
+//!
+//! - [`ProviderArgs`] — clap argument group covering the minimum surface
+//!   needed to construct a [`ClawCodeLlmProvider`]
+//!   ([`ProviderKind`], model, base URL, API key from `--api-key` or env).
+//! - [`build_responder`] — pure factory turning [`ProviderArgs`] into a
+//!   [`LlmProviderResponder<ClawCodeLlmProvider>`] ready to plug into
+//!   [`crate::run`].
+//!
+//! ## What this is not
+//!
+//! - Not a config-file loader. The CLI deliberately accepts only argv /
+//!   env so it stays a thin smoke driver around the runtime.
+//! - Not a credential store. Secrets are taken straight from the
+//!   environment and wrapped in [`SecretString`]; persistence belongs in
+//!   the desktop client.
+//! - Not a router. The CLI picks one provider per invocation; smart
+//!   routing, fallback, and circuit breaking live in
+//!   `dasclaw_llm_provider::provider` and stay opt-in for callers that
+//!   need them.
+
+use std::sync::Arc;
+
+use clap::{Args, ValueEnum};
+use dasclaw_llm_provider::provider::claw_code_provider::ClawCodeLlmProvider;
+use dasclaw_llm_provider::provider::config::{CacheRetention, RegistryProviderConfig};
+use dasclaw_llm_provider::provider::registry::ProviderProtocol;
+use dasclaw_runtime::LlmProviderResponder;
+use secrecy::SecretString;
+use thiserror::Error;
+
+/// Wire protocol selectable from the CLI.
+///
+/// Mirrors the subset of [`ProviderProtocol`] that the headless smoke
+/// driver supports. `GithubCopilot` is intentionally left out because it
+/// requires desktop-side token exchange.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum ProviderKind {
+    /// Anthropic Messages API (`https://api.anthropic.com`).
+    Anthropic,
+    /// OpenAI Chat Completions API (`https://api.openai.com/v1`).
+    Openai,
+    /// Any OpenAI-compatible endpoint (xAI, DashScope, Groq, vLLM, …).
+    /// `--base-url` is required.
+    OpenaiCompat,
+    /// Ollama local server (`http://localhost:11434`).
+    Ollama,
+}
+
+impl ProviderKind {
+    fn protocol(self) -> ProviderProtocol {
+        match self {
+            Self::Anthropic => ProviderProtocol::Anthropic,
+            Self::Openai | Self::OpenaiCompat => ProviderProtocol::OpenAiCompletions,
+            Self::Ollama => ProviderProtocol::Ollama,
+        }
+    }
+
+    fn default_base_url(self) -> &'static str {
+        match self {
+            Self::Anthropic => "https://api.anthropic.com",
+            Self::Openai => "https://api.openai.com/v1",
+            Self::OpenaiCompat => "",
+            Self::Ollama => "http://localhost:11434",
+        }
+    }
+
+    fn default_model(self) -> &'static str {
+        match self {
+            Self::Anthropic => "claude-3-5-sonnet-latest",
+            Self::Openai | Self::OpenaiCompat => "gpt-4o-mini",
+            Self::Ollama => "llama3",
+        }
+    }
+
+    fn requires_api_key(self) -> bool {
+        !matches!(self, Self::Ollama)
+    }
+}
+
+/// Clap argument group covering the minimum surface to build a real
+/// LLM-backed responder from the command line.
+///
+/// Keep this struct flat: it is `#[command(flatten)]`-ed into the binary
+/// CLI in [`crate::main`] and into integration test harnesses.
+#[derive(Debug, Args, Clone)]
+pub struct ProviderArgs {
+    /// LLM provider wire protocol.
+    #[arg(long, value_enum)]
+    pub provider: ProviderKind,
+
+    /// Model identifier (e.g. `claude-3-5-sonnet-latest`, `gpt-4o-mini`).
+    /// Defaults depend on `--provider`.
+    #[arg(long)]
+    pub model: Option<String>,
+
+    /// API endpoint base URL. Required for `openai-compat`; overrides
+    /// the protocol default for the other variants.
+    #[arg(long)]
+    pub base_url: Option<String>,
+
+    /// API key. Read from `--api-key` or, if omitted, from the protocol's
+    /// canonical environment variable (`ANTHROPIC_API_KEY`,
+    /// `OPENAI_API_KEY`). Ignored for `ollama`.
+    #[arg(long, env = "DASCLAW_API_KEY")]
+    pub api_key: Option<String>,
+}
+
+/// Errors surfaced while assembling a real provider from CLI args.
+#[derive(Debug, Error)]
+pub enum ProviderBuildError {
+    /// `--api-key` was empty and no fallback env var was set.
+    #[error(
+        "missing API key for provider {provider:?}: pass --api-key or set DASCLAW_API_KEY / {env_hint}"
+    )]
+    MissingApiKey {
+        /// Provider variant the caller selected.
+        provider: ProviderKind,
+        /// Canonical env var name the user can set as a fallback.
+        env_hint: &'static str,
+    },
+
+    /// `openai-compat` was selected without `--base-url`.
+    #[error("provider 'openai-compat' requires --base-url")]
+    MissingBaseUrl,
+
+    /// `dasclaw_llm_provider` rejected the resolved configuration.
+    #[error("provider construction failed: {0}")]
+    Builder(String),
+}
+
+/// Construct a [`LlmProviderResponder`] wrapping a
+/// [`ClawCodeLlmProvider`] from the parsed [`ProviderArgs`].
+///
+/// On success the returned responder is ready for
+/// [`dasclaw_runtime::AgentBuilder::responder`]. Network I/O is deferred
+/// until the agent actually invokes `respond` — this function is pure
+/// modulo `std::env::var` lookups for the per-protocol API-key fallback.
+pub fn build_responder(
+    args: &ProviderArgs,
+) -> Result<LlmProviderResponder<ClawCodeLlmProvider>, ProviderBuildError> {
+    let api_key = resolve_api_key(args)?;
+    let base_url = resolve_base_url(args)?;
+    let model = args
+        .model
+        .clone()
+        .unwrap_or_else(|| args.provider.default_model().to_string());
+
+    let config = RegistryProviderConfig {
+        protocol: args.provider.protocol(),
+        provider_id: provider_id(args.provider).to_string(),
+        api_key,
+        base_url,
+        model,
+        extra_headers: Vec::new(),
+        oauth_token: None,
+        is_codex_chatgpt: false,
+        refresh_token: None,
+        auth_path: None,
+        cache_retention: CacheRetention::default(),
+        unsupported_params: Vec::new(),
+        strict_tools_schema: true,
+    };
+
+    let provider = ClawCodeLlmProvider::from_registry_config(&config)
+        .map_err(|e| ProviderBuildError::Builder(e.to_string()))?;
+    Ok(LlmProviderResponder::new(Arc::new(provider)))
+}
+
+fn resolve_api_key(args: &ProviderArgs) -> Result<Option<SecretString>, ProviderBuildError> {
+    if !args.provider.requires_api_key() {
+        return Ok(None);
+    }
+    if let Some(key) = args.api_key.as_deref()
+        && !key.is_empty()
+    {
+        return Ok(Some(SecretString::new(key.to_string().into())));
+    }
+    let env_hint = canonical_env(args.provider);
+    if let Ok(key) = std::env::var(env_hint)
+        && !key.is_empty()
+    {
+        return Ok(Some(SecretString::new(key.into())));
+    }
+    Err(ProviderBuildError::MissingApiKey {
+        provider: args.provider,
+        env_hint,
+    })
+}
+
+fn resolve_base_url(args: &ProviderArgs) -> Result<String, ProviderBuildError> {
+    match (args.base_url.clone(), args.provider) {
+        (Some(url), _) if !url.is_empty() => Ok(url),
+        (_, ProviderKind::OpenaiCompat) => Err(ProviderBuildError::MissingBaseUrl),
+        (_, kind) => Ok(kind.default_base_url().to_string()),
+    }
+}
+
+fn provider_id(kind: ProviderKind) -> &'static str {
+    match kind {
+        ProviderKind::Anthropic => "anthropic",
+        ProviderKind::Openai => "openai",
+        ProviderKind::OpenaiCompat => "openai_compat",
+        ProviderKind::Ollama => "ollama",
+    }
+}
+
+fn canonical_env(kind: ProviderKind) -> &'static str {
+    match kind {
+        ProviderKind::Anthropic => "ANTHROPIC_API_KEY",
+        ProviderKind::Openai | ProviderKind::OpenaiCompat => "OPENAI_API_KEY",
+        ProviderKind::Ollama => "OLLAMA_API_KEY",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn args(kind: ProviderKind) -> ProviderArgs {
+        ProviderArgs {
+            provider: kind,
+            model: None,
+            base_url: None,
+            api_key: Some("test-key".to_string()),
+        }
+    }
+
+    #[test]
+    fn anthropic_defaults_fill_base_url_and_model() {
+        let r = build_responder(&args(ProviderKind::Anthropic));
+        assert!(r.is_ok(), "{:?}", r.err());
+    }
+
+    #[test]
+    fn openai_compat_requires_base_url() {
+        let mut a = args(ProviderKind::OpenaiCompat);
+        a.base_url = None;
+        match build_responder(&a) {
+            Err(ProviderBuildError::MissingBaseUrl) => {}
+            Err(other) => panic!("expected MissingBaseUrl, got {other:?}"),
+            Ok(_) => panic!("expected MissingBaseUrl, got Ok"),
+        }
+    }
+
+    #[test]
+    fn ollama_does_not_require_api_key() {
+        let mut a = args(ProviderKind::Ollama);
+        a.api_key = None;
+        let r = build_responder(&a);
+        assert!(r.is_ok(), "{:?}", r.err());
+    }
+
+    #[test]
+    fn missing_api_key_surfaces_env_hint() {
+        // Use a process-unique env var name we know is unset, by clearing
+        // the canonical one for the duration of the assertion.
+        // SAFETY: tests in this module run single-threaded under nextest
+        // by default; if that ever changes, switch to a mock layer.
+        let saved = std::env::var("ANTHROPIC_API_KEY").ok();
+        // SAFETY: scoped restore below.
+        unsafe { std::env::remove_var("ANTHROPIC_API_KEY") };
+
+        let mut a = args(ProviderKind::Anthropic);
+        a.api_key = None;
+        let err = match build_responder(&a) {
+            Err(e) => e,
+            Ok(_) => panic!("expected MissingApiKey, got Ok"),
+        };
+
+        if let Some(v) = saved {
+            // SAFETY: scoped restore of pre-existing value.
+            unsafe { std::env::set_var("ANTHROPIC_API_KEY", v) };
+        }
+
+        match err {
+            ProviderBuildError::MissingApiKey { env_hint, .. } => {
+                assert_eq!(env_hint, "ANTHROPIC_API_KEY");
+            }
+            other => panic!("expected MissingApiKey, got {other:?}"),
+        }
+    }
+}

--- a/crates/dasclaw_cli/tests/live_provider.rs
+++ b/crates/dasclaw_cli/tests/live_provider.rs
@@ -1,0 +1,57 @@
+//! Integration test for the real-LLM wiring in `dasclaw_cli::provider`.
+//!
+//! ADR-153 §4.4 step 5 proof: a `dasclaw_runtime::Agent` constructed
+//! purely from `dasclaw_cli::provider::build_responder` drives a real
+//! OpenAI-Chat-Completions wire format end-to-end against a wiremock
+//! server. No desktop deps, no network, no API key — the mock answers
+//! `"pong"` and the agent's reply round-trips through the entire stack.
+
+use dasclaw_cli::provider::{ProviderArgs, ProviderKind, build_responder};
+use dasclaw_cli::run;
+use serde_json::json;
+use wiremock::matchers::{header, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+const TEST_API_KEY: &str = "sk-test";
+
+fn success_body(reply: &str) -> serde_json::Value {
+    json!({
+        "id": "chatcmpl-test",
+        "object": "chat.completion",
+        "model": "gpt-4o-mini",
+        "choices": [{
+            "index": 0,
+            "message": { "role": "assistant", "content": reply },
+            "finish_reason": "stop"
+        }],
+        "usage": { "prompt_tokens": 3, "completion_tokens": 1 }
+    })
+}
+
+#[tokio::test]
+async fn openai_compat_round_trips_through_agent() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .and(header(
+            "authorization",
+            format!("Bearer {TEST_API_KEY}").as_str(),
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_json(success_body("pong")))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let args = ProviderArgs {
+        provider: ProviderKind::OpenaiCompat,
+        model: Some("gpt-4o-mini".to_string()),
+        base_url: Some(server.uri()),
+        api_key: Some(TEST_API_KEY.to_string()),
+    };
+    let responder = build_responder(&args).expect("responder builds");
+    let reply = run(responder, "You are a test agent.", "ping")
+        .await
+        .expect("agent run succeeds");
+
+    assert_eq!(reply.trim(), "pong");
+}

--- a/docs/plans/architecture-refactor/31-target-architecture.md
+++ b/docs/plans/architecture-refactor/31-target-architecture.md
@@ -6,6 +6,7 @@
 >   3. **§4.6 薄壳化已完成**：`desktop-client/ironclaw/src/tools/builtin/mod.rs` 已转为 wildcard re-export 入口（PR #792），同时为下沉 crate 留 `pub mod` 仅限留守 6 类；shim `shell.rs` / `lsp/mod.rs` 已删。
 >   4. **crate 总数**：47（v2.5 写作时 45，新增 `dasclaw_misc_tools` 等本期产物）；`scripts/check_blueprint_sync.py` 自检为 `47 crates on disk / 2 planned`（剩 `dasclaw_bridge_lite` + `dasclaw_memory_tools` 处于 PLANNED 状态，后者按 ADR-156 §6.3.1 永久搁置）。
 >   5. **ADR-153 §4.4 step 4 落点**：新增 `crates/dasclaw_cli`（headless agent CLI，骨架 + EchoResponder 端到端 demo），证明 `dasclaw_runtime::Agent` 在零 desktop 依赖（无 Tauri / 无 DB / 无 HTTP server）下可独立运行；真实 LLM provider 与 tool executor 接线留待 ADR-153 后续 slice。
+>   6. **ADR-153 §4.4 step 5 落点**：`crates/dasclaw_cli` 引入 `provider` 模块，把 `dasclaw_llm_provider::ClawCodeLlmProvider` 通过 `dasclaw_runtime::LlmProviderResponder` 接入 headless agent，新增 `dasclaw-cli run --provider {anthropic|openai|openai_compat|ollama}` 子命令 + wiremock 端到端集成测试，证明真实 LLM 走 `Agent` 完整回路（无 desktop / 无 Tauri / 无 HTTP server）。Tool executor 接线仍留待后续 slice。
 > 本次升级是状态同步性质，不改架构决策，不重画 §1 总览图。原 v2.5 内容保留（§4.6 表格仅增"PR / 状态"列覆盖）。
 
 > **v2.5 (2026-05-23)** · 蓝图对齐 4-5 天发展（基于 [40-tool-ecosystem-inventory.md](40-tool-ecosystem-inventory.md) §1-3 实测 + [41-target-architecture-drift-analysis.md](41-target-architecture-drift-analysis.md) 漂移识别）：


### PR DESCRIPTION
## 背景 / 目标

PR #800 (issue #799) 落地了 `crates/dasclaw_cli` headless 骨架 + `EchoResponder` 端到端 demo，但 Echo 只证明了 "loop 编排不依赖 desktop"，没证明真实 LLM provider 也能通过同一回路走通。本 PR 落地 ADR-153 §4.4 step 5：把 `dasclaw_llm_provider::ClawCodeLlmProvider` 通过 PR #749 已经存在的 `dasclaw_runtime::LlmProviderResponder` 接到 headless agent，并用 wiremock 跑一遍真实 OpenAI-Chat-Completions wire format 证明回路打通。

## 改动范围

- `crates/dasclaw_cli/Cargo.toml`：新增 `dasclaw_llm_provider` / `secrecy 0.10` 生产依赖，dev-deps 新增 `wiremock 0.6` / `serde_json`。
- `crates/dasclaw_cli/src/provider.rs`（新增）：`ProviderKind` (Anthropic / Openai / OpenaiCompat / Ollama)、`ProviderArgs`、`ProviderBuildError`、`build_responder()` 工厂——把 argv/env 映射成 `RegistryProviderConfig`，构造 `ClawCodeLlmProvider`，包成 `LlmProviderResponder`。
- `crates/dasclaw_cli/src/lib.rs`：`pub mod provider;`，更新模块文档移除 "real LLM provider 留待后续" 的占位说明。
- `crates/dasclaw_cli/src/main.rs`：clap 子命令重构。`echo`（默认 / 无 LLM）与 `run --provider {anthropic|openai|openai_compat|ollama} [--model] [--base-url] [--api-key]`。共享 `--prompt` / `--system`。
- `crates/dasclaw_cli/tests/live_provider.rs`（新增）：wiremock 集成测试，假 `/chat/completions` 返回 "pong"，断言 `run(build_responder(args), …)` 完整 round-trip。
- `crates/dasclaw_cli/src/provider.rs` 内含 4 个单元测试（defaults / openai_compat 必填 base_url / ollama 不需 api_key / env-var fallback 提示）。
- `docs/plans/architecture-refactor/31-target-architecture.md` v2.6 banner 新增 step-5 落点 bullet（满足 blueprint sync guard）。

## 非目标（What's NOT in this PR）

- Tool executor 接线（留待后续 slice）
- 多 provider 同时配置 / provider 路由
- Streaming / 交互 REPL
- GithubCopilot provider（不走 ClawCodeLlmProvider，另起 slice）
- ADR-153 §4.4 step 6 之后内容

## 验证（命令 + 结果）

```text
cargo check -p dasclaw_cli --tests         # ✅ Finished
cargo nextest run -p dasclaw_cli           # ✅ 6 passed (含 wiremock round-trip)
cargo clippy --no-deps -p dasclaw_cli --all-targets -- -D warnings  # ✅ clean
python3.12 scripts/check_no_panics.py --base origin/feat/dasclaw-cli-skeleton   # ✅ OK
python3.12 scripts/check_no_new_ironclaw_literal.py --base origin/xClaw         # ✅ OK
python3.12 scripts/check_blueprint_sync.py # ✅ 48 crates / 2 planned
```

## Sources read

- `docs/plans/architecture-refactor/adr-153-dasclaw-cli-headless-loop.md` §4.4 step 5
- `docs/plans/architecture-refactor/31-target-architecture.md` v2.6 banner
- `crates/dasclaw_runtime/src/llm_adapter.rs` (LlmProviderResponder)
- `crates/dasclaw_llm_provider/src/provider/claw_code_provider.rs` (from_registry_config)
- `crates/dasclaw_llm_provider/src/provider/config.rs` (RegistryProviderConfig 字段)
- `crates/dasclaw_llm_provider/tests/openai_compat_client.rs` (wiremock 范式)
- `AGENTS.md` §"Rust 开发规范" / §"GitHub PR 工作流"

## Cross-cuts

- ADR-114（`.ironclaw` → `.dasclaw` 命名迁移）：**类A**（无新增 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量；grep guard 已自查通过）

## Stacked PR 注意

- **base 分支不是 `xClaw`，是 `feat/dasclaw-cli-skeleton`（PR #800）**
- merge 顺序：**先 merge #800 → 再合本 PR**
- 直接 review 本 PR 即可，但 base 切换到 xClaw 之前必须先合 #800

Closes #801