### PR TITLE
feat(dasclaw_cli): B10 stdio+HTTP MCP merge agent-loop e2e (ADR-153 §2.2 / e26)

### DIFF
--- a/crates/dasclaw_cli/tests/agent_stdio_and_http_mcp_merge_e2e.rs
+++ b/crates/dasclaw_cli/tests/agent_stdio_and_http_mcp_merge_e2e.rs
@@ -1,0 +1,236 @@
+//! ADR-153 §2.2 case **e26 (B10)** — D1+D3 跨 transport MCP merge e2e.
+//!
+//! Loads one stdio MCP server + one HTTP MCP server from a single
+//! `--mcp-config`, then drives a scripted agent loop that calls **both**
+//! sides via [`dasclaw_cli::run_with_tools_and_hooks`]. The invariants
+//! pinned here are:
+//!
+//! 1. `McpToolExecutor::from_clients(...)` aggregates **both** transports'
+//!    tool definitions under `<server>_<tool>` qualified names, with no
+//!    namespace collision.
+//! 2. Inside the agent loop, the model can address either side by its
+//!    qualified name and the dispatcher routes to the right transport
+//!    (stdio fixture for `stdio_srv_echo`, wiremock HTTP for
+//!    `http_srv_echo`).
+//! 3. The agent loop terminates normally after both tools have been
+//!    invoked (no namespace-induced "unknown tool" error).
+//!
+//! Companion to:
+//! - [`tests/mcp_multi_e2e.rs`] — two-stdio merge (e3/e4).
+//! - [`tests/mcp_http_e2e.rs`] — single HTTP transport (e5/e6).
+//! - [`tests/agent_loop_*`] — agent-loop scaffolding (e17/e18/e21/e23).
+//!
+//! This test adds the missing diagonal: **agent loop × mixed transports**.
+
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use dasclaw_cli::mcp::load_executor;
+use dasclaw_cli::run_with_tools_and_hooks;
+use dasclaw_core::hooks::HookBundle;
+use dasclaw_core::messages::{ToolCall, ToolResult};
+use dasclaw_core::traits::HostError;
+use dasclaw_runtime::ToolExecutor;
+use serde_json::{Value, json};
+use tempfile::tempdir;
+use wiremock::matchers::{body_partial_json, method};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+#[path = "fixtures/agent_loop_fixtures.rs"]
+mod agent_loop_fixtures;
+use agent_loop_fixtures::{ScriptedResponder, text_turn, tool_call_turn};
+
+fn stdio_fixture_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_stdio_echo_mcp_fixture"))
+}
+
+fn write_mixed_config(dir: &Path, stdio_cmd: &str, http_url: &str) -> PathBuf {
+    let path = dir.join("mcp.json");
+    let body = json!({
+        "servers": [
+            { "name": "stdio_srv", "command": stdio_cmd, "args": [], "env": {} },
+            { "name": "http_srv",  "url": http_url, "headers": {} }
+        ]
+    });
+    std::fs::write(&path, body.to_string()).expect("write config");
+    path
+}
+
+fn echo_tool_def() -> Value {
+    json!({
+        "name": "echo",
+        "description": "Echoes its `message` argument back verbatim.",
+        "inputSchema": {
+            "type": "object",
+            "properties": { "message": { "type": "string" } },
+            "required": ["message"]
+        }
+    })
+}
+
+/// Mount handshake + tools/list + tools/call on the wiremock HTTP MCP
+/// fixture. Mirrors [`tests/mcp_http_e2e.rs::mount_handshake`] but adds
+/// a fixed `tools/call` response so we can validate the merged dispatch.
+async fn mount_http_mcp(server: &MockServer) {
+    Mock::given(method("POST"))
+        .and(body_partial_json(json!({ "method": "initialize" })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": { "tools": {} },
+                "serverInfo": { "name": "http_mcp_merge_fixture", "version": "0.1.0" }
+            }
+        })))
+        .mount(server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(body_partial_json(
+            json!({ "method": "notifications/initialized" }),
+        ))
+        .respond_with(ResponseTemplate::new(202))
+        .mount(server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(body_partial_json(json!({ "method": "tools/list" })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "result": { "tools": [ echo_tool_def() ] }
+        })))
+        .mount(server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(body_partial_json(json!({ "method": "tools/call" })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "jsonrpc": "2.0",
+            "id": 3,
+            "result": {
+                "content": [ { "type": "text", "text": "from-http" } ],
+                "isError": false
+            }
+        })))
+        .mount(server)
+        .await;
+}
+
+/// Wrapping [`ToolExecutor`] that records every dispatched tool name
+/// before forwarding to the inner executor.
+///
+/// The agent loop signature consumes the executor by value, so we cannot
+/// inspect the inner `McpToolExecutor` afterwards; this thin recorder
+/// captures the routing decisions on the way through.
+struct InspectingToolExecutor<E: ToolExecutor> {
+    inner: E,
+    calls: Arc<Mutex<Vec<String>>>,
+}
+
+#[async_trait]
+impl<E: ToolExecutor> ToolExecutor for InspectingToolExecutor<E> {
+    async fn execute(&self, call: &ToolCall) -> Result<ToolResult, HostError> {
+        self.calls
+            .lock()
+            .expect("inspector mutex")
+            .push(call.name.clone());
+        self.inner.execute(call).await
+    }
+}
+
+#[tokio::test]
+async fn req_dasclaw_cli_agent_b10_e26_stdio_and_http_mcp_merge() {
+    // ---- arrange: HTTP fixture ----
+    let http_server = MockServer::start().await;
+    mount_http_mcp(&http_server).await;
+
+    // ---- arrange: mixed config (stdio + HTTP) ----
+    let dir = tempdir().expect("tempdir");
+    let stdio_bin = stdio_fixture_bin();
+    let stdio_str = stdio_bin.to_str().expect("utf-8 stdio path");
+    let config = write_mixed_config(dir.path(), stdio_str, &http_server.uri());
+
+    // ---- act: load merged executor ----
+    let mcp = load_executor(&config)
+        .await
+        .expect("load_executor must succeed with mixed stdio+http config");
+
+    // Invariant 1: both transports surface their tool with qualified
+    // names, no collision.
+    let defs = mcp.definitions();
+    let names: Vec<&str> = defs.iter().map(|d| d.name.as_str()).collect();
+    assert!(
+        names.contains(&"stdio_srv_echo"),
+        "expected stdio_srv_echo in merged defs, got {names:?}"
+    );
+    assert!(
+        names.contains(&"http_srv_echo"),
+        "expected http_srv_echo in merged defs, got {names:?}"
+    );
+    assert_eq!(
+        defs.len(),
+        2,
+        "expected exactly two merged tool defs, got {names:?}"
+    );
+
+    // ---- act: drive a scripted agent loop that calls both sides ----
+    let calls = Arc::new(Mutex::new(Vec::<String>::new()));
+    let inspector = InspectingToolExecutor {
+        inner: mcp,
+        calls: calls.clone(),
+    };
+
+    let responder = ScriptedResponder::with_queue(vec![
+        tool_call_turn("stdio_srv_echo", "c1", json!({ "message": "hello-stdio" })),
+        tool_call_turn("http_srv_echo", "c2", json!({ "message": "hello-http" })),
+        text_turn("done"),
+    ]);
+
+    let out = run_with_tools_and_hooks(
+        responder,
+        inspector,
+        defs,
+        HookBundle::noop(),
+        "system",
+        "please call both MCP servers",
+    )
+    .await
+    .expect("agent loop should terminate normally across merged transports");
+
+    // ---- assert: agent terminated on the final text turn ----
+    assert_eq!(
+        out, "done",
+        "agent loop must return the final scripted text turn"
+    );
+
+    // Invariant 2 + 3: both qualified names were dispatched exactly
+    // once, in scripted order.
+    let observed = calls.lock().expect("inspector mutex").clone();
+    assert_eq!(
+        observed,
+        vec!["stdio_srv_echo".to_string(), "http_srv_echo".to_string(),],
+        "merged dispatcher must route both qualified names in order, got {observed:?}"
+    );
+
+    // Cross-check: the HTTP side actually received its tools/call (not
+    // just answered list).
+    let received = http_server
+        .received_requests()
+        .await
+        .expect("wiremock should expose received requests");
+    let http_tool_calls = received
+        .iter()
+        .filter(|r| {
+            std::str::from_utf8(&r.body)
+                .map(|s| s.contains("\"method\":\"tools/call\""))
+                .unwrap_or(false)
+        })
+        .count();
+    assert_eq!(
+        http_tool_calls, 1,
+        "HTTP MCP server must see exactly one tools/call (got {http_tool_calls})"
+    );
+}


