### PR TITLE
chore(ci): add workflow_dispatch to 4 core workflows for manual trigger

### DIFF
--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -1,5 +1,6 @@
 name: Code Style
 on:
+  workflow_dispatch:
   pull_request:
     # xClaw fork: skip lint/format/deny/no-panics on doc-only PRs
     # (Markdown / docs / IDE config / license-only changes can't break code).

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -28,6 +28,7 @@
 
 name: Code Coverage
 on:
+  workflow_dispatch:
   push:
     branches: [xClaw]
 

--- a/.github/workflows/regression-test-check.yml
+++ b/.github/workflows/regression-test-check.yml
@@ -1,6 +1,7 @@
 name: Regression Test Check
 
 on:
+  workflow_dispatch:
   pull_request:
     # xClaw fork: doc-only PRs don't require regression tests.
     paths-ignore:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,7 @@
 name: Run Tests
 on:
   workflow_call:
+  workflow_dispatch:
   pull_request:
     branches:
       - xClaw


### PR DESCRIPTION
## 背景

最近的 PR（#871 / #872 / #873）`pull_request` 事件不再触发 GitHub Actions —— 经排查仓库的 Actions 是 `enabled: true`、所有 workflow 都 `active`、`paths-ignore` 也匹配，但提交后 head commit 上**根本没有 github-actions 这个 app 的 check_suite**（只有 figma 三方 app 的 suite）。判定是账号级 webhook 投递 / billing 限额问题，不是仓库代码或配置问题。

## 改动

给 4 个核心 workflow 的 `on:` 块加上 `workflow_dispatch:` 触发，提供手动启动的兜底入口：

- `test.yml`
- `code_style.yml`
- `regression-test-check.yml`
- `coverage.yml`

`e2e.yml` 和 `windows-ci.yml` 之前就有 `workflow_dispatch`，不需要改。

## 非目标（What's NOT in this PR）

- ❌ 不解决账号级 billing / webhook 根因（那要在 GitHub 网页 billing/payment/webhook 页面处理，代码层面无能为力）
- ❌ 不改任何 job 内部逻辑
- ❌ 不调整 `pull_request` / `push` / `schedule` 现有触发条件

## 合并后效果

任何分支都能通过命令行手动启动 workflow：

```
gh workflow run "Run Tests"               --ref <branch>
gh workflow run "Code Style"              --ref <branch>
gh workflow run "Regression Test Check"   --ref <branch>
gh workflow run "Code Coverage"           --ref <branch>
```

也可以在 GitHub 网页 https://github.com/Linnanli/xClaw/actions 进入对应 workflow 点 "Run workflow" 按钮。

## 验证

- 4 个文件改动各只新增 1 行 `workflow_dispatch:`，无现有触发条件丢失
- 本地 YAML head 检视通过

## Cross-cuts

- ADR-114（`.dasclaw` 命名空间）：**类 A** — 无 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量
- 关联：#873（被该 webhook 问题阻塞的红测试 PR）、ADR-153 §1.1（依赖 CI 验证的安全合约）
