### PR TITLE
docs(adr-153): mark §4.4 main flow closed (step 6/7/8 + milestone)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,6 +125,10 @@
     - base 分支不是 `xClaw` 而是上一个 feature branch
     - merge 顺序
     - “请先 merge #X，再看本 PR”
+    - **合并下层 PR 时，必须在以下两条路径里二选一，禁止两条都不做就直接 squash + delete branch**：
+      - **路径 A（推荐）**：合并下层 PR 时**不要勾选 "Delete branch"**，等所有 stacked 上层 PR 都已 rebase + 合并完，再统一清理分支
+      - **路径 B**：合并下层 PR 后，**在下层分支被删之前**，立刻在 GitHub 上把上层 PR 的 base 切到 `xClaw`（或下一层仍存活的 base）
+    - 若两条路径都没做、下层分支已删，GitHub 会**自动关闭上层 PR 且无法 reopen**（GraphQL 报 "base ref 已删，无法 reopen"），届时只能本地 `git rebase --onto origin/<base> <lower-tip>` 后**新开 PR 替代**，原 PR 编号永久失效。实证：2026-05-25 #816 因合 #814 后 base 被删自动关闭，被迫开 #817 替代
 8. 开完 PR 后，**必须用 `gh pr checks <PR#> --watch --fail-fast` 等 CI**（事件驱动，CI 一结束就返回）。**禁止用 `sleep N && gh pr checks` 轮询**——`sleep` 既浪费时间又拿不到精确完成点，违反本规约。把 watch 输出的结果同步给用户。
 9. 若当前闭环 milestone 已完成，按“会话轮换原则”判断是否该建议新会话
 
@@ -139,6 +143,7 @@
 
 - ❌ 还没跑基本验证就开 PR
 - ❌ stacked PR 不写 base / merge 顺序
+- ❌ 合并 stacked 下层 PR 时既未保留分支、也未提前把上层 PR 的 base 切到 xClaw（会导致上层 PR 自动关闭且无法 reopen）
 - ❌ PR 标题和 commit / 实际改动边界不一致
 - ❌ 一个 PR 混入多个互不相干的主题
 - ❌ 明明已经完成闭环 milestone，却继续在同一会话无限追加新阶段

--- a/docs/plans/architecture-refactor/31-target-architecture.md
+++ b/docs/plans/architecture-refactor/31-target-architecture.md
@@ -1,5 +1,13 @@
 # 31 — 目标架构（边界清晰、可复用）
 
+> **v2.7 (2026-05-25)** · ADR-153 §4.4 主流程收尾（基于已合并 PR #800 / #802 / #804 / #806 / #812 / #814 / #817）：
+>   1. **ADR-153 §4.4 step 6 落点**：`crates/dasclaw_cli` 引入 `tools` 模块（`StaticToolExecutor` + `default_builtins()` 内置 `echo` / `now`），新增 `run --enable-tools` 开关；`dasclaw_cli::run_with_tools` 作为第二个库入口与 `run` 并存，不破坏零工具路径。证明 headless agent 可在零 desktop 依赖下完成 LLM ↔ 本地工具的完整往返（PR #804）。
+>   2. **ADR-153 §4.4 step 7 落点**：`dasclaw_mcp` 新增 `McpToolExecutor`，把一个或多个 `Arc<McpClient>` 包成 `dasclaw_runtime::ToolExecutor`；工具名按 `<server>_<tool>` 限定避免多 server 冲突；未知工具 / 传输错误一律返回 `is_error=true` 的 `ToolResult`，喂回 LLM 而不是抛进 agent loop。该桥接住在 `dasclaw_mcp` 而非 `dasclaw_cli`，因为任何无头宿主都需要它（PR #806）。
+>   3. **ADR-153 §4.4 step 8 落点**：`crates/dasclaw_cli` 新增 `mcp` 模块（stdio + HTTP 两种 transport，按 JSON config entry 形状路由），新增 `run --mcp-config <path>` 子开关；`dasclaw_runtime` 新增 `CompositeToolExecutor`，把 `StaticToolExecutor` 与 `McpToolExecutor` 按工具名求并、按 name 分发，`--enable-tools` 与 `--mcp-config` 可同时启用。配 `tests/mcp_e2e.rs` 端到端测试（stdio 子进程 + e1 成功 + e2 未知工具错误注入）。`#816 → #817` 实证：合并 stacked 下层 PR 时未保留分支也未提前切上层 base，会触发 GitHub 自动关闭且无法 reopen 的失败模式，AGENTS.md "标准流程" §7 已新增"路径 A / 路径 B"硬规则与对应禁止事项（PR #812 + #814 + #817）。
+>   4. **ADR-153 主流程闭环宣告**：step 1（F3.x）/ step 2（dasclaw_runtime）/ step 4 ~ 8（CLI 五子步）全部落地；step 3（dasclaw_session）按 ADR 原文「等到有第二个调用方时再抽」保持暂搁；§4.4.6 必要性表里标"必要"的 4 项全部完成，"暂不必要"的 5 项（OAuth-backed MCP / 审批 / streaming / 工具白名单 / inline `--mcp-stdio` flag）按计划留给后续 ADR。
+>   5. **crate 总数**：仍为 47；本期无新增 crate，全部能力以模块形式落入已有 `dasclaw_cli` / `dasclaw_runtime` / `dasclaw_mcp`。
+> 本次升级是状态同步性质，不改架构决策，不重画 §1 总览图。
+
 > **v2.6 (2026-05-25)** · ADR-156 落地收尾（基于已合并 PR #784 / #786 / #788 / #790 / #792）：
 >   1. **§4.6 F4.6 工具壳全部执行完毕**：8 个子波次 F4.6.1 ~ F4.6.8 + §6.4 mod.rs 薄壳化对应 PR 全部合入 xClaw。原 v2.5 "计划落点"现转为"已落地"状态（详见 §4.6 表格的"PR / 状态"列）。
 >   2. **F4.6.3 `dasclaw_memory_tools` 取消下沉**：按 [ADR-156 §6.3.1](adr-156-f46-builtin-tools-landing-decision.md) 决定，`memory` 模块依赖 `runtime` workspace crate（mtime / 大小 / 路径治理），强行下沉会绕过 ADR-153 边界，故 `memory` 留 desktop（与 §4.6 "留桌面 5 类"合并为 6 类：memory / extension / skill / job / routine / message）。

