### PR TITLE
test(dasclaw_cli): A7 follow-up — wasm capability matrix e2e (workspace/secrets/rate-limit)

### DIFF
--- a/crates/dasclaw_cli/tests/fixtures/wasm_capability_helpers.rs
+++ b/crates/dasclaw_cli/tests/fixtures/wasm_capability_helpers.rs
@@ -1,0 +1,112 @@
+//! Shared helpers for the broader wasm capability-matrix e2e tests
+//! (ADR-153 §1.1 A7 follow-up, issue #869).
+//!
+//! Builds a `ToolExecutor` that routes a single named tool call into a
+//! `WasmToolWrapper` configured with caller-supplied `Capabilities` and an
+//! optional `HttpInterceptor`. Errors from the wrapper surface as
+//! `ToolResult { is_error: true, content: <err.to_string()> }` so the agent
+//! loop treats capability denials as reported tool failures, matching the
+//! contract pinned by the A7 baseline test.
+//!
+//! Kept separate from `safety_wasm_capability_optin_e2e.rs` so the A7
+//! baseline (http opt-in) stays self-contained, while the workspace /
+//! secrets / rate-limit follow-up tests share one builder.
+
+#![allow(dead_code)] // each test file uses a different subset of helpers
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use dasclaw_core::messages::{ToolCall, ToolDefinition, ToolResult};
+use dasclaw_core::traits::HostError;
+use dasclaw_runtime::context::JobContext;
+use dasclaw_runtime::recording::HttpInterceptor;
+use dasclaw_runtime::{Tool, ToolExecutor};
+use dasclaw_wasm_tools::{
+    Capabilities, NO_HTTP_CAP_WASM, WasmRuntimeConfig, WasmToolRuntime, WasmToolWrapper,
+};
+use serde_json::json;
+
+/// `ToolExecutor` that routes one named tool call through a single
+/// `WasmToolWrapper`. Mirrors the helper in
+/// `safety_wasm_capability_optin_e2e.rs` but is parameterised by
+/// `Capabilities` + optional `HttpInterceptor` so the capability-matrix
+/// follow-up tests can share construction logic.
+pub struct CapWasmExecutor {
+    tool_name: String,
+    wrapper: Arc<WasmToolWrapper>,
+}
+
+impl CapWasmExecutor {
+    pub async fn build(
+        tool_name: &str,
+        capabilities: Capabilities,
+        interceptor: Option<Arc<dyn HttpInterceptor>>,
+    ) -> Self {
+        // Match the A7 baseline: lift the per-instance memory cap to
+        // 4 MiB so the wasip2 fixture's ~17 starting pages fit (the
+        // `for_testing` default is 1 MiB).
+        let mut config = WasmRuntimeConfig::for_testing();
+        config.default_limits = config.default_limits.with_memory(4 * 1024 * 1024);
+        let runtime = Arc::new(WasmToolRuntime::new(config).expect("init wasm runtime"));
+        let prepared = runtime
+            .prepare(tool_name, NO_HTTP_CAP_WASM, None)
+            .await
+            .expect("prepare fixture component");
+
+        let mut wrapper = WasmToolWrapper::new(Arc::clone(&runtime), prepared, capabilities);
+        if let Some(interceptor) = interceptor {
+            wrapper = wrapper.with_http_interceptor(interceptor);
+        }
+
+        Self {
+            tool_name: tool_name.to_string(),
+            wrapper: Arc::new(wrapper),
+        }
+    }
+}
+
+#[async_trait]
+impl ToolExecutor for CapWasmExecutor {
+    async fn execute(&self, call: &ToolCall) -> Result<ToolResult, HostError> {
+        if call.name != self.tool_name {
+            return Err(HostError::from(format!(
+                "unexpected tool call: {} (test only wires {})",
+                call.name, self.tool_name
+            )));
+        }
+
+        let mut ctx = JobContext::new("a7-followup", "wasm capability matrix e2e");
+        let outcome = self.wrapper.execute(call.arguments.clone(), &mut ctx).await;
+
+        let (is_error, content) = match outcome {
+            Ok(output) => (false, serde_json::to_string(&output).unwrap_or_default()),
+            Err(err) => (true, err.to_string()),
+        };
+
+        Ok(ToolResult {
+            tool_call_id: call.id.clone(),
+            name: call.name.clone(),
+            content,
+            is_error,
+        })
+    }
+}
+
+/// Build the `ToolDefinition` advertised to the scripted LLM.
+pub fn fixture_tool_def(name: &str) -> ToolDefinition {
+    ToolDefinition {
+        name: name.to_string(),
+        description: "Sandboxed capability-matrix fixture (workspace / secrets / rate_limit)"
+            .to_string(),
+        parameters: json!({
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": ["http", "workspace", "secrets", "rate_limit"]
+                }
+            }
+        }),
+    }
+}

