### PR TITLE
test(dasclaw_cli): W6.5a agent-loop P1 tests (e19 + e20)

### DIFF
--- a/crates/dasclaw_cli/tests/agent_namespace_collision_e2e.rs
+++ b/crates/dasclaw_cli/tests/agent_namespace_collision_e2e.rs
@@ -1,0 +1,72 @@
+//! ADR-153 §1.1 B4 (e20): namespace collision across two simulated MCP
+//! servers. Both servers expose a tool conceptually called `search`,
+//! exposed via the qualified names `a_search` and `b_search`. The
+//! scripted model only ever calls `b_search`; the loop must route
+//! exactly there, never invoking `a_search`. We verify this with a
+//! single `RecordingToolExecutor` that owns both qualified names — the
+//! executor's call log is the authoritative routing record.
+
+#[path = "fixtures/agent_loop_fixtures.rs"]
+mod fixtures;
+
+use dasclaw_runtime::Agent;
+use serde_json::json;
+
+use fixtures::{
+    RecordingToolExecutor, ScriptedResponder, no_tool_defs, text_turn, tool_call_turn,
+};
+
+#[tokio::test]
+async fn req_dasclaw_cli_loop_e20_namespace_collision_routes_to_b() {
+    // Two scripted turns:
+    //   T1: model picks the b-side search explicitly.
+    //   T2: model surfaces a final answer citing b's content.
+    // A would-be ambiguous "search" tool is never named, so a correct
+    // implementation must not silently pick a fallback.
+    let script = vec![
+        tool_call_turn(
+            "b_search",
+            "call_b_search_1",
+            json!({ "q": "release notes" }),
+        ),
+        text_turn("found in b: b-result-payload"),
+    ];
+    let responder = ScriptedResponder::with_queue(script);
+
+    let executor = RecordingToolExecutor::new()
+        .with_reply("a_search", "a-result-payload")
+        .with_reply("b_search", "b-result-payload");
+    let calls = executor.calls();
+
+    let agent = Agent::builder()
+        .responder(responder)
+        .tool_executor(executor)
+        .tools(no_tool_defs())
+        .build()
+        .expect("agent builds");
+
+    let reply = agent
+        .run("look it up in b")
+        .await
+        .expect("routing the b-side tool must succeed");
+
+    assert!(
+        reply.contains("b-result-payload"),
+        "final reply must cite the b-side payload, got: {reply:?}"
+    );
+
+    let log = calls.lock().expect("calls log");
+    assert_eq!(
+        log.len(),
+        1,
+        "exactly one tool dispatch must have happened, got: {log:#?}"
+    );
+    assert_eq!(
+        log[0].name, "b_search",
+        "routing must hit the qualified b-side name, not the a-side"
+    );
+    assert!(
+        log.iter().all(|c| c.name != "a_search"),
+        "a_search must never be invoked when the model only names b_search"
+    );
+}

--- a/crates/dasclaw_cli/tests/agent_namespace_collision_e2e.rs
+++ b/crates/dasclaw_cli/tests/agent_namespace_collision_e2e.rs
@@ -12,9 +12,7 @@ mod fixtures;
 use dasclaw_runtime::Agent;
 use serde_json::json;
 
