### PR TITLE
feat(dasclaw_channels): add Serialize derives + real JSON round-trip tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2875,6 +2875,7 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "async-trait",
+ "chrono",
  "clap",
  "dasclaw_channels",
  "dasclaw_core",
@@ -2901,6 +2902,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "uuid",
  "wiremock",
 ]
 
@@ -6060,6 +6062,7 @@ checksum = "7b4a6248eb93a4401ed2f37dfe8ea592d3cf05b7cf4f8efa867b6895af7e094e"
 dependencies = [
  "console",
  "once_cell",
+ "serde",
  "similar",
  "tempfile",
 ]

--- a/crates/dasclaw_channels/src/channel.rs
+++ b/crates/dasclaw_channels/src/channel.rs
@@ -6,12 +6,13 @@ use std::pin::Pin;
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use futures::Stream;
+use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use crate::error::ChannelError;
 
 /// Kind of attachment carried on an incoming message.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum AttachmentKind {
     /// Audio content (voice notes, audio files).
     Audio,
@@ -36,7 +37,7 @@ impl AttachmentKind {
 }
 
 /// A file or media attachment on an incoming message.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct IncomingAttachment {
     /// Unique identifier within the channel (e.g., Telegram file_id).
     pub id: String,
@@ -61,7 +62,7 @@ pub struct IncomingAttachment {
 }
 
 /// A message received from an external channel.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct IncomingMessage {
     /// Unique message ID.
     pub id: Uuid,
@@ -229,7 +230,7 @@ pub fn routing_target_from_metadata(metadata: &serde_json::Value) -> Option<Stri
 pub type MessageStream = Pin<Box<dyn Stream<Item = IncomingMessage> + Send>>;
 
 /// Response to send back to a channel.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct OutgoingResponse {
     /// The content to send.
     pub content: String,
@@ -266,7 +267,7 @@ impl OutgoingResponse {
 }
 
 /// A single tool decision within a reasoning update.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ToolDecision {
     /// Tool name.
     pub tool_name: String,
@@ -275,7 +276,7 @@ pub struct ToolDecision {
 }
 
 /// Status update types for showing agent activity.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum StatusUpdate {
     /// Agent is thinking/processing.
     Thinking(String),

--- a/crates/dasclaw_channels/src/error.rs
+++ b/crates/dasclaw_channels/src/error.rs
@@ -2,8 +2,10 @@
 //!
 //! F4.5 verbatim port from `desktop-client/ironclaw/src/error.rs` (ADR-129 §1.3).
 
+use serde::Serialize;
+
 /// Channel-related errors.
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, thiserror::Error, Serialize)]
 pub enum ChannelError {
     #[error("Channel {name} failed to start: {reason}")]
     StartupFailed { name: String, reason: String },

--- a/crates/dasclaw_channels/src/relay/channel.rs
+++ b/crates/dasclaw_channels/src/relay/channel.rs
@@ -8,6 +8,7 @@
 use std::collections::HashMap;
 
 use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc;
 
 use crate::channel::{Channel, IncomingMessage, MessageStream, OutgoingResponse, StatusUpdate};
@@ -18,7 +19,7 @@ use crate::relay::client::{ChannelEvent, RelayClient};
 pub const DEFAULT_RELAY_NAME: &str = "slack-relay";
 
 /// The messaging provider backing a relay channel.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum RelayProvider {
     Slack,
 }