--- a/crates/dasclaw_cli/tests/safety_wasm_capability_rate_limit_e2e.rs
+++ b/crates/dasclaw_cli/tests/safety_wasm_capability_rate_limit_e2e.rs
@@ -1,0 +1,138 @@
+//! ADR-153 §1.1 A7 follow-up — capability matrix: per-execution HTTP
+//! rate-limit default-deny e2e (issue #869).
+//!
+//! Differs from the workspace / secrets rows in that the rate-limit gate
+//! lives **inside** the `http` capability, so the test must:
+//!
+//! 1. Grant the `http` capability with an allowlist covering the fixture
+//!    target URL (otherwise the allowlist check trips before rate limit
+//!    and we'd measure the wrong gate).
+//! 2. Install an `HttpInterceptor` that returns a canned 200 response,
+//!    so the test never touches real network. (The interceptor sits
+//!    **after** the rate-limit check inside the wrapper, so calls 1..50
+//!    flow allowlist → rate-limit-record → leak-scan → IP-check → canned
+//!    reply, and call 51 trips rate-limit before any of the later
+//!    stages.)
+//! 3. Use a public, literal IPv4 (TEST-NET-3, RFC 5737) so the
+//!    `reject_private_ip` step skips DNS resolution entirely.
+//!
+//! The fixture loops up to 60 calls and breaks on the first host error;
+//! both the agent-loop test and the direct ToolExecutor test pin the
+//! verbatim host gate string `"Too many HTTP requests in single
+//! execution (max 50)"` and the wrapper's `"Rate limit exceeded: "`
+//! prefix so a future change to either layer surfaces immediately.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use dasclaw_cli::run_with_tools_and_hooks;
+use dasclaw_core::hooks::HookBundle;
+use dasclaw_core::messages::ToolCall;
+use dasclaw_runtime::recording::{HttpExchangeRequest, HttpExchangeResponse, HttpInterceptor};
+use dasclaw_wasm_tools::{Capabilities, EndpointPattern, HttpCapability};
+use serde_json::json;
+
+#[path = "fixtures/agent_loop_fixtures.rs"]
+mod agent_loop_fixtures;
+#[path = "fixtures/wasm_capability_helpers.rs"]
+mod wasm_capability_helpers;
+
+use agent_loop_fixtures::{ScriptedResponder, text_turn, tool_call_turn};
+use wasm_capability_helpers::{CapWasmExecutor, fixture_tool_def};
+
+/// Interceptor that short-circuits every outbound request with a canned
+/// 200 OK reply. Lets the rate-limit test exercise the gate without
+/// touching real network.
+#[derive(Debug, Default)]
+struct CannedOkInterceptor;
+
+#[async_trait]
+impl HttpInterceptor for CannedOkInterceptor {
+    async fn before_request(&self, _req: &HttpExchangeRequest) -> Option<HttpExchangeResponse> {
+        Some(HttpExchangeResponse {
+            status: 200,
+            headers: vec![("content-type".to_string(), "application/json".to_string())],
+            body: r#"{"ok":true}"#.to_string(),
+        })
+    }
+
+    async fn after_response(&self, _req: &HttpExchangeRequest, _resp: &HttpExchangeResponse) {}
+}
+
+fn http_caps_for_test_net() -> Capabilities {
+    let pattern = EndpointPattern::host("203.0.113.1");
+    let http = HttpCapability::new(vec![pattern]);
+    Capabilities::default().with_http(http)
+}
+
+#[tokio::test]
+async fn req_dasclaw_cli_safety_a7_wasm_http_rate_limit_surfaces_as_tool_error() {
+    let tool_name = "fixture_rate_limit";
+    let interceptor: Arc<dyn HttpInterceptor> = Arc::new(CannedOkInterceptor);
+    let executor =
+        CapWasmExecutor::build(tool_name, http_caps_for_test_net(), Some(interceptor)).await;
+
+    let responder = ScriptedResponder::with_queue(vec![
+        tool_call_turn(tool_name, "call-rl", json!({ "action": "rate_limit" })),
+        text_turn("acknowledged: rate limit tripped"),
+    ]);
+
+    let outcome = run_with_tools_and_hooks(
+        responder,
+        executor,
+        vec![fixture_tool_def(tool_name)],
+        HookBundle::noop(),
+        "you are running inside a capability-gated CLI",
+        "please call the fixture rate_limit tool",
+    )
+    .await;
+
+    let reply = outcome.expect("agent loop must not crash on rate-limit denial");
+    assert_eq!(reply, "acknowledged: rate limit tripped");
+}
+
+#[tokio::test]
+async fn req_dasclaw_cli_safety_a7_wasm_rate_limit_tool_result_carries_host_gate_message() {
+    let tool_name = "fixture_rate_limit";
+    let interceptor: Arc<dyn HttpInterceptor> = Arc::new(CannedOkInterceptor);
+    let executor =
+        CapWasmExecutor::build(tool_name, http_caps_for_test_net(), Some(interceptor)).await;
+
+    let call = ToolCall {
+        id: "direct-call-rl".to_string(),
+        name: tool_name.to_string(),
+        arguments: json!({ "action": "rate_limit" }),
+        reasoning: None,
+    };
+
+    let result = dasclaw_runtime::ToolExecutor::execute(&executor, &call)
+        .await
+        .expect("ToolExecutor must not raise HostError on rate-limit denial");
+
+    assert!(
+        result.is_error,
+        "rate-limited tool must report is_error=true, got: {result:?}"
+    );
+    // The fixture surfaces the host error verbatim, prefixed by the
+    // wrapper. Pin both the wrapper-layer prefix and the host-layer
+    // message so regressions in either layer are caught.
+    assert!(
+        result.content.contains("Rate limit exceeded"),
+        "tool result must carry the wrapper rate-limit prefix, got: {}",
+        result.content
+    );
+    assert!(
+        result
+            .content
+            .contains("Too many HTTP requests in single execution (max 50)"),
+        "tool result must carry the host gate string verbatim, got: {}",
+        result.content
+    );
+    // The fixture reports which iteration tripped the gate. After 50
+    // successful canned replies the 51st call (index 50) must fail.
+    assert!(
+        result.content.contains("call 50:"),
+        "rate limit must trip on the 51st call (index 50), got: {}",
+        result.content
+    );
+}

