### PR TITLE
ci(coverage): add lean dasclaw-core coverage job

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -256,6 +256,12 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: llvm-tools-preview
+          # The dasclaw_wasm_tools build script compiles a wasm32-wasip2
+          # fixture component (see crates/dasclaw_wasm_tools/build.rs +
+          # tests/fixtures/minimal_http_component/). Without this target the
+          # wasm_tools crate (which dasclaw_runtime/cli/safety transitively
+          # link in tests) fails with E0463 "can't find crate for `core`".
+          targets: wasm32-wasip2
 
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -30,6 +30,13 @@ name: Code Coverage
 on:
   push:
     branches: [xClaw]
+  pull_request:
+    branches: [xClaw]
+    paths:
+      - 'crates/dasclaw_cli/**'
+      - 'crates/dasclaw_safety/**'
+      - 'crates/dasclaw_runtime/**'
+      - '.github/workflows/coverage.yml'
 
 concurrency:
   group: coverage-${{ github.workflow }}-${{ github.ref }}
@@ -234,14 +241,82 @@ jobs:
           path: tests/e2e/screenshots/
           if-no-files-found: ignore
 
+  coverage-dasclaw-core:
+    # Lean coverage job for the xClaw fork's headless crates. Bypasses the
+    # WASM channel build and PostgreSQL service that gate the legacy
+    # ironclaw-flavored jobs above (which remain `if: false` until the
+    # `scripts/build-wasm-extensions.sh` script returns to the xClaw root).
+    # Scoped to the three crates that ADR-153 §1.1 + §2.1 cover end-to-end.
+    name: Coverage (dasclaw-core lean)
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: coverage-dasclaw-core
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@nextest
+
+      - name: Generate coverage
+        run: |
+          cargo llvm-cov nextest \
+            -p dasclaw_cli \
+            -p dasclaw_safety \
+            -p dasclaw_runtime \
+            --lcov --output-path lcov-dasclaw-core.info
+
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: lcov-dasclaw-core.info
+          flags: dasclaw-core
+          disable_search: true
+          use_oidc: true
+          # Soft-fail on Codecov upload: the artifact itself is the source of
+          # truth for the gate; Codecov outage should not block the merge
+          # train. The artifact upload below preserves the lcov for review.
+          fail_ci_if_error: false
+
+      - name: Upload lcov artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: lcov-dasclaw-core
+          path: lcov-dasclaw-core.info
+          if-no-files-found: error
+
   coverage-gate:
     name: Coverage
     runs-on: ubuntu-latest
     if: always()
-    needs: [coverage, e2e-coverage]
+    needs: [coverage, e2e-coverage, coverage-dasclaw-core]
     steps:
-      - run: |
-          if [[ "${{ needs.coverage.result }}" != "success" || "${{ needs.e2e-coverage.result }}" != "success" ]]; then
-            echo "One or more coverage jobs failed"
-            exit 1
+      - name: Evaluate coverage results
+        run: |
+          # Legacy `coverage` / `e2e-coverage` jobs are intentionally disabled
+          # in the xClaw fork (see `if: false` guards above). Treat their
+          # `skipped` result as acceptable, but still hard-fail on any real
+          # failure. The lean `coverage-dasclaw-core` job is mandatory.
+          set -euo pipefail
+          fail=0
+          if [[ "${{ needs.coverage-dasclaw-core.result }}" != "success" ]]; then
+            echo "coverage-dasclaw-core failed: ${{ needs.coverage-dasclaw-core.result }}"
+            fail=1
           fi
+          for r in "${{ needs.coverage.result }}" "${{ needs.e2e-coverage.result }}"; do
+            if [[ "$r" != "success" && "$r" != "skipped" ]]; then
+              echo "Legacy coverage job in unexpected state: $r"
+              fail=1
+            fi
+          done
+          exit $fail


### PR DESCRIPTION
## 背景

子 agent 审计报告（见上下文）发现：[.github/workflows/coverage.yml](.github/workflows/coverage.yml) 的两个 job (`coverage`、`e2e-coverage`) 都被 `if: false` 整体关停，原因是它们调用了 `./scripts/build-wasm-extensions.sh`，该脚本在 xClaw fork 根目录不存在。`coverage-gate` 又硬性要求两者都是 `success`，于是 **xClaw 每次 push 都失败、且没有任何覆盖率数字产出**。

ADR-153 §1.1 + §2.1 已经把 `dasclaw_cli` / `dasclaw_safety` / `dasclaw_runtime` 这条主链路用 e2e 覆盖到位，但我们看不到具体覆盖了多少。

## 改动

新增一个 **lean coverage job** `coverage-dasclaw-core`：

```yaml
cargo llvm-cov nextest \
  -p dasclaw_cli \
  -p dasclaw_safety \
  -p dasclaw_runtime \
  --lcov --output-path lcov-dasclaw-core.info
```

- 不走 WASM 构建路径、不需要 PostgreSQL、不跑 Playwright
- 通过 `taiki-e/install-action@cargo-llvm-cov` + `@nextest` 安装工具链
- 上传 Codecov，flag `dasclaw-core`，`fail_ci_if_error: false`（Codecov 故障不阻塞合并）
- 同时上传 `lcov-dasclaw-core.info` 作为 workflow artifact（这个是 `if-no-files-found: error` 硬要求）

`coverage-gate` 调整为：
- 对 legacy `coverage` / `e2e-coverage` 的 `skipped` 结果宽容
- 新 lean job 必须是 `success`

PR trigger 新增 `pull_request`（paths 限定到三个相关 crate + 本 workflow），让 PR 也能看到覆盖率数字。

## 非目标

- 不复活 legacy `coverage` / `e2e-coverage` matrix（那是 ironclaw 流派的 WASM channels 路径，独立 PR）
- 不引入覆盖率 threshold gate（先有数字，再谈门槛）
- 不动 Rust 源码

## 验证

- ✅ YAML 语法：`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/coverage.yml'))"` → `YAML OK`
- ✅ 本地无 Rust 改动，不跑 cargo
- ⏳ CI 上 `coverage-dasclaw-core` job 第一次跑会产出 lcov-dasclaw-core artifact + Codecov 上传

## Sources read

- `.github/workflows/coverage.yml` § 全文 247 行
- `docs/plans/architecture-refactor/adr-153-cli-test-matrix.md` § §1.1 / §2.1（确认这三个 crate 是 e2e 矩阵主链路）
- `AGENTS.md` § Skills 强制使用规范、§ 完成后纪律

## Skills 自查

本 PR 改动是单文件 YAML（85 行 diff），无 Rust 源码，code-quality-audit / code-simplifier / code-review-expert 三层 skills 主要面向 Rust 实现，不直接适用；手工核对：
- ✅ 无补丁式代码（YAML 是结构化新增 job + 改 gate 逻辑，非"if 分支追加"）
- ✅ 无 `unwrap` / `expect` / `panic`
- ✅ 评论密度合适，解释了"为什么 lean job"、"为什么 fail_ci_if_error: false"、"为什么 gate 宽容 skipped"
- ✅ Codecov flag 命名 `dasclaw-core` 与 ADR-153 命名空间一致

属于"建议 ①"（救覆盖率 workflow）。后续 PR2 (GUI-only 盲区集成测试) + PR3 (fuzz nightly + insta) 同一线索。



Closes #900
