### PR TITLE
feat(dasclaw_cli): wire SafetyLayer::sanitize_for_stash as default tool-output sanitizer (#882)

### DIFF
--- a/crates/dasclaw_cli/Cargo.toml
+++ b/crates/dasclaw_cli/Cargo.toml
@@ -57,6 +57,15 @@ dasclaw_wasm_tools = { path = "../dasclaw_wasm_tools", optional = true }
 # enforces. Kept as a prod dep (not dev) because main.rs constructs
 # the tool at startup when the user passes the flag.
 dasclaw_shell_tools = { path = "../dasclaw_shell_tools" }
+# ADR-153 §1.1 B6 / e22 / issue #882: the binary defaults to wiring
+# `SafetyLayer::sanitize_for_stash` through the `ToolOutputSanitizer`
+# seam so the LLM never sees raw tool output that contains secrets.
+# The `sanitizer` module exposes `SafetyStashSanitizer` as the default
+# adapter; callers that want a different safety stack can still go
+# through `Agent::builder().tool_output_sanitizer(...)` directly. The
+# `egress-gate` feature is also what lets `IronclawEgressGate`
+# implement `dasclaw_core::EgressGate` for the e7–e16 hook tests.
+dasclaw_safety = { path = "../dasclaw_safety", features = ["egress-gate"] }
 anyhow = "1"
 clap = { version = "4", features = ["derive", "env"] }
 secrecy = "0.10"
@@ -69,15 +78,11 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dev-dependencies]
-# W6.1: egress-gate feature is what lets dasclaw_safety::IronclawEgressGate
-# implement dasclaw_core::EgressGate, which is the trait that test cases
-# e7–e16 (ADR-153-cli-test-matrix §1) inject through run_with_tools_and_hooks.
-# W6.5b B6: same crate also provides SafetyLayer::sanitize_for_stash, which is
-# wired into the agent loop via the ToolOutputSanitizer seam (e22).
-# Kept as dev-dependency: dasclaw_cli the library stays safety-stack-agnostic;
-# downstream callers wire their own HookBundle from whichever safety crate
-# they prefer.
-dasclaw_safety = { path = "../dasclaw_safety", features = ["egress-gate"] }
+# W6.1 e7–e16: the `egress-gate` feature is enabled via the production
+# dependency above. `dasclaw_safety` itself is now a `[dependencies]`
+# entry so the binary's default `SafetyStashSanitizer` can be wired
+# without forcing every downstream lib consumer to opt into the safety
+# stack. See the `[dependencies]` comment for the rationale.
 dasclaw_governance = { path = "../dasclaw_governance" }
 # W6.4 e11 (ADR-153 §1.1, A5 L1 path-escape) plus binary-level A6/e12
 # (#868): `dasclaw_workspace_cap` is now a runtime dep (see

--- a/crates/dasclaw_cli/src/lib.rs
+++ b/crates/dasclaw_cli/src/lib.rs
@@ -39,6 +39,17 @@
 //! sandbox, audit). This is the single point at which the 9-layer
 //! defence stack from `13-security-capability-inventory.md` can be
 //! opted-in from a headless caller.
+//!
+//! ## Default tool-output sanitization (ADR-153 §1.1 B6 / e22 / #882)
+//!
+//! See [`run_with_tools_and_safety_sanitizer`] for the entry the
+//! shipped binary uses by default. It wires
+//! [`sanitizer::SafetyStashSanitizer`] through
+//! [`dasclaw_runtime::ToolOutputSanitizer`] so `tool_result` payloads
+//! are redacted **before** the next LLM call observes them. The plain
+//! [`run_with_tools`] entry stays as the no-sanitizer escape hatch so
+//! the e22 negative-control test can still pin the runtime's
+//! forward-verbatim contract.
 
 use std::sync::Mutex;
 
@@ -53,6 +64,7 @@ use dasclaw_runtime::{Agent, AgentError, AgentResponder, ToolExecutor};
 pub mod mcp;
 pub mod provider;
 pub mod sandbox_exec;
+pub mod sanitizer;
 pub mod tools;
 #[cfg(feature = "wasm-tools")]
 pub mod wasm;
@@ -153,6 +165,44 @@ where
         .tool_executor(tool_executor)
         .tools(tool_definitions)
         .hooks(hooks)