--- a/crates/dasclaw_channels/src/relay/client.rs
+++ b/crates/dasclaw_channels/src/relay/client.rs
@@ -377,7 +377,7 @@ impl RelayClient {
 }
 
 /// Errors from relay client operations.
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, thiserror::Error, Serialize)]
 pub enum RelayError {
     #[error("Network error: {0}")]
     Network(String),

--- a/crates/dasclaw_cli/Cargo.toml
+++ b/crates/dasclaw_cli/Cargo.toml
@@ -117,6 +117,17 @@ dasclaw_wasm_tools = { path = "../dasclaw_wasm_tools" }
 # binary via `assert_cmd` to pin the on-deny exit-code + stderr
 # contract.
 assert_cmd = "2"
+# Issue #895: deterministic timestamp/UUID construction for the
+# `dasclaw_channels` JSON snapshot tests in
+# tests/channels_status_contract_e2e.rs. `serde` features pulled in so the
+# fixtures match the production serializers.
+chrono = { version = "0.4", features = ["serde"] }
+uuid = { version = "1", features = ["v4", "serde"] }
+# Issue #895: snapshot pinning of `dasclaw_channels` JSON wire shapes from a
+# non-GUI consumer. Used by tests/channels_status_contract_e2e.rs. Matches the
+# version selected for nightly-fuzz parity in PR #893; consolidated here so
+# this PR remains self-contained on top of PR #891.
+insta = { version = "1.46.3", features = ["json"] }
 predicates = "3"
 tempfile = "3"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "test-util", "sync"] }

--- a/crates/dasclaw_cli/tests/channels_status_contract_e2e.rs
+++ b/crates/dasclaw_cli/tests/channels_status_contract_e2e.rs
@@ -20,12 +20,12 @@
 //!    non-tool keys untouched).
 //! 5. `routing_target_from_metadata` parses `target` from both strings
 //!    and numbers; `OutgoingResponse::text` default field state.