### PR DESCRIPTION
## 背景 / 目标

ADR-153 §2.2 row **B10 / case e26** — D1+D3 跨 transport 合并。

`--mcp-config` 同时声明一个 stdio + 一个 HTTP MCP server，agent loop 中模型按需调两边。补足 `mcp_multi_e2e.rs`（两 stdio 合并 e3/e4）与 `mcp_http_e2e.rs`（单 HTTP transport e5/e6）之间缺失的对角线 — **agent loop × 混合 transport**。

Closes #859
Refs ADR-153 §2.2 row B10

## 改动范围

- ✅ 新增 `crates/dasclaw_cli/tests/agent_stdio_and_http_mcp_merge_e2e.rs`（~210 行）

## 验证策略

混合 config：

```json
{ "servers": [
  { "name": "stdio_srv", "command": "<fixture>", ... },
  { "name": "http_srv",  "url": "<wiremock_uri>", ... }
]}
```

ScriptedResponder 三轮：
1. tool_call `stdio_srv_echo` { message: hello-stdio }
2. tool_call `http_srv_echo` { message: hello-http }
3. text `done`

四条不变式：

| # | 不变式 | 断言 |
|---|---|---|
| 1 | namespace 合并无碰撞 | defs 含 `stdio_srv_echo` + `http_srv_echo` |
| 2 | agent loop 正常终止 | 返回 `done` |
| 3 | 两边各 dispatch 一次 | InspectingToolExecutor 记录顺序匹配 |
| 4 | HTTP 真被路由（不止 list） | wiremock `received_requests` 含 1 个 `tools/call` |