--- a/crates/dasclaw_cli/tests/safety_wasm_capability_secrets_e2e.rs
+++ b/crates/dasclaw_cli/tests/safety_wasm_capability_secrets_e2e.rs
@@ -1,0 +1,82 @@
+//! ADR-153 §1.1 A7 follow-up — capability matrix: `secret_exists`
+//! default-deny e2e (issue #869).
+//!
+//! Companion to the http and workspace rows. Drives the wasip2 fixture
+//! through the `action="secrets"` branch, which calls the host
+//! `secret-exists` import. With `Capabilities::default()` (no `secrets`
+//! granted), the host returns `false` over the `bool` WIT signature.
+//! There is no error channel back to the guest at this WIT signature, so
+//! the default-deny gate is observable only as `false`. The fixture
+//! turns that into a stable error prefix so the tool-result envelope
+//! pins both contracts.
+
+use dasclaw_cli::run_with_tools_and_hooks;
+use dasclaw_core::hooks::HookBundle;
+use dasclaw_core::messages::ToolCall;
+use dasclaw_wasm_tools::Capabilities;
+use serde_json::json;
+
+#[path = "fixtures/agent_loop_fixtures.rs"]
+mod agent_loop_fixtures;
+#[path = "fixtures/wasm_capability_helpers.rs"]
+mod wasm_capability_helpers;
+
+use agent_loop_fixtures::{ScriptedResponder, text_turn, tool_call_turn};
+use wasm_capability_helpers::{CapWasmExecutor, fixture_tool_def};
+
+#[tokio::test]
+async fn req_dasclaw_cli_safety_a7_wasm_no_secrets_capability_surfaces_as_tool_error() {
+    let tool_name = "fixture_secrets";
+    let executor = CapWasmExecutor::build(tool_name, Capabilities::default(), None).await;
+
+    let responder = ScriptedResponder::with_queue(vec![
+        tool_call_turn(tool_name, "call-sec", json!({ "action": "secrets" })),
+        text_turn("acknowledged: secrets capability denied"),
+    ]);
+
+    let outcome = run_with_tools_and_hooks(
+        responder,
+        executor,
+        vec![fixture_tool_def(tool_name)],
+        HookBundle::noop(),
+        "you are running inside a capability-gated CLI",
+        "please call the fixture secrets tool",
+    )
+    .await;
+
+    let reply = outcome.expect("agent loop must not crash on secrets capability denial");
+    assert_eq!(reply, "acknowledged: secrets capability denied");
+}
+
+#[tokio::test]
+async fn req_dasclaw_cli_safety_a7_wasm_secrets_tool_result_carries_denial_signal() {
+    let tool_name = "fixture_secrets";
+    let executor = CapWasmExecutor::build(tool_name, Capabilities::default(), None).await;
+
+    let call = ToolCall {
+        id: "direct-call-sec".to_string(),
+        name: tool_name.to_string(),
+        arguments: json!({ "action": "secrets" }),
+        reasoning: None,
+    };
+
+    let result = dasclaw_runtime::ToolExecutor::execute(&executor, &call)
+        .await
+        .expect("ToolExecutor must not raise HostError on capability denial");
+
+    assert!(
+        result.is_error,
+        "capability-gated secret-exists must report is_error=true, got: {result:?}"
+    );
+    assert!(
+        result.content.contains("secret-exists returned false"),
+        "tool result content must signal the default-deny gate, got: {}",
+        result.content
+    );
+    // Negative assertion: the envelope must not claim the probe succeeded.
+    assert!(
+        !result.content.contains("\"secret_exists\":true"),
+        "no secret_exists=true payload may appear when capability is denied, got: {}",
+        result.content
+    );
+}

