### PR TITLE
docs+test(dasclaw_runtime,dasclaw_cli): API README + 多 MCP 服务端 namespace 测试

### DIFF
--- a/crates/dasclaw_cli/README.md
+++ b/crates/dasclaw_cli/README.md
@@ -1,0 +1,184 @@
+# `dasclaw_cli`
+
+Headless agent CLI binary (`dasclaw-cli`). The proof-point that
+[`dasclaw_runtime::Agent`](../dasclaw_runtime/README.md) runs without any
+desktop dependency: no Tauri, no database, no channels, no HTTP server.
+
+ADR reference: [ADR-153 §4.4](../../docs/plans/architecture-refactor/adr-153-headless-agent-framework.md)
+(CLI proof-point — slices 4 through 8).
+
+```text
+$ dasclaw-cli --prompt "Hi"
+echo: Hi
+```
+
+## Install / run
+
+```bash
+cargo build -p dasclaw_cli --release
+./target/release/dasclaw-cli --help
+```
+
+Or use it as a library from another crate — `lib.rs` exposes `run`,
+`run_with_tools`, `EchoResponder`, plus the `provider`, `tools`, `mcp` modules.
+
+## Subcommands
+
+### `echo` (default)
+
+Deterministic built-in responder; replies `echo: <last user content>`. **No
+network, no LLM key.** Used as the default smoke driver and exercised in
+[`tests/end_to_end.rs`](tests/end_to_end.rs).
+
+```bash
+dasclaw-cli echo --prompt "Hi"          # → echo: Hi
+dasclaw-cli echo                        # reads prompt from stdin
+echo "Hi" | dasclaw-cli echo
+```
+
+### `run` — real LLM-backed agent
+
+Wires a `dasclaw_llm_provider`-backed responder. Honours the standard provider
+env vars (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `DASCLAW_API_KEY`, …).
+
+```bash
+dasclaw-cli run --provider anthropic --model claude-sonnet-4 \
+  --prompt "Summarise this README."
+```
+
+#### Tool dispatch (`run` only)
+
+Two opt-in flags, freely combinable:
+
+| Flag | Effect |
+|---|---|
+| `--enable-tools` | Advertise the builtin demo tools `echo` and `now` and dispatch them locally. |
+| `--mcp-config <path>` | Spin up one or more MCP servers from a JSON file; their tools are advertised under `<server_name>_<tool>`. |
+
+When both flags are set, the two executors are merged through
+[`CompositeToolExecutor`](../dasclaw_runtime/src/composite_executor.rs). Duplicate
+tool names across the two sources fail at startup, not at dispatch — matching
+the safety stance of the rest of the runtime.
+
+#### Builtin tools
+
+| Tool | Description |
+|---|---|
+| `echo` | Returns the `message` argument verbatim. |
+| `now`  | Returns the current epoch seconds. |
+
+Useful for smoke-testing the agent ↔ tool round-trip without any external
+service. Implementation in [`src/tools.rs`](src/tools.rs).
+
+## Common flags
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `--prompt <text>` | — | User prompt. When omitted, the prompt is read from stdin. |
+| `--system <text>` | `"You are dasclaw, a headless agent."` | System prompt prepended to the conversation. |
+
+## MCP config schema (`--mcp-config`)
+
+Top-level shape, loaded by [`mcp::load_executor`](src/mcp.rs):
+
+```json
+{
+  "servers": [
+    {
+      "name": "fs",
+      "command": "npx",
+      "args": ["@modelcontextprotocol/server-filesystem", "/tmp"],
+      "env": { "EXTRA": "value" }
+    },
+    {
+      "name": "remote",
+      "url": "https://mcp.example.com/v1",
+      "headers": { "Authorization": "Bearer XYZ" }
+    }
+  ]
+}
+```
+
+Transport is selected by which fields the entry carries:
+
+- **stdio** — entry has `command` (and optional `args`, `env`); launched as a
+  subprocess via `StdioMcpTransport`. The parent's environment is inherited;
+  `env` is layered on top.
+- **HTTP** — entry has `url` (and optional `headers`); spoken to via
+  `HttpMcpTransport`.
+
+Mixing both `command` and `url` in one entry, or omitting both, is a parse-time
+error (`McpConfigError`).
+
+### Ordering and name collisions
+
+`servers` is ordered. Each advertised tool ends up qualified as
+`<server_name>_<tool>` in the LLM-visible list. If two servers ever advertise
+the **same qualified name**, the **last** one wins, matching the contract of
+`McpToolExecutor::from_clients`.
+
+Combining `--enable-tools` with `--mcp-config` is stricter: the merge through
+`CompositeToolExecutor` errors out on duplicates — caught at startup.
+
+### What is **not** wired (deliberate)
+
+- **Hosted / OAuth-backed servers.** The CLI has no persistent secrets store,
+  so the HTTP transport sends only the static `headers` map and does not wire
+  `Mcp-Session-Id` or `SecretsStore`. Hosted servers belong in ironclaw.
+- **Approval prompts.** Headless mode surfaces `AgentError::ApprovalRequested`
+  instead of stalling on a TTY.
+- **Streaming REPL.** This slice is request-response only.
+
+## Library entry points (`lib.rs`)
+
+| Symbol | Purpose |
+|---|---|
+| `run(responder, system, user) -> Result<String, CliError>` | Build a no-tools agent and run one prompt. |
+| `run_with_tools(responder, executor, defs, system, user) -> Result<String, CliError>` | Same, with a `ToolExecutor` and advertised tool defs. |
+| `EchoResponder` | Deterministic `AgentResponder` for tests / smoke. |
+| `CliError` | `Agent(AgentError)` or `Build(String)`. |
+| Module [`provider`](src/provider.rs) | `ProviderArgs` clap group + `build_responder` factory. |
+| Module [`tools`](src/tools.rs) | `StaticToolExecutor` + `default_builtins`. |
+| Module [`mcp`](src/mcp.rs) | `load_executor` + `McpConfig` schema types + `McpConfigError`. |
+
+Keeping I/O (argv / stdin / stdout) out of these functions is what lets the
+integration tests assert behaviour without spawning the binary.
+
+## Tests
+
+End-to-end coverage under [`tests/`](tests/):
+
+| File | What it locks in |
+|---|---|
+| [`end_to_end.rs`](tests/end_to_end.rs) | `EchoResponder` round-trip through `run`. |
+| [`tool_e2e.rs`](tests/tool_e2e.rs) | Mock LLM → builtin `echo` tool → final text (full agent loop with tools). |
+| [`mcp_e2e.rs`](tests/mcp_e2e.rs) | Single-server `--mcp-config` drives stdio fixture through `initialize` / `tools/list` / `tools/call`. |
+| [`mcp_multi_e2e.rs`](tests/mcp_multi_e2e.rs) | Two stdio MCP servers in one config; `<name>_<tool>` namespacing keeps them disjoint. |
+| [`live_provider.rs`](tests/live_provider.rs) | Optional live-LLM smoke (skipped without API key). |
+| [`fixtures/stdio_echo_mcp.rs`](tests/fixtures/stdio_echo_mcp.rs) | Minimal stdio MCP server used by the MCP tests. |
+
+Run them all with `cargo nextest run -p dasclaw_cli`.
+
+## Errors
+
+| Error | Meaning |
+|---|---|
+| `CliError::Build(msg)` | `AgentBuilder` rejected the configuration. |
+| `CliError::Agent(AgentError)` | Loop failure — see `AgentError` variants in `dasclaw_runtime`. |
+| `McpConfigError::Read / Parse` | Config file missing or invalid JSON. |
+| `McpConfigError::Spawn { server, … }` | Could not start a stdio subprocess. |
+| `McpConfigError::ListTools` | `tools/list` round-trip failed for at least one server. |
+
+## Stability
+
+The library surface (`run`, `run_with_tools`, `EchoResponder`, `provider`,
+`tools`, `mcp`) is shared by ironclaw and admin-backend wiring slices. Pin to
+the exact patch version while ADR-153 is open; the CLI flag shape will stay
+stable across the §4.4 slices.
+
+## See also
+
+- [`dasclaw_runtime`](../dasclaw_runtime/README.md) — the agent + traits this CLI is built on.
+- [`dasclaw_llm_provider`](../dasclaw_llm_provider/) — concrete LLM backends behind `--provider`.
+- [`dasclaw_mcp`](../dasclaw_mcp/) — stdio / HTTP MCP transports loaded by `--mcp-config`.
+- ADR-153 §4.4 — the slice-by-slice plan and milestones.

