### PR TITLE
feat(dasclaw_cli): wire StaticToolExecutor with builtin echo/now tools (ADR-153 step 6)

### DIFF
--- a/crates/dasclaw_cli/Cargo.toml
+++ b/crates/dasclaw_cli/Cargo.toml
@@ -21,6 +21,7 @@ clap = { version = "4", features = ["derive", "env"] }
 secrecy = "0.10"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "io-std", "io-util"] }
 async-trait = "0.1"
+serde_json = "1"
 thiserror = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
@@ -28,4 +29,3 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "test-util"] }
 wiremock = "0.6"
-serde_json = "1"

--- a/crates/dasclaw_cli/src/lib.rs
+++ b/crates/dasclaw_cli/src/lib.rs
@@ -17,7 +17,6 @@
 //!
 //! ## Out of scope (deliberately not in this slice)
 //!
-//! - Tool execution wiring ([`dasclaw_runtime::ToolExecutor`]).
 //! - Streaming / interactive REPL. The first slice is request-response.
 //!
 //! ## Real LLM provider wiring
@@ -25,17 +24,25 @@
 //! See [`provider`] for the [`ProviderArgs`](provider::ProviderArgs) →
 //! [`LlmProviderResponder`](dasclaw_runtime::LlmProviderResponder)
 //! factory used by the binary's non-echo mode (ADR-153 §4.4 step 5).
+//!
+//! ## Tool dispatch
+//!
+//! See [`tools`] for the in-memory [`StaticToolExecutor`](tools::StaticToolExecutor)
+//! used by `dasclaw-cli run --enable-tools` (ADR-153 §4.4 step 6).
+//! Drive it through [`run_with_tools`] when the agent should be allowed
+//! to call tools.
 
 use std::sync::Mutex;
 
 use async_trait::async_trait;
-use dasclaw_core::messages::{FinishReason, Role};
+use dasclaw_core::messages::{FinishReason, Role, ToolDefinition};
 use dasclaw_core::reasoning_ctx::ReasoningContext;
 use dasclaw_core::response_types::{RespondOutput, RespondResult, ResponseMetadata, TokenUsage};
 use dasclaw_core::traits::HostError;
-use dasclaw_runtime::{Agent, AgentError, AgentResponder};
+use dasclaw_runtime::{Agent, AgentError, AgentResponder, ToolExecutor};
 
 pub mod provider;
+pub mod tools;
 
 /// Errors surfaced by the CLI library layer.
 #[derive(Debug, thiserror::Error)]
