### PR TITLE
chore(adr-152): F4 fusion-cleanup — verify fusion flags absent, drop 2 stale dev-deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1352,20 +1352,14 @@ dependencies = [
  "futures-core",
  "futures-util",
  "hex",
- "home",
  "http 1.4.0",
  "http-body-util",
  "hyper 1.8.1",
  "hyper-named-pipe",
- "hyper-rustls 0.27.7",
  "hyper-util",
  "hyperlocal",
  "log",
  "pin-project-lite",
- "rustls 0.23.37",
- "rustls-native-certs 0.8.3",
- "rustls-pemfile 2.2.0",
- "rustls-pki-types",
  "serde",
  "serde_derive",
  "serde_json",
@@ -2719,7 +2713,6 @@ dependencies = [
  "pdf-extract",
  "pgvector",
  "postgres-types",
- "pretty_assertions",
  "pty-process",
  "rand 0.8.5",
  "refinery",
@@ -2742,7 +2735,6 @@ dependencies = [
  "tar",
  "tempfile",
  "termimad",
- "testcontainers-modules",
  "thiserror 2.0.18",
  "tokio",
  "tokio-postgres",
@@ -3990,17 +3982,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "docker_credential"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d89dfcba45b4afad7450a99b39e751590463e45c04728cf555d36bb66940de8"
-dependencies = [
- "base64 0.21.7",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -7919,31 +7900,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parse-display"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "914a1c2265c98e2446911282c6ac86d8524f495792c38c5bd884f80499c7538a"
-dependencies = [
- "parse-display-derive",
- "regex",
- "regex-syntax 0.8.10",
-]
-
-[[package]]
-name = "parse-display-derive"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ae7800a4c974efd12df917266338e79a7a74415173caf7e70aa0a0707345281"
-dependencies = [
- "proc-macro2",
- "quote",
- "regex",
- "regex-syntax 0.8.10",
- "structmeta",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "password-hash"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9429,15 +9385,6 @@ dependencies = [
  "thiserror 1.0.69",
  "url",
  "v_htmlescape",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
-dependencies = [
- "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -11429,29 +11376,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
-name = "structmeta"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e1575d8d40908d70f6fd05537266b90ae71b15dbbe7a8b7dffa2b759306d329"
-dependencies = [
- "proc-macro2",
- "quote",
- "structmeta-derive",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "structmeta-derive"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "152a0b65a590ff6c3da95cabe2353ee04e6167c896b28e3b14478c2636c922fc"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "strum"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12055,44 +11979,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
-name = "testcontainers"
-version = "0.23.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59a4f01f39bb10fc2a5ab23eb0d888b1e2bb168c157f61a1b98e6c501c639c74"
-dependencies = [
- "async-trait",
- "bollard",
- "bollard-stubs",
- "bytes",
- "docker_credential",
- "either",
- "etcetera",
- "futures",
- "log",
- "memchr",
- "parse-display",
- "pin-project-lite",
- "serde",
- "serde_json",
- "serde_with",
- "thiserror 2.0.18",
- "tokio",
- "tokio-stream",
- "tokio-tar",
- "tokio-util",
- "url",
-]
-
-[[package]]
-name = "testcontainers-modules"
-version = "0.11.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d43ed4e8f58424c3a2c6c56dbea6643c3c23e8666a34df13c54f0a184e6c707"
-dependencies = [
- "testcontainers",
-]
-
-[[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12391,21 +12277,6 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-util",
-]
-
-[[package]]
-name = "tokio-tar"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d5714c010ca3e5c27114c1cdeb9d14641ace49874aa5626d7149e47aedace75"
-dependencies = [
- "filetime",
- "futures-core",
- "libc",
- "redox_syscall 0.3.5",
- "tokio",
- "tokio-stream",
- "xattr",
 ]
 
 [[package]]

--- a/desktop-client/ironclaw/Cargo.toml
+++ b/desktop-client/ironclaw/Cargo.toml
@@ -305,8 +305,6 @@ windows = { version = "0.58", features = [
 ironclaw = { path = ".", features = ["test-support"], package = "dasclaw" }
 tokio-test = "0.4"
 tracing-test = "0.2"
-testcontainers-modules = { version = "0.11", features = ["postgres"] }
-pretty_assertions = "1"
 tempfile = "3"
 # Snapshot tests. Version is centrally pinned via the root
 # `[workspace.dependencies]` table (issues #898 / #899); the workspace


### PR DESCRIPTION
## 背景 / 目标

ADR-152 §3 阶段 F4 fusion 收尾审计。F1–F3 已 CLOSED（#625-#632）。

本 PR 严格按 issue #633 "只动依赖图，不改业务逻辑" 的范围执行：盘点 fusion 候选 flag、审计 ironclaw 侧六个目录的残留、清理无引用 dev-deps、校验依赖反向边。

## 审计清单

### (a) fusion 候选 flag 表

| 候选 flag | 源码出现 | Cargo manifest 出现 | 结论 |
|---|---|---|---|
| `fusion_v1` | 0（仅 ADR-152 文档自指）| 0 | **不存在，无需删除** |
| `legacy_*` | 0 | 0 | **不存在** |
| `claw-code-llm` | 1（不同血统，W6-C PR-A.4 lineage）| 1 | **不在 F4 范围**，保留 |

### (b) ironclaw 六目录残留审查

| 目录 | 行数 | 性质 | 处置 |
|---|---|---|---|
| `routines/mod.rs` | 36 | 真实模块声明 | 保留 |
| `channels/mod.rs` | 54 | http/repl/signal/status/wasm/web/webhook_server，ADR-152 F4.5 范围 | 保留 |
| `orchestrator/mod.rs` | 332 | 真实 HTTP API + ContainerJobManager（ADR-155）| 保留 |
| `secrets/mod.rs` + `keychain.rs` | 120 + 44 | Ironclaw 宿主胶水 + brand-pinned `IRONCLAW_KEYCHAIN`（ADR-152 phase 2 PR 4b' 要求）| 保留 |
| `import/mod.rs` | 93 | `openclaw` 迁移（ADR-152 line 90 明确 **不在 F4 范围**）| 保留 |
| `tools/builtin/mod.rs` | 54 | 8 个 `pub use dasclaw_*_tools::*` re-exports + 7 个 T3/T4 desktop-resident `pub mod`（ADR-156 §6.4）| 保留 |

**结论：六个目录全部是真实代码或合法 facade，无纯 `pub use crate::dasclaw_*` shell 可删。**

### (c) dev-dep 清理表

| dev-dep | tests/benches/src 引用数 | 处置 |
|---|---|---|
| `testcontainers-modules` | 0 | **删除** |
| `pretty_assertions` | 0 | **删除** |
| `tempfile` | 72 | 保留 |
| `tokio-test` | 1 | 保留 |
| `tracing-test` | 1 | 保留 |
| `insta` | 2 | 保留 |
| `criterion` | 2 | 保留 |

### (d) `cargo tree` 红线校验

```
$ cargo tree -p dasclaw -e features 2>&1 | grep -i fusion
（空）

$ cargo tree -p dasclaw_core 2>&1 | grep -i "dasclaw "
（无反向依赖到 ironclaw / desktop-client）
```

两条红线均 PASS。

## 改动范围

仅 `desktop-client/ironclaw/Cargo.toml`：

```diff
-testcontainers-modules = { version = "0.11", features = ["postgres"] }
-pretty_assertions = "1"
```

`Cargo.lock` 同步移除 129 行传递依赖。**无源码改动，无 cfg 变化，无业务逻辑改动。**

## 非目标（What's NOT in this PR）

- ❌ **不动** ADR-113 redline：`dasclaw_hooks::count_hook_systems()` 编译期断言
- ❌ **不动** ADR-148 redline：`safety/egress.rs` 唯一安全网关
- ❌ **不动** ADR-155：`desktop-client/ironclaw/src/orchestrator/`
- ❌ **不动** `import/openclaw`（ADR-152 line 90 显式排除）
- ❌ **不动** `claw-code-llm = []` flag（不同血统，W6-C 工程线）
- ❌ **不动** 任何 src/tests 文件

## 验证

```bash
# 1. 编译验证（证明 0 引用结论正确）
cargo check -p dasclaw --tests          # ✅ 通过，6m57s

# 2. 红线扫描
cargo tree -p dasclaw -e features 2>&1 | grep -i fusion   # 空 ✅
cargo tree -p dasclaw_core 2>&1 | grep -i "dasclaw "      # 空 ✅

# 3. 格式 + panic 守门
cargo fmt --all                                            # ✅
python3.12 scripts/check_no_panics.py --base origin/xClaw  # ✅ No panic-inducing calls in changed production code.
```

完整 `cargo build` / workspace clippy / heavy integration 由 CI 兜底。

**`cargo nextest run -p dasclaw` 不在本地 PR 必跑项内**：本 PR 仅删除 0-引用 dev-deps，`cargo check -p dasclaw --tests` 已编译验证无源码引用，不存在测试行为可受影响的路径；workspace nextest 由 CI Tests job 兜底。

## Out-of-scope findings（后续 follow-up 候选，不在本 PR 处理）

审计中发现两个 ironclaw 侧 pure-shell 文件，但都不在本 issue 的六目录范围内：

- `desktop-client/ironclaw/src/tools/rate_limiter.rs`（8 行，仅 `pub use dasclaw_runtime::rate_limit::{...};`）
- `desktop-client/ironclaw/src/profile.rs`（6 行，仅 `pub use dasclaw_workspace_cap::profile::*;`）

建议在 ADR-152 后续 follow-up issue 中单独处理，避免本 PR 越界。

## Cross-cuts

类 A（无新增 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量；仅删除两个无引用 crates.io dev-dep 名称）。

## Sources read

- `docs/plans/architecture-refactor/adr-152-agent-and-capability-fusion.md` §3 F4 (line 87)、line 90 (import scope)、line 108 (fusion_v1)、line 172 (hook redline)
- `docs/plans/architecture-refactor/adr-113-hook-engine-unification.md` § hook entry redline
- `docs/plans/architecture-refactor/adr-148-egress-gateway-unification.md` § safety gateway uniqueness
- `docs/plans/architecture-refactor/adr-155-orchestrator-host-residency.md` § orchestrator stays in desktop-client
- `docs/plans/architecture-refactor/adr-156-tools-residency.md` §6.3.1 + §6.4 T3/T4 desktop-resident
- `desktop-client/ironclaw/Cargo.toml` [dev-dependencies] block
- `desktop-client/ironclaw/src/{routines,channels,orchestrator,import,secrets,tools/builtin}/mod.rs`

Closes #633
