### PR TITLE
test(dasclaw_cli): A6b/A6c WorkspaceWrite + carve-out e2e (closes #870)

### DIFF
--- a/crates/dasclaw_cli/tests/fixtures/sandbox_bash_executor.rs
+++ b/crates/dasclaw_cli/tests/fixtures/sandbox_bash_executor.rs
@@ -1,0 +1,127 @@
+//! Shared sandbox-backed `bash` `ToolExecutor` for W6.6 A6 e2e family
+//! (ADR-153 §1.1 A6 / A6b / A6c).
+//!
+//! Wires [`dasclaw_exec::SandboxedExecutor`] under a caller-supplied
+//! [`dasclaw_workspace_cap::policy::SandboxPolicy`] so each test can pin
+//! a different policy (ReadOnly / WorkspaceWrite / carve-out probe)
+//! against the same agent-loop scaffold.
+//!
+//! The sibling test [`safety_sandbox_default_deny_e2e.rs`] inlines an
+//! equivalent helper for historical reasons; new tests under this family
+//! must include this module via
+//! `#[path = "fixtures/sandbox_bash_executor.rs"] mod sandbox_bash_executor;`
+//! rather than copy-paste the executor.
+#![allow(dead_code)] // Each test binary uses only a subset.
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use dasclaw_core::messages::{ToolCall, ToolDefinition, ToolResult};
+use dasclaw_core::response_types::RespondOutput;
+use dasclaw_core::traits::HostError;
+use dasclaw_exec::{ExecRequest, ProcessExecutor, SandboxedExecutor};
+use dasclaw_runtime::ToolExecutor;
+use dasclaw_sandbox::SandboxablePreference;
+use dasclaw_workspace_cap::policy::SandboxPolicy;
+use serde_json::json;
+
+#[path = "agent_loop_fixtures.rs"]
+mod agent_loop_fixtures;
+pub use agent_loop_fixtures::{ScriptedResponder, text_turn, tool_call_turn};
+
+/// `ToolExecutor` that pipes the `command` argument of each call into
+/// `bash -c` through the real OS sandbox. Errors from the sandbox
+/// (`ExecError::Sandbox`) and non-zero exits both surface as
+/// `is_error=true` so the agent loop sees them as tool failures, matching
+/// the A6/A6b/A6c matrix expectation.
+pub struct SandboxedBashExecutor {
+    inner: Arc<SandboxedExecutor>,
+    cwd: PathBuf,
+}
+
+impl SandboxedBashExecutor {
+    pub fn new(policy: SandboxPolicy, cwd: PathBuf) -> Self {
+        Self {
+            inner: Arc::new(SandboxedExecutor::new(
+                policy,
+                SandboxablePreference::Require,
+                false,
+                None,
+            )),
+            cwd,
+        }
+    }
+}
+
+#[async_trait]
+impl ToolExecutor for SandboxedBashExecutor {
+    async fn execute(&self, call: &ToolCall) -> Result<ToolResult, HostError> {
+        let command = call
+            .arguments
+            .get("command")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| HostError::from("missing `command` arg"))?
+            .to_string();
+
+        let mut cmd = Command::new("/bin/bash");
+        cmd.arg("-c").arg(&command);
+
+        let inner = Arc::clone(&self.inner);
+        let cwd = self.cwd.clone();
+        // SandboxedExecutor::execute is sync + spawns sandbox-exec, so
+        // hop to a blocking pool to keep the tokio runtime responsive.
+        let outcome =
+            tokio::task::spawn_blocking(move || inner.execute(ExecRequest { command: cmd, cwd }))
+                .await
+                .map_err(|e| HostError::from(format!("blocking pool: {e}")))?;
+
+        let (is_error, content) = match outcome {
+            Ok(output) if output.status.success() => {
+                (false, String::from_utf8_lossy(&output.stdout).into_owned())
+            }
+            Ok(output) => {
+                // Sandbox let the command run but the command itself
+                // failed (e.g. shell error on a denied write). For A6/A6b/A6c
+                // this still counts as a sandbox-enforced denial when
+                // stderr names sandbox-exec / Operation not permitted.
+                let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+                (
+                    true,
+                    format!("sandbox: command exited with {}: {stderr}", output.status),
+                )
+            }
+            Err(err) => (true, format!("sandbox: denied: {err}")),
+        };
+
+        Ok(ToolResult {
+            tool_call_id: call.id.clone(),
+            name: call.name.clone(),
+            content,
+            is_error,
+        })
+    }
+}
+
+/// Standard `bash` tool definition used by all A6 family e2e tests.
+pub fn bash_tool_def() -> ToolDefinition {
+    ToolDefinition {
+        name: "bash".to_string(),
+        description: "Execute a bash command inside the OS sandbox.".to_string(),
+        parameters: json!({
+            "type": "object",
+            "properties": {
+                "command": { "type": "string" }
+            },
+            "required": ["command"]
+        }),
+    }
+}
+
+/// Acknowledgement turn the scripted model emits after seeing a tool
+/// error. Kept short so tests focus on whether the loop actually halted
+/// on the sandbox decision rather than on prompt content.
+pub fn ack_turn() -> RespondOutput {
+    text_turn("understood: sandbox denied the write")
+}

