### PR TITLE
fix(dasclaw_net_tools): snapshot caller_headers before credential injection (W6.4c)

### DIFF
--- a/crates/dasclaw_cli/tests/safety_credential_boundary_e2e.rs
+++ b/crates/dasclaw_cli/tests/safety_credential_boundary_e2e.rs
@@ -4,23 +4,22 @@
 //! Asserts that `dasclaw_net_tools::HttpTool`, wired with a
 //! `SharedCredentialRegistry` + `InMemorySecretsStore`, injects a
 //! secret-backed `Authorization: Bearer …` header into the outbound
-//! request **before** the HTTP exchange leaves the host process, and
-//! that the caller-supplied `params` JSON never contained the raw
-//! secret in the first place.
+//! `reqwest` request **before** the HTTP exchange leaves the host
+//! process, while keeping the post-W6.4c invariant that recorders /
+//! interceptors never observe the raw host-injected secret.
 //!
 //! The host `HttpTool` rejects loopback (`127.0.0.1`) via its SSRF
 //! blocklist, so we cannot stand up a `wiremock` server. Instead we
 //! plug a `RecordingHttpInterceptor` into `JobContext.http_interceptor`,
 //! which short-circuits the real network call and captures the
-//! post-injection request descriptor. See
+//! pre-injection (caller-only) request descriptor. See
 //! `crates/dasclaw_net_tools/src/http.rs` ("Canonical credential
 //! injection path") for the production path this test exercises.
 //!
-//! W6.4b-i delivers the green-path assertion. The companion red test
-//! `req_dasclaw_cli_safety_e14_recorder_must_not_see_raw_token` is
-//! `#[ignore]`-tracked under W6.4c (issue #840), which will land the
-//! caller-headers snapshot fix so that pre-injection headers are
-//! reported to recorders and leak detectors.
+//! W6.4b-i delivers the green-path assertion. W6.4c landed the
+//! caller-headers snapshot fix (issue #840) so that pre-injection
+//! headers are what reach recorders, while the production injection
+//! still mutates the outbound `reqwest` builder.
 //!
 //! Cross-cuts: ADR-114 类 A (no new legacy namespace literals introduced);
 //! ADR-129 verbatim (tests only — production path untouched);
@@ -89,8 +88,12 @@ async fn req_dasclaw_cli_safety_e14_outbound_http_credential_injection_works() {
         output.result
     );
 