+        .system_prompt(system_prompt)
+        .build()
+        .map_err(|e| CliError::Build(e.to_string()))?;
+    let reply = agent.run(user_prompt).await?;
+    Ok(reply)
+}
+
+/// Variant of [`run_with_tools`] that wires the default
+/// [`sanitizer::SafetyStashSanitizer`] before handing tool output back
+/// to the LLM (ADR-153 §1.1 B6 / e22 / issue #882).
+///
+/// This is the entry the binary now uses for tool-enabled runs, so the
+/// shipped `dasclaw-cli` never feeds raw tool output to a model. The
+/// existing [`run_with_tools`] entry stays byte-for-byte stable so
+/// downstream callers that want **no** sanitizer (the verbatim
+/// `tool_result` contract checked by the e22 negative-control test) can
+/// still opt in by routing through the original signature.
+///
+/// Like [`run_with_tools_and_hooks`], this is a separate entry rather
+/// than an optional parameter. The CLI's `run_*` family has standardised
+/// on additive entries so each new capability adds one well-typed path
+/// instead of growing a combinatorial signature.
+pub async fn run_with_tools_and_safety_sanitizer<R, E>(
+    responder: R,
+    tool_executor: E,
+    tool_definitions: Vec<ToolDefinition>,
+    system_prompt: &str,
+    user_prompt: &str,
+) -> Result<String, CliError>
+where
+    R: AgentResponder + 'static,
+    E: ToolExecutor + 'static,
+{
+    let agent: Agent = Agent::builder()
+        .responder(responder)
+        .tool_executor(tool_executor)
+        .tools(tool_definitions)
+        .tool_output_sanitizer_arc(sanitizer::default_safety_sanitizer())
         .system_prompt(system_prompt)
         .build()
         .map_err(|e| CliError::Build(e.to_string()))?;

--- a/crates/dasclaw_cli/src/main.rs
+++ b/crates/dasclaw_cli/src/main.rs
@@ -28,7 +28,7 @@ use dasclaw_cli::mcp::load_executor as load_mcp_executor;
 use dasclaw_cli::provider::{ProviderArgs, build_responder};
 use dasclaw_cli::sandbox_exec::run_sandbox_exec;
 use dasclaw_cli::tools::default_builtins;
-use dasclaw_cli::{EchoResponder, run, run_with_tools};
+use dasclaw_cli::{EchoResponder, run, run_with_tools_and_safety_sanitizer};
 use dasclaw_core::messages::ToolDefinition;
 use dasclaw_runtime::{CompositeToolExecutor, Tool, ToolExecutor, ToolToExecutorAdapter};
 use dasclaw_shell_tools::{SandboxedShellExecutor, ShellTool};
@@ -160,11 +160,15 @@ async fn real_main() -> Result<()> {
                 None => run(responder, &cli.system, prompt.trim())
                     .await
                     .context("LLM agent run failed")?,
-                Some((executor, definitions)) => {
-                    run_with_tools(responder, executor, definitions, &cli.system, prompt.trim())
-                        .await
-                        .context("LLM agent (with tools) run failed")?
-                }
+                Some((executor, definitions)) => run_with_tools_and_safety_sanitizer(
+                    responder,
+                    executor,
+                    definitions,
+                    &cli.system,
+                    prompt.trim(),
+                )
+                .await
+                .context("LLM agent (with tools) run failed")?,
             }
         }
     };

