### PR TITLE
test(dasclaw_cli): W6.3 agent-loop P0 tests (e17/e18/e21/e23)

### DIFF
--- a/crates/dasclaw_cli/tests/agent_max_iterations_e2e.rs
+++ b/crates/dasclaw_cli/tests/agent_max_iterations_e2e.rs
@@ -1,0 +1,67 @@
+//! ADR-153 §1.1 B5 (e21): `max_iterations` is an exact, observable cap.
+//! With `max_iterations = 3` and a responder that always asks for one
+//! more tool call, the loop must exit with
+//! `AgentError::MaxIterations(3)` after exactly 3 tool dispatches —
+//! not 2 (off-by-one early), not 4 (off-by-one late).
+
+#[path = "fixtures/agent_loop_fixtures.rs"]
+mod fixtures;
+
+use dasclaw_core::agentic_loop::AgenticLoopConfig;
+use dasclaw_runtime::{Agent, AgentError};
+use serde_json::json;
+
+use fixtures::{
+    RecordingToolExecutor, ScriptedResponder, no_tool_defs, tool_call_turn,
+};
+
+#[tokio::test]
+async fn req_dasclaw_cli_loop_e21_max_iterations_3_exact_count() {
+    // Queue more turns than the cap so a successful early exit would
+    // visibly leave headroom in the queue. Every turn is a tool call so
+    // the loop never reaches a terminal text state on its own.
+    let script = (0..10)
+        .map(|i| {
+            tool_call_turn(
+                "noop",
+                format!("call_noop_{i}"),
+                json!({ "iteration": i }),
+            )
+        })
+        .collect();
+    let responder = ScriptedResponder::with_queue(script);
+
+    let executor = RecordingToolExecutor::new().with_reply("noop", "ok");
+    let calls = executor.calls();
+
+    let cfg = AgenticLoopConfig {
+        max_iterations: 3,
+        ..AgenticLoopConfig::default()
+    };
+
+    let agent = Agent::builder()
+        .responder(responder)
+        .tool_executor(executor)
+        .tools(no_tool_defs())
+        .loop_config(cfg)
+        .build()
+        .expect("agent builds");
+
+    let err = agent
+        .run("spin forever")
+        .await
+        .expect_err("looped responder must trip the cap");
+
+    match err {
+        AgentError::MaxIterations(n) => {
+            assert_eq!(n, 3, "AgentError::MaxIterations must echo the configured cap");
+        }
+        other => panic!("expected MaxIterations(3), got {other:?}"),
+    }
+
+    let count = calls.lock().expect("calls log").len();
+    assert_eq!(
+        count, 3,
+        "exactly max_iterations tool dispatches must have run, got {count}"
+    );
+}

--- a/crates/dasclaw_cli/tests/agent_max_iterations_e2e.rs
+++ b/crates/dasclaw_cli/tests/agent_max_iterations_e2e.rs
@@ -11,9 +11,7 @@ use dasclaw_core::agentic_loop::AgenticLoopConfig;
 use dasclaw_runtime::{Agent, AgentError};
 use serde_json::json;
 
