### PR TITLE
test(dasclaw_cli): W6.4b-ii — caller Authorization coexistence + LeakDetector block (ADR-153 §1.1 e14)

### DIFF
--- a/crates/dasclaw_cli/tests/safety_credential_boundary_e2e.rs
+++ b/crates/dasclaw_cli/tests/safety_credential_boundary_e2e.rs
@@ -159,3 +159,144 @@ async fn req_dasclaw_cli_safety_e14_recorder_must_not_see_raw_token() {
         request.headers
     );
 }
+
+/// Boundary snapshot: when the caller already supplies an
+/// `Authorization` header **and** a `CredentialMapping` matches the same
+/// host, the host injection path **appends** the host header rather than
+/// replacing the caller's. Both end up in the outbound exchange.
+///
+/// This is not necessarily the *desired* long-term behaviour (see ADR-153
+/// §1.1 e14 follow-ups), but it is the contract the production
+/// `dasclaw_net_tools::HttpTool` exposes today. We pin it here so that
+/// any future override-vs-append decision becomes a deliberate
+/// design change rather than a silent regression.
+#[tokio::test(flavor = "multi_thread")]
+async fn req_dasclaw_cli_safety_e14_caller_authorization_header_is_preserved_alongside_injection() {
+    const CALLER_TOKEN: &str = "callertokenbbbbbbbbbbbbbbbb";
+    const HOST_SECRET_NAME: &str = "host_secret";
+    const HOST_SECRET_VALUE: &str = "hosttokenaaaaaaaaaaaaaaaaaa";
+
+    let store = test_secrets_store();
+    seed_secret(&store, TEST_USER, HOST_SECRET_NAME, HOST_SECRET_VALUE).await;
+
+    let registry = Arc::new(SharedCredentialRegistry::new());
+    registry.add_mappings([CredentialMapping::bearer(HOST_SECRET_NAME, TEST_HOST)]);
+
+    let tool = HttpTool::new().with_credentials(registry, store);
+
+    let interceptor = Arc::new(RecordingHttpInterceptor::new("{\"ok\":true}"));
+    let mut ctx = JobContext::with_user(TEST_USER, "e14-coexist", "caller + host authz");
+    ctx.http_interceptor = Some(interceptor.clone());
+
+    let caller_bearer = format!("Bearer {}", CALLER_TOKEN);
+    let args = json!({
+        "method": "GET",
+        "url": format!("https://{}/v1/things", TEST_HOST),
+        "headers": { "Authorization": caller_bearer.clone() },
+    });
+
+    let output = tool
+        .execute(args, &mut ctx)
+        .await
+        .expect("HttpTool::execute should succeed under the interceptor short-circuit");
+    assert!(
+        output.result.get("status").and_then(|s| s.as_u64()) == Some(200),
+        "interceptor short-circuit should surface status 200, got {:?}",
+        output.result
+    );
+
+    let captured = interceptor.captured();
+    assert_eq!(
+        captured.len(),
+        1,
+        "interceptor should observe exactly one outbound request, saw {}",
+        captured.len()
+    );
+    let request = &captured[0];
+
+    let auth_values: Vec<&String> = request
+        .headers
+        .iter()
+        .filter(|(name, _)| name.eq_ignore_ascii_case("authorization"))
+        .map(|(_, value)| value)
+        .collect();
+    assert_eq!(
+        auth_values.len(),
+        2,
+        "expected both caller and host Authorization headers, saw {} (all headers = {:?})",
+        auth_values.len(),
+        request.headers
+    );
+
+    let host_bearer = format!("Bearer {}", HOST_SECRET_VALUE);
+    assert!(
+        auth_values.iter().any(|v| **v == caller_bearer),
+        "caller's Authorization header missing from outbound request; auth_values = {:?}",
+        auth_values
+    );
+    assert!(
+        auth_values.iter().any(|v| **v == host_bearer),
+        "host-injected Authorization header missing from outbound request; auth_values = {:?}",
+        auth_values
+    );
+}
+
+/// Fail-safe: when the secret bound to a host mapping is shaped like an
+/// OpenAI API key (`sk-(?:proj-)?[A-Za-z0-9]{20,}`), the outbound
+/// [`LeakDetector::scan_http_request`] **Block**s the request before any
+/// network exchange is handed to interceptors / recorders. This pins the
+/// ADR-153 §1.1 e14 Fail-Safe contract: the secret never escapes the
+/// host, and the interceptor must see zero requests.
+#[tokio::test(flavor = "multi_thread")]
+async fn req_dasclaw_cli_safety_e14_leak_detector_blocks_openai_shaped_secret_injection() {
+    use dasclaw_tool::ToolError;
+
+    const OPENAI_SHAPED_SECRET_NAME: &str = "openai_key";
+    const OPENAI_SHAPED_SECRET_VALUE: &str = "sk-proj-test1234567890abcdefghij";
+
+    let store = test_secrets_store();
+    seed_secret(
+        &store,
+        TEST_USER,
+        OPENAI_SHAPED_SECRET_NAME,
+        OPENAI_SHAPED_SECRET_VALUE,
+    )
+    .await;
+
+    let registry = Arc::new(SharedCredentialRegistry::new());
+    registry.add_mappings([CredentialMapping::bearer(
+        OPENAI_SHAPED_SECRET_NAME,
+        TEST_HOST,
+    )]);
+
+    let tool = HttpTool::new().with_credentials(registry, store);
+
+    let interceptor = Arc::new(RecordingHttpInterceptor::new("{\"ok\":true}"));
+    let mut ctx = JobContext::with_user(TEST_USER, "e14-failsafe", "leak detector blocks openai");
+    ctx.http_interceptor = Some(interceptor.clone());
+
+    let result = tool
+        .execute(
+            json!({
+                "method": "GET",
+                "url": format!("https://{}/v1/things", TEST_HOST),
+            }),
+            &mut ctx,
+        )
+        .await;
+
+    let err = result.expect_err(
+        "LeakDetector must Block an openai-shaped secret before the outbound exchange leaves the host",
+    );
+    assert!(
+        matches!(err, ToolError::NotAuthorized(_)),
+        "expected ToolError::NotAuthorized from LeakDetector Block, got {:?}",
+        err
+    );
+
+    assert!(
+        interceptor.captured().is_empty(),
+        "interceptor must not observe any outbound request when LeakDetector Blocks; captured = {:?}",
+        interceptor.captured()
+    );
+}