@@ -66,6 +73,35 @@ where
 {
     let agent: Agent = Agent::builder()
         .responder(responder)
+        .system_prompt(system_prompt)
+        .build()
+        .map_err(|e| CliError::Build(e.to_string()))?;
+    let reply = agent.run(user_prompt).await?;
+    Ok(reply)
+}
+
+/// Variant of [`run`] that wires a [`ToolExecutor`] and advertises its
+/// tool definitions to the model.
+///
+/// `tool_definitions` is normally [`tools::StaticToolExecutor::definitions`].
+/// Keeping [`run`] and `run_with_tools` as separate entries avoids a
+/// patch-style optional parameter on the original signature and keeps
+/// the no-tools call-path free of executor plumbing.
+pub async fn run_with_tools<R, E>(
+    responder: R,
+    tool_executor: E,
+    tool_definitions: Vec<ToolDefinition>,
+    system_prompt: &str,
+    user_prompt: &str,
+) -> Result<String, CliError>
+where
+    R: AgentResponder + 'static,
+    E: ToolExecutor + 'static,
+{
+    let agent: Agent = Agent::builder()
+        .responder(responder)
+        .tool_executor(tool_executor)
+        .tools(tool_definitions)
         .system_prompt(system_prompt)
         .build()
         .map_err(|e| CliError::Build(e.to_string()))?;

--- a/crates/dasclaw_cli/src/main.rs
+++ b/crates/dasclaw_cli/src/main.rs
@@ -15,9 +15,10 @@ use std::io::{self, Read};
 use std::process::ExitCode;
 
 use anyhow::{Context, Result};
-use clap::{Parser, Subcommand};
+use clap::{Args, Parser, Subcommand};
 use dasclaw_cli::provider::{ProviderArgs, build_responder};
-use dasclaw_cli::{EchoResponder, run};
+use dasclaw_cli::tools::default_builtins;
+use dasclaw_cli::{EchoResponder, run, run_with_tools};
 
 const DEFAULT_SYSTEM: &str = "You are dasclaw, a headless agent.";
 
@@ -45,7 +46,22 @@ enum Command {
     Run {
         #[command(flatten)]
         provider: ProviderArgs,
+        #[command(flatten)]
+        tools: ToolArgs,
     },
+}
+
+/// Tool-dispatch knobs for the `run` subcommand.
+///
+/// Kept in a flattened group so the future MCP-backed executor can land
+/// next to `--enable-tools` without churning the top-level CLI shape.
+#[derive(Debug, Args)]
+struct ToolArgs {
+    /// Advertise the builtin demo tools (`echo`, `now`) to the model and
+    /// dispatch them locally. Defaults to off so the bare `run`
+    /// subcommand stays a pure chat-completion driver.
+    #[arg(long = "enable-tools", default_value_t = false)]
+    enable_tools: bool,
 }
 
 #[tokio::main]
@@ -71,11 +87,19 @@ async fn real_main() -> Result<()> {
         Command::Echo => run(EchoResponder::new(), &cli.system, prompt)
             .await
             .context("echo agent run failed")?,
-        Command::Run { provider } => {
+        Command::Run { provider, tools } => {
             let responder = build_responder(&provider).context("building LLM responder")?;
-            run(responder, &cli.system, prompt)
-                .await
-                .context("LLM agent run failed")?
+            if tools.enable_tools {
+                let executor = default_builtins();
+                let definitions = executor.definitions();
+                run_with_tools(responder, executor, definitions, &cli.system, prompt)
+                    .await
+                    .context("LLM agent (with tools) run failed")?
+            } else {
+                run(responder, &cli.system, prompt)
+                    .await
+                    .context("LLM agent run failed")?
+            }
         }
     };
     println!("{reply}");

--- a/crates/dasclaw_cli/src/tools.rs
+++ b/crates/dasclaw_cli/src/tools.rs
@@ -30,8 +30,7 @@ use serde_json::{Value, json};
 ///
 /// Returning `Err(_)` becomes a [`ToolResult`] with `is_error = true`,
 /// which the runtime feeds back to the model as a tool_result block.
-pub type ToolHandler =
-    Arc<dyn Fn(&Value) -> Result<String, String> + Send + Sync + 'static>;
+pub type ToolHandler = Arc<dyn Fn(&Value) -> Result<String, String> + Send + Sync + 'static>;
 
 /// One named CLI tool: its LLM-facing schema plus its local handler.
 #[derive(Clone)]
@@ -154,9 +153,7 @@ pub fn builtin_echo() -> CliTool {
             args.get("message")
                 .and_then(Value::as_str)
                 .map(str::to_owned)
-                .ok_or_else(|| {
-                    "echo: missing required string argument `message`".to_string()
-                })
+                .ok_or_else(|| "echo: missing required string argument `message`".to_string())
         },
     )
 }
@@ -264,11 +261,7 @@ mod tests {
     #[test]
     fn definitions_are_sorted_and_complete() {
         let executor = default_builtins();
-        let names: Vec<_> = executor
-            .definitions()
-            .into_iter()
-            .map(|d| d.name)
-            .collect();
+        let names: Vec<_> = executor.definitions().into_iter().map(|d| d.name).collect();
         assert_eq!(names, vec!["echo".to_string(), "now".to_string()]);
     }
 }

