### PR TITLE
feat(dasclaw_cli): wire --wasm-tool CLI flag (closes #867)

### DIFF
--- a/crates/dasclaw_cli/Cargo.toml
+++ b/crates/dasclaw_cli/Cargo.toml
@@ -23,6 +23,16 @@ doc = false
 [lib]
 path = "src/lib.rs"
 
+# ADR-153 §1.1 A7 / #867: `wasm-tools` feature gates the optional
+# `--wasm-tool` CLI flag and its dependency on `dasclaw_wasm_tools`
+# (which pulls in wasmtime, ~50–80 MB to the shipped binary). Default-on
+# so the headless CLI keeps its W6.6c e13 capability story; downstream
+# consumers that want a leaner binary can opt out with
+# `--no-default-features`.
+[features]
+default = ["wasm-tools"]
+wasm-tools = ["dep:dasclaw_wasm_tools"]
+
 [dependencies]
 dasclaw_runtime = { path = "../dasclaw_runtime" }
 dasclaw_core = { path = "../dasclaw_core" }
@@ -30,6 +40,9 @@ dasclaw_llm_provider = { path = "../dasclaw_llm_provider" }
 # ADR-153 §4.4 sub-step 8: CLI wires MCP-backed ToolExecutor.
 dasclaw_mcp = { path = "../dasclaw_mcp" }
 dasclaw_tool = { path = "../dasclaw_tool" }
+# Optional: only pulled in when the `wasm-tools` feature is enabled. See
+# the `[features]` block above for the binary-size rationale.
+dasclaw_wasm_tools = { path = "../dasclaw_wasm_tools", optional = true }
 anyhow = "1"
 clap = { version = "4", features = ["derive", "env"] }
 secrecy = "0.10"
@@ -63,6 +76,8 @@ dasclaw_workspace_cap = { path = "../dasclaw_workspace_cap" }
 # the outbound request without touching the real network (the host
 # SSRF blocklist refuses 127.0.0.1, so wiremock is not usable here).
 dasclaw_net_tools = { path = "../dasclaw_net_tools" }
+# W6.6c (ADR-153 §1.1 A7 / e13): wasm fixture also reused by the prod
+# `--wasm-tool` flag e2e in tests/cli_wasm_tool_flag_e2e.rs.
 dasclaw_wasm_tools = { path = "../dasclaw_wasm_tools" }
 # W6.6b (ADR-153 §1.1 A6 / e12, L2 sub-process sandbox default-deny):
 # tests/safety_sandbox_default_deny_e2e.rs wires a `bash` tool whose

--- a/crates/dasclaw_cli/src/lib.rs
+++ b/crates/dasclaw_cli/src/lib.rs
@@ -53,6 +53,8 @@ use dasclaw_runtime::{Agent, AgentError, AgentResponder, ToolExecutor};
 pub mod mcp;
 pub mod provider;
 pub mod tools;
+#[cfg(feature = "wasm-tools")]
+pub mod wasm;
 
 /// Errors surfaced by the CLI library layer.
 #[derive(Debug, thiserror::Error)]

--- a/crates/dasclaw_cli/src/main.rs
+++ b/crates/dasclaw_cli/src/main.rs
@@ -27,6 +27,7 @@ use dasclaw_cli::mcp::load_executor as load_mcp_executor;
 use dasclaw_cli::provider::{ProviderArgs, build_responder};
 use dasclaw_cli::tools::default_builtins;
 use dasclaw_cli::{EchoResponder, run, run_with_tools};
+use dasclaw_core::messages::ToolDefinition;
 use dasclaw_runtime::{CompositeToolExecutor, ToolExecutor};
 const DEFAULT_SYSTEM: &str = "You are dasclaw, a headless agent.";
 
@@ -107,61 +108,72 @@ async fn real_main() -> Result<()> {
             .context("echo agent run failed")?,
         Command::Run { provider, tools } => {
             let responder = build_responder(&provider).context("building LLM responder")?;
-
-            // Step 8 (ADR-153 §4.4.5): assemble the tool stack from
-            // whichever sources the user opted in to. Branch explicitly
-            // on the four (enable_tools × mcp_config) combinations to
-            // keep the `run_with_tools` generic signature happy.
-            match (tools.enable_tools, tools.mcp_config.as_deref()) {
-                (false, None) => run(responder, &cli.system, prompt)
+            let assembled = assemble_tool_executor(&tools).await?;
+            match assembled {
+                None => run(responder, &cli.system, prompt)
                     .await
                     .context("LLM agent run failed")?,
-                (true, None) => {
-                    let executor = default_builtins();
-                    let definitions = executor.definitions();
+                Some((executor, definitions)) => {
                     run_with_tools(responder, executor, definitions, &cli.system, prompt)
                         .await
-                        .context("LLM agent (with builtin tools) run failed")?
-                }
-                (false, Some(path)) => {
-                    let executor = load_mcp_executor(path)
-                        .await
-                        .with_context(|| format!("loading MCP config {}", path.display()))?;
-                    let definitions = executor.definitions();
-                    run_with_tools(responder, executor, definitions, &cli.system, prompt)
-                        .await
-                        .context("LLM agent (with MCP tools) run failed")?
-                }
-                (true, Some(path)) => {
-                    let static_exec = default_builtins();
-                    let static_defs = static_exec.definitions();
-                    let static_names: Vec<String> =
-                        static_defs.iter().map(|d| d.name.clone()).collect();
-
-                    let mcp_exec = load_mcp_executor(path)
-                        .await
-                        .with_context(|| format!("loading MCP config {}", path.display()))?;
-                    let mcp_defs = mcp_exec.definitions();
-                    let mcp_names: Vec<String> = mcp_defs.iter().map(|d| d.name.clone()).collect();
-
-                    let mut definitions = static_defs;
-                    definitions.extend(mcp_defs);
-
-                    let composite = CompositeToolExecutor::new([
-                        (static_names, Arc::new(static_exec) as Arc<dyn ToolExecutor>),
-                        (mcp_names, Arc::new(mcp_exec) as Arc<dyn ToolExecutor>),
-                    ])
-                    .context("merging tool executors (duplicate tool name?)")?;
-
-                    run_with_tools(responder, composite, definitions, &cli.system, prompt)
-                        .await
-                        .context("LLM agent (with composite tools) run failed")?
+                        .context("LLM agent (with tools) run failed")?
                 }
             }
         }
     };
     println!("{reply}");
     Ok(())
+}
+
+/// Collect every tool source the user opted into and merge them via
+/// [`CompositeToolExecutor`].
+///
+/// Returns `None` when no source is enabled — the caller falls back to
+/// the plain [`run`] entry. Returning `Some((executor, defs))` for the
+/// uniform `≥1 source` case keeps the call site free of the
+/// combinatorial branch explosion that the original
+/// `(enable_tools × mcp_config × …)` match would grow into as each new
+/// tool source (e.g. ADR-153 §1.1 A7 wasm tools) lands.
+async fn assemble_tool_executor(
+    tools: &ToolArgs,
+) -> Result<Option<(CompositeToolExecutor, Vec<ToolDefinition>)>> {
+    let mut sources: Vec<(Vec<String>, Arc<dyn ToolExecutor>)> = Vec::new();
+    let mut definitions: Vec<ToolDefinition> = Vec::new();
+
+    if tools.enable_tools {
+        let exec = default_builtins();
+        let defs = exec.definitions();
+        push_source(&mut sources, &mut definitions, defs, Arc::new(exec));
+    }
+
+    if let Some(path) = tools.mcp_config.as_deref() {
+        let exec = load_mcp_executor(path)
+            .await
+            .with_context(|| format!("loading MCP config {}", path.display()))?;
+        let defs = exec.definitions();
+        push_source(&mut sources, &mut definitions, defs, Arc::new(exec));
+    }
+
+    if sources.is_empty() {
+        return Ok(None);
+    }
+    let composite = CompositeToolExecutor::new(sources)
+        .context("merging tool executors (duplicate tool name?)")?;
+    Ok(Some((composite, definitions)))
+}
+
+/// Push one tool source into the accumulator: the executor is stored
+/// keyed by the tool names it owns, and the matching [`ToolDefinition`]s
+/// are appended to the advertised schema list.
+fn push_source(
+    sources: &mut Vec<(Vec<String>, Arc<dyn ToolExecutor>)>,
+    definitions: &mut Vec<ToolDefinition>,
+    defs: Vec<ToolDefinition>,
+    executor: Arc<dyn ToolExecutor>,
+) {
+    let names: Vec<String> = defs.iter().map(|d| d.name.clone()).collect();
+    definitions.extend(defs);
+    sources.push((names, executor));
 }
 
 fn init_tracing() {

--- a/crates/dasclaw_cli/src/main.rs
+++ b/crates/dasclaw_cli/src/main.rs
@@ -81,6 +81,16 @@ struct ToolArgs {
     /// under the `<server_name>_<tool>` qualified name.
     #[arg(long = "mcp-config")]
     mcp_config: Option<PathBuf>,
+
+    /// Path to a `wasm32-wasip2` component file. Loaded under the
+    /// default-deny capability policy (no http, no workspace writes, no
+    /// secrets — see ADR-153 §1.1 A7 / e13). The tool's name is the
+    /// file stem; calls that touch ungated host imports surface as
+    /// `ToolResult { is_error: true, .. }` carrying the host gate
+    /// message verbatim. Capability grant flags are tracked as #869.
+    #[cfg(feature = "wasm-tools")]
+    #[arg(long = "wasm-tool")]
+    wasm_tool: Option<PathBuf>,
 }
 
 #[tokio::main]
@@ -152,6 +162,17 @@ async fn assemble_tool_executor(
             .with_context(|| format!("loading MCP config {}", path.display()))?;
         let defs = exec.definitions();
         push_source(&mut sources, &mut definitions, defs, Arc::new(exec));
+    }
+
+    #[cfg(feature = "wasm-tools")]
+    if let Some(path) = tools.wasm_tool.as_deref() {
+        let loaded = dasclaw_cli::wasm::load_wasm_tool(path).await?;
+        push_source(
+            &mut sources,
+            &mut definitions,
+            vec![loaded.definition],
+            Arc::new(loaded.executor),
+        );
     }
 
     if sources.is_empty() {

--- a/crates/dasclaw_cli/src/wasm.rs
+++ b/crates/dasclaw_cli/src/wasm.rs
@@ -1,0 +1,125 @@
+//! `--wasm-tool` flag wiring (ADR-153 §1.1 A7 / #867).
+//!
+//! Loads a `wasm32-wasip2` component from disk and wraps it in a
+//! [`ToolExecutor`] suitable for the [`crate::run_with_tools`] /
+//! [`crate::run_with_tools_and_hooks`] entry points.
+//!
+//! Capability policy: the wrapper is constructed with
+//! [`Capabilities::default()`] (no `http`, no workspace writes, no
+//! secrets). This matches the W6.6c e13 default-deny posture — a wasm
+//! tool that tries to call an ungated host import sees the gate string
+//! (`"HTTP capability not granted"`, etc.) come back as
+//! `ToolResult { is_error: true, .. }` rather than crashing the host.
+//! Granting capabilities to a CLI-loaded wasm tool is out of scope for
+//! #867 and tracked as #869.
+//!
+//! This module is only compiled with the `wasm-tools` feature; see
+//! `Cargo.toml` for the binary-size rationale.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+use dasclaw_core::messages::{ToolCall, ToolDefinition, ToolResult};
+use dasclaw_core::traits::HostError;
+use dasclaw_runtime::Tool;
+use dasclaw_runtime::ToolExecutor;
+use dasclaw_runtime::context::JobContext;
+use dasclaw_wasm_tools::{Capabilities, WasmRuntimeConfig, WasmToolRuntime, WasmToolWrapper};
+use serde_json::json;
+
+/// A loaded wasm tool ready to plug into [`crate::run_with_tools`].
+///
+/// Exposes the [`ToolDefinition`] separately so the caller can merge it
+/// with builtin/MCP definitions in `main.rs` without re-deriving it.
+pub struct LoadedWasmTool {
+    pub definition: ToolDefinition,
+    pub executor: WasmToolExecutor,
+}
+
+/// Read a wasm component from `path` and prepare it for execution under
+/// the headless capability-default-deny policy.
+///
+/// The tool's LLM-facing name is the file stem (filename without the
+/// `.wasm` extension). The advertised schema is an empty object — wasm
+/// tools today don't ship their own JSON schema, so we hand the model
+/// the most permissive shape; refining this is a follow-up tracked in
+/// #869.
+pub async fn load_wasm_tool(path: &Path) -> Result<LoadedWasmTool> {
+    let bytes = std::fs::read(path)
+        .with_context(|| format!("reading wasm component from {}", path.display()))?;
+
+    let tool_name = path
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| anyhow::anyhow!("wasm path has no usable file stem: {}", path.display()))?
+        .to_string();
+
+    // Default config is too tight for the W6.6c fixture (~17 pages ≈ 1.1 MB
+    // > 1 MB cap). Lift the per-tool memory limit to 4 MB — same value the
+    // e13 fixture uses — without touching the global default. Anything
+    // larger should land via a future `--wasm-mem-limit` flag (#869).
+    let mut config = WasmRuntimeConfig::for_testing();
+    config.default_limits = config.default_limits.with_memory(4 * 1024 * 1024);
+
+    let runtime =
+        Arc::new(WasmToolRuntime::new(config).context("initializing wasm component runtime")?);
+    let prepared = runtime
+        .prepare(&tool_name, &bytes, None)
+        .await
+        .with_context(|| format!("preparing wasm tool `{tool_name}`"))?;
+    let wrapper = Arc::new(WasmToolWrapper::new(
+        Arc::clone(&runtime),
+        prepared,
+        Capabilities::default(),
+    ));
+
+    Ok(LoadedWasmTool {
+        definition: ToolDefinition {
+            name: tool_name.clone(),
+            description: format!("Sandboxed wasm tool loaded from {}", path.display()),
+            parameters: json!({ "type": "object", "properties": {} }),
+        },
+        executor: WasmToolExecutor { tool_name, wrapper },
+    })
+}
+
+/// [`ToolExecutor`] that forwards a single named call into a
+/// [`WasmToolWrapper`] and maps wrapper errors (including capability
+/// gate refusals) onto reported tool errors rather than `HostError`s.
+///
+/// Mirrors the routing shape used by the e13 fixture executor: any
+/// wrapper failure becomes `ToolResult { is_error: true, content: <msg> }`,
+/// matching the contract `run_with_tools_and_hooks` expects.
+pub struct WasmToolExecutor {
+    tool_name: String,
+    wrapper: Arc<WasmToolWrapper>,
+}
+
+#[async_trait]
+impl ToolExecutor for WasmToolExecutor {
+    async fn execute(&self, call: &ToolCall) -> Result<ToolResult, HostError> {
+        if call.name != self.tool_name {
+            return Err(HostError::from(format!(
+                "unexpected tool call: {} (wasm executor only routes {})",
+                call.name, self.tool_name
+            )));
+        }
+
+        let mut ctx = JobContext::new("cli-wasm", "wasm tool invocation");
+        let outcome = self.wrapper.execute(call.arguments.clone(), &mut ctx).await;
+        let (is_error, content) = match outcome {
+            Ok(output) => (false, serde_json::to_string(&output).unwrap_or_default()),
+            Err(err) => (true, err.to_string()),
+        };
+
+        Ok(ToolResult {
+            tool_call_id: call.id.clone(),
+            name: call.name.clone(),
+            content,
+            is_error,
+        })
+    }
+}

--- a/crates/dasclaw_cli/tests/cli_wasm_tool_flag_e2e.rs
+++ b/crates/dasclaw_cli/tests/cli_wasm_tool_flag_e2e.rs
@@ -1,0 +1,159 @@
+//! #867 — `--wasm-tool` CLI flag end-to-end test (ADR-153 §1.1 A7).
+//!
+//! Exercises the production wiring added in #867: `ToolArgs::wasm_tool`
+//! → `dasclaw_cli::wasm::load_wasm_tool` → composite assembly →
+//! `run_with_tools_and_hooks` agent loop. Asserts the default-deny
+//! capability posture survives the prod path: a wasm tool that calls
+//! `host.http-request` without an `http` grant surfaces as
+//! `is_error=true` with the host gate message intact, exactly like the
+//! W6.6c library-seam e13 test.
+//!
+//! ## Why a separate file (not folded into `safety_wasm_capability_optin_e2e.rs`)
+//!
+//! The W6.6c test fixes the library seam (`ToolExecutor → WasmToolWrapper`).
+//! This file fixes the *prod CLI helper* `dasclaw_cli::wasm::load_wasm_tool`:
+//! the file-stem → tool-name derivation, the file-read error path, and the
+//! capability posture chosen by the CLI (`Capabilities::default()` rather
+//! than caller-supplied). Keeping the two tests separate means a refactor
+//! of either surface fails the right test.
+//!
+//! ## Non-goals (#867 §"非目标")
+//!
+//! - Does **not** spawn the `dasclaw-cli` binary (assert_cmd would be a
+//!   new pattern in the repo — tracked as #868).
+//! - Does **not** test capability *grants* (#869 covers the broader
+//!   matrix: http allowed, workspace writes, secrets injection).
+//! - Does **not** test wasm tools alongside MCP / builtin tools — the
+//!   composite path is already covered by the upstream A5/A7 tests.
+
+#![cfg(feature = "wasm-tools")]
+
+use std::io::Write;
+
+use dasclaw_cli::run_with_tools_and_hooks;
+use dasclaw_cli::wasm::load_wasm_tool;
+use dasclaw_core::hooks::HookBundle;
+use dasclaw_core::messages::ToolCall;
+use dasclaw_runtime::ToolExecutor;
+use dasclaw_wasm_tools::NO_HTTP_CAP_WASM;
+use serde_json::json;
+use tempfile::NamedTempFile;
+
+#[path = "fixtures/agent_loop_fixtures.rs"]
+mod fixtures;
+use fixtures::{ScriptedResponder, text_turn, tool_call_turn};
+
+/// Write the bundled `NO_HTTP_CAP_WASM` component to a tempfile so
+/// `load_wasm_tool` exercises its real path-based loader (file read +
+/// stem-based name derivation). The `.wasm` suffix matters: `load_wasm_tool`
+/// derives the tool name from the file stem.
+fn fixture_wasm_on_disk(name: &str) -> NamedTempFile {
+    let mut file = tempfile::Builder::new()
+        .prefix(name)
+        .suffix(".wasm")
+        .tempfile()
+        .expect("create wasm tempfile");
+    file.write_all(NO_HTTP_CAP_WASM)
+        .expect("write wasm bytes to tempfile");
+    file.flush().expect("flush tempfile");
+    file
+}
+
+/// Drives the same scripted dialogue as W6.6c e13 but through the
+/// production CLI loader. The model emits a single tool call into the
+/// disk-loaded wasm component; the capability gate refuses it; the
+/// agent loop receives a reported tool error and completes with the
+/// acknowledgement turn.
+#[tokio::test]
+async fn req_dasclaw_cli_867_wasm_tool_flag_default_deny_surfaces_as_tool_error() {
+    let wasm_file = fixture_wasm_on_disk("fixture_http_");
+    let loaded = load_wasm_tool(wasm_file.path())
+        .await
+        .expect("load_wasm_tool should accept a valid wasip2 component");
+
+    // Tool name MUST be the file stem so the scripted tool call resolves.
+    let expected_name = wasm_file
+        .path()
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .expect("tempfile has a stem")
+        .to_string();
+    assert_eq!(
+        loaded.definition.name, expected_name,
+        "load_wasm_tool must derive the LLM-facing tool name from the file stem"
+    );
+
+    let responder = ScriptedResponder::with_queue(vec![
+        tool_call_turn(&expected_name, "call-1", json!({})),
+        text_turn("acknowledged: capability gate refused"),
+    ]);
+
+    let reply = run_with_tools_and_hooks(
+        responder,
+        loaded.executor,
+        vec![loaded.definition],
+        HookBundle::noop(),
+        "you are running inside a capability-gated CLI",
+        "please call the wasm fixture tool",
+    )
+    .await
+    .expect("agent loop must not crash on capability denial");
+
+    assert_eq!(reply, "acknowledged: capability gate refused");
+}
+
+/// Pins the exact tool-result envelope: `is_error=true` plus the host
+/// gate string `"HTTP capability not granted"`. Drives the executor
+/// directly (bypassing the agent loop) so the assertion isolates the
+/// CLI's `Capabilities::default()` choice from the broader scripted
+/// dialogue.
+#[tokio::test]
+async fn req_dasclaw_cli_867_wasm_tool_flag_tool_result_carries_host_gate_message() {
+    let wasm_file = fixture_wasm_on_disk("fixture_http_");
+    let loaded = load_wasm_tool(wasm_file.path())
+        .await
+        .expect("load_wasm_tool should accept a valid wasip2 component");
+
+    let call = ToolCall {
+        id: "direct-call".to_string(),
+        name: loaded.definition.name.clone(),
+        arguments: json!({}),
+        reasoning: None,
+    };
+
+    let result = loaded
+        .executor
+        .execute(&call)
+        .await
+        .expect("ToolExecutor must not raise HostError on capability denial");
+
+    assert!(
+        result.is_error,
+        "capability-gated wasm tool must report is_error=true, got: {result:?}"
+    );
+    assert!(
+        result.content.contains("HTTP capability not granted"),
+        "tool result content must carry the host gate string verbatim, got: {}",
+        result.content
+    );
+}
+
+/// Failure-path coverage: a bogus path must surface as a normal error
+/// (no panic, no `HostError`) so `main.rs` can attach `with_context`
+/// without surprise.
+#[tokio::test]
+async fn req_dasclaw_cli_867_wasm_tool_flag_missing_file_surfaces_as_error() {
+    let missing = std::env::temp_dir().join("dasclaw_867_does_not_exist.wasm");
+    // Defensive: the file genuinely should not exist.
+    let _ = std::fs::remove_file(&missing);
+
+    let outcome = load_wasm_tool(&missing).await;
+    let err = outcome
+        .err()
+        .expect("load_wasm_tool must error on missing file");
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("reading wasm component"),
+        "error must mention the read step for diagnosability, got: {msg}"
+    );
+}


### PR DESCRIPTION
## 背景 / 目标

Closes #867。ADR-153 §1.1 A7 / e13 早在 W6.6c 把 wasm 默认拒绝 capability 的契约钉在了 library seam（`safety_wasm_capability_optin_e2e.rs`）。本 PR 把同一条契约接到 `dasclaw-cli` 的实际生产入口：新增 `--wasm-tool <PATH>` flag，让 CLI 真正能加载 `wasm32-wasip2` component 并在 capability 默认拒绝下运行。

## 改动范围

两个 commit，按"先重构后加功能"切片：

**Commit 1 — `refactor(dasclaw_cli): collapse tool-assembly match into accumulator`**

把 `main.rs` 里 `(enable_tools × mcp_config)` 的 2×2 = 4 分支 match 重构成累加器：

```rust
let mut sources: Vec<(Vec<String>, Arc<dyn ToolExecutor>)> = Vec::new();
let mut definitions: Vec<ToolDefinition> = Vec::new();
if tools.enable_tools { push_source(...); }
if let Some(path) = tools.mcp_config { push_source(...); }
// 0 sources → run(); ≥1 → CompositeToolExecutor::new(sources)
```

直接套用原结构往里加 `--wasm-tool` 会扩张到 2³ = 8 分支并大量复制逻辑（违反"禁止补丁式代码"）。重构后每加一种 tool source 只新增一个 if-let block。

**Commit 2 — `feat(dasclaw_cli): wire --wasm-tool CLI flag behind wasm-tools feature`**

- `Cargo.toml`：新 feature `wasm-tools = ["dep:dasclaw_wasm_tools"]`，`default = ["wasm-tools"]`；`dasclaw_wasm_tools` 升到生产依赖（`optional = true`）。需要瘦身的下游可 `--no-default-features` 移除 wasmtime（≈50–80 MB）。
- `src/wasm.rs`（新）：`load_wasm_tool(path)` helper，读取 component → `WasmToolRuntime::new + prepare` → 用 `Capabilities::default()` 包成 `WasmToolWrapper`，并提供把 wrapper 错误映射成 `ToolResult { is_error: true }` 的 `WasmToolExecutor`。
- `src/main.rs`：在 `ToolArgs` 加 feature-gated `wasm_tool: Option<PathBuf>`，在累加器里多一个 if-let block。
- `tests/cli_wasm_tool_flag_e2e.rs`（新）3 个测试：
  1. Happy path — scripted dialogue + wasm fixture，capability 拒绝呈现为 tool error，agent loop 正常完成
  2. Envelope 契约 — `is_error=true` + `"HTTP capability not granted"` 字面量原样落到 `ToolResult`
  3. 失败路径 — 不存在的文件返回 `anyhow::Error`，错误信息含 `"reading wasm component"`

## 非目标（What's NOT in this PR）

- ❌ 不引入 `assert_cmd` 做二进制级 exit-code e2e —— 仓内零先例，单独跟到 #868
- ❌ 不覆盖更广的 capability 矩阵（http allowed / workspace writes / secrets）—— #869
- ❌ 不实现 WorkspaceWrite + writable-root carve-out —— #870
- ❌ 不把 `--wasm-tool` 与 `--enable-tools` / `--mcp-config` 的组合做穷举测试 —— composite 路径在上游 A5/A7 测试中已覆盖

## 验证

```bash
cargo check -p dasclaw_cli --tests                                # default features, 0 errors / 0 warnings
cargo check -p dasclaw_cli --no-default-features --lib --bins     # opt-out 编译通过
cargo nextest run -p dasclaw_cli                                  # 66 passed, 0 failed, 0 skipped
cargo clippy --no-deps -p dasclaw_cli --all-targets -- -D warnings  # clean
cargo fmt --all                                                   # clean
python3.12 scripts/check_no_panics.py --base origin/xClaw         # OK
```

完整 `cargo build` / workspace clippy / heavy integration 由 CI 兜底（per AGENTS.md 本地节奏）。

## Cross-cuts

ADR-114 **类A** — 本 PR 未新增任何 `.ironclaw` 或 `IRONCLAW_BASE_DIR` 字面量。

## 后续

- 把 PR 合掉后，继续推 #868 / #869 / #870 三个 A7 / A6 follow-up
- #867 一关，ADR-153 §1.1 A7 在 CLI 端的最后一个 wiring 缺口闭合