-//!
-//! Note: these types deliberately do **not** derive `serde::Serialize`
-//! (only `Debug, Clone`), so we can't pin them via
-//! `serde_json::to_value`. Structural assertions are the available
-//! contract surface today; promoting `StatusUpdate` to `Serialize` is
-//! a separate decision.
+//! 6. Issue #895 follow-up: real `serde_json` round-trips and `insta`
+//!    snapshots now that `StatusUpdate` / `OutgoingResponse` /
+//!    `IncomingMessage` derive `Serialize` + `Deserialize`. These pin the
+//!    wire shape so a renamed field or a re-tagged enum variant fails
+//!    the test instead of silently breaking GUI consumers that ingest
+//!    the JSON.
 
 use dasclaw_channels::{
     AttachmentKind, IncomingAttachment, IncomingMessage, OutgoingResponse, StatusUpdate,
@@ -283,4 +283,233 @@ fn req_dasclaw_cli_channels_pr2_incoming_attachment_round_trip() {
     assert_eq!(att.kind, AttachmentKind::Image);
     assert!(att.data.is_empty());
     assert!(att.filename.is_none());
+}
+
+// ---------------------------------------------------------------------------
+// Issue #895: real `serde_json` round-trip + `insta` snapshot pins for the
+// public wire shapes now that `dasclaw_channels` derives `Serialize` +
+// `Deserialize`. Snapshots use `assert_json_snapshot!` so a renamed field or
+// a re-tagged enum variant fails the test instead of silently drifting from
+// GUI consumers that ingest the JSON.
+// ---------------------------------------------------------------------------
+
+use chrono::TimeZone;
+use uuid::Uuid;
+
+/// Build a deterministic `IncomingMessage` for snapshot tests (fixed UUID +
+/// timestamp so `cargo insta review` only flags real surface changes).
+fn fixed_incoming_message() -> IncomingMessage {
+    let mut msg = IncomingMessage::new("cli", "alice", "hello");
+    msg.id = Uuid::nil();
+    msg.received_at = chrono::Utc.with_ymd_and_hms(2024, 1, 2, 3, 4, 5).unwrap();
+    msg
+}
+
+/// `req_dasclaw_cli_channels_pr3_attachment_kind_json_roundtrip` — the
+/// serde representation of `AttachmentKind` must round-trip losslessly.
+/// Default external tagging emits the variant name as a bare string.
+#[test]
+fn req_dasclaw_cli_channels_pr3_attachment_kind_json_roundtrip() {
+    for kind in [
+        AttachmentKind::Image,
+        AttachmentKind::Audio,
+        AttachmentKind::Document,
+    ] {
+        let json = serde_json::to_value(&kind).expect("AttachmentKind must serialize");
+        let back: AttachmentKind =
+            serde_json::from_value(json.clone()).expect("AttachmentKind must deserialize");
+        assert_eq!(kind, back, "AttachmentKind round-trip must be lossless");
+    }
+}
+
+/// `req_dasclaw_cli_channels_pr3_tool_decision_json_roundtrip` — the
+/// `StatusUpdate::ReasoningUpdate.decisions` payload is consumed by the GUI
+/// reasoning panel; pin the JSON shape so a field rename breaks the test.
+#[test]
+fn req_dasclaw_cli_channels_pr3_tool_decision_json_roundtrip() {
+    let decision = ToolDecision {
+        tool_name: "shell".into(),
+        rationale: "list files to confirm path".into(),
+    };
+    let json = serde_json::to_value(&decision).expect("ToolDecision serializes");
+    assert_eq!(json["tool_name"], json!("shell"));
+    assert_eq!(json["rationale"], json!("list files to confirm path"));
+    let back: ToolDecision = serde_json::from_value(json).expect("ToolDecision deserializes");
+    assert_eq!(decision.tool_name, back.tool_name);
+    assert_eq!(decision.rationale, back.rationale);
+}
+
+/// `req_dasclaw_cli_channels_pr3_incoming_message_json_roundtrip` —
+/// `IncomingMessage` is the primary inbound payload. Round-trip both the
+/// default-state and a fully populated form so every optional field is
+/// exercised through serde.
+#[test]
+fn req_dasclaw_cli_channels_pr3_incoming_message_json_roundtrip() {
+    let mut msg = fixed_incoming_message();
+    msg.user_name = Some("Alice".into());
+    msg.thread_id = Some("T-1".into());
+    msg.conversation_scope_id = Some("scope-1".into());
+    msg.metadata = json!({"target": "chat-42"});
+    msg.timezone = Some("America/New_York".into());
+    msg.attachments.push(IncomingAttachment {
+        id: "f1".into(),
+        kind: AttachmentKind::Image,
+        mime_type: "image/png".into(),
+        filename: Some("snap.png".into()),
+        size_bytes: Some(42),
+        source_url: None,
+        storage_key: None,
+        extracted_text: None,
+        data: vec![1, 2, 3],
+        duration_secs: None,
+    });
+
+    let json = serde_json::to_value(&msg).expect("IncomingMessage serializes");
+    assert_eq!(json["channel"], json!("cli"));
+    assert_eq!(json["user_id"], json!("alice"));
+    assert_eq!(json["owner_id"], json!("alice"));
+    assert_eq!(json["is_internal"], json!(false));
+    assert_eq!(json["attachments"][0]["mime_type"], json!("image/png"));
+
+    let back: IncomingMessage = serde_json::from_value(json).expect("IncomingMessage deserializes");
+    assert_eq!(msg.id, back.id);
+    assert_eq!(msg.user_id, back.user_id);
+    assert_eq!(msg.thread_id, back.thread_id);
+    assert_eq!(msg.attachments.len(), back.attachments.len());
+    assert_eq!(msg.attachments[0].kind, back.attachments[0].kind);
+    assert_eq!(msg.received_at, back.received_at);
+}
+
+/// `req_dasclaw_cli_channels_pr3_outgoing_response_json_roundtrip` — pin
+/// the outbound payload shape so the GUI's response renderer doesn't drift.
+#[test]
+fn req_dasclaw_cli_channels_pr3_outgoing_response_json_roundtrip() {
+    let response = OutgoingResponse::text("hi")
+        .in_thread("T-1")
+        .with_attachments(vec!["a.png".into(), "b.png".into()]);
+
+    let json = serde_json::to_value(&response).expect("OutgoingResponse serializes");
+    assert_eq!(json["content"], json!("hi"));
+    assert_eq!(json["thread_id"], json!("T-1"));
+    assert_eq!(json["attachments"], json!(["a.png", "b.png"]));
+    assert_eq!(json["metadata"], serde_json::Value::Null);
+
+    let back: OutgoingResponse =
+        serde_json::from_value(json).expect("OutgoingResponse deserializes");
+    assert_eq!(response.content, back.content);
+    assert_eq!(response.thread_id, back.thread_id);
+    assert_eq!(response.attachments, back.attachments);
+}
+
+/// `req_dasclaw_cli_channels_pr3_status_update_json_roundtrip` — exercise
+/// every `StatusUpdate` variant through serde. Pairs with the
+/// pattern-exhaustive matcher above so a new variant fails both the
+/// compile-time guard and the round-trip guard.
+#[test]
+fn req_dasclaw_cli_channels_pr3_status_update_json_roundtrip() {
+    let samples = vec![
+        StatusUpdate::Thinking("think".into()),
+        StatusUpdate::ToolStarted {
+            name: "shell".into(),
+        },
+        StatusUpdate::ToolCompleted {
+            name: "shell".into(),
+            success: true,
+            error: None,
+            parameters: Some("{\"cmd\":\"ls\"}".into()),
+        },
+        StatusUpdate::ToolResult {
+            name: "shell".into(),
+            preview: "ok".into(),
+        },
+        StatusUpdate::StreamChunk("chunk".into()),
+        StatusUpdate::Status("status".into()),
+        StatusUpdate::JobStarted {
+            job_id: "j1".into(),
+            title: "t".into(),
+            browse_url: "/jobs/j1".into(),
+        },
+        StatusUpdate::ApprovalNeeded {
+            request_id: "r1".into(),
+            tool_name: "shell".into(),
+            description: "rm -rf /".into(),
+            parameters: json!({"cmd": "rm"}),
+            allow_always: false,
+        },
+        StatusUpdate::AuthRequired {
+            extension_name: "gh".into(),
+            instructions: Some("install".into()),
+            auth_url: None,
+            setup_url: None,
+        },
+        StatusUpdate::AuthCompleted {
+            extension_name: "gh".into(),
+            success: true,
+            message: "ok".into(),
+        },
+        StatusUpdate::ImageGenerated {
+            data_url: "data:image/png;base64,AAA".into(),
+            path: Some("/tmp/x.png".into()),
+        },
+        StatusUpdate::Suggestions {
+            suggestions: vec!["a".into(), "b".into()],
+        },
+        StatusUpdate::ReasoningUpdate {
+            narrative: "n".into(),
+            decisions: vec![ToolDecision {
+                tool_name: "shell".into(),
+                rationale: "test".into(),
+            }],
+        },
+        StatusUpdate::TurnCost {
+            input_tokens: 1,
+            output_tokens: 2,
+            cost_usd: "0.001".into(),
+        },
+    ];
+    for sample in &samples {
+        let json = serde_json::to_value(sample).expect("StatusUpdate serializes");
+        let back: StatusUpdate = serde_json::from_value(json).expect("StatusUpdate deserializes");
+        // Re-serialize both sides and compare as JSON: `StatusUpdate` does
+        // not implement `PartialEq` (it carries `serde_json::Value` and
+        // free-form strings), so JSON equality is the contract here.
+        let lhs = serde_json::to_value(sample).expect("lhs serializes");
+        let rhs = serde_json::to_value(&back).expect("rhs serializes");
+        assert_eq!(lhs, rhs, "StatusUpdate round-trip must be JSON-stable");
+    }
+}
+
+/// `req_dasclaw_cli_channels_pr3_status_update_snapshot_tool_completed` —
+/// insta snapshot of `StatusUpdate::ToolCompleted`. Pins the externally
+/// tagged enum shape so a `#[serde(rename_all)]` or a variant rename fails
+/// the snapshot.
+#[test]
+fn req_dasclaw_cli_channels_pr3_status_update_snapshot_tool_completed() {
+    let sample = StatusUpdate::ToolCompleted {
+        name: "shell".into(),
+        success: true,
+        error: None,
+        parameters: Some("{\"cmd\":\"ls\"}".into()),
+    };
+    insta::assert_json_snapshot!("status_update_tool_completed", sample);
+}
+
+/// `req_dasclaw_cli_channels_pr3_outgoing_response_snapshot_text` — insta
+/// snapshot of the default `OutgoingResponse::text` builder output. Pins
+/// the field set and null-metadata default.
+#[test]
+fn req_dasclaw_cli_channels_pr3_outgoing_response_snapshot_text() {
+    let sample = OutgoingResponse::text("hi")
+        .in_thread("T-1")
+        .with_attachments(vec!["a.png".into()]);
+    insta::assert_json_snapshot!("outgoing_response_text", sample);
+}
+
+/// `req_dasclaw_cli_channels_pr3_incoming_message_snapshot_default` — insta
+/// snapshot of the minimal `IncomingMessage::new` output. Uses a fixed UUID
+/// and timestamp so the snapshot is deterministic.
+#[test]
+fn req_dasclaw_cli_channels_pr3_incoming_message_snapshot_default() {
+    let sample = fixed_incoming_message();
+    insta::assert_json_snapshot!("incoming_message_default", sample);
 }

--- a/crates/dasclaw_cli/tests/snapshots/channels_status_contract_e2e__incoming_message_default.snap
+++ b/crates/dasclaw_cli/tests/snapshots/channels_status_contract_e2e__incoming_message_default.snap
@@ -1,0 +1,20 @@
+---
+source: crates/dasclaw_cli/tests/channels_status_contract_e2e.rs
+expression: sample
+---
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "channel": "cli",
+  "user_id": "alice",
+  "owner_id": "alice",
+  "sender_id": "alice",
+  "user_name": null,
+  "content": "hello",
+  "thread_id": null,
+  "conversation_scope_id": null,
+  "received_at": "2024-01-02T03:04:05Z",
+  "metadata": null,
+  "timezone": null,
+  "attachments": [],
+  "is_internal": false
+}

