### PR TITLE
feat(dasclaw_cli): wire StaticToolExecutor with builtin echo/now tools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2860,11 +2860,15 @@ dependencies = [
  "async-trait",
  "clap",
  "dasclaw_core",
+ "dasclaw_llm_provider",
  "dasclaw_runtime",
+ "secrecy",
+ "serde_json",
  "thiserror 1.0.69",
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "wiremock",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2853,6 +2853,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "dasclaw_cli"
+version = "0.0.0-w6"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "clap",
+ "dasclaw_core",
+ "dasclaw_runtime",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "dasclaw_core"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,9 @@ members = [
 	"crates/dasclaw_sandbox_linux",
 	# W8 ADR-139 §4.5 PR1 — MITM CA trust-chain manager (dasclaw original, not verbatim)
 	"crates/dasclaw_cert_trust",
+	# ADR-153 §4.4 step 4 — headless agent CLI (proof that dasclaw_runtime::Agent
+	# runs without desktop: no Tauri, no DB, no HTTP server)
+	"crates/dasclaw_cli",
 	"desktop-client/ironclaw",
 	"desktop-client/ironclaw/crates/ironclaw_common",
 	"crates/dasclaw_safety",

--- a/crates/dasclaw_cli/Cargo.toml
+++ b/crates/dasclaw_cli/Cargo.toml
@@ -21,6 +21,7 @@ clap = { version = "4", features = ["derive", "env"] }
 secrecy = "0.10"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "io-std", "io-util"] }
 async-trait = "0.1"
+serde_json = "1"
 thiserror = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
@@ -28,4 +29,3 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "test-util"] }
 wiremock = "0.6"
-serde_json = "1"

--- a/crates/dasclaw_cli/Cargo.toml
+++ b/crates/dasclaw_cli/Cargo.toml
@@ -15,8 +15,10 @@ path = "src/lib.rs"
 [dependencies]
 dasclaw_runtime = { path = "../dasclaw_runtime" }
 dasclaw_core = { path = "../dasclaw_core" }
+dasclaw_llm_provider = { path = "../dasclaw_llm_provider" }
 anyhow = "1"
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive", "env"] }
+secrecy = "0.10"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "io-std", "io-util"] }
 async-trait = "0.1"
 thiserror = "1"
@@ -25,3 +27,5 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "test-util"] }
+wiremock = "0.6"
+serde_json = "1"

--- a/crates/dasclaw_cli/Cargo.toml
+++ b/crates/dasclaw_cli/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "dasclaw_cli"
+version = "0.0.0-w6"
+edition = "2024"
+description = "Headless agent CLI binary (ADR-153 §4.4 step 4). Demonstrates dasclaw_runtime::Agent::builder() end-to-end without desktop dependencies (no Tauri, no database, no HTTP server)."
+license = "MIT OR Apache-2.0"
+
+[[bin]]
+name = "dasclaw-cli"
+path = "src/main.rs"
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+dasclaw_runtime = { path = "../dasclaw_runtime" }
+dasclaw_core = { path = "../dasclaw_core" }
+anyhow = "1"
+clap = { version = "4", features = ["derive"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "io-std", "io-util"] }
+async-trait = "0.1"
+thiserror = "1"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "test-util"] }

--- a/crates/dasclaw_cli/src/lib.rs
+++ b/crates/dasclaw_cli/src/lib.rs
@@ -17,12 +17,14 @@
 //!
 //! ## Out of scope (deliberately not in this slice)
 //!
-//! - Real LLM provider wiring (would expose
-//!   `dasclaw_llm_provider` config surface; lands in a follow-up PR once
-//!   provider selection mechanism is settled).
-//! - Tool execution wiring ([`dasclaw_runtime::ToolExecutor`]). Same
-//!   reason.
+//! - Tool execution wiring ([`dasclaw_runtime::ToolExecutor`]).
 //! - Streaming / interactive REPL. The first slice is request-response.
+//!
+//! ## Real LLM provider wiring
+//!
+//! See [`provider`] for the [`ProviderArgs`](provider::ProviderArgs) →
+//! [`LlmProviderResponder`](dasclaw_runtime::LlmProviderResponder)
+//! factory used by the binary's non-echo mode (ADR-153 §4.4 step 5).
 
 use std::sync::Mutex;
 
@@ -32,6 +34,8 @@ use dasclaw_core::reasoning_ctx::ReasoningContext;
 use dasclaw_core::response_types::{RespondOutput, RespondResult, ResponseMetadata, TokenUsage};
 use dasclaw_core::traits::HostError;
 use dasclaw_runtime::{Agent, AgentError, AgentResponder};
+
+pub mod provider;
 
 /// Errors surfaced by the CLI library layer.
 #[derive(Debug, thiserror::Error)]

--- a/crates/dasclaw_cli/src/lib.rs
+++ b/crates/dasclaw_cli/src/lib.rs
@@ -89,7 +89,13 @@ impl EchoResponder {
 
     /// Number of times [`AgentResponder::respond`] has been called.
     pub fn call_count(&self) -> usize {
-        *self.call_count.lock().expect("call_count mutex poisoned")
+        // Mutex poisoning here only happens if a previous holder panicked.
+        // The counter has no invariants to protect, so recovering the inner
+        // value is safe and lets us stay panic-free in production code.
+        *self
+            .call_count
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
     }
 }
 