--- a/crates/dasclaw_cli/tests/mcp_multi_e2e.rs
+++ b/crates/dasclaw_cli/tests/mcp_multi_e2e.rs
@@ -1,0 +1,112 @@
+//! End-to-end integration test for ADR-153 §4.4.5 (step 8): when the CLI
+//! loads multiple stdio MCP servers from a single config, each server's
+//! tools are namespaced as `<server_name>_<tool>` so two servers that
+//! happen to expose the same underlying tool name (`echo`) coexist
+//! without collision and each call routes to the right subprocess.
+//!
+//! Uses the same `stdio_echo_mcp_fixture` binary built from
+//! [`tests/fixtures/stdio_echo_mcp.rs`] for both servers; the only
+//! difference between them is the logical `name` in the config.
+
+use std::path::PathBuf;
+
+use dasclaw_cli::mcp::load_executor;
+use dasclaw_core::messages::ToolCall;
+use dasclaw_runtime::ToolExecutor;
+use serde_json::json;
+use tempfile::tempdir;
+
+fn fixture_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_stdio_echo_mcp_fixture"))
+}
+
+fn write_two_server_config(dir: &std::path::Path, command: &str) -> PathBuf {
+    let path = dir.join("mcp.json");
+    let body = json!({
+        "servers": [
+            { "name": "srv_a", "command": command, "args": [], "env": {} },
+            { "name": "srv_b", "command": command, "args": [], "env": {} }
+        ]
+    });
+    std::fs::write(&path, body.to_string()).expect("write config");
+    path
+}
+
+#[tokio::test]
+async fn req_dasclaw_cli_mcp_e3_two_servers_namespace_disjointly() {
+    let dir = tempdir().expect("tempdir");
+    let bin = fixture_bin();
+    let bin_str = bin.to_str().expect("utf-8 path");
+    let config = write_two_server_config(dir.path(), bin_str);
+
+    let executor = load_executor(&config).await.expect("load_executor");
+    let defs = executor.definitions();
+
+    // Both servers expose `echo`, qualified by server name. Order
+    // follows the config order.
+    let names: Vec<&str> = defs.iter().map(|d| d.name.as_str()).collect();
+    assert_eq!(
+        names,
+        vec!["srv_a_echo", "srv_b_echo"],
+        "expected two namespaced tool defs, got {names:?}"
+    );
+
+    // Dispatch hits the right subprocess: each call should round-trip its
+    // own message verbatim, and the response is tagged with the
+    // qualified name (not the underlying `echo`).
+    let call_a = ToolCall {
+        id: "a-1".into(),
+        name: "srv_a_echo".into(),
+        arguments: json!({ "message": "from A" }),
+        reasoning: None,
+    };
+    let result_a = executor.execute(&call_a).await.expect("execute A");
+    assert!(!result_a.is_error, "A failed: {}", result_a.content);
+    assert_eq!(result_a.name, "srv_a_echo");
+    assert_eq!(result_a.tool_call_id, "a-1");
+    assert_eq!(result_a.content, "from A");
+
+    let call_b = ToolCall {
+        id: "b-1".into(),
+        name: "srv_b_echo".into(),
+        arguments: json!({ "message": "from B" }),
+        reasoning: None,
+    };
+    let result_b = executor.execute(&call_b).await.expect("execute B");
+    assert!(!result_b.is_error, "B failed: {}", result_b.content);
+    assert_eq!(result_b.name, "srv_b_echo");
+    assert_eq!(result_b.tool_call_id, "b-1");
+    assert_eq!(result_b.content, "from B");
+}
+
+#[tokio::test]
+async fn req_dasclaw_cli_mcp_e4_call_to_other_servers_unqualified_name_is_tool_error() {
+    // Routing must require the full `<server>_<tool>` qualified name.
+    // Calling the bare underlying `echo` (no prefix) when two servers
+    // both publish `echo` must surface a tool error rather than
+    // ambiguously picking one subprocess.
+    let dir = tempdir().expect("tempdir");
+    let bin = fixture_bin();
+    let bin_str = bin.to_str().expect("utf-8 path");
+    let config = write_two_server_config(dir.path(), bin_str);
+
+    let executor = load_executor(&config).await.expect("load_executor");
+
+    let call = ToolCall {
+        id: "x-1".into(),
+        name: "echo".into(), // unqualified — must NOT route
+        arguments: json!({ "message": "unrouted" }),
+        reasoning: None,
+    };
+    let result = executor.execute(&call).await.expect("execute");
+    assert!(
+        result.is_error,
+        "unqualified call must fail, got success: {}",
+        result.content
+    );
+    assert!(
+        result.content.contains("unknown MCP tool"),
+        "error message should mention unknown MCP tool, got: {}",
+        result.content
+    );
+}