--- a/crates/dasclaw_cli/tests/safety_sandbox_carve_out_e2e.rs
+++ b/crates/dasclaw_cli/tests/safety_sandbox_carve_out_e2e.rs
@@ -22,11 +22,12 @@
 //!
 //! The decision-layer policy in `dasclaw_workspace_cap` also carves out
 //! `.dasclaw/` (with `protect_missing_project_meta=true`), but the
-//! kernel projection in `dasclaw_protocol::permissions` currently only
-//! emits `.git` + `.codex` exclusions to seatbelt. This test pins **only
-//! the kernel-enforced subset** so it reflects what actually happens on
-//! the wire; tightening kernel-layer `.dasclaw` enforcement is tracked
-//! separately and is out of scope for #870.
+//! kernel projection in `dasclaw_protocol::permissions::
+//! default_read_only_subpaths_for_writable_root` currently only emits
+//! `.git` + `.codex` exclusions to seatbelt. The `.dasclaw` row below
+//! is therefore **expected to fail** today; it is intentionally shipped
+//! red as a TDD pin against the missing kernel projection. Follow-up
+//! work to extend the projection to `.dasclaw/` is tracked in #874.
 //!
 //! ## Test rows
 //!
@@ -34,7 +35,10 @@
 //!    policy actually emits the carve-out (`.git` / `.codex` carves
 //!    only trigger when the directory is present, mirroring upstream
 //!    `codex` behaviour).
-//! 2. Regular subdir control — proves the carve-out is targeted and
+//! 2. `.dasclaw/state` — RED. Pins the policy gap: the decision layer
+//!    intends to carve `.dasclaw/`, but kernel projection does not
+//!    emit the exclusion, so the write currently lands on disk.
+//! 3. Regular subdir control — proves the carve-out is targeted and
 //!    not just "WorkspaceWrite denies everything".
 
 #![cfg(target_os = "macos")]