--- a/crates/dasclaw_cli/tests/safety_wasm_capability_workspace_e2e.rs
+++ b/crates/dasclaw_cli/tests/safety_wasm_capability_workspace_e2e.rs
@@ -1,0 +1,93 @@
+//! ADR-153 §1.1 A7 follow-up — capability matrix: `workspace_read`
+//! default-deny e2e (issue #869).
+//!
+//! Companion to `safety_wasm_capability_optin_e2e.rs` (the http row).
+//! Drives the same wasip2 fixture through a fresh `action="workspace"`
+//! branch that calls the host `workspace-read` import. With
+//! `Capabilities::default()` (no `workspace_read` granted), the host
+//! returns `None` over the `option<string>` WIT signature; the fixture
+//! reports that observation as an error so the tool-result envelope
+//! preserves the "no data crossed the boundary" contract.
+//!
+//! ## Why we assert on the fixture-emitted string and not a host string
+//!
+//! The host `workspace-read` export returns `option<string>` — there is
+//! no error channel back to the guest, so the default-deny gate is
+//! "the option is `None`". The fixture turns that into a stable error
+//! prefix (`"workspace-read returned None"`) so this test pins both the
+//! WIT-level contract (option is empty) and the agent-loop contract
+//! (`is_error=true`).
+
+use dasclaw_cli::run_with_tools_and_hooks;
+use dasclaw_core::hooks::HookBundle;
+use dasclaw_core::messages::ToolCall;
+use dasclaw_wasm_tools::Capabilities;
+use serde_json::json;
+
+#[path = "fixtures/agent_loop_fixtures.rs"]
+mod agent_loop_fixtures;
+#[path = "fixtures/wasm_capability_helpers.rs"]
+mod wasm_capability_helpers;
+
+use agent_loop_fixtures::{ScriptedResponder, text_turn, tool_call_turn};
+use wasm_capability_helpers::{CapWasmExecutor, fixture_tool_def};
+
+#[tokio::test]
+async fn req_dasclaw_cli_safety_a7_wasm_no_workspace_capability_surfaces_as_tool_error() {
+    let tool_name = "fixture_workspace";
+    let executor = CapWasmExecutor::build(tool_name, Capabilities::default(), None).await;
+
+    let responder = ScriptedResponder::with_queue(vec![
+        tool_call_turn(tool_name, "call-ws", json!({ "action": "workspace" })),
+        text_turn("acknowledged: workspace capability denied"),
+    ]);
+
+    let outcome = run_with_tools_and_hooks(
+        responder,
+        executor,
+        vec![fixture_tool_def(tool_name)],
+        HookBundle::noop(),
+        "you are running inside a capability-gated CLI",
+        "please call the fixture workspace tool",
+    )
+    .await;
+
+    let reply = outcome.expect("agent loop must not crash on workspace capability denial");
+    assert_eq!(reply, "acknowledged: workspace capability denied");
+}
+
+#[tokio::test]
+async fn req_dasclaw_cli_safety_a7_wasm_workspace_tool_result_carries_denial_signal() {
+    let tool_name = "fixture_workspace";
+    let executor = CapWasmExecutor::build(tool_name, Capabilities::default(), None).await;
+
+    let call = ToolCall {
+        id: "direct-call-ws".to_string(),
+        name: tool_name.to_string(),
+        arguments: json!({ "action": "workspace" }),
+        reasoning: None,
+    };
+
+    let result = dasclaw_runtime::ToolExecutor::execute(&executor, &call)
+        .await
+        .expect("ToolExecutor must not raise HostError on capability denial");
+
+    assert!(
+        result.is_error,
+        "capability-gated workspace-read must report is_error=true, got: {result:?}"
+    );
+    assert!(
+        result.content.contains("workspace-read returned None"),
+        "tool result content must signal the default-deny gate, got: {}",
+        result.content
+    );
+    // Negative assertion: no file content from the host crossed the
+    // boundary. The fixture never has access to disk in this config, so
+    // the only way `test.txt` could appear in the envelope is a host
+    // bug that leaks the path's contents.
+    assert!(
+        !result.content.contains("\"workspace_read\":"),
+        "no workspace_read payload may appear when capability is denied, got: {}",
+        result.content
+    );
+}

