### PR TITLE
docs(adr-153): flesh out §4.4 dasclaw_cli sub-steps 4–8 + necessity analysis

### DIFF
--- a/docs/plans/architecture-refactor/adr-153-headless-agent-framework-draft.md
+++ b/docs/plans/architecture-refactor/adr-153-headless-agent-framework-draft.md
@@ -68,9 +68,88 @@ async fn main() -> anyhow::Result<()> {
 - 把 ironclaw 的 channels/ + history/ 中**与桌面无关**的会话状态机抽出来（消息历史、断点续传、超时）
 - 仍然不绑定 db；用 trait `SessionStore` 让调用方自己选 in-memory / sqlite / postgres
 
-### 4.4 步骤 4：dasclaw_cli（新）
-- 一个最小 CLI 二进制，演示「无 db、无 HTTP」直接跑 agent
-- 类似 claw-code 当前的体验，但全部来自 crates/
+### 4.4 步骤 4 起：dasclaw_cli（新）
+
+`crates/dasclaw_cli/` 是一个最小 CLI 二进制，证明「无 db、无 HTTP、无 Tauri」就能直接跑 agent。它本身**不是**桌面后端的替代品；它是验证 dasclaw_* 这一套 crate 真的能在第三方进程里独立运行的「最小宿主」。CLI 自己只做三件事：拿到一个 LLM provider、构造 agent loop、把工具集喂给 agent。
+
+为了避免一次性塞太多东西进一个 PR，CLI 按子步骤递进交付，每一子步对应一个独立 PR、每一步都保留前面所有子步的行为不退化：
+
+#### 4.4.1 子步骤 4：CLI 骨架（已落地，PR #800）
+
+- 提供 `dasclaw_cli::run(responder, system, user) -> String` 这一**唯一**库入口，不做任何 I/O。
+- 提供内置 `EchoResponder`：返回 `echo: <last user content>`，仅供 smoke test，不打网络。
+- 二进制 `dasclaw-cli` 默认子命令 `echo`：从 stdin 或 `--prompt` 读用户输入，把回复打到 stdout。
+- 范围之外：不接真实 provider、没有工具调度、没有 streaming。
+
+#### 4.4.2 子步骤 5：CLI 接真实 LLM provider（已落地，PR #802）
+
+- 新增 `dasclaw_cli::provider::ProviderArgs` 把 provider 类型（anthropic / openai-compat / ollama）+ base-url + model + 环境变量名打成一个 clap flatten。
+- 新增 `dasclaw_cli::provider::build_responder(&ProviderArgs)`，把上面的 args 转成 `dasclaw_runtime::LlmProviderResponder`。
+- 二进制增加 `run` 子命令；`echo` 不变。
+- API key 走环境变量：`ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `DASCLAW_API_KEY`；缺 key 时给出明确的环境变量提示。
+- 测试用 wiremock 跑一次完整 round-trip，不连真实 provider。
+
+#### 4.4.3 子步骤 6：CLI 接本地工具（已落地，PR #804）
+
+- 新增 `dasclaw_cli::tools` 模块：
+  - `ToolHandler = Arc<dyn Fn(&Value) -> Result<String, String> + Send + Sync>`
+  - `CliTool { definition, handler }`
+  - `StaticToolExecutor`：name → handler 字典，实现 `async dasclaw_runtime::ToolExecutor`。
+  - 内置两个演示工具：`echo`（返回入参 `message`）、`now`（返回 epoch 秒）。
+- 新增 `dasclaw_cli::run_with_tools(...)`：第二个入口，和 `run` 并存；不破坏 `run` 的零工具调用路径。
+- `run` 子命令增加 `--enable-tools` flag（默认关），开启后把 `default_builtins()` 喂给 agent。
+- 范围之外：不接 MCP；不桥接 `dasclaw_fs_tools` / `dasclaw_shell_command`（这俩的 `Tool` trait 还在 ironclaw 里耦合着 `JobContext`，另开 issue 解耦）。
+
+#### 4.4.4 子步骤 7：dasclaw_mcp::McpToolExecutor（已落地，PR #806）
+
+这一步**不在** `dasclaw_cli` 里落，是在 `dasclaw_mcp` 里加一层：
+
+- 新增 `dasclaw_mcp::McpToolExecutor`，把一个或多个 `Arc<McpClient>` 包成 `dasclaw_runtime::ToolExecutor`。
+- 工具名按 `<server>_<tool>` 限定，避免多 server 命名冲突（与 ironclaw `create_tools_for` 同步）。
+- 未知工具 / 传输错误一律返回 `is_error=true` 的 `ToolResult`，喂回 LLM 而不是把异常抛进 agent loop。
+- 提供 `from_clients(...)`（生产用，自动调 `list_tools()`）与 `from_routes(...)`（测试用，跳过 transport）两种构造入口。
+- 与 #804 文件零重叠，并行交付。
+
+为什么这一步独立成 PR 而不是塞进 CLI：`McpToolExecutor` 是一个**通用**桥接，无头 agent 框架的任何宿主（CLI、ironclaw 桌面后端、第三方进程）都会用到它，让它住在 `dasclaw_mcp` 里、不依赖任何 CLI 概念，是正确的分层。
+
+#### 4.4.5 子步骤 8：CLI 接 MCP 服务器（下一步）
+
+把 #806 的 `McpToolExecutor` 真正接进 `dasclaw-cli`，让用户能在不写代码的情况下把任意 MCP 服务器挂上 agent。设计要点：
+
+- **配置面**：新增 `--mcp-config <path>` 指向一个 JSON 文件，结构复用 `dasclaw_mcp::config::McpServerConfig`：
+
+  ```jsonc
+  {
+    "servers": [
+      { "name": "fs", "command": "npx", "args": ["@modelcontextprotocol/server-filesystem", "/tmp"] },
+      { "name": "http-demo", "url": "https://mcp.example.com/v1", "headers": { "Authorization": "Bearer …" } }
+    ]
+  }
+  ```
+
+  选 JSON config 而不是逐个 CLI flag 的原因：MCP server 的参数空间（command/args/env/url/headers/auth）太大，flag 化会让 `run` 子命令的入口爆炸；JSON config 跟 claw-code / ironclaw 现有的 MCP 配置思路一致，未来加 OAuth / 多 server 不需要再动 CLI。
+
+- **运行面**：CLI 启动时按 config 顺序起每个 server：
+  - 对 stdio 类型：用 `dasclaw_mcp::StdioMcpTransport::spawn` 起子进程。
+  - 对 HTTP 类型：构造 `HttpMcpTransport`（不带 session-manager / secrets，CLI 暂不接 OAuth）。
+  - 把每个 transport 包成 `McpClient::new_with_transport(name, transport, None, None, "cli", Some(config))`，再喂给 `McpToolExecutor::from_clients(...)`。
+
+- **合并面**：`--enable-tools` 与 `--mcp-config` 可同时启用。届时需要一个 `CompositeToolExecutor`（在 `dasclaw_runtime` 或 `dasclaw_cli` 里）把 `StaticToolExecutor` 和 `McpToolExecutor` 的工具集求并、按 name 分发。**注意**：合并器是个新的小公共组件，会按 3 层代码审查先确认 crates/ 没有等价物再决定落在哪。
+
+- **范围之外**：
+  - 不接 OAuth（hosted MCP 服务器需要 `SessionManager + SecretsStore`，CLI 暂时没有持久化存储，另开 issue）。
+  - 不做工具白名单 / 审批（CLI 默认信任 config 里列出的 server；审批走 agent 层的 hook 系统，不在 CLI 入口里硬编码）。
+  - 不做 `--mcp-stdio name=cmd` 这种 shell 友好的 inline flag；先用 JSON config 收口，inline flag 等用户真有需求再加。
+
+#### 4.4.6 必要性分析（为什么无头 agent 框架真的需要这些能力）
+
+| 能力 | 是否必要 | 理由 |
+|------|----------|------|
+| 真实 LLM provider 接入（4.4.2） | **必要** | 无头框架的存在意义就是「一个进程跑 agent」，没有 provider 就只剩 echo |
+| 本地工具调度（4.4.3） | **必要** | agent loop 的 tool dispatch trait 不接 executor 就触发 `AgentError::ToolsNotSupported`，模型一旦返回 `tool_call` 就崩；至少要有一个 executor 兜底 |
+| MCP 桥接（4.4.4） | **必要** | MCP 已是模型生态的事实标准工具协议，连 fs/github/postgres 等服务的标准路径；不接 MCP 等于把无头框架封在「只能用内置工具」的玩具状态 |
+| CLI 接 MCP（4.4.5） | **必要但可后置** | 库层（#806）做完后，任何宿主都能在代码里接 MCP；CLI 接 MCP 的价值是「不写代码就能用」，是降低无头框架对用户的门槛，但不是无头框架本身的依赖 |
+| OAuth-backed MCP / 审批 / streaming / 工具白名单 | **暂不必要** | 这些都属于「桌面后端 / 企业部署」层的关注点，无头 CLI 的最小目标是验证 dasclaw_* 能独立工作，不应一次性把全部生态搬过来 |
 
 完成这 4 步以后，desktop-client/ironclaw 就是一个**纯粹的「桌面后端业务皮」**——HTTP + 数据库 + 租户 + Web 钩子，里面调 `dasclaw_runtime::Agent` 来真正跑 agent。
 


### PR DESCRIPTION
## 背景

按 PR #806 反馈中用户的指示「dasclaw_cli设计直接写在 adr-153 中」，把 §4.4 从 4 行的 stub 扩成完整的子步骤推进表 + 必要性分析。

之前 §4.4 只列了「最小 CLI 二进制，演示无 db、无 HTTP 跑 agent」这一句话，外加 3 个 bullet。实际上 dasclaw_cli 已经按子步骤分批落地了 4/5/6 三步（PR #800 / #802 / #804），又有 PR #806 在 dasclaw_mcp 里加了 McpToolExecutor，下一步要把这俩接起来。本 PR 把这条路线一次性写清楚。

## 改动范围

- 仅改 `docs/plans/architecture-refactor/adr-153-headless-agent-framework-draft.md` §4.4 一节，纯文档。
- 拆成 4.4.1 ~ 4.4.6 六个子段：每个落地 PR 一段、下一步 CLI 接 MCP 一段、必要性分析表一段。
- §1–3、§4.1–4.3、§5–7 完全不动；§4.4 之后的整段「完成这 4 步以后…」收尾文字保留不变。

## 非目标

- 不动任何代码。
- 不改 ADR 状态（仍是 Accepted 草稿）。
- 不重新分配现有 issue / PR 的编号。

## 验证

- `docs/plans/architecture-refactor/adr-153-headless-agent-framework-draft.md` 99 → 178 行
- 渲染：本地预览 Markdown 表格、jsonc fence 正常
- 没有改 crates/ 里任何文件，所有代码红线（panic guard / ADR-114 / verbatim drift）天然不触发

## Sources read

- docs/plans/architecture-refactor/adr-153-headless-agent-framework-draft.md（改前全文）
- crates/dasclaw_cli/src/{lib.rs,main.rs,tools.rs}（确认 4.4.1–4.4.3 的「已落地」描述真实匹配代码）
- crates/dasclaw_mcp/src/executor.rs（确认 4.4.4 的 API 描述准确）
- crates/dasclaw_mcp/src/{stdio_transport.rs,config.rs,client.rs}（确认 4.4.5 设计可落地）

## Cross-cuts

- ADR-114：类A（无新增 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量）