--- a/crates/dasclaw_runtime/README.md
+++ b/crates/dasclaw_runtime/README.md
@@ -1,0 +1,167 @@
+# `dasclaw_runtime`
+
+Headless agent runtime shared across all dasclaw hosts (ironclaw, admin-backend,
+claw-code, …). Contains the **application-layer** vocabulary that lets a host
+spin up an LLM-driven agent in four lines without pulling in Tauri, a database,
+channels, or any desktop infrastructure.
+
+ADR reference: [ADR-153 §3](../../docs/plans/architecture-refactor/adr-153-headless-agent-framework.md)
+(headless agent framework) and §4.4 (CLI proof-point).
+
+## At a glance
+
+```rust
+use dasclaw_runtime::{Agent, AgentResponder};
+
+let agent = Agent::builder()
+    .responder(my_responder)              // anything that knows how to call an LLM
+    .system_prompt("You are a helpful assistant.")
+    .build()?;
+let text = agent.run("Hello!").await?;
+```
+
+That is the entire happy path. `my_responder` is anything that implements
+[`AgentResponder`](src/agent.rs); the runtime ships
+[`LlmProviderResponder`](src/llm_adapter.rs) which adapts any
+`dasclaw_llm_provider::LlmProvider` automatically.
+
+## Public surface
+
+Re-exported from `lib.rs` (the only types third-party code should depend on):
+
+| Symbol | Purpose |
+|---|---|
+| `Agent`, `AgentBuilder`, `AgentConfig` | Headless agent + fluent constructor. |
+| `AgentResponder` (trait) | Narrow LLM seam — `async fn respond(ctx) -> RespondOutput`. |
+| `ToolExecutor` (trait) | Narrow tool-dispatch seam — `async fn execute(call) -> ToolResult`. |
+| `AgentError` | Loop failure modes (`MissingResponder`, `MaxIterations`, `ToolsNotSupported`, …). |
+| `LlmProviderResponder` | Ready-made adapter wrapping `dasclaw_llm_provider`. |
+| `CompositeToolExecutor`, `CompositeError` | Merge several executors under disjoint tool-name sets. |
+| `Tool` | Application-layer tool trait (the in-runtime form). |
+| `ToolError` | Application-layer tool error carrying the failing tool's `name`. |
+| `JobState`, `StateTransition`, `TokenBudgetExceeded` | Pure job state machine. |
+| `JobContextCore` | Per-job runtime context value object. |
+| `ToolFeatureFlags`, `SharedFeatureFlags` | Atomic flags consulted by tools. |
+| `RateLimiter`, `LimitType`, `RateLimitResult`, `RateLimitError` | Token-bucket rate limiting. |
+| `Secret`, `SecretRef`, `DecryptedSecret`, `SecretError`, `SecretsStore` (trait), `CreateSecretParams`, `CredentialLocation`, `CredentialMapping` | Secret-management vocabulary (concrete backends live in hosts). |
+| `HttpExchange`, `HttpInterceptor`, … | Recording hooks for replay. |
+
+The two **traits you actually have to implement** to integrate a new host are
+`AgentResponder` and (optionally) `ToolExecutor`. Everything else is data.
+
+## Building an agent
+
+`AgentBuilder` (fluent, all setters consume + return `self`):
+
+| Setter | Required? | Notes |
+|---|---|---|
+| `.responder(impl AgentResponder + 'static)` | **yes** | Or `.responder_arc(Arc<dyn …>)` to share. |
+| `.tool_executor(impl ToolExecutor + 'static)` | only when tools are advertised | Or `.tool_executor_arc(...)`. |
+| `.tools(Vec<ToolDefinition>)` | only when tool calls are expected | Empty ⇒ text-only mode. |
+| `.system_prompt(impl Into<String>)` | no | Prepended to every LLM call. |
+| `.model(impl Into<String>)` | no | Per-call model override. |
+| `.hooks(HookBundle)` | no | Defaults to `HookBundle::noop()`. |
+| `.loop_config(AgenticLoopConfig)` | no | Defaults to 50 iterations + intent nudges on. |
+| `.build() -> Result<Agent, AgentError>` | terminal | Fails with `MissingResponder` if `.responder` was not called. |
+
+### Why two narrow traits instead of one fat one
+
+`AgentResponder` mirrors `LoopDelegate::call_llm` one-to-one and is a single
+method. `ToolExecutor` is likewise single-method. Splitting along the LLM ↔
+tool seam means an adapter author only implements the side they care about, and
+the runtime never has to construct a no-op tool executor for text-only flows.
+
+`dasclaw_core::traits::LlmCompleter` exists too but is **text-only** — it
+returns `String`, not `RespondOutput`, so it cannot carry tool calls or finish
+reasons. The agent loop fundamentally needs `RespondOutput`, hence the
+dedicated `AgentResponder`.
+
+## Failure modes
+
+`Agent::run` returns `Result<String, AgentError>`. The variants:
+
+| Variant | When |
+|---|---|
+| `MissingResponder` | Builder was missing `.responder(...)`. Caller bug. |
+| `MaxIterations(n)` | Loop hit `loop_config.max_iterations` without a final text. |
+| `ToolsNotSupported` | Model asked for a tool but no `ToolExecutor` was wired. |
+| `LoopFailure(reason)` | `LoopOutcome::Failure(_)`, typically from an egress hook. |
+| `Stopped` | External `LoopSignal::Stop` halted the loop. |
+| `ApprovalRequested` | Headless delegate refuses approval prompts. |
+| `Responder(HostError)` | Underlying responder / hook errored. |
+
+The runtime **does not retry**. If a tool fails, the implementation should
+return `ToolResult { is_error: true, ... }`, feeding the failure back to the
+model rather than aborting the loop.
+
+## Two-layer `ToolError` model (read once, then forget)
+
+There are *two* `ToolError`s in the codebase, intentionally:
+
+- `dasclaw_tool::ToolError` — tool-impl layer. Returned by a tool's
+  `execute()`. Does not carry a tool name (the tool already knows who it is).
+- `dasclaw_runtime::ToolError` — dispatcher / application layer. Each variant
+  carries the failing tool's `name` plus extra runtime context (e.g.
+  `retry_after`).
+
+Conversion is **not** a blanket `From` impl — that would silently fall back to
+`"<unknown>"`, which is fail-open and unacceptable. Callers attach the name
+explicitly at the boundary via `ToolError::from_tool_impl(name, err)`.
+
+## Composing multiple tool executors
+
+When a host wants tools from two sources (e.g. builtin demo tools **and** MCP
+tools), wire them through `CompositeToolExecutor`:
+
+```rust
+use std::sync::Arc;
+use dasclaw_runtime::{CompositeToolExecutor, ToolExecutor};
+
+let composite = CompositeToolExecutor::new([
+    (static_tool_names, Arc::new(static_exec) as Arc<dyn ToolExecutor>),
+    (mcp_tool_names,    Arc::new(mcp_exec)    as Arc<dyn ToolExecutor>),
+])?; // errors on duplicate tool names
+```
+
+The constructor enforces a **disjoint name set** invariant up front, so the
+fail-mode is loud and at startup rather than silent and at dispatch time.
+
+## Hooks
+
+`HookBundle` (from `dasclaw_core::hooks`) is passed unchanged into the loop. By
+default the runtime uses `HookBundle::noop()`. Hosts can install pre-call /
+post-call / pre-tool / post-tool / egress hooks via the standard `HookBundle`
+builder API — `dasclaw_runtime` does not wrap it.
+
+## Module map
+
+| Module | Sketch |
+|---|---|
+| [`agent`](src/agent.rs) | `Agent`, `AgentBuilder`, `AgentResponder`, `ToolExecutor`, `AgentError`, `AgentConfig`, internal `HeadlessDelegate`. |
+| [`composite_executor`](src/composite_executor.rs) | `CompositeToolExecutor` + `CompositeError`. |
+| [`context`](src/context/) | Per-job context object & helpers. |
+| [`error`](src/error.rs) | App-layer `ToolError`. |
+| [`feature_flags`](src/feature_flags.rs) | Atomic shared flags consulted by tools. |
+| [`job`](src/job.rs) | Pure `JobState` machine + `TokenBudgetExceeded`. |
+| [`job_context`](src/job_context.rs) | `JobContextCore` value object. |
+| [`llm_adapter`](src/llm_adapter.rs) | `LlmProviderResponder` — adapt `dasclaw_llm_provider` into `AgentResponder`. |
+| [`rate_limit`](src/rate_limit.rs) | Token-bucket rate limiting (`RateLimiter` + types). |
+| [`recording`](src/recording.rs) | HTTP exchange record/replay (`HttpExchange`, `HttpInterceptor`). |
+| [`secrets`](src/secrets/) | Secret-management vocabulary + `SecretsStore` trait. |
+| [`tool`](src/tool.rs) | App-layer `Tool` trait. |
+
+## Stability
+
+`Agent`, `AgentBuilder`, `AgentResponder`, `ToolExecutor`, `AgentError`,
+`LlmProviderResponder` and `CompositeToolExecutor` are the **stable public
+surface** consumed by `dasclaw_cli` and (in flight) by ironclaw / admin-backend.
+Everything else is in-flight and may break before ADR-153 closes — pin to the
+exact patch version if you depend on those modules.
+
+## See also
+
+- [`dasclaw_cli`](../dasclaw_cli/README.md) — the headless CLI built on this runtime; ADR-153 proof-point.
+- [`dasclaw_core`](../dasclaw_core/) — the agentic loop primitives this runtime wraps.
+- [`dasclaw_llm_provider`](../dasclaw_llm_provider/) — concrete LLM clients adapted via `LlmProviderResponder`.
+- [`dasclaw_mcp`](../dasclaw_mcp/) — MCP transports and `McpToolExecutor` (plugged in by `dasclaw_cli`).
+- ADR-153 — headless agent framework rationale and milestones.


