### PR TITLE
feat(dasclaw_cli): HTTP MCP transport + CompositeToolExecutor (ADR-153 §4.4.5 step 8 closeout)

### DIFF
--- a/crates/dasclaw_cli/src/main.rs
+++ b/crates/dasclaw_cli/src/main.rs
@@ -7,10 +7,11 @@
 //! - `run` — wires a real `dasclaw_llm_provider`-backed responder via
 //!   [`dasclaw_cli::provider::ProviderArgs`] (step 5). Honours
 //!   `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `DASCLAW_API_KEY`.
-//!   Tool dispatch is opt-in via either `--enable-tools` (builtin
-//!   `echo` / `now`, step 6) or `--mcp-config <path>` (MCP servers,
-//!   step 8). The two flags are mutually exclusive in this sub-step;
-//!   a future composite executor will let them combine.
+//!   Tool dispatch is opt-in via `--enable-tools` (builtin
+//!   `echo` / `now`, step 6) and/or `--mcp-config <path>` (MCP servers
+//!   over stdio or HTTP, step 8). When both flags are set the two
+//!   tool sources are merged via
+//!   [`dasclaw_runtime::CompositeToolExecutor`].
 //!
 //! Both subcommands accept `--prompt` or read the user prompt from stdin
 //! and share `--system` for the system message.
@@ -18,6 +19,7 @@
 use std::io::{self, Read};
 use std::path::PathBuf;
 use std::process::ExitCode;
+use std::sync::Arc;
 
 use anyhow::{Context, Result};
 use clap::{Args, Parser, Subcommand};
@@ -25,7 +27,7 @@ use dasclaw_cli::mcp::load_executor as load_mcp_executor;
 use dasclaw_cli::provider::{ProviderArgs, build_responder};
 use dasclaw_cli::tools::default_builtins;
 use dasclaw_cli::{EchoResponder, run, run_with_tools};
-
+use dasclaw_runtime::{CompositeToolExecutor, ToolExecutor};
 const DEFAULT_SYSTEM: &str = "You are dasclaw, a headless agent.";
 
 /// Headless dasclaw agent CLI.
@@ -61,23 +63,20 @@ enum Command {
 ///
 /// Kept in a flattened group so future tool sources land here without
 /// churning the top-level CLI shape. `--enable-tools` and
-/// `--mcp-config` are currently mutually exclusive (clap enforces this);
-/// composing them is deferred to a follow-up that introduces a
-/// composite [`ToolExecutor`].
+/// `--mcp-config` may be combined: when both are set the two
+/// executors are merged via
+/// [`dasclaw_runtime::CompositeToolExecutor`].
 #[derive(Debug, Args)]
 struct ToolArgs {
     /// Advertise the builtin demo tools (`echo`, `now`) to the model and
     /// dispatch them locally. Defaults to off so the bare `run`
     /// subcommand stays a pure chat-completion driver.
-    #[arg(
-        long = "enable-tools",
-        default_value_t = false,
-        conflicts_with = "mcp_config"
-    )]
+    #[arg(long = "enable-tools", default_value_t = false)]
     enable_tools: bool,
 
-    /// Path to an MCP server config JSON file. Each entry is spawned as
-    /// a stdio child process; its tools are advertised to the model
+    /// Path to an MCP server config JSON file. Each entry is started
+    /// either as a stdio child process (`command` field) or as an HTTP
+    /// client (`url` field); its tools are advertised to the model
     /// under the `<server_name>_<tool>` qualified name.
     #[arg(long = "mcp-config")]
     mcp_config: Option<PathBuf>,
