### PR TITLE
test(dasclaw_cli): 补 HTTP transport 的 --mcp-config e2e

### DIFF
--- a/crates/dasclaw_cli/tests/mcp_http_e2e.rs
+++ b/crates/dasclaw_cli/tests/mcp_http_e2e.rs
@@ -1,0 +1,175 @@
+//! End-to-end integration test for ADR-153 §4.4.5 (step 8) HTTP branch:
+//! verifies that `dasclaw_cli::mcp::load_executor` drives a real
+//! `HttpMcpTransport` through `initialize` →
+//! `notifications/initialized` → `tools/list` → `tools/call` against an
+//! HTTP MCP server.
+//!
+//! Companion to [`tests/mcp_e2e.rs`] (stdio path) and
+//! [`tests/mcp_multi_e2e.rs`] (multi-server namespace). The stdio tests
+//! cover the subprocess fixture; this file covers the HTTP transport
+//! path that those tests never touch.
+//!
+//! The HTTP MCP server is built from the existing `wiremock` dev-dep
+//! (already used by [`tests/live_provider.rs`]) so no new dependency is
+//! introduced.
+
+use std::path::{Path, PathBuf};
+
+use dasclaw_cli::mcp::load_executor;
+use dasclaw_core::messages::ToolCall;
+use dasclaw_runtime::ToolExecutor;
+use serde_json::{Value, json};
+use tempfile::tempdir;
+use wiremock::matchers::{body_partial_json, method};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn write_http_config(dir: &Path, name: &str, url: &str) -> PathBuf {
+    let path = dir.join("mcp.json");
+    let body = json!({
+        "servers": [
+            { "name": name, "url": url, "headers": {} }
+        ]
+    });
+    std::fs::write(&path, body.to_string()).expect("write config");
+    path
+}
+
+/// Mount the initialize / initialized-notification / tools/list mocks
+/// that every test in this file needs.  Returns the server so the caller
+/// can mount additional `tools/call` behaviour on top.
+async fn mount_handshake(server: &MockServer, tool_def: Value) {
+    Mock::given(method("POST"))
+        .and(body_partial_json(json!({ "method": "initialize" })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": { "tools": {} },
+                "serverInfo": { "name": "http_echo_mcp_fixture", "version": "0.1.0" }
+            }
+        })))
+        .mount(server)
+        .await;
+
+    // Per HttpMcpTransport regression test for #1436: notifications return 202.
+    Mock::given(method("POST"))
+        .and(body_partial_json(
+            json!({ "method": "notifications/initialized" }),
+        ))
+        .respond_with(ResponseTemplate::new(202))
+        .mount(server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(body_partial_json(json!({ "method": "tools/list" })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "result": { "tools": [ tool_def ] }
+        })))
+        .mount(server)
+        .await;
+}
+
+fn echo_tool_def() -> Value {
+    json!({
+        "name": "echo",
+        "description": "Echoes its `message` argument back verbatim.",
+        "inputSchema": {
+            "type": "object",
+            "properties": { "message": { "type": "string" } },
+            "required": ["message"]
+        }
+    })
+}
+
+#[tokio::test]
+async fn req_dasclaw_cli_mcp_e5_http_transport_dispatches_tool_call() {
+    let server = MockServer::start().await;
+    mount_handshake(&server, echo_tool_def()).await;
+
+    // tools/call returns a fixed echoed text content (the fixture does
+    // not parse arguments — verifying that round-trip happens at all is
+    // enough at this layer; argument plumbing is covered by the stdio
+    // fixture in mcp_e2e.rs).
+    Mock::given(method("POST"))
+        .and(body_partial_json(json!({ "method": "tools/call" })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "jsonrpc": "2.0",
+            "id": 3,
+            "result": {
+                "content": [ { "type": "text", "text": "from-http" } ],
+                "isError": false
+            }
+        })))
+        .mount(&server)
+        .await;
+
+    let dir = tempdir().expect("tempdir");
+    let config = write_http_config(dir.path(), "remote", &server.uri());
+
+    let executor = load_executor(&config).await.expect("load_executor");
+
+    // tools/list should have surfaced exactly the one echo tool,
+    // qualified with the server name from the config (not the
+    // serverInfo.name advertised by the MCP server).
+    let defs = executor.definitions();
+    assert_eq!(defs.len(), 1, "expected one tool, got {defs:?}");
+    assert_eq!(defs[0].name, "remote_echo");
+    assert!(
+        defs[0].description.contains("Echoes"),
+        "description should propagate from tool def, got {:?}",
+        defs[0].description
+    );
+
+    let call = ToolCall {
+        id: "h-1".into(),
+        name: "remote_echo".into(),
+        arguments: json!({ "message": "ignored by fixture" }),
+        reasoning: None,
+    };
+    let result = executor.execute(&call).await.expect("execute");
+    assert!(!result.is_error, "tool call failed: {}", result.content);
+    assert_eq!(result.tool_call_id, "h-1");
+    assert_eq!(result.name, "remote_echo");
+    assert_eq!(result.content, "from-http");
+}
+
+#[tokio::test]
+async fn req_dasclaw_cli_mcp_e6_http_tools_call_5xx_is_tool_error_not_panic() {
+    // Handshake + list succeed, only tools/call returns 500. This
+    // pins the contract in McpToolExecutor (docstring at
+    // crates/dasclaw_mcp/src/executor.rs:15): "transport errors are
+    // surfaced as ToolResult { is_error: true }" — so the agent loop
+    // sees a recoverable tool error, not a propagated Err.
+    let server = MockServer::start().await;
+    mount_handshake(&server, echo_tool_def()).await;
+
+    Mock::given(method("POST"))
+        .and(body_partial_json(json!({ "method": "tools/call" })))
+        .respond_with(ResponseTemplate::new(500).set_body_string("backend on fire"))
+        .mount(&server)
+        .await;
+
+    let dir = tempdir().expect("tempdir");
+    let config = write_http_config(dir.path(), "remote", &server.uri());
+    let executor = load_executor(&config).await.expect("load_executor");
+
+    let call = ToolCall {
+        id: "h-2".into(),
+        name: "remote_echo".into(),
+        arguments: json!({ "message": "anything" }),
+        reasoning: None,
+    };
+    let result = executor.execute(&call).await.expect(
+        "execute must return Ok with is_error=true for transport failures, \
+         not propagate the error",
+    );
+    assert!(
+        result.is_error,
+        "5xx on tools/call must surface is_error=true, got {result:?}"
+    );
+    assert_eq!(result.tool_call_id, "h-2");
+    assert_eq!(result.name, "remote_echo");
+}