### PR DESCRIPTION
## 背景 / 目标

ADR-153 §1.1 e14 凭证边界第二批红测：W6.4b-ii。

在 W6.4b-i 引入 `HttpTool` skeleton 后，本 PR 补两个 boundary 测试，
锁定当前出站凭证注入路径的行为，给 W6.4c 修复留 fail-safe 基线。

## 改动范围

`crates/dasclaw_cli/tests/safety_credential_boundary_e2e.rs` 追加两个测试：

1. `req_dasclaw_cli_safety_e14_caller_authorization_header_is_preserved_alongside_injection`
   - caller 在 `args.headers` 里塞自己的 `Authorization`，registry 又把 host bearer 映射进同 host
   - 当前 `HttpTool` 用 `headers_vec.push` 拼注入头 → 出站请求会同时包含两个 `Authorization`
   - 测试 snapshot 当前行为，便于 W6.4c snapshot fix 后翻转断言（不是固化错误，而是显式标注当前实现 + 标注待修语义）

2. `req_dasclaw_cli_safety_e14_leak_detector_blocks_openai_shaped_secret_injection`
   - 种一个 OpenAI 形状的 secret（`sk-proj-…`）进 registry
   - 断言规范注入路径 `LeakDetector::scan_http_request` 在 `HttpInterceptor` 之前把请求拦下（返回 `ToolError::NotAuthorized`）
   - **Fail-Safe** 契约：危险模式的密钥绝不能进 trace 文件 / 出 wire

## 非目标（What's NOT in this PR）

- 不动 `crates/dasclaw_net_tools/src/http.rs`（W6.4c 才动）
- 不动 `crates/dasclaw_net_proxy`（ADR-137 PR-N23 红线）
- 不修 caller/host Authorization 冲突的语义（W6.4c snapshot 修复后会改）

## 验证（命令 + 结果）

```bash
$ cargo nextest run -p dasclaw_cli -E 'test(req_dasclaw_cli_safety_e14_)'
4 tests run: 4 passed
$ cargo fmt --all -- --check  # OK
$ python3.12 scripts/check_no_panics.py --base origin/xClaw  # OK
$ python3.12 scripts/check_no_new_ironclaw_literal.py --base origin/xClaw --head HEAD  # OK
```

## Cross-cuts

- **ADR-114**（`.ironclaw` → `.dasclaw` 命名迁移）：**类 A** —— 本 PR diff 不含 legacy namespace literal 新增
- **ADR-129** verbatim：production path 完全未动，仅追加测试
- **ADR-153** §1.1 e14：boundary 红测

## stacked PR

base 不是 `xClaw` 而是 `feat/dasclaw-cli-w6-4b-i-secrets-http-skeleton`（PR #841）。

merge 顺序：#839 → #841 → 本 PR → #846。请先看 #839 #841 再 review 本 PR。

## 后续

- W6.4c（PR #846）：snapshot caller_headers，前面两个测试的断言会跟着翻转

Closes #845
