### PR TITLE
test(dasclaw_cli): W6.4 add e9 + e11 safety P1 integration tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2866,6 +2866,7 @@ dependencies = [
  "dasclaw_runtime",
  "dasclaw_safety",
  "dasclaw_tool",
+ "dasclaw_workspace_cap",
  "secrecy",
  "serde",
  "serde_json",

--- a/crates/dasclaw_cli/Cargo.toml
+++ b/crates/dasclaw_cli/Cargo.toml
@@ -52,6 +52,10 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 # they prefer.
 dasclaw_safety = { path = "../dasclaw_safety", features = ["egress-gate"] }
 dasclaw_governance = { path = "../dasclaw_governance" }
+# W6.4 e11 (ADR-153 §1.1, A5 L1 path-escape): tests/safety_path_escape_e2e.rs
+# constructs a capability-bound workspace and asserts that paths escaping
+# the root surface as a tool error rather than a host crash.
+dasclaw_workspace_cap = { path = "../dasclaw_workspace_cap" }
 tempfile = "3"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "test-util"] }
 wiremock = "0.6"

--- a/crates/dasclaw_cli/tests/safety_credential_leak_in_tool_result_e2e.rs
+++ b/crates/dasclaw_cli/tests/safety_credential_leak_in_tool_result_e2e.rs
@@ -63,8 +63,14 @@ async fn req_dasclaw_cli_safety_e9_tool_result_credential_redacted() {
         .build()
         .expect("build agent");
 
-    let reply = agent.run("dump env").await.expect("agent.run should succeed");
-    assert_eq!(reply, FINAL_REPLY, "final reply should match scripted turn 2");
+    let reply = agent
+        .run("dump env")
+        .await
+        .expect("agent.run should succeed");
+    assert_eq!(
+        reply, FINAL_REPLY,
+        "final reply should match scripted turn 2"
+    );
 
     // --- Assertion 1: second LLM turn's ctx.messages tool_result is redacted.
     let snapshot = responder

--- a/crates/dasclaw_cli/tests/safety_credential_leak_in_tool_result_e2e.rs
+++ b/crates/dasclaw_cli/tests/safety_credential_leak_in_tool_result_e2e.rs
@@ -1,0 +1,109 @@
+//! ADR-153 §1.1 e9 (A3 — L6 outbound credential leak in tool result).
+//!
+//! Setup: scripted responder emits one tool call; the executor returns a
+//! `ToolResult` whose content embeds an OpenAI-style secret
+//! (`sk-leaked-key-AAAA1111BBBB2222`). The agent is wired with a
+//! [`SanitizingDisplayGate`] that rewrites every
+//! `EgressKind::UserDisplay` payload containing the `sk-` prefix to a
+//! fixed `[REDACTED]` placeholder, wrapped in a [`RecordingEgressGate`]
+//! so the test can assert which kind tripped the redaction.
+//!
+//! Contract verified (matches ADR-153 §1.1 e9 row):
+//!   * The second LLM turn's `ReasoningContext` contains the tool_result
+//!     with `[REDACTED]` substituted; the raw secret never reaches the
+//!     next LLM turn.
+//!   * At least one `EgressKind::UserDisplay` check resulted in
+//!     `EgressDecision::Redact { .. }`.
+//!   * The final reply does not echo the raw secret.
+
+use std::sync::Arc;
+
+use dasclaw_core::hooks::{EgressDecision, EgressKind, HookBundle};
+use dasclaw_core::messages::Role;
+use dasclaw_runtime::Agent;
+
+#[path = "fixtures/safety_fixtures.rs"]
+mod safety_fixtures;
+
+use safety_fixtures::{
+    LeakyToolExecutor, RecordingEgressGate, SanitizingDisplayGate, ScriptedResponder, text_turn,
+    tool_call_turn,
+};
+
+const RAW_SECRET: &str = "sk-leaked-key-AAAA1111BBBB2222";
+const LEAKY_CONTENT: &str =
+    "Found env var: OPENAI_API_KEY=sk-leaked-key-AAAA1111BBBB2222 export it now";
+const SANITIZED_CONTENT: &str = "Found env var: OPENAI_API_KEY=[REDACTED] export it now";
+const REDACTED_MARKER: &str = "[REDACTED]";
+const FINAL_REPLY: &str = "done: credentials masked";
+
+#[tokio::test]
+async fn req_dasclaw_cli_safety_e9_tool_result_credential_redacted() {
+    let responder = Arc::new(ScriptedResponder::with_queue(vec![
+        tool_call_turn("fetch_secrets", "call_1", serde_json::json!({})),
+        text_turn(FINAL_REPLY),
+    ]));
+
+    let executor = LeakyToolExecutor::new(LEAKY_CONTENT);
+
+    let sanitizing_gate: Arc<dyn dasclaw_core::hooks::EgressGate> =
+        Arc::new(SanitizingDisplayGate::new("sk-", SANITIZED_CONTENT));
+    let recording_gate = RecordingEgressGate::wrap(sanitizing_gate);
+    let calls_log = recording_gate.calls();
+
+    let hooks = HookBundle {
+        egress: Arc::new(recording_gate),
+        ..HookBundle::noop()
+    };
+
+    let agent = Agent::builder()
+        .responder_arc(responder.clone())
+        .tool_executor(executor)
+        .hooks(hooks)
+        .build()
+        .expect("build agent");
+
+    let reply = agent.run("dump env").await.expect("agent.run should succeed");
+    assert_eq!(reply, FINAL_REPLY, "final reply should match scripted turn 2");
+
+    // --- Assertion 1: second LLM turn's ctx.messages tool_result is redacted.
+    let snapshot = responder
+        .snapshot(1)
+        .expect("responder should have been called for the second turn");
+    let tool_result_msg = snapshot
+        .iter()
+        .find(|m| matches!(m.role, Role::Tool))
+        .expect("second-turn ctx.messages must contain a Tool message");
+
+    assert!(
+        !tool_result_msg.content.contains(RAW_SECRET),
+        "raw secret must not survive into next LLM turn; got: {:?}",
+        tool_result_msg.content,
+    );
+    assert!(
+        tool_result_msg.content.contains(REDACTED_MARKER),
+        "tool_result content must contain [REDACTED] marker; got: {:?}",
+        tool_result_msg.content,
+    );
+
+    // --- Assertion 2: at least one UserDisplay check resulted in Redact.
+    let log = calls_log.lock().expect("calls_log mutex not poisoned");
+    let user_display_redactions = log
+        .iter()
+        .filter(|(kind, _payload, decision)| {
+            matches!(kind, EgressKind::UserDisplay)
+                && matches!(decision, EgressDecision::Redact { .. })
+        })
+        .count();
+    assert!(
+        user_display_redactions >= 1,
+        "expected ≥1 UserDisplay Redact decisions; recorded calls: {:?}",
+        *log,
+    );
+
+    // --- Assertion 3: final reply is clean (defensive — text_turn is direct).
+    assert!(
+        !reply.contains(RAW_SECRET),
+        "final reply must not echo raw secret; got: {reply:?}"
+    );
+}

--- a/crates/dasclaw_cli/tests/safety_path_escape_e2e.rs
+++ b/crates/dasclaw_cli/tests/safety_path_escape_e2e.rs
@@ -1,0 +1,210 @@
+//! ADR-153 §1.1 e11 (A5 — L1 path escape via cap_std).
+//!
+//! Setup: a temporary workspace root holds a single safe file. A
+//! [`CapBoundedFsExecutor`] (defined inline below — intentionally **not**
+//! added to `safety_fixtures.rs` because fs semantics are unique to this
+//! row) wraps a [`WorkspaceCapability`] and exposes one tool, `fs_read`,
+//! which takes a `{ "path": "..." }` argument. The scripted responder
+//! drives two scenarios:
+//!
+//! 1. The model tries to read `../../../../etc/passwd` — cap-std rejects
+//!    it as [`WorkspaceCapError::PolicyViolation`]; the executor returns
+//!    a `ToolResult` with `is_error = true` and a message containing
+//!    `"outside workspace"` (ADR-153 wording) plus the underlying cap-std
+//!    detail. The agent loop continues and the model's follow-up turn
+//!    becomes the final reply.
+//!
+//! 2. The model reads `safe.txt` — cap-std resolves the path inside the
+//!    workspace; the executor returns the file bytes as `content` and
+//!    `is_error = false`. This is the happy-path counterpart that proves
+//!    the cap really can serve reads, i.e. the negative case isn't just
+//!    failing because every path fails.
+//!
+//! Contract verified (matches `tests/safety_path_escape_e2e.rs` row in
+//! ADR-153 §1.1 line 80):
+//!   * Path escape -> `ToolResult { is_error: true, content contains
+//!     "outside workspace" }`.
+//!   * Loop does not crash; model's follow-up text turn is returned.
+//!   * In-bounds read produces the file contents and **no** "outside
+//!     workspace" string.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use dasclaw_core::hooks::HookBundle;
+use dasclaw_core::messages::{Role, ToolCall, ToolResult};
+use dasclaw_core::traits::HostError;
+use dasclaw_runtime::{Agent, ToolExecutor};
+use dasclaw_workspace_cap::{WorkspaceCapError, WorkspaceCapability};
+use tempfile::TempDir;
+
+#[path = "fixtures/safety_fixtures.rs"]
+mod safety_fixtures;
+
+use safety_fixtures::{ScriptedResponder, text_turn, tool_call_turn};
+
+/// Inline tool executor that bridges `fs_read({ path })` calls into a
+/// capability-bound workspace. Lives in this test file (not the shared
+/// fixtures module) because no other e2e row reads files through the
+/// host's filesystem capability — keeping it local avoids polluting
+/// `safety_fixtures.rs` with single-use scaffolding.
+struct CapBoundedFsExecutor {
+    cap: WorkspaceCapability,
+}
+
+impl CapBoundedFsExecutor {
+    fn new(cap: WorkspaceCapability) -> Self {
+        Self { cap }
+    }
+}
+
+#[async_trait]
+impl ToolExecutor for CapBoundedFsExecutor {
+    async fn execute(&self, call: &ToolCall) -> Result<ToolResult, HostError> {
+        // Extract `path` from the call arguments without panicking on
+        // malformed input: a missing/non-string `path` is itself a tool
+        // error, not a host crash.
+        let Some(path) = call.arguments.get("path").and_then(|v| v.as_str()) else {
+            return Ok(ToolResult {
+                tool_call_id: call.id.clone(),
+                name: call.name.clone(),
+                content: "error: missing 'path' argument".to_string(),
+                is_error: true,
+            });
+        };
+
+        let content = match self.cap.read(Path::new(path)) {
+            Ok(bytes) => ToolResult {
+                tool_call_id: call.id.clone(),
+                name: call.name.clone(),
+                content: String::from_utf8_lossy(&bytes).into_owned(),
+                is_error: false,
+            },
+            // Natural host-layer translation: the ADR wording calls for
+            // "outside workspace" in the error message; cap-std's own
+            // `Display` impl says "path escapes workspace root". Wrapping
+            // it preserves both so future readers can trace which layer
+            // tripped without us patching cap-std's error string.
+            Err(e @ WorkspaceCapError::PolicyViolation(_)) => ToolResult {
+                tool_call_id: call.id.clone(),
+                name: call.name.clone(),
+                content: format!("error: path outside workspace ({e})"),
+                is_error: true,
+            },
+            Err(e) => ToolResult {
+                tool_call_id: call.id.clone(),
+                name: call.name.clone(),
+                content: format!("error: io ({e})"),
+                is_error: true,
+            },
+        };
+
+        Ok(content)
+    }
+}
+
+/// Build a tempdir containing `safe.txt` with known contents and return
+/// `(tempdir, cap)` — the tempdir handle must be kept alive for the
+/// duration of the test so the directory isn't deleted out from under
+/// the capability.
+fn setup_workspace() -> (TempDir, WorkspaceCapability) {
+    let tmp = TempDir::new().expect("create tempdir");
+    std::fs::write(tmp.path().join("safe.txt"), b"safe content")
+        .expect("seed safe.txt in workspace root");
+    let cap = WorkspaceCapability::open(tmp.path()).expect("open workspace capability");
+    (tmp, cap)
+}
+
+#[tokio::test]
+async fn req_dasclaw_cli_safety_e11_path_escape_returns_tool_error() {
+    let (_tmp, cap) = setup_workspace();
+
+    let responder = Arc::new(ScriptedResponder::with_queue(vec![
+        tool_call_turn(
+            "fs_read",
+            "c1",
+            serde_json::json!({ "path": "../../../../etc/passwd" }),
+        ),
+        text_turn("declined: path outside workspace"),
+    ]));
+
+    let executor = CapBoundedFsExecutor::new(cap);
+
+    let agent = Agent::builder()
+        .responder_arc(responder.clone())
+        .tool_executor(executor)
+        .hooks(HookBundle::noop())
+        .build()
+        .expect("build agent");
+
+    let reply = agent.run("read it").await.expect("agent loop completes");
+    assert_eq!(
+        reply, "declined: path outside workspace",
+        "loop must complete normally with the model's follow-up turn"
+    );
+
+    // Second LLM turn (index 1) is the one that sees the tool_result.
+    let snapshot = responder
+        .snapshot(1)
+        .expect("responder must have been called twice");
+    let tool_result_msg = snapshot
+        .iter()
+        .find(|m| matches!(m.role, Role::Tool))
+        .expect("ctx.messages must contain a Tool message after fs_read");
+
+    assert!(
+        tool_result_msg.content.contains("outside workspace"),
+        "tool_result must surface the ADR-153 boundary phrase; got: {:?}",
+        tool_result_msg.content,
+    );
+    assert!(
+        !tool_result_msg.content.contains("safe content"),
+        "tool_result must not leak in-workspace file bytes on an escape; got: {:?}",
+        tool_result_msg.content,
+    );
+}
+
+#[tokio::test]
+async fn req_dasclaw_cli_safety_e11_path_inside_workspace_succeeds() {
+    let (_tmp, cap) = setup_workspace();
+
+    let responder = Arc::new(ScriptedResponder::with_queue(vec![
+        tool_call_turn("fs_read", "c1", serde_json::json!({ "path": "safe.txt" })),
+        text_turn("file content read"),
+    ]));
+
+    let executor = CapBoundedFsExecutor::new(cap);
+
+    let agent = Agent::builder()
+        .responder_arc(responder.clone())
+        .tool_executor(executor)
+        .hooks(HookBundle::noop())
+        .build()
+        .expect("build agent");
+
+    let reply = agent.run("read it").await.expect("agent loop completes");
+    assert_eq!(
+        reply, "file content read",
+        "happy path must complete with the model's follow-up turn"
+    );
+
+    let snapshot = responder
+        .snapshot(1)
+        .expect("responder must have been called twice");
+    let tool_result_msg = snapshot
+        .iter()
+        .find(|m| matches!(m.role, Role::Tool))
+        .expect("ctx.messages must contain a Tool message after fs_read");
+
+    assert!(
+        tool_result_msg.content.contains("safe content"),
+        "in-bounds read must surface the file contents; got: {:?}",
+        tool_result_msg.content,
+    );
+    assert!(
+        !tool_result_msg.content.contains("outside workspace"),
+        "happy path must not be tagged as an escape; got: {:?}",
+        tool_result_msg.content,
+    );
+}


### PR DESCRIPTION
## 背景 / 目标

延续 W6.2a/W6.2b/W6.3/W6.5a/W6.5b（#831 / #833 / #835 / #837 / #838）的 ADR-153 §1.1 测试矩阵补全，本 PR 在 `dasclaw_cli` 集成测试层增加 W6.4 的两个 P1 安全行：

- **e9（A3 / L6）**：tool result 中带 outbound 凭证，post-execute `EgressKind::UserDisplay` gate 必须在内容进入下一轮 LLM 上下文之前完成 redact。
- **e11（A5 / L1）**：通过 `dasclaw_workspace_cap::WorkspaceCapability` 给 tool 暴露的 fs read 设置 capability 边界，越界路径返回 `is_error=true` 的 ToolResult，agent loop 不 crash。

## 改动范围

- 新增 `crates/dasclaw_cli/tests/safety_credential_leak_in_tool_result_e2e.rs`（109 行，1 个测试函数）
- 新增 `crates/dasclaw_cli/tests/safety_path_escape_e2e.rs`（210 行，2 个测试函数：逃逸 + 反证 happy path）
- `crates/dasclaw_cli/Cargo.toml`：`[dev-dependencies]` 增加 `dasclaw_workspace_cap = { path = "../dasclaw_workspace_cap" }`（4 行含注释）
- `Cargo.lock` 自动更新

不动 src/，不动现有 fixture，不动现有测试。

### 复用情况

| 复用 | 来源 |
|---|---|
| `ScriptedResponder` / `text_turn` / `tool_call_turn` | `safety_fixtures.rs` |
| `LeakyToolExecutor` / `SanitizingDisplayGate` / `RecordingEgressGate` | `safety_fixtures.rs`（e15 也用了同样组合） |
| `WorkspaceCapability` | `crates/dasclaw_workspace_cap`（已存在 crate） |

e11 的 `CapBoundedFsExecutor` 是**单用途内联 fixture**——只这一行测试需要 fs read 语义，按"不污染共享 fixture"原则没有加进 `safety_fixtures.rs`。

### e11 的错误消息处理

ADR-153 §1.1 e11 行期望错误 message 含 `"outside workspace"`，但 `WorkspaceCapError::PolicyViolation` 的实际 `Display` 是 `"path escapes workspace root: {rel}"`。
我们**没有**修改 dasclaw_workspace_cap 来迁就 ADR 文字（那是补丁式代码）。
而是在 host 层 `CapBoundedFsExecutor::execute` 中做自然的错误翻译：`format!("error: path outside workspace ({e})")`，让 ToolResult 同时含 ADR 字面 `"outside workspace"` + 保留 cap-std 原始 `"path escapes workspace root"` 细节，便于 future debug 追溯哪一层触发。理由在测试文件注释里写清了。

## 非目标（What's NOT in this PR）

- **e14（A6 / L7：outbound HTTP credential injection）**：ADR-153 §1.1 期望 ToolCall arguments 不带明文 token、只在 outbound HTTP header 里出现。这需要 `SecretsStore → ToolExecutor` 的运行时接线，当前 `dasclaw_cli` 只有 LLM provider 的 `SecretString` 流向，没有到 tool executor。属于接线 gap 不是测试 gap，**推迟到独立 W6.4b 接线 PR**（模式同 W6.1 → W6.2 的拆法）。
- 任何 src/ 修改
- 任何对 dasclaw_workspace_cap 的修改
- 共享 fixture 调整

## 验证（命令 + 结果）

```bash
$ cargo check -p dasclaw_cli --tests
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 44.54s
# 0 errors, 0 warnings

$ cargo nextest run -p dasclaw_cli \
    -E 'test(req_dasclaw_cli_safety_e9_) | test(req_dasclaw_cli_safety_e11_)'
    PASS  dasclaw_cli::safety_path_escape_e2e          req_dasclaw_cli_safety_e11_path_escape_returns_tool_error
    PASS  dasclaw_cli::safety_credential_leak_in_tool_result_e2e  req_dasclaw_cli_safety_e9_tool_result_credential_redacted
    PASS  dasclaw_cli::safety_path_escape_e2e          req_dasclaw_cli_safety_e11_path_inside_workspace_succeeds
    Summary [1.928s] 3 tests run: 3 passed, 42 skipped

$ cargo clippy --no-deps -p dasclaw_cli --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 27.79s
# 0 warnings

$ python3.12 scripts/check_no_panics.py --base origin/xClaw
OK: No panic-inducing calls in changed production code.
```

完整 workspace build / clippy / heavy integration 由 CI 兜底（本地分层策略）。

## Cross-cuts

- **ADR-114（`.ironclaw` → `.dasclaw` 命名迁移）**：**类 A** —— 本 PR diff 不含任何 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量新增。

## 后续

- W6.4b：补 `SecretsStore → ToolExecutor` 接线 + e14 测试（独立 PR）
- W6.5b 补漏：e24（A6 retry/timeout 时凭证泄漏）跟 e14 同一接线后再补



Closes #843