--- a/crates/dasclaw_cli/src/sanitizer.rs
+++ b/crates/dasclaw_cli/src/sanitizer.rs
@@ -1,0 +1,113 @@
+//! Default `ToolOutputSanitizer` adapter for the headless CLI.
+//!
+//! ADR-153 §1.1 B6 / e22 wiring (issue #882). `dasclaw_runtime` keeps
+//! its `ToolOutputSanitizer` trait safety-stack-agnostic; this module
+//! is where the CLI binary picks a concrete safety stack — currently
+//! [`dasclaw_safety::SafetyLayer::sanitize_for_stash`], the same
+//! redact-only path the legacy ironclaw loop calls before stashing
+//! tool output. The seam matches the legacy contract byte-for-byte:
+//! leak detection + policy enforcement, **no length capping**
+//! (`cap_for_llm` is a separate concern and is not wired here).
+//!
+//! Downstream lib consumers that want a different safety stack should
+//! reach for [`dasclaw_runtime::Agent::builder`] directly with their
+//! own `ToolOutputSanitizer` impl — this module is the binary's
+//! default, not a forced choice.
+
+use std::sync::Arc;
+
+use dasclaw_runtime::ToolOutputSanitizer;
+use dasclaw_safety::{SafetyConfig, SafetyLayer};
+
+/// Adapter that delegates to [`SafetyLayer::sanitize_for_stash`].
+///
+/// Cheap to clone (the inner [`SafetyLayer`] is held by [`Arc`]) so the
+/// same instance can be shared across the agent loop and the egress
+/// gate without re-initialising the leak-detector regex set on every
+/// tool invocation.
+pub struct SafetyStashSanitizer {
+    layer: Arc<SafetyLayer>,
+}
+
+impl SafetyStashSanitizer {
+    /// Wrap an existing [`SafetyLayer`] so it can be installed via
+    /// [`dasclaw_runtime::AgentBuilder::tool_output_sanitizer`]. Callers
+    /// that already hold a shared `Arc<SafetyLayer>` (e.g. because the
+    /// same layer powers their `EgressGate`) should prefer this entry
+    /// so leak-pattern compilation happens exactly once per process.
+    pub fn new(layer: Arc<SafetyLayer>) -> Self {
+        Self { layer }
+    }
+}
+
+impl ToolOutputSanitizer for SafetyStashSanitizer {
+    fn sanitize(&self, tool_name: &str, content: &str) -> String {
+        self.layer.sanitize_for_stash(tool_name, content).content
+    }
+}
+
+/// Build the binary's default `ToolOutputSanitizer`.
+///
+/// Uses the same [`SafetyConfig`] values as the desktop client's
+/// production wiring (`max_output_length = 100_000`,
+/// `injection_check_enabled = true`) so the redact-only path here stays
+/// consistent with the parallel ironclaw loop. `max_output_length` is
+/// only consulted by `cap_for_llm` and is irrelevant to
+/// `sanitize_for_stash`, but it is plumbed through anyway to keep the
+/// config single-source-of-truth for the day someone wires capping at
+/// this seam too.
+pub fn default_safety_sanitizer() -> Arc<dyn ToolOutputSanitizer> {
+    let layer = Arc::new(SafetyLayer::new(&SafetyConfig {
+        max_output_length: 100_000,
+        injection_check_enabled: true,
+    }));
+    Arc::new(SafetyStashSanitizer::new(layer))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sanitizer_redacts_bearer_token_in_tool_output() {
+        let sanitizer = default_safety_sanitizer();
+        let raw = "found credential: Bearer abcdef0123456789ABCDEFXYZ (please rotate)";
+        let out = sanitizer.sanitize("read_file", raw);
+        assert!(
+            !out.contains("Bearer abcdef0123456789ABCDEFXYZ"),
+            "raw token leaked through default sanitizer: {out}"
+        );
+        assert!(
+            out.contains("[REDACTED]"),
+            "expected `[REDACTED]` marker in sanitized output, got {out}"
+        );
+        assert!(
+            out.contains("please rotate"),
+            "non-secret context must survive redaction: {out}"
+        );
+    }
+
+    #[test]
+    fn sanitizer_passes_clean_output_through_unchanged() {
+        let sanitizer = default_safety_sanitizer();
+        let raw = "ok: 42 rows scanned";
+        assert_eq!(sanitizer.sanitize("query", raw), raw);
+    }
+
+    #[test]
+    fn shared_layer_is_reused_across_calls() {
+        let layer = Arc::new(SafetyLayer::new(&SafetyConfig {
+            max_output_length: 100_000,
+            injection_check_enabled: false,
+        }));
+        let sanitizer = SafetyStashSanitizer::new(Arc::clone(&layer));
+        // Two back-to-back calls share the same underlying layer; the
+        // test passes simply by virtue of compiling + not panicking,
+        // but also pins the redact-on-second-call behaviour so a
+        // future refactor that caches per-call state would surface.
+        let first = sanitizer.sanitize("a", "Bearer abcdef0123456789ABCDEFXYZ");
+        let second = sanitizer.sanitize("b", "Bearer abcdef0123456789ABCDEFXYZ");
+        assert_eq!(first, second);
+        assert!(first.contains("[REDACTED]"));
+    }
+}

