### PR TITLE
test(runtime): cross-platform keychain e2e + slim dasclaw_cli to contract-only

### DIFF
--- a/crates/dasclaw_cli/tests/secrets_keychain_namespace_e2e.rs
+++ b/crates/dasclaw_cli/tests/secrets_keychain_namespace_e2e.rs
@@ -1,85 +1,132 @@
-//! PR2 GUI-only blind-spot: `dasclaw_runtime::secrets::keychain::KeychainConfig`
-//! round-trip from a non-GUI consumer (ADR-153 §1).
+//! CLI-side contract sentinel for `dasclaw_runtime::secrets::keychain::KeychainConfig`
+//! (issue #897).
 //!
-//! Why this test exists in `dasclaw_cli` and not closer to the source:
-//! the keychain code is shared across CLI + desktop hosts, but only the
-//! GUI host (`desktop-client/ironclaw`) currently exercises it on macOS.
-//! A regression in the platform back-end's service-name handling or
-//! account-suffix collision would silently break CLI master-key
-//! bootstrapping. This e2e pins the contract from the CLI side.
+//! # Why this file is contract-only now
 //!
-//! Platform gating:
-//!   - macOS: real `Security.framework` round-trip (this test).
-//!   - Linux: requires a running D-Bus secret service (CI runners
-//!     usually lack one); covered separately in the runtime crate.
-//!   - Windows: same family of issues; runtime-crate-side coverage
-//!     handles it.
+//! The previous revision of this file ran a real macOS Keychain round-trip
+//! and was gated `#![cfg(target_os = "macos")]`, which left Linux and Windows
+//! completely uncovered from any test suite. Issue #897 moved the real-OS
+//! cross-platform coverage into
+//! `crates/dasclaw_runtime/tests/keychain_e2e.rs`, where it lives next to
+//! the implementation and runs on all three platforms (Linux gracefully
+//! skips when `DBUS_SESSION_BUS_ADDRESS` is unset).
 //!
-//! For now we gate the whole file to `target_os = "macos"`.
+//! What's left for the CLI crate is a **public-API contract sentinel**:
+//! `dasclaw_cli/src` does not itself construct a `KeychainConfig` today
+//! (verified by `grep -rn "KeychainConfig" crates/dasclaw_cli/src/` returning
+//! no hits), but the CLI binary links `dasclaw_runtime` transitively and any
+//! future CLI feature that bootstraps a master key will rely on the same
+//! public surface. This file pins that surface — field names, public
+//! constructor, `const`-constructibility — so a silent rename or visibility
+//! change in `dasclaw_runtime` breaks a CLI test, not a downstream user.
 //!
-//! Isolation:
-//!   - Each test run synthesises a unique `service_name` from pid + a
-//!     monotonic nanos counter, so concurrent CI shards do not collide.
-//!   - The test calls `delete_master_key` before *and* after asserting,
-//!     so a previously-crashed run cannot poison the slot.
+//! The file is **not** gated on any platform: the contract test exercises
+//! only struct construction and field access, which has no OS dependency.
+//!
+//! An additional `#[ignore]`'d macOS smoke test is preserved at the bottom
+//! as a CLI-side backup; run it explicitly with
+//! `cargo test -p dasclaw_cli --test secrets_keychain_namespace_e2e -- --ignored`.
 
-#![cfg(target_os = "macos")]
+use dasclaw_runtime::secrets::keychain::KeychainConfig;
 
-use std::process;
-use std::time::{SystemTime, UNIX_EPOCH};
-
-use dasclaw_runtime::secrets::keychain::{KeychainConfig, generate_master_key};
-
-/// Build a `KeychainConfig` with a process-unique service name.
+/// `req_dasclaw_cli_secrets_keychain_config_public_contract` — the
+/// public surface of `KeychainConfig` that the CLI relies on
+/// transitively must remain stable:
 ///