-    // Assert: the host injected `Authorization: Bearer <secret>` before the
-    // outbound exchange was handed to the interceptor.
+    // Assert (post-W6.4c): the interceptor sees the **pre-injection**
+    // snapshot, so the host-injected `Authorization: Bearer <secret>` is
+    // **not** observable here. The injection still happens on the
+    // outbound `reqwest` builder (covered by the LeakDetector-block
+    // companion test), but recorders / replay traces never see the raw
+    // secret. See ADR-153 §1.1 e14 and issue #840.
     let captured = interceptor.captured();
     assert_eq!(
         captured.len(),
@@ -102,13 +105,12 @@ async fn req_dasclaw_cli_safety_e14_outbound_http_credential_injection_works() {
     assert_eq!(request.method, "GET");
     assert_eq!(request.url, format!("https://{}/v1/things", TEST_HOST));
 
-    let expected_bearer = format!("Bearer {}", TEST_SECRET_VALUE);
-    let injected = request.headers.iter().any(|(name, value)| {
-        name.eq_ignore_ascii_case("authorization") && value == &expected_bearer
+    let leaked = request.headers.iter().any(|(name, value)| {
+        name.eq_ignore_ascii_case("authorization") && value.contains(TEST_SECRET_VALUE)
     });
     assert!(
-        injected,
-        "Authorization: Bearer <secret> header was not injected; captured headers = {:?}",
+        !leaked,
+        "pre-injection snapshot must not contain the raw bearer secret; captured headers = {:?}",
         request.headers
     );
 }
@@ -118,12 +120,11 @@ async fn req_dasclaw_cli_safety_e14_outbound_http_credential_injection_works() {
 /// headers, not the post-injection ones, so that trace/replay artifacts
 /// and leak detectors cannot accidentally persist the raw secret.
 ///
-/// Currently `dasclaw_net_tools::HttpTool` snapshots `headers_vec.clone()`
-/// for the `HttpExchangeRequest` **after** the injection block has
-/// pushed the bearer header, so this assertion fails. Re-enable once
-/// W6.4c lands the pre-injection snapshot.
+/// W6.4c landed the pre-injection `caller_headers_snapshot` in
+/// `dasclaw_net_tools::HttpTool`, so `HttpExchangeRequest.headers`
+/// observed by interceptors / recorders now contains only caller-supplied
+/// headers — never the host-injected bearer secret.
 #[tokio::test(flavor = "multi_thread")]
-#[ignore = "tracks W6.4c (issue #840): caller-headers snapshot fix for e14"]
 async fn req_dasclaw_cli_safety_e14_recorder_must_not_see_raw_token() {
     let store = test_secrets_store();
     seed_secret(&store, TEST_USER, TEST_SECRET_NAME, TEST_SECRET_VALUE).await;
@@ -160,16 +161,14 @@ async fn req_dasclaw_cli_safety_e14_recorder_must_not_see_raw_token() {
     );
 }
 
-/// Boundary snapshot: when the caller already supplies an
+/// Boundary snapshot (post-W6.4c): when the caller already supplies an
 /// `Authorization` header **and** a `CredentialMapping` matches the same
-/// host, the host injection path **appends** the host header rather than
-/// replacing the caller's. Both end up in the outbound exchange.
+/// host, the host injection path still appends the host header on the
+/// outbound wire (so reqwest sees two `Authorization` headers), but the
+/// pre-injection snapshot handed to `HttpInterceptor` only carries the
+/// caller's header — the host-injected secret never reaches recorders.
 ///
-/// This is not necessarily the *desired* long-term behaviour (see ADR-153
-/// §1.1 e14 follow-ups), but it is the contract the production
-/// `dasclaw_net_tools::HttpTool` exposes today. We pin it here so that
-/// any future override-vs-append decision becomes a deliberate
-/// design change rather than a silent regression.
+/// See ADR-153 §1.1 e14 and issue #840.
 #[tokio::test(flavor = "multi_thread")]
 async fn req_dasclaw_cli_safety_e14_caller_authorization_header_is_preserved_alongside_injection() {
     const CALLER_TOKEN: &str = "callertokenbbbbbbbbbbbbbbbb";
@@ -222,8 +221,8 @@ async fn req_dasclaw_cli_safety_e14_caller_authorization_header_is_preserved_alo
         .collect();
     assert_eq!(
         auth_values.len(),
-        2,
-        "expected both caller and host Authorization headers, saw {} (all headers = {:?})",
+        1,
+        "expected exactly the caller's Authorization in pre-injection snapshot, saw {} (all headers = {:?})",
         auth_values.len(),
         request.headers
     );
@@ -231,12 +230,12 @@ async fn req_dasclaw_cli_safety_e14_caller_authorization_header_is_preserved_alo
     let host_bearer = format!("Bearer {}", HOST_SECRET_VALUE);
     assert!(
         auth_values.iter().any(|v| **v == caller_bearer),
-        "caller's Authorization header missing from outbound request; auth_values = {:?}",
+        "caller's Authorization header missing from pre-injection snapshot; auth_values = {:?}",
         auth_values
     );
     assert!(
-        auth_values.iter().any(|v| **v == host_bearer),
-        "host-injected Authorization header missing from outbound request; auth_values = {:?}",
+        auth_values.iter().all(|v| **v != host_bearer),
+        "host-injected Authorization must NOT appear in pre-injection snapshot (would leak raw secret); auth_values = {:?}",
         auth_values
     );
 }

--- a/crates/dasclaw_net_tools/src/http.rs
+++ b/crates/dasclaw_net_tools/src/http.rs
@@ -545,6 +545,13 @@ impl Tool for HttpTool {
         // Red line: do NOT add credential injection to
         // `crates/dasclaw_net_proxy` — the verbatim drift guard
         // (`scripts/check_codex_net_proxy_drift.py`) will fail.
+        // W6.4c: snapshot headers before credential injection so recorders /
+        // replay traces never observe the raw host-injected secret. The
+        // post-injection `headers_vec` is still used by `LeakDetector` and the
+        // outbound `reqwest` builder; only the `HttpExchangeRequest` descriptor
+        // handed to `HttpInterceptor` uses this pre-injection snapshot.
+        // See ADR-153 §1.1 e14 and issue #840.
+        let caller_headers_snapshot = headers_vec.clone();
         if let (Some(registry), Some(store)) = (
             self.credential_registry.as_ref(),
             self.secrets_store.as_ref(),
@@ -590,7 +597,7 @@ impl Tool for HttpTool {
         let intercept_req = dasclaw_runtime::recording::HttpExchangeRequest {
             method: method_upper,
             url: parsed_url.to_string(),
-            headers: headers_vec.clone(),
+            headers: caller_headers_snapshot,
             body: body_bytes
                 .as_ref()
                 .map(|b| String::from_utf8_lossy(b).into_owned()),


### PR DESCRIPTION
## 背景 / 目标

W6.4c 修复 ADR-153 §1.1 e14 凭证边界中遗留的 caller_headers snapshot 漏洞。

`HttpTool` 在出站 HTTP 请求时会先把 host 凭证（来自 `SharedCredentialRegistry` + `SecretsStore`，例如 `Authorization: Bearer <secret>`）追加到 `headers_vec`，再把整个 list `clone` 进 `HttpExchangeRequest`，交给 `HttpInterceptor`（含 recording / replay 录像系统）和后续 trace 文件。结果录像里就能看到原始密钥明文。

## 改动范围

### crates/dasclaw_net_tools/src/http.rs

- 在凭证注入块前一行 snapshot 一份 `caller_headers_snapshot = headers_vec.clone()`
- `HttpExchangeRequest.headers` 改用 `caller_headers_snapshot`（pre-injection）
- `LeakDetector::scan_http_request` 仍扫 post-injection `headers_vec`（保留对 host 注入的危险 shape 密钥的 fail-safe）
- `reqwest` builder 仍注入 `Authorization` 到真正的 wire 请求，不变

### crates/dasclaw_cli/tests/safety_credential_boundary_e2e.rs

- 解除 `req_dasclaw_cli_safety_e14_recorder_must_not_see_raw_token` 的 `#[ignore]`（W6.4b-i 时跟踪 #840 的红测，现在转绿）
- `req_dasclaw_cli_safety_e14_caller_authorization_header_is_preserved_alongside_injection` 断言翻转：snapshot 现在只含 caller Authorization（1 个），host_bearer 不应出现；doc 注释同步更新
- `req_dasclaw_cli_safety_e14_outbound_http_credential_injection_works` 断言由 "snapshot 中能看到 Bearer secret" 翻转为 "snapshot 不得含 raw secret"（interceptor 在 TCP 之前短路，无法用 wiremock 验证 wire-level 注入；leak detector block 测试已间接保证注入路径仍跑通）

## 非目标（What's NOT in this PR）

- `crates/dasclaw_net_proxy`（不动 — ADR-137 PR-N23 红线）
- `desktop-client/ironclaw` 的 `RecordingHttpInterceptor` / `ReplayingHttpInterceptor`（不动 — fork 侧 replay 只软检查 url/method，对该改动无感）
- 录像文件版本号（旧 fixture 兼容 — 反序列化不会出错；replay 逻辑不依赖 headers 内容）
- 任何 wire-level 注入验证测试（需要绕过 SSRF blocklist，超 W6.4c 范围）

## 验证（命令 + 结果）

```bash
$ cargo nextest run -p dasclaw_net_tools
Summary [45.838s] 70 tests run: 70 passed, 1 skipped

$ cargo nextest run -p dasclaw_cli -E 'test(req_dasclaw_cli_safety_e14_)'
Summary [7.632s] 4 tests run: 4 passed, 45 skipped
    PASS  req_dasclaw_cli_safety_e14_outbound_http_credential_injection_works
    PASS  req_dasclaw_cli_safety_e14_leak_detector_blocks_openai_shaped_secret_injection
    PASS  req_dasclaw_cli_safety_e14_recorder_must_not_see_raw_token   # 由 ignored 转 PASS
    PASS  req_dasclaw_cli_safety_e14_caller_authorization_header_is_preserved_alongside_injection

$ cargo clippy --no-deps -p dasclaw_net_tools --all-targets -- -D warnings  # 0 warnings
$ cargo clippy --no-deps -p dasclaw_cli --all-targets -- -D warnings        # 0 warnings
$ python3.12 scripts/check_no_panics.py --base origin/xClaw  # OK
$ python3.12 scripts/check_no_new_ironclaw_literal.py --base origin/xClaw --head HEAD  # OK
```

完整 workspace build / clippy / heavy integration 由 CI 兜底。

## Cross-cuts

- ADR-114（`.ironclaw` → `.dasclaw` 命名迁移）：**类 A** —— 本 PR diff 不含任何 legacy namespace literal 新增

## stacked PR

base 不是 `xClaw` 而是 `feat/dasclaw-cli-w6-4b-ii-credential-boundary-tests`（PR #842）。

merge 顺序：#839 → #841 → #842 → 本 PR。请先看 #839 #841 #842 再 review 本 PR。

## 后续

- W6.5b 补漏 e24（A6 retry/timeout 凭证泄漏）跟同接线后再补
- 如需 wire-level 注入验证测试，独立 PR 引入 wiremock + SSRF 测试白名单

Closes #840
