### PR TITLE
chore(insta): pin to =1.47.2 via workspace deps + document snapshot workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -645,6 +645,29 @@ tests/
 
 详细案例分析、代码示例和 E2E 测试模式见 `docs/testing-guide.md`。
 
+### Snapshot 测试工作流（insta）
+
+**版本来源**：`insta` 在根 `Cargo.toml` 的 `[workspace.dependencies]` 中精确 pin 为 `=1.47.2`（issues #898 / #899）。成员 crate 通过 `insta = { workspace = true }` 引用，不允许在成员 crate 里写浮动版本，避免 SemVer 漂移导致快照行为变化。
+
+**首次准备**：
+
+```bash
+cargo install cargo-insta --locked
+```
+
+**新增 / 修改快照测试的流程**：
+
+1. 写 `insta::assert_snapshot!(...)`（或 `assert_json_snapshot!`、`assert_debug_snapshot!` 等），首次跑测试会生成 `tests/snapshots/*.snap.new`。
+2. 用 `cargo insta review -p <crate>` 交互式审核每个 `.snap.new`，按 `a` 接受、`r` 拒绝、`s` 跳过；接受后会落盘为 `*.snap`，必须随本 PR 一起 commit。
+3. 一次性接受全部（确认无意外 diff 时）：`cargo insta accept -p <crate>`。
+4. 一次性运行 + 自动接受（CI 不要用）：`INSTA_UPDATE=auto cargo nextest run -p <crate> --test <name>`。
+
+**升级 `insta` 版本时的纪律**：
+
+- 只能改根 `[workspace.dependencies]` 里的 pin，禁止在成员 crate 单独提版本。
+- 升级 PR 必须重新跑全部既有快照，用 `cargo insta review` 逐个确认 diff（通常是格式 / redaction 行为变化），把更新后的 `*.snap` 一并 commit；不允许只升版本不刷 baseline。
+- 升级范围注意：当前快照测试在 `crates/dasclaw_cli/tests/` 与 `desktop-client/ironclaw/tests/` 两处，至少这两个 crate 要全跑。
+
 ---
 
 ## Admin Backend 冒烟测试（integration_smoke_tests.rs）

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,22 @@ members = [
 exclude = ["ironclaw", "claw-code", "vendor"]
 resolver = "2"
 
+# Workspace-pinned third-party deps. Only deps shared across multiple
+# member crates and benefiting from a single source of truth live here.
+# Verbatim-port crates (e.g. dasclaw_async_utils, dasclaw_utils_*,
+# dasclaw_sandbox_linux) intentionally inline their versions — see their
+# crate-level comments — so do NOT migrate them here.
+#
+# Issues #898 / #899: `insta` is pinned to an exact version (`=1.47.2`)
+# so all snapshot-test consumers (`crates/dasclaw_cli`,
+# `desktop-client/ironclaw`) see the same engine version. Upgrading
+# requires re-accepting all `*.snap` baselines (see AGENTS.md →
+# "Snapshot 测试工作流（insta）"). The `json` feature is the union of
+# what current consumers request; extra features are inert for consumers
+# that don't use them.
+[workspace.dependencies]
+insta = { version = "=1.47.2", features = ["json"] }
+
 [profile.dev]
 opt-level = 0                       # 本 crate 不优化，编译快
 incremental = true                  # 增量编译

--- a/crates/dasclaw_cli/Cargo.toml
+++ b/crates/dasclaw_cli/Cargo.toml
@@ -123,11 +123,12 @@ assert_cmd = "2"
 # fixtures match the production serializers.
 chrono = { version = "0.4", features = ["serde"] }
 uuid = { version = "1", features = ["v4", "serde"] }
-# Issue #895: snapshot pinning of `dasclaw_channels` JSON wire shapes from a
-# non-GUI consumer. Used by tests/channels_status_contract_e2e.rs. Matches the
-# version selected for nightly-fuzz parity in PR #893; consolidated here so
-# this PR remains self-contained on top of PR #891.
-insta = { version = "1.46.3", features = ["json"] }
+# Issue #895 + PR3 demo: snapshot pinning of `dasclaw_channels` JSON wire
+# shapes (tests/channels_status_contract_e2e.rs) and the `dasclaw-cli --help`
+# surface (tests/insta_snapshot_demo_e2e.rs). Version is centrally pinned
+# via the root `[workspace.dependencies]` table (issues #898 / #899); the
+# `json` feature is enabled there for all workspace consumers.
+insta = { workspace = true }
 predicates = "3"
 tempfile = "3"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "test-util", "sync"] }
@@ -137,4 +138,3 @@ wiremock = "0.6"
 # unintended CLI surface drift surfaces as a snapshot diff. Other tests
 # can opt in by adding their own `insta::assert_snapshot!(...)` calls and
 # committing the generated `tests/snapshots/*.snap` baseline.
-insta = "1.46.3"

--- a/crates/dasclaw_cli/tests/insta_snapshot_demo_e2e.rs
+++ b/crates/dasclaw_cli/tests/insta_snapshot_demo_e2e.rs
@@ -1,5 +1,9 @@
 //! PR3 demo: `insta` snapshot test for `dasclaw-cli --help`.
 //!