-use fixtures::{
-    RecordingToolExecutor, ScriptedResponder, no_tool_defs, tool_call_turn,
-};
+use fixtures::{RecordingToolExecutor, ScriptedResponder, no_tool_defs, tool_call_turn};
 
 #[tokio::test]
 async fn req_dasclaw_cli_loop_e21_max_iterations_3_exact_count() {
@@ -21,13 +19,7 @@ async fn req_dasclaw_cli_loop_e21_max_iterations_3_exact_count() {
     // visibly leave headroom in the queue. Every turn is a tool call so
     // the loop never reaches a terminal text state on its own.
     let script = (0..10)
-        .map(|i| {
-            tool_call_turn(
-                "noop",
-                format!("call_noop_{i}"),
-                json!({ "iteration": i }),
-            )
-        })
+        .map(|i| tool_call_turn("noop", format!("call_noop_{i}"), json!({ "iteration": i })))
         .collect();
     let responder = ScriptedResponder::with_queue(script);
 
@@ -54,7 +46,10 @@ async fn req_dasclaw_cli_loop_e21_max_iterations_3_exact_count() {
 
     match err {
         AgentError::MaxIterations(n) => {
-            assert_eq!(n, 3, "AgentError::MaxIterations must echo the configured cap");
+            assert_eq!(
+                n, 3,
+                "AgentError::MaxIterations must echo the configured cap"
+            );
         }
         other => panic!("expected MaxIterations(3), got {other:?}"),
     }

--- a/crates/dasclaw_cli/tests/agent_multitool_chain_e2e.rs
+++ b/crates/dasclaw_cli/tests/agent_multitool_chain_e2e.rs
@@ -1,0 +1,64 @@
+//! ADR-153 §1.1 B1 (e17): multi-tool chain — three LLM turns drive two
+//! distinct tool calls, then a final text turn that cites both tool
+//! outputs. Verifies the loop genuinely round-trips tool_result back
+//! into the model and doesn't short-circuit on the first turn.
+//!
+//! Fixtures live in a dedicated file (`agent_loop_fixtures.rs`) to keep
+//! zero file overlap with the W6.2 safety-stack tests.
+
+#[path = "fixtures/agent_loop_fixtures.rs"]
+mod fixtures;
+
+use dasclaw_runtime::Agent;
+use serde_json::json;
+
+use fixtures::{
+    RecordingToolExecutor, ScriptedResponder, no_tool_defs, text_turn, tool_call_turn,
+};
+
+#[tokio::test]
+async fn req_dasclaw_cli_loop_e17_multitool_chain_completes() {
+    // Three LLM turns: list_files → read_file → final text.
+    let script = vec![
+        tool_call_turn("list_files", "call_list_1", json!({ "path": "." })),
+        tool_call_turn(
+            "read_file",
+            "call_read_1",
+            json!({ "path": "fileA.txt" }),
+        ),
+        text_turn("done: listed=[fileA.txt,fileB.txt], read=contents-of-fileA"),
+    ];
+    let responder = ScriptedResponder::with_queue(script);
+
+    let executor = RecordingToolExecutor::new()
+        .with_reply("list_files", "fileA.txt\nfileB.txt")
+        .with_reply("read_file", "contents-of-fileA");
+    let calls = executor.calls();
+
+    let agent = Agent::builder()
+        .responder(responder)
+        .tool_executor(executor)
+        .tools(no_tool_defs())
+        .build()
+        .expect("agent builds");
+
+    let reply = agent
+        .run("please list the dir and then read fileA")
+        .await
+        .expect("multi-tool chain succeeds");
+
+    assert!(
+        reply.contains("fileA.txt") && reply.contains("contents-of-fileA"),
+        "final reply must cite evidence from both tool calls, got: {reply:?}"
+    );
+
+    let log = calls.lock().expect("calls log");
+    assert_eq!(log.len(), 2, "expected exactly 2 tool calls, got: {log:#?}");
+    assert_eq!(log[0].name, "list_files", "first call must be list_files");
+    assert_eq!(log[1].name, "read_file", "second call must be read_file");
+    assert_eq!(
+        log[1].arguments,
+        json!({ "path": "fileA.txt" }),
+        "second call must forward the model's chosen path"
+    );
+}

--- a/crates/dasclaw_cli/tests/agent_multitool_chain_e2e.rs
+++ b/crates/dasclaw_cli/tests/agent_multitool_chain_e2e.rs
@@ -12,20 +12,14 @@ mod fixtures;
 use dasclaw_runtime::Agent;
 use serde_json::json;
 
-use fixtures::{
-    RecordingToolExecutor, ScriptedResponder, no_tool_defs, text_turn, tool_call_turn,
-};
+use fixtures::{RecordingToolExecutor, ScriptedResponder, no_tool_defs, text_turn, tool_call_turn};
 
 #[tokio::test]
 async fn req_dasclaw_cli_loop_e17_multitool_chain_completes() {
     // Three LLM turns: list_files → read_file → final text.
     let script = vec![
         tool_call_turn("list_files", "call_list_1", json!({ "path": "." })),
-        tool_call_turn(
-            "read_file",
-            "call_read_1",
-            json!({ "path": "fileA.txt" }),
-        ),
+        tool_call_turn("read_file", "call_read_1", json!({ "path": "fileA.txt" })),
         text_turn("done: listed=[fileA.txt,fileB.txt], read=contents-of-fileA"),
     ];
     let responder = ScriptedResponder::with_queue(script);

--- a/crates/dasclaw_cli/tests/agent_refusal_path_e2e.rs
+++ b/crates/dasclaw_cli/tests/agent_refusal_path_e2e.rs
@@ -8,9 +8,7 @@ mod fixtures;
 
 use std::sync::Arc;
 
-use dasclaw_core::hooks::{
-    AutoApproveGate, HookBundle, InMemorySecrets, NoopSandboxExecutor,
-};
+use dasclaw_core::hooks::{AutoApproveGate, HookBundle, InMemorySecrets, NoopSandboxExecutor};
 use dasclaw_runtime::{Agent, AgentError};
 
 use fixtures::{

--- a/crates/dasclaw_cli/tests/agent_refusal_path_e2e.rs
+++ b/crates/dasclaw_cli/tests/agent_refusal_path_e2e.rs
@@ -1,0 +1,69 @@
+//! ADR-153 §1.1 B7 (e23): refusal path. The user prompt contains a
+//! bait phrase ("SecretsStore"); the egress gate Blocks the LlmRequest
+//! before the model sees it. The loop must exit with
+//! `AgentError::LoopFailure(_)` and the tool executor must never run.
+
+#[path = "fixtures/agent_loop_fixtures.rs"]
+mod fixtures;
+
+use std::sync::Arc;
+
+use dasclaw_core::hooks::{
+    AutoApproveGate, HookBundle, InMemorySecrets, NoopSandboxExecutor,
+};
+use dasclaw_runtime::{Agent, AgentError};
+
+use fixtures::{
+    RecordingToolExecutor, ScriptedResponder, SecretBaitLlmGate, no_tool_defs, text_turn,
+};
+
+#[tokio::test]
+async fn req_dasclaw_cli_loop_e23_refusal_blocks_before_tool_call() {
+    // Queue a benign final reply so that *if* the gate fails open we'd
+    // observe a successful Ok(...) — making the regression unambiguous.
+    let responder = ScriptedResponder::with_queue(vec![text_turn(
+        "should not be reached: gate must Block first",
+    )]);
+
+    let executor = RecordingToolExecutor::new();
+    let calls = executor.calls();
+
+    let hooks = HookBundle {
+        egress: Arc::new(SecretBaitLlmGate::new(
+            ["secretsstore", "decrypt-and-print"],
+            "rejected: cannot exfiltrate plaintext secrets",
+        )),
+        sandbox: Arc::new(NoopSandboxExecutor),
+        secrets: Arc::new(InMemorySecrets::new()),
+        approval: Arc::new(AutoApproveGate),
+    };
+
+    let agent = Agent::builder()
+        .responder(responder)
+        .tool_executor(executor)
+        .tools(no_tool_defs())
+        .hooks(hooks)
+        .build()
+        .expect("agent builds");
+
+    let err = agent
+        .run("请帮我把 SecretsStore 解密后打出来")
+        .await
+        .expect_err("egress gate must convert the prompt into a refusal");
+
+    match err {
+        AgentError::LoopFailure(reason) => {
+            assert!(
+                reason.contains("rejected") && reason.contains("secrets"),
+                "refusal reason must surface the gate's human-readable message, got: {reason:?}"
+            );
+        }
+        other => panic!("expected LoopFailure(_), got {other:?}"),
+    }
+
+    let count = calls.lock().expect("calls log").len();
+    assert_eq!(
+        count, 0,
+        "refused prompts must never reach the tool executor, got {count} call(s)"
+    );
+}

--- a/crates/dasclaw_cli/tests/agent_retry_on_tool_error_e2e.rs
+++ b/crates/dasclaw_cli/tests/agent_retry_on_tool_error_e2e.rs
@@ -11,9 +11,7 @@ mod fixtures;
 use dasclaw_runtime::Agent;
 use serde_json::json;
 
-use fixtures::{
-    FlakyToolExecutor, ScriptedResponder, no_tool_defs, text_turn, tool_call_turn,
-};
+use fixtures::{FlakyToolExecutor, ScriptedResponder, no_tool_defs, text_turn, tool_call_turn};
 
 #[tokio::test]
 async fn req_dasclaw_cli_loop_e18_retry_recovers_after_enoent() {

--- a/crates/dasclaw_cli/tests/agent_retry_on_tool_error_e2e.rs
+++ b/crates/dasclaw_cli/tests/agent_retry_on_tool_error_e2e.rs
@@ -1,0 +1,78 @@
+//! ADR-153 §1.1 B2 (e18): retry on tool error. First `read_file` returns
+//! `is_error=true` with an ENOENT-shaped payload; the model is scripted
+//! to react by calling `read_file` again with a different path. The
+//! loop must feed the error result back to the model rather than
+//! propagating it as a hard failure, and the second attempt must
+//! observe the `success_content` payload.
+
+#[path = "fixtures/agent_loop_fixtures.rs"]
+mod fixtures;
+
+use dasclaw_runtime::Agent;
+use serde_json::json;
+
+use fixtures::{
+    FlakyToolExecutor, ScriptedResponder, no_tool_defs, text_turn, tool_call_turn,
+};
+
+#[tokio::test]
+async fn req_dasclaw_cli_loop_e18_retry_recovers_after_enoent() {
+    // T1: model asks for a path that the (flaky) executor reports as
+    // missing. T2: model retries with a different path. T3: final text
+    // cites the recovered content.
+    let script = vec![
+        tool_call_turn(
+            "read_file",
+            "call_read_bad",
+            json!({ "path": "missing.txt" }),
+        ),
+        tool_call_turn(
+            "read_file",
+            "call_read_good",
+            json!({ "path": "exists.txt" }),
+        ),
+        text_turn("recovered: hello-from-disk"),
+    ];
+    let responder = ScriptedResponder::with_queue(script);
+
+    let executor = FlakyToolExecutor::new(
+        ["read_file"],
+        "ENOENT: no such file 'missing.txt'",
+        "hello-from-disk",
+    );
+    let calls = executor.calls();
+
+    let agent = Agent::builder()
+        .responder(responder)
+        .tool_executor(executor)
+        .tools(no_tool_defs())
+        .build()
+        .expect("agent builds");
+
+    let reply = agent
+        .run("read the report file")
+        .await
+        .expect("retry path must surface as Ok(...) from the loop");
+
+    assert!(
+        reply.contains("hello-from-disk"),
+        "final reply must cite the recovered content, got: {reply:?}"
+    );
+
+    let log = calls.lock().expect("calls log");
+    assert_eq!(
+        log.len(),
+        2,
+        "expected exactly 2 read_file invocations (1 error + 1 success), got: {log:#?}"
+    );
+    assert_eq!(
+        log[0].arguments,
+        json!({ "path": "missing.txt" }),
+        "first attempt must hit the bad path"
+    );
+    assert_eq!(
+        log[1].arguments,
+        json!({ "path": "exists.txt" }),
+        "retry must use the model's corrected path"
+    );
+}

--- a/crates/dasclaw_cli/tests/fixtures/agent_loop_fixtures.rs
+++ b/crates/dasclaw_cli/tests/fixtures/agent_loop_fixtures.rs
@@ -1,0 +1,272 @@
+//! Shared fixtures for W6.3 agent-loop integration tests
+//! (ADR-153 §1.1 B1/B2/B5/B7 — e17/e18/e21/e23).
+//!
+//! Designed for **zero file overlap** with `safety_fixtures.rs` (W6.2)
+//! so the two PR chains can be reviewed in parallel without rebase
+//! conflicts. The shapes intentionally mirror the unit-test
+//! `ScriptedResponder` already living inside `dasclaw_runtime::agent`,
+//! re-exported here in the public-API form callers will use.
+//!
+//! Allowed `dead_code` because each `tests/*.rs` integration binary
+//! only consumes a subset of these helpers.
+
+#![allow(dead_code)]
+
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use dasclaw_core::hooks::{EgressDecision, EgressGate, EgressKind, RedactionStats};
+use dasclaw_core::messages::{FinishReason, ToolCall, ToolDefinition, ToolResult};
+use dasclaw_core::reasoning_ctx::ReasoningContext;
+use dasclaw_core::response_types::{
+    RespondOutput, RespondResult, ResponseMetadata, TokenUsage,
+};
+use dasclaw_core::traits::HostError;
+use dasclaw_runtime::{AgentResponder, ToolExecutor};
+use serde_json::Value as JsonValue;
+
+/// Convenience constructor for a `Text(...)` `RespondOutput` with
+/// [`FinishReason::Stop`].
+pub fn text_turn(text: impl Into<String>) -> RespondOutput {
+    RespondOutput {
+        result: RespondResult::Text(text.into()),
+        usage: TokenUsage::default(),
+        finish_reason: FinishReason::Stop,
+        metadata: ResponseMetadata::default(),
+    }
+}
+
+/// Convenience constructor for a `ToolCalls { … }` `RespondOutput` with
+/// [`FinishReason::ToolUse`]. Single-call helper — most agent-loop tests
+/// only need one tool call per turn.
+pub fn tool_call_turn(
+    tool: impl Into<String>,
+    call_id: impl Into<String>,
+    arguments: JsonValue,
+) -> RespondOutput {
+    RespondOutput {
+        result: RespondResult::ToolCalls {
+            tool_calls: vec![ToolCall {
+                id: call_id.into(),
+                name: tool.into(),
+                arguments,
+                reasoning: None,
+            }],
+            content: None,
+        },
+        usage: TokenUsage::default(),
+        finish_reason: FinishReason::ToolUse,
+        metadata: ResponseMetadata::default(),
+    }
+}
+
+/// Mock [`AgentResponder`] driven by a fixed `Vec<RespondOutput>` queue.
+///
+/// Each `respond` call pops the front and returns it. Once the queue is
+/// empty, returns `HostError("script exhausted")` so test failures point
+/// to the off-by-one cause directly.
+pub struct ScriptedResponder {
+    script: Mutex<Vec<RespondOutput>>,
+}
+
+impl ScriptedResponder {
+    pub fn with_queue(script: Vec<RespondOutput>) -> Self {
+        Self {
+            script: Mutex::new(script),
+        }
+    }
+}
+
+#[async_trait]
+impl AgentResponder for ScriptedResponder {
+    async fn respond(&self, _ctx: &mut ReasoningContext) -> Result<RespondOutput, HostError> {
+        let mut s = self.script.lock().expect("scripted responder mutex");
+        if s.is_empty() {
+            return Err("script exhausted".into());
+        }
+        Ok(s.remove(0))
+    }
+}
+
+/// Per-tool call record so tests can verify both call ordering and
+/// argument payloads without re-deriving them from log strings.
+#[derive(Debug, Clone)]
+pub struct ToolInvocation {
+    pub name: String,
+    pub call_id: String,
+    pub arguments: JsonValue,
+}
+
+/// [`ToolExecutor`] that records every invocation and routes to a
+/// per-tool reply table. Falls back to a generic "ok" reply when the
+/// tool name is unknown so tests don't have to enumerate every variant.
+pub struct RecordingToolExecutor {
+    calls: Arc<Mutex<Vec<ToolInvocation>>>,
+    replies: Vec<(String, String)>,
+}
+
+impl RecordingToolExecutor {
+    pub fn new() -> Self {
+        Self {
+            calls: Arc::new(Mutex::new(Vec::new())),
+            replies: Vec::new(),
+        }
+    }
+
+    /// Bind `tool_name → content` so the first call to that tool returns
+    /// `content`. Subsequent calls also return the same content; tests
+    /// that need step-wise behaviour should use [`FlakyToolExecutor`].
+    pub fn with_reply(mut self, tool_name: impl Into<String>, content: impl Into<String>) -> Self {
+        self.replies.push((tool_name.into(), content.into()));
+        self
+    }
+
+    pub fn calls(&self) -> Arc<Mutex<Vec<ToolInvocation>>> {
+        Arc::clone(&self.calls)
+    }
+
+    pub fn call_count(&self) -> usize {
+        self.calls.lock().expect("recording executor mutex").len()
+    }
+}
+
+impl Default for RecordingToolExecutor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl ToolExecutor for RecordingToolExecutor {
+    async fn execute(&self, call: &ToolCall) -> Result<ToolResult, HostError> {
+        self.calls
+            .lock()
+            .expect("recording executor mutex")
+            .push(ToolInvocation {
+                name: call.name.clone(),
+                call_id: call.id.clone(),
+                arguments: call.arguments.clone(),
+            });
+        let reply = self
+            .replies
+            .iter()
+            .find(|(name, _)| name == &call.name)
+            .map(|(_, body)| body.clone())
+            .unwrap_or_else(|| format!("ok:{}", call.name));
+        Ok(ToolResult {
+            tool_call_id: call.id.clone(),
+            name: call.name.clone(),
+            content: reply,
+            is_error: false,
+        })
+    }
+}
+
+/// [`ToolExecutor`] that returns `is_error=true` on the first call to
+/// any tool listed in `error_first`, then succeeds afterwards. Used by
+/// e18 to drive the model's recovery branch.
+pub struct FlakyToolExecutor {
+    calls: Arc<Mutex<Vec<ToolInvocation>>>,
+    error_first: Vec<String>,
+    error_message: String,
+    success_content: String,
+}
+
+impl FlakyToolExecutor {
+    pub fn new(
+        error_first: impl IntoIterator<Item = impl Into<String>>,
+        error_message: impl Into<String>,
+        success_content: impl Into<String>,
+    ) -> Self {
+        Self {
+            calls: Arc::new(Mutex::new(Vec::new())),
+            error_first: error_first.into_iter().map(Into::into).collect(),
+            error_message: error_message.into(),
+            success_content: success_content.into(),
+        }
+    }
+
+    pub fn calls(&self) -> Arc<Mutex<Vec<ToolInvocation>>> {
+        Arc::clone(&self.calls)
+    }
+
+    pub fn call_count_for(&self, tool: &str) -> usize {
+        self.calls
+            .lock()
+            .expect("flaky executor mutex")
+            .iter()
+            .filter(|c| c.name == tool)
+            .count()
+    }
+}
+
+#[async_trait]
+impl ToolExecutor for FlakyToolExecutor {
+    async fn execute(&self, call: &ToolCall) -> Result<ToolResult, HostError> {
+        let mut log = self.calls.lock().expect("flaky executor mutex");
+        log.push(ToolInvocation {
+            name: call.name.clone(),
+            call_id: call.id.clone(),
+            arguments: call.arguments.clone(),
+        });
+        let prior_attempts = log.iter().filter(|c| c.name == call.name).count() - 1;
+        let should_fail = prior_attempts == 0 && self.error_first.iter().any(|t| t == &call.name);
+        Ok(ToolResult {
+            tool_call_id: call.id.clone(),
+            name: call.name.clone(),
+            content: if should_fail {
+                self.error_message.clone()
+            } else {
+                self.success_content.clone()
+            },
+            is_error: should_fail,
+        })
+    }
+}
+
+/// [`EgressGate`] that returns `Block { reason }` when an
+/// [`EgressKind::LlmRequest`] payload contains any of the configured
+/// bait phrases (case-insensitive). All other kinds Pass through.
+/// Used by e23 to validate the refusal path: model never speaks, no
+/// tool is invoked, and the CLI surfaces a human-readable reason.
+pub struct SecretBaitLlmGate {
+    pub bait: Vec<String>,
+    pub reason: String,
+}
+
+impl SecretBaitLlmGate {
+    pub fn new(
+        bait: impl IntoIterator<Item = impl Into<String>>,
+        reason: impl Into<String>,
+    ) -> Self {
+        Self {
+            bait: bait.into_iter().map(|s| s.into().to_lowercase()).collect(),
+            reason: reason.into(),
+        }
+    }
+}
+
+#[async_trait]
+impl EgressGate for SecretBaitLlmGate {
+    async fn check(&self, kind: &EgressKind, payload: &str) -> EgressDecision {
+        if !matches!(kind, EgressKind::LlmRequest) {
+            return EgressDecision::Allow;
+        }
+        let lower = payload.to_lowercase();
+        if self.bait.iter().any(|b| lower.contains(b)) {
+            EgressDecision::Block {
+                reason: self.reason.clone(),
+                stats: RedactionStats::default(),
+            }
+        } else {
+            EgressDecision::Allow
+        }
+    }
+}
+
+/// Convenience: build an empty `Vec<ToolDefinition>` for tests that
+/// don't care about schema validation. Kept here so each test file
+/// doesn't re-import the type.
+pub fn no_tool_defs() -> Vec<ToolDefinition> {
+    Vec::new()
+}

--- a/crates/dasclaw_cli/tests/fixtures/agent_loop_fixtures.rs
+++ b/crates/dasclaw_cli/tests/fixtures/agent_loop_fixtures.rs
@@ -18,9 +18,7 @@ use async_trait::async_trait;
 use dasclaw_core::hooks::{EgressDecision, EgressGate, EgressKind, RedactionStats};
 use dasclaw_core::messages::{FinishReason, ToolCall, ToolDefinition, ToolResult};
 use dasclaw_core::reasoning_ctx::ReasoningContext;
-use dasclaw_core::response_types::{
-    RespondOutput, RespondResult, ResponseMetadata, TokenUsage,
-};
+use dasclaw_core::response_types::{RespondOutput, RespondResult, ResponseMetadata, TokenUsage};
 use dasclaw_core::traits::HostError;
 use dasclaw_runtime::{AgentResponder, ToolExecutor};
 use serde_json::Value as JsonValue;


### PR DESCRIPTION
## 背景 / 目标

ADR-153 §1.1 标记 W6.3 为 B1+B2+B5+B7 的 P0 解题四件套：

| ID  | B-bucket | 解题点                               |
| --- | -------- | ------------------------------------ |
| e17 | B1       | multi-tool chain（多步工具链能完成） |
| e18 | B2       | retry on tool error（错误后重试）    |
| e21 | B5       | max_iterations 是精确边界            |
| e23 | B7       | refusal path（拒答路径不调工具）     |

四个 case 全部走 `dasclaw_runtime::Agent::builder()` 公开 API，零运行时改动。

Closes #834

## 改动范围

新增 5 个测试文件，无源码变更：

- `crates/dasclaw_cli/tests/fixtures/agent_loop_fixtures.rs` — 共享脚手架（`ScriptedResponder` / `RecordingToolExecutor` / `FlakyToolExecutor` / `SecretBaitLlmGate` + 两个 `RespondOutput` 便捷构造器）
- `crates/dasclaw_cli/tests/agent_multitool_chain_e2e.rs` — e17
- `crates/dasclaw_cli/tests/agent_retry_on_tool_error_e2e.rs` — e18
- `crates/dasclaw_cli/tests/agent_max_iterations_e2e.rs` — e21
- `crates/dasclaw_cli/tests/agent_refusal_path_e2e.rs` — e23

每个 test 文件通过 `#[path = "fixtures/agent_loop_fixtures.rs"] mod fixtures;` 引入脚手架，互不耦合。

## 非目标 (What's NOT in this PR)

- ❌ 不动 `dasclaw_runtime` / `dasclaw_core` 任何源码（W6.2b 的 tool-call egress 加固在并行链上，本 PR 不依赖它，因为 e17/e18/e21 不需要 tool 级 egress，e23 只用 agentic_loop 已经原生 wire 好的 `EgressKind::LlmRequest` gate）
- ❌ 不新增 dev-dependency（沿用 W6.1 的 `async-trait` / `tokio` / `serde_json`）
- ❌ 不动 `safety_fixtures.rs`（W6.2 链专属）—— 本 PR 用独立 fixture 文件确保**文件零重叠**

## 验证 (commands + results)

```bash
$ cargo check -p dasclaw_cli --tests
Finished `dev` profile in 1.97s   # 0 错 0 警

$ cargo nextest run -p dasclaw_cli -E 'test(req_dasclaw_cli_loop_e17) | test(req_dasclaw_cli_loop_e18) | test(req_dasclaw_cli_loop_e21) | test(req_dasclaw_cli_loop_e23)'
PASS [0.557s] req_dasclaw_cli_loop_e18_retry_recovers_after_enoent
PASS [1.098s] req_dasclaw_cli_loop_e21_max_iterations_3_exact_count
PASS [1.641s] req_dasclaw_cli_loop_e23_refusal_blocks_before_tool_call
PASS [2.185s] req_dasclaw_cli_loop_e17_multitool_chain_completes
Summary: 4 tests run: 4 passed, 26 skipped

$ cargo clippy --no-deps -p dasclaw_cli --all-targets -- -D warnings
Finished `dev` profile in 12.98s   # 0 警告

$ python3.12 scripts/check_no_panics.py --base origin/xClaw
OK: No panic-inducing calls in changed production code.

$ python3 scripts/check_no_new_ironclaw_literal.py --base origin/xClaw
OK: No new .ironclaw / IRONCLAW_BASE_DIR literals introduced.
```

完整 `cargo build` / workspace clippy / heavy integration 由 CI 兜底。

## Cross-cuts

- **ADR-114 命名迁移**：类A — 本 PR 未引入任何 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量。
- **ADR-129 verbatim port**：`dasclaw_cli` 测试**不**在 verbatim 列表 → `code-simplifier` 允许；已自审通过。

## Stacked PR 关系

- **Base 分支**：`feat/dasclaw-cli-run-with-hooks`（W6.1 入口，PR #826）
- **本 PR 与 W6.2 链的关系**：**并行**，不是 stacked。`feat/dasclaw-cli-w6-2-safety-tests` (#831) 与 `feat/dasclaw-cli-w6-2b-tool-egress-stacked` (#833) 是 W6.2 的两段叠层；本 PR 是同一个 W6.1 base 上的**第二个兄弟分支**，与 #831/#833 **文件零重叠**：
  - 本 PR 改动：`tests/fixtures/agent_loop_fixtures.rs`（新文件） + 4 个新 `agent_*_e2e.rs`
  - W6.2 链改动：`tests/fixtures/safety_fixtures.rs` + `tests/run_with_hooks_*` 系列 + （W6.2b）`crates/dasclaw_runtime/src/agent.rs` 等
- **Merge 顺序**：先 merge #826 → 再 merge W6.2 链 (#831 → #833) → 本 PR 在 #826 进入 `xClaw` 之后 rebase 到 `xClaw` 即可；本 PR 与 W6.2 链相互不阻塞。

## Sources read

- `docs/plans/architecture-refactor/adr-153-w6-agent-loop.md` §1.1 B1/B2/B5/B7（e17/e18/e21/e23 验收口径）
- `crates/dasclaw_core/src/agentic_loop.rs` L178-235（`for iteration in 1..=max_iterations` + `EgressKind::LlmRequest` Block → `LoopOutcome::Failure(reason)` 原生链路）
- `crates/dasclaw_core/src/agentic_loop.rs` L634-686（`test_max_iterations_reached` 单测 — 复用其断言 pattern）
- `crates/dasclaw_runtime/src/agent.rs` L92-115（`AgentError` 完整变体）、L164-291（`Agent::builder()` 全 API）、L389-398（`map_outcome` —— `LoopOutcome::MaxIterations` → `AgentError::MaxIterations(usize)`、`LoopOutcome::Failure` → `AgentError::LoopFailure(String)`）
- `crates/dasclaw_core/src/hooks/*`（`EgressDecision::Block { reason, stats }` 当前字段 shape，含 `RedactionStats`）
- `crates/dasclaw_core/src/response_types.rs` L30-70（`RespondOutput { result, usage, finish_reason, metadata }` shape）
- `crates/dasclaw_core/src/messages.rs` L260-285（`ToolResult { tool_call_id, name, content, is_error }`）
- `crates/dasclaw_cli/tests/run_with_hooks_wiring.rs`（W6.1 既有 `HookBundle` 装配示例 —— 包含 4 个字段的直接构造模式）

## 自审清单

- ✅ TDD 红 → 绿（先写 4 个测试，含 `expect_err` 失败路径）
- ✅ 单元 + 集成 + 失败路径都覆盖
- ✅ `cargo check -p dasclaw_cli --tests` 0 错 0 警
- ✅ Skills 管线：`code-quality-audit`（5 项通过）+ `code-simplifier`（无需简化）+ `code-review-expert`（SOLID / 安全 OK，test crate 无外部 IO）
- ✅ `check_no_panics` + `check_no_new_ironclaw_literal` 通过
- ✅ PR 描述含背景 / 改动范围 / 非目标 / 验证 / Cross-cuts / Sources read / `Closes #834`