--- a/docs/plans/architecture-refactor/adr-153-headless-agent-framework-draft.md
+++ b/docs/plans/architecture-refactor/adr-153-headless-agent-framework-draft.md
@@ -112,7 +112,7 @@ async fn main() -> anyhow::Result<()> {
 
 为什么这一步独立成 PR 而不是塞进 CLI：`McpToolExecutor` 是一个**通用**桥接，无头 agent 框架的任何宿主（CLI、ironclaw 桌面后端、第三方进程）都会用到它，让它住在 `dasclaw_mcp` 里、不依赖任何 CLI 概念，是正确的分层。
 
-#### 4.4.5 子步骤 8：CLI 接 MCP 服务器（下一步）
+#### 4.4.5 子步骤 8：CLI 接 MCP 服务器（已落地，PR #812 + #814 + #817）
 
 把 #806 的 `McpToolExecutor` 真正接进 `dasclaw-cli`，让用户能在不写代码的情况下把任意 MCP 服务器挂上 agent。设计要点：
 
@@ -152,6 +152,34 @@ async fn main() -> anyhow::Result<()> {
 | OAuth-backed MCP / 审批 / streaming / 工具白名单 | **暂不必要** | 这些都属于「桌面后端 / 企业部署」层的关注点，无头 CLI 的最小目标是验证 dasclaw_* 能独立工作，不应一次性把全部生态搬过来 |
 
 完成这 4 步以后，desktop-client/ironclaw 就是一个**纯粹的「桌面后端业务皮」**——HTTP + 数据库 + 租户 + Web 钩子，里面调 `dasclaw_runtime::Agent` 来真正跑 agent。
+
+#### 4.4.7 主流程完成里程碑（2026-05-25）
+
+§4.4 规划的 5 个 CLI 子步骤（step 4 ~ 8）全部落地：
+
+| 子步 | PR | 内容 |
+|------|------|------|
+| 4 | #800 | CLI 骨架 + `EchoResponder` + `echo` 子命令 |
+| 5 | #802 | `provider` 模块 + `run --provider {anthropic\|openai\|openai_compat\|ollama}` + wiremock e2e |
+| 6 | #804 | `tools` 模块 + `StaticToolExecutor` + `--enable-tools` + `run_with_tools` |
+| 7 | #806 | `dasclaw_mcp::McpToolExecutor`（住在 `dasclaw_mcp`，不在 CLI） |
+| 8 | #812 + #814 + #817 | `mcp` 模块（stdio + HTTP transport）+ `--mcp-config` + `dasclaw_runtime::CompositeToolExecutor` 合并器 |
+
+集成测试就位（[crates/dasclaw_cli/tests/](../../../crates/dasclaw_cli/tests/)）：
+
+- `end_to_end.rs` — echo / provider 基线
+- `live_provider.rs` — wiremock LLM round-trip
+- `tool_e2e.rs` — `--enable-tools` 路径
+- `mcp_e2e.rs` — stdio MCP server 子进程端到端（成功 + 未知工具错误注入）
+
+PR #817 CI 实测 Tests (default) 3m26s 通过、Clippy (default) 11m49s 通过。
+
+**仍待事项（均按 ADR 原文规划留给后续 slice，非本路径阻塞）**：
+
+- step 3 `dasclaw_session`：ADR §4.3 标「可选，等到有第二个调用方时再抽」，当前仍只有 ironclaw 桌面后端一个调用方，暂搁。
+- §4.4.6 列「暂不必要」的 5 项：OAuth-backed MCP / 审批 / streaming / 工具白名单 / inline `--mcp-stdio` flag — 全部属于桌面后端 / 企业部署关注点，按规划另开 ADR。
+
+**过程教训沉淀**：本批次 step 8 的 PR #816 因合并 stacked 下层 PR #814 时 base 分支被同时删除，触发 GitHub 自动关闭且无法 reopen 的失败模式（GraphQL 报 `base ref deleted`），被迫开 #817 替代、原 PR 编号永久失效。AGENTS.md "标准流程" §7 已新增「路径 A / 路径 B」硬规则与对应禁止事项条款。
 
 ## 5. 不属于本 ADR 范围
 


### PR DESCRIPTION
## 背景 / 目标

ADR-153 §4.4 CLI 子步骤 8（HTTP MCP transport + CompositeToolExecutor）已随 #812 + #814 + #817 合入 xClaw，§4.4 全部 5 个子步骤（4 ~ 8）落地完毕。但两份蓝图文档存在叙述滞后：

- [`docs/plans/architecture-refactor/31-target-architecture.md`](docs/plans/architecture-refactor/31-target-architecture.md) v2.6 顶部升级条目只记到 ADR-153 step 5
- [`docs/plans/architecture-refactor/adr-153-headless-agent-framework-draft.md`](docs/plans/architecture-refactor/adr-153-headless-agent-framework-draft.md) §4.4.5 仍标 "下一步"，无主流程完成的统一里程碑章节

本 PR 是纯文档收尾，把 ADR-153 §4.4 主流程的完成状态写进文档真理来源。

## 改动范围

| 文件 | 变更 |
|---|---|
| 31-target-architecture.md | 新增 v2.7 升级条目（5 项），保留 v2.6 全文不动 |
| adr-153-headless-agent-framework-draft.md | §4.4.5 标题改为「已落地，PR #812 + #814 + #817」；新增 §4.4.7「主流程完成里程碑（2026-05-25）」含落点表、集成测试清单、待办、过程教训 |
| AGENTS.md | 「标准流程」§7 stacked PR 注意事项新增「路径 A / 路径 B」硬规则 + #816 → #817 实证记录；「禁止事项」补对应反模式条款 |

## 非目标（What's NOT in this PR）

- 不动任何 Rust 代码 / 测试 / CI / 构建配置
- 不修改 v2.6 之前的历史升级条目
- 不抽 `dasclaw_session`（ADR §4.3 标可选，暂搁）
- 不接 OAuth-backed MCP / 审批 / streaming / 工具白名单 / inline `--mcp-stdio` flag（§4.4.6 "暂不必要"列条目，留给后续 ADR）

## 验证

```bash
# ADR-114 grep guard
python3.12 scripts/check_no_new_ironclaw_literal.py --base origin/xClaw
# → OK: No new .ironclaw / IRONCLAW_BASE_DIR literals introduced.
```

无代码改动，无需 `cargo check` / `cargo build` / `cargo nextest`。

## Cross-cuts

**类A**：无新增 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量，ADR-114 grep guard 本地预检通过。

## 后续 PR / 下一步

- step 3 `dasclaw_session` 抽取：等到出现第二个调用方时再触发新 ADR
- §4.4.6 "暂不必要" 5 项：按各自时机另开 ADR
- 真实第三方 MCP server smoke 验证（如 `@modelcontextprotocol/server-filesystem`）：手动验证，无需 PR

Closes #819