### PR TITLE
test(dasclaw_cli): W6.5c — ADR-153 §1.1 B8 (e24) tool-arg schema gate tests

### DIFF
--- a/crates/dasclaw_cli/tests/agent_tool_args_schema_e2e.rs
+++ b/crates/dasclaw_cli/tests/agent_tool_args_schema_e2e.rs
@@ -1,0 +1,296 @@
+//! ADR-153 §1.1 B8 (e24): tool-arg schema validation as a pre-execute
+//! egress gate.
+//!
+//! Setup: the scripted responder emits a `read_file` tool call whose
+//! arguments are missing the required `path` field (model hallucinated
+//! `{"depth": 3}` instead). An `EgressGate` wired with a
+//! [`SchemaValidatingToolExecGate`] inspects the serialised arguments
+//! at `EgressKind::ToolExecution { tool }` and returns
+//! [`EgressDecision::Block`] when the schema check fails. The check
+//! itself reuses `dasclaw_safety::Validator::validate_tool_params`
+//! for string-content validation (matrix line 138 calls this out by
+//! name), layered with a small required-string-field check that the
+//! `Validator` itself doesn't perform.
+//!
+//! Contract verified:
+//!   * Block fires at `EgressKind::ToolExecution { tool: "read_file" }`.
+//!   * The executor is **never** invoked (`call_count() == 0`).
+//!   * The model observes an `Error: …` tool_result containing the
+//!     refusal reason and produces a graceful final reply.
+//!
+//! A positive control (`valid_schema_allows_executor`) pins the
+//! contract: a well-formed `{"path":"/tmp/x"}` call passes through
+//! and the executor runs exactly once. Without this baseline the
+//! Block test could vacuously pass if the gate over-blocked.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use dasclaw_core::hooks::{
+    AutoApproveGate, EgressDecision, EgressGate, EgressKind, HookBundle, InMemorySecrets,
+    NoopSandboxExecutor, RedactionStats,
+};
+use dasclaw_runtime::Agent;
+use dasclaw_safety::Validator;
+use serde_json::json;
+
+#[path = "fixtures/agent_loop_fixtures.rs"]
+mod fixtures;
+
+use fixtures::{RecordingToolExecutor, ScriptedResponder, no_tool_defs, text_turn, tool_call_turn};
+
+/// `EgressGate` that validates a single tool's arguments against a
+/// minimal "required string fields" schema, plus the project-wide
+/// `dasclaw_safety::Validator::validate_tool_params` content checks.
+///
+/// Scoped to `EgressKind::ToolExecution { tool: target }`; all other
+/// kinds (and other tools) pass through. This narrow scope is what
+/// e24 asserts: the schema gate must not interfere with `LlmRequest`
+/// or `UserDisplay`.
+struct SchemaValidatingToolExecGate {
+    target_tool: String,
+    required_string_fields: Vec<String>,
+    refuse_reason_prefix: String,
+    validator: Validator,
+}
+
+impl SchemaValidatingToolExecGate {
+    fn new(
+        target_tool: impl Into<String>,
+        required_string_fields: impl IntoIterator<Item = impl Into<String>>,
+        refuse_reason_prefix: impl Into<String>,
+    ) -> Self {
+        Self {
+            target_tool: target_tool.into(),
+            required_string_fields: required_string_fields.into_iter().map(Into::into).collect(),
+            refuse_reason_prefix: refuse_reason_prefix.into(),
+            validator: Validator::new(),
+        }
+    }
+
+    /// Returns `Err(structured-reason)` if the payload violates the
+    /// schema. Splitting this out keeps `EgressGate::check` async-free
+    /// from JSON parsing concerns and makes the failure modes easy
+    /// to enumerate in test assertions.
+    fn validate(&self, payload: &str) -> Result<(), String> {
+        let args: serde_json::Value = serde_json::from_str(payload).map_err(|e| {
+            format!(
+                "{}: arguments are not valid JSON ({e})",
+                self.refuse_reason_prefix
+            )
+        })?;
+
+        let obj = args.as_object().ok_or_else(|| {
+            format!(
+                "{}: arguments must be a JSON object, got {}",
+                self.refuse_reason_prefix,
+                kind_of(&args)
+            )
+        })?;
+
+        for field in &self.required_string_fields {
+            match obj.get(field) {
+                None => {
+                    return Err(format!(
+                        "{}: missing required field `{field}` (expected string)",
+                        self.refuse_reason_prefix
+                    ));
+                }
+                Some(v) if !v.is_string() => {
+                    return Err(format!(
+                        "{}: field `{field}` must be a string, got {}",
+                        self.refuse_reason_prefix,
+                        kind_of(v)
+                    ));
+                }
+                Some(_) => {}
+            }
+        }
+
+        // Layer content checks from `dasclaw_safety` on top of the
+        // structural ones above. The matrix specifically names
+        // `Validator::validate_tool_params` here, so even when the
+        // structural check passes we surface the safety verdict.
+        let result = self.validator.validate_tool_params(&args);
+        if !result.is_valid {
+            let detail = result
+                .errors
+                .iter()
+                .map(|e| format!("{}={}", e.field, e.message))
+                .collect::<Vec<_>>()
+                .join("; ");
+            return Err(format!(
+                "{}: dasclaw_safety::Validator rejected params [{detail}]",
+                self.refuse_reason_prefix
+            ));
+        }
+
+        Ok(())
+    }
+}
+
+/// Build the HookBundle used by every test in this file: the
+/// `read_file({path:string})` schema gate wired in front of the
+/// stock no-op sandbox / in-memory secrets / auto-approve stack.
+///
+/// Centralising this keeps the three test bodies focused on what
+/// they actually assert (block, allow, scope) instead of repeating
+/// the same four-field literal.
+fn build_hooks() -> HookBundle {
+    HookBundle {
+        egress: Arc::new(SchemaValidatingToolExecGate::new(
+            "read_file",
+            ["path"],
+            "schema-violation",
+        )),
+        sandbox: Arc::new(NoopSandboxExecutor),
+        secrets: Arc::new(InMemorySecrets::new()),
+        approval: Arc::new(AutoApproveGate),
+    }
+}
+
+fn kind_of(v: &serde_json::Value) -> &'static str {
+    match v {
+        serde_json::Value::Null => "null",
+        serde_json::Value::Bool(_) => "bool",
+        serde_json::Value::Number(_) => "number",
+        serde_json::Value::String(_) => "string",
+        serde_json::Value::Array(_) => "array",
+        serde_json::Value::Object(_) => "object",
+    }
+}
+
+#[async_trait]
+impl EgressGate for SchemaValidatingToolExecGate {
+    async fn check(&self, kind: &EgressKind, payload: &str) -> EgressDecision {
+        let EgressKind::ToolExecution { tool } = kind else {
+            return EgressDecision::Allow;
+        };
+        if tool != &self.target_tool {
+            return EgressDecision::Allow;
+        }
+        match self.validate(payload) {
+            Ok(()) => EgressDecision::Allow,
+            Err(reason) => EgressDecision::Block {
+                reason,
+                stats: RedactionStats::default(),
+            },
+        }
+    }
+}
+
+#[tokio::test]
+async fn req_dasclaw_cli_loop_e24_invalid_schema_blocks_executor() {
+    // Turn 1: model hallucinates an arg shape — `depth:3` instead of the
+    // required `path:string`.
+    // Turn 2: after seeing the `Error: …` tool_result, the model
+    //         produces a graceful final reply.
+    let responder = ScriptedResponder::with_queue(vec![
+        tool_call_turn("read_file", "call_bad_args", json!({ "depth": 3 })),
+        text_turn("declined: invalid params for read_file"),
+    ]);
+
+    let executor = RecordingToolExecutor::new();
+    let calls = executor.calls();
+
+    let agent = Agent::builder()
+        .responder(responder)
+        .tool_executor(executor)
+        .tools(no_tool_defs())
+        .hooks(build_hooks())
+        .build()
+        .expect("agent builds");
+
+    let reply = agent
+        .run("read the report file")
+        .await
+        .expect("loop must finish — Block on a tool call is non-fatal");
+
+    assert_eq!(reply, "declined: invalid params for read_file");
+
+    let log = calls.lock().expect("calls log");
+    assert_eq!(
+        log.len(),
+        0,
+        "schema-violating tool calls must never reach the executor, got: {log:#?}"
+    );
+}
+
+#[tokio::test]
+async fn req_dasclaw_cli_loop_e24_valid_schema_allows_executor() {
+    // Positive control: well-formed args pass the schema gate and the
+    // executor runs exactly once. Pins that the gate isn't over-broad.
+    let responder = ScriptedResponder::with_queue(vec![
+        tool_call_turn(
+            "read_file",
+            "call_good_args",
+            json!({ "path": "/tmp/report.txt" }),
+        ),
+        text_turn("read complete"),
+    ]);
+
+    let executor = RecordingToolExecutor::new().with_reply("read_file", "file body");
+    let calls = executor.calls();
+
+    let agent = Agent::builder()
+        .responder(responder)
+        .tool_executor(executor)
+        .tools(no_tool_defs())
+        .hooks(build_hooks())
+        .build()
+        .expect("agent builds");
+
+    let reply = agent
+        .run("read the report file")
+        .await
+        .expect("baseline must run");
+
+    assert_eq!(reply, "read complete");
+
+    let log = calls.lock().expect("calls log");
+    assert_eq!(
+        log.len(),
+        1,
+        "valid schema must let exactly one execution through, got: {log:#?}"
+    );
+    assert_eq!(log[0].name, "read_file");
+    assert_eq!(log[0].arguments, json!({ "path": "/tmp/report.txt" }));
+}
+
+#[tokio::test]
+async fn req_dasclaw_cli_loop_e24_schema_gate_scoped_to_target_tool() {
+    // The gate is configured for `read_file`. A call to a different
+    // tool (`list_files`) — even one whose args would fail the same
+    // schema — must Pass through. This pins the scoping contract so a
+    // future refactor can't silently make the gate global.
+    let responder = ScriptedResponder::with_queue(vec![
+        tool_call_turn(
+            "list_files",
+            "call_list",
+            json!({ "depth": 3 }), // would fail `path:string` schema if applied
+        ),
+        text_turn("listing complete"),
+    ]);
+
+    let executor = RecordingToolExecutor::new().with_reply("list_files", "a.txt\nb.txt");
+    let calls = executor.calls();
+
+    let agent = Agent::builder()
+        .responder(responder)
+        .tool_executor(executor)
+        .tools(no_tool_defs())
+        .hooks(build_hooks())
+        .build()
+        .expect("agent builds");
+
+    let reply = agent
+        .run("list files")
+        .await
+        .expect("non-target tool must not be gated");
+
+    assert_eq!(reply, "listing complete");
+
+    let log = calls.lock().expect("calls log");
+    assert_eq!(log.len(), 1, "non-target tool should run, got: {log:#?}");
+    assert_eq!(log[0].name, "list_files");
+}