@@ -108,24 +107,56 @@ async fn real_main() -> Result<()> {
             .context("echo agent run failed")?,
         Command::Run { provider, tools } => {
             let responder = build_responder(&provider).context("building LLM responder")?;
-            if let Some(path) = tools.mcp_config.as_deref() {
-                let executor = load_mcp_executor(path)
+
+            // Step 8 (ADR-153 §4.4.5): assemble the tool stack from
+            // whichever sources the user opted in to. Branch explicitly
+            // on the four (enable_tools × mcp_config) combinations to
+            // keep the `run_with_tools` generic signature happy.
+            match (tools.enable_tools, tools.mcp_config.as_deref()) {
+                (false, None) => run(responder, &cli.system, prompt)
                     .await
-                    .with_context(|| format!("loading MCP config {}", path.display()))?;
-                let definitions = executor.definitions();
-                run_with_tools(responder, executor, definitions, &cli.system, prompt)
-                    .await
-                    .context("LLM agent (with MCP tools) run failed")?
-            } else if tools.enable_tools {
-                let executor = default_builtins();
-                let definitions = executor.definitions();
-                run_with_tools(responder, executor, definitions, &cli.system, prompt)
-                    .await
-                    .context("LLM agent (with tools) run failed")?
-            } else {
-                run(responder, &cli.system, prompt)
-                    .await
-                    .context("LLM agent run failed")?
+                    .context("LLM agent run failed")?,
+                (true, None) => {
+                    let executor = default_builtins();
+                    let definitions = executor.definitions();
+                    run_with_tools(responder, executor, definitions, &cli.system, prompt)
+                        .await
+                        .context("LLM agent (with builtin tools) run failed")?
+                }
+                (false, Some(path)) => {
+                    let executor = load_mcp_executor(path)
+                        .await
+                        .with_context(|| format!("loading MCP config {}", path.display()))?;
+                    let definitions = executor.definitions();
+                    run_with_tools(responder, executor, definitions, &cli.system, prompt)
+                        .await
+                        .context("LLM agent (with MCP tools) run failed")?
+                }
+                (true, Some(path)) => {
+                    let static_exec = default_builtins();
+                    let static_defs = static_exec.definitions();
+                    let static_names: Vec<String> =
+                        static_defs.iter().map(|d| d.name.clone()).collect();
+
+                    let mcp_exec = load_mcp_executor(path)
+                        .await
+                        .with_context(|| format!("loading MCP config {}", path.display()))?;
+                    let mcp_defs = mcp_exec.definitions();
+                    let mcp_names: Vec<String> = mcp_defs.iter().map(|d| d.name.clone()).collect();
+
+                    let mut definitions = static_defs;
+                    definitions.extend(mcp_defs);
+
+                    let composite = CompositeToolExecutor::new([
+                        (static_names, Arc::new(static_exec) as Arc<dyn ToolExecutor>),
+                        (mcp_names, Arc::new(mcp_exec) as Arc<dyn ToolExecutor>),
+                    ])
+                    .context("merging tool executors (duplicate tool name?)")?;
+
+                    run_with_tools(responder, composite, definitions, &cli.system, prompt)
+                        .await
+                        .context("LLM agent (with composite tools) run failed")?
+                }
             }
         }
     };

--- a/crates/dasclaw_cli/src/mcp.rs
+++ b/crates/dasclaw_cli/src/mcp.rs
@@ -1,8 +1,9 @@
 //! MCP server wiring for the headless CLI (ADR-153 §4.4 sub-step 8).
 //!
-//! Loads a JSON file listing one or more MCP servers, spawns each one
-//! over stdio via [`dasclaw_mcp::StdioMcpTransport`], wraps them as
-//! [`dasclaw_mcp::McpClient`] instances and builds a
+//! Loads a JSON file listing one or more MCP servers, starts each one
+//! via the appropriate [`dasclaw_mcp`] transport (`StdioMcpTransport`
+//! for stdio entries or `HttpMcpTransport` for HTTP entries), wraps
+//! them as [`dasclaw_mcp::McpClient`] instances and builds a
 //! [`dasclaw_mcp::McpToolExecutor`] that the CLI feeds into
 //! [`crate::run_with_tools`].
 //!
@@ -16,22 +17,31 @@
 //!       "command": "npx",
 //!       "args": ["@modelcontextprotocol/server-filesystem", "/tmp"],
 //!       "env": { "EXTRA": "value" }
+//!     },
+//!     {
+//!       "name": "remote",
+//!       "url": "https://mcp.example.com/v1",
+//!       "headers": { "Authorization": "Bearer ${TOKEN}" }
 //!     }
 //!   ]
 //! }
 //! ```
 //!
-//! This sub-step only supports stdio servers. HTTP/UDS support stays in
-//! `dasclaw_mcp` and is reachable from code; the CLI surface picks the
-//! smallest config that's still useful from a single `--mcp-config`
-//! flag. Hosted (OAuth-backed) servers are out of scope because the CLI
-//! has no persistent secrets store.
+//! Entries are dispatched by shape: an entry with `command` is treated
+//! as stdio; an entry with `url` is treated as HTTP. Mixing both
+//! `command` and `url` in the same entry, or omitting both, is a config
+//! error reported at parse time.
+//!
+//! Hosted (OAuth-backed) servers are out of scope for the CLI because
+//! it has no persistent secrets store; the HTTP transport here uses
+//! whatever static headers the user provides in `headers` and does not
+//! wire `Mcp-Session-Id`/`SecretsStore`.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use dasclaw_mcp::{McpClient, McpToolExecutor, StdioMcpTransport};
+use dasclaw_mcp::{HttpMcpTransport, McpClient, McpToolExecutor, StdioMcpTransport};
 use serde::Deserialize;
 
 /// Errors surfaced while loading and starting MCP servers from a config
@@ -77,21 +87,48 @@ pub struct McpConfig {
     pub servers: Vec<McpServerSpec>,
 }
 
-/// One stdio MCP server entry.
+/// One MCP server entry. Logical `name` lives at the top level; the
+/// transport-specific fields are flattened in so the JSON stays flat
+/// (`{ "name": "fs", "command": "npx", ... }` or
+/// `{ "name": "fs", "url": "https://...", ... }`).
 #[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
 pub struct McpServerSpec {
     /// Logical server name. Used both for log lines and as the prefix in
     /// the qualified tool name (`<name>_<tool>`).
     pub name: String,
-    /// Executable to spawn (e.g. `npx`, `uvx`, `/usr/bin/my-server`).
-    pub command: String,
-    /// Arguments passed to `command`. Default empty.
-    #[serde(default)]
-    pub args: Vec<String>,
-    /// Extra environment variables for the child process. Default empty.
-    /// The parent process's environment is also inherited.
-    #[serde(default)]
-    pub env: BTreeMap<String, String>,
+    /// Transport-specific configuration. Selected by which fields the
+    /// entry actually carries (`command` ⇒ stdio, `url` ⇒ HTTP).
+    #[serde(flatten)]
+    pub transport: McpTransportSpec,
+}
+
+/// Transport selector for an MCP server entry. `untagged` so the JSON
+/// shape matches whichever variant's required fields are present.
+#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum McpTransportSpec {
+    /// Local subprocess launched over stdio.
+    Stdio {
+        /// Executable to spawn (e.g. `npx`, `uvx`, `/usr/bin/my-server`).
+        command: String,
+        /// Arguments passed to `command`. Default empty.
+        #[serde(default)]
+        args: Vec<String>,
+        /// Extra environment variables for the child process. Default
+        /// empty. The parent process's environment is also inherited.
+        #[serde(default)]
+        env: BTreeMap<String, String>,
+    },
+    /// Remote MCP server reached over HTTP (Streamable HTTP transport).
+    Http {
+        /// Full URL of the MCP endpoint (e.g.
+        /// `https://mcp.example.com/v1`).
+        url: String,
+        /// Static headers applied to every request (e.g.
+        /// `Authorization: Bearer …`). Default empty.
+        #[serde(default)]
+        headers: BTreeMap<String, String>,
+    },
 }
 
 impl McpConfig {
@@ -102,7 +139,7 @@ impl McpConfig {
     }
 }
 
