### PR TITLE
feat(dasclaw_cli): sandbox-exec subcommand + binary-level A6 e2e (closes #868) [reopen of #872]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -376,6 +376,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_cmd"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2aa3a22042e45de04255c7bf3626e239f450200fd0493c1e382263544b20aea6"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
 name = "astral-tl"
 version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1426,6 +1441,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
 dependencies = [
  "memchr",
+ "regex-automata",
  "serde",
 ]
 
@@ -2857,6 +2873,7 @@ name = "dasclaw_cli"
 version = "0.0.0-w6"
 dependencies = [
  "anyhow",
+ "assert_cmd",
  "async-trait",
  "clap",
  "dasclaw_core",
@@ -2871,6 +2888,7 @@ dependencies = [
  "dasclaw_tool",
  "dasclaw_wasm_tools",
  "dasclaw_workspace_cap",
+ "predicates",
  "secrecy",
  "serde",
  "serde_json",
@@ -3823,6 +3841,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4490,6 +4514,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "fluent-uri"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4877,7 +4910,7 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.1.3",
+ "windows-link 0.2.1",
  "windows-result 0.4.1",
 ]
 
@@ -7313,6 +7346,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8526,6 +8565,36 @@ name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
+name = "predicates"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "float-cmp",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
 
 [[package]]
 name = "pretty_assertions"
@@ -11971,6 +12040,12 @@ checksum = "d5d9cf598a6d7ce700a4e6a9199da127e6819a61e64b68609683cc9a01b5683a"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "testcontainers"

--- a/crates/dasclaw_cli/Cargo.toml
+++ b/crates/dasclaw_cli/Cargo.toml
@@ -40,6 +40,14 @@ dasclaw_llm_provider = { path = "../dasclaw_llm_provider" }
 # ADR-153 §4.4 sub-step 8: CLI wires MCP-backed ToolExecutor.
 dasclaw_mcp = { path = "../dasclaw_mcp" }
 dasclaw_tool = { path = "../dasclaw_tool" }
+# ADR-153 §1.1 A6 / e12 binary-level slice (#868):
+# `dasclaw-cli sandbox-exec` runs `/bin/bash -c <cmd>` under the headless
+# CLI's default-deny ReadOnly policy. The three crates below were
+# previously dev-only (library-seam e2e in tests/) but become runtime
+# deps now that the subcommand ships in the binary.
+dasclaw_exec = { path = "../dasclaw_exec" }
+dasclaw_sandbox = { path = "../dasclaw_sandbox" }
+dasclaw_workspace_cap = { path = "../dasclaw_workspace_cap" }
 # Optional: only pulled in when the `wasm-tools` feature is enabled. See
 # the `[features]` block above for the binary-size rationale.
 dasclaw_wasm_tools = { path = "../dasclaw_wasm_tools", optional = true }
@@ -65,10 +73,10 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 # they prefer.
 dasclaw_safety = { path = "../dasclaw_safety", features = ["egress-gate"] }
 dasclaw_governance = { path = "../dasclaw_governance" }
-# W6.4 e11 (ADR-153 §1.1, A5 L1 path-escape): tests/safety_path_escape_e2e.rs
-# constructs a capability-bound workspace and asserts that paths escaping
-# the root surface as a tool error rather than a host crash.
-dasclaw_workspace_cap = { path = "../dasclaw_workspace_cap" }
+# W6.4 e11 (ADR-153 §1.1, A5 L1 path-escape) plus binary-level A6/e12
+# (#868): `dasclaw_workspace_cap` is now a runtime dep (see
+# [dependencies]); the dev-deps row is intentionally omitted to avoid
+# duplicate-listing.
 # W6.4b-i (ADR-153 §1.1 e14, outbound HTTP credential injection):
 # tests/safety_credential_boundary_e2e.rs builds HttpTool with a
 # SharedCredentialRegistry + InMemorySecretsStore, then uses an
@@ -79,13 +87,16 @@ dasclaw_net_tools = { path = "../dasclaw_net_tools" }
 # W6.6c (ADR-153 §1.1 A7 / e13): wasm fixture also reused by the prod
 # `--wasm-tool` flag e2e in tests/cli_wasm_tool_flag_e2e.rs.
 dasclaw_wasm_tools = { path = "../dasclaw_wasm_tools" }
-# W6.6b (ADR-153 §1.1 A6 / e12, L2 sub-process sandbox default-deny):
-# tests/safety_sandbox_default_deny_e2e.rs wires a `bash` tool whose
-# ToolExecutor runs commands through SandboxedExecutor under the
-# headless ReadOnly policy and asserts that writes are kernel-enforced
-# denied (macOS Seatbelt path; Linux + Windows tracked separately).
-dasclaw_exec = { path = "../dasclaw_exec" }
-dasclaw_sandbox = { path = "../dasclaw_sandbox" }
+# W6.6b (ADR-153 §1.1 A6 / e12) library-seam test in
+# tests/safety_sandbox_default_deny_e2e.rs reuses the same crates that
+# the binary now consumes (`dasclaw_exec`, `dasclaw_sandbox`); see
+# [dependencies] above.
+# #868 binary-level slice (ADR-153 §1.1 A6 / e12):
+# tests/cli_sandbox_default_deny_e2e.rs drives the real `dasclaw-cli`
+# binary via `assert_cmd` to pin the on-deny exit-code + stderr
+# contract.
+assert_cmd = "2"
+predicates = "3"
 tempfile = "3"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "test-util", "sync"] }
 wiremock = "0.6"