@@ -102,7 +108,12 @@ impl Default for EchoResponder {
 #[async_trait]
 impl AgentResponder for EchoResponder {
     async fn respond(&self, ctx: &mut ReasoningContext) -> Result<RespondOutput, HostError> {
-        *self.call_count.lock().expect("call_count mutex poisoned") += 1;
+        // See call_count(): a poisoned mutex around a plain counter has no
+        // invariants to protect, so recover instead of panicking.
+        *self
+            .call_count
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) += 1;
         let last_user_text = ctx
             .messages
             .iter()

--- a/crates/dasclaw_cli/src/lib.rs
+++ b/crates/dasclaw_cli/src/lib.rs
@@ -1,0 +1,120 @@
+//! `dasclaw_cli` — headless agent CLI (ADR-153 §4.4 step 4).
+//!
+//! This crate is the proof-point that [`dasclaw_runtime::Agent`] runs
+//! without any desktop dependency: no Tauri, no database, no channels, no
+//! HTTP server. The binary in `src/main.rs` takes a prompt on argv or
+//! stdin and prints the agent's reply on stdout.
+//!
+//! ## Scope of this skeleton (step 4, slice 1)
+//!
+//! - [`run`] — pure async function. Takes any
+//!   [`dasclaw_runtime::AgentResponder`] plus system / user prompts and
+//!   returns the agent's text reply. Does no I/O.
+//! - [`EchoResponder`] — deterministic built-in
+//!   [`AgentResponder`] that replies with `echo: <last user content>`. It
+//!   exists solely to let the binary and integration tests demonstrate
+//!   end-to-end wire-up without a real LLM key.
+//!
+//! ## Out of scope (deliberately not in this slice)
+//!
+//! - Real LLM provider wiring (would expose
+//!   `dasclaw_llm_provider` config surface; lands in a follow-up PR once
+//!   provider selection mechanism is settled).
+//! - Tool execution wiring ([`dasclaw_runtime::ToolExecutor`]). Same
+//!   reason.
+//! - Streaming / interactive REPL. The first slice is request-response.
+
+use std::sync::Mutex;
+
+use async_trait::async_trait;
+use dasclaw_core::messages::{FinishReason, Role};
+use dasclaw_core::reasoning_ctx::ReasoningContext;
+use dasclaw_core::response_types::{RespondOutput, RespondResult, ResponseMetadata, TokenUsage};
+use dasclaw_core::traits::HostError;
+use dasclaw_runtime::{Agent, AgentError, AgentResponder};
+
+/// Errors surfaced by the CLI library layer.
+#[derive(Debug, thiserror::Error)]
+pub enum CliError {
+    /// Agent loop returned an error.
+    #[error("agent error: {0}")]
+    Agent(#[from] AgentError),
+
+    /// Builder rejected the configuration (e.g. missing responder).
+    #[error("agent builder error: {0}")]
+    Build(String),
+}
+
+/// Build an [`Agent`] from `responder` + `system_prompt` and run it once
+/// against `user_prompt`, returning the text reply.
+///
+/// Single library entry point used by both the binary in `src/main.rs`
+/// and integration tests under `tests/`. Keeping the I/O (stdin / stdout
+/// / argv) out of this function is what lets the integration tests
+/// assert behaviour without spawning subprocesses.
+pub async fn run<R>(
+    responder: R,
+    system_prompt: &str,
+    user_prompt: &str,
+) -> Result<String, CliError>
+where
+    R: AgentResponder + 'static,
+{
+    let agent: Agent = Agent::builder()
+        .responder(responder)
+        .system_prompt(system_prompt)
+        .build()
+        .map_err(|e| CliError::Build(e.to_string()))?;
+    let reply = agent.run(user_prompt).await?;
+    Ok(reply)
+}
+
+/// Deterministic [`AgentResponder`] that replies `echo: <last user
+/// content>`.
+///
+/// Intended for smoke-testing the headless wiring without an LLM key.
+/// Production callers should plug in a real [`AgentResponder`] (e.g.
+/// [`dasclaw_runtime::LlmProviderResponder`]).
+pub struct EchoResponder {
+    call_count: Mutex<usize>,
+}
+
+impl EchoResponder {
+    /// Create a new echo responder.
+    pub fn new() -> Self {
+        Self {
+            call_count: Mutex::new(0),
+        }
+    }
+
+    /// Number of times [`AgentResponder::respond`] has been called.
+    pub fn call_count(&self) -> usize {
+        *self.call_count.lock().expect("call_count mutex poisoned")
+    }
+}
+
+impl Default for EchoResponder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl AgentResponder for EchoResponder {
+    async fn respond(&self, ctx: &mut ReasoningContext) -> Result<RespondOutput, HostError> {
+        *self.call_count.lock().expect("call_count mutex poisoned") += 1;
+        let last_user_text = ctx
+            .messages
+            .iter()
+            .rev()
+            .find(|m| matches!(m.role, Role::User))
+            .map(|m| m.content.clone())
+            .unwrap_or_default();
+        Ok(RespondOutput {
+            result: RespondResult::Text(format!("echo: {last_user_text}")),
+            usage: TokenUsage::default(),
+            finish_reason: FinishReason::Stop,
+            metadata: ResponseMetadata::default(),
+        })
+    }
+}

--- a/crates/dasclaw_cli/src/lib.rs
+++ b/crates/dasclaw_cli/src/lib.rs
@@ -17,7 +17,6 @@
 //!
 //! ## Out of scope (deliberately not in this slice)
 //!
-//! - Tool execution wiring ([`dasclaw_runtime::ToolExecutor`]).
 //! - Streaming / interactive REPL. The first slice is request-response.
 //!
 //! ## Real LLM provider wiring
@@ -25,17 +24,25 @@
 //! See [`provider`] for the [`ProviderArgs`](provider::ProviderArgs) →
 //! [`LlmProviderResponder`](dasclaw_runtime::LlmProviderResponder)
 //! factory used by the binary's non-echo mode (ADR-153 §4.4 step 5).
+//!
+//! ## Tool dispatch
+//!
+//! See [`tools`] for the in-memory [`StaticToolExecutor`](tools::StaticToolExecutor)
+//! used by `dasclaw-cli run --enable-tools` (ADR-153 §4.4 step 6).
+//! Drive it through [`run_with_tools`] when the agent should be allowed
+//! to call tools.
 
 use std::sync::Mutex;
 
 use async_trait::async_trait;
-use dasclaw_core::messages::{FinishReason, Role};
+use dasclaw_core::messages::{FinishReason, Role, ToolDefinition};
 use dasclaw_core::reasoning_ctx::ReasoningContext;
 use dasclaw_core::response_types::{RespondOutput, RespondResult, ResponseMetadata, TokenUsage};
 use dasclaw_core::traits::HostError;
-use dasclaw_runtime::{Agent, AgentError, AgentResponder};
+use dasclaw_runtime::{Agent, AgentError, AgentResponder, ToolExecutor};
 
 pub mod provider;
+pub mod tools;
 
 /// Errors surfaced by the CLI library layer.
 #[derive(Debug, thiserror::Error)]
@@ -66,6 +73,35 @@ where
 {
     let agent: Agent = Agent::builder()
         .responder(responder)
+        .system_prompt(system_prompt)
+        .build()
+        .map_err(|e| CliError::Build(e.to_string()))?;
+    let reply = agent.run(user_prompt).await?;
+    Ok(reply)
+}
+
+/// Variant of [`run`] that wires a [`ToolExecutor`] and advertises its
+/// tool definitions to the model.
+///
+/// `tool_definitions` is normally [`tools::StaticToolExecutor::definitions`].
+/// Keeping [`run`] and `run_with_tools` as separate entries avoids a
+/// patch-style optional parameter on the original signature and keeps
+/// the no-tools call-path free of executor plumbing.
+pub async fn run_with_tools<R, E>(
+    responder: R,
+    tool_executor: E,
+    tool_definitions: Vec<ToolDefinition>,
+    system_prompt: &str,
+    user_prompt: &str,
+) -> Result<String, CliError>
+where
+    R: AgentResponder + 'static,
+    E: ToolExecutor + 'static,
+{
+    let agent: Agent = Agent::builder()
+        .responder(responder)
+        .tool_executor(tool_executor)
+        .tools(tool_definitions)
         .system_prompt(system_prompt)
         .build()
         .map_err(|e| CliError::Build(e.to_string()))?;

--- a/crates/dasclaw_cli/src/main.rs
+++ b/crates/dasclaw_cli/src/main.rs
@@ -1,33 +1,51 @@
-//! Headless `dasclaw` CLI binary (ADR-153 §4.4 step 4).
+//! Headless `dasclaw` CLI binary (ADR-153 §4.4 steps 4 + 5).
 //!
-//! Thin wrapper around [`dasclaw_cli::run`]. Parses argv with `clap`,
-//! initialises `tracing`, acquires the prompt (from `--prompt` or stdin),
-//! invokes the agent, prints the reply, and maps errors to exit codes.
+//! Thin wrapper around [`dasclaw_cli::run`]. Two subcommands:
 //!
-//! For programmatic use, depend on the `dasclaw_cli` library directly.
+//! - `echo` — built-in deterministic responder, no LLM key needed.
+//!   Default smoke driver inherited from the step-4 skeleton.
+//! - `run` — wires a real `dasclaw_llm_provider`-backed responder via
+//!   [`dasclaw_cli::provider::ProviderArgs`] (step 5). Honours
+//!   `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `DASCLAW_API_KEY`.
+//!
+//! Both subcommands accept `--prompt` or read the user prompt from stdin
+//! and share `--system` for the system message.
 
 use std::io::{self, Read};
 use std::process::ExitCode;
 
 use anyhow::{Context, Result};
-use clap::Parser;
+use clap::{Parser, Subcommand};
+use dasclaw_cli::provider::{ProviderArgs, build_responder};
 use dasclaw_cli::{EchoResponder, run};
 
+const DEFAULT_SYSTEM: &str = "You are dasclaw, a headless agent.";
+
 /// Headless dasclaw agent CLI.
-///
-/// Runs a single prompt through a `dasclaw_runtime::Agent` and prints the
-/// reply. The default responder is a deterministic echo for smoke
-/// testing — wire a real LLM responder in once provider selection lands.
 #[derive(Debug, Parser)]
 #[command(name = "dasclaw-cli", version, about, long_about = None)]
 struct Cli {
+    #[command(subcommand)]
+    command: Option<Command>,
+
     /// User prompt. When omitted, the prompt is read from stdin.
-    #[arg(short, long)]
+    #[arg(short, long, global = true)]
     prompt: Option<String>,
 
     /// System prompt prepended to the conversation.
-    #[arg(short, long, default_value = "You are dasclaw, a headless agent.")]
+    #[arg(short, long, default_value = DEFAULT_SYSTEM, global = true)]
     system: String,
+}
+
+#[derive(Debug, Subcommand)]
+enum Command {
+    /// Run the deterministic built-in echo responder (no LLM, no network).
+    Echo,
+    /// Run a real LLM-backed responder via `dasclaw_llm_provider`.
+    Run {
+        #[command(flatten)]
+        provider: ProviderArgs,
+    },
 }
 
 #[tokio::main]
@@ -40,6 +58,31 @@ async fn main() -> ExitCode {
 }
 
 async fn real_main() -> Result<()> {
+    init_tracing();
+
+    let cli = Cli::parse();
+    let prompt = match cli.prompt.as_deref() {
+        Some(p) => p.to_string(),
+        None => read_stdin_prompt().context("reading prompt from stdin")?,
+    };
+    let prompt = prompt.trim();
+
+    let reply = match cli.command.unwrap_or(Command::Echo) {
+        Command::Echo => run(EchoResponder::new(), &cli.system, prompt)
+            .await
+            .context("echo agent run failed")?,
+        Command::Run { provider } => {
+            let responder = build_responder(&provider).context("building LLM responder")?;
+            run(responder, &cli.system, prompt)
+                .await
+                .context("LLM agent run failed")?
+        }
+    };
+    println!("{reply}");
+    Ok(())
+}
+
+fn init_tracing() {
     tracing_subscriber::fmt()
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()
@@ -48,18 +91,6 @@ async fn real_main() -> Result<()> {
         .with_writer(io::stderr)
         .try_init()
         .ok();
-
-    let cli = Cli::parse();
-    let prompt = match cli.prompt {
-        Some(p) => p,
-        None => read_stdin_prompt().context("reading prompt from stdin")?,
-    };
-
-    let reply = run(EchoResponder::new(), &cli.system, prompt.trim())
-        .await
-        .context("agent run failed")?;
-    println!("{reply}");
-    Ok(())
 }
 
 fn read_stdin_prompt() -> io::Result<String> {

--- a/crates/dasclaw_cli/src/main.rs
+++ b/crates/dasclaw_cli/src/main.rs
@@ -15,9 +15,10 @@ use std::io::{self, Read};
 use std::process::ExitCode;
 
 use anyhow::{Context, Result};
-use clap::{Parser, Subcommand};
+use clap::{Args, Parser, Subcommand};
 use dasclaw_cli::provider::{ProviderArgs, build_responder};
-use dasclaw_cli::{EchoResponder, run};
+use dasclaw_cli::tools::default_builtins;
+use dasclaw_cli::{EchoResponder, run, run_with_tools};
 
 const DEFAULT_SYSTEM: &str = "You are dasclaw, a headless agent.";
 
@@ -45,7 +46,22 @@ enum Command {
     Run {
         #[command(flatten)]
         provider: ProviderArgs,
+        #[command(flatten)]
+        tools: ToolArgs,
     },
+}
+
+/// Tool-dispatch knobs for the `run` subcommand.
+///
+/// Kept in a flattened group so the future MCP-backed executor can land
+/// next to `--enable-tools` without churning the top-level CLI shape.
+#[derive(Debug, Args)]
+struct ToolArgs {
+    /// Advertise the builtin demo tools (`echo`, `now`) to the model and
+    /// dispatch them locally. Defaults to off so the bare `run`
+    /// subcommand stays a pure chat-completion driver.
+    #[arg(long = "enable-tools", default_value_t = false)]
+    enable_tools: bool,
 }
 
 #[tokio::main]
@@ -71,11 +87,19 @@ async fn real_main() -> Result<()> {
         Command::Echo => run(EchoResponder::new(), &cli.system, prompt)
             .await
             .context("echo agent run failed")?,
-        Command::Run { provider } => {
+        Command::Run { provider, tools } => {
             let responder = build_responder(&provider).context("building LLM responder")?;
-            run(responder, &cli.system, prompt)
-                .await
-                .context("LLM agent run failed")?
+            if tools.enable_tools {
+                let executor = default_builtins();
+                let definitions = executor.definitions();
+                run_with_tools(responder, executor, definitions, &cli.system, prompt)
+                    .await
+                    .context("LLM agent (with tools) run failed")?
+            } else {
+                run(responder, &cli.system, prompt)
+                    .await
+                    .context("LLM agent run failed")?
+            }
         }
     };
     println!("{reply}");

--- a/crates/dasclaw_cli/src/main.rs
+++ b/crates/dasclaw_cli/src/main.rs
@@ -1,0 +1,69 @@
+//! Headless `dasclaw` CLI binary (ADR-153 §4.4 step 4).
+//!
+//! Thin wrapper around [`dasclaw_cli::run`]. Parses argv with `clap`,
+//! initialises `tracing`, acquires the prompt (from `--prompt` or stdin),
+//! invokes the agent, prints the reply, and maps errors to exit codes.
+//!
+//! For programmatic use, depend on the `dasclaw_cli` library directly.
+
+use std::io::{self, Read};
+use std::process::ExitCode;
+
+use anyhow::{Context, Result};
+use clap::Parser;
+use dasclaw_cli::{EchoResponder, run};
+
+/// Headless dasclaw agent CLI.
+///
+/// Runs a single prompt through a `dasclaw_runtime::Agent` and prints the
+/// reply. The default responder is a deterministic echo for smoke
+/// testing — wire a real LLM responder in once provider selection lands.
+#[derive(Debug, Parser)]
+#[command(name = "dasclaw-cli", version, about, long_about = None)]
+struct Cli {
+    /// User prompt. When omitted, the prompt is read from stdin.
+    #[arg(short, long)]
+    prompt: Option<String>,
+
+    /// System prompt prepended to the conversation.
+    #[arg(short, long, default_value = "You are dasclaw, a headless agent.")]
+    system: String,
+}
+
+#[tokio::main]
+async fn main() -> ExitCode {
+    if let Err(err) = real_main().await {
+        eprintln!("dasclaw: {err:#}");
+        return ExitCode::from(1);
+    }
+    ExitCode::SUCCESS
+}
+
+async fn real_main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("warn")),
+        )
+        .with_writer(io::stderr)
+        .try_init()
+        .ok();
+
+    let cli = Cli::parse();
+    let prompt = match cli.prompt {
+        Some(p) => p,
+        None => read_stdin_prompt().context("reading prompt from stdin")?,
+    };
+
+    let reply = run(EchoResponder::new(), &cli.system, prompt.trim())
+        .await
+        .context("agent run failed")?;
+    println!("{reply}");
+    Ok(())
+}
+
+fn read_stdin_prompt() -> io::Result<String> {
+    let mut buf = String::new();
+    io::stdin().read_to_string(&mut buf)?;
+    Ok(buf)
+}

--- a/crates/dasclaw_cli/src/provider.rs
+++ b/crates/dasclaw_cli/src/provider.rs
@@ -1,0 +1,287 @@
+//! CLI-side wiring from argv/env → [`dasclaw_runtime::LlmProviderResponder`].
+//!
+//! ADR-153 §4.4 step 5 follow-up to the step-4 skeleton: prove that
+//! [`dasclaw_runtime::Agent`] drives a real provider end-to-end without
+//! any desktop dependency. This module exposes:
+//!
+//! - [`ProviderArgs`] — clap argument group covering the minimum surface
+//!   needed to construct a [`ClawCodeLlmProvider`]
+//!   ([`ProviderKind`], model, base URL, API key from `--api-key` or env).
+//! - [`build_responder`] — pure factory turning [`ProviderArgs`] into a
+//!   [`LlmProviderResponder<ClawCodeLlmProvider>`] ready to plug into
+//!   [`crate::run`].
+//!
+//! ## What this is not
+//!
+//! - Not a config-file loader. The CLI deliberately accepts only argv /
+//!   env so it stays a thin smoke driver around the runtime.
+//! - Not a credential store. Secrets are taken straight from the
+//!   environment and wrapped in [`SecretString`]; persistence belongs in
+//!   the desktop client.
+//! - Not a router. The CLI picks one provider per invocation; smart
+//!   routing, fallback, and circuit breaking live in
+//!   `dasclaw_llm_provider::provider` and stay opt-in for callers that
+//!   need them.
+
+use std::sync::Arc;
+
+use clap::{Args, ValueEnum};
+use dasclaw_llm_provider::provider::claw_code_provider::ClawCodeLlmProvider;
+use dasclaw_llm_provider::provider::config::{CacheRetention, RegistryProviderConfig};
+use dasclaw_llm_provider::provider::registry::ProviderProtocol;
+use dasclaw_runtime::LlmProviderResponder;
+use secrecy::SecretString;
+use thiserror::Error;
+
+/// Wire protocol selectable from the CLI.
+///
+/// Mirrors the subset of [`ProviderProtocol`] that the headless smoke
+/// driver supports. `GithubCopilot` is intentionally left out because it
+/// requires desktop-side token exchange.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum ProviderKind {
+    /// Anthropic Messages API (`https://api.anthropic.com`).
+    Anthropic,
+    /// OpenAI Chat Completions API (`https://api.openai.com/v1`).
+    Openai,
+    /// Any OpenAI-compatible endpoint (xAI, DashScope, Groq, vLLM, …).
+    /// `--base-url` is required.
+    OpenaiCompat,
+    /// Ollama local server (`http://localhost:11434`).
+    Ollama,
+}
+
+impl ProviderKind {
+    fn protocol(self) -> ProviderProtocol {
+        match self {
+            Self::Anthropic => ProviderProtocol::Anthropic,
+            Self::Openai | Self::OpenaiCompat => ProviderProtocol::OpenAiCompletions,
+            Self::Ollama => ProviderProtocol::Ollama,
+        }
+    }
+
+    fn default_base_url(self) -> &'static str {
+        match self {
+            Self::Anthropic => "https://api.anthropic.com",
+            Self::Openai => "https://api.openai.com/v1",
+            Self::OpenaiCompat => "",
+            Self::Ollama => "http://localhost:11434",
+        }
+    }
+
+    fn default_model(self) -> &'static str {
+        match self {
+            Self::Anthropic => "claude-3-5-sonnet-latest",
+            Self::Openai | Self::OpenaiCompat => "gpt-4o-mini",
+            Self::Ollama => "llama3",
+        }
+    }
+
+    fn requires_api_key(self) -> bool {
+        !matches!(self, Self::Ollama)
+    }
+}
+
+/// Clap argument group covering the minimum surface to build a real
+/// LLM-backed responder from the command line.
+///
+/// Keep this struct flat: it is `#[command(flatten)]`-ed into the binary
+/// CLI in [`crate::main`] and into integration test harnesses.
+#[derive(Debug, Args, Clone)]
+pub struct ProviderArgs {
+    /// LLM provider wire protocol.
+    #[arg(long, value_enum)]
+    pub provider: ProviderKind,
+
+    /// Model identifier (e.g. `claude-3-5-sonnet-latest`, `gpt-4o-mini`).
+    /// Defaults depend on `--provider`.
+    #[arg(long)]
+    pub model: Option<String>,
+
+    /// API endpoint base URL. Required for `openai-compat`; overrides
+    /// the protocol default for the other variants.
+    #[arg(long)]
+    pub base_url: Option<String>,
+
+    /// API key. Read from `--api-key` or, if omitted, from the protocol's
+    /// canonical environment variable (`ANTHROPIC_API_KEY`,
+    /// `OPENAI_API_KEY`). Ignored for `ollama`.
+    #[arg(long, env = "DASCLAW_API_KEY")]
+    pub api_key: Option<String>,
+}
+
+/// Errors surfaced while assembling a real provider from CLI args.
+#[derive(Debug, Error)]
+pub enum ProviderBuildError {
+    /// `--api-key` was empty and no fallback env var was set.
+    #[error(
+        "missing API key for provider {provider:?}: pass --api-key or set DASCLAW_API_KEY / {env_hint}"
+    )]
+    MissingApiKey {
+        /// Provider variant the caller selected.
+        provider: ProviderKind,
+        /// Canonical env var name the user can set as a fallback.
+        env_hint: &'static str,
+    },
+
+    /// `openai-compat` was selected without `--base-url`.
+    #[error("provider 'openai-compat' requires --base-url")]
+    MissingBaseUrl,
+
+    /// `dasclaw_llm_provider` rejected the resolved configuration.
+    #[error("provider construction failed: {0}")]
+    Builder(String),
+}
+
+/// Construct a [`LlmProviderResponder`] wrapping a
+/// [`ClawCodeLlmProvider`] from the parsed [`ProviderArgs`].
+///
+/// On success the returned responder is ready for
+/// [`dasclaw_runtime::AgentBuilder::responder`]. Network I/O is deferred
+/// until the agent actually invokes `respond` — this function is pure
+/// modulo `std::env::var` lookups for the per-protocol API-key fallback.
+pub fn build_responder(
+    args: &ProviderArgs,
+) -> Result<LlmProviderResponder<ClawCodeLlmProvider>, ProviderBuildError> {
+    let api_key = resolve_api_key(args)?;
+    let base_url = resolve_base_url(args)?;
+    let model = args
+        .model
+        .clone()
+        .unwrap_or_else(|| args.provider.default_model().to_string());
+
+    let config = RegistryProviderConfig {
+        protocol: args.provider.protocol(),
+        provider_id: provider_id(args.provider).to_string(),
+        api_key,
+        base_url,
+        model,
+        extra_headers: Vec::new(),
+        oauth_token: None,
+        is_codex_chatgpt: false,
+        refresh_token: None,
+        auth_path: None,
+        cache_retention: CacheRetention::default(),
+        unsupported_params: Vec::new(),
+        strict_tools_schema: true,
+    };
+
+    let provider = ClawCodeLlmProvider::from_registry_config(&config)
+        .map_err(|e| ProviderBuildError::Builder(e.to_string()))?;
+    Ok(LlmProviderResponder::new(Arc::new(provider)))
+}
+
+fn resolve_api_key(args: &ProviderArgs) -> Result<Option<SecretString>, ProviderBuildError> {
+    if !args.provider.requires_api_key() {
+        return Ok(None);
+    }
+    if let Some(key) = args.api_key.as_deref()
+        && !key.is_empty()
+    {
+        return Ok(Some(SecretString::new(key.to_string().into())));
+    }
+    let env_hint = canonical_env(args.provider);
+    if let Ok(key) = std::env::var(env_hint)
+        && !key.is_empty()
+    {
+        return Ok(Some(SecretString::new(key.into())));
+    }
+    Err(ProviderBuildError::MissingApiKey {
+        provider: args.provider,
+        env_hint,
+    })
+}
+
+fn resolve_base_url(args: &ProviderArgs) -> Result<String, ProviderBuildError> {
+    match (args.base_url.clone(), args.provider) {
+        (Some(url), _) if !url.is_empty() => Ok(url),
+        (_, ProviderKind::OpenaiCompat) => Err(ProviderBuildError::MissingBaseUrl),
+        (_, kind) => Ok(kind.default_base_url().to_string()),
+    }
+}
+
+fn provider_id(kind: ProviderKind) -> &'static str {
+    match kind {
+        ProviderKind::Anthropic => "anthropic",
+        ProviderKind::Openai => "openai",
+        ProviderKind::OpenaiCompat => "openai_compat",
+        ProviderKind::Ollama => "ollama",
+    }
+}
+
+fn canonical_env(kind: ProviderKind) -> &'static str {
+    match kind {
+        ProviderKind::Anthropic => "ANTHROPIC_API_KEY",
+        ProviderKind::Openai | ProviderKind::OpenaiCompat => "OPENAI_API_KEY",
+        ProviderKind::Ollama => "OLLAMA_API_KEY",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn args(kind: ProviderKind) -> ProviderArgs {
+        ProviderArgs {
+            provider: kind,
+            model: None,
+            base_url: None,
+            api_key: Some("test-key".to_string()),
+        }
+    }
+
+    #[test]
+    fn anthropic_defaults_fill_base_url_and_model() {
+        let r = build_responder(&args(ProviderKind::Anthropic));
+        assert!(r.is_ok(), "{:?}", r.err());
+    }
+
+    #[test]
+    fn openai_compat_requires_base_url() {
+        let mut a = args(ProviderKind::OpenaiCompat);
+        a.base_url = None;
+        match build_responder(&a) {
+            Err(ProviderBuildError::MissingBaseUrl) => {}
+            Err(other) => panic!("expected MissingBaseUrl, got {other:?}"),
+            Ok(_) => panic!("expected MissingBaseUrl, got Ok"),
+        }
+    }
+
+    #[test]
+    fn ollama_does_not_require_api_key() {
+        let mut a = args(ProviderKind::Ollama);
+        a.api_key = None;
+        let r = build_responder(&a);
+        assert!(r.is_ok(), "{:?}", r.err());
+    }
+
+    #[test]
+    fn missing_api_key_surfaces_env_hint() {
+        // Use a process-unique env var name we know is unset, by clearing
+        // the canonical one for the duration of the assertion.
+        // SAFETY: tests in this module run single-threaded under nextest
+        // by default; if that ever changes, switch to a mock layer.
+        let saved = std::env::var("ANTHROPIC_API_KEY").ok();
+        // SAFETY: scoped restore below.
+        unsafe { std::env::remove_var("ANTHROPIC_API_KEY") };
+
+        let mut a = args(ProviderKind::Anthropic);
+        a.api_key = None;
+        let err = match build_responder(&a) {
+            Err(e) => e,
+            Ok(_) => panic!("expected MissingApiKey, got Ok"),
+        };
+
+        if let Some(v) = saved {
+            // SAFETY: scoped restore of pre-existing value.
+            unsafe { std::env::set_var("ANTHROPIC_API_KEY", v) };
+        }
+
+        match err {
+            ProviderBuildError::MissingApiKey { env_hint, .. } => {
+                assert_eq!(env_hint, "ANTHROPIC_API_KEY");
+            }
+            other => panic!("expected MissingApiKey, got {other:?}"),
+        }
+    }
+}