-use fixtures::{
-    RecordingToolExecutor, ScriptedResponder, no_tool_defs, text_turn, tool_call_turn,
-};
+use fixtures::{RecordingToolExecutor, ScriptedResponder, no_tool_defs, text_turn, tool_call_turn};
 
 #[tokio::test]
 async fn req_dasclaw_cli_loop_e20_namespace_collision_routes_to_b() {

--- a/crates/dasclaw_cli/tests/agent_retry_on_tool_error_e2e.rs
+++ b/crates/dasclaw_cli/tests/agent_retry_on_tool_error_e2e.rs
@@ -1,17 +1,25 @@
-//! ADR-153 §1.1 B2 (e18): retry on tool error. First `read_file` returns
-//! `is_error=true` with an ENOENT-shaped payload; the model is scripted
-//! to react by calling `read_file` again with a different path. The
-//! loop must feed the error result back to the model rather than
-//! propagating it as a hard failure, and the second attempt must
-//! observe the `success_content` payload.
+//! ADR-153 §1.1 B2 (e18) + B3 (e19): retry / max-iterations cap on tool error.
+//!
+//! - **e18**: First `read_file` returns `is_error=true` with an ENOENT-shaped
+//!   payload; the model is scripted to react by calling `read_file` again
+//!   with a different path. The loop must feed the error result back to the
+//!   model rather than propagating it as a hard failure, and the second
+//!   attempt must observe the `success_content` payload.
+//! - **e19**: Tool keeps failing forever; the model also keeps retrying. The
+//!   loop must terminate at `max_iterations = 5` with
+//!   `AgentError::MaxIterations(5)` instead of looping forever.
 
 #[path = "fixtures/agent_loop_fixtures.rs"]
 mod fixtures;
 
-use dasclaw_runtime::Agent;
+use dasclaw_core::agentic_loop::AgenticLoopConfig;
+use dasclaw_runtime::{Agent, AgentError};
 use serde_json::json;
 
-use fixtures::{FlakyToolExecutor, ScriptedResponder, no_tool_defs, text_turn, tool_call_turn};
+use fixtures::{
+    AlwaysFailingToolExecutor, FlakyToolExecutor, ScriptedResponder, no_tool_defs, text_turn,
+    tool_call_turn,
+};
 
 #[tokio::test]
 async fn req_dasclaw_cli_loop_e18_retry_recovers_after_enoent() {
@@ -72,5 +80,65 @@ async fn req_dasclaw_cli_loop_e18_retry_recovers_after_enoent() {
         log[1].arguments,
         json!({ "path": "exists.txt" }),
         "retry must use the model's corrected path"
+    );
+}
+
+// ADR-153 §1.1 B3 (e19): when a tool keeps failing and the scripted
+// model keeps retrying, the loop must terminate at `max_iterations`
+// instead of looping forever. We set `max_iterations = 5` explicitly
+// (matrix value), queue more turns than the cap, and assert both the
+// echoed cap inside `AgentError::MaxIterations(n)` and the exact tool
+// dispatch count (n).
+#[tokio::test]
+async fn req_dasclaw_cli_loop_e19_max_iterations_5_with_permanent_failure() {
+    let script = (0..10)
+        .map(|i| {
+            tool_call_turn(
+                "read_file",
+                format!("call_read_retry_{i}"),
+                json!({ "path": format!("attempt_{i}.txt") }),
+            )
+        })
+        // A trailing text_turn would be unreachable: the cap fires
+        // before the model gets a chance to give up. Keeping the queue
+        // tool-only makes the failure mode unambiguous.
+        .collect();
+    let responder = ScriptedResponder::with_queue(script);
+
+    let executor = AlwaysFailingToolExecutor::new("ENOENT: target never exists");
+    let calls = executor.calls();
+
+    let cfg = AgenticLoopConfig {
+        max_iterations: 5,
+        ..AgenticLoopConfig::default()
+    };
+
+    let agent = Agent::builder()
+        .responder(responder)
+        .tool_executor(executor)
+        .tools(no_tool_defs())
+        .loop_config(cfg)
+        .build()
+        .expect("agent builds");
+
+    let err = agent
+        .run("keep retrying the broken file")
+        .await
+        .expect_err("permanent failure must reach the cap, not silently succeed");
+
+    match err {
+        AgentError::MaxIterations(n) => {
+            assert_eq!(
+                n, 5,
+                "AgentError::MaxIterations must echo the configured cap (5)"
+            );
+        }
+        other => panic!("expected MaxIterations(5), got {other:?}"),
+    }
+
+    let count = calls.lock().expect("always-failing calls log").len();
+    assert_eq!(
+        count, 5,
+        "permanent-failure retries must dispatch exactly max_iterations tool calls, got {count}"
     );
 }

--- a/crates/dasclaw_cli/tests/fixtures/agent_loop_fixtures.rs
+++ b/crates/dasclaw_cli/tests/fixtures/agent_loop_fixtures.rs
@@ -222,6 +222,47 @@ impl ToolExecutor for FlakyToolExecutor {
     }
 }
 
+/// [`ToolExecutor`] that returns `is_error=true` on **every** call.
+/// Used by e19 (B3) to drive the max_iterations cap when the model
+/// keeps retrying a permanently-broken tool.
+pub struct AlwaysFailingToolExecutor {
+    calls: Arc<Mutex<Vec<ToolInvocation>>>,
+    error_message: String,
+}
+
+impl AlwaysFailingToolExecutor {
+    pub fn new(error_message: impl Into<String>) -> Self {
+        Self {
+            calls: Arc::new(Mutex::new(Vec::new())),
+            error_message: error_message.into(),
+        }
+    }
+
+    pub fn calls(&self) -> Arc<Mutex<Vec<ToolInvocation>>> {
+        Arc::clone(&self.calls)
+    }
+}
+
+#[async_trait]
+impl ToolExecutor for AlwaysFailingToolExecutor {
+    async fn execute(&self, call: &ToolCall) -> Result<ToolResult, HostError> {
+        self.calls
+            .lock()
+            .expect("always-failing executor mutex")
+            .push(ToolInvocation {
+                name: call.name.clone(),
+                call_id: call.id.clone(),
+                arguments: call.arguments.clone(),
+            });
+        Ok(ToolResult {
+            tool_call_id: call.id.clone(),
+            name: call.name.clone(),
+            content: self.error_message.clone(),
+            is_error: true,
+        })
+    }
+}
+
 /// [`EgressGate`] that returns `Block { reason }` when an
 /// [`EgressKind::LlmRequest`] payload contains any of the configured
 /// bait phrases (case-insensitive). All other kinds Pass through.


### PR DESCRIPTION
## 背景 / 目标

按 ADR-153 §1.1 W6.5（agent-loop P1 矩阵）补 B3 + B4 两条 P1 集成测试。这是 W6.5a 切片，纯测试新增，零运行时代码改动。

Closes #836

**Source**:
- [docs/plans/architecture-refactor/adr-153-w6-agent-loop-tests.md](docs/plans/architecture-refactor/adr-153-w6-agent-loop-tests.md) §1.1 B3/B4

