### PR TITLE
feat(dasclaw_cli): A10 EgressGate audit-log e2e (ADR-153 §1.1 / e16)

### DIFF
--- a/crates/dasclaw_cli/tests/safety_egress_audit_log_e2e.rs
+++ b/crates/dasclaw_cli/tests/safety_egress_audit_log_e2e.rs
@@ -1,0 +1,185 @@
+//! ADR-153 §1.1 case **e16 (A10)** — L8 网络审计。
+//!
+//! Contract:
+//! - 一轮带工具的对话中，`HookBundle.egress` 会被分别以 `LlmRequest` /
+//!   `ToolExecution { tool }` / `UserDisplay` 三种 [`EgressKind`] 触发
+//!   至少一次（W6.1 接线分别在 `dasclaw_core::agentic_loop` 和
+//!   `dasclaw_runtime::agent` 中落地）。
+//! - 一个 audit-recording gate 可以把这三类 egress 全部记录下来，
+//!   且记录里 payload **已 redact**，即 audit log 本身不会成为新的
+//!   信息泄露 sink。
+//!
+//! 这与 e7（A1，单点 LlmRequest 阻断）、e8（A2，单点 ToolExecution 阻断）、
+//! e15（A8，单点 UserDisplay 重写）互补：那三例验证单一 kind 路径，
+//! 本例验证 audit gate **跨三类 kind** 的端到端可观测性。
+
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use dasclaw_cli::run_with_tools_and_hooks;
+use dasclaw_core::hooks::{
+    AutoApproveGate, EgressDecision, EgressGate, EgressKind, HookBundle, InMemorySecrets,
+    NoopSandboxExecutor,
+};
+use dasclaw_core::messages::ToolDefinition;
+
+#[path = "fixtures/safety_fixtures.rs"]
+mod safety_fixtures;
+
+use safety_fixtures::{RecordingToolExecutor, ScriptedResponder, text_turn, tool_call_turn};
+
+/// Trigger token that must never appear in any audit record.
+///
+/// Chosen to be distinctive so an accidental partial match (e.g. only
+/// "SK_LIVE") would still fail the assertion.
+const TRIGGER: &str = "SK_LIVE_TRIGGER_AUDIT_E16";
+
+/// Single audit record: `(kind, post-decision payload)`.
+type AuditRecord = (EgressKind, String);
+type AuditLog = Arc<Mutex<Vec<AuditRecord>>>;
+
+/// Audit-safe `EgressGate`:
+///
+/// - If the payload contains [`TRIGGER`], return [`EgressDecision::Redact`]
+///   with `[REDACTED]` substituted in.
+/// - Otherwise [`EgressDecision::Allow`].
+///
+/// **Audit invariant**: only the post-decision (sanitized) payload is
+/// stored in the call log. The raw `payload` argument is never persisted,
+/// so the audit log itself cannot leak the trigger.
+struct AuditRedactingGate {
+    records: AuditLog,
+}
+
+impl AuditRedactingGate {
+    fn new() -> (Arc<Self>, AuditLog) {
+        let records: AuditLog = Arc::new(Mutex::new(Vec::new()));
+        let gate = Arc::new(Self {
+            records: Arc::clone(&records),
+        });
+        (gate, records)
+    }
+}
+
+#[async_trait]
+impl EgressGate for AuditRedactingGate {
+    async fn check(&self, kind: &EgressKind, payload: &str) -> EgressDecision {
+        let (decision, audit_payload) = if payload.contains(TRIGGER) {
+            let sanitized = payload.replace(TRIGGER, "[REDACTED]");
+            (
+                EgressDecision::Redact {
+                    sanitized: sanitized.clone(),
+                    stats: Default::default(),
+                },
+                sanitized,
+            )
+        } else {
+            (EgressDecision::Allow, payload.to_string())
+        };
+
+        if let Ok(mut log) = self.records.lock() {
+            log.push((kind.clone(), audit_payload));
+        }
+        decision
+    }
+}
+
+fn tool_def() -> ToolDefinition {
+    ToolDefinition {
+        name: "do_thing".into(),
+        description: "test tool for A10 audit coverage".into(),
+        parameters: serde_json::json!({
+            "type": "object",
+            "properties": {
+                "key": { "type": "string" }
+            }
+        }),
+    }
+}
+
+#[tokio::test]
+async fn req_dasclaw_cli_safety_a10_egress_audit_log_redacts_all_kinds() {
+    // user prompt embeds the trigger → exercises the LlmRequest path.
+    let user_prompt = format!("please call do_thing with {TRIGGER}");
+
+    // Turn 1: model emits a tool call whose arguments contain the
+    //         trigger → exercises the ToolExecution path.
+    // Turn 2: model emits a plain-text reply that echoes the trigger
+    //         → exercises the UserDisplay path.
+    let responder = ScriptedResponder::with_queue(vec![
+        tool_call_turn("do_thing", "call_1", serde_json::json!({ "key": TRIGGER })),
+        text_turn(format!("done observing {TRIGGER}")),
+    ]);
+
+    let executor = RecordingToolExecutor::with_content(format!("observed {TRIGGER}"));
+
+    let (gate, records) = AuditRedactingGate::new();
+    let hooks = HookBundle {
+        egress: gate,
+        sandbox: Arc::new(NoopSandboxExecutor),
+        secrets: Arc::new(InMemorySecrets::new()),
+        approval: Arc::new(AutoApproveGate),
+    };
+
+    let reply = run_with_tools_and_hooks(
+        responder,
+        executor,
+        vec![tool_def()],
+        hooks,
+        "system",
+        user_prompt.as_str(),
+    )
+    .await
+    .expect("Redact is non-blocking; agent run must succeed");
+
+    // The final reply that surfaces to the caller has flowed through the
+    // UserDisplay gate, so the trigger must already be redacted.
+    assert!(
+        !reply.contains(TRIGGER),
+        "rendered reply must be redacted, got: {reply}"
+    );
+
+    let log = records.lock().expect("audit log lock");
+    assert!(
+        !log.is_empty(),
+        "audit gate must have observed at least one egress event"
+    );
+
+    let mut saw_llm_request = false;
+    let mut saw_tool_execution = false;
+    let mut saw_user_display = false;
+
+    for (kind, audit_payload) in log.iter() {
+        // Core A10 invariant: no audit record may carry the raw trigger.
+        assert!(
+            !audit_payload.contains(TRIGGER),
+            "audit record payload leaked the trigger: kind={kind:?} payload={audit_payload}"
+        );
+
+        match kind {
+            EgressKind::LlmRequest => saw_llm_request = true,
+            EgressKind::ToolExecution { tool } => {
+                assert_eq!(
+                    tool, "do_thing",
+                    "ToolExecution kind must carry the registered tool name"
+                );
+                saw_tool_execution = true;
+            }
+            EgressKind::UserDisplay => saw_user_display = true,
+            _ => {}
+        }
+    }
+
+    assert!(
+        saw_llm_request,
+        "expected at least one EgressKind::LlmRequest audit record, observed: {log:?}"
+    );
+    assert!(
+        saw_tool_execution,
+        "expected at least one EgressKind::ToolExecution audit record, observed: {log:?}"
+    );
+    assert!(
+        saw_user_display,
+        "expected at least one EgressKind::UserDisplay audit record, observed: {log:?}"
+    );
+}