### PR DESCRIPTION
## 背景 / 目标

ADR-153 §1.1 P1 切片 **W6.5c** — 完成 W6.5 测试族最后一格：B8 / e24
工具参数 schema 校验。本 PR 是**纯测试新增、零接线改动**。

W6.5 测试族（B3+B4+B6+B8）进度：
- W6.5a B3+B4 → #837 (merged)
- W6.5b B6/e22 → #838 (merged)
- **W6.5c B8/e24 → 本 PR**

## 改动范围

新增单一测试文件 `crates/dasclaw_cli/tests/agent_tool_args_schema_e2e.rs`（+296）：

测试族（3 个）——
1. `req_dasclaw_cli_loop_e24_invalid_schema_blocks_executor` — 主断言：
   模型发 `read_file({"depth":3})` → schema 要求 `path:string` → pre-execute
   `EgressGate` 返回 `Block` → executor 永不被调（`call_count == 0`）→
   模型读到 `Error: …` tool_result 后给出 graceful final reply。
2. `req_dasclaw_cli_loop_e24_valid_schema_allows_executor` — 正面控制：
   `read_file({"path":"/tmp/x"})` 通过 schema → executor 调用 1 次。
   防止 gate 过度拦截导致主断言空过。
3. `req_dasclaw_cli_loop_e24_schema_gate_scoped_to_target_tool` — scoping pin：
   非目标工具（`list_files`）即使 args 同样违反 schema 也必须 Pass，
   防止未来重构把 gate 改成全局生效。