--- a/crates/dasclaw_cli/tests/agent_large_tool_output_e2e.rs
+++ b/crates/dasclaw_cli/tests/agent_large_tool_output_e2e.rs
@@ -4,36 +4,25 @@
 //! is the redacted payload — not the raw secret returned by the tool.
 //!
 //! The test deliberately runs the **full** runtime → safety chain. It
-//! does **not** mock `sanitize_for_stash`; it constructs a real
-//! `SafetyLayer` with the default leak-detector and asserts the
-//! conversation snapshot taken by a capturing responder on iteration 2.
+//! does **not** mock `sanitize_for_stash`; it pulls the
+//! `SafetyStashSanitizer` adapter that the CLI binary uses by default
+//! (`dasclaw_cli::sanitizer`, ADR-153 §1.1 B6 / issue #882) so the
+//! test path stays byte-for-byte aligned with the production wiring.
 
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
+use dasclaw_cli::sanitizer::SafetyStashSanitizer;
 use dasclaw_core::messages::{
     ChatMessage, FinishReason, Role, ToolCall, ToolDefinition, ToolResult,
 };
 use dasclaw_core::reasoning_ctx::ReasoningContext;
 use dasclaw_core::response_types::{RespondOutput, RespondResult, ResponseMetadata, TokenUsage};
 use dasclaw_core::traits::HostError;
-use dasclaw_runtime::{Agent, AgentResponder, ToolExecutor, ToolOutputSanitizer};
+use dasclaw_runtime::{Agent, AgentResponder, ToolExecutor};
 use dasclaw_safety::{SafetyConfig, SafetyLayer};
 use serde_json::json;
-
-/// Adapter wiring `SafetyLayer::sanitize_for_stash` (redact-only, no
-/// length cap) into the `ToolOutputSanitizer` seam. Lives in the test
-/// because `dasclaw_runtime` stays safety-stack-agnostic by design.
-struct SafetyStashSanitizer {
-    layer: Arc<SafetyLayer>,
-}
-
-impl ToolOutputSanitizer for SafetyStashSanitizer {
-    fn sanitize(&self, tool_name: &str, content: &str) -> String {
-        self.layer.sanitize_for_stash(tool_name, content).content
-    }
-}
 
 /// Responder that **captures** `ctx.messages.clone()` on every call
 /// before popping a scripted reply. Lets the test assert what the LLM
@@ -155,9 +144,7 @@ async fn req_dasclaw_cli_loop_e22_tool_output_redacted_before_next_llm_call() {
         max_output_length: 65_536,
         injection_check_enabled: false,
     }));
-    let sanitizer = SafetyStashSanitizer {
-        layer: Arc::clone(&safety),
-    };
+    let sanitizer = SafetyStashSanitizer::new(Arc::clone(&safety));
 
     let agent = Agent::builder()
         .responder_arc(responder.clone())