+//! First time authoring snapshot tests? Install the CLI once:
+//!   `cargo install cargo-insta --locked`
+//! Workflow reference: AGENTS.md → "Snapshot 测试工作流（insta）".
+//!
 //! Purpose
 //! -------
 //! Establish a working insta baseline in the dasclaw_cli crate so the rest

--- a/desktop-client/ironclaw/Cargo.toml
+++ b/desktop-client/ironclaw/Cargo.toml
@@ -308,7 +308,11 @@ tracing-test = "0.2"
 testcontainers-modules = { version = "0.11", features = ["postgres"] }
 pretty_assertions = "1"
 tempfile = "3"
-insta = "1.46.3"
+# Snapshot tests. Version is centrally pinned via the root
+# `[workspace.dependencies]` table (issues #898 / #899); the workspace
+# entry also enables the `json` feature, which is inert for tests that
+# only use `assert_snapshot!`.
+insta = { workspace = true }
 criterion = "0.5"
 
 [[bench]]


### PR DESCRIPTION
## 背景 / 目标

本 PR 单次关闭两个相邻 issue：

- **#898**：把 `insta` 提到 workspace 级集中管理 + 精确 pin。新增根 `Cargo.toml` 的 `[workspace.dependencies]` 段（xClaw 首次引入），用 `insta = { version = "=1.47.2", features = ["json"] }` 精确锁定；两个消费者 crate（`crates/dasclaw_cli`、`desktop-client/ironclaw`）改用 `insta = { workspace = true }`。`Cargo.lock` 已经在 `1.47.2`，本 PR 不会引发依赖解析变化。
- **#899**：把 cargo-insta 快照工作流写进规范文档与示例。`AGENTS.md` 在 `## 测试规则` section 末尾新增 `### Snapshot 测试工作流（insta）` 子节，覆盖版本来源、首次准备命令、`*.snap.new` → `cargo insta review -p <crate>` → `cargo insta accept -p <crate>` 流程、以及升级 `insta` 版本时的纪律（必须 workspace-only pin、必须重新接受所有 baseline、范围限 `crates/dasclaw_cli/tests/` + `desktop-client/ironclaw/tests/` 两处）。同时在 `crates/dasclaw_cli/tests/insta_snapshot_demo_e2e.rs` 头部加 3 行注释指引一次性安装 `cargo install cargo-insta --locked` 并指向 `AGENTS.md`。

## 改动范围

- `Cargo.toml`：新增 `[workspace.dependencies]` 段（首次引入），含 verbatim-port 例外说明
- `crates/dasclaw_cli/Cargo.toml`：折叠原本同表内两条重复 `insta = ...` 为单条 `workspace = true`（cargo 之前是静默容忍）
- `desktop-client/ironclaw/Cargo.toml`：`insta = "1.46.3"` → `insta = { workspace = true }`
- `crates/dasclaw_cli/tests/insta_snapshot_demo_e2e.rs`：3 行文件头注释，指引首次安装 cargo-insta 与 AGENTS.md 工作流
- `AGENTS.md`：新增 `### Snapshot 测试工作流（insta）` 子节

## 非目标（What's NOT in this PR）

- 不动 CI workflow（`code_style.yml` / `test.yml` 等）
- 不升级 `insta` 版本（升级路径由文档定义，但本 PR 仅做集中管理）
- 不替换 `cargo nextest run` 为 `cargo insta test`（snapshot 测试仍由 nextest 调度）
- 不把 verbatim-port crate（`dasclaw_async_utils` / `dasclaw_utils_*` / `dasclaw_sandbox_linux` 等）的 inline 依赖搬到 workspace（新增的 root 注释已显式声明此例外，与既有 crate-level 注释一致）

## 验证

```bash
$ cargo metadata --format-version 1 --no-deps >/dev/null 2>&1 && echo METADATA_OK
METADATA_OK

# Cargo.lock 已锁定 1.47.2
$ grep -A1 '^name = "insta"$' Cargo.lock | head -2
name = "insta"
version = "1.47.2"

$ cargo check -p dasclaw_cli --tests
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 55s

$ cargo fmt --all && python3.12 scripts/check_no_panics.py --base origin/xClaw
OK: No panic-inducing calls in changed production code.
```

完整 workspace build / clippy / nextest 由 CI 兜底。

## Cross-cuts

`类A`（无新增 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量）

## 风险 / 后续

- 本 PR 是 xClaw 首次引入 `[workspace.dependencies]`，root `Cargo.toml` 注释明确：verbatim-port crate 仍保留 inline 版本（与它们 crate 级注释互相印证）。
- `dasclaw_cli/Cargo.toml` 原本同 `[dev-dependencies]` 表里有两条 `insta` 键，cargo 静默容忍；本次折叠为单条 `workspace = true`，行为没有变化（lock 仍 1.47.2）。
- 后续如需升级 `insta`，按 `AGENTS.md` 新加的"升级 insta 版本时的纪律"操作：只改根 pin、跑全部既有快照、`cargo insta review` 逐个 diff、把更新的 `*.snap` 一并 commit。

Closes #898
Closes #899