## 非目标（What's NOT in this PR）

- ❌ 不改 `main.rs` / `lib.rs`（`load_executor` / `McpToolExecutor::from_clients` 已就绪）
- ❌ 不改 `fixtures/agent_loop_fixtures.rs`：`InspectingToolExecutor` 是 B10 专用包装（agent loop by value 消耗 executor）
- ❌ 不改 `Cargo.toml`（零新增依赖，wiremock + tempfile + serde_json 都是既有 dev-deps）
- ❌ 不覆盖单 transport tools/call 失败语义（归 e6）
- ❌ 不覆盖单 transport tools/list 排序（归 e3/e5）

## 验证

```
cargo nextest run -p dasclaw_cli --test agent_stdio_and_http_mcp_merge_e2e
  → 1 test run: 1 passed (3.40s)                            ✅
cargo fmt --all                                              ✅
python3.12 scripts/check_no_panics.py --base origin/xClaw    ✅
cargo clippy --no-deps -p dasclaw_cli --all-targets -- -D warnings ✅
```

完整 workspace build / heavy integration 由 CI 兜底。

## 设计要点 — 为什么需要 `InspectingToolExecutor`

`run_with_tools_and_hooks<E: ToolExecutor + 'static>(executor: E, ...)` 按值消耗 executor，agent loop 跑完后无法回访 `McpToolExecutor`。`InspectingToolExecutor` 是栈上薄包装：每次 `execute` 记录 `call.name`，然后转发给内层 `McpToolExecutor`。这是观察式验证，**不**改变路由行为。

## Cross-cuts

**类A**：本 PR 无新增 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量。

## 后续

W6.6 §2.2 P2 (B 路) 至此覆盖完毕（B9 #858 已开 PR，B10 本 PR）。

接下来候选：
- A 路 P2 剩余 (A11+，需 ADR §2.2 复核)
- A7 (e13 wasm 能力) 仍阻塞于 #854