--- a/crates/dasclaw_cli/tests/snapshots/channels_status_contract_e2e__outgoing_response_text.snap
+++ b/crates/dasclaw_cli/tests/snapshots/channels_status_contract_e2e__outgoing_response_text.snap
@@ -1,0 +1,12 @@
+---
+source: crates/dasclaw_cli/tests/channels_status_contract_e2e.rs
+expression: sample
+---
+{
+  "content": "hi",
+  "thread_id": "T-1",
+  "attachments": [
+    "a.png"
+  ],
+  "metadata": null
+}

--- a/crates/dasclaw_cli/tests/snapshots/channels_status_contract_e2e__status_update_tool_completed.snap
+++ b/crates/dasclaw_cli/tests/snapshots/channels_status_contract_e2e__status_update_tool_completed.snap
@@ -1,0 +1,12 @@
+---
+source: crates/dasclaw_cli/tests/channels_status_contract_e2e.rs
+expression: sample
+---
+{
+  "ToolCompleted": {
+    "name": "shell",
+    "success": true,
+    "error": null,
+    "parameters": "{\"cmd\":\"ls\"}"
+  }
+}


### PR DESCRIPTION
## 背景 / 目标

Closes #895

`dasclaw_channels` 的核心数据类型此前缺少 `Serialize` / `Deserialize` derive，导致：