## 改动范围

3 个文件，全部位于 `crates/dasclaw_cli/tests/`：

1. `fixtures/agent_loop_fixtures.rs` — 新增 `AlwaysFailingToolExecutor`（永远返回 `is_error=true` 的 `ToolExecutor`，给 e19 用）。
2. `agent_retry_on_tool_error_e2e.rs` — 新增 `req_dasclaw_cli_loop_e19_max_iterations_5_with_permanent_failure`：B3 永久失败 → max_iterations=5 必须触顶。
3. `agent_namespace_collision_e2e.rs`（新文件）— `req_dasclaw_cli_loop_e20_namespace_collision_routes_to_b`：B4 命名空间冲突路由验证。

## 非目标（What's NOT in this PR）

- ❌ **B6 (e22) `sanitize_for_stash` 测试** —— `grep_search` 验证该函数在 `crates/dasclaw_runtime/` 与 `crates/dasclaw_core/` 内 **零接线**。需先开接线 PR，再补 e22。延后到 W6.5b，已在 #836 记录。
- ❌ **B8 (e24) `validate_tool_params` JSON Schema 测试** —— 实读 `crates/dasclaw_safety/src/validator.rs:197` 确认该函数是 **forbidden-pattern 内容扫描**，并非 JSON Schema 校验器。延后到 W6.5b（需先确定是接线 schema 校验器还是改 ADR 描述），已在 #836 记录。
- ❌ 任何 `dasclaw_runtime` / `dasclaw_core` / `dasclaw_safety` src/ 修改。
- ❌ ADR-153 P0 矩阵改动（W6.3 PR #835 已覆盖）。

## 验证

```bash
# 1. compile gate
cargo check -p dasclaw_cli --tests
# → Finished `dev` profile in 2.87s, 0 errors / 0 warnings

# 2. targeted tests
cargo nextest run -p dasclaw_cli \
  -E 'test(req_dasclaw_cli_loop_e19) | test(req_dasclaw_cli_loop_e20)'
# → Summary: 2 tests run: 2 passed, 30 skipped

# 3. clippy on touched crate
cargo clippy --no-deps -p dasclaw_cli --all-targets -- -D warnings
# → Finished `dev` profile, 0 warnings

# 4. ADR-128 panic guard
python3.12 scripts/check_no_panics.py --base origin/xClaw
# → OK: No panic-inducing calls in changed production code.

# 5. ADR-114 ironclaw 字面量 guard
python3 scripts/check_no_new_ironclaw_literal.py --base origin/xClaw
# → OK: No new .ironclaw / IRONCLAW_BASE_DIR literals introduced.
```

完整 `cargo build` / workspace clippy / heavy integration 由 CI 兜底（不本地 watch）。

## Cross-cuts

- **ADR-114**: 类A（diff 内零 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量新增；grep guard 已绿）
- **ADR-129**: 非 verbatim port 范畴（纯新增测试，无 codex/ironclaw 端口对应）
- **ADR-128**: panic guard 已绿；测试代码里的 `expect(...)` / `panic!(...)` 在 `tests/` 目录，不受生产代码红线约束

## Stacked PR

- **base**: `feat/dasclaw-cli-w6-3-agent-loop-tests`（PR #835，W6.3 P0 测试），**不是** `xClaw`
- **merge 顺序**: #826（W6.1 实现，已 open）→ #835（W6.3 P0 测试）→ **本 PR**（W6.5a P1 测试）
- **请先 review #835 再看本 PR**：本 PR 复用 #835 引入的 `agent_loop_fixtures.rs` 模式与 fixture 类型
- 与并行兄弟链 W6.2a/W6.2b（#831/#833）**文件零重叠**，互不依赖

## Sources read

- `docs/plans/architecture-refactor/adr-153-w6-agent-loop-tests.md` §1.1（W6.5 P1 矩阵 B3/B4/B6/B8）
- `crates/dasclaw_safety/src/validator.rs:197-280` — 实读 `validate_tool_params` 确认是内容扫描，不是 schema 校验
- `crates/dasclaw_safety/src/egress_gate.rs` — `IronclawEgressGate::check` mapping table（B5/e21 已在 #835 覆盖的相邻能力）
- `crates/dasclaw_core/src/agentic_loop.rs` — `AgenticLoopConfig::max_iterations` 与 `AgentError::MaxIterations(n)` 的契约
- `crates/dasclaw_cli/tests/fixtures/agent_loop_fixtures.rs`（W6.3 版本）— `FlakyToolExecutor` / `RecordingToolExecutor` 模式
- `grep_search`：`sanitize_for_stash` 在 `crates/dasclaw_runtime/`、`crates/dasclaw_core/` 内零匹配 → B6 延后

## 后续 / 下一步

- **W6.5b**（追踪在 #836）: 先开 sanitize_for_stash 与 validate_tool_params 的接线 PR，再补 e22/e24。
- 本 PR 合并后会按 stacked 规约：要么保留分支等上层 rebase 完，要么先把上层 PR 的 base 切到下一层。