### PR DESCRIPTION
## 背景/目标

ADR-153 §4.4 主路径已合并（PR #818），但 crates/dasclaw_runtime 与 crates/dasclaw_cli 都还没有 README，新人入门只能直接读 lib.rs；集成测试也缺少「多 MCP 服务端 + 同名底层工具」这类 namespace 场景的覆盖。本 PR 补上两份 API 文档与一份集成测试。

## 改动范围

- 新增 crates/dasclaw_runtime/README.md
  - 公开 API 表（17 个 re-export 都列出）
  - AgentBuilder 全套 setter 表 + AgentError 失败矩阵
  - 两层 ToolError 模型说明（为何不能用 blanket From）
  - CompositeToolExecutor 用法示例
  - 模块地图（agent / composite_executor / context / error / ...）
- 新增 crates/dasclaw_cli/README.md
  - echo / run 两个子命令
  - --enable-tools × --mcp-config 四种组合矩阵
  - MCP 配置 JSON schema（stdio + http 两个 transport）
  - 命名冲突规则（同 server 内 last-wins；CompositeToolExecutor 严格去重）
  - tests/ 文件清单
- 新增 crates/dasclaw_cli/tests/mcp_multi_e2e.rs：两个集成测试
  - req_dasclaw_cli_mcp_e3_two_servers_namespace_disjointly — 验证两个 stdio MCP 服务端各自的 echo 工具被 namespace 成 srv_a_echo / srv_b_echo，且分别路由到对应子进程
  - req_dasclaw_cli_mcp_e4_call_to_other_servers_unqualified_name_is_tool_error — 验证不带前缀的 echo 调用不会模糊匹配任一服务端，而是返回 tool error

