### PR TITLE
ci(fuzz)+test(dasclaw_cli): nightly fuzz workflow + insta snapshot baseline

### DIFF
--- a/.github/workflows/fuzz-smoke.yml
+++ b/.github/workflows/fuzz-smoke.yml
@@ -1,0 +1,113 @@
+# Nightly fuzz smoke workflow (PR3).
+#
+# Runs every cargo-fuzz target in this fork for a short bounded duration
+# so regressions in the safety/tools parsers surface within 24h instead of
+# waiting for an opportunistic manual run.
+#
+# Scope:
+#   - crates/dasclaw_safety/fuzz/ (5 targets)
+#   - desktop-client/ironclaw/fuzz/ (1 target)
+#
+# This workflow is NOT wired into PR gates or `coverage-gate`. It runs
+# nightly on schedule and on manual dispatch only. Per-step failures do
+# not fail the whole job — corpus artifacts are uploaded for triage.
+#
+# Budget: 6 targets × 60s ≈ 6 min total runtime, well under the 30 min cap.
+
+name: Fuzz Smoke (nightly)
+
+on:
+  schedule:
+    # 06:00 UTC daily (~14:00 CST / 23:00 PT)
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: fuzz-smoke-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  fuzz-smoke:
+    name: Fuzz smoke (libfuzzer, bounded)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust nightly
+        uses: dtolnay/rust-toolchain@nightly
+
+      - name: Install cargo-fuzz
+        run: cargo install cargo-fuzz --locked
+
+      - name: Run dasclaw_safety fuzz targets
+        id: safety_fuzz
+        continue-on-error: true
+        working-directory: crates/dasclaw_safety/fuzz
+        run: |
+          set +e
+          failed=0
+          for target in fuzz_config_env fuzz_credential_detect fuzz_leak_detector fuzz_safety_sanitizer fuzz_safety_validator; do
+            echo "::group::dasclaw_safety :: $target"
+            cargo fuzz run "$target" -- -runs=10000 -max_total_time=60
+            rc=$?
+            echo "::endgroup::"
+            if [ "$rc" -ne 0 ]; then
+              echo "FAIL: dasclaw_safety/$target (exit $rc)"
+              failed=1
+            fi
+          done
+          exit "$failed"
+
+      - name: Run ironclaw fuzz targets
+        id: ironclaw_fuzz
+        continue-on-error: true
+        working-directory: desktop-client/ironclaw/fuzz
+        run: |
+          set +e
+          failed=0
+          for target in fuzz_tool_params; do
+            echo "::group::ironclaw :: $target"
+            cargo fuzz run "$target" -- -runs=10000 -max_total_time=60
+            rc=$?
+            echo "::endgroup::"
+            if [ "$rc" -ne 0 ]; then
+              echo "FAIL: ironclaw/$target (exit $rc)"
+              failed=1
+            fi
+          done
+          exit "$failed"
+
+      - name: Upload dasclaw_safety crash artifacts (on failure)
+        if: steps.safety_fuzz.outcome == 'failure'
+        uses: actions/upload-artifact@v4
+        with:
+          name: fuzz-artifacts-dasclaw_safety
+          path: crates/dasclaw_safety/fuzz/artifacts/**
+          if-no-files-found: ignore
+          retention-days: 14
+
+      - name: Upload ironclaw crash artifacts (on failure)
+        if: steps.ironclaw_fuzz.outcome == 'failure'
+        uses: actions/upload-artifact@v4
+        with:
+          name: fuzz-artifacts-ironclaw
+          path: desktop-client/ironclaw/fuzz/artifacts/**
+          if-no-files-found: ignore
+          retention-days: 14
+
+      - name: Summarize fuzz run
+        if: always()
+        run: |
+          echo "## Fuzz smoke summary" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- dasclaw_safety: ${{ steps.safety_fuzz.outcome }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- ironclaw: ${{ steps.ironclaw_fuzz.outcome }}" >> "$GITHUB_STEP_SUMMARY"
+          if [ "${{ steps.safety_fuzz.outcome }}" = "failure" ] || [ "${{ steps.ironclaw_fuzz.outcome }}" = "failure" ]; then
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "One or more fuzz targets failed. See uploaded \`fuzz-artifacts-*\` for crash corpora." >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2889,6 +2889,7 @@ dependencies = [
  "dasclaw_tool",
  "dasclaw_wasm_tools",
  "dasclaw_workspace_cap",
+ "insta",
  "predicates",
  "secrecy",
  "serde",

--- a/crates/dasclaw_cli/Cargo.toml
+++ b/crates/dasclaw_cli/Cargo.toml
@@ -111,3 +111,9 @@ predicates = "3"
 tempfile = "3"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "test-util", "sync"] }
 wiremock = "0.6"
+# PR3 demo: insta snapshot testing. One demo test in
+# tests/insta_snapshot_demo_e2e.rs pins the `dasclaw-cli --help` output so
+# unintended CLI surface drift surfaces as a snapshot diff. Other tests
+# can opt in by adding their own `insta::assert_snapshot!(...)` calls and
+# committing the generated `tests/snapshots/*.snap` baseline.
+insta = "1.46.3"

--- a/crates/dasclaw_cli/tests/insta_snapshot_demo_e2e.rs
+++ b/crates/dasclaw_cli/tests/insta_snapshot_demo_e2e.rs
@@ -1,0 +1,57 @@
+//! PR3 demo: `insta` snapshot test for `dasclaw-cli --help`.
+//!
+//! Purpose
+//! -------
+//! Establish a working insta baseline in the dasclaw_cli crate so the rest
+//! of the team has a concrete template for adding snapshot assertions
+//! (e.g. CLI surface, structured JSON outputs, error messages).
+//!
+//! What this pins
+//! --------------
+//! The exact stdout of `dasclaw-cli --help`. Clap-derived help text is
+//! deterministic across builds: argument order, flag names, default
+//! values, and the description strings all flow from `#[derive(Parser)]`
+//! attributes in `src/main.rs` / argument modules. Any of the following
+//! will fail the snapshot:
+//!
+//!   - a new top-level flag / subcommand
+//!   - renaming an existing flag
+//!   - editing a `#[arg(help = "...")]` doc string
+//!   - clap major version bump that reformats the help layout
+//!
+//! Updating the baseline
+//! ---------------------
+//! When the diff is intentional:
+//!
+//!   ```
+//!   cargo insta test -p dasclaw_cli --test insta_snapshot_demo_e2e
+//!   cargo insta accept -p dasclaw_cli
+//!   ```
+//!
+//! Or one-shot via the env var:
+//!
+//!   ```
+//!   INSTA_UPDATE=auto cargo nextest run -p dasclaw_cli --test insta_snapshot_demo_e2e
+//!   ```
+//!
+//! Then commit `tests/snapshots/insta_snapshot_demo_e2e__dasclaw_cli_help.snap`.
+
+use assert_cmd::Command;
+
+#[test]
+fn dasclaw_cli_help_snapshot() {
+    let output = Command::cargo_bin("dasclaw-cli")
+        .expect("dasclaw-cli binary built")
+        .arg("--help")
+        .output()
+        .expect("dasclaw-cli --help ran");
+
+    assert!(
+        output.status.success(),
+        "`dasclaw-cli --help` exited non-zero: stderr=\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8(output.stdout).expect("help text is utf-8");
+    insta::assert_snapshot!("dasclaw_cli_help", stdout);
+}

--- a/crates/dasclaw_cli/tests/snapshots/insta_snapshot_demo_e2e__dasclaw_cli_help.snap
+++ b/crates/dasclaw_cli/tests/snapshots/insta_snapshot_demo_e2e__dasclaw_cli_help.snap
@@ -1,0 +1,20 @@
+---
+source: crates/dasclaw_cli/tests/insta_snapshot_demo_e2e.rs
+assertion_line: 56
+expression: stdout
+---
+Headless agent CLI binary (ADR-153 §4.4 step 4). Demonstrates dasclaw_runtime::Agent::builder() end-to-end without desktop dependencies (no Tauri, no database, no HTTP server).
+
+Usage: dasclaw-cli [OPTIONS] [COMMAND]
+
+Commands:
+  echo          Run the deterministic built-in echo responder (no LLM, no network)
+  run           Run a real LLM-backed responder via `dasclaw_llm_provider`
+  sandbox-exec  Run a single `bash -c <command>` under the headless CLI's default-deny `ReadOnly` sandbox policy (ADR-153 §1.1 A6 / e12)
+  help          Print this message or the help of the given subcommand(s)
+
+Options:
+  -p, --prompt <PROMPT>  User prompt. When omitted, the prompt is read from stdin
+  -s, --system <SYSTEM>  System prompt prepended to the conversation [default: "You are dasclaw, a headless agent."]
+  -h, --help             Print help
+  -V, --version          Print version


### PR DESCRIPTION
## 背景 / 目标

PR3 落地两件可独立验证的事：

1. **nightly fuzz smoke**：把 6 个已写好的 fuzz target（5 个 `crates/dasclaw_safety/fuzz/` + 1 个 `desktop-client/ironclaw/fuzz/`）接到 GitHub Actions，每天 06:00 UTC 跑一遍，单 target 60s/10000 runs，纯回归报警，不阻塞 PR。
2. **insta snapshot demo**：在 `dasclaw_cli` 引入 insta 并落一个 `dasclaw-cli --help` 输出的 baseline 快照，给后续测试一个可复制的模板。

## 改动范围

- `.github/workflows/fuzz-smoke.yml`（新）：`schedule: '0 6 * * *'` + `workflow_dispatch`，单 job，shell for-loop 跑 6 个 target，`continue-on-error: true`，失败上传 `**/artifacts/**` 到 `actions/upload-artifact@v4`，最后步骤汇总写 `$GITHUB_STEP_SUMMARY` 并在任一 target 失败时 `exit 1`，`timeout-minutes: 30`，nightly Rust。
- `crates/dasclaw_cli/Cargo.toml`：dev-dep 加 `insta = "1.46.3"`（cargo 实际解析到 1.47.2，1.46.3 为 semver floor）。
- `crates/dasclaw_cli/tests/insta_snapshot_demo_e2e.rs`（新）：1 个 `#[test]` 用 `assert_cmd` 跑 `dasclaw-cli --help` 并 `insta::assert_snapshot!`。
- `crates/dasclaw_cli/tests/snapshots/insta_snapshot_demo_e2e__dasclaw_cli_help.snap`（新）：提交的 baseline。
- `Cargo.lock`：insta 依赖解析结果。

## 非目标（NOT in this PR）

- 不把 fuzz 加入 PR-time gate（继续只在 nightly cron 跑）。
- 不引入 clippy/lint 新规则。
- 不在其它 crate 启用 insta；仅 `dasclaw_cli` 一个 demo 测试 opt-in。
- 不修任何 fuzz target 自身或 corpus。

## 验证

```
python3 -c "import yaml; yaml.safe_load(open('.github/workflows/fuzz-smoke.yml'))"  -> YAML OK
cargo fmt --all                                                                     -> clean
python3.12 scripts/check_no_panics.py --base origin/xClaw                           -> OK: No panic-inducing calls
cargo clippy --no-deps -p dasclaw_cli --tests -- -D warnings                        -> clean (1m33s)
cargo nextest run -p dasclaw_cli --tests                                            -> 103 tests run: 103 passed (1 leaky), 0 skipped [133.893s]
cargo nextest run -p dasclaw_cli --test insta_snapshot_demo_e2e                     -> 1 passed, 0 skipped [2.065s]
```

## Cross-cuts

类A（无新增 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量）。

## 备注

- `INSTA_UPDATE=auto` 只产 `.snap.new`，要 `cargo insta accept` 或 `mv` 才落基线。后续测试请走 `cargo insta accept`。
- workflow 第一次实际跑由下一次 cron 触发或手动 `workflow_dispatch`。


Closes #894