--- a/docs/plans/architecture-refactor/adr-153-cli-test-matrix.md
+++ b/docs/plans/architecture-refactor/adr-153-cli-test-matrix.md
@@ -196,6 +196,7 @@ python3.12 scripts/check_no_panics.py --base origin/xClaw
 
 - **R1**：A6（L2 sandbox）需要 `dasclaw_sandbox` 暴露一个 "default-deny policy 工厂"；当前接口可能要新增 `default_policy_headless()`。**先 issue，不在本批 PR 内做**。
 - **R2**：A7（WASM capability）需要 fixture .wasm 二进制；`dasclaw_wasm_tools` 是否已有 test fixture wasm 待确认；若无要么放进 W6.6，要么用 wasm-bindgen-test 现造。
+  - **2026 W6.6c 评估结论**：`dasclaw_wasm_tools` **没有** fixture wasm；CLI tests 目录也无 `.wasm`/`.wat`。W6.6c 选择 **路径 C**：A7 阻塞于 fixture 缺失，先在 `dasclaw_wasm_tools`（capability owner）开 fixture issue，CLI A7 e2e 等 fixture 落地后再做。理由：把 fixture 工程做在 wasm_tools owner crate 内，desktop/CLI 共享；CLI 单独造会跨边界拉 `cargo-component` / `wit-component` 依赖。
 - **R3**：B6 大 payload 测试需要确认 `dasclaw_runtime` 是否真的把 `sanitize_for_stash` 接到回路。Round 0 验证：`rg "sanitize_for_stash" crates/dasclaw_runtime/` —— 若 0 命中，B6 也变成 "接线 + 测试" 两步。
 - **R4**：所有 P0 case 都依赖 G1 改造。G1 改造若用 builder pattern，会牵动现有 `tool_e2e.rs` / `mcp_e2e.rs` 的调用形式；改 API 时**保持 `run` / `run_with_tools` 兼容签名不动**，新增 `run_with_hooks`，避免连锁炸现有 e1–e6。
 


