### PR TITLE
chore(ci): unblock base xClaw — fix yanked kuchikikiki + ghost dasclaw_session

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4870,7 +4870,7 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.2.1",
+ "windows-link 0.1.3",
  "windows-result 0.4.1",
 ]
 
@@ -6394,17 +6394,17 @@ dependencies = [
 
 [[package]]
 name = "kuchikikiki"
-version = "0.9.2"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73885c6a3cefdf7a1db0327cefbe4b9b72cac94cae4b19ede4fa492d8af02a0"
+checksum = "14683223e533503d404478bfd32826a4cba1b4906034ff74135404372390e87b"
 dependencies = [
  "bitflags 2.11.0",
  "crc",
  "cssparser 0.36.0",
- "html5ever 0.38.0",
+ "html5ever 0.36.1",
  "indexmap 2.13.0",
  "precomputed-hash",
- "selectors 0.35.0",
+ "selectors 0.33.0",
 ]
 
 [[package]]
@@ -10340,25 +10340,6 @@ name = "selectors"
 version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "feef350c36147532e1b79ea5c1f3791373e61cbd9a6a2615413b3807bb164fb7"
-dependencies = [
- "bitflags 2.11.0",
- "cssparser 0.36.0",
- "derive_more 2.1.1",
- "log",
- "new_debug_unreachable",
- "phf 0.13.1",
- "phf_codegen 0.13.1",
- "precomputed-hash",
- "rustc-hash 2.1.1",
- "servo_arc 0.4.3",
- "smallvec",
-]
-
-[[package]]
-name = "selectors"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fdfed56cd634f04fe8b9ddf947ae3dc493483e819593d2ba17df9ad05db8b2"
 dependencies = [
  "bitflags 2.11.0",
  "cssparser 0.36.0",

--- a/scripts/check_blueprint_sync.py
+++ b/scripts/check_blueprint_sync.py
@@ -51,6 +51,11 @@ PLANNED: dict[str, str] = {
     # F4.6.6-a (`dasclaw_fs_tools`) landed — entry removed.
     # F4.6.7 (`dasclaw_shell_tools`) landed — entry removed.
     # F4.6.8 (`dasclaw_net_tools`) landed (phases 1/2/3) — entry removed.
+    # ADR-153 §4.3 step 3 — optional session crate, deliberately deferred
+    # until a second caller appears. Mentioned in 31-target-architecture.md
+    # §ADR-153 closure note (footnote: "step 3 暂搁"). Keep here so the
+    # blueprint can reference the planned name without the guard going red.
+    "dasclaw_session": "ADR-153 §4.3 step 3 — deferred until 2nd caller emerges",
 }
 
 # Symbols that look like crate names but are not. Examples: conceptual


### PR DESCRIPTION
## 背景 / 目标

Base xClaw 当前两条 CI 红线阻塞所有 in-flight PR（#822/#823/#825/#826），按 AGENTS.md「Base 分支既有 broken 测试处置规范」一次性修齐。

## 改动范围

1. **`Cargo.lock`** — `cargo update -p kuchikikiki` 把 0.9.2 (yanked) 回退到 0.9.1。无源码改动；副产物：未被任何 crate 引用的 selectors v0.35.0 被一并清掉。
2. **`scripts/check_blueprint_sync.py`** — `PLANNED` 字典新增 `dasclaw_session` 条目，引用 ADR-153 §4.3 step 3 暂搁说明。

## 非目标

- 不动 deny.toml / 不加白名单豁免
- 不创建 `dasclaw_session` crate（ADR-153 §4.3 明确说"等到第二个调用方再抽"）
- 不改其它 yanked / unmaintained 告警（不在本 PR 触发列表内）

## 验证

- `python3.12 scripts/check_blueprint_sync.py` → `OK: 48 crates on disk, 3 planned`
- `cargo update -p kuchikikiki` → `Downgrading kuchikikiki v0.9.2 -> v0.9.1`

## Cross-cuts

- ADR-114（.ironclaw → .dasclaw 命名迁移）：**类A**（无新增 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量）

## 后续

本 PR merge 后，#822/#823/#825/#826 需 rebase 到 xClaw 重跑 CI。

Closes #827