--- a/crates/dasclaw_wasm_tools/tests/fixtures/minimal_http_component/src/lib.rs
+++ b/crates/dasclaw_wasm_tools/tests/fixtures/minimal_http_component/src/lib.rs
@@ -1,12 +1,19 @@
 //! Minimal WASM component fixture for `dasclaw_wasm_tools` capability opt-in tests.
 //!
-//! Implements the `sandboxed-tool` world from `wit/tool.wit`. On `execute()`,
-//! attempts a host HTTP request and returns the host's error string. When the
-//! host has no `http` capability granted, the host returns
-//! `"HTTP capability not granted"` (see `crates/dasclaw_wasm_tools/src/host.rs`
-//! `HostState::check_http_allowed`).
+//! Implements the `sandboxed-tool` world from `wit/tool.wit`. The fixture
+//! dispatches on a minimal `"action"` substring in `req.params`:
 //!
-//! Used by `dasclaw_wasm_tools` self-tests and downstream `dasclaw_cli` A7 e2e.
+//! | action substring   | host import probed | default-deny behaviour locked            |
+//! |--------------------|--------------------|------------------------------------------|
+//! | (none / `http`)    | `http-request`     | host returns `"HTTP capability not …"`   |
+//! | `workspace`        | `workspace-read`   | host returns `None` (no value crosses)   |
+//! | `secrets`          | `secret-exists`    | host returns `false` (existence denied)  |
+//! | `rate_limit`       | `http-request` ×N  | host returns rate-limit error after cap  |
+//!
+//! Parsing is intentionally a substring check, not full JSON parsing, to
+//! keep the produced wasm artifact small and avoid pulling in serde at the
+//! fixture boundary. Tests that mis-spell the action fall through to the
+//! default `http` branch, which is the original `#854` behaviour.
 
 wit_bindgen::generate!({
     world: "sandboxed-tool",
@@ -18,28 +25,98 @@ use near::agent::host;
 
 struct Component;
 
+fn run_http() -> Response {
+    match host::http_request("GET", "https://example.com/", "{}", None, None) {
+        Ok(_) => Response {
+            output: Some(r#"{"status":"ok"}"#.to_string()),
+            error: None,
+        },
+        Err(msg) => Response {
+            output: None,
+            error: Some(msg),
+        },
+    }
+}
+
+fn run_workspace() -> Response {
+    // `workspace-read` returns `option<string>`. Without the capability the
+    // host returns `None` (see `HostState::workspace_read`); the fixture
+    // reports that observation back as an error so the test can assert the
+    // "no data crossed the boundary" contract.
+    match host::workspace_read("test.txt") {
+        Some(value) => Response {
+            output: Some(format!(r#"{{"workspace_read":{value:?}}}"#)),
+            error: None,
+        },
+        None => Response {
+            output: None,
+            error: Some("workspace-read returned None (capability denied)".to_string()),
+        },
+    }
+}
+
+fn run_secrets() -> Response {
+    // `secret-exists` returns `bool`. Without the capability the host
+    // returns `false` (see `HostState::secret_exists`).
+    if host::secret_exists("ANY_KEY") {
+        Response {
+            output: Some(r#"{"secret_exists":true}"#.to_string()),
+            error: None,
+        }
+    } else {
+        Response {
+            output: None,
+            error: Some("secret-exists returned false (capability denied)".to_string()),
+        }
+    }
+}
+
+fn run_rate_limit() -> Response {
+    // Loop the host `http-request` import until the per-execution rate
+    // limit trips. Uses a TEST-NET literal IP so `reject_private_ip` skips
+    // DNS resolution; the test grants an `http` capability allowlist + an
+    // `HttpInterceptor` that short-circuits with a canned 200, so the
+    // first 50 calls succeed and the 51st surfaces the rate-limit error
+    // verbatim. `MAX_REQUESTS_PER_EXECUTION = 50` lives in `host.rs`.
+    const URL: &str = "https://203.0.113.1/";
+    const ATTEMPTS: usize = 60;
+    let mut last_err = String::from("no calls attempted");
+    let mut succeeded = 0usize;
+    for i in 0..ATTEMPTS {
+        match host::http_request("GET", URL, "{}", None, None) {
+            Ok(_) => succeeded += 1,
+            Err(msg) => {
+                last_err = format!("call {i}: {msg}");
+                break;
+            }
+        }
+    }
+    Response {
+        output: Some(format!(r#"{{"succeeded":{succeeded}}}"#)),
+        error: Some(last_err),
+    }
+}
+
 impl Guest for Component {
-    fn execute(_req: Request) -> Response {
-        // Attempt the simplest possible HTTP call. The host enforces capability
-        // gating; without the `http` capability this returns Err immediately.
-        match host::http_request("GET", "https://example.com/", "{}", None, None) {
-            Ok(_) => Response {
-                output: Some(r#"{"status":"ok"}"#.to_string()),
-                error: None,
-            },
-            Err(msg) => Response {
-                output: None,
-                error: Some(msg),
-            },
+    fn execute(req: Request) -> Response {
+        let p = req.params.as_str();
+        if p.contains("\"workspace\"") {
+            run_workspace()
+        } else if p.contains("\"secrets\"") {
+            run_secrets()
+        } else if p.contains("\"rate_limit\"") {
+            run_rate_limit()
+        } else {
+            run_http()
         }
     }
 
     fn schema() -> String {
-        r#"{"type":"object","properties":{},"additionalProperties":true}"#.to_string()
+        r#"{"type":"object","properties":{"action":{"type":"string","enum":["http","workspace","secrets","rate_limit"]}},"additionalProperties":true}"#.to_string()
     }
 
     fn description() -> String {
-        "Minimal HTTP fixture for capability opt-in tests".to_string()
+        "Minimal capability fixture (http/workspace/secrets/rate_limit) for opt-in tests".to_string()
     }
 }
 


### PR DESCRIPTION
test(dasclaw_cli): A7 follow-up — wasm capability matrix e2e (workspace/secrets/rate-limit)

Adds three independent e2e tests covering the rest of the L7 wasm
capability matrix from ADR-153 §1.1 A7 / e13, closing the gap called
out by the A7 baseline (#855) which pinned only the http opt-in row.

Closes #869

## What this PR does

- Extends the existing wasip2 fixture (`minimal_http_component`) with
  a substring-dispatched `action` field so one fixture can probe
  workspace-read, secret-exists, and the per-execution HTTP rate-limit
  gate. The original `#854` http branch stays the default to keep the
  A7 baseline test untouched.
- Adds `crates/dasclaw_cli/tests/fixtures/wasm_capability_helpers.rs`
  with a shared `CapWasmExecutor::build(capabilities, interceptor)`
  builder so each capability row is independent without copy-paste.
- Adds three test binaries, one per capability row, each with an
  agent-loop assertion + a direct ToolExecutor envelope assertion:
  - `safety_wasm_capability_workspace_e2e.rs` — workspace-read None
    crosses the boundary as is_error=true; no payload leaks.
  - `safety_wasm_capability_secrets_e2e.rs` — secret-exists false
    crosses the boundary as is_error=true; no exists=true leak.
  - `safety_wasm_capability_rate_limit_e2e.rs` — installs a canned
    200 `HttpInterceptor` + grants http allowlist for 203.0.113.1
    (TEST-NET-3, no DNS) so calls 1..50 succeed and call 51 trips the
    host `Too many HTTP requests in single execution (max 50)` gate
    verbatim.

## What this PR does NOT do

- Does not add `workspace_read` / `secrets` error channels to the
  WIT (the option<string> / bool signatures are the contract being
  pinned; changing them is a separate decision).
- Does not promote `dasclaw_wasm_tools` to a production dep of
  `dasclaw_cli` (still dev-dep — wasmtime stays out of the shipped
  binary).
- Does not add a `--wasm-tool` CLI flag (production wiring tracked
  by #871).

## Verification

```
cargo nextest run -p dasclaw_cli \
  --test safety_wasm_capability_workspace_e2e \
  --test safety_wasm_capability_secrets_e2e \
  --test safety_wasm_capability_rate_limit_e2e
# 6 passed (3 agent-loop + 3 direct-envelope)

cargo fmt --all
python3.12 scripts/check_no_panics.py --base origin/xClaw   # OK
cargo clippy --no-deps -p dasclaw_cli --all-targets -- -D warnings   # clean
cargo clippy --no-deps -p dasclaw_wasm_tools --all-targets -- -D warnings   # clean
```

## Cross-cuts

ADR-114 类 A — no new `.ironclaw` / `IRONCLAW_BASE_DIR` literals.

已检查 dasclaw_cli/tests 是否已有等价 e2e，结论：仅 http row 存在 (#855)；本 PR 补齐 workspace / secrets / rate-limit。