-/// `KeychainConfig` requires `&'static str` for both fields so the
-/// struct is `const`-constructible; we leak a small `Box<str>` per test
-/// (≤ one allocation per process; gated to macOS only) to satisfy that
-/// lifetime without resorting to `OnceLock` gymnastics.
-fn unique_keychain_config() -> KeychainConfig {
-    let nanos = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_nanos())
-        .unwrap_or(0);
-    let service: &'static str =
-        Box::leak(format!("dasclaw_test_cli_pr2_{}_{}", process::id(), nanos).into_boxed_str());
-    KeychainConfig::new(service, "master_key")
+/// 1. `KeychainConfig::new(service, account)` is callable in `const`
+///    context with two `&'static str` arguments.
+/// 2. Both `service_name` and `account` are publicly readable fields
+///    that round-trip the constructor arguments verbatim.
+/// 3. The struct derives `Copy + Clone + PartialEq + Eq + Debug` so
+///    hosts can pass it by value and compare it in tests.
+///
+/// A silent rename of either field, a loss of `pub` visibility, or a
+/// change to a non-`const` constructor would break this test before it
+/// breaks downstream CLI code.
+#[test]
+fn req_dasclaw_cli_secrets_keychain_config_public_contract() {
+    // (1) `const`-constructibility: if `KeychainConfig::new` ever
+    // becomes non-`const`, this binding fails to compile.
+    const NS: KeychainConfig = KeychainConfig::new("svc-x", "acc-y");
+
+    // (2) Field-access contract: both fields stay `pub` and carry the
+    // exact bytes passed to the constructor (no normalization).
+    assert_eq!(NS.service_name, "svc-x");
+    assert_eq!(NS.account, "acc-y");
+
+    // (3) Derived-trait contract: `Copy` (implicit move-after-use),
+    // `Clone`, `PartialEq`, and `Debug` must remain on the type. The
+    // assertions below would not compile otherwise.
+    let copy_a = NS;
+    let copy_b = NS;
+    assert_eq!(copy_a, copy_b);
+    let cloned = copy_a;
+    assert_eq!(cloned, NS);
+    let _ = format!("{NS:?}");
+
+    // (4) Equality is structural — different inputs produce inequal
+    // configs. Guards against an accidental `PartialEq` override that
+    // would treat all configs as equal.
+    let other = KeychainConfig::new("svc-x", "acc-z");
+    assert_ne!(NS, other);
 }
 
-/// `req_dasclaw_cli_secrets_pr2_keychain_store_get_round_trip` — a
-/// CLI consumer can store, retrieve, and delete a master key through
-/// the public `KeychainConfig` API without reaching for any GUI-only
-/// state. Catches drift in:
-///   - the service-name + account namespace contract,
-///   - the `Vec<u8>` round-trip (no UTF-8 lossy conversion on macOS),
-///   - the `has_master_key` truthiness after delete.
-#[tokio::test(flavor = "multi_thread")]
-async fn req_dasclaw_cli_secrets_pr2_keychain_store_get_round_trip()
--> Result<(), Box<dyn std::error::Error>> {
-    let cfg = unique_keychain_config();
+// -------------------------------------------------------------------
+// Optional macOS smoke test (ignored by default).
+//
+// Cross-platform real-OS coverage lives in
+// `crates/dasclaw_runtime/tests/keychain_e2e.rs`. The block below is
+// kept as a CLI-side backup that a developer can run on demand when
+// debugging keychain-related CLI regressions on macOS:
+//
+//   cargo test -p dasclaw_cli --test secrets_keychain_namespace_e2e \
+//       -- --ignored
+// -------------------------------------------------------------------
 
-    // Defensive pre-clean: a previously-crashed run might have left the
-    // slot populated. Ignore the result; the slot may legitimately be
-    // empty.
-    let _ = cfg.delete_master_key().await;
+#[cfg(target_os = "macos")]
+mod macos_smoke {
+    use std::process;
+    use std::time::{SystemTime, UNIX_EPOCH};
 
-    let key = generate_master_key();
-    assert_eq!(key.len(), 32, "master key must be 32 bytes");
+    use dasclaw_runtime::secrets::keychain::{KeychainConfig, generate_master_key};
 
-    cfg.store_master_key(&key).await?;
-    assert!(
-        cfg.has_master_key().await,
-        "key must be present after store"
-    );
+    fn unique_keychain_config() -> KeychainConfig {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        let service: &'static str = Box::leak(
+            format!("dasclaw_test_cli_smoke_{}_{}", process::id(), nanos).into_boxed_str(),
+        );
+        KeychainConfig::new(service, "master_key")
+    }
 
-    let read_back = cfg.get_master_key().await?;
-    assert_eq!(read_back, key, "round-trip must return identical bytes");
+    #[tokio::test]
+    #[ignore = "macOS keychain smoke; run with `-- --ignored`"]
+    async fn req_dasclaw_cli_secrets_macos_smoke_round_trip()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let cfg = unique_keychain_config();
 
-    cfg.delete_master_key().await?;
-    assert!(
-        !cfg.has_master_key().await,
-        "key must be absent after delete"
-    );
+        let _ = cfg.delete_master_key().await;
 
-    Ok(())
+        let key = generate_master_key();
+        assert_eq!(key.len(), 32, "master key must be 32 bytes");
+
+        cfg.store_master_key(&key).await?;
+        assert!(
+            cfg.has_master_key().await,
+            "key must be present after store"
+        );
+
+        let read_back = cfg.get_master_key().await?;
+        assert_eq!(read_back, key, "round-trip must return identical bytes");
+
+        cfg.delete_master_key().await?;
+        assert!(
+            !cfg.has_master_key().await,
+            "key must be absent after delete"
+        );
+
+        Ok(())
+    }
 }