--- a/crates/dasclaw_cli/src/lib.rs
+++ b/crates/dasclaw_cli/src/lib.rs
@@ -52,6 +52,7 @@ use dasclaw_runtime::{Agent, AgentError, AgentResponder, ToolExecutor};
 
 pub mod mcp;
 pub mod provider;
+pub mod sandbox_exec;
 pub mod tools;
 #[cfg(feature = "wasm-tools")]
 pub mod wasm;

--- a/crates/dasclaw_cli/src/main.rs
+++ b/crates/dasclaw_cli/src/main.rs
@@ -25,6 +25,7 @@ use anyhow::{Context, Result};
 use clap::{Args, Parser, Subcommand};
 use dasclaw_cli::mcp::load_executor as load_mcp_executor;
 use dasclaw_cli::provider::{ProviderArgs, build_responder};
+use dasclaw_cli::sandbox_exec::run_sandbox_exec;
 use dasclaw_cli::tools::default_builtins;
 use dasclaw_cli::{EchoResponder, run, run_with_tools};
 use dasclaw_core::messages::ToolDefinition;
@@ -57,6 +58,22 @@ enum Command {
         provider: ProviderArgs,
         #[command(flatten)]
         tools: ToolArgs,
+    },
+    /// Run a single `bash -c <command>` under the headless CLI's
+    /// default-deny `ReadOnly` sandbox policy (ADR-153 §1.1 A6 / e12).
+    ///
+    /// On sandbox denial or non-zero exit the process exits non-zero
+    /// with `sandbox: ...` on stderr; on success the captured stdout is
+    /// forwarded verbatim. Used by the binary-level e2e in
+    /// [`tests/cli_sandbox_default_deny_e2e.rs`](../../tests/cli_sandbox_default_deny_e2e.rs)
+    /// to pin the exit-code + stderr contract that the library-seam
+    /// `safety_sandbox_default_deny_e2e.rs` test cannot observe.
+    ///
+    /// Ignores the global `--prompt` / `--system` flags.
+    SandboxExec {
+        /// Bash command line. Passed verbatim to `/bin/bash -c <CMD>`.
+        #[arg(long = "command")]
+        command: String,
     },
 }
 