--- a/crates/dasclaw_cli/src/tools.rs
+++ b/crates/dasclaw_cli/src/tools.rs
@@ -30,8 +30,7 @@ use serde_json::{Value, json};
 ///
 /// Returning `Err(_)` becomes a [`ToolResult`] with `is_error = true`,
 /// which the runtime feeds back to the model as a tool_result block.
-pub type ToolHandler =
-    Arc<dyn Fn(&Value) -> Result<String, String> + Send + Sync + 'static>;
+pub type ToolHandler = Arc<dyn Fn(&Value) -> Result<String, String> + Send + Sync + 'static>;
 
 /// One named CLI tool: its LLM-facing schema plus its local handler.
 #[derive(Clone)]
@@ -154,9 +153,7 @@ pub fn builtin_echo() -> CliTool {
             args.get("message")
                 .and_then(Value::as_str)
                 .map(str::to_owned)
-                .ok_or_else(|| {
-                    "echo: missing required string argument `message`".to_string()
-                })
+                .ok_or_else(|| "echo: missing required string argument `message`".to_string())
         },
     )
 }
@@ -264,11 +261,7 @@ mod tests {
     #[test]
     fn definitions_are_sorted_and_complete() {
         let executor = default_builtins();
-        let names: Vec<_> = executor
-            .definitions()
-            .into_iter()
-            .map(|d| d.name)
-            .collect();
+        let names: Vec<_> = executor.definitions().into_iter().map(|d| d.name).collect();
         assert_eq!(names, vec!["echo".to_string(), "now".to_string()]);
     }
 }

