### PR TITLE
feat(dasclaw_runtime): wire ToolOutputSanitizer trait seam for W6.5b B6 (e22)

### DIFF
--- a/crates/dasclaw_cli/Cargo.toml
+++ b/crates/dasclaw_cli/Cargo.toml
@@ -45,6 +45,8 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 # W6.1: egress-gate feature is what lets dasclaw_safety::IronclawEgressGate
 # implement dasclaw_core::EgressGate, which is the trait that test cases
 # e7–e16 (ADR-153-cli-test-matrix §1) inject through run_with_tools_and_hooks.
+# W6.5b B6: same crate also provides SafetyLayer::sanitize_for_stash, which is
+# wired into the agent loop via the ToolOutputSanitizer seam (e22).
 # Kept as dev-dependency: dasclaw_cli the library stays safety-stack-agnostic;
 # downstream callers wire their own HookBundle from whichever safety crate
 # they prefer.

--- a/crates/dasclaw_cli/tests/agent_large_tool_output_e2e.rs
+++ b/crates/dasclaw_cli/tests/agent_large_tool_output_e2e.rs
@@ -1,0 +1,246 @@
+//! ADR-153 §1.1 B6 (e22): wire `dasclaw_safety::SafetyLayer::sanitize_for_stash`
+//! into the agent loop via the new `ToolOutputSanitizer` seam, and prove
+//! that what the **next** LLM iteration sees in its `tool_result` block
+//! is the redacted payload — not the raw secret returned by the tool.
+//!
+//! The test deliberately runs the **full** runtime → safety chain. It
+//! does **not** mock `sanitize_for_stash`; it constructs a real
+//! `SafetyLayer` with the default leak-detector and asserts the
+//! conversation snapshot taken by a capturing responder on iteration 2.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use dasclaw_core::messages::{
+    ChatMessage, FinishReason, Role, ToolCall, ToolDefinition, ToolResult,
+};
+use dasclaw_core::reasoning_ctx::ReasoningContext;
+use dasclaw_core::response_types::{RespondOutput, RespondResult, ResponseMetadata, TokenUsage};
+use dasclaw_core::traits::HostError;
+use dasclaw_runtime::{Agent, AgentResponder, ToolExecutor, ToolOutputSanitizer};
+use dasclaw_safety::{SafetyConfig, SafetyLayer};
+use serde_json::json;
+
+/// Adapter wiring `SafetyLayer::sanitize_for_stash` (redact-only, no
+/// length cap) into the `ToolOutputSanitizer` seam. Lives in the test
+/// because `dasclaw_runtime` stays safety-stack-agnostic by design.
+struct SafetyStashSanitizer {
+    layer: Arc<SafetyLayer>,
+}
+
+impl ToolOutputSanitizer for SafetyStashSanitizer {
+    fn sanitize(&self, tool_name: &str, content: &str) -> String {
+        self.layer.sanitize_for_stash(tool_name, content).content
+    }
+}
+
+/// Responder that **captures** `ctx.messages.clone()` on every call
+/// before popping a scripted reply. Lets the test assert what the LLM
+/// saw on iteration 2 (the call that observes the post-tool-result
+/// snapshot), without having to expose internal loop state.
+struct CapturingResponder {
+    script: Mutex<Vec<RespondOutput>>,
+    snapshots: Mutex<Vec<Vec<ChatMessage>>>,
+}
+
+impl CapturingResponder {
+    fn new(script: Vec<RespondOutput>) -> Self {
+        Self {
+            script: Mutex::new(script),
+            snapshots: Mutex::new(Vec::new()),
+        }
+    }
+
+    fn snapshots(&self) -> Vec<Vec<ChatMessage>> {
+        self.snapshots.lock().expect("snapshots mutex").clone()
+    }
+}
+
+#[async_trait]
+impl AgentResponder for CapturingResponder {
+    async fn respond(&self, ctx: &mut ReasoningContext) -> Result<RespondOutput, HostError> {
+        self.snapshots
+            .lock()
+            .expect("snapshots mutex")
+            .push(ctx.messages.clone());
+        let mut s = self.script.lock().expect("script mutex");
+        if s.is_empty() {
+            return Err("script exhausted".into());
+        }
+        Ok(s.remove(0))
+    }
+}
+
+/// Minimal map-based tool executor used only for e22. Returns the
+/// configured reply for a tool name, or a generic "ok" body.
+struct ReplyingToolExecutor {
+    replies: HashMap<String, String>,
+}
+
+impl ReplyingToolExecutor {
+    fn new() -> Self {
+        Self {
+            replies: HashMap::new(),
+        }
+    }
+
+    fn with_reply(mut self, name: &str, body: impl Into<String>) -> Self {
+        self.replies.insert(name.to_string(), body.into());
+        self
+    }
+}
+
+#[async_trait]
+impl ToolExecutor for ReplyingToolExecutor {
+    async fn execute(&self, call: &ToolCall) -> Result<ToolResult, HostError> {
+        let content = self
+            .replies
+            .get(&call.name)
+            .cloned()
+            .unwrap_or_else(|| "ok".to_string());
+        Ok(ToolResult {
+            tool_call_id: call.id.clone(),
+            name: call.name.clone(),
+            content,
+            is_error: false,
+        })
+    }
+}
+
+fn text_turn(text: &str) -> RespondOutput {
+    RespondOutput {
+        result: RespondResult::Text(text.to_string()),
+        usage: TokenUsage::default(),
+        finish_reason: FinishReason::Stop,
+        metadata: ResponseMetadata::default(),
+    }
+}
+
+fn tool_call_turn(name: &str, id: &str, args: serde_json::Value) -> RespondOutput {
+    RespondOutput {
+        result: RespondResult::ToolCalls {
+            content: None,
+            tool_calls: vec![ToolCall {
+                id: id.to_string(),
+                name: name.to_string(),
+                arguments: args,
+                reasoning: None,
+            }],
+        },
+        usage: TokenUsage::default(),
+        finish_reason: FinishReason::ToolUse,
+        metadata: ResponseMetadata::default(),
+    }
+}
+
+#[tokio::test]
+async fn req_dasclaw_cli_loop_e22_tool_output_redacted_before_next_llm_call() {
+    // A Bearer-style token (matches the `bearer_token` LeakPattern's
+    // regex `Bearer\s+[a-zA-Z0-9_-]{20,}`). That pattern uses
+    // `LeakAction::Redact`, so `sanitize_for_stash` rewrites the secret
+    // to `[REDACTED]` while keeping the surrounding context intact.
+    let secret = "Bearer abcdef0123456789ABCDEFXYZ";
+    let tool_payload = format!("found credential: {secret} (please rotate)");
+
+    let script = vec![
+        tool_call_turn("read_file", "call_read_1", json!({ "path": "secrets.txt" })),
+        text_turn("done — credential surfaced and routed for rotation"),
+    ];
+    let responder = Arc::new(CapturingResponder::new(script));
+
+    let executor = ReplyingToolExecutor::new().with_reply("read_file", tool_payload.clone());
+
+    let safety = Arc::new(SafetyLayer::new(&SafetyConfig {
+        max_output_length: 65_536,
+        injection_check_enabled: false,
+    }));
+    let sanitizer = SafetyStashSanitizer {
+        layer: Arc::clone(&safety),
+    };
+
+    let agent = Agent::builder()
+        .responder_arc(responder.clone())
+        .tool_executor(executor)
+        .tool_output_sanitizer(sanitizer)
+        .tools(Vec::<ToolDefinition>::new())
+        .build()
+        .expect("agent builds");
+
+    let reply = agent
+        .run("scan for leaked credentials")
+        .await
+        .expect("loop must finish — redaction is non-fatal");
+    assert_eq!(reply, "done — credential surfaced and routed for rotation");
+
+    let snapshots = responder.snapshots();
+    assert_eq!(
+        snapshots.len(),
+        2,
+        "expected exactly two LLM calls (tool-call turn, then final-text turn), got {}",
+        snapshots.len()
+    );
+
+    // Iteration 2 is the LLM call that observes the tool_result message
+    // produced after the tool ran. That message must carry the redacted
+    // payload, never the raw secret — that's the whole point of B6.
+    let second_view = &snapshots[1];
+    let tool_result_msg = second_view
+        .iter()
+        .rev()
+        .find(|m| matches!(m.role, Role::Tool))
+        .expect("iteration 2 must see at least one tool_result message");
+    let body = &tool_result_msg.content;
+
+    assert!(
+        !body.contains(secret),
+        "tool_result body must NOT contain the raw secret; got body = {body:?}"
+    );
+    assert!(
+        body.contains("[REDACTED]"),
+        "tool_result body must contain `[REDACTED]` from sanitize_for_stash; got body = {body:?}"
+    );
+    assert!(
+        body.contains("please rotate"),
+        "non-secret context must survive redaction; got body = {body:?}"
+    );
+}
+
+#[tokio::test]
+async fn req_dasclaw_cli_loop_e22_no_sanitizer_forwards_verbatim_baseline() {
+    // Negative control: without `tool_output_sanitizer`, the loop must
+    // forward tool output verbatim. This pins the opt-in contract so a
+    // future refactor can't silently start redacting without callers
+    // asking for it.
+    let secret_like = "Bearer abcdef0123456789ABCDEFXYZ";
+    let tool_payload = format!("verbatim: {secret_like}");
+
+    let script = vec![
+        tool_call_turn("read_file", "call_read_1", json!({ "path": "verbatim.txt" })),
+        text_turn("ok"),
+    ];
+    let responder = Arc::new(CapturingResponder::new(script));
+    let executor = ReplyingToolExecutor::new().with_reply("read_file", tool_payload.clone());
+
+    let agent = Agent::builder()
+        .responder_arc(responder.clone())
+        .tool_executor(executor)
+        .tools(Vec::<ToolDefinition>::new())
+        .build()
+        .expect("agent builds");
+
+    agent.run("baseline").await.expect("baseline must run");
+
+    let snapshots = responder.snapshots();
+    assert_eq!(snapshots.len(), 2);
+    let second_view = &snapshots[1];
+    let tool_result_msg = second_view
+        .iter()
+        .rev()
+        .find(|m| matches!(m.role, Role::Tool))
+        .expect("iteration 2 must see a tool_result");
+    assert_eq!(
+        tool_result_msg.content, tool_payload,
+        "without a sanitizer, the loop must forward tool output byte-for-byte"
+    );
+}