--- a/crates/dasclaw_runtime/src/agent.rs
+++ b/crates/dasclaw_runtime/src/agent.rs
@@ -111,7 +111,10 @@ impl ToolExecutor for std::sync::Arc<dyn ToolExecutor> {
 /// its `tool_result` block. Implementations typically delegate to a
 /// safety crate (e.g. `dasclaw_safety::SafetyLayer::sanitize_for_stash`),
 /// but the runtime stays safety-stack-agnostic: any `Fn`-like wrapper
-/// works as long as it returns the post-redaction string.
+/// works as long as it returns the post-redaction string. The production
+/// binding is provided by `dasclaw_cli::run_with_tools_and_safety_sanitizer`
+/// (issue #882), which installs the safety-layer-backed adapter as the
+/// default for the CLI agent loop.
 ///
 /// When no sanitizer is wired (the default), tool output is forwarded
 /// to the LLM **verbatim**. The trait is sync because production
@@ -474,8 +477,10 @@ impl LoopDelegate for HeadlessDelegate {
             };
 
             // ADR-153 §1.1 e22/B6: chain a second sanitizer seam after the
-            // egress gate. Callers can inject SafetyLayer::sanitize_for_stash
-            // (or any other strategy) without touching the hook stack.
+            // egress gate. Production default is bound by
+            // `dasclaw_cli::run_with_tools_and_safety_sanitizer` (issue #882),
+            // which wraps `SafetyLayer::sanitize_for_stash`; alternative
+            // strategies can be injected without touching the hook stack.
             let pushed_content = match self.tool_output_sanitizer.as_ref() {
                 Some(sanitizer) => sanitizer.sanitize(&result.name, &post_gate_content),
                 None => post_gate_content,

--- a/docs/plans/architecture-refactor/adr-153-cli-test-matrix.md
+++ b/docs/plans/architecture-refactor/adr-153-cli-test-matrix.md
@@ -200,6 +200,7 @@ python3.12 scripts/check_no_panics.py --base origin/xClaw
   - **2026-05-25 修订**：`crates/dasclaw_wasm_tools/tests/fixtures/minimal_http_component/` 下已存在 `dasclaw_wasm_tools_fixture_minimal_http.wasm`，fixture 阻塞已解除。CLI 侧已存在 `safety_wasm_capability_optin_e2e.rs` 及三个相关 capability 测试文件。剩余工作（核对是否真用了 fixture、是否跑通）已开 issue #883 跟踪。R2 状态：**fixture 已就绪，落地核对追踪中**。
 - **R3**：B6 大 payload 测试需要确认 `dasclaw_runtime` 是否真的把 `sanitize_for_stash` 接到回路。
   - **2026-05-25 修订**：`rg sanitize_for_stash crates/dasclaw_runtime/` 仅命中 `agent.rs:97,462` 两处注释，原文是"调用方可以注入"——runtime 默认回路**未接线**。B6/e22 测试是靠测试侧手动注入 SafetyLayer 才过。已开 issue #882 跟踪 runtime 默认接线工作。R3 状态：**未接线，issue 跟踪中**。
+  - **2026-05-26 修订**：issue #882 已交付。runtime 维持 safety-stack-agnostic（不新增 `dasclaw_safety` 依赖），由 `crates/dasclaw_cli` 提供 `sanitizer::SafetyStashSanitizer` 适配器 + `run_with_tools_and_safety_sanitizer` 入口（CLI 二进制 Run 路径默认走该入口），把 `SafetyLayer::sanitize_for_stash` 装到 `AgentBuilder::tool_output_sanitizer_arc` 上。e22 正测试改为通过 `dasclaw_cli::sanitizer::SafetyStashSanitizer` 走生产路径，反向 baseline 保持不变以钉住 runtime 默认 verbatim 语义。R3 状态：**已交付**。
 - **R4**：所有 P0 case 都依赖 G1 改造。G1 改造若用 builder pattern，会牵动现有 `tool_e2e.rs` / `mcp_e2e.rs` 的调用形式；改 API 时**保持 `run` / `run_with_tools` 兼容签名不动**，新增 `run_with_hooks`，避免连锁炸现有 e1–e6。
   - **2026-05-25 修订**：G1 已通过 `crates/dasclaw_cli/tests/run_with_hooks_wiring.rs` 完成接线，e1–e6 未受影响。R4 状态：**已交付**。
 
@@ -211,7 +212,7 @@ python3.12 scripts/check_no_panics.py --base origin/xClaw
 | A10 | #884 | egress audit log e2e |
 | B9 | #885 | agent cancel 语义 |
 | B10 | #886 | stdio + HTTP MCP merge |
-| §5 R3 接线 | #882 | runtime 默认接 `sanitize_for_stash` |
+| §5 R3 接线 | #882 | runtime 默认接 `sanitize_for_stash`（**已交付**：CLI 层 `run_with_tools_and_safety_sanitizer` 默认装载） |
 
 ---
 


### PR DESCRIPTION
Closes #882.

## 背景 / 目标

ADR-153 §5 R3 指出 `dasclaw_runtime` 的 `ToolOutputSanitizer` trait 在 runtime 默认回路上**未接线**——e22 仅靠测试侧手动注入 `SafetyLayer` 才过。本 PR 在 `dasclaw_cli` 层落地生产默认接线（**方案 B**：runtime 保持 safety-stack-agnostic，CLI 负责装载）。

## 改动范围

- **`crates/dasclaw_cli/Cargo.toml`**：`dasclaw_safety` 从 `[dev-dependencies]` 提升到 `[dependencies]`，启用 `egress-gate` feature。
- **`crates/dasclaw_cli/src/sanitizer.rs`（新增）**：
  - `SafetyStashSanitizer { layer: Arc<SafetyLayer> }`：`ToolOutputSanitizer` 适配器，body 仅做 `self.layer.sanitize_for_stash(...).content`。
  - `default_safety_sanitizer() -> Arc<dyn ToolOutputSanitizer>`：用 desktop-client 同款 `SafetyConfig { max_output_length: 100_000, injection_check_enabled: true }` 构造 `SafetyLayer`，包成共享 `Arc`。
  - 3 个单元测试：Bearer token 被 redact、clean 输出原样透传、共享 layer 跨调用稳定。
- **`crates/dasclaw_cli/src/lib.rs`**：
  - 注册 `pub mod sanitizer;`。
  - 新增 `run_with_tools_and_safety_sanitizer`，链上 `.tool_output_sanitizer_arc(sanitizer::default_safety_sanitizer())`。**与 `run_with_tools_and_hooks` 同形**——additive 入口而非给 `run_with_tools` 加 optional 参数，避免补丁式签名爆炸。doc 显式声明该政策。
- **`crates/dasclaw_cli/src/main.rs`**：Run 路径默认走新入口；Echo 路径保持 `run`。
- **`crates/dasclaw_cli/tests/agent_large_tool_output_e2e.rs`**：删除本地 duplicate `SafetyStashSanitizer`，改用 lib 版导入，正测从 e22 走真实生产路径；反向 `_no_sanitizer_forwards_verbatim_baseline` 保持不变，钉住 runtime 默认 verbatim 语义。
- **`crates/dasclaw_runtime/src/agent.rs`**：仅注释更新（trait doc + builder field doc），指向 CLI 默认接线点。**无 API 改动、无新增依赖**。
- **`docs/plans/architecture-refactor/adr-153-cli-test-matrix.md`**：§5 R3 + §5.1 #882 行标 `已交付`。

## 非目标（What's NOT in this PR）

- 不改 `dasclaw_runtime` 公共 API。
- 不在 `dasclaw_runtime` 引入对 `dasclaw_safety` 的依赖（保持 safety-stack-agnostic）。
- 不接 `cap_for_llm`（capping 与 `sanitize_for_stash` 是独立关注点，见 ADR-153 §1.1 e22/B6 注释）。
- 不动 legacy ironclaw 路径。
- 不在 `run_with_tools` 上加 optional sanitizer 参数（additive 入口政策）。

## 验证

本地 scope-local（完整由 CI 兜底）：

\`\`\`bash
cargo check -p dasclaw_cli --tests              # 通过
cargo nextest run -p dasclaw_cli \
  -E 'test(agent_large_tool_output) | test(sanitizer)'   # 4 passed
cargo nextest run -p dasclaw_cli \
  --test agent_large_tool_output_e2e           # 2/2 passed (正测 + verbatim baseline)
cargo fmt --all                                # 通过
python3.12 scripts/check_no_panics.py --base origin/xClaw   # OK
cargo clippy --no-deps -p dasclaw_cli --all-targets -- -D warnings  # 通过
\`\`\`

## Cross-cuts

不涉及（无新增 \`.ironclaw\` / \`IRONCLAW_BASE_DIR\` 字面量；grep guard 自动 PASS）。

## 3 层审查

- **code-quality-audit**：无补丁式（additive 入口 + doc 声明）、无 `unwrap`/`expect`/`panic!`（check_no_panics PASS）、函数 < 50 行、嵌套 ≤ 2 层。
- **adr-compliance-check**：ADR-153 §5 R3 已交付；ADR-148 边界保持（sanitizer 在 egress gate **之后**跑，不替代 egress gate）；ADR-114 无新增字面量；ADR-129 verbatim 红线不适用（本 PR 不是 verbatim port）。
- **code-review-expert**：SRP 单一职责（sanitizer.rs 仅做适配器）；DI 注入式（`Arc<dyn ToolOutputSanitizer>` 可替换）；安全默认开启 leak detection；runtime 仍 safety-agnostic，无逆向依赖。