@@ -57,8 +61,8 @@ use sandbox_bash_executor::{
 /// the rationale: on macOS `tempfile::tempdir` lives under `$TMPDIR`,
 /// and a `$TMPDIR` writable root only carries cwd-bound carve-outs when
 /// `root == cwd`. Excluding both `/tmp` and `$TMPDIR` keeps cwd the
-/// only writable root, so the `.git` / `.codex` carve-outs are the
-/// only thing standing between the agent and the sensitive file.
+/// only writable root, so the `.git` / `.dasclaw` / `.codex` carve-outs
+/// are the only thing standing between the agent and the sensitive file.
 fn cwd_only_workspace_write() -> SandboxPolicy {
     SandboxPolicy::WorkspaceWrite {
         writable_roots: Vec::new(),
@@ -127,6 +131,54 @@ async fn req_dasclaw_cli_loop_a6c_carve_out_denies_dot_git_and_dot_codex() {
     assert!(
         !codex_target.exists(),
         ".codex carve-out breached: file created at {codex_target:?}"
+    );
+}
+
+/// A6c **RED** — `.dasclaw/` should be carved out alongside `.git` and
+/// `.codex`, but the kernel projection in
+/// `dasclaw_protocol::permissions::default_read_only_subpaths_for_writable_root`
+/// currently does not emit it. This test is shipped failing on purpose
+/// as a TDD pin; flip green once the projection is extended (see #874).
+#[tokio::test]
+async fn req_dasclaw_cli_loop_a6c_carve_out_denies_dot_dasclaw() {
+    let tempdir = tempfile::tempdir().expect("create tempdir");
+    let cwd = tempdir.path();
+    let dot_dasclaw = cwd.join(".dasclaw");
+    fs::create_dir(&dot_dasclaw).expect("seed .dasclaw dir so policy emits carve-out");
+
+    let dasclaw_target = dot_dasclaw.join("state");
+    let dasclaw_path_str = dasclaw_target.to_string_lossy().into_owned();
+
+    let executor = SandboxedBashExecutor::new(cwd_only_workspace_write(), cwd.to_path_buf());
+
+    let responder = ScriptedResponder::with_queue(vec![
+        tool_call_turn(
+            "bash",
+            "call-carve-dasclaw-1",
+            json!({ "command": format!("echo pwn > {dasclaw_path_str}") }),
+        ),
+        ack_turn(),
+    ]);
+
+    let outcome = dasclaw_cli::run_with_tools_and_hooks(
+        responder,
+        executor,
+        vec![bash_tool_def()],
+        HookBundle::noop(),
+        "you are running inside a sandboxed CLI",
+        "please attempt to write inside .dasclaw",
+    )
+    .await;
+
+    assert!(
+        outcome.is_ok(),
+        "agent loop must not crash on carve-out denial, got {outcome:?}"
+    );
+    assert!(
+        !dasclaw_target.exists(),
+        ".dasclaw carve-out breached: file created at {dasclaw_target:?} \
+         (kernel projection in default_read_only_subpaths_for_writable_root \
+          does not emit .dasclaw; tracked by #874)"
     );
 }
 

--- a/crates/dasclaw_cli/tests/safety_sandbox_carve_out_e2e.rs
+++ b/crates/dasclaw_cli/tests/safety_sandbox_carve_out_e2e.rs
@@ -1,0 +1,179 @@
+//! W6.6 — ADR-153 §1.1 A6c: L2 sub-process sandbox **hole-in-hole**
+//! ("洞中洞") carve-out contract.
+//!
+//! Under `WorkspaceWrite`, the kernel-enforced sandbox profile must
+//! additionally refuse writes to sensitive sub-trees of the workspace
+//! root — `.git/` and `.codex/` (when present) — even though the rest
+//! of the cwd is writable. Without this carve-out an agent could
+//! rewrite git hooks to land RCE on the next commit
+//! ([`dasclaw_workspace_cap::policy`] docs §"洞中洞").
+//!
+//! ## Platform gate
+//!
+//! macOS only, mirroring [`safety_sandbox_workspace_write_e2e.rs`].
+//! The carve-out is materialised via Seatbelt's exclusion clauses by
+//! `dasclaw_sandboxing::seatbelt`, which projects the cwd-anchored
+//! carve-out list emitted by
+//! [`dasclaw_protocol::permissions::FileSystemSandboxPolicy::from_legacy_sandbox_policy_for_cwd`]
+//! (see `crates/dasclaw_protocol/src/permissions.rs` `default_read_only_subpaths_for_writable_root`).
+//! Linux landlock / Windows DACL wiring is out of scope for this slice.
+//!
+//! ## Scope vs. policy decision layer
+//!
+//! The decision-layer policy in `dasclaw_workspace_cap` also carves out
+//! `.dasclaw/` (with `protect_missing_project_meta=true`), but the
+//! kernel projection in `dasclaw_protocol::permissions` currently only
+//! emits `.git` + `.codex` exclusions to seatbelt. This test pins **only
+//! the kernel-enforced subset** so it reflects what actually happens on
+//! the wire; tightening kernel-layer `.dasclaw` enforcement is tracked
+//! separately and is out of scope for #870.
+//!
+//! ## Test rows
+//!
+//! 1. `.git/config` and `.codex/config` — pre-created on disk so the
+//!    policy actually emits the carve-out (`.git` / `.codex` carves
+//!    only trigger when the directory is present, mirroring upstream
+//!    `codex` behaviour).
+//! 2. Regular subdir control — proves the carve-out is targeted and
+//!    not just "WorkspaceWrite denies everything".
+
+#![cfg(target_os = "macos")]
+
+use std::fs;
+
+use dasclaw_core::hooks::HookBundle;
+use dasclaw_workspace_cap::policy::SandboxPolicy;
+use serde_json::json;
+
+#[path = "fixtures/sandbox_bash_executor.rs"]
+mod sandbox_bash_executor;
+use sandbox_bash_executor::{
+    SandboxedBashExecutor, ScriptedResponder, ack_turn, bash_tool_def, text_turn, tool_call_turn,
+};
+
+/// Build a `WorkspaceWrite` policy whose only writable root is `cwd`.
+///
+/// See the twin helper in `safety_sandbox_workspace_write_e2e.rs` for
+/// the rationale: on macOS `tempfile::tempdir` lives under `$TMPDIR`,
+/// and a `$TMPDIR` writable root only carries cwd-bound carve-outs when
+/// `root == cwd`. Excluding both `/tmp` and `$TMPDIR` keeps cwd the
+/// only writable root, so the `.git` / `.codex` carve-outs are the
+/// only thing standing between the agent and the sensitive file.
+fn cwd_only_workspace_write() -> SandboxPolicy {
+    SandboxPolicy::WorkspaceWrite {
+        writable_roots: Vec::new(),
+        network_access: false,
+        exclude_tmpdir_env_var: true,
+        exclude_slash_tmp: true,
+    }
+}
+
+/// A6c deny path — writing into a pre-existing `.git/` or `.codex/`
+/// carve-out must be refused even though the surrounding cwd is
+/// writable.
+#[tokio::test]
+async fn req_dasclaw_cli_loop_a6c_carve_out_denies_dot_git_and_dot_codex() {
+    let tempdir = tempfile::tempdir().expect("create tempdir");
+    let cwd = tempdir.path();
+    let dot_git = cwd.join(".git");
+    let dot_codex = cwd.join(".codex");
+    fs::create_dir(&dot_git).expect("seed .git dir so policy emits carve-out");
+    fs::create_dir(&dot_codex).expect("seed .codex dir so policy emits carve-out");
+
+    let git_target = dot_git.join("config");
+    let codex_target = dot_codex.join("config");
+    let git_path_str = git_target.to_string_lossy().into_owned();
+    let codex_path_str = codex_target.to_string_lossy().into_owned();
+
+    let executor = SandboxedBashExecutor::new(cwd_only_workspace_write(), cwd.to_path_buf());
+
+    let responder = ScriptedResponder::with_queue(vec![
+        tool_call_turn(
+            "bash",
+            "call-carve-git-1",
+            json!({ "command": format!("echo pwn > {git_path_str}") }),
+        ),
+        tool_call_turn(
+            "bash",
+            "call-carve-codex-1",
+            json!({ "command": format!("echo pwn > {codex_path_str}") }),
+        ),
+        ack_turn(),
+    ]);
+
+    let outcome = dasclaw_cli::run_with_tools_and_hooks(
+        responder,
+        executor,
+        vec![bash_tool_def()],
+        HookBundle::noop(),
+        "you are running inside a sandboxed CLI",
+        "please attempt to write inside .git and .codex",
+    )
+    .await;
+
+    assert!(
+        outcome.is_ok(),
+        "agent loop must not crash on carve-out denial, got {outcome:?}"
+    );
+    let reply = outcome.expect("loop completion checked above");
+    assert!(
+        reply.contains("sandbox") || reply.contains("understood"),
+        "reply should reflect the denial, got {reply:?}"
+    );
+    assert!(
+        !git_target.exists(),
+        ".git carve-out breached: file created at {git_target:?}"
+    );
+    assert!(
+        !codex_target.exists(),
+        ".codex carve-out breached: file created at {codex_target:?}"
+    );
+}
+
+/// A6c positive control — a write to a non-carved subdirectory of the
+/// workspace must still succeed. This is the row that distinguishes
+/// "carve-out is targeted" from "WorkspaceWrite is silently broken".
+#[tokio::test]
+async fn req_dasclaw_cli_loop_a6c_carve_out_admits_regular_subdir_write() {
+    let tempdir = tempfile::tempdir().expect("create tempdir");
+    let cwd = tempdir.path();
+    let target = cwd.join("regular_subdir").join("file.txt");
+    let target_path_str = target.to_string_lossy().into_owned();
+
+    let executor = SandboxedBashExecutor::new(cwd_only_workspace_write(), cwd.to_path_buf());
+
+    let responder = ScriptedResponder::with_queue(vec![
+        tool_call_turn(
+            "bash",
+            "call-regular-subdir-1",
+            json!({
+                "command": format!(
+                    "mkdir -p $(dirname {target_path_str}) && echo allowed > {target_path_str}"
+                )
+            }),
+        ),
+        text_turn("done"),
+    ]);
+
+    let reply = dasclaw_cli::run_with_tools_and_hooks(
+        responder,
+        executor,
+        vec![bash_tool_def()],
+        HookBundle::noop(),
+        "you are running inside a sandboxed CLI",
+        "please write into a regular subdir",
+    )
+    .await
+    .expect("agent loop ran to completion");
+
+    assert_eq!(reply, "done");
+    assert!(
+        target.exists(),
+        "regular subdir write should be admitted; missing at {target:?}"
+    );
+    let body = fs::read_to_string(&target).expect("read regular subdir file");
+    assert!(
+        body.contains("allowed"),
+        "regular subdir file content unexpected: {body:?}"
+    );
+}

--- a/crates/dasclaw_cli/tests/safety_sandbox_carve_out_e2e.rs
+++ b/crates/dasclaw_cli/tests/safety_sandbox_carve_out_e2e.rs
@@ -20,14 +20,13 @@
 //!
 //! ## Scope vs. policy decision layer
 //!
-//! The decision-layer policy in `dasclaw_workspace_cap` also carves out
-//! `.dasclaw/` (with `protect_missing_project_meta=true`), but the
-//! kernel projection in `dasclaw_protocol::permissions::
-//! default_read_only_subpaths_for_writable_root` currently only emits
-//! `.git` + `.codex` exclusions to seatbelt. The `.dasclaw` row below
-//! is therefore **expected to fail** today; it is intentionally shipped
-//! red as a TDD pin against the missing kernel projection. Follow-up
-//! work to extend the projection to `.dasclaw/` is tracked in #874.
+//! The decision-layer policy in `dasclaw_workspace_cap` carves out
+//! `.dasclaw/` (with `protect_missing_project_meta=true`), and as of
+//! #874 the kernel projection in `dasclaw_protocol::permissions::
+//! default_read_only_subpaths_for_writable_root` also emits `.dasclaw`
+//! alongside `.git` and `.codex`. All three rows below are therefore
+//! green; any future regression that lets `.dasclaw` writes through
+//! must be treated as a contract break, not a known gap.
 //!
 //! ## Test rows
 //!
@@ -35,9 +34,8 @@
 //!    policy actually emits the carve-out (`.git` / `.codex` carves
 //!    only trigger when the directory is present, mirroring upstream
 //!    `codex` behaviour).
-//! 2. `.dasclaw/state` — RED. Pins the policy gap: the decision layer
-//!    intends to carve `.dasclaw/`, but kernel projection does not
-//!    emit the exclusion, so the write currently lands on disk.
+//! 2. `.dasclaw/state` — green post-#874. Pins the kernel-side carve-out
+//!    for the dasclaw project-meta directory.
 //! 3. Regular subdir control — proves the carve-out is targeted and
 //!    not just "WorkspaceWrite denies everything".
 
@@ -134,11 +132,11 @@ async fn req_dasclaw_cli_loop_a6c_carve_out_denies_dot_git_and_dot_codex() {
     );
 }
 
-/// A6c **RED** — `.dasclaw/` should be carved out alongside `.git` and
-/// `.codex`, but the kernel projection in
+/// A6c — `.dasclaw/` is carved out alongside `.git` and `.codex` via
+/// the kernel projection in
 /// `dasclaw_protocol::permissions::default_read_only_subpaths_for_writable_root`
-/// currently does not emit it. This test is shipped failing on purpose
-/// as a TDD pin; flip green once the projection is extended (see #874).
+/// (extended in #874). A write into the carve-out must be refused by
+/// seatbelt even though the surrounding cwd is writable.
 #[tokio::test]
 async fn req_dasclaw_cli_loop_a6c_carve_out_denies_dot_dasclaw() {
     let tempdir = tempfile::tempdir().expect("create tempdir");
@@ -176,9 +174,7 @@ async fn req_dasclaw_cli_loop_a6c_carve_out_denies_dot_dasclaw() {
     );
     assert!(
         !dasclaw_target.exists(),
-        ".dasclaw carve-out breached: file created at {dasclaw_target:?} \
-         (kernel projection in default_read_only_subpaths_for_writable_root \
-          does not emit .dasclaw; tracked by #874)"
+        ".dasclaw carve-out breached: file created at {dasclaw_target:?}"
     );
 }
 

--- a/crates/dasclaw_cli/tests/safety_sandbox_workspace_write_e2e.rs
+++ b/crates/dasclaw_cli/tests/safety_sandbox_workspace_write_e2e.rs
@@ -21,7 +21,7 @@
 //!   territory; see [`cli_sandbox_default_deny_e2e.rs`] for the A6
 //!   binary-seam contract).
 //! - Not exercising the writable-root hole-in-hole carve-out logic
-//!   (`.git` / `.codex`). That is A6c, lives in
+//!   (`.git` / `.dasclaw` / `.codex`). That is A6c, lives in
 //!   [`safety_sandbox_carve_out_e2e.rs`].
 
 #![cfg(target_os = "macos")]

--- a/crates/dasclaw_cli/tests/safety_sandbox_workspace_write_e2e.rs
+++ b/crates/dasclaw_cli/tests/safety_sandbox_workspace_write_e2e.rs
@@ -1,0 +1,155 @@
+//! W6.6 — ADR-153 §1.1 A6b: L2 sub-process sandbox **WorkspaceWrite**
+//! policy contract.
+//!
+//! Sister to [`safety_sandbox_default_deny_e2e.rs`] (which pins the
+//! `ReadOnly` row of the matrix). This file pins the production-default
+//! `WorkspaceWrite` row: writes **inside** the workspace root (cwd) are
+//! admitted, writes **outside** must be refused by the OS sandbox and
+//! surface as `is_error=true` with a `sandbox` reason.
+//!
+//! ## Platform gate
+//!
+//! macOS only: the Seatbelt backend in `dasclaw_sandbox::macos` is fully
+//! wired (W2.2 / ADR-135 §3 PR-C1) and `/usr/bin/sandbox-exec` ships in
+//! the base image, so the OS kernel actually enforces the policy locally
+//! and in CI macOS runners. Linux landlock + Windows backends need
+//! external helpers and are tracked separately by #481.
+//!
+//! ## Non-goals
+//!
+//! - Not asserting binary-level CLI exit codes (that is `assert_cmd`
+//!   territory; see [`cli_sandbox_default_deny_e2e.rs`] for the A6
+//!   binary-seam contract).
+//! - Not exercising the writable-root hole-in-hole carve-out logic
+//!   (`.git` / `.codex`). That is A6c, lives in
+//!   [`safety_sandbox_carve_out_e2e.rs`].
+
+#![cfg(target_os = "macos")]
+
+use dasclaw_core::hooks::HookBundle;
+use dasclaw_workspace_cap::policy::SandboxPolicy;
+use serde_json::json;
+
+#[path = "fixtures/sandbox_bash_executor.rs"]
+mod sandbox_bash_executor;
+use sandbox_bash_executor::{
+    SandboxedBashExecutor, ScriptedResponder, ack_turn, bash_tool_def, text_turn, tool_call_turn,
+};
+
+/// Build a `WorkspaceWrite` policy whose only writable root is `cwd`.
+///
+/// The factory `new_workspace_write_policy()` also auto-promotes
+/// `/tmp` and `$TMPDIR` to writable roots. On macOS `tempfile::tempdir`
+/// lives under `$TMPDIR` (`/var/folders/...`), so leaving those flags
+/// at their defaults would let writes to *any* tempdir slip through and
+/// mask the actual cwd-bounded contract this row is meant to pin.
+fn cwd_only_workspace_write() -> SandboxPolicy {
+    SandboxPolicy::WorkspaceWrite {
+        writable_roots: Vec::new(),
+        network_access: false,
+        exclude_tmpdir_env_var: true,
+        exclude_slash_tmp: true,
+    }
+}
+
+/// A6b positive path — a write **inside** the workspace root (here
+/// `cwd`, which `new_workspace_write_policy()` auto-promotes to a
+/// writable root) must succeed under the same kernel-enforced sandbox
+/// that denies the corresponding `ReadOnly` case.
+///
+/// This is the row that proves WorkspaceWrite is not just "ReadOnly with
+/// a typo": without it the deny test below could trivially pass from any
+/// sandbox misconfiguration that denies every write.
+#[tokio::test]
+async fn req_dasclaw_cli_loop_a6b_workspace_write_admits_write_under_cwd() {
+    let tempdir = tempfile::tempdir().expect("create tempdir");
+    let target = tempdir.path().join("a6b_inside_cwd.txt");
+    let target_path_str = target.to_string_lossy().into_owned();
+
+    let executor =
+        SandboxedBashExecutor::new(cwd_only_workspace_write(), tempdir.path().to_path_buf());
+
+    let responder = ScriptedResponder::with_queue(vec![
+        tool_call_turn(
+            "bash",
+            "call-write-inside-1",
+            json!({ "command": format!("echo allowed-by-sandbox > {target_path_str}") }),
+        ),
+        text_turn("done"),
+    ]);
+
+    let reply = dasclaw_cli::run_with_tools_and_hooks(
+        responder,
+        executor,
+        vec![bash_tool_def()],
+        HookBundle::noop(),
+        "you are running inside a sandboxed CLI",
+        "please write a marker inside the workspace",
+    )
+    .await
+    .expect("agent loop ran to completion");
+
+    assert_eq!(reply, "done");
+    assert!(
+        target.exists(),
+        "WorkspaceWrite must admit writes under cwd; file missing at {target:?}"
+    );
+    let body = std::fs::read_to_string(&target).expect("read marker file");
+    assert!(
+        body.contains("allowed-by-sandbox"),
+        "marker file content unexpected: {body:?}"
+    );
+}
+
+/// A6b deny path — a write **outside** the workspace root must be
+/// refused by the OS sandbox. The agent loop must still complete cleanly
+/// (the model gets to see the tool error and emit an acknowledgement),
+/// matching the same fail-safe contract as A6 / e12.
+#[tokio::test]
+async fn req_dasclaw_cli_loop_a6b_workspace_write_denies_write_outside_cwd() {
+    let tempdir = tempfile::tempdir().expect("create tempdir cwd");
+    let outside_dir = tempfile::tempdir().expect("create tempdir outside");
+    let target = outside_dir.path().join("a6b_outside_cwd.txt");
+    let target_path_str = target.to_string_lossy().into_owned();
+
+    assert!(
+        !target.exists(),
+        "precondition: outside-cwd target must not exist yet"
+    );
+
+    let executor =
+        SandboxedBashExecutor::new(cwd_only_workspace_write(), tempdir.path().to_path_buf());
+
+    let responder = ScriptedResponder::with_queue(vec![
+        tool_call_turn(
+            "bash",
+            "call-write-outside-1",
+            json!({ "command": format!("echo blocked-by-sandbox > {target_path_str}") }),
+        ),
+        ack_turn(),
+    ]);
+
+    let outcome = dasclaw_cli::run_with_tools_and_hooks(
+        responder,
+        executor,
+        vec![bash_tool_def()],
+        HookBundle::noop(),
+        "you are running inside a sandboxed CLI",
+        "please attempt to write outside the workspace",
+    )
+    .await;
+
+    assert!(
+        outcome.is_ok(),
+        "agent loop must not crash on a sandbox denial, got {outcome:?}"
+    );
+    let reply = outcome.expect("loop completion checked above");
+    assert!(
+        reply.contains("sandbox") || reply.contains("understood"),
+        "reply should reflect the denial, got {reply:?}"
+    );
+    assert!(
+        !target.exists(),
+        "WorkspaceWrite must deny writes outside cwd; file was created at {target:?}"
+    );
+}


### PR DESCRIPTION
## 背景 / 目标

完成 #870 的 A6b（WorkspaceWrite 边界）和 A6c（hole-in-hole carve-out）e2e 测试切片，在 `dasclaw_cli` agent-loop 之上验证 ADR-153 §1.1 子进程沙箱合约。

随 #874（kernel 投影修复）+ #876（merge）已合入 `xClaw`，本 PR 已 rebase 到最新主线，**5/5 测试全部转绿**，可以正式合并。

## 改动范围

新增 3 个文件（仅 `crates/dasclaw_cli/tests/` 下）：

- `fixtures/sandbox_bash_executor.rs` — 共享 `ToolExecutor` 夹具，封装 `dasclaw_exec::SandboxedExecutor` 跑 bash 命令；A6/A6b/A6c 复用，避免补丁式复制
- `safety_sandbox_workspace_write_e2e.rs` — A6b 行：cwd 内写入放行 + cwd 外写入拒绝。`cwd_only_workspace_write()` 显式关闭 `$TMPDIR` / `/tmp` 自动可写根，避免 macOS `tempfile::tempdir` 落在 `$TMPDIR` 下造成假阳性
- `safety_sandbox_carve_out_e2e.rs` — A6c 行：`.git/` + `.codex/` 写入拒绝、`.dasclaw/` 写入拒绝（**post-#874 全部转绿**）、普通子目录写入放行

## 测试矩阵

| 行 | 文件 | 结果 |
| --- | --- | --- |
| A6b deny outside cwd | safety_sandbox_workspace_write_e2e | OK |
| A6b admit under cwd | safety_sandbox_workspace_write_e2e | OK |
| A6c deny .git + .codex | safety_sandbox_carve_out_e2e | OK |
| A6c deny .dasclaw | safety_sandbox_carve_out_e2e | OK post-#874 |
| A6c admit regular subdir | safety_sandbox_carve_out_e2e | OK |

## 非目标（What's NOT in this PR）

- 不扩展 Linux landlock / Windows DACL 投影器（归 #481 平台 matrix）
- 不覆盖 A6a 行（无沙箱基线），已由 #872 / #879 覆盖
- 不覆盖 binary-seam（assert_cmd）层 A6，已由 #868 / #880 覆盖

## 本地验证

```
git rebase origin/xClaw                                              # clean rebase, 3 commits preserved
cargo fmt --all -- --check                                           # OK
python3.12 scripts/check_no_panics.py --base origin/xClaw            # OK: No panic-inducing calls
cargo clippy --no-deps -p dasclaw_cli --all-targets -- -D warnings   # 0 warning
cargo nextest run -p dasclaw_cli \
  --test safety_sandbox_carve_out_e2e \
  --test safety_sandbox_workspace_write_e2e \
  --test safety_sandbox_default_deny_e2e
# Summary [7.585s] 8 tests run: 8 passed (1 leaky), 0 skipped
```

`1 leaky` 是 nextest 对 `tokio::task::spawn_blocking` 跑 `sandbox-exec` 子进程的常规报告（子进程在测试结束瞬间未必已 reap），不是失败。

## Sources read

- docs/plans/architecture-refactor/adr-153-cli-test-matrix.md §1.1 A6b / A6c
- docs/plans/architecture-refactor/adr-114-compatibility-evaluation.md（.dasclaw 命名空间）
- crates/dasclaw_protocol/src/permissions.rs `default_read_only_subpaths_for_writable_root` (1287–1330)
- crates/dasclaw_workspace_cap/src/policy.rs `SandboxPolicy::WorkspaceWrite`
- crates/dasclaw_cli/tests/safety_sandbox_default_deny_e2e.rs（同源 A6 测试，作为结构参照）

## Cross-cuts

- ADR-153 §1.1 A6b / A6c — 本 PR 直接交付
- ADR-114（.dasclaw 命名空间）：类 A — 没有新增 .ironclaw / IRONCLAW_BASE_DIR 字面量
- ADR-129 verbatim port mandate：不适用 — 本 PR 不动 verbatim-protected 文件

Closes #870
