### PR TITLE
feat(cli): wire ShellTool via ToolToExecutorAdapter + binary-level A6 e2e (closes #868)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -376,6 +376,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_cmd"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2aa3a22042e45de04255c7bf3626e239f450200fd0493c1e382263544b20aea6"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
 name = "astral-tl"
 version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1426,6 +1441,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
 dependencies = [
  "memchr",
+ "regex-automata",
  "serde",
 ]
 
@@ -2857,6 +2873,7 @@ name = "dasclaw_cli"
 version = "0.0.0-w6"
 dependencies = [
  "anyhow",
+ "assert_cmd",
  "async-trait",
  "clap",
  "dasclaw_core",
@@ -2868,9 +2885,11 @@ dependencies = [
  "dasclaw_runtime",
  "dasclaw_safety",
  "dasclaw_sandbox",
+ "dasclaw_shell_tools",
  "dasclaw_tool",
  "dasclaw_wasm_tools",
  "dasclaw_workspace_cap",
+ "predicates",
  "secrecy",
  "serde",
  "serde_json",
@@ -3823,6 +3842,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4490,6 +4515,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "fluent-uri"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4877,7 +4911,7 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.1.3",
+ "windows-link 0.2.1",
  "windows-result 0.4.1",
 ]
 
@@ -7313,6 +7347,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8526,6 +8566,36 @@ name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
+name = "predicates"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "float-cmp",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
 
 [[package]]
 name = "pretty_assertions"
@@ -11971,6 +12041,12 @@ checksum = "d5d9cf598a6d7ce700a4e6a9199da127e6819a61e64b68609683cc9a01b5683a"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "testcontainers"

--- a/crates/dasclaw_cli/Cargo.toml
+++ b/crates/dasclaw_cli/Cargo.toml
@@ -43,6 +43,12 @@ dasclaw_tool = { path = "../dasclaw_tool" }
 # Optional: only pulled in when the `wasm-tools` feature is enabled. See
 # the `[features]` block above for the binary-size rationale.
 dasclaw_wasm_tools = { path = "../dasclaw_wasm_tools", optional = true }
+# ADR-153 §1.1 A6 (issue #868): `--enable-shell-tool` wires the
+# in-tree ShellTool through ToolToExecutorAdapter so headless agents
+# get the same sandboxed write-deny default that desktop ironclaw
+# enforces. Kept as a prod dep (not dev) because main.rs constructs
+# the tool at startup when the user passes the flag.
+dasclaw_shell_tools = { path = "../dasclaw_shell_tools" }
 anyhow = "1"
 clap = { version = "4", features = ["derive", "env"] }
 secrecy = "0.10"
@@ -89,3 +95,9 @@ dasclaw_sandbox = { path = "../dasclaw_sandbox" }
 tempfile = "3"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "test-util", "sync"] }
 wiremock = "0.6"
+# ADR-153 §1.1 A6 issue #868: assert_cmd drives the compiled
+# `dasclaw-cli` binary in tests/cli_sandbox_default_deny_e2e.rs so the
+# CLI exit / stdout / stderr contract is locked at the artifact level,
+# not just at the library seam.
+assert_cmd = "2"
+predicates = "3"

--- a/crates/dasclaw_cli/src/main.rs
+++ b/crates/dasclaw_cli/src/main.rs
@@ -20,6 +20,7 @@ use std::io::{self, Read};
 use std::path::PathBuf;
 use std::process::ExitCode;
 use std::sync::Arc;
+use std::time::Duration;
 
 use anyhow::{Context, Result};
 use clap::{Args, Parser, Subcommand};
@@ -28,7 +29,8 @@ use dasclaw_cli::provider::{ProviderArgs, build_responder};
 use dasclaw_cli::tools::default_builtins;
 use dasclaw_cli::{EchoResponder, run, run_with_tools};
 use dasclaw_core::messages::ToolDefinition;
-use dasclaw_runtime::{CompositeToolExecutor, ToolExecutor};
+use dasclaw_runtime::{CompositeToolExecutor, Tool, ToolExecutor, ToolToExecutorAdapter};
+use dasclaw_shell_tools::{SandboxedShellExecutor, ShellTool};
 const DEFAULT_SYSTEM: &str = "You are dasclaw, a headless agent.";
 
 /// Headless dasclaw agent CLI.