### PR DESCRIPTION
## 背景 / 目标

ADR-153 §1.1 row **A10 / case e16** — L8 网络审计 e2e。

W6.6 EgressGate 在 `dasclaw_core::agentic_loop` 和 `dasclaw_runtime::agent` 已分别接入 `LlmRequest` / `ToolExecution { tool }` / `UserDisplay` 三种 `EgressKind`。本 PR 用一个 audit-recording gate 端到端验证三路径全部可观测，且 audit 记录中 payload 已 redact。

与 e7 (A1)、e8 (A2)、e15 (A8) 单点测试互补：那三例验证 **单一 kind 阻断/重写**，本例验证 audit gate **跨三类 kind** 的端到端覆盖。

Closes #855
Refs ADR-153 §1.1 row A10

## 改动范围

- ✅ 新增 `crates/dasclaw_cli/tests/safety_egress_audit_log_e2e.rs`（~150 行）
- ✅ `docs/plans/architecture-refactor/adr-153-cli-test-matrix.md` §3 R2 补 W6.6c 注记（A7 阻塞 → 转 A10）

## 非目标（What's NOT in this PR）

- ❌ 不改 `main.rs` / `lib.rs`（生产代码已在 W6.1 接好，本轮纯组合验证）
- ❌ 不改 `fixtures/safety_fixtures.rs`（A10 audit-safe 语义与共享 `RecordingEgressGate` 记录原文的设计冲突，故内联在测试文件内不污染 fixtures）
- ❌ 不改 `Cargo.toml`（零新增依赖）
- ❌ 不涉及 A7（wasm 能力 opt-in）—— 仍阻塞于 #854 wasm fixture，W6.6c 已 redirect 到本 issue #855
- ❌ 不涉及 `Persistence` kind（A10 契约只覆盖 LLM / tool / display 三路径）

## 验证

```
cargo check -p dasclaw_cli --tests                       ✅ 0 错 0 警
cargo nextest run -p dasclaw_cli --test safety_egress_audit_log_e2e
  → 1 test run: 1 passed                                  ✅
cargo fmt --all                                           ✅
python3.12 scripts/check_no_panics.py --base origin/xClaw ✅
cargo clippy --no-deps -p dasclaw_cli --all-targets -- -D warnings ✅
```

完整 workspace build / workspace clippy / heavy integration 由 CI 兜底。

## Cross-cuts

**类A**：本 PR 无新增 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量（grep 自查通过）。

## 设计亮点 — 为什么 audit 记录里存 sanitized 而不存原文

`RecordingEgressGate`（fixtures.rs）按设计记录 `(kind, payload_原文, decision)` 三元组，便于 e7/e8/e15 调试观察输入。但 **A10 契约要求 audit 记录已 redact**——如果 audit log 自身存原文 secret，audit 就成了新的泄露 sink。

本 PR 在测试文件内部声明 `AuditRedactingGate`，audit log 字段类型是 `Vec<(EgressKind, String)>`（无 raw payload），写入的是 **post-decision** safe payload（Redact 时为 sanitized，Allow 时为原 payload——但测试已确保 Allow 路径下 payload 不含 trigger）。这才是审计安全的语义。

## 后续

- A7 e13 (L4 WASM 能力 opt-in) 仍阻塞于 #854 fixture wasm component
- W6.6 剩余：B 路（B10/B11/B12 其它 e）按 ADR-153 §1.1 优先级继续推进