-/// Read `path`, spawn one stdio MCP server per entry, and return an
+/// Read `path`, start one MCP server per entry, and return an
 /// [`McpToolExecutor`] aware of every advertised tool.
 ///
 /// This function is async because each server's `tools/list` round-trip
@@ -120,28 +157,46 @@ pub async fn load_executor(path: &Path) -> Result<McpToolExecutor, McpConfigErro
     spawn_executor(config).await
 }
 
-/// Spawn every server in `config` and return the assembled executor.
+/// Start every server in `config` and return the assembled executor.
 ///
-/// Split out from [`load_executor`] so unit tests can exercise the spawn
-/// branch with an in-memory config (no file I/O).
+/// Split out from [`load_executor`] so unit tests can exercise the
+/// transport branches with in-memory configs (no file I/O).
 async fn spawn_executor(config: McpConfig) -> Result<McpToolExecutor, McpConfigError> {
     let mut clients: Vec<Arc<McpClient>> = Vec::with_capacity(config.servers.len());
     for spec in config.servers {
-        let transport =
-            StdioMcpTransport::spawn(spec.name.clone(), &spec.command, &spec.args, spec.env)
-                .await
-                .map_err(|source| McpConfigError::Spawn {
-                    server: spec.name.clone(),
-                    source,
-                })?;
-        let client = McpClient::new_with_transport(
-            spec.name,
-            Arc::new(transport),
-            None,
-            None,
-            "dasclaw-cli",
-            None,
-        );
+        let McpServerSpec { name, transport } = spec;
+        let client = match transport {
+            McpTransportSpec::Stdio { command, args, env } => {
+                let transport = StdioMcpTransport::spawn(name.clone(), &command, &args, env)
+                    .await
+                    .map_err(|source| McpConfigError::Spawn {
+                        server: name.clone(),
+                        source,
+                    })?;
+                McpClient::new_with_transport(
+                    name,
+                    Arc::new(transport),
+                    None,
+                    None,
+                    "dasclaw-cli",
+                    None,
+                )
+            }
+            McpTransportSpec::Http { url, headers } => {
+                // BTreeMap → HashMap for HttpMcpTransport.
+                let header_map: HashMap<String, String> = headers.into_iter().collect();
+                let transport =
+                    HttpMcpTransport::new(url, name.clone()).with_custom_headers(header_map);
+                McpClient::new_with_transport(
+                    name,
+                    Arc::new(transport),
+                    None,
+                    None,
+                    "dasclaw-cli",
+                    None,
+                )
+            }
+        };
         clients.push(Arc::new(client));
     }
     McpToolExecutor::from_clients(clients)
@@ -160,9 +215,14 @@ mod tests {
                 .expect("parse");
         assert_eq!(cfg.servers.len(), 1);
         assert_eq!(cfg.servers[0].name, "fs");
-        assert_eq!(cfg.servers[0].command, "uvx");
-        assert!(cfg.servers[0].args.is_empty());
-        assert!(cfg.servers[0].env.is_empty());
+        match &cfg.servers[0].transport {
+            McpTransportSpec::Stdio { command, args, env } => {
+                assert_eq!(command, "uvx");
+                assert!(args.is_empty());
+                assert!(env.is_empty());
+            }
+            other => panic!("expected Stdio, got {other:?}"),
+        }
     }
 
     #[test]
@@ -180,14 +240,19 @@ mod tests {
             }"#,
         )
         .expect("parse");