--- a/crates/dasclaw_cli/src/tools.rs
+++ b/crates/dasclaw_cli/src/tools.rs
@@ -1,0 +1,274 @@
+//! Static tool dispatch for [`dasclaw_cli`] (ADR-153 §4.4 step 6).
+//!
+//! Wires a minimal [`dasclaw_runtime::ToolExecutor`] into the headless
+//! CLI so the agent can complete a real tool-using turn. The executor is
+//! deliberately self-contained — no MCP, no sandbox, no filesystem
+//! mutation — so it stays decoupled from the still-pending `Tool` trait
+//! decoupling work in ironclaw (see ADR-153 §4.1).
+//!
+//! Two builtin demo tools ship with the CLI:
+//!
+//! - [`builtin_echo`] — returns the `message` argument verbatim.
+//! - [`builtin_now`] — returns the current epoch seconds.
+//!
+//! Higher-level integrations (MCP gateways, dasclaw_fs_tools, ...) are
+//! expected to plug their own [`ToolExecutor`] impls in via
+//! [`crate::run_with_tools`].
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use async_trait::async_trait;
+use dasclaw_core::messages::{ToolCall, ToolDefinition, ToolResult};
+use dasclaw_core::traits::HostError;
+use dasclaw_runtime::ToolExecutor;
+use serde_json::{Value, json};
+
+/// Pure-function tool handler: takes the parsed `arguments` JSON object
+/// and returns either a textual success payload or a textual error.
+///
+/// Returning `Err(_)` becomes a [`ToolResult`] with `is_error = true`,
+/// which the runtime feeds back to the model as a tool_result block.
+pub type ToolHandler =
+    Arc<dyn Fn(&Value) -> Result<String, String> + Send + Sync + 'static>;
+
+/// One named CLI tool: its LLM-facing schema plus its local handler.
+#[derive(Clone)]
+pub struct CliTool {
+    /// LLM-facing definition (name + description + JSON schema). Sent
+    /// verbatim to the provider via [`crate::run_with_tools`].
+    pub definition: ToolDefinition,
+    /// Local handler invoked when the model calls the tool.
+    pub handler: ToolHandler,
+}
+
+impl CliTool {
+    /// Build a [`CliTool`] from its parts.
+    pub fn new(
+        name: impl Into<String>,
+        description: impl Into<String>,
+        parameters: Value,
+        handler: impl Fn(&Value) -> Result<String, String> + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            definition: ToolDefinition {
+                name: name.into(),
+                description: description.into(),
+                parameters,
+            },
+            handler: Arc::new(handler),
+        }
+    }
+}
+
+/// In-memory [`ToolExecutor`] that dispatches by tool name.
+///
+/// Mirrors the design of `claw-code`'s `StaticToolExecutor` but uses an
+/// async-trait impl so it slots into [`dasclaw_runtime::AgentBuilder`]
+/// directly.
+#[derive(Default, Clone)]
+pub struct StaticToolExecutor {
+    tools: BTreeMap<String, CliTool>,
+}
+
+impl StaticToolExecutor {
+    /// Build an empty executor.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register a tool. Later registrations with the same name replace
+    /// earlier ones — same semantics as `BTreeMap::insert`.
+    #[must_use]
+    pub fn with_tool(mut self, tool: CliTool) -> Self {
+        self.tools.insert(tool.definition.name.clone(), tool);
+        self
+    }
+
+    /// All tool definitions, in deterministic name order. Pass this to
+    /// [`crate::run_with_tools`] so the model sees the same set the
+    /// executor can serve.
+    pub fn definitions(&self) -> Vec<ToolDefinition> {
+        self.tools.values().map(|t| t.definition.clone()).collect()
+    }
+
+    /// Number of registered tools.
+    pub fn len(&self) -> usize {
+        self.tools.len()
+    }
+
+    /// Whether the executor has no registered tools.
+    pub fn is_empty(&self) -> bool {
+        self.tools.is_empty()
+    }
+}
+
+#[async_trait]
+impl ToolExecutor for StaticToolExecutor {
+    async fn execute(&self, call: &ToolCall) -> Result<ToolResult, HostError> {
+        // Unknown tool → feed the failure back to the model rather than
+        // bubbling a HostError. The runtime treats `is_error = true` as a
+        // tool_result error the LLM can recover from.
+        let Some(tool) = self.tools.get(&call.name) else {
+            return Ok(ToolResult {
+                tool_call_id: call.id.clone(),
+                name: call.name.clone(),
+                content: format!("unknown tool: {}", call.name),
+                is_error: true,
+            });
+        };
+        let (content, is_error) = match (tool.handler)(&call.arguments) {
+            Ok(c) => (c, false),
+            Err(e) => (e, true),
+        };
+        Ok(ToolResult {
+            tool_call_id: call.id.clone(),
+            name: call.name.clone(),
+            content,
+            is_error,
+        })
+    }
+}
+
+/// Builtin: `echo` — returns the `message` argument verbatim.
+///
+/// JSON schema: `{ "message": string }`. Missing or non-string `message`
+/// returns an error to the model.
+pub fn builtin_echo() -> CliTool {
+    CliTool::new(
+        "echo",
+        "Return the `message` argument back to the caller verbatim. \
+         Useful for smoke-testing the agent's tool-use loop.",
+        json!({
+            "type": "object",
+            "properties": {
+                "message": {
+                    "type": "string",
+                    "description": "The text to echo back."
+                }
+            },
+            "required": ["message"]
+        }),
+        |args| {
+            args.get("message")
+                .and_then(Value::as_str)
+                .map(str::to_owned)
+                .ok_or_else(|| {
+                    "echo: missing required string argument `message`".to_string()
+                })
+        },
+    )
+}
+
+/// Builtin: `now` — returns the current Unix epoch seconds as a string.
+///
+/// No arguments. Useful for sanity-checking that the agent can drive a
+/// tool with side effects (clock read).
+pub fn builtin_now() -> CliTool {
+    CliTool::new(
+        "now",
+        "Return the current Unix epoch time in seconds as a decimal \
+         integer string. Takes no arguments.",
+        json!({
+            "type": "object",
+            "properties": {}
+        }),
+        |_args| {
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .map(|d| d.as_secs().to_string())
+                .map_err(|e| format!("now: system clock is before UNIX_EPOCH: {e}"))
+        },
+    )
+}
+
+/// Returns a [`StaticToolExecutor`] preloaded with the two builtin demo
+/// tools ([`builtin_echo`], [`builtin_now`]).
+///
+/// Used by `dasclaw-cli run --enable-tools` and by integration tests.
+pub fn default_builtins() -> StaticToolExecutor {
+    StaticToolExecutor::new()
+        .with_tool(builtin_echo())
+        .with_tool(builtin_now())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn call(name: &str, args: Value) -> ToolCall {
+        ToolCall {
+            id: "call-1".to_string(),
+            name: name.to_string(),
+            arguments: args,
+            reasoning: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn req_dasclaw_cli_tools_a1_unknown_tool_returns_error_result() {
+        let executor = default_builtins();
+        let result = executor
+            .execute(&call("does-not-exist", json!({})))
+            .await
+            .expect("executor returned HostError unexpectedly");
+        assert!(result.is_error, "unknown tool must flag is_error=true");
+        assert!(
+            result.content.contains("unknown tool"),
+            "expected diagnostic message, got: {}",
+            result.content
+        );
+        assert_eq!(result.tool_call_id, "call-1");
+    }
+
+    #[tokio::test]
+    async fn req_dasclaw_cli_tools_a2_echo_returns_message_verbatim() {
+        let executor = default_builtins();
+        let result = executor
+            .execute(&call("echo", json!({ "message": "hello" })))
+            .await
+            .expect("executor returned HostError unexpectedly");
+        assert!(!result.is_error);
+        assert_eq!(result.content, "hello");
+        assert_eq!(result.name, "echo");
+    }
+
+    #[tokio::test]
+    async fn req_dasclaw_cli_tools_a3_echo_missing_argument_is_tool_error() {
+        let executor = default_builtins();
+        let result = executor
+            .execute(&call("echo", json!({})))
+            .await
+            .expect("executor returned HostError unexpectedly");
+        assert!(result.is_error);
+        assert!(result.content.contains("missing required"));
+    }
+
+    #[tokio::test]
+    async fn req_dasclaw_cli_tools_a4_now_returns_decimal_seconds() {
+        let executor = default_builtins();
+        let result = executor
+            .execute(&call("now", json!({})))
+            .await
+            .expect("executor returned HostError unexpectedly");
+        assert!(!result.is_error);
+        // Parse as u64 to confirm it is a decimal integer string.
+        let secs: u64 = result
+            .content
+            .parse()
+            .expect("`now` should return decimal seconds");
+        assert!(secs > 1_700_000_000, "epoch seconds should be post-2023");
+    }
+
+    #[test]
+    fn definitions_are_sorted_and_complete() {
+        let executor = default_builtins();
+        let names: Vec<_> = executor
+            .definitions()
+            .into_iter()
+            .map(|d| d.name)
+            .collect();
+        assert_eq!(names, vec!["echo".to_string(), "now".to_string()]);
+    }
+}

--- a/crates/dasclaw_cli/tests/end_to_end.rs
+++ b/crates/dasclaw_cli/tests/end_to_end.rs
@@ -1,0 +1,21 @@
+//! End-to-end smoke test for ADR-153 §4.4 step 4: prove that
+//! `dasclaw_runtime::Agent` runs headlessly (no desktop) via the
+//! `dasclaw_cli` library entry point with the built-in fake responder.
+
+use dasclaw_cli::{EchoResponder, run};
+
+#[tokio::test]
+async fn echo_responder_round_trip() {
+    let reply = run(EchoResponder::new(), "system prompt", "hello world")
+        .await
+        .expect("agent run should succeed");
+
+    assert!(
+        reply.starts_with("echo:"),
+        "expected echo prefix, got: {reply:?}"
+    );
+    assert!(
+        reply.contains("hello world"),
+        "expected reply to echo prompt, got: {reply:?}"
+    );
+}

--- a/crates/dasclaw_cli/tests/live_provider.rs
+++ b/crates/dasclaw_cli/tests/live_provider.rs
@@ -1,0 +1,57 @@
+//! Integration test for the real-LLM wiring in `dasclaw_cli::provider`.
+//!
+//! ADR-153 §4.4 step 5 proof: a `dasclaw_runtime::Agent` constructed
+//! purely from `dasclaw_cli::provider::build_responder` drives a real
+//! OpenAI-Chat-Completions wire format end-to-end against a wiremock
+//! server. No desktop deps, no network, no API key — the mock answers
+//! `"pong"` and the agent's reply round-trips through the entire stack.
+
+use dasclaw_cli::provider::{ProviderArgs, ProviderKind, build_responder};
+use dasclaw_cli::run;
+use serde_json::json;
+use wiremock::matchers::{header, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+const TEST_API_KEY: &str = "sk-test";
+
+fn success_body(reply: &str) -> serde_json::Value {
+    json!({
+        "id": "chatcmpl-test",
+        "object": "chat.completion",
+        "model": "gpt-4o-mini",
+        "choices": [{
+            "index": 0,
+            "message": { "role": "assistant", "content": reply },
+            "finish_reason": "stop"
+        }],
+        "usage": { "prompt_tokens": 3, "completion_tokens": 1 }
+    })
+}
+
+#[tokio::test]
+async fn openai_compat_round_trips_through_agent() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .and(header(
+            "authorization",
+            format!("Bearer {TEST_API_KEY}").as_str(),
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_json(success_body("pong")))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let args = ProviderArgs {
+        provider: ProviderKind::OpenaiCompat,
+        model: Some("gpt-4o-mini".to_string()),
+        base_url: Some(server.uri()),
+        api_key: Some(TEST_API_KEY.to_string()),
+    };
+    let responder = build_responder(&args).expect("responder builds");
+    let reply = run(responder, "You are a test agent.", "ping")
+        .await
+        .expect("agent run succeeds");
+
+    assert_eq!(reply.trim(), "pong");
+}

--- a/crates/dasclaw_cli/tests/tool_e2e.rs
+++ b/crates/dasclaw_cli/tests/tool_e2e.rs
@@ -1,0 +1,112 @@
+//! Integration test for [`dasclaw_cli::run_with_tools`].
+//!
+//! ADR-153 §4.4 step 6 proof: a `dasclaw_runtime::Agent` constructed
+//! from `build_responder` + `tools::default_builtins` runs a full
+//! two-turn tool dispatch loop against a wiremock OpenAI-Chat-Completions
+//! server. Turn 1 the model emits a `tool_call`, the local
+//! [`StaticToolExecutor`](dasclaw_cli::tools::StaticToolExecutor) runs
+//! the `echo` builtin, and turn 2 the model returns the final text.
+
+use dasclaw_cli::provider::{ProviderArgs, ProviderKind, build_responder};
+use dasclaw_cli::run_with_tools;
+use dasclaw_cli::tools::default_builtins;
+use serde_json::json;
+use wiremock::matchers::{header, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+const TEST_API_KEY: &str = "sk-test";
+
+fn tool_call_body() -> serde_json::Value {
+    json!({
+        "id": "chatcmpl-tool-call",
+        "object": "chat.completion",
+        "model": "gpt-4o-mini",
+        "choices": [{
+            "index": 0,
+            "message": {
+                "role": "assistant",
+                "content": null,
+                "tool_calls": [{
+                    "id": "call_echo_1",
+                    "type": "function",
+                    "function": {
+                        "name": "echo",
+                        "arguments": "{\"message\":\"hello-from-tool\"}"
+                    }
+                }]
+            },
+            "finish_reason": "tool_calls"
+        }],
+        "usage": { "prompt_tokens": 5, "completion_tokens": 8 }
+    })
+}
+
+fn final_text_body() -> serde_json::Value {
+    json!({
+        "id": "chatcmpl-final",
+        "object": "chat.completion",
+        "model": "gpt-4o-mini",
+        "choices": [{
+            "index": 0,
+            "message": {
+                "role": "assistant",
+                "content": "tool said: hello-from-tool"
+            },
+            "finish_reason": "stop"
+        }],
+        "usage": { "prompt_tokens": 12, "completion_tokens": 6 }
+    })
+}
+
+#[tokio::test]
+async fn req_dasclaw_cli_tools_e2e_echo_tool_round_trips_through_agent() {
+    let server = MockServer::start().await;
+
+    // Turn 1: the assistant emits a tool_call. `up_to_n_times(1)` ensures
+    // wiremock falls through to the second mock on the next request.
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .and(header(
+            "authorization",
+            format!("Bearer {TEST_API_KEY}").as_str(),
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_json(tool_call_body()))
+        .up_to_n_times(1)
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // Turn 2: after the tool_result is fed back, the assistant finalizes.
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .and(header(
+            "authorization",
+            format!("Bearer {TEST_API_KEY}").as_str(),
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_json(final_text_body()))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let args = ProviderArgs {
+        provider: ProviderKind::OpenaiCompat,
+        model: Some("gpt-4o-mini".to_string()),
+        base_url: Some(server.uri()),
+        api_key: Some(TEST_API_KEY.to_string()),
+    };
+    let responder = build_responder(&args).expect("responder builds");
+    let executor = default_builtins();
+    let definitions = executor.definitions();
+
+    let reply = run_with_tools(
+        responder,
+        executor,
+        definitions,
+        "You are a test agent.",
+        "please call echo",
+    )
+    .await
+    .expect("agent run with tools succeeds");
+
+    assert_eq!(reply.trim(), "tool said: hello-from-tool");
+}

--- a/docs/plans/architecture-refactor/31-target-architecture.md
+++ b/docs/plans/architecture-refactor/31-target-architecture.md
@@ -6,6 +6,7 @@
 >   3. **§4.6 薄壳化已完成**：`desktop-client/ironclaw/src/tools/builtin/mod.rs` 已转为 wildcard re-export 入口（PR #792），同时为下沉 crate 留 `pub mod` 仅限留守 6 类；shim `shell.rs` / `lsp/mod.rs` 已删。
 >   4. **crate 总数**：47（v2.5 写作时 45，新增 `dasclaw_misc_tools` 等本期产物）；`scripts/check_blueprint_sync.py` 自检为 `47 crates on disk / 2 planned`（剩 `dasclaw_bridge_lite` + `dasclaw_memory_tools` 处于 PLANNED 状态，后者按 ADR-156 §6.3.1 永久搁置）。
 >   5. **ADR-153 §4.4 step 4 落点**：新增 `crates/dasclaw_cli`（headless agent CLI，骨架 + EchoResponder 端到端 demo），证明 `dasclaw_runtime::Agent` 在零 desktop 依赖（无 Tauri / 无 DB / 无 HTTP server）下可独立运行；真实 LLM provider 与 tool executor 接线留待 ADR-153 后续 slice。
+>   6. **ADR-153 §4.4 step 5 落点**：`crates/dasclaw_cli` 引入 `provider` 模块，把 `dasclaw_llm_provider::ClawCodeLlmProvider` 通过 `dasclaw_runtime::LlmProviderResponder` 接入 headless agent，新增 `dasclaw-cli run --provider {anthropic|openai|openai_compat|ollama}` 子命令 + wiremock 端到端集成测试，证明真实 LLM 走 `Agent` 完整回路（无 desktop / 无 Tauri / 无 HTTP server）。Tool executor 接线仍留待后续 slice。
 > 本次升级是状态同步性质，不改架构决策，不重画 §1 总览图。原 v2.5 内容保留（§4.6 表格仅增"PR / 状态"列覆盖）。
 
 > **v2.5 (2026-05-23)** · 蓝图对齐 4-5 天发展（基于 [40-tool-ecosystem-inventory.md](40-tool-ecosystem-inventory.md) §1-3 实测 + [41-target-architecture-drift-analysis.md](41-target-architecture-drift-analysis.md) 漂移识别）：

--- a/docs/plans/architecture-refactor/31-target-architecture.md
+++ b/docs/plans/architecture-refactor/31-target-architecture.md
@@ -5,6 +5,7 @@
 >   2. **F4.6.3 `dasclaw_memory_tools` 取消下沉**：按 [ADR-156 §6.3.1](adr-156-f46-builtin-tools-landing-decision.md) 决定，`memory` 模块依赖 `runtime` workspace crate（mtime / 大小 / 路径治理），强行下沉会绕过 ADR-153 边界，故 `memory` 留 desktop（与 §4.6 "留桌面 5 类"合并为 6 类：memory / extension / skill / job / routine / message）。
 >   3. **§4.6 薄壳化已完成**：`desktop-client/ironclaw/src/tools/builtin/mod.rs` 已转为 wildcard re-export 入口（PR #792），同时为下沉 crate 留 `pub mod` 仅限留守 6 类；shim `shell.rs` / `lsp/mod.rs` 已删。
 >   4. **crate 总数**：47（v2.5 写作时 45，新增 `dasclaw_misc_tools` 等本期产物）；`scripts/check_blueprint_sync.py` 自检为 `47 crates on disk / 2 planned`（剩 `dasclaw_bridge_lite` + `dasclaw_memory_tools` 处于 PLANNED 状态，后者按 ADR-156 §6.3.1 永久搁置）。
+>   5. **ADR-153 §4.4 step 4 落点**：新增 `crates/dasclaw_cli`（headless agent CLI，骨架 + EchoResponder 端到端 demo），证明 `dasclaw_runtime::Agent` 在零 desktop 依赖（无 Tauri / 无 DB / 无 HTTP server）下可独立运行；真实 LLM provider 与 tool executor 接线留待 ADR-153 后续 slice。
 > 本次升级是状态同步性质，不改架构决策，不重画 §1 总览图。原 v2.5 内容保留（§4.6 表格仅增"PR / 状态"列覆盖）。
 
 > **v2.5 (2026-05-23)** · 蓝图对齐 4-5 天发展（基于 [40-tool-ecosystem-inventory.md](40-tool-ecosystem-inventory.md) §1-3 实测 + [41-target-architecture-drift-analysis.md](41-target-architecture-drift-analysis.md) 漂移识别）：


### PR DESCRIPTION
## 背景 / 目标

ADR-153 §4.4 step 6：让 `dasclaw-cli` 真正能跑 tool 调用，落地一条 OpenAI 兼容协议下的两轮 tool 循环（model → tool_call → 本地执行 → tool_result → model finalize）。

在此之前 PR #800 搭了 skeleton（EchoResponder），PR #802 接通了真实 LLM provider。本 PR 接上去把 `dasclaw_runtime::ToolExecutor` 这条链路也接通，并附带两个 demo 工具用于自测和后续 MCP-backed executor 的对照基准。

**Closes #803**

## 改动范围

- `crates/dasclaw_cli/src/tools.rs`（新增）：
  - `CliTool` + `StaticToolExecutor`：BTreeMap 名字索引的内存执行器，实现 `dasclaw_runtime::ToolExecutor`。未知工具与 handler 错误一律走 `ToolResult { is_error: true }`，不抛 `HostError`。
  - 两个 builtin 工具：`echo`（schema 含 required \`message\`）、`now`（无参数，返回 UNIX epoch 秒数）。
  - `default_builtins()` 一次性装好两者，供 binary 用。
  - 5 个 unit test：未知工具 / echo 正常 / echo 缺参 / now 形态 / definitions 排序完备。
- `crates/dasclaw_cli/src/lib.rs`：
  - 暴露 `pub mod tools`。
  - 新增 `run_with_tools(responder, tool_executor, tool_definitions, system, user)` 入口；保留原有 `run` 不变，避免在已有签名上加可选参数搞补丁式接口。
- `crates/dasclaw_cli/src/main.rs`：
  - `Run` 子命令新增 `--enable-tools` flag（默认关），开启后从 `default_builtins()` 装配执行器并走 `run_with_tools`。
- `crates/dasclaw_cli/Cargo.toml`：
  - 将 `serde_json` 从 dev-dependencies 提到 main dependencies（`tools.rs` 在非测试代码里直接用 `serde_json::{Value, json}`）。
- `crates/dasclaw_cli/tests/tool_e2e.rs`（新增）：
  - wiremock 双 mock 串接（`up_to_n_times(1)`）：turn-1 返回 `tool_calls`，turn-2 返回最终文本。
  - 通过 `run_with_tools(build_responder(...), default_builtins(), definitions, ...)` 跑完整链路，断言最终回复为 \`tool said: hello-from-tool\`。

## 非目标（What's NOT in this PR）

- 不接 MCP-backed `ToolExecutor`（step 7 之后再做）。
- 不实现流式 / 交互式 REPL。
- 不动 `dasclaw_runtime` 任何代码（仅作为依赖使用）。
- 不引入新的工具种类，echo/now 仅作为 demo + 测试 fixture。

## 验证

```bash
cargo check -p dasclaw_cli --tests                                    # OK
cargo nextest run -p dasclaw_cli                                       # 12 passed, 0 failed
cargo clippy --no-deps -p dasclaw_cli --all-targets -- -D warnings    # 0 warning
python3.12 scripts/check_no_panics.py --base origin/feat/dasclaw-cli-real-llm-provider  # OK
```

E2E test 单独跑：
```
PASS dasclaw_cli::tool_e2e req_dasclaw_cli_tools_e2e_echo_tool_round_trips_through_agent (8.493s)
```

## Stacked PR 提示

- **base 不是 \`xClaw\`，是 \`feat/dasclaw-cli-real-llm-provider\`（PR #802）**。
- Merge 顺序：#800 → #802 → 本 PR。
- 评审建议：**先看完 #802 再回来看本 PR**，否则会看不到 \`build_responder\` 的来历。

## Cross-cuts

- **ADR-114**：类A（无新增 \`.ironclaw\` / \`IRONCLAW_BASE_DIR\` 字面量）

## Sources read

- [docs/plans/architecture-refactor/adr-153](../docs/plans/architecture-refactor/) §4.4 step 6
- crates/dasclaw_runtime/src/agent.rs::HeadlessDelegate::execute_tool_calls
- crates/dasclaw_core/src/messages.rs::{ToolCall, ToolResult, ToolDefinition}
- crates/dasclaw_cli/tests/live_provider.rs（wiremock 模板）

## 后续

- step 7：MCP-backed `ToolExecutor`，替换 / 并存 `StaticToolExecutor`，把 `dasclaw_mcp` 客户端真正接进来。