## 非目标（What's NOT in this PR）

- 不改 dasclaw_runtime / dasclaw_cli 的源码
- 不加新 builtin tool / 不改 transport 实现
- 不改 ADR-153 / AGENTS.md

## 验证（命令 + 结果）

```bash
$ cargo check -p dasclaw_cli --tests
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 13.79s

$ cargo nextest run -p dasclaw_cli --test mcp_multi_e2e --test mcp_e2e
    Starting 4 tests across 2 binaries
        PASS [   2.431s] (1/4) mcp_multi_e2e::req_dasclaw_cli_mcp_e4_call_to_other_servers_unqualified_name_is_tool_error
        PASS [   2.431s] (2/4) mcp_e2e::req_dasclaw_cli_mcp_e1_end_to_end_loads_tool_and_dispatches_call
        PASS [   2.431s] (3/4) mcp_e2e::req_dasclaw_cli_mcp_e2_unknown_qualified_tool_is_tool_error_not_panic
        PASS [   2.431s] (4/4) mcp_multi_e2e::req_dasclaw_cli_mcp_e3_two_servers_namespace_disjointly
     Summary [   2.438s] 4 tests run: 4 passed, 0 skipped

$ cargo fmt --all && python3.12 scripts/check_no_panics.py --base origin/xClaw
OK: No panic-inducing calls in changed production code.

$ cargo clippy --no-deps -p dasclaw_cli --all-targets -- -D warnings
    Finished `dev` profile in 14.53s   (无 warning)
```

## Sources read

- AGENTS.md §「测试纪律」、§「PR 必填项」、§「不要碰的红线」
- docs/plans/architecture-refactor/adr-153-headless-agent-framework.md §3 + §4.4
- crates/dasclaw_runtime/src/lib.rs + agent.rs（公开 API 与文档来源）
- crates/dasclaw_cli/src/{lib.rs, main.rs, mcp.rs, tools.rs}
- crates/dasclaw_cli/tests/{mcp_e2e.rs, fixtures/stdio_echo_mcp.rs}

Closes #821