### PR TITLE
fix(dasclaw_sandbox_linux): sync bwrap carve-out test with .dasclaw projection

### DIFF
--- a/crates/dasclaw_sandbox_linux/src/bwrap.rs
+++ b/crates/dasclaw_sandbox_linux/src/bwrap.rs
@@ -1431,6 +1431,15 @@ mod tests {
                 "--ro-bind".to_string(),
                 "/dev/null".to_string(),
                 "/.codex".to_string(),
+                // CODEX-DRIFT-IGNORE-START: dasclaw .dasclaw carve-out (#874, ADR-136 amendment 3)
+                // Symmetric carve-out for the dasclaw-native `.dasclaw`
+                // subpath. Projected right after `.codex` to mirror the
+                // protocol-layer subpath ordering emitted by
+                // `default_read_only_subpaths_for_writable_root`.
+                "--ro-bind".to_string(),
+                "/dev/null".to_string(),
+                "/.dasclaw".to_string(),
+                // CODEX-DRIFT-IGNORE-END
                 // Rebind /dev after the root bind so device nodes remain
                 // writable/usable inside the writable root.
                 "--bind".to_string(),

--- a/scripts/check_codex_linux_sandbox_drift.py
+++ b/scripts/check_codex_linux_sandbox_drift.py
@@ -81,6 +81,51 @@ SWAP_PATTERNS: list[tuple[re.Pattern[str], str]] = [
 _USE_RE = re.compile(r"^\s*use\s+")
 _ATTR_RE = re.compile(r"^\s*#\[")
 
+# Marker comments that delimit dasclaw-local extensions inside an otherwise
+# verbatim-ported file. Lines between a START / END pair are stripped before
+# hashing so they don't show up as drift. Mirrors the same machinery in
+# check_codex_protocol_drift.py (ADR-136 amendment 3 / #874 authorization).
+_DRIFT_IGNORE_START_RE = re.compile(r"^\s*//\s*CODEX-DRIFT-IGNORE-START\b")
+_DRIFT_IGNORE_END_RE = re.compile(r"^\s*//\s*CODEX-DRIFT-IGNORE-END\b")
+
+
+def _strip_drift_ignore_blocks(text: str, source_label: str) -> str:
+    """Remove lines between paired CODEX-DRIFT-IGNORE markers.
+
+    When a marker block is preceded by a blank line that exists solely to
+    separate the local extension from the upstream code above, that blank
+    line is also dropped so the surrounding whitespace matches upstream
+    after the block is removed.
+
+    Raises SystemExit if a START marker has no matching END (or vice
+    versa) so misuse fails loudly rather than silently widening the
+    exemption surface.
+    """
+    out: list[str] = []
+    skip = False
+    for lineno, line in enumerate(text.split("\n"), start=1):
+        if not skip and _DRIFT_IGNORE_START_RE.match(line):
+            if out and out[-1] == "":
+                out.pop()
+            skip = True
+            continue
+        if skip and _DRIFT_IGNORE_END_RE.match(line):
+            skip = False
+            continue
+        if not skip and _DRIFT_IGNORE_END_RE.match(line):
+            raise SystemExit(
+                f"ERROR: {source_label}:{lineno}: stray "
+                f"// CODEX-DRIFT-IGNORE-END without matching START"
+            )
+        if not skip:
+            out.append(line)
+    if skip:
+        raise SystemExit(
+            f"ERROR: {source_label}: unterminated // CODEX-DRIFT-IGNORE-START "
+            f"block; missing matching // CODEX-DRIFT-IGNORE-END"
+        )
+    return "\n".join(out)
+
 
 def _sort_use_blocks(text: str) -> str:
     """Sort consecutive `use ...;` lines alphabetically.
@@ -151,7 +196,8 @@ def _collapse_ws(text: str) -> str:
     return re.sub(r"\s+", " ", text).strip()
 
 
-def normalize_local(text: str) -> str:
+def normalize_local(text: str, source_label: str) -> str:
+    text = _strip_drift_ignore_blocks(text, source_label)
     for pat, repl in SWAP_PATTERNS:
         text = pat.sub(repl, text)
     return _collapse_ws(_sort_use_blocks(text))
@@ -173,7 +219,12 @@ def _check_pair(local: Path, upstream: Path, *, swap: bool) -> str | None:
         return f"upstream missing: {upstream.relative_to(REPO_ROOT)}"
     local_text = local.read_text(encoding="utf-8")
     upstream_text = upstream.read_text(encoding="utf-8")
-    local_norm = normalize_local(local_text) if swap else local_text
+    source_label = str(local.relative_to(REPO_ROOT))
+    local_norm = (
+        normalize_local(local_text, source_label)
+        if swap
+        else _strip_drift_ignore_blocks(local_text, source_label)
+    )
     upstream_norm = normalize_upstream(upstream_text) if swap else upstream_text
     if sha(local_norm) != sha(upstream_norm):
         suffix = (


### PR DESCRIPTION
## 背景

#874（ADR-136 amendment 3）在 `dasclaw_protocol::permissions::default_read_only_subpaths_for_writable_root` 里把 `.dasclaw/` 投影加入了 carve-out 列表（紧跟 `.codex` 之后），但没有同步 `dasclaw_sandbox_linux::bwrap` 里的 strict-eq 测试断言。结果 `mounts_dev_before_writable_dev_binds` 这条单元测试在 base 上就是红的，**每个下游 PR 的 Linux Tests gate 都被它挡住**，包括当前 in-flight 的 #879 和 #880。

这是 base broken，不是 #879 / #880 引入的问题，按 AGENTS.md "Base 分支既有 broken 测试处置规范" 单独发 fix PR 处理。

## 改动范围

仅两文件：

1. `crates/dasclaw_sandbox_linux/src/bwrap.rs` — 在 `mounts_dev_before_writable_dev_binds` 的 `assert_eq!` 期望 argv 中，紧跟 `/.codex` 之后插入对称的 `--ro-bind /dev/null /.dasclaw` 块，用 `// CODEX-DRIFT-IGNORE-START` / `// CODEX-DRIFT-IGNORE-END` 包裹（与 #874 在 `permissions.rs` 中的标记方式完全一致）。
2. `scripts/check_codex_linux_sandbox_drift.py` — 移植 `scripts/check_codex_protocol_drift.py` 已有的 `_strip_drift_ignore_blocks` 函数（机械搬运，逻辑一比一），使得 linux-sandbox drift guard 也能识别 IGNORE 块。未使用标记的文件行为不变。

## 不在本 PR 范围

- 不改任何生产代码（只改测试断言和 drift guard 脚本）
- 不改 Seatbelt / Landlock 后端（它们没有 strict-eq 形式的 carve-out 断言，未受影响——已 grep 确认）
- 不动 #879 / #880 自身——这两个 PR 在本 PR 合并后 rebase 即自动转绿

## 验证

```bash
python3.12 scripts/check_codex_linux_sandbox_drift.py
# OK: 9 src files + 1 root files match upstream verbatim.

cargo check -p dasclaw_sandbox_linux --tests
# Finished, no warnings.

cargo fmt --all && python3.12 scripts/check_no_panics.py --base origin/xClaw
# OK: No panic-inducing calls in changed production code.
```

`bwrap` 测试本身是 Linux-only，macOS 跑不了，靠 CI Linux runner 兜底。

## Cross-cuts

- **ADR-144**：verbatim drift guard。IGNORE 块的合法性由 ADR-136 amendment 3 / #874 在 `permissions.rs` 中已经先开了同款先例，本 PR 把同一机制延伸到 linux-sandbox 包，没有新概念。
- **ADR-136 amendment 3**：`.dasclaw` 子路径 carve-out 的完整闭环（protocol → sandbox 后端测试断言）。
- **ADR-114 class A**：无任何新增 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量。

## 引用

- Refs #879, #880 — 两个 PR 的 red 单测都是这条；本 PR 合后 rebase 即转绿
- Refs #874 — 提供 IGNORE 块先例并引入需要同步的 protocol 投影



Closes #888