- channels 模块产物无法通过 `serde_json` 直接序列化送往 IPC / 日志 / 持久层
- `crates/dasclaw_cli/tests/channels_status_contract_e2e.rs` 只能做 `Debug` 字符串包含断言，无法验证真实 JSON 契约

本 PR 给 channels 公共数据类型补齐 serde derive，并把上述 e2e 测试升级为真实 JSON round-trip + insta snapshot。

## 改动范围

**`crates/dasclaw_channels/`**（新增 derive，不改字段名、不加 `#[serde(rename)]`）：

- `src/channel.rs` — `Serialize + Deserialize` 加在：`AttachmentKind` / `IncomingAttachment` / `IncomingMessage` / `OutgoingResponse` / `ToolDecision` / `StatusUpdate`
- `src/relay/channel.rs` — `Serialize + Deserialize` 加在 `RelayProvider`
- `src/error.rs` — `Serialize` 加在 `ChannelError`（仅 Serialize）
- `src/relay/client.rs` — `Serialize` 加在 `RelayError`（仅 Serialize）

**`crates/dasclaw_cli/`**：

- `Cargo.toml` — dev-deps 新增 `chrono`（serde）/ `uuid`（v4+serde）/ `insta 1.46.3`（json）
- `tests/channels_status_contract_e2e.rs` — 保留原 7 个 PR2 测试，追加 5 个 `*_json_roundtrip` + 3 个 `*_snapshot_*` 测试，共 15 个
- `tests/snapshots/channels_status_contract_e2e__*.snap` × 3（insta 基线）