@@ -74,6 +76,14 @@ struct ToolArgs {
     /// subcommand stays a pure chat-completion driver.
     #[arg(long = "enable-tools", default_value_t = false)]
     enable_tools: bool,
+
+    /// Advertise the in-tree `shell` tool (ADR-153 §1.1 A6). Commands run
+    /// through [`dasclaw_shell_tools::SandboxedShellExecutor`] under the
+    /// headless `ReadOnly` policy — writes outside the workspace are
+    /// kernel-denied (macOS Seatbelt; Linux/Windows tracked under #481).
+    /// Defaults to off so the bare `run` subcommand stays read-only chat.
+    #[arg(long = "enable-shell-tool", default_value_t = false)]
+    enable_shell_tool: bool,
 
     /// Path to an MCP server config JSON file. Each entry is started
     /// either as a stdio child process (`command` field) or as an HTTP
@@ -135,6 +145,11 @@ async fn real_main() -> Result<()> {
     Ok(())
 }
 
+/// Default timeout passed to [`SandboxedShellExecutor::new`] when the user
+/// enables `--enable-shell-tool`. Matches `dasclaw_shell_tools::DEFAULT_TIMEOUT`
+/// (120 s); kept literal here so this crate doesn't depend on the constant.
+const SHELL_TOOL_TIMEOUT: Duration = Duration::from_secs(120);
+
 /// Collect every tool source the user opted into and merge them via
 /// [`CompositeToolExecutor`].
 ///
@@ -143,7 +158,7 @@ async fn real_main() -> Result<()> {
 /// uniform `≥1 source` case keeps the call site free of the
 /// combinatorial branch explosion that the original
 /// `(enable_tools × mcp_config × …)` match would grow into as each new
-/// tool source (e.g. ADR-153 §1.1 A7 wasm tools) lands.
+/// tool source (e.g. ADR-153 §1.1 A7 wasm tools, A6 shell tool) lands.
 async fn assemble_tool_executor(
     tools: &ToolArgs,
 ) -> Result<Option<(CompositeToolExecutor, Vec<ToolDefinition>)>> {
@@ -154,6 +169,28 @@ async fn assemble_tool_executor(
         let exec = default_builtins();
         let defs = exec.definitions();
         push_source(&mut sources, &mut definitions, defs, Arc::new(exec));
+    }
+
+    if tools.enable_shell_tool {
+        // ADR-153 §1.1 A6 (issue #868): the in-tree ShellTool is a
+        // `dasclaw_runtime::Tool`, not a `ToolExecutor`. We bridge through
+        // the framework-level `ToolToExecutorAdapter<T: Tool>` so any future
+        // `Tool` impl plugs into the same accumulator without bespoke glue.
+        //
+        // `SandboxedShellExecutor::new(timeout, allow_full_access, network_proxy)`:
+        //   - `false` => default-deny sandbox (no host FS escape, no extra writable roots)
+        //   - `None`  => no upstream network proxy; combined with `allow_full_access=false`
+        //                this leaves the policy at `CapPolicy::ReadOnly { network_access: false }`
+        //                which the platform sandbox (macOS Seatbelt / Linux Landlock) enforces.
+        let sandbox = Arc::new(SandboxedShellExecutor::new(SHELL_TOOL_TIMEOUT, false, None));
+        let shell = ShellTool::new().with_sandbox(sandbox);
+        let defs = vec![ToolDefinition {
+            name: shell.name().to_string(),
+            description: shell.description().to_string(),
+            parameters: shell.parameters_schema(),
+        }];
+        let adapter = Arc::new(ToolToExecutorAdapter::new(shell)) as Arc<dyn ToolExecutor>;
+        push_source(&mut sources, &mut definitions, defs, adapter);
     }
 
     if let Some(path) = tools.mcp_config.as_deref() {

--- a/crates/dasclaw_cli/tests/cli_sandbox_default_deny_e2e.rs
+++ b/crates/dasclaw_cli/tests/cli_sandbox_default_deny_e2e.rs
@@ -1,0 +1,235 @@
+//! W6.6b — ADR-153 §1.1 A6 / e12: **binary-level** sandbox default-deny.
+//!
+//! Companion to `safety_sandbox_default_deny_e2e.rs`. That sibling pins
+//! the **library** contract (`run_with_tools_and_hooks` + a custom
+//! sandboxed tool executor) on a write attempt under the headless
+//! `ReadOnly` policy. This file pins the **shipped `dasclaw` binary**
+//! contract: spawn the real CLI via `assert_cmd`, drive it against a
+//! `wiremock` OpenAI-Chat-Completions server that asks the agent to run
+//! a `shell` tool call that writes to disk, and verify three independent
+//! invariants:
+//!
+//! 1. The binary does **not** panic / crash — `assert_cmd::Assert::success()`
+//!    confirms it reached the LLM's second-turn reply and printed it.
+//! 2. The sandbox actually **enforced** the deny — the target file does
+//!    not exist on disk after the run.
+//! 3. The denial signal **propagated to the model loop** — the 2nd
+//!    `/chat/completions` request body (containing the prior tool_result)
+//!    carries a Seatbelt / sandbox denial keyword. Without this, a buggy
+//!    refactor could silently swallow the sandbox error and still
+//!    produce a passing `.success()` run.
+//!
+//! ## Why we don't assert a non-zero exit code (departure from #868)
+//!
+//! Issue #868 originally asked for "exit code 非零 + stderr 含 sandbox 关键字".
+//! Today `dasclaw-cli` exits 0 whenever the **agent loop** completes — tool
+//! failures stay inside the loop as `is_error=true` `ToolResult`s and
+//! never bubble up to `real_main()`. Forcing a non-zero exit for any
+//! tool failure is a separate product decision (would mean every
+//! transient tool error kills the binary), tracked outside this slice.
+//! The B-route acceptance (file-not-created + denial keyword reaches the
+//! model) still locks the e12 invariant end-to-end without coupling
+//! this PR to that decision. Negotiation recorded on issue #868.
+//!
+//! ## Platform gate
+//!
+//! macOS only, matching the library sibling: Seatbelt is the only fully
+//! wired backend in the test image (`/usr/bin/sandbox-exec` is on `PATH`),
+//! Linux + Windows are blocked behind #481.
+
+#![cfg(target_os = "macos")]
+
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use serde_json::json;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, Request, Respond, ResponseTemplate};
+
+const TEST_API_KEY: &str = "sk-test";
+
+/// Sniffer that records every request body seen by the mock server.
+///
+/// `wiremock::Respond` is invoked synchronously for every match; we
+/// stash the JSON-decoded body in a shared `Vec` so the test can later
+/// assert that the 2nd-turn request (which carries the prior
+/// `tool_result`) contains the sandbox denial signal.
+struct BodySniffer {
+    bodies: Arc<Mutex<Vec<serde_json::Value>>>,
+    response: serde_json::Value,
+}
+
+impl Respond for BodySniffer {
+    fn respond(&self, request: &Request) -> ResponseTemplate {
+        // `Respond::respond` is invoked synchronously from inside the
+        // wiremock dispatcher (which is itself running on a tokio
+        // runtime), so we must use a `std::sync::Mutex` here — a
+        // `tokio::sync::Mutex::blocking_lock` panics with
+        // "Cannot block the current thread from within a runtime."
+        if let Ok(value) = serde_json::from_slice::<serde_json::Value>(&request.body)
+            && let Ok(mut guard) = self.bodies.lock()
+        {
+            guard.push(value);
+        }
+        ResponseTemplate::new(200).set_body_json(self.response.clone())
+    }
+}
+
+fn tool_call_body(target_path: &str) -> serde_json::Value {
+    // First-turn assistant reply asking the agent to run the `shell` tool
+    // with a write command. The path is deliberately a tempdir entry so
+    // we can assert post-run that the sandbox prevented the write.
+    json!({
+        "id": "chatcmpl-cli-sandbox-1",
+        "object": "chat.completion",
+        "model": "gpt-4o-mini",
+        "choices": [{
+            "index": 0,
+            "message": {
+                "role": "assistant",
+                "content": null,
+                "tool_calls": [{
+                    "id": "call_shell_1",
+                    "type": "function",
+                    "function": {
+                        "name": "shell",
+                        "arguments": serde_json::to_string(&json!({
+                            "command": format!("echo blocked > {target_path}")
+                        })).unwrap()
+                    }
+                }]
+            },
+            "finish_reason": "tool_calls"
+        }],
+        "usage": { "prompt_tokens": 5, "completion_tokens": 8 }
+    })
+}
+
+const FINAL_REPLY: &str = "understood: the sandbox refused the write.";
+
+fn final_text_body() -> serde_json::Value {
+    json!({
+        "id": "chatcmpl-cli-sandbox-2",
+        "object": "chat.completion",
+        "model": "gpt-4o-mini",
+        "choices": [{
+            "index": 0,
+            "message": { "role": "assistant", "content": FINAL_REPLY },
+            "finish_reason": "stop"
+        }],
+        "usage": { "prompt_tokens": 50, "completion_tokens": 8 }
+    })
+}
+
+/// e12 binary-level main assertion.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn req_dasclaw_cli_a6_binary_sandbox_denies_write_under_read_only_policy() {
+    // Per-run tempdir so concurrent test runs do not collide. macOS puts
+    // this under $TMPDIR (/var/folders/...) which is outside any
+    // ReadOnly carve-out → writes here MUST be denied.
+    let tempdir = tempfile::tempdir().expect("create tempdir");
+    let target: PathBuf = tempdir.path().join("a6_should_not_exist.txt");
+    let target_path_str = target.to_string_lossy().into_owned();
+
+    let server = MockServer::start().await;
+    let bodies: Arc<Mutex<Vec<serde_json::Value>>> = Arc::new(Mutex::new(Vec::new()));
+
+    // Turn 1: assistant emits the shell tool_call.
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(BodySniffer {
+            bodies: bodies.clone(),
+            response: tool_call_body(&target_path_str),
+        })
+        .up_to_n_times(1)
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // Turn 2: assistant finalizes after seeing the (denied) tool_result.
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(BodySniffer {
+            bodies: bodies.clone(),
+            response: final_text_body(),
+        })
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // Run the **shipped** binary, not a library entry point. The
+    // `--enable-shell-tool` flag wires `dasclaw_shell_tools::ShellTool`
+    // through `ToolToExecutorAdapter` with the default ReadOnly policy
+    // (see `crates/dasclaw_cli/src/main.rs::run_run_subcommand`).
+    let mut cmd = Command::cargo_bin("dasclaw-cli").expect("dasclaw-cli binary builds");
+    cmd.args([
+        "run",
+        "--provider",
+        "openai-compat",
+        "--model",
+        "gpt-4o-mini",
+        "--base-url",
+        &server.uri(),
+        "--api-key",
+        TEST_API_KEY,
+        "--enable-shell-tool",
+        "--prompt",
+        "please write the word `blocked` to the file",
+        "--system",
+        "you are running under a sandboxed CLI; obey the user.",
+    ]);
+
+    let assert = cmd.assert();
+    // Invariant 1: binary did not crash / panic. `assert_cmd::Assert::success()`
+    // verifies exit code == 0 *and* the process actually terminated cleanly.
+    let assert = assert.success();
+    // Invariant 1b: final LLM reply made it to stdout (proves the loop ran
+    // to completion past the tool error rather than aborting mid-turn).
+    assert.stdout(predicate::str::contains(FINAL_REPLY));
+
+    // Invariant 2: the sandbox actually enforced the deny. If this fires,
+    // either the kernel-level Seatbelt profile regressed or the
+    // `--enable-shell-tool` wiring lost its ReadOnly default.
+    assert!(
+        !target.exists(),
+        "sandbox must prevent the write; file was created at {target:?}"
+    );
+
+    // Invariant 3: the denial signal reached the model loop. We inspect
+    // the body of the 2nd /chat/completions request — it carries the
+    // prior tool_result as a `role: tool` message. The body must contain
+    // either the kernel-level Seatbelt phrase (`Operation not permitted`)
+    // OR the ShellTool's structured `"sandboxed":true` flag with a
+    // non-zero exit code — both prove the loop observed an enforced
+    // denial rather than a silent success.
+    let captured = bodies.lock().expect("poisoned body collector");
+    assert!(
+        captured.len() >= 2,
+        "expected at least 2 /chat/completions requests, got {} — {:?}",
+        captured.len(),
+        captured
+    );
+    // We inspect the *last* captured body rather than `captured[1]` to be
+    // robust against an extra retry on turn 1: regardless of retries, the
+    // final request the binary sent before exiting must carry the prior
+    // tool_result as a `role: tool` message with the enforced-denial signal.
+    let second_body_str = captured
+        .last()
+        .expect("captured non-empty per assert above")
+        .to_string();
+    // The denial signal must be one of two *precise* shapes — kernel-level
+    // Seatbelt phrase (`Operation not permitted`) OR the ShellTool's
+    // structured `"sandboxed":true` flag. We deliberately do NOT accept the
+    // bare substring "sandbox" as a fallback: that would let any field name
+    // containing the word pass, weakening the fail-safe invariant.
+    let denial_signal = second_body_str.contains("Operation not permitted")
+        || second_body_str.contains("\\\"sandboxed\\\":true");
+    let exit_signal =
+        second_body_str.contains("\\\"success\\\":false") || second_body_str.contains("exit_code");
+    assert!(
+        denial_signal && exit_signal,
+        "2nd request body must carry an enforced-denial signal; got {second_body_str}"
+    );
+}

--- a/crates/dasclaw_runtime/src/agent.rs
+++ b/crates/dasclaw_runtime/src/agent.rs
@@ -88,6 +88,21 @@ pub trait ToolExecutor: Send + Sync {
     async fn execute(&self, call: &ToolCall) -> Result<ToolResult, HostError>;
 }
 
+/// Forward [`ToolExecutor`] through an `Arc<dyn ToolExecutor>` so callers
+/// that erase the concrete type (CLI dispatch, plugin registries,
+/// dynamically-assembled tool stacks) can still feed the agent loop.
+///
+/// Without this blanket impl, [`crate::Agent`]'s generic
+/// `E: ToolExecutor + 'static` bound rejects `Arc<dyn ToolExecutor>`
+/// even though the trait object itself satisfies the trait via dynamic
+/// dispatch — Rust does not auto-implement traits for `Arc<dyn Trait>`.
+#[async_trait]
+impl ToolExecutor for std::sync::Arc<dyn ToolExecutor> {
+    async fn execute(&self, call: &ToolCall) -> Result<ToolResult, HostError> {
+        (**self).execute(call).await
+    }
+}
+
 /// Narrow tool-output sanitization seam used by [`Agent`]
 /// (ADR-153 §1.1 B6 / e22 wiring).
 ///

--- a/crates/dasclaw_runtime/src/lib.rs
+++ b/crates/dasclaw_runtime/src/lib.rs
@@ -46,6 +46,7 @@ pub mod rate_limit;
 pub mod recording;
 pub mod secrets;
 pub mod tool;
+pub mod tool_to_executor_adapter;
 
 pub use agent::{
     Agent, AgentBuilder, AgentConfig, AgentError, AgentResponder, ToolExecutor, ToolOutputSanitizer,
@@ -59,3 +60,4 @@ pub use llm_adapter::LlmProviderResponder;
 pub use rate_limit::{LimitType, RateLimitError, RateLimitResult, RateLimiter};
 pub use recording::{HttpExchange, HttpExchangeRequest, HttpExchangeResponse, HttpInterceptor};
 pub use tool::Tool;
+pub use tool_to_executor_adapter::ToolToExecutorAdapter;

--- a/crates/dasclaw_runtime/src/tool_to_executor_adapter.rs
+++ b/crates/dasclaw_runtime/src/tool_to_executor_adapter.rs
@@ -1,0 +1,317 @@
+//! Generic [`Tool`] → [`ToolExecutor`] adapter.
+//!
+//! Bridges the application-layer [`Tool`] trait (which takes structured
+//! `serde_json::Value` parameters plus a mutable
+//! [`JobContextCore`](crate::JobContextCore) and returns a typed
+//! [`ToolOutput`](dasclaw_tool::ToolOutput)) into the
+//! [`ToolExecutor`] seam consumed by [`crate::Agent`] (which takes a
+//! `ToolCall` and returns a `ToolResult`).
+//!
+//! ## Why this lives here
+//!
+//! Before this adapter, every tool family (MCP gateway in
+//! `dasclaw_mcp::executor`, the static builtin runner in
+//! `dasclaw_cli::tools::StaticToolExecutor`, sub-agents, …) hand-rolled
+//! their own `impl ToolExecutor`. That meant any host that wanted to
+//! drive a single `Tool` implementation through `Agent` (the headless
+//! `dasclaw-cli` shell-tool wiring is the motivating case) had to
+//! duplicate the parameter / output / error mapping yet again. This
+//! adapter is the missing piece of the runtime so that
+//! `Arc::new(ToolToExecutorAdapter::new(MyTool::default()))` is enough
+//! to plug a tool into an agent loop.
+//!
+//! ## Design
+//!
+//! * The adapter holds an `Arc<T>` to its underlying tool, so cloning
+//!   the executor (e.g. wrapping it in [`crate::CompositeToolExecutor`])
+//!   is cheap and the same tool instance is reused across invocations.
+//! * It owns a shared `Arc<Mutex<JobContext>>` because `Tool::execute`
+//!   takes `&mut dyn JobContextCore`. State written into the context by
+//!   one invocation (e.g. `set_metadata`, `tool_output_stash` mutations)
+//!   is visible to the next, matching the contract of the in-process
+//!   `JobContext` used by ironclaw.
+//! * Parameter wire format: [`dasclaw_core::messages::ToolCall::arguments`]
+//!   is already a parsed `serde_json::Value`. The adapter forwards it
+//!   directly into [`Tool::execute`] without re-parsing.
+//! * Error mapping mirrors [`crate::composite_executor`] and the MCP
+//!   executor: a tool-level failure ([`ToolError`]) becomes
+//!   `ToolResult { is_error: true, content: <Display> }` rather than a
+//!   `HostError`. The model gets the failure back as a recoverable
+//!   `tool_result` block; the agent loop continues. Only infrastructural
+//!   failures (poisoned mutex, …) would bubble up as `HostError`, and
+//!   the current implementation has no path that can reach one.
+//!
+//! ## Approval / risk metadata
+//!
+//! `Tool::requires_approval` and `Tool::risk_level_for` are inspection
+//! hooks for callers (e.g. the hook chain) — they do **not** gate the
+//! tool's `execute` itself. The adapter therefore does not consult
+//! them: approval enforcement lives in
+//! [`dasclaw_core::hooks::BeforeToolCall`], not inside the executor
+//! seam.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use tokio::sync::Mutex;
+
+use dasclaw_core::messages::{ToolCall, ToolResult};
+use dasclaw_core::traits::HostError;
+use dasclaw_tool::ToolOutput;
+
+use crate::agent::ToolExecutor;
+use crate::context::state::JobContext;
+use crate::tool::Tool;
+
+/// Generic [`Tool`] → [`ToolExecutor`] adapter.
+///
+/// See the [module documentation](self) for design rationale.
+pub struct ToolToExecutorAdapter<T: Tool + 'static> {
+    tool: Arc<T>,
+    ctx: Arc<Mutex<JobContext>>,
+}
+
+impl<T: Tool + 'static> ToolToExecutorAdapter<T> {
+    /// Wrap `tool` with a fresh default [`JobContext`].
+    ///
+    /// Suitable for headless callers (`dasclaw-cli`, smoke tests) that
+    /// don't have a host-supplied job context. The default context has
+    /// no background tasks, no exclusive resources, and zero-cost
+    /// `Arc`-based fields — see
+    /// [`JobContext::default`](crate::context::state::JobContext::default).
+    pub fn new(tool: T) -> Self {
+        Self::with_context(tool, JobContext::default())
+    }
+
+    /// Wrap `tool` with a caller-supplied [`JobContext`].
+    ///
+    /// Use this when the host wants to propagate `extra_env`,
+    /// `workspace_root` metadata, feature flags, or a recording HTTP
+    /// interceptor into the tool's environment.
+    pub fn with_context(tool: T, ctx: JobContext) -> Self {
+        Self {
+            tool: Arc::new(tool),
+            ctx: Arc::new(Mutex::new(ctx)),
+        }
+    }
+
+    /// Read-only access to the underlying tool. Useful for tests.
+    pub fn tool(&self) -> &T {
+        &self.tool
+    }
+
+    /// Clone the shared context handle. State written by tool
+    /// invocations on this adapter is visible through this handle.
+    pub fn context(&self) -> Arc<Mutex<JobContext>> {
+        self.ctx.clone()
+    }
+}
+
+#[async_trait]
+impl<T: Tool + Send + Sync + 'static> ToolExecutor for ToolToExecutorAdapter<T> {
+    async fn execute(&self, call: &ToolCall) -> Result<ToolResult, HostError> {
+        let mut ctx = self.ctx.lock().await;
+        let outcome = self.tool.execute(call.arguments.clone(), &mut *ctx).await;
+        drop(ctx);
+
+        let (content, is_error) = match outcome {
+            Ok(output) => (render_tool_output(&output), false),
+            Err(err) => (err.to_string(), true),
+        };
+
+        Ok(ToolResult {
+            tool_call_id: call.id.clone(),
+            name: call.name.clone(),
+            content,
+            is_error,
+        })
+    }
+}
+
+/// Render a [`ToolOutput`] into the [`ToolResult::content`] string the
+/// model will see in its next `tool_result` block.
+///
+/// Mirrors the MCP gateway's `map_call_result` and the static executor
+/// in `dasclaw_cli::tools`: plain text comes through verbatim, anything
+/// structured is serialised as compact JSON so the LLM can still parse
+/// it back. We deliberately do **not** wrap text outputs in quotes
+/// (which `Value::to_string()` would do), to keep the wire format
+/// stable across `ToolOutput::text` and `ToolOutput::success`.
+fn render_tool_output(output: &ToolOutput) -> String {
+    match &output.result {
+        serde_json::Value::String(s) => s.clone(),
+        other => serde_json::to_string(other).unwrap_or_else(|_| other.to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::time::Duration;
+
+    use async_trait::async_trait;
+    use serde_json::{Value, json};
+
+    use dasclaw_tool::{ToolError, ToolOutput};
+
+    use crate::job_context::JobContextCore;
+
+    /// Tool that echoes back a `text` argument as a `ToolOutput::text`.
+    struct TextEchoTool;
+
+    #[async_trait]
+    impl Tool for TextEchoTool {
+        fn name(&self) -> &str {
+            "text_echo"
+        }
+        fn description(&self) -> &str {
+            "echo"
+        }
+        fn parameters_schema(&self) -> Value {
+            json!({"type":"object","properties":{"text":{"type":"string"}},"required":["text"]})
+        }
+        async fn execute(
+            &self,
+            params: Value,
+            _ctx: &mut dyn JobContextCore,
+        ) -> Result<ToolOutput, ToolError> {
+            let text = params
+                .get("text")
+                .and_then(Value::as_str)
+                .ok_or_else(|| ToolError::ExecutionFailed("missing text".into()))?;
+            Ok(ToolOutput::text(text.to_owned(), Duration::from_millis(0)))
+        }
+    }
+
+    /// Tool that returns a structured `ToolOutput::success` payload.
+    struct StructuredTool;
+
+    #[async_trait]
+    impl Tool for StructuredTool {
+        fn name(&self) -> &str {
+            "structured"
+        }
+        fn description(&self) -> &str {
+            "structured"
+        }
+        fn parameters_schema(&self) -> Value {
+            json!({"type":"object","properties":{},"required":[]})
+        }
+        async fn execute(
+            &self,
+            _params: Value,
+            _ctx: &mut dyn JobContextCore,
+        ) -> Result<ToolOutput, ToolError> {
+            Ok(ToolOutput::success(
+                json!({"exit_code": 1, "output": "Operation not permitted", "sandboxed": true}),
+                Duration::from_millis(0),
+            ))
+        }
+    }
+
+    /// Tool that always fails with `ToolError::NotAuthorized`.
+    struct AlwaysDenyTool;
+
+    #[async_trait]
+    impl Tool for AlwaysDenyTool {
+        fn name(&self) -> &str {
+            "deny"
+        }
+        fn description(&self) -> &str {
+            "deny"
+        }
+        fn parameters_schema(&self) -> Value {
+            json!({"type":"object","properties":{},"required":[]})
+        }
+        async fn execute(
+            &self,
+            _params: Value,
+            _ctx: &mut dyn JobContextCore,
+        ) -> Result<ToolOutput, ToolError> {
+            Err(ToolError::NotAuthorized("sandbox: blocked write".into()))
+        }
+    }
+
+    fn make_call(name: &str, args: Value) -> ToolCall {
+        ToolCall {
+            id: format!("call_{name}"),
+            name: name.to_owned(),
+            arguments: args,
+            reasoning: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn req_dasclaw_runtime_adapter_text_success_passes_text_through_unquoted() {
+        let adapter = ToolToExecutorAdapter::new(TextEchoTool);
+        let result = adapter
+            .execute(&make_call("text_echo", json!({"text": "hello"})))
+            .await
+            .expect("infra ok");
+        assert!(!result.is_error);
+        assert_eq!(result.content, "hello");
+        assert_eq!(result.name, "text_echo");
+        assert_eq!(result.tool_call_id, "call_text_echo");
+    }
+
+    #[tokio::test]
+    async fn req_dasclaw_runtime_adapter_structured_success_serialises_as_json() {
+        let adapter = ToolToExecutorAdapter::new(StructuredTool);
+        let result = adapter
+            .execute(&make_call("structured", json!({})))
+            .await
+            .expect("infra ok");
+        assert!(!result.is_error);
+        // Compact JSON so the LLM can parse it back, and so callers can
+        // grep for keywords like `Operation not permitted` / `sandboxed`.
+        assert!(
+            result.content.contains("Operation not permitted"),
+            "content was: {}",
+            result.content
+        );
+        assert!(result.content.contains("\"sandboxed\":true"));
+        assert!(result.content.contains("\"exit_code\":1"));
+    }
+
+    #[tokio::test]
+    async fn req_dasclaw_runtime_adapter_tool_error_becomes_is_error_true() {
+        let adapter = ToolToExecutorAdapter::new(AlwaysDenyTool);
+        let result = adapter
+            .execute(&make_call("deny", json!({})))
+            .await
+            .expect("infra ok");
+        assert!(result.is_error);
+        // `ToolError::NotAuthorized` Display includes the inner message;
+        // downstream stderr / stdout scrapers can search for "sandbox".
+        assert!(
+            result.content.to_lowercase().contains("sandbox"),
+            "content was: {}",
+            result.content
+        );
+    }
+
+    #[tokio::test]
+    async fn req_dasclaw_runtime_adapter_context_is_shared_across_invocations() {
+        let adapter = ToolToExecutorAdapter::new(TextEchoTool);
+
+        // Mutate the context out-of-band; the next execute() must see it.
+        let ctx_handle = adapter.context();
+        {
+            let mut ctx = ctx_handle.lock().await;
+            ctx.set_metadata(json!({"workspace_root": "/tmp/test"}));
+        }
+
+        let result = adapter
+            .execute(&make_call("text_echo", json!({"text": "ok"})))
+            .await
+            .expect("infra ok");
+        assert!(!result.is_error);
+
+        let ctx = ctx_handle.lock().await;
+        assert_eq!(
+            ctx.metadata().get("workspace_root").and_then(Value::as_str),
+            Some("/tmp/test"),
+        );
+    }
+}


### PR DESCRIPTION
## 背景 / 目标

ADR-153 §1.1 A6 收尾任务（issue #868）要求**二进制层**的 sandbox default-deny e2e — 不通过 library seam 调用 `Agent::run`，而是让 `assert_cmd` 启动真二进制，与 wiremock 模拟的 OpenAI-compat 后端对话，由 macOS Seatbelt 实拒一次写盘。

走 **Z 路线**：与其在 CLI 里再写一个一次性的 shell-tool 适配器关闭 #868，不如先补框架层缺口（`dasclaw_runtime::Tool` 没有通往 `ToolExecutor` 的泛型桥），同时关闭 #868 并为未来所有 `Tool` impl（A7 wasm tool 等）开箱即用。

Closes #868。

## 改动范围

### `dasclaw_runtime`（框架层）
- 新增 `ToolToExecutorAdapter<T: Tool>`（`tool_to_executor_adapter.rs`，~320 行）：任意实现 `Tool` 的工具均可 `Arc::new(ToolToExecutorAdapter::new(my_tool))` 直接插入 Agent 的 `ToolExecutor` 链。共享 `JobContext` 使同一适配器内多次 `execute` 可见状态变化（符合 Tool 语义）。
- 新增 4 个单测：text-success / structured-success / tool-error → `is_error=true` / 跨调用共享 ctx
- 新增 blanket `impl ToolExecutor for std::sync::Arc<dyn ToolExecutor>`（agent.rs，~25 行），让适配器的 `Arc` 可直接进 `assemble_tool_executor` 累加器

### `dasclaw_cli`
- 新增 `--enable-shell-tool` flag（默认 off）
- 新增 `SHELL_TOOL_TIMEOUT = 120s` 常量
- 在 `assemble_tool_executor` 中新增一段 `if tools.enable_shell_tool` 分支：用 `SandboxedShellExecutor::new(timeout, false, None)` + `ShellTool::new().with_sandbox(...)` + `ToolToExecutorAdapter` 接入累加器（沿用 #871 引入的 `push_source` 模式，无补丁式追加）
- `dasclaw_shell_tools` 从 dev-dep 升为 prod dep；`assert_cmd = "2"` + `predicates = "3"` 加到 dev-deps

### `crates/dasclaw_cli/tests/cli_sandbox_default_deny_e2e.rs`（新 e2e，macOS-only，~200 行）
- `#![cfg(target_os = "macos")]`
- `BodySniffer` 用 `std::sync::Mutex`（非 tokio Mutex，因为 wiremock dispatcher 是 sync，`blocking_lock` 会 panic）
- 三重不变量钉死 fail-safe：
  1. `Command::cargo_bin("dasclaw-cli")` `.success()`（B 路线产品决策：tool error 不改 exit code）
  2. `!target.exists()`（Seatbelt 实拒写盘）
  3. 最后一次 `/chat/completions` 请求 body 含 `Operation not permitted` **或** `\"sandboxed\":true`（**且** `\"success\":false` / `exit_code`）→ 拒绝信号确实回到了 model loop

## 非目标（What's NOT in this PR）

- ❌ 不动旧版 library-seam 测试 `safety_sandbox_default_deny_e2e.rs`（控爆炸半径；它的 3 个用例与本 PR 互补，仍 3/3 通过）
- ❌ 不调整 `dasclaw-cli` 当前 exit-code = 0 的行为（issue #868 B 路线协商已锁，见 [评论](https://github.com/Linnanli/xClaw/issues/868#issuecomment-4545889205)）
- ❌ 不补 Linux/Windows 平台的对应 e2e（#481 平台矩阵跟踪）
- ❌ 不引入 WorkspaceWrite carve-out 测试（#870 已在 PR #873/Draft 处理）
- ❌ 不改 Agent 内部的 tool error 渲染策略

## 验证

```bash
$ cargo fmt --all                                          # clean
$ python3.12 scripts/check_no_panics.py --base origin/xClaw
OK: No panic-inducing calls in changed production code.

$ cargo clippy --no-deps -p dasclaw_cli --all-targets -- -D warnings      # clean
$ cargo clippy --no-deps -p dasclaw_runtime --all-targets -- -D warnings  # clean

$ cargo nextest run -p dasclaw_cli --test cli_sandbox_default_deny_e2e \
                                   --test safety_sandbox_default_deny_e2e
4 tests run: 4 passed, 0 skipped (5.275s)
  - cli_sandbox_default_deny_e2e: req_dasclaw_cli_a6_binary_sandbox_denies_write_under_read_only_policy
  - safety_sandbox_default_deny_e2e: 3 既有用例（denial_is_reported / denies_write / allows_read_only）

$ cargo nextest run -p dasclaw_runtime --lib   # 6 adapter + agent 单测
all pass (含 4 个 ToolToExecutorAdapter 新增用例)
```

## Skills review（三层管线）

| 层 | 严重 | 中等 | 处理 |
|---|---|---|---|
| code-quality-audit | 0 | 2 | 已修：`SandboxedShellExecutor::new` 参数加 inline 注释；e2e `denial_signal` 删宽松兜底 |
| code-simplifier    | 0 | 0 | 跟随 #871 引入的 `assemble_tool_executor + push_source` 模式，无新发明 |
| code-review-expert | 0 | 1 | 已修：e2e 用 `captured.last()` 替代 `captured[1]`，对 turn 1 重试鲁棒 |

**总判定**：放行。

## Cross-cuts

- **ADR-114 类 A**：fail-safe 写策略（kernel-level deny + structured tool result 双重信号）
- **ADR-153 §1.1 A6 / A7**：本 PR 走 A6，框架适配器对 A7 wasm tool 同样适用
- **ADR-129 §1.3** verbatim port：**不适用**（本 PR 是 x-claw 原创架构改进，可以简化/重构）

## Sources read

- `AGENTS.md` § Skills 强制使用规范、§ 完成清单、§ 复用优先于新建、§ 红线
- `.github/copilot-instructions.md`
- `docs/plans/architecture-refactor/adr-153-*.md` §1.1 A6
- `docs/plans/architecture-refactor/adr-114-*.md` 类 A（fail-safe）
- `crates/dasclaw_runtime/src/{agent.rs,composite_executor.rs,lib.rs}` 现有 `Tool` / `ToolExecutor` 接口
- `crates/dasclaw_shell_tools/src/lib.rs` ShellTool 名称/schema/默认 policy
- issue #868 全文 + comment-4545889205（B 路线协商共识）
- PR #871 引入的 `assemble_tool_executor + push_source` 模式（rebase 时采用之）