--- a/crates/dasclaw_cli/src/tools.rs
+++ b/crates/dasclaw_cli/src/tools.rs
@@ -1,0 +1,274 @@
+//! Static tool dispatch for [`dasclaw_cli`] (ADR-153 §4.4 step 6).
+//!
+//! Wires a minimal [`dasclaw_runtime::ToolExecutor`] into the headless
+//! CLI so the agent can complete a real tool-using turn. The executor is
+//! deliberately self-contained — no MCP, no sandbox, no filesystem
+//! mutation — so it stays decoupled from the still-pending `Tool` trait
+//! decoupling work in ironclaw (see ADR-153 §4.1).
+//!
+//! Two builtin demo tools ship with the CLI:
+//!
+//! - [`builtin_echo`] — returns the `message` argument verbatim.
+//! - [`builtin_now`] — returns the current epoch seconds.
+//!
+//! Higher-level integrations (MCP gateways, dasclaw_fs_tools, ...) are
+//! expected to plug their own [`ToolExecutor`] impls in via
+//! [`crate::run_with_tools`].
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use async_trait::async_trait;
+use dasclaw_core::messages::{ToolCall, ToolDefinition, ToolResult};
+use dasclaw_core::traits::HostError;
+use dasclaw_runtime::ToolExecutor;
+use serde_json::{Value, json};
+
+/// Pure-function tool handler: takes the parsed `arguments` JSON object
+/// and returns either a textual success payload or a textual error.
+///
+/// Returning `Err(_)` becomes a [`ToolResult`] with `is_error = true`,
+/// which the runtime feeds back to the model as a tool_result block.
+pub type ToolHandler =
+    Arc<dyn Fn(&Value) -> Result<String, String> + Send + Sync + 'static>;
+
+/// One named CLI tool: its LLM-facing schema plus its local handler.
+#[derive(Clone)]
+pub struct CliTool {
+    /// LLM-facing definition (name + description + JSON schema). Sent
+    /// verbatim to the provider via [`crate::run_with_tools`].
+    pub definition: ToolDefinition,
+    /// Local handler invoked when the model calls the tool.
+    pub handler: ToolHandler,
+}
+
+impl CliTool {
+    /// Build a [`CliTool`] from its parts.
+    pub fn new(
+        name: impl Into<String>,
+        description: impl Into<String>,
+        parameters: Value,
+        handler: impl Fn(&Value) -> Result<String, String> + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            definition: ToolDefinition {
+                name: name.into(),
+                description: description.into(),
+                parameters,
+            },
+            handler: Arc::new(handler),
+        }
+    }
+}
+
+/// In-memory [`ToolExecutor`] that dispatches by tool name.
+///
+/// Mirrors the design of `claw-code`'s `StaticToolExecutor` but uses an
+/// async-trait impl so it slots into [`dasclaw_runtime::AgentBuilder`]
+/// directly.
+#[derive(Default, Clone)]
+pub struct StaticToolExecutor {
+    tools: BTreeMap<String, CliTool>,
+}
+
+impl StaticToolExecutor {
+    /// Build an empty executor.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register a tool. Later registrations with the same name replace
+    /// earlier ones — same semantics as `BTreeMap::insert`.
+    #[must_use]
+    pub fn with_tool(mut self, tool: CliTool) -> Self {
+        self.tools.insert(tool.definition.name.clone(), tool);
+        self
+    }
+
+    /// All tool definitions, in deterministic name order. Pass this to
+    /// [`crate::run_with_tools`] so the model sees the same set the
+    /// executor can serve.
+    pub fn definitions(&self) -> Vec<ToolDefinition> {
+        self.tools.values().map(|t| t.definition.clone()).collect()
+    }
+
+    /// Number of registered tools.
+    pub fn len(&self) -> usize {
+        self.tools.len()
+    }
+
+    /// Whether the executor has no registered tools.
+    pub fn is_empty(&self) -> bool {
+        self.tools.is_empty()
+    }
+}
+
+#[async_trait]
+impl ToolExecutor for StaticToolExecutor {
+    async fn execute(&self, call: &ToolCall) -> Result<ToolResult, HostError> {
+        // Unknown tool → feed the failure back to the model rather than
+        // bubbling a HostError. The runtime treats `is_error = true` as a
+        // tool_result error the LLM can recover from.
+        let Some(tool) = self.tools.get(&call.name) else {
+            return Ok(ToolResult {
+                tool_call_id: call.id.clone(),
+                name: call.name.clone(),
+                content: format!("unknown tool: {}", call.name),
+                is_error: true,
+            });
+        };
+        let (content, is_error) = match (tool.handler)(&call.arguments) {
+            Ok(c) => (c, false),
+            Err(e) => (e, true),
+        };
+        Ok(ToolResult {
+            tool_call_id: call.id.clone(),
+            name: call.name.clone(),
+            content,
+            is_error,
+        })
+    }
+}
+
+/// Builtin: `echo` — returns the `message` argument verbatim.
+///
+/// JSON schema: `{ "message": string }`. Missing or non-string `message`
+/// returns an error to the model.
+pub fn builtin_echo() -> CliTool {
+    CliTool::new(
+        "echo",
+        "Return the `message` argument back to the caller verbatim. \
+         Useful for smoke-testing the agent's tool-use loop.",
+        json!({
+            "type": "object",
+            "properties": {
+                "message": {
+                    "type": "string",
+                    "description": "The text to echo back."
+                }
+            },
+            "required": ["message"]
+        }),
+        |args| {
+            args.get("message")
+                .and_then(Value::as_str)
+                .map(str::to_owned)
+                .ok_or_else(|| {
+                    "echo: missing required string argument `message`".to_string()
+                })
+        },
+    )
+}
+
+/// Builtin: `now` — returns the current Unix epoch seconds as a string.
+///
+/// No arguments. Useful for sanity-checking that the agent can drive a
+/// tool with side effects (clock read).
+pub fn builtin_now() -> CliTool {
+    CliTool::new(
+        "now",
+        "Return the current Unix epoch time in seconds as a decimal \
+         integer string. Takes no arguments.",
+        json!({
+            "type": "object",
+            "properties": {}
+        }),
+        |_args| {
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .map(|d| d.as_secs().to_string())
+                .map_err(|e| format!("now: system clock is before UNIX_EPOCH: {e}"))
+        },
+    )
+}
+
+/// Returns a [`StaticToolExecutor`] preloaded with the two builtin demo
+/// tools ([`builtin_echo`], [`builtin_now`]).
+///
+/// Used by `dasclaw-cli run --enable-tools` and by integration tests.
+pub fn default_builtins() -> StaticToolExecutor {
+    StaticToolExecutor::new()
+        .with_tool(builtin_echo())
+        .with_tool(builtin_now())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn call(name: &str, args: Value) -> ToolCall {
+        ToolCall {
+            id: "call-1".to_string(),
+            name: name.to_string(),
+            arguments: args,
+            reasoning: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn req_dasclaw_cli_tools_a1_unknown_tool_returns_error_result() {
+        let executor = default_builtins();
+        let result = executor
+            .execute(&call("does-not-exist", json!({})))
+            .await
+            .expect("executor returned HostError unexpectedly");
+        assert!(result.is_error, "unknown tool must flag is_error=true");
+        assert!(
+            result.content.contains("unknown tool"),
+            "expected diagnostic message, got: {}",
+            result.content
+        );
+        assert_eq!(result.tool_call_id, "call-1");
+    }
+
+    #[tokio::test]
+    async fn req_dasclaw_cli_tools_a2_echo_returns_message_verbatim() {
+        let executor = default_builtins();
+        let result = executor
+            .execute(&call("echo", json!({ "message": "hello" })))
+            .await
+            .expect("executor returned HostError unexpectedly");
+        assert!(!result.is_error);
+        assert_eq!(result.content, "hello");
+        assert_eq!(result.name, "echo");
+    }
+
+    #[tokio::test]
+    async fn req_dasclaw_cli_tools_a3_echo_missing_argument_is_tool_error() {
+        let executor = default_builtins();
+        let result = executor
+            .execute(&call("echo", json!({})))
+            .await
+            .expect("executor returned HostError unexpectedly");
+        assert!(result.is_error);
+        assert!(result.content.contains("missing required"));
+    }
+
+    #[tokio::test]
+    async fn req_dasclaw_cli_tools_a4_now_returns_decimal_seconds() {
+        let executor = default_builtins();
+        let result = executor
+            .execute(&call("now", json!({})))
+            .await
+            .expect("executor returned HostError unexpectedly");
+        assert!(!result.is_error);
+        // Parse as u64 to confirm it is a decimal integer string.
+        let secs: u64 = result
+            .content
+            .parse()
+            .expect("`now` should return decimal seconds");
+        assert!(secs > 1_700_000_000, "epoch seconds should be post-2023");
+    }
+
+    #[test]
+    fn definitions_are_sorted_and_complete() {
+        let executor = default_builtins();
+        let names: Vec<_> = executor
+            .definitions()
+            .into_iter()
+            .map(|d| d.name)
+            .collect();
+        assert_eq!(names, vec!["echo".to_string(), "now".to_string()]);
+    }
+}

--- a/crates/dasclaw_cli/tests/tool_e2e.rs
+++ b/crates/dasclaw_cli/tests/tool_e2e.rs
@@ -1,0 +1,112 @@
+//! Integration test for [`dasclaw_cli::run_with_tools`].
+//!
+//! ADR-153 §4.4 step 6 proof: a `dasclaw_runtime::Agent` constructed
+//! from `build_responder` + `tools::default_builtins` runs a full
+//! two-turn tool dispatch loop against a wiremock OpenAI-Chat-Completions
+//! server. Turn 1 the model emits a `tool_call`, the local
+//! [`StaticToolExecutor`](dasclaw_cli::tools::StaticToolExecutor) runs
+//! the `echo` builtin, and turn 2 the model returns the final text.
+
+use dasclaw_cli::provider::{ProviderArgs, ProviderKind, build_responder};
+use dasclaw_cli::run_with_tools;
+use dasclaw_cli::tools::default_builtins;
+use serde_json::json;
+use wiremock::matchers::{header, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+const TEST_API_KEY: &str = "sk-test";
+
+fn tool_call_body() -> serde_json::Value {
+    json!({
+        "id": "chatcmpl-tool-call",
+        "object": "chat.completion",
+        "model": "gpt-4o-mini",
+        "choices": [{
+            "index": 0,
+            "message": {
+                "role": "assistant",
+                "content": null,
+                "tool_calls": [{
+                    "id": "call_echo_1",
+                    "type": "function",
+                    "function": {
+                        "name": "echo",
+                        "arguments": "{\"message\":\"hello-from-tool\"}"
+                    }
+                }]
+            },
+            "finish_reason": "tool_calls"
+        }],
+        "usage": { "prompt_tokens": 5, "completion_tokens": 8 }
+    })
+}
+
+fn final_text_body() -> serde_json::Value {
+    json!({
+        "id": "chatcmpl-final",
+        "object": "chat.completion",
+        "model": "gpt-4o-mini",
+        "choices": [{
+            "index": 0,
+            "message": {
+                "role": "assistant",
+                "content": "tool said: hello-from-tool"
+            },
+            "finish_reason": "stop"
+        }],
+        "usage": { "prompt_tokens": 12, "completion_tokens": 6 }
+    })
+}
+
+#[tokio::test]
+async fn req_dasclaw_cli_tools_e2e_echo_tool_round_trips_through_agent() {
+    let server = MockServer::start().await;
+
+    // Turn 1: the assistant emits a tool_call. `up_to_n_times(1)` ensures
+    // wiremock falls through to the second mock on the next request.
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .and(header(
+            "authorization",
+            format!("Bearer {TEST_API_KEY}").as_str(),
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_json(tool_call_body()))
+        .up_to_n_times(1)
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // Turn 2: after the tool_result is fed back, the assistant finalizes.
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .and(header(
+            "authorization",
+            format!("Bearer {TEST_API_KEY}").as_str(),
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_json(final_text_body()))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let args = ProviderArgs {
+        provider: ProviderKind::OpenaiCompat,
+        model: Some("gpt-4o-mini".to_string()),
+        base_url: Some(server.uri()),
+        api_key: Some(TEST_API_KEY.to_string()),
+    };
+    let responder = build_responder(&args).expect("responder builds");
+    let executor = default_builtins();
+    let definitions = executor.definitions();
+
+    let reply = run_with_tools(
+        responder,
+        executor,
+        definitions,
+        "You are a test agent.",
+        "please call echo",
+    )
+    .await
+    .expect("agent run with tools succeeds");
+
+    assert_eq!(reply.trim(), "tool said: hello-from-tool");
+}


### PR DESCRIPTION
Re-open of #804 after its base branch (#802) was deleted.

Closes #804

Original body: https://github.com/Linnanli/xClaw/pull/804