--- a/crates/dasclaw_runtime/tests/keychain_e2e.rs
+++ b/crates/dasclaw_runtime/tests/keychain_e2e.rs
@@ -1,0 +1,149 @@
+//! Cross-platform OS-keychain end-to-end tests for
+//! [`dasclaw_runtime::secrets::keychain::KeychainConfig`].
+//!
+//! Tracks issue #897: PR #891 left the only real keychain coverage in
+//! `dasclaw_cli` gated to `target_os = "macos"`. The actual `keychain.rs`
+//! back-end is fully crate-split per target:
+//!
+//!   - macOS: `security-framework` (Keychain Services)
+//!   - Linux: `secret-service` over D-Bus (GNOME Keyring / KWallet)
+//!   - Windows: `windows` crate / DPAPI-sealed Credential Manager
+//!
+//! All three are headless-capable, so this file exercises the real OS
+//! API on every platform. Linux runners without a session D-Bus
+//! gracefully skip (eprintln + early return) instead of failing — CI
+//! containers commonly lack `DBUS_SESSION_BUS_ADDRESS`.
+//!
+//! Isolation: every test uses a uuid-derived service name so concurrent
+//! shards and previously-crashed runs cannot collide. A `Cleanup`
+//! drop-guard removes the slot even on panic.
+
+use dasclaw_runtime::secrets::keychain::{KeychainConfig, generate_master_key};
+use dasclaw_runtime::secrets::types::SecretError;
+use uuid::Uuid;
+
+/// Build a process-unique `KeychainConfig`.
+///
+/// `KeychainConfig` requires `&'static str` for both fields so the type
+/// stays `const`-constructible. We leak a single small `Box<str>` per
+/// test invocation to satisfy the lifetime — bounded by test count and
+/// only inside the test binary.
+fn unique_keychain_config(prefix: &str) -> KeychainConfig {
+    let service: &'static str =
+        Box::leak(format!("dasclaw_test_{}_{}", prefix, Uuid::new_v4().simple()).into_boxed_str());
+    KeychainConfig::new(service, "master_key")
+}
+
+/// RAII guard that best-effort deletes the keychain slot on drop, even
+/// if a test panics or returns early. Errors are ignored — the slot may
+/// legitimately be empty (e.g. after a successful explicit delete).
+struct Cleanup {
+    cfg: KeychainConfig,
+}
+
+impl Drop for Cleanup {
+    fn drop(&mut self) {
+        // Spawn into whichever runtime is alive. Inside `#[tokio::test]`
+        // we are still on the runtime thread, so `Handle::try_current`
+        // succeeds.
+        if let Ok(handle) = tokio::runtime::Handle::try_current() {
+            let cfg = self.cfg;
+            // `block_in_place` is not available on current_thread; use
+            // a dedicated short-lived thread to avoid nesting runtimes.
+            std::thread::scope(|s| {
+                s.spawn(|| {
+                    handle.block_on(async {
+                        let _ = cfg.delete_master_key().await;
+                    });
+                });
+            });
+        }
+    }
+}
+
+/// Shared contract executor used by every platform branch: store →
+/// has → get → delete → has(false) → get → `SecretError::NotFound`.
+async fn run_keychain_contract(cfg: KeychainConfig) -> Result<(), Box<dyn std::error::Error>> {
+    let _guard = Cleanup { cfg };
+
+    // Defensive pre-clean (slot may be poisoned by a crashed prior run).
+    let _ = cfg.delete_master_key().await;
+
+    let key = generate_master_key();
+    assert_eq!(key.len(), 32, "master key must be 32 bytes");
+
+    cfg.store_master_key(&key).await?;
+    assert!(
+        cfg.has_master_key().await,
+        "key must be present after store"
+    );
+
+    let read_back = cfg.get_master_key().await?;
+    assert_eq!(read_back, key, "round-trip must return identical bytes");
+
+    cfg.delete_master_key().await?;
+    assert!(
+        !cfg.has_master_key().await,
+        "key must be absent after delete"
+    );
+
+    // After delete, reading must surface an error rather than `Ok`.
+    //
+    // We deliberately do *not* pin the exact variant: the OS keychain
+    // back-ends in `keychain.rs` (macOS Security.framework, Linux
+    // secret-service, Windows Credential Manager) fold "item not
+    // found" into the generic `SecretError::KeychainError(_)` rather
+    // than `SecretError::NotFound(_)` — the latter is reserved for
+    // the higher-level `secrets::store*` layer. The contract that
+    // matters for the OS-keychain layer is "read-after-delete is not
+    // `Ok`", which is what we assert here.
+    match cfg.get_master_key().await {
+        Err(SecretError::KeychainError(_)) | Err(SecretError::NotFound(_)) => Ok(()),
+        Err(other) => {
+            Err(format!("expected KeychainError or NotFound after delete, got: {other:?}").into())
+        }
+        Ok(_) => Err("expected an error after delete, got Ok".into()),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// macOS — CI macOS runner has an ephemeral login keychain; no skipping.
+// ---------------------------------------------------------------------------
+#[cfg(target_os = "macos")]
+#[tokio::test]
+async fn req_runtime_keychain_macos_round_trip_then_notfound()
+-> Result<(), Box<dyn std::error::Error>> {
+    let cfg = unique_keychain_config("macos");
+    run_keychain_contract(cfg).await
+}
+
+// ---------------------------------------------------------------------------
+// Linux — requires a session D-Bus. CI containers usually lack one,
+// so gracefully skip rather than fail.
+// ---------------------------------------------------------------------------
+#[cfg(target_os = "linux")]
+#[tokio::test]
+async fn req_runtime_keychain_linux_round_trip_then_notfound()
+-> Result<(), Box<dyn std::error::Error>> {
+    if std::env::var("DBUS_SESSION_BUS_ADDRESS").is_err() {
+        eprintln!(
+            "SKIP req_runtime_keychain_linux_round_trip_then_notfound: \
+             DBUS_SESSION_BUS_ADDRESS not set; no session secret service available"
+        );
+        return Ok(());
+    }
+    let cfg = unique_keychain_config("linux");
+    run_keychain_contract(cfg).await
+}
+
+// ---------------------------------------------------------------------------
+// Windows — DPAPI / CredMan is available in any user session, headless
+// or otherwise. No skip path.
+// ---------------------------------------------------------------------------
+#[cfg(target_os = "windows")]
+#[tokio::test]
+async fn req_runtime_keychain_windows_round_trip_then_notfound()
+-> Result<(), Box<dyn std::error::Error>> {
+    let cfg = unique_keychain_config("windows");
+    run_keychain_contract(cfg).await
+}


### PR DESCRIPTION
## 背景 / 目标

Issue #897 要求补齐 keychain 真实 OS 端到端覆盖。原来只有 `crates/dasclaw_cli/tests/secrets_keychain_namespace_e2e.rs` 一个 macOS-only round-trip，且测试位置错配（`dasclaw_cli/src` 实际不引用 `KeychainConfig`，是 `dasclaw_runtime` 的实现）。

## 改动范围

仅两个 **测试** 文件，零生产代码改动，零 CI workflow 改动。

1. **新增** `crates/dasclaw_runtime/tests/keychain_e2e.rs`（~140 行）
   - 三个 `#[tokio::test]`，每个 `#[cfg(target_os = "...")]` 互斥：macOS / Linux / Windows
   - 命名 `req_runtime_keychain_<platform>_round_trip_then_notfound`
   - 共享 `run_keychain_contract`：defensive pre-delete → store → `has==true` → `get==key` → delete → `has==false` → 读必须返回 `Err(KeychainError(_) | NotFound(_))`（OS 后端把"not found"归到 `KeychainError`，store 层才返回 `NotFound`，所以 contract 接受两种）
   - 每个测试用 `dasclaw_test_<prefix>_<uuid_v4>` 唯一 service_name 避免互窜
   - Linux 测试在 `DBUS_SESSION_BUS_ADDRESS` 未设置时 `eprintln "SKIP ..."` 并 `return Ok(())`（CI runner 无 D-Bus session 时不 fail）
   - RAII `Cleanup` Drop：用 `std::thread::scope` + `Handle::block_on` 避开 nested-runtime panic
   - 全部用 `?` + `Result<(), Box<dyn Error>>`，零 `unwrap/expect/panic`

2. **重写** `crates/dasclaw_cli/tests/secrets_keychain_namespace_e2e.rs`（~130 行）
   - 删 `#![cfg(target_os = "macos")]`：现在每个 OS 都跑
   - 主测试 `req_dasclaw_cli_secrets_keychain_config_public_contract`：公共 API 契约哨兵，断言 `service_name`/`account` 字段可见、`const fn new()`、`Copy`/`Clone`/`PartialEq`/`Eq`/`Debug` 派生、结构相等性
   - 保留原 macOS round-trip 为 `#[ignore]` 的 `macos_smoke::req_dasclaw_cli_secrets_macos_smoke_round_trip`，作为 CLI 侧后备 smoke（`cargo nextest run -- --ignored` 才跑）

## 非目标 (What's NOT in this PR)

- ❌ 不改 `crates/dasclaw_runtime/src/secrets/keychain.rs` 任何实现（包括 OS 后端把 not-found 折叠成 `KeychainError` 的语义）
- ❌ 不动 `KeychainConfig` 公共 API
- ❌ 不改 CI workflow
- ❌ 不动 `dasclaw_cli/src` 任何文件

## 验证

```bash
# 1. 编译
cargo check -p dasclaw_runtime --tests   # ✅ 31.78s, 仅 pre-existing ironclaw bin-target 警告
cargo check -p dasclaw_cli --tests       # ✅ 9.70s, 同上

# 2. 测试（macOS host）
cargo nextest run -p dasclaw_runtime --test keychain_e2e
# ✅ Summary [5.642s] 1 test run: 1 passed, 0 skipped
#    PASS req_runtime_keychain_macos_round_trip_then_notfound
#    (linux/windows 通过 #[cfg] 在 macOS host 上不编译进 binary)

cargo nextest run -p dasclaw_cli --test secrets_keychain_namespace_e2e
# ✅ Summary [1.069s] 1 test run: 1 passed, 1 skipped
#    PASS req_dasclaw_cli_secrets_keychain_config_public_contract
#    (skipped = #[ignore]'d macos_smoke)

# 3. 风格
cargo fmt --all
python3.12 scripts/check_no_panics.py --base origin/xClaw
# ✅ OK: No panic-inducing calls in changed production code.
```

### Action 2 推理（为什么是 contract sentinel 而不是真 round-trip）

`grep -r KeychainConfig crates/dasclaw_cli/src/` 零命中——CLI 不直接引用，是 runtime 层的实现细节。所以 mock/trait/args-parsing 都没有目标可断言。Contract 哨兵断言"CLI 依赖的可观察接口表面"（字段可见性 + const-fn + 派生 traits + 结构相等性），同时把真实 OS 覆盖迁到正确位置 (`dasclaw_runtime/tests/`)。原 macOS round-trip 留作 `#[ignore]`'d backup smoke。

### CI 隐含假设

- Linux CI runner 可能无 `DBUS_SESSION_BUS_ADDRESS` → 测试用 `eprintln + return Ok(())` 优雅 skip，不 fail
- macOS / Windows CI runner 假设默认 session 提供 login keychain / Credential Manager
- CLI contract 测试零 OS 凭据前置条件，每 OS 都跑

### Skill 自查

- **code-quality-audit**：无补丁式代码、无重复逻辑、无 unwrap/clone 滥用、函数均 < 50 行、无超 3 层嵌套
- **code-simplifier**：`run_keychain_contract` 抽取共享 contract、`unique_keychain_config` 抽取唯一命名工厂；RAII Cleanup 一处实现
- **code-review-expert**：失败路径覆盖（NotFound/error）、Fail-Safe（删除后必须报错）、安全审计（master_key 32 bytes 断言）、防互窜（uuid v4 + defensive pre-delete + RAII cleanup）

Cross-cuts: 类A

Closes #897
