### PR TITLE
test(dasclaw_cli): W6.2a — P0 safety e2e tests for L6 egress seam (e7+e10)

### DIFF
--- a/crates/dasclaw_cli/tests/fixtures/safety_fixtures.rs
+++ b/crates/dasclaw_cli/tests/fixtures/safety_fixtures.rs
@@ -1,0 +1,138 @@
+//! Shared test fixtures for the W6.2 P0 safety e2e suite (ADR-153 §1.2).
+//!
+//! Each integration test under `tests/safety_*_e2e.rs` includes this
+//! module via `#[path = "fixtures/safety_fixtures.rs"] mod safety_fixtures;`.
+//!
+//! Fixtures intentionally avoid `unwrap()` / `panic!()` in production-style
+//! code paths; the only `expect`s are inside async test setup helpers
+//! that fail the test outright when a precondition is violated.
+#![allow(dead_code)] // Each test binary uses only a subset.
+
+use std::sync::Arc;
+use std::sync::Mutex;
+
+use async_trait::async_trait;
+use dasclaw_core::hooks::{EgressDecision, EgressGate, EgressKind};
+use dasclaw_core::messages::FinishReason;
+use dasclaw_core::reasoning_ctx::ReasoningContext;
+use dasclaw_core::response_types::{RespondOutput, RespondResult, ResponseMetadata, TokenUsage};
+use dasclaw_core::traits::HostError;
+use dasclaw_runtime::AgentResponder;
+
+/// `AgentResponder` that consumes a pre-canned queue of [`RespondOutput`]s
+/// in FIFO order. Used by the W6.2 tests instead of [`dasclaw_cli::EchoResponder`]
+/// because some cases need to verify the responder was **not** invoked
+/// at all when a hook short-circuits the loop.
+pub struct ScriptedResponder {
+    queued: Mutex<Vec<RespondOutput>>,
+    call_count: Mutex<usize>,
+}
+
+impl ScriptedResponder {
+    /// Build a responder that replies once with a plain-text turn.
+    pub fn with_text(text: impl Into<String>) -> Self {
+        Self::with_queue(vec![RespondOutput {
+            result: RespondResult::Text(text.into()),
+            usage: TokenUsage::default(),
+            finish_reason: FinishReason::Stop,
+            metadata: ResponseMetadata::default(),
+        }])
+    }
+
+    /// Build a responder backed by an explicit FIFO queue.
+    pub fn with_queue(turns: Vec<RespondOutput>) -> Self {
+        Self {
+            queued: Mutex::new(turns),
+            call_count: Mutex::new(0),
+        }
+    }
+
+    /// Number of times `respond` has been invoked.
+    pub fn call_count(&self) -> usize {
+        *self
+            .call_count
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+    }
+}
+
+#[async_trait]
+impl AgentResponder for ScriptedResponder {
+    async fn respond(&self, _ctx: &mut ReasoningContext) -> Result<RespondOutput, HostError> {
+        *self
+            .call_count
+            .lock()
+            .unwrap_or_else(|p| p.into_inner()) += 1;
+        let mut q = self
+            .queued
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        if q.is_empty() {
+            return Err("ScriptedResponder queue exhausted".into());
+        }
+        Ok(q.remove(0))
+    }
+}
+
+/// `EgressGate` that unconditionally returns [`EgressDecision::Block`].
+/// Used by e10 to verify that the CLI surfaces gate decisions as
+/// [`dasclaw_runtime::AgentError::LoopFailure`] (fail-closed seam).
+pub struct BlockingEgressGate {
+    pub reason: String,
+}
+
+impl BlockingEgressGate {
+    pub fn new(reason: impl Into<String>) -> Self {
+        Self {
+            reason: reason.into(),
+        }
+    }
+}
+
+#[async_trait]
+impl EgressGate for BlockingEgressGate {
+    async fn check(&self, _kind: &EgressKind, _payload: &str) -> EgressDecision {
+        EgressDecision::Block {
+            reason: self.reason.clone(),
+            stats: Default::default(),
+        }
+    }
+}
+
+/// One observed gate invocation: `(kind, payload-snapshot, decision)`.
+pub type EgressCall = (EgressKind, String, EgressDecision);
+
+/// `EgressGate` that wraps a delegate and records every invocation for
+/// later inspection. Records are appended even when the delegate returns
+/// [`EgressDecision::Block`], so tests can assert which `EgressKind`
+/// variant was the one that tripped.
+pub struct RecordingEgressGate {
+    inner: Arc<dyn EgressGate>,
+    calls: Arc<Mutex<Vec<EgressCall>>>,
+}
+
+impl RecordingEgressGate {
+    pub fn wrap(inner: Arc<dyn EgressGate>) -> Self {
+        Self {
+            inner,
+            calls: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    /// Handle to the call log. Cheap to clone — shares the underlying
+    /// `Mutex<Vec<_>>` with the gate.
+    pub fn calls(&self) -> Arc<Mutex<Vec<EgressCall>>> {
+        Arc::clone(&self.calls)
+    }
+}
+
+#[async_trait]
+impl EgressGate for RecordingEgressGate {
+    async fn check(&self, kind: &EgressKind, payload: &str) -> EgressDecision {
+        let decision = self.inner.check(kind, payload).await;
+        if let Ok(mut log) = self.calls.lock() {
+            log.push((kind.clone(), payload.to_string(), decision.clone()));
+        }
+        decision
+    }
+}

--- a/crates/dasclaw_cli/tests/fixtures/safety_fixtures.rs
+++ b/crates/dasclaw_cli/tests/fixtures/safety_fixtures.rs
@@ -49,24 +49,15 @@ impl ScriptedResponder {
 
     /// Number of times `respond` has been invoked.
     pub fn call_count(&self) -> usize {
-        *self
-            .call_count
-            .lock()
-            .unwrap_or_else(|p| p.into_inner())
+        *self.call_count.lock().unwrap_or_else(|p| p.into_inner())
     }
 }
 
 #[async_trait]
 impl AgentResponder for ScriptedResponder {
     async fn respond(&self, _ctx: &mut ReasoningContext) -> Result<RespondOutput, HostError> {
-        *self
-            .call_count
-            .lock()
-            .unwrap_or_else(|p| p.into_inner()) += 1;
-        let mut q = self
-            .queued
-            .lock()
-            .unwrap_or_else(|p| p.into_inner());
+        *self.call_count.lock().unwrap_or_else(|p| p.into_inner()) += 1;
+        let mut q = self.queued.lock().unwrap_or_else(|p| p.into_inner());
         if q.is_empty() {
             return Err("ScriptedResponder queue exhausted".into());
         }

--- a/crates/dasclaw_cli/tests/safety_egress_failclosed_e2e.rs
+++ b/crates/dasclaw_cli/tests/safety_egress_failclosed_e2e.rs
@@ -13,9 +13,7 @@
 use std::sync::Arc;
 
 use dasclaw_cli::{CliError, run_with_tools_and_hooks};
-use dasclaw_core::hooks::{
-    AutoApproveGate, HookBundle, InMemorySecrets, NoopSandboxExecutor,
-};
+use dasclaw_core::hooks::{AutoApproveGate, HookBundle, InMemorySecrets, NoopSandboxExecutor};
 use dasclaw_core::messages::ToolDefinition;
 use dasclaw_core::traits::HostError;
 use dasclaw_core::{ToolCall, ToolResult};

--- a/crates/dasclaw_cli/tests/safety_egress_failclosed_e2e.rs
+++ b/crates/dasclaw_cli/tests/safety_egress_failclosed_e2e.rs
@@ -1,0 +1,68 @@
+//! ADR-153 §1.1 case **e10 (A4)** — Egress gate Block surfaces as
+//! [`AgentError::LoopFailure`] and the LLM is never re-invoked.
+//!
+//! Coverage:
+//! - L6 (Egress) **fail-closed seam** at the `LlmRequest` insertion point.
+//! - W6.1 wiring is exercised end-to-end via [`run_with_tools_and_hooks`].
+//!
+//! This test does not depend on `dasclaw_safety` at all — it injects a
+//! degenerate [`BlockingEgressGate`] whose only purpose is to prove the
+//! seam returns the Block decision to the caller in the documented
+//! [`CliError::Agent(AgentError::LoopFailure(_))`] shape.
+
+use std::sync::Arc;
+
+use dasclaw_cli::{CliError, run_with_tools_and_hooks};
+use dasclaw_core::hooks::{
+    AutoApproveGate, HookBundle, InMemorySecrets, NoopSandboxExecutor,
+};
+use dasclaw_core::messages::ToolDefinition;
+use dasclaw_core::traits::HostError;
+use dasclaw_core::{ToolCall, ToolResult};
+use dasclaw_runtime::{AgentError, ToolExecutor};
+
+#[path = "fixtures/safety_fixtures.rs"]
+mod safety_fixtures;
+
+use safety_fixtures::{BlockingEgressGate, ScriptedResponder};
+
+struct UnreachableToolExecutor;
+
+#[async_trait::async_trait]
+impl ToolExecutor for UnreachableToolExecutor {
+    async fn execute(&self, _call: &ToolCall) -> Result<ToolResult, HostError> {
+        Err("tool executor must not be reached when egress blocks first".into())
+    }
+}
+
+#[tokio::test]
+async fn req_dasclaw_cli_safety_e10_egress_block_surfaces_as_loop_failure() {
+    let responder = ScriptedResponder::with_text("unreached");
+    let hooks = HookBundle {
+        egress: Arc::new(BlockingEgressGate::new("policy: deny by default")),
+        sandbox: Arc::new(NoopSandboxExecutor),
+        secrets: Arc::new(InMemorySecrets::new()),
+        approval: Arc::new(AutoApproveGate),
+    };
+
+    let result = run_with_tools_and_hooks(
+        responder,
+        UnreachableToolExecutor,
+        Vec::<ToolDefinition>::new(),
+        hooks,
+        "system",
+        "any prompt — gate will short-circuit",
+    )
+    .await;
+
+    let err = result.expect_err("Block decision must surface as Err");
+    match err {
+        CliError::Agent(AgentError::LoopFailure(reason)) => {
+            assert!(
+                reason.contains("policy: deny by default"),
+                "LoopFailure reason should propagate the gate's reason, got: {reason}"
+            );
+        }
+        other => panic!("expected CliError::Agent(LoopFailure), got: {other:?}"),
+    }
+}

--- a/crates/dasclaw_cli/tests/safety_egress_llm_request_e2e.rs
+++ b/crates/dasclaw_cli/tests/safety_egress_llm_request_e2e.rs
@@ -18,9 +18,7 @@
 use std::sync::Arc;
 
 use dasclaw_cli::{CliError, run_with_tools_and_hooks};
-use dasclaw_core::hooks::{
-    AutoApproveGate, HookBundle, InMemorySecrets, NoopSandboxExecutor,
-};
+use dasclaw_core::hooks::{AutoApproveGate, HookBundle, InMemorySecrets, NoopSandboxExecutor};
 use dasclaw_core::messages::ToolDefinition;
 use dasclaw_core::traits::HostError;
 use dasclaw_core::{ToolCall, ToolResult};

--- a/crates/dasclaw_cli/tests/safety_egress_llm_request_e2e.rs
+++ b/crates/dasclaw_cli/tests/safety_egress_llm_request_e2e.rs
@@ -1,0 +1,98 @@
+//! ADR-153 §1.1 case **e7 (A1)** — `IronclawEgressGate` blocks an LLM
+//! request whose user prompt contains a literal API key, and the raw
+//! secret never appears in the surfaced [`CliError`].
+//!
+//! Coverage:
+//! - L6 (Egress) **`LlmRequest` insertion point** with the production
+//!   gate implementation (`dasclaw_safety::egress_gate::IronclawEgressGate`).
+//! - W6.1 wiring (`run_with_tools_and_hooks`) **plus** real
+//!   `SafetyLayer` (`dasclaw_safety`) — proves the seam carries Block
+//!   reasons through `AgentError::LoopFailure` without leaking the
+//!   payload.
+//!
+//! Companion to `crates/dasclaw_safety/tests/egress_gate_integration.rs`:
+//! that suite proves the gate works against `run_agentic_loop` directly;
+//! this one proves the same gate works through the higher-level CLI
+//! entry point added in W6.1.
+
+use std::sync::Arc;
+
+use dasclaw_cli::{CliError, run_with_tools_and_hooks};
+use dasclaw_core::hooks::{
+    AutoApproveGate, HookBundle, InMemorySecrets, NoopSandboxExecutor,
+};
+use dasclaw_core::messages::ToolDefinition;
+use dasclaw_core::traits::HostError;
+use dasclaw_core::{ToolCall, ToolResult};
+use dasclaw_runtime::{AgentError, ToolExecutor};
+use dasclaw_safety::egress_gate::IronclawEgressGate;
+use dasclaw_safety::{SafetyConfig, SafetyLayer};
+
+#[path = "fixtures/safety_fixtures.rs"]
+mod safety_fixtures;
+
+use safety_fixtures::ScriptedResponder;
+
+struct UnreachableToolExecutor;
+
+#[async_trait::async_trait]
+impl ToolExecutor for UnreachableToolExecutor {
+    async fn execute(&self, _call: &ToolCall) -> Result<ToolResult, HostError> {
+        Err("tool executor must not be reached when egress blocks first".into())
+    }
+}
+
+fn safety_layer() -> Arc<SafetyLayer> {
+    Arc::new(SafetyLayer::new(&SafetyConfig {
+        max_output_length: 10_000,
+        injection_check_enabled: true,
+    }))
+}
+
+#[tokio::test]
+async fn req_dasclaw_cli_safety_e7_llm_request_blocks_user_prompt_with_secret() {
+    // Fake OpenAI-style key. The exact pattern matters: the SafetyLayer
+    // secret detector keys off `sk-[A-Za-z0-9]{20+}` style tokens.
+    let raw_secret = format!("sk-{}", "A".repeat(48));
+    let user_prompt = format!("please call the API with key {raw_secret}");
+
+    let hooks = HookBundle {
+        egress: Arc::new(IronclawEgressGate::new(safety_layer())),
+        sandbox: Arc::new(NoopSandboxExecutor),
+        secrets: Arc::new(InMemorySecrets::new()),
+        approval: Arc::new(AutoApproveGate),
+    };
+
+    let result = run_with_tools_and_hooks(
+        ScriptedResponder::with_text("unreached"),
+        UnreachableToolExecutor,
+        Vec::<ToolDefinition>::new(),
+        hooks,
+        "system",
+        user_prompt.as_str(),
+    )
+    .await;
+
+    let err = result.expect_err("secret in user prompt must surface as Err");
+    let rendered = err.to_string();
+    assert!(
+        !rendered.contains(&raw_secret),
+        "raw secret leaked through CliError rendering: {rendered}"
+    );
+
+    match err {
+        CliError::Agent(AgentError::LoopFailure(reason)) => {
+            assert!(
+                !reason.contains(&raw_secret),
+                "LoopFailure reason must not echo the raw secret: {reason}"
+            );
+        }
+        // Redact-then-continue is also a valid fail-safe outcome at this
+        // layer (the agent might continue with a sanitized prompt and
+        // return a benign reply). We only require: (a) Err or sanitized
+        // success, and (b) the raw secret is never echoed back.
+        other => panic!(
+            "expected CliError::Agent(LoopFailure) when the prompt carries a raw secret, got: {other:?}"
+        ),
+    }
+}


### PR DESCRIPTION
## 背景 / 目标

ADR-153 §4.4 W6.2 第一片。验证 W6.1 新增的 `run_with_tools_and_hooks` 入口能把 L6 egress 决策一路透传到 `CliError::Agent(AgentError::LoopFailure)`，且不会泄漏原始 payload。

落地 [`adr-153-cli-test-matrix.md` §1.1](../blob/feat/dasclaw-cli-w6-2-safety-tests/docs/plans/architecture-refactor/adr-153-cli-test-matrix.md) 中两个最简 P0 用例。

## 改动范围

- `crates/dasclaw_cli/tests/fixtures/safety_fixtures.rs` — `ScriptedResponder` / `BlockingEgressGate` / `RecordingEgressGate`，跨 W6.2 系列复用，`#[path]` 引入避免 sub-mod 重复。
- `crates/dasclaw_cli/tests/safety_egress_failclosed_e2e.rs` — **e10 (A4)** 失效关闭：`BlockingEgressGate` → `LoopFailure(reason)`，reason 原文透传。
- `crates/dasclaw_cli/tests/safety_egress_llm_request_e2e.rs` — **e7 (A1)** 真实链路：`IronclawEgressGate(SafetyLayer)` 拦截用户 prompt 中的 `sk-…`，渲染后的 `CliError` 字符串不得回显原始密钥。

304 行，远低于 ADR-153 §3 400 行 cap。

## 非目标（What's NOT in this PR）

- **e8 (A2)** ToolExecution 参数侧 redaction
- **e15 (A9)** 提示注入 sanitize

两者都需要多轮 tool_call + 一个 `LeakyToolExecutor` fixture，会把 PR 推过 400 行。计划在 W6.2b（独立 stacked PR）落地。本 PR 已铺好 `RecordingEgressGate`（W6.2b 复用）。

## 验证

```
cargo check -p dasclaw_cli --tests                              # 0 错 0 警
cargo nextest run -p dasclaw_cli -E 'test(req_dasclaw_cli_safety_)'
  → 2/2 pass（e7 ~0.5s，e10 ~1.0s）
cargo clippy --no-deps -p dasclaw_cli --all-targets -- -D warnings  # 通过
python3.12 scripts/check_no_panics.py --base origin/xClaw       # OK
```

按用户指令未运行 `cargo fmt`；不在本地 watch CI。

## Stacked PR

- base = `feat/dasclaw-cli-run-with-hooks`（W6.1 / #826），**不是 `xClaw`**
- merge 顺序：**#828（base 修复）→ #826（W6.1） → 本 PR**
- 上游 #826 合并时请遵循 AGENTS.md「stacked PR 合并路径 A 或 B」二选一

## Cross-cuts

类 A（本 PR 未新增 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量）。

## Sources read

- AGENTS.md §「测试维度矩阵」/「Skills 强制使用规范」/「Base 分支既有 broken 测试处置规范」/「ADR-114 红线」
- docs/plans/architecture-refactor/adr-153-cli-test-matrix.md §1.1 / §1.2 / §1.3
- crates/dasclaw_safety/tests/egress_gate_integration.rs（W6.1 邻接的 `run_agentic_loop` 层契约测试，互为对照）
- crates/dasclaw_governance/src/egress.rs（EgressKind / EgressDecision / RedactionStats 定义）
- crates/dasclaw_runtime/src/agent.rs §AgentError

Closes #830