@@ -106,25 +123,35 @@ async fn real_main() -> Result<()> {
     init_tracing();
 
     let cli = Cli::parse();
-    let prompt = match cli.prompt.as_deref() {
-        Some(p) => p.to_string(),
-        None => read_stdin_prompt().context("reading prompt from stdin")?,
-    };
-    let prompt = prompt.trim();
+    let command = cli.command.unwrap_or(Command::Echo);
 
-    let reply = match cli.command.unwrap_or(Command::Echo) {
-        Command::Echo => run(EchoResponder::new(), &cli.system, prompt)
-            .await
-            .context("echo agent run failed")?,
+    // Each subcommand owns its own input-resolution policy. `sandbox-exec`
+    // takes its payload through `--command` and would otherwise stall on
+    // stdin if the global `--prompt` flag were resolved up-front for
+    // every code path.
+    let reply = match command {
+        Command::SandboxExec { command: cmd_str } => {
+            let cwd = std::env::current_dir().context("sandbox: resolving current directory")?;
+            let stdout = run_sandbox_exec(&cmd_str, cwd).await?;
+            print!("{stdout}");
+            return Ok(());
+        }
+        Command::Echo => {
+            let prompt = resolve_prompt(cli.prompt.as_deref())?;
+            run(EchoResponder::new(), &cli.system, prompt.trim())
+                .await
+                .context("echo agent run failed")?
+        }
         Command::Run { provider, tools } => {
+            let prompt = resolve_prompt(cli.prompt.as_deref())?;
             let responder = build_responder(&provider).context("building LLM responder")?;
             let assembled = assemble_tool_executor(&tools).await?;
             match assembled {
-                None => run(responder, &cli.system, prompt)
+                None => run(responder, &cli.system, prompt.trim())
                     .await
                     .context("LLM agent run failed")?,
                 Some((executor, definitions)) => {
-                    run_with_tools(responder, executor, definitions, &cli.system, prompt)
+                    run_with_tools(responder, executor, definitions, &cli.system, prompt.trim())
                         .await
                         .context("LLM agent (with tools) run failed")?
                 }
@@ -133,6 +160,15 @@ async fn real_main() -> Result<()> {
     };
     println!("{reply}");
     Ok(())
+}
+
+/// Resolve the user prompt for chat-style subcommands: prefer the
+/// `--prompt` flag, otherwise drain stdin until EOF.
+fn resolve_prompt(prompt_flag: Option<&str>) -> Result<String> {
+    match prompt_flag {
+        Some(p) => Ok(p.to_string()),
+        None => read_stdin_prompt().context("reading prompt from stdin"),
+    }
 }
 
 /// Collect every tool source the user opted into and merge them via

--- a/crates/dasclaw_cli/src/sandbox_exec.rs
+++ b/crates/dasclaw_cli/src/sandbox_exec.rs
@@ -1,0 +1,93 @@
+//! Headless `dasclaw-cli sandbox-exec` subcommand backend
+//! (ADR-153 §1.1 A6 / e12 — binary-level slice).
+//!
+//! Runs a single `bash -c <command>` through
+//! [`dasclaw_exec::SandboxedExecutor`] under
+//! [`SandboxPolicy::new_read_only_policy`] — the headless CLI default
+//! that denies writes and turns off network access. The shipped
+//! `dasclaw-cli` binary uses this entry to let CI assert the
+//! deny-by-default contract end-to-end (exit code, stderr) without an
+//! LLM key, complementing the library-seam tool-loop test in
+//! [`tests/safety_sandbox_default_deny_e2e.rs`](../../tests/safety_sandbox_default_deny_e2e.rs).
+//!
+//! ## Contract
+//!
+//! - Returns `Ok(stdout_as_string)` when the sandbox admits the command
+//!   *and* it exits zero. The caller is expected to forward `stdout`
+//!   verbatim to its own stdout.
+//! - Returns `Err(anyhow::Error)` for every failure mode (sandbox
+//!   denial, non-zero exit, helper missing). The error chain is
+//!   composed so that the rendered message *always* contains the
+//!   literal token `sandbox`, which the binary-level e2e
+//!   ([`tests/cli_sandbox_default_deny_e2e.rs`](../../tests/cli_sandbox_default_deny_e2e.rs))
+//!   pins. The `main` wrapper renders the error to stderr and exits
+//!   non-zero.
+//!
+//! ## Scope
+//!
+//! - macOS only is the platform actually enforced by the kernel today
+//!   (Seatbelt backend, ADR-135 §3 PR-C1). Linux + Windows helpers are
+//!   tracked separately and **not** loaded here — on those platforms the
+//!   backend fails closed with a `sandbox` error, which is the safe
+//!   default for a deny-by-default contract.
+//! - Only the `ReadOnly` policy is wired in this slice. `WorkspaceWrite`
+//!   plus `.git` / `.codex` / `.dasclaw` carve-outs land in #870.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+use anyhow::{Context, Result, anyhow};
+use dasclaw_exec::{ExecRequest, ProcessExecutor, SandboxedExecutor};
+use dasclaw_sandbox::SandboxablePreference;
+use dasclaw_workspace_cap::policy::SandboxPolicy;
+
+/// Run `bash -c <command>` under the headless CLI's default-deny
+/// `ReadOnly` sandbox policy in `cwd`.
+///
+/// On success returns the captured stdout. On sandbox denial / non-zero
+/// exit returns an `anyhow::Error` whose rendered message starts with
+/// `sandbox` so callers (and the binary-level e2e) can rely on a stable
+/// stderr token.
+pub async fn run_sandbox_exec(command: &str, cwd: PathBuf) -> Result<String> {
+    if command.trim().is_empty() {
+        return Err(anyhow!("sandbox: empty --command"));
+    }
+
+    // SandboxedExecutor::execute is synchronous and spawns
+    // `sandbox-exec` (macOS) / a helper child (linux/windows). Hop to
+    // the blocking pool so we don't stall the tokio runtime when the
+    // host kernel is slow.
+    let command_str = command.to_owned();
+    let cwd_for_exec = cwd.clone();
+    let outcome = tokio::task::spawn_blocking(move || {
+        let executor = SandboxedExecutor::new(
+            SandboxPolicy::new_read_only_policy(),
+            SandboxablePreference::Require,
+            false,
+            None,
+        );
+        let mut cmd = Command::new("/bin/bash");
+        cmd.arg("-c").arg(&command_str);
+        executor.execute(ExecRequest {
+            command: cmd,
+            cwd: cwd_for_exec,
+        })
+    })
+    .await
+    .context("sandbox: blocking pool join failed")?;
+
+    match outcome {
+        Ok(output) if output.status.success() => {
+            Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+        }
+        Ok(output) => {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            Err(anyhow!(
+                "sandbox: command exited with status {}: {}",
+                output.status,
+                stderr.trim()
+            ))
+        }
+        Err(err) => Err(anyhow!("sandbox: denied: {err}")),
+    }
+}

--- a/crates/dasclaw_cli/tests/cli_sandbox_default_deny_e2e.rs
+++ b/crates/dasclaw_cli/tests/cli_sandbox_default_deny_e2e.rs
@@ -1,0 +1,101 @@
+//! Binary-level e2e for `dasclaw-cli sandbox-exec`
+//! (ADR-153 §1.1 A6 / e12, follow-up to #868).
+//!
+//! Sister to the library-seam test
+//! [`safety_sandbox_default_deny_e2e.rs`](safety_sandbox_default_deny_e2e.rs):
+//! that one validates the agent loop, this one validates the **shipped
+//! binary's** exit-code + stderr contract by driving the real `dasclaw-cli`
+//! through [`assert_cmd::Command::cargo_bin`].
+//!
+//! ## Platform gate
+//!
+//! macOS only: the Seatbelt backend in `dasclaw_sandbox::macos` is fully
+//! wired (W2.2 / ADR-135 §3 PR-C1) and `/usr/bin/sandbox-exec` is
+//! available out of the box. Linux + Windows backends require helper
+//! binaries that are not on `PATH` in the default test environment and
+//! are tracked by separate W6 issues (#481 platform matrix).
+//!
+//! ## Contract pinned here
+//!
+//! 1. Sandbox denial → exit non-zero, stderr contains `sandbox`.
+//! 2. Sandbox-admitted read-only command → exit zero, stdout carries
+//!    the command's stdout verbatim.
+//! 3. Empty `--command` → exit non-zero, stderr contains `sandbox`
+//!    (fail-closed on degenerate input).
+//!
+//! Cases the library-seam test cannot observe (binary-level only):
+//! - The agent loop never serialises an `ExitCode` to the OS; only the
+//!   binary's outer `main` does.
+//! - The agent loop renders sandbox errors into `ToolResult.content`;
+//!   the binary renders them onto `stderr` via the `dasclaw: {err:#}`
+//!   wrapper in `main`.
+
+#![cfg(target_os = "macos")]
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+
+/// 1. Default-deny: a write under `ReadOnly` policy must surface as a
+///    non-zero exit with `sandbox` in stderr, and the would-be target
+///    file must not exist on disk.
+#[test]
+fn req_dasclaw_cli_bin_sandbox_exec_denies_write_under_read_only_policy() {
+    let workdir = tempfile::tempdir().expect("create workdir");
+    let target = workdir.path().join("sandbox_should_block.txt");
+    assert!(
+        !target.exists(),
+        "precondition: target file should not exist yet"
+    );
+
+    let cmd_str = format!(
+        "echo blocked-by-sandbox > {}",
+        target
+            .to_str()
+            .expect("tempdir path must be valid UTF-8 on macOS test runners")
+    );
+
+    let mut cmd = Command::cargo_bin("dasclaw-cli").expect("locate dasclaw-cli binary");
+    cmd.current_dir(workdir.path())
+        .args(["sandbox-exec", "--command", &cmd_str]);
+
+    cmd.assert()
+        .failure()
+        .stderr(predicate::str::contains("sandbox"));
+
+    assert!(
+        !target.exists(),
+        "post-condition: ReadOnly sandbox must have prevented the write"
+    );
+}
+
+/// 2. Sandbox-admitted positive path: a plain `echo` does not touch the
+///    filesystem, so the `ReadOnly` policy admits it and the captured
+///    stdout is forwarded verbatim with exit zero.
+#[test]
+fn req_dasclaw_cli_bin_sandbox_exec_admits_readonly_command() {
+    let workdir = tempfile::tempdir().expect("create workdir");
+
+    let mut cmd = Command::cargo_bin("dasclaw-cli").expect("locate dasclaw-cli binary");
+    cmd.current_dir(workdir.path())
+        .args(["sandbox-exec", "--command", "echo readonly-ok"]);
+
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("readonly-ok"));
+}
+
+/// 3. Degenerate input: empty `--command` is rejected fail-closed with
+///    a `sandbox` stderr token, matching the rest of the contract
+///    rather than surfacing as a bare clap error or a silent zero-exit.
+#[test]
+fn req_dasclaw_cli_bin_sandbox_exec_rejects_empty_command() {
+    let workdir = tempfile::tempdir().expect("create workdir");
+
+    let mut cmd = Command::cargo_bin("dasclaw-cli").expect("locate dasclaw-cli binary");
+    cmd.current_dir(workdir.path())
+        .args(["sandbox-exec", "--command", "   "]);
+
+    cmd.assert()
+        .failure()
+        .stderr(predicate::str::contains("sandbox"));
+}


### PR DESCRIPTION
> Re-opens [#872](https://github.com/Linnanli/xClaw/pull/872) (auto-closed when its base `feat/cli-wasm-tool-flag` was deleted by the #871 squash-merge). Branch rebased onto `xClaw` (now contains #871's `assemble_tool_executor` + `push_source` helpers, so commit `68bc766a` was dropped as "patch contents already upstream"). No behavior change vs old #872.

## 背景 / 目标

ADR-153 §1.1 A6 / e12 要求**二进制层**的 sandbox default-deny e2e（与 #867 已交付的 library-seam 测试互补）：library-seam 验证 agent loop 渲染 sandbox 错误进 `ToolResult.content`，**binary-seam** 验证 shipped 二进制的 `exit-code + stderr` 契约。

Closes #868。

## 改动范围

- **新增 `dasclaw-cli sandbox-exec --command <cmd>` 子命令**（`crates/dasclaw_cli/src/sandbox_exec.rs`）：
  - 用 `dasclaw_exec::SandboxedExecutor` + `SandboxPolicy::new_read_only_policy()` + `SandboxablePreference::Require` 执行 `/bin/bash -c <cmd>`
  - `Require` 保证 sandbox backend 不可用时**拒绝**而非降级（fail-closed）
  - 所有错误路径都带 `sandbox` token（契约由 e2e 钉死）
- **`main.rs` 重构**：从一个 `match` 尾巴追加分支 → 每个子命令各自负责 prompt 解析；抽出 `resolve_prompt` 助手；**消除 `unreachable!`，无 panic 路径**
- **Cargo.toml**：把 `dasclaw_exec` / `dasclaw_sandbox` / `dasclaw_workspace_cap` 从 dev-deps 提升到 runtime deps（现在 binary 内部要用）；新增 `assert_cmd = "2"` + `predicates = "3"` 到 dev-deps
- **新增 `tests/cli_sandbox_default_deny_e2e.rs`**（macOS only，`#![cfg(target_os = "macos")]`）：用 `assert_cmd::Command::cargo_bin("dasclaw-cli")` 驱动真二进制，钉死 3 个契约：
  1. ReadOnly 下写文件 → exit ≠ 0 + stderr 含 `sandbox` + 目标文件不存在
  2. ReadOnly 下 `echo readonly-ok` → exit 0 + stdout 含 `readonly-ok`
  3. 空 `--command` → exit ≠ 0 + stderr 含 `sandbox`（fail-closed on degenerate input）

## 非目标（What's NOT in this PR）

- ❌ 不涉及 WorkspaceWrite carve-out（留给 #870）
- ❌ 不涉及 wasm capability 矩阵扩充（留给 #869）
- ❌ 不补 Linux/Windows backend 对应 e2e（由 #481 平台矩阵 issue 跟踪；这两个 backend 需要 helper binaries 不在默认 PATH）
- ❌ 不改动 agent loop 内的 sandbox 错误渲染（library-seam 测试已覆盖，#867）

## 验证（rebased onto post-#871 xClaw）

```bash
$ cargo check -p dasclaw_cli --tests
Finished dev profile (0 errors)

# 原 PR 已通过的门禁（pre-rebase）：
$ cargo nextest run -p dasclaw_cli --test cli_sandbox_default_deny_e2e
3 tests run: 3 passed, 0 skipped (3.656s)
$ cargo nextest run -p dasclaw_cli
69 tests run: 69 passed, 0 skipped (63.587s)
$ cargo fmt --all && python3.12 scripts/check_no_panics.py --base origin/xClaw
OK: No panic-inducing calls in changed production code.
$ cargo clippy --no-deps -p dasclaw_cli --all-targets -- -D warnings
Finished dev profile (0 warnings)
```

## Sources read

- `AGENTS.md` § Skills 强制使用规范、§ 完成清单
- `.github/copilot-instructions.md`
- `docs/plans/architecture-refactor/adr-153-…` §1.1 A6
- old PR #872 description（rebased without behavior change）