--- a/crates/dasclaw_cli/tests/agent_large_tool_output_e2e.rs
+++ b/crates/dasclaw_cli/tests/agent_large_tool_output_e2e.rs
@@ -216,7 +216,11 @@ async fn req_dasclaw_cli_loop_e22_no_sanitizer_forwards_verbatim_baseline() {
     let tool_payload = format!("verbatim: {secret_like}");
 
     let script = vec![
-        tool_call_turn("read_file", "call_read_1", json!({ "path": "verbatim.txt" })),
+        tool_call_turn(
+            "read_file",
+            "call_read_1",
+            json!({ "path": "verbatim.txt" }),
+        ),
         text_turn("ok"),
     ];
     let responder = Arc::new(CapturingResponder::new(script));

--- a/crates/dasclaw_runtime/src/agent.rs
+++ b/crates/dasclaw_runtime/src/agent.rs
@@ -282,10 +282,7 @@ impl AgentBuilder {
     /// the redacted payload. When unset (default), output is forwarded
     /// verbatim — matching the pre-W6.5b behaviour.
     #[must_use]
-    pub fn tool_output_sanitizer(
-        mut self,
-        sanitizer: impl ToolOutputSanitizer + 'static,
-    ) -> Self {
+    pub fn tool_output_sanitizer(mut self, sanitizer: impl ToolOutputSanitizer + 'static) -> Self {
         self.tool_output_sanitizer = Some(Arc::new(sanitizer));
         self
     }
@@ -293,10 +290,7 @@ impl AgentBuilder {
     /// Same as [`Self::tool_output_sanitizer`] but accepts a pre-built
     /// `Arc` so callers can share a single sanitizer across agents.
     #[must_use]
-    pub fn tool_output_sanitizer_arc(
-        mut self,
-        sanitizer: Arc<dyn ToolOutputSanitizer>,
-    ) -> Self {
+    pub fn tool_output_sanitizer_arc(mut self, sanitizer: Arc<dyn ToolOutputSanitizer>) -> Self {
         self.tool_output_sanitizer = Some(sanitizer);
         self
     }

--- a/crates/dasclaw_runtime/src/agent.rs
+++ b/crates/dasclaw_runtime/src/agent.rs
@@ -88,6 +88,28 @@ pub trait ToolExecutor: Send + Sync {
     async fn execute(&self, call: &ToolCall) -> Result<ToolResult, HostError>;
 }
 
+/// Narrow tool-output sanitization seam used by [`Agent`]
+/// (ADR-153 §1.1 B6 / e22 wiring).
+///
+/// Sits between [`ToolExecutor::execute`] and the message-history push,
+/// so the redacted content is what the **next** LLM iteration sees in
+/// its `tool_result` block. Implementations typically delegate to a
+/// safety crate (e.g. `dasclaw_safety::SafetyLayer::sanitize_for_stash`),
+/// but the runtime stays safety-stack-agnostic: any `Fn`-like wrapper
+/// works as long as it returns the post-redaction string.
+///
+/// When no sanitizer is wired (the default), tool output is forwarded
+/// to the LLM **verbatim**. The trait is sync because production
+/// sanitizers run regex passes that don't await, and forcing async would
+/// push spurious `Box::pin` allocations into the hot loop path.
+pub trait ToolOutputSanitizer: Send + Sync {
+    /// Return the sanitized content for `tool_name`'s output. The
+    /// implementation owns any redaction, masking, policy enforcement
+    /// and length capping; the runtime treats the return value as
+    /// authoritative and pushes it straight into the conversation.
+    fn sanitize(&self, tool_name: &str, content: &str) -> String;
+}
+
 /// Errors surfaced by [`Agent::run`].
 #[derive(Debug, thiserror::Error)]
 pub enum AgentError {
@@ -155,6 +177,7 @@ pub struct AgentConfig {
 pub struct Agent {
     responder: Arc<dyn AgentResponder>,
     tool_executor: Option<Arc<dyn ToolExecutor>>,
+    tool_output_sanitizer: Option<Arc<dyn ToolOutputSanitizer>>,
     hooks: HookBundle,
     config: AgentConfig,
 }
@@ -192,6 +215,7 @@ impl Agent {
             responder: Arc::clone(&self.responder),
             tool_executor: self.tool_executor.clone(),
             hooks: self.hooks.clone(),
+            tool_output_sanitizer: self.tool_output_sanitizer.clone(),
         };
 
         let outcome = run_agentic_loop(&delegate, &mut ctx, &loop_config, &self.hooks)
@@ -216,6 +240,7 @@ fn clone_loop_config(src: &AgenticLoopConfig) -> AgenticLoopConfig {
 pub struct AgentBuilder {
     responder: Option<Arc<dyn AgentResponder>>,
     tool_executor: Option<Arc<dyn ToolExecutor>>,
+    tool_output_sanitizer: Option<Arc<dyn ToolOutputSanitizer>>,
     hooks: Option<HookBundle>,
     config: AgentConfig,
 }
@@ -248,6 +273,31 @@ impl AgentBuilder {
     #[must_use]
     pub fn tool_executor_arc(mut self, executor: Arc<dyn ToolExecutor>) -> Self {
         self.tool_executor = Some(executor);
+        self
+    }
+
+    /// Plug in a tool-output sanitizer. When set, every `ToolResult`'s
+    /// `content` is run through [`ToolOutputSanitizer::sanitize`] before
+    /// being appended to the conversation, so the **next** LLM call sees
+    /// the redacted payload. When unset (default), output is forwarded
+    /// verbatim — matching the pre-W6.5b behaviour.
+    #[must_use]
+    pub fn tool_output_sanitizer(
+        mut self,
+        sanitizer: impl ToolOutputSanitizer + 'static,
+    ) -> Self {
+        self.tool_output_sanitizer = Some(Arc::new(sanitizer));
+        self
+    }
+
+    /// Same as [`Self::tool_output_sanitizer`] but accepts a pre-built
+    /// `Arc` so callers can share a single sanitizer across agents.
+    #[must_use]
+    pub fn tool_output_sanitizer_arc(
+        mut self,
+        sanitizer: Arc<dyn ToolOutputSanitizer>,
+    ) -> Self {
+        self.tool_output_sanitizer = Some(sanitizer);
         self
     }
 
@@ -296,6 +346,7 @@ impl AgentBuilder {
         Ok(Agent {
             responder,
             tool_executor: self.tool_executor,
+            tool_output_sanitizer: self.tool_output_sanitizer,
             hooks,
             config: self.config,
         })
@@ -311,6 +362,7 @@ struct HeadlessDelegate {
     responder: Arc<dyn AgentResponder>,
     tool_executor: Option<Arc<dyn ToolExecutor>>,
     hooks: HookBundle,
+    tool_output_sanitizer: Option<Arc<dyn ToolOutputSanitizer>>,
 }
 
 #[async_trait]
@@ -400,7 +452,7 @@ impl LoopDelegate for HeadlessDelegate {
                 .egress
                 .check(&EgressKind::UserDisplay, &content_buf)
                 .await;
-            let pushed_content = match apply_egress_decision(
+            let post_gate_content = match apply_egress_decision(
                 decision,
                 &mut content_buf,
                 &post_label,
@@ -410,6 +462,14 @@ impl LoopDelegate for HeadlessDelegate {
                     tracing::warn!(tool = %result.name, %reason, "egress gate blocked tool output");
                     format!("[redacted: {reason}]")
                 }
+            };
+
+            // ADR-153 §1.1 e22/B6: chain a second sanitizer seam after the
+            // egress gate. Callers can inject SafetyLayer::sanitize_for_stash
+            // (or any other strategy) without touching the hook stack.
+            let pushed_content = match self.tool_output_sanitizer.as_ref() {
+                Some(sanitizer) => sanitizer.sanitize(&result.name, &post_gate_content),
+                None => post_gate_content,
             };
             ctx.messages.push(ChatMessage::tool_result(
                 &result.tool_call_id,

--- a/crates/dasclaw_runtime/src/lib.rs
+++ b/crates/dasclaw_runtime/src/lib.rs
@@ -48,8 +48,7 @@ pub mod secrets;
 pub mod tool;
 
 pub use agent::{
-    Agent, AgentBuilder, AgentConfig, AgentError, AgentResponder, ToolExecutor,
-    ToolOutputSanitizer,
+    Agent, AgentBuilder, AgentConfig, AgentError, AgentResponder, ToolExecutor, ToolOutputSanitizer,
 };
 pub use composite_executor::{CompositeError, CompositeToolExecutor};
 pub use error::ToolError;

--- a/crates/dasclaw_runtime/src/lib.rs
+++ b/crates/dasclaw_runtime/src/lib.rs
@@ -47,7 +47,10 @@ pub mod recording;
 pub mod secrets;
 pub mod tool;
 
-pub use agent::{Agent, AgentBuilder, AgentConfig, AgentError, AgentResponder, ToolExecutor};
+pub use agent::{
+    Agent, AgentBuilder, AgentConfig, AgentError, AgentResponder, ToolExecutor,
+    ToolOutputSanitizer,
+};
 pub use composite_executor::{CompositeError, CompositeToolExecutor};
 pub use error::ToolError;
 pub use feature_flags::{SharedFeatureFlags, ToolFeatureFlags};


### PR DESCRIPTION
## 背景 / 目标

ADR-153 §1.1 B6 (W6.5b) 要求：agent loop 必须在把 tool 输出推回 LLM 上下文之前给调用方一个**可选**的拦截点，用来做秘密 redaction / 长度截断 / 策略检查。本 PR 在 `dasclaw_runtime` 加一条窄缝 `ToolOutputSanitizer`，并补 e22 e2e 测试证明：当宿主把 `SafetyLayer::sanitize_for_stash` 接到这条缝上时，下一轮 LLM 不会再看到原始秘密。

Refs ADR-153 §1.1 B6 · W6.5b · Closes #836

## 改动范围

- **`crates/dasclaw_runtime/src/agent.rs`**:
  - 新增 `pub trait ToolOutputSanitizer { fn sanitize(&self, tool_name: &str, content: &str) -> String; }`,与 `ToolExecutor` 同形(`Send + Sync`,sync 函数)。
  - `Agent` / `AgentBuilder` / `HeadlessDelegate` 各加一个字段 `tool_output_sanitizer: Option<Arc<dyn ToolOutputSanitizer>>`。
  - Builder 方法对: `tool_output_sanitizer(impl ...)` 与 `tool_output_sanitizer_arc(Arc<...>)`,与 `tool_executor` 命名风格一致。
  - `HeadlessDelegate::execute_tool_calls` 在 push `ChatMessage::tool_result` 之前过一次 sanitizer (None → verbatim,Some → sanitize)。
- **`crates/dasclaw_runtime/src/lib.rs`**: 公开 `ToolOutputSanitizer`。
- **`crates/dasclaw_cli/Cargo.toml`**: 加 `dasclaw_safety` 到 `[dev-dependencies]`(test-only,生产路径仍然零耦合)。
- **`crates/dasclaw_cli/tests/agent_large_tool_output_e2e.rs`** (新): 两个测试 + 内联 fixtures(独立于尚未合并的 W6.5a fixtures)。

## 非目标 (What's NOT in this PR)

- B8 / e24 (`sanitize_for_stash` 在 hook 链路上的回写)还停着,后续切片处理。
- 不动 `dasclaw_safety` 本身;不改 `LeakDetector` 的 pattern 表。
- 不动 `dasclaw_runtime` 的 dependency graph(零新增运行期依赖)。
- 不接入 `MessageInjectionGuard` / 长度截断;留给后续策略接入。

## 验证

```bash
cargo nextest run -p dasclaw_cli -E 'test(req_dasclaw_cli_loop_e22)'
# 2 tests run: 2 passed (redaction + verbatim baseline)

cargo nextest run -p dasclaw_runtime
# 167 tests run: 167 passed

cargo clippy --no-deps -p dasclaw_runtime --all-targets -- -D warnings   # clean
cargo clippy --no-deps -p dasclaw_cli     --all-targets -- -D warnings   # clean

python3.12 scripts/check_no_panics.py        --base origin/xClaw   # OK
python3   scripts/check_no_new_ironclaw_literal.py --base origin/xClaw   # OK
```

测试要点:
- **`req_dasclaw_cli_loop_e22_tool_output_redacted_before_next_llm_call`**: `SafetyStashSanitizer` 包 `SafetyLayer::sanitize_for_stash`,tool 返回 `"found credential: Bearer abcdef0123456789ABCDEFXYZ (please rotate)"`,iter-2 LLM 上下文里的 `Tool` role 消息不再含原始 token,而是 `[REDACTED]`,周围 `"please rotate"` 文本保留。
- **`req_dasclaw_cli_loop_e22_no_sanitizer_forwards_verbatim_baseline`**: 不调 `.tool_output_sanitizer(...)`,iter-2 tool_result 字节级等于 payload — pin 住默认 opt-in 语义。

## Cross-cuts

- **ADR-114**: 类A,无新增 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量,grep guard 已跑通。
- **ADR-129**: 非 verbatim port,新 trait 缝由本仓本地设计(与 `ToolExecutor` 对称)。
- **ADR-153 §1.1 B6**: 直接落地 B6 的契约 — runtime 给缝、宿主提供 sanitizer、e22 测试钉死"原始秘密不进下一轮 LLM"。

## Sources read

- [`docs/plans/architecture-refactor/adr-153-...`](docs/plans/architecture-refactor/) §1.1 B6 (W6.5b 任务卡)
- [`crates/dasclaw_runtime/src/agent.rs`](crates/dasclaw_runtime/src/agent.rs) — `ToolExecutor` / `HeadlessDelegate::execute_tool_calls` 既有形状
- [`crates/dasclaw_safety/src/lib.rs`](crates/dasclaw_safety/src/lib.rs) — `SafetyLayer::sanitize_for_stash` 返回 `SanitizedOutput`
- [`crates/dasclaw_safety/src/leak_detector.rs`](crates/dasclaw_safety/src/leak_detector.rs) — `LeakAction::Block` vs `Redact` 语义(确认 bearer_token 走 Redact 路径)
- [`crates/dasclaw_core/src/messages.rs`](crates/dasclaw_core/src/messages.rs) — `ChatMessage::tool_result` 签名

## 后续步骤

- 等本 PR 合并后,W6.5b B8 / e24 切片开第二个独立 PR,把 sanitizer 接到桌面端 / cli 的实际启动路径。
- 未来若有异步 sanitization 需求(如远端 DLP 调用),可在保留同步缝的同时加 `AsyncToolOutputSanitizer`,不会破坏当前 API。