-        assert_eq!(
-            cfg.servers[0].args,
-            vec![
-                "@modelcontextprotocol/server-filesystem".to_string(),
-                "/tmp".to_string()
-            ]
-        );
-        assert_eq!(cfg.servers[0].env.get("K").map(String::as_str), Some("V"));
+        match &cfg.servers[0].transport {
+            McpTransportSpec::Stdio { args, env, .. } => {
+                assert_eq!(
+                    *args,
+                    vec![
+                        "@modelcontextprotocol/server-filesystem".to_string(),
+                        "/tmp".to_string()
+                    ]
+                );
+                assert_eq!(env.get("K").map(String::as_str), Some("V"));
+            }
+            other => panic!("expected Stdio, got {other:?}"),
+        }
     }
 
     #[test]
@@ -206,14 +271,80 @@ mod tests {
     }
 
     #[test]
-    fn req_dasclaw_cli_mcp_c4_rejects_missing_required_field() {
-        // `command` is required; serde should reject this.
+    fn req_dasclaw_cli_mcp_c4_rejects_entry_without_command_or_url() {
+        // Neither `command` nor `url` ⇒ untagged enum has no matching
+        // variant ⇒ parse error.
         let err = McpConfig::from_json_str(r#"{ "servers": [ { "name": "x" } ] }"#)
             .expect_err("must reject");
+        let msg = err.to_string();
         assert!(
-            err.to_string().contains("command"),
-            "error should mention missing field `command`, got: {err}"
+            msg.contains("variant") || msg.contains("McpTransportSpec") || msg.contains("data"),
+            "error should mention untagged-enum failure, got: {msg}"
         );
+    }
+
+    #[test]
+    fn req_dasclaw_cli_mcp_c8_parses_minimal_http_entry() {
+        let cfg = McpConfig::from_json_str(
+            r#"{ "servers": [ { "name": "remote", "url": "https://mcp.example.com/v1" } ] }"#,
+        )
+        .expect("parse");
+        assert_eq!(cfg.servers[0].name, "remote");
+        match &cfg.servers[0].transport {
+            McpTransportSpec::Http { url, headers } => {
+                assert_eq!(url, "https://mcp.example.com/v1");
+                assert!(headers.is_empty());
+            }
+            other => panic!("expected Http, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn req_dasclaw_cli_mcp_c9_parses_http_with_headers() {
+        let cfg = McpConfig::from_json_str(
+            r#"{
+                "servers": [
+                    {
+                        "name": "remote",
+                        "url": "https://mcp.example.com/v1",
+                        "headers": { "Authorization": "Bearer T", "X-Trace": "1" }
+                    }
+                ]
+            }"#,
+        )
+        .expect("parse");
+        match &cfg.servers[0].transport {
+            McpTransportSpec::Http { headers, .. } => {
+                assert_eq!(
+                    headers.get("Authorization").map(String::as_str),
+                    Some("Bearer T")
+                );
+                assert_eq!(headers.get("X-Trace").map(String::as_str), Some("1"));
+            }
+            other => panic!("expected Http, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn req_dasclaw_cli_mcp_c10_parses_mixed_stdio_and_http_entries() {
+        let cfg = McpConfig::from_json_str(
+            r#"{
+                "servers": [
+                    { "name": "fs",     "command": "npx", "args": ["x"] },
+                    { "name": "remote", "url": "https://m.example.com" }
+                ]
+            }"#,
+        )
+        .expect("parse");
+        assert_eq!(cfg.servers.len(), 2);
+        assert!(matches!(
+            cfg.servers[0].transport,
+            McpTransportSpec::Stdio { .. }
+        ));
+        assert!(matches!(
+            cfg.servers[1].transport,
+            McpTransportSpec::Http { .. }
+        ));
     }
 
     #[tokio::test]
@@ -243,9 +374,11 @@ mod tests {
         let cfg = McpConfig {
             servers: vec![McpServerSpec {
                 name: "ghost".to_string(),
-                command: "/definitely/not/a/binary".to_string(),
-                args: vec![],
-                env: BTreeMap::new(),
+                transport: McpTransportSpec::Stdio {
+                    command: "/definitely/not/a/binary".to_string(),
+                    args: vec![],
+                    env: BTreeMap::new(),
+                },
             }],
         };
         match spawn_executor(cfg).await {

--- a/crates/dasclaw_mcp/src/http_transport.rs
+++ b/crates/dasclaw_mcp/src/http_transport.rs
@@ -52,7 +52,12 @@ impl HttpMcpTransport {
     }
 
     /// Set custom headers that will be sent with every request.
-    #[cfg(test)]
+    ///
+    /// Used by hosts that need to inject static credentials or routing
+    /// hints (e.g. `Authorization` for a bearer-token-protected MCP
+    /// endpoint). Per-request headers from
+    /// [`McpClient`](crate::client::McpClient) (such as `Mcp-Session-Id`)
+    /// are applied on top of these and override on key collision.
     pub fn with_custom_headers(mut self, headers: HashMap<String, String>) -> Self {
         self.custom_headers = headers;
         self

--- a/crates/dasclaw_runtime/src/composite_executor.rs
+++ b/crates/dasclaw_runtime/src/composite_executor.rs
@@ -1,0 +1,204 @@
+//! [`CompositeToolExecutor`] — fan out tool calls across multiple
+//! [`ToolExecutor`]s by tool name.
+//!
+//! ## Why
+//!
+//! Real hosts (the headless CLI, the ironclaw desktop backend, anything
+//! third-party that uses `dasclaw_runtime`) typically draw tools from
+//! more than one source at the same time:
+//!
+//! - a handful of in-process builtins (`echo`, `now`, recorded fixtures)
+//! - one or more MCP servers
+//! - a future skill registry
+//!
+//! Without a composite, a host has to choose **one** [`ToolExecutor`] to
+//! plug into [`AgentBuilder::tool_executor`](crate::AgentBuilder), which
+//! forces an artificial either/or between tool sources. The composite
+//! removes that constraint while keeping the `ToolExecutor` contract
+//! single-method: dispatch is by **tool name**, decided up front at
+//! construction time so the runtime path stays O(1).
+//!
+//! ## Construction contract
+//!
+//! Callers pass a list of `(owned_tool_names, executor)` pairs. The
+//! composite builds an internal `name → executor` map. Tool names must
+//! be **globally unique** across members — duplicates produce a
+//! [`CompositeError::DuplicateTool`] at construction so collisions
+//! surface at wiring time rather than as silent shadowing at runtime.
+//!
+//! ## Unknown tools
+//!
+//! A call with a name that no member owns returns a [`ToolResult`] with
+//! `is_error = true` and `content = "unknown tool: <name>"`. This
+//! matches both [`McpToolExecutor`](https://docs.rs/dasclaw_mcp) and the
+//! CLI's `StaticToolExecutor`, so the model sees a uniform failure shape
+//! regardless of which executor would have owned the call.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use dasclaw_core::messages::{ToolCall, ToolResult};
+use dasclaw_core::traits::HostError;
+
+use crate::agent::ToolExecutor;
+
+/// Errors raised when assembling a [`CompositeToolExecutor`].
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum CompositeError {
+    /// Two members claimed ownership of the same tool name. The wiring
+    /// caller must rename, qualify, or drop one of them.
+    #[error("duplicate tool name across composite members: `{0}`")]
+    DuplicateTool(String),
+}
+
+/// Routes a [`ToolCall`] to one of several wrapped [`ToolExecutor`]s.
+///
+/// See the [module docs](crate::composite_executor) for the design
+/// rationale and construction contract.
+pub struct CompositeToolExecutor {
+    routes: HashMap<String, Arc<dyn ToolExecutor>>,
+}
+
+impl std::fmt::Debug for CompositeToolExecutor {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CompositeToolExecutor")
+            .field("tools", &self.routes.keys().collect::<Vec<_>>())
+            .finish()
+    }
+}
+
+impl CompositeToolExecutor {
+    /// Build a composite from a list of `(owned_tool_names, executor)`
+    /// pairs.
+    ///
+    /// Returns [`CompositeError::DuplicateTool`] if any name appears in
+    /// more than one member.
+    pub fn new<I>(members: I) -> Result<Self, CompositeError>
+    where
+        I: IntoIterator<Item = (Vec<String>, Arc<dyn ToolExecutor>)>,
+    {
+        let mut routes: HashMap<String, Arc<dyn ToolExecutor>> = HashMap::new();
+        for (names, exec) in members {
+            for name in names {
+                if routes.contains_key(&name) {
+                    return Err(CompositeError::DuplicateTool(name));
+                }
+                routes.insert(name, exec.clone());
+            }
+        }
+        Ok(Self { routes })
+    }
+
+    /// Number of tool names this composite can route. Exposed for tests
+    /// and diagnostics; the agent runtime never reads it.
+    pub fn len(&self) -> usize {
+        self.routes.len()
+    }
+
+    /// Whether the composite owns no tools.
+    pub fn is_empty(&self) -> bool {
+        self.routes.is_empty()
+    }
+}
+
+#[async_trait]
+impl ToolExecutor for CompositeToolExecutor {
+    async fn execute(&self, call: &ToolCall) -> Result<ToolResult, HostError> {
+        match self.routes.get(&call.name) {
+            Some(exec) => exec.execute(call).await,
+            None => Ok(ToolResult {
+                tool_call_id: call.id.clone(),
+                name: call.name.clone(),
+                content: format!("unknown tool: {}", call.name),
+                is_error: true,
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::Value;
+
+    /// Trivial in-test executor: every call it accepts echoes a fixed
+    /// `marker` so dispatch tests can verify "which member was hit".
+    struct MarkerExecutor {
+        marker: &'static str,
+    }
+
+    #[async_trait]
+    impl ToolExecutor for MarkerExecutor {
+        async fn execute(&self, call: &ToolCall) -> Result<ToolResult, HostError> {
+            Ok(ToolResult {
+                tool_call_id: call.id.clone(),
+                name: call.name.clone(),
+                content: self.marker.to_string(),
+                is_error: false,
+            })
+        }
+    }
+
+    fn call(name: &str) -> ToolCall {
+        ToolCall {
+            id: format!("id-{name}"),
+            name: name.to_string(),
+            arguments: Value::Null,
+            reasoning: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn req_runtime_composite_d1_dispatches_to_owning_member() {
+        let alpha = Arc::new(MarkerExecutor { marker: "alpha" }) as Arc<dyn ToolExecutor>;
+        let beta = Arc::new(MarkerExecutor { marker: "beta" }) as Arc<dyn ToolExecutor>;
+        let composite = CompositeToolExecutor::new([
+            (vec!["echo".to_string(), "now".to_string()], alpha),
+            (vec!["fs_read".to_string()], beta),
+        ])
+        .expect("construct");
+
+        let echo_res = composite.execute(&call("echo")).await.expect("echo");
+        assert_eq!(echo_res.content, "alpha");
+        assert!(!echo_res.is_error);
+
+        let fs_res = composite.execute(&call("fs_read")).await.expect("fs");
+        assert_eq!(fs_res.content, "beta");
+        assert!(!fs_res.is_error);
+    }
+
+    #[tokio::test]
+    async fn req_runtime_composite_d2_unknown_tool_returns_is_error() {
+        let alpha = Arc::new(MarkerExecutor { marker: "alpha" }) as Arc<dyn ToolExecutor>;
+        let composite =
+            CompositeToolExecutor::new([(vec!["echo".to_string()], alpha)]).expect("construct");
+
+        let res = composite.execute(&call("ghost")).await.expect("ok wrapper");
+        assert!(res.is_error);
+        assert_eq!(res.content, "unknown tool: ghost");
+        assert_eq!(res.name, "ghost");
+        assert_eq!(res.tool_call_id, "id-ghost");
+    }
+
+    #[test]
+    fn req_runtime_composite_d3_rejects_duplicate_tool_name() {
+        let alpha = Arc::new(MarkerExecutor { marker: "alpha" }) as Arc<dyn ToolExecutor>;
+        let beta = Arc::new(MarkerExecutor { marker: "beta" }) as Arc<dyn ToolExecutor>;
+        let err = CompositeToolExecutor::new([
+            (vec!["echo".to_string()], alpha),
+            (vec!["echo".to_string()], beta),
+        ])
+        .expect_err("duplicate");
+        assert_eq!(err, CompositeError::DuplicateTool("echo".to_string()));
+    }
+
+    #[test]
+    fn req_runtime_composite_d4_empty_members_yields_empty_composite() {
+        let composite =
+            CompositeToolExecutor::new(std::iter::empty::<(Vec<String>, Arc<dyn ToolExecutor>)>())
+                .expect("construct");
+        assert!(composite.is_empty());
+        assert_eq!(composite.len(), 0);
+    }
+}

--- a/crates/dasclaw_runtime/src/lib.rs
+++ b/crates/dasclaw_runtime/src/lib.rs
@@ -35,6 +35,7 @@
 //! [`ToolError::from_tool_impl`].
 
 pub mod agent;
+pub mod composite_executor;
 pub mod context;
 pub mod error;
 pub mod feature_flags;
@@ -47,6 +48,7 @@ pub mod secrets;
 pub mod tool;
 
 pub use agent::{Agent, AgentBuilder, AgentConfig, AgentError, AgentResponder, ToolExecutor};
+pub use composite_executor::{CompositeError, CompositeToolExecutor};
 pub use error::ToolError;
 pub use feature_flags::{SharedFeatureFlags, ToolFeatureFlags};
 pub use job::{JobState, StateTransition, TokenBudgetExceeded};


### PR DESCRIPTION
> **Stacked PR** — base 是 `feat/dasclaw-cli-mcp-e2e-fixture`（PR #814），不是 `xClaw`。请**先 merge #814，再 review/merge 本 PR**。本 PR 仅显示 step-8 收尾的增量改动。

## 背景 / 目标

ADR-153 §4.4.5 step 8 收尾两块：
1. **HTTP MCP transport** — CLI 之前只能 spawn 本地 stdio 子进程；CI / serverless 必须能走 HTTP。ADR JSON 示例已含 `url` + `headers` 字段。
2. **CompositeToolExecutor** — `--enable-tools` 与 `--mcp-config` 之前在 clap 层互斥；真实 agent 场景必须同时启用两类 tool 源。ADR §4.4.5 明确要求 composite 求并、按 name 分发。

详细动机：见 issue #815。

## 改动范围

- `crates/dasclaw_mcp/src/http_transport.rs`：`with_custom_headers` 从 `#[cfg(test)]` 改为 `pub`（无逻辑变化），扩展 doc-comment 标明静态 headers 用途。
- `crates/dasclaw_cli/src/mcp.rs`：
  - `McpServerSpec` 改为 `{ name, #[serde(flatten)] transport: McpTransportSpec }`
  - 新 `McpTransportSpec` 是 `#[serde(untagged)]` 枚举：`Stdio { command, args, env }` / `Http { url, headers }`
  - `spawn_executor` 按变体分支：stdio 走 `StdioMcpTransport::spawn`；http 走 `HttpMcpTransport::new(..).with_custom_headers(..)`
  - 测试：c1–c7 沿用；新增 c8 (HTTP minimal)、c9 (HTTP with headers)、c10 (mixed stdio + http)
- `crates/dasclaw_runtime/src/composite_executor.rs`（新）：~180 LOC
  - `CompositeToolExecutor::new(members)`：接 `(tool_names: Vec<String>, executor: Arc<dyn ToolExecutor>)` 对，构造期检测重名并报错
  - `impl ToolExecutor`：按 `call.name` 路由到拥有该 name 的成员；未知 name 返回 `is_error: true` ToolResult
  - 手写 `impl Debug`（让 `expect_err` 等需要 `T: Debug` 的断言可用）
  - 测试 d1–d4 覆盖 dispatch、unknown tool、duplicate detection、empty composite
- `crates/dasclaw_runtime/src/lib.rs`：导出 `composite_executor` 模块 + re-export `CompositeError` / `CompositeToolExecutor`
- `crates/dasclaw_cli/src/main.rs`：
  - 移除 `enable_tools` 上的 `conflicts_with = "mcp_config"`
  - `real_main` dispatch 改成显式 `match (enable_tools, mcp_config)` 四分支；两者皆开时构造 `CompositeToolExecutor`
  - 顶部 doc-comment 更新

## 非目标

- ❌ MCP HTTP OAuth / session-manager（ADR 明确"CLI 暂不接 OAuth"）
- ❌ HTTP headers 通过 secret-store 注入（本 PR 仅支持 JSON 明文静态头）
- ❌ 修改 `ToolExecutor` trait（composite 通过预解析 tool name 列表实现，避免动 trait 表面）
- ❌ `definitions()` 提升为 trait 方法（保持 `StaticToolExecutor` / `McpToolExecutor` 的 inherent method）

## 验证

```text
cargo check -p dasclaw_cli -p dasclaw_mcp --tests          → PASS
cargo nextest run -p dasclaw_cli -p dasclaw_runtime -p dasclaw_mcp
                                                            → 392/392 PASS (230s)
cargo clippy --no-deps -p dasclaw_cli -p dasclaw_runtime -p dasclaw_mcp
  --all-targets -- -D warnings                              → 0 warnings
python3.12 scripts/check_no_panics.py --base origin/xClaw   → OK
python3   scripts/check_no_new_ironclaw_literal.py --base origin/xClaw
                                                            → OK
```

完整 workspace build + clippy + heavy integration 由 CI 兜底（本地不跑，遵 AGENTS.md 节奏）。

## Sources read

- `docs/plans/architecture-refactor/adr-153-headless-cli-binary.md` §4.4 + §4.4.5（step 8 完整范围 + JSON 配置 schema）
- `crates/dasclaw_mcp/src/http_transport.rs:1–100`（确认 `HttpMcpTransport::new` + `with_session_manager` + `with_custom_headers` API）
- `crates/dasclaw_mcp/src/lib.rs:58`（确认 `HttpMcpTransport` 已 re-export）
- `crates/dasclaw_runtime/src/agent.rs:70–110` 与 `:230–260`（确认 `ToolExecutor` trait + `Agent::Builder::tool_executor` 接 `impl ToolExecutor + 'static`）
- `crates/dasclaw_cli/src/lib.rs:85–115`（确认 `run_with_tools<R, E: ToolExecutor + 'static>` 泛型签名，复用而无需新增 `_arc` 变体）

## Cross-cuts

- **类A**：本 PR 无新增 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量。grep guard 通过。

## ADR / Issue

- Closes #815
- ADR-153 §4.4.5 step 8 至此完整收尾（stdio 子进程 + HTTP 静态 headers + composite tool 求并）

## 后续

- 若未来需要 HTTP OAuth / per-server secret-ref：在 `McpTransportSpec::Http` 上扩 `auth: Option<HttpAuthSpec>` 字段，复用 `dasclaw_runtime::secrets`
- 若 ironclaw desktop backend 需要 builtin + MCP + IDE-tools 三源合并：直接复用 `dasclaw_runtime::CompositeToolExecutor`