### PR DESCRIPTION
## 背景/目标

ADR-153 §4.4.5（step 8）落地 \`--mcp-config\` 时同时支持 stdio 与 HTTP 两种 transport。集成测试当前缺口：

- \`crates/dasclaw_cli/tests/mcp_e2e.rs\` — 只测 stdio
- \`crates/dasclaw_cli/tests/mcp_multi_e2e.rs\` — 也只测 stdio（PR #823 刚加）
- \`crates/dasclaw_mcp/src/http_transport.rs\` 自带 5 个 axum 单元测试，但只覆盖 transport 层（headers / 202 / OAuth），从未走过 \`load_executor\` → \`McpToolExecutor\` → 真实路由 → \`tools/call\` 这条 CLI 路径

本 PR 补这条缺口。

## 改动范围

新增 \`crates/dasclaw_cli/tests/mcp_http_e2e.rs\`（仅 1 文件）。用已有的 \`wiremock\` dev-dep（不新增依赖，复用 \`live_provider.rs\` 已用的模式）起一个最小 MCP-over-HTTP 服务端，包含两个集成测试：

1. \`req_dasclaw_cli_mcp_e5_http_transport_dispatches_tool_call\`：成功路径，跑完 initialize → notifications/initialized (202) → tools/list → tools/call。校验 qualified name = \`remote_echo\`、definitions 长度、round-trip 的 \`id\` / \`name\` / \`content\` / \`is_error=false\`。
2. \`req_dasclaw_cli_mcp_e6_http_tools_call_5xx_is_tool_error_not_panic\`：失败注入，handshake 与 \`tools/list\` 仍正常，仅 \`tools/call\` 返 HTTP 500。校验 \`executor.execute\` 返回 \`Ok(ToolResult { is_error: true })\`，钉死 \`crates/dasclaw_mcp/src/executor.rs:15\` 文档承诺的「transport 错误转 \`is_error=true\` 而不是 \`Err\`」。

两个测试共用 \`mount_handshake\` 辅助函数，避免补丁式重复。

## 非目标（What's NOT in this PR）

- 不动 \`dasclaw_mcp::http_transport\` 源码
- 不动 \`dasclaw_cli/src/mcp.rs\` 源码
- 不引入 \`axum\` 到 \`dasclaw_cli\` 的 dev-deps（OAuth / Mcp-Session-Id 已在 \`mcp.rs\` 文档中标注为 CLI 不覆盖项）
- 不覆盖超时 / 重试 / 流式响应（另起 issue）

## 验证（命令 + 结果）

```bash
$ cargo check -p dasclaw_cli --tests
    Finished \`dev\` profile in 4.26s

$ cargo nextest run -p dasclaw_cli --test mcp_http_e2e
    Starting 2 tests across 1 binary
        PASS [   3.874s] (1/2) req_dasclaw_cli_mcp_e5_http_transport_dispatches_tool_call
        PASS [   5.046s] (2/2) req_dasclaw_cli_mcp_e6_http_tools_call_5xx_is_tool_error_not_panic
     Summary [   5.046s] 2 tests run: 2 passed, 0 skipped

$ cargo clippy --no-deps -p dasclaw_cli --all-targets -- -D warnings
    Finished \`dev\` profile in 10.87s   (无 warning)

$ python3.12 scripts/check_no_panics.py --base origin/xClaw
OK: No panic-inducing calls in changed production code.
```

完整 \`cargo build\` / workspace clippy / 其它 crate 测试交给 PR CI 跑。

## Sources read

- AGENTS.md §「测试纪律」、§「复用优先于新建」、§「PR 必填项」
- \`docs/plans/architecture-refactor/adr-153-headless-agent-framework-draft.md\` §4.4.5 / §4.4.7
- \`crates/dasclaw_cli/src/mcp.rs\`（HTTP transport 分支与 config schema）
- \`crates/dasclaw_cli/tests/{mcp_e2e.rs, mcp_multi_e2e.rs, live_provider.rs}\`（对照模式 + 复用 wiremock dev-dep）
- \`crates/dasclaw_mcp/src/http_transport.rs\`（5 个已存在的 axum 单元测试，确认缺口）
- \`crates/dasclaw_mcp/src/executor.rs\`（\`is_error=true\` 契约 + handshake 顺序）
- \`crates/dasclaw_cli/tests/fixtures/stdio_echo_mcp.rs\`（MCP JSON-RPC 最小响应集对照）

Closes #824