## 非目标（What's NOT in this PR）

- **不动 `ChannelManager` / `RelayChannel` / `RelayClient` / `Channel` trait** — 它们持有 `Arc` / `RwLock` / `mpsc::Sender` / `SecretString` / `reqwest::Client` 等运行期句柄，无法 serde；如需对外暴露快照需另行设计 DTO，超出本 PR
- **`ChannelError` / `RelayError` 仅加 `Serialize`，不加 `Deserialize`** — 这两者用 `#[from]` 包了 `serde_json::Error` / `reqwest::Error` 等不可序列化的 source，round-trip 不闭合，沿用 thiserror 常见做法
- 不重命名任何字段、不加 `#[serde(rename)]` / `rename_all`、不加额外 derive

## 验证

```
cargo fmt --all
cargo nextest run -p dasclaw_channels --tests        # 21/21 passed
cargo nextest run -p dasclaw_cli --test channels_status_contract_e2e  # 15/15 passed
cargo clippy --no-deps -p dasclaw_channels --tests -- -D warnings     # clean
cargo clippy --no-deps -p dasclaw_cli --tests -- -D warnings          # clean
python3.12 scripts/check_no_panics.py --base origin/feat/cli-gui-blind-spot-e2e
# OK: No panic-inducing calls in changed production code.
```

最后一行 e2e 测试输出：

```
Summary [  17.485s] 15 tests run: 15 passed, 0 skipped
```

完整 `cargo build` / workspace clippy / heavy integration 由 CI 兜底。

## Cross-cuts

类A（diff 内无新增 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量）

## Stacked PR 说明

- base 不是 `xClaw`，而是 `feat/cli-gui-blind-spot-e2e`（PR #891，引入本 PR 修改的测试文件）
- merge 顺序：**先 merge #891，再 merge 本 PR**
- 与 PR #893 并行：两者都新增了 `insta` dev-dep，预期会产生一处 `crates/dasclaw_cli/Cargo.toml` 轻微冲突；后合并者把对应行 rebase 保留即可

## Sources read

- `AGENTS.md`（PR 工作流 / ADR-114 红线 / 本地节奏）
- `.github/copilot-instructions.md`
- `crates/dasclaw_channels/src/channel.rs`（确认字段类型，尤其 `StatusUpdate::ToolCompleted.parameters: Option<String>` vs `ApprovalNeeded.parameters: serde_json::Value`）
- `crates/dasclaw_channels/src/error.rs`
- `crates/dasclaw_channels/src/relay/channel.rs`
- `crates/dasclaw_channels/src/relay/client.rs`
- `crates/dasclaw_cli/tests/channels_status_contract_e2e.rs`（PR #891 引入的测试基线）



---
> Re-opened from #901 after base branch (feat/cli-gui-blind-spot-e2e) was deleted by merging PR #891. Branch rebased onto current xClaw HEAD.