实现要点：
- 内联 `SchemaValidatingToolExecGate`，组合两层校验：
  - (1) 自写的 "required string fields" 结构校验
  - (2) `dasclaw_safety::Validator::validate_tool_params` 字符串内容校验
    （矩阵 §1.1 line 138 点名）
- 复用现有 fixtures（`fixtures/agent_loop_fixtures.rs`）：
  `RecordingToolExecutor` / `ScriptedResponder` / `no_tool_defs` /
  `text_turn` / `tool_call_turn`
- 提取 `build_hooks()` helper 消除 3 个测试间的 `HookBundle` 重复构造

## 非目标 (What's NOT in this PR)

- 不接入真 JSON Schema 库（`jsonschema` crate）；测试范围内自写两字段必填检查即可。
- 不动 `dasclaw_safety::Validator` 本身；schema 结构校验留在测试侧适配层。
- 不改 `dasclaw_runtime::Agent` 的 gate 接线（W6.2 已就位）。
- 不动 W6.5a/W6.5b 的既有测试文件。

## 验证

本地节奏（AGENTS.md 规定）：

```
cargo check -p dasclaw_cli --tests          # Finished in 19.34s, 0 错
cargo nextest run -p dasclaw_cli --test agent_tool_args_schema_e2e
  → 3/3 passed [   1.942s]
cargo fmt --all                             # 已格式化
python3.12 scripts/check_no_panics.py --base origin/xClaw
  → OK: No panic-inducing calls in changed production code
cargo clippy --no-deps -p dasclaw_cli --all-targets -- -D warnings
  → 0 警告
```

3 层 skills 自审已完成（`code-quality-audit` / `code-simplifier` /
`code-review-expert`）：消除了一处 3 次 `HookBundle` 重复构造，提取
为 `build_hooks()` helper。

完整 `cargo build` / workspace clippy / heavy integration 由 CI 兜底。

## Cross-cuts

- **ADR-114**：类A — 无新增 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量。
- **ADR-129**：not a verbatim port — 新建测试文件，无上游对应。

## 后续

- W6.5 测试族 (B3+B4+B6+B8) 全部完成；进入 W6.6 或下一波。
- 如需将 schema 结构校验下沉到 `Validator` 本身（变成第一公民），
  需另开 ADR/issue 讨论是否引入 `jsonschema` crate；本 PR 不预设方向。

Closes #847
