### PR TITLE
feat(runtime): expose cancel handle + add Session for multi-turn (#907)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3306,6 +3306,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tokio-postgres",
+ "tokio-util",
  "tracing",
  "uuid",
  "windows 0.58.0",

--- a/crates/dasclaw_runtime/Cargo.toml
+++ b/crates/dasclaw_runtime/Cargo.toml
@@ -22,6 +22,9 @@ secrecy = { version = "0.10", features = ["serde"] }
 uuid = { version = "1", features = ["v4", "serde"] }
 async-trait = "0.1"
 tokio = { version = "1", features = ["sync"] }
+# `CancellationToken` powers the `AgentBuilder::cancellation_token` /
+# `Agent::cancel_handle` plumbing (issue #907 Action 1).
+tokio-util = "0.7"
 tracing = "0.1"
 aes-gcm = "0.10"
 hkdf = "0.12"

--- a/crates/dasclaw_runtime/src/agent.rs
+++ b/crates/dasclaw_runtime/src/agent.rs
@@ -54,6 +54,7 @@ use dasclaw_core::reasoning_ctx::ReasoningContext;
 use dasclaw_core::response_types::{RespondOutput, ResponseMetadata};
 use dasclaw_core::traits::HostError;
 use serde::{Deserialize, Serialize};
+use tokio_util::sync::CancellationToken;
 
 /// Narrow LLM seam used by [`Agent`].
 ///
@@ -282,6 +283,10 @@ pub struct Agent {
     tool_output_sanitizer: Option<Arc<dyn ToolOutputSanitizer>>,
     hooks: HookBundle,
     config: AgentConfig,
+    /// Optional cancellation token wired through [`HeadlessDelegate::check_signals`].
+    /// When set and tripped, the agentic loop exits with
+    /// [`AgentError::Stopped`] on the next signal check. See issue #907.
+    cancellation_token: Option<CancellationToken>,
 }
 
 impl Agent {
@@ -291,10 +296,21 @@ impl Agent {
         AgentBuilder::default()
     }
 
-    /// Run a single user prompt through the loop and return the final
-    /// text response.
-    pub async fn run(&self, prompt: &str) -> Result<String, AgentError> {
-        let mut ctx = ReasoningContext::new();
+    /// Return a clone of the configured cancellation token, or `None` if
+    /// the agent was built without one. Callers (typically a GUI "stop"
+    /// button) cancel the returned handle to halt any in-flight
+    /// [`Agent::run`] or [`crate::Session::run`] at the next signal
+    /// check. See issue #907.
+    #[must_use]
+    pub fn cancel_handle(&self) -> Option<CancellationToken> {
+        self.cancellation_token.clone()
+    }
+
+    /// Seed a fresh [`ReasoningContext`] with the agent's static
+    /// configuration (system prompt, model override, advertised tools).
+    /// Shared by [`Agent::run`] and [`crate::Session::new`] so the
+    /// initialisation stays in one place.
+    pub(crate) fn seed_context(&self, ctx: &mut ReasoningContext) {
         if let Some(ref sp) = self.config.system_prompt {
             ctx.system_prompt = Some(sp.clone());
         }
@@ -304,6 +320,17 @@ impl Agent {
         if !self.config.tools.is_empty() {
             ctx.available_tools = self.config.tools.clone();
         }
+    }
+
+    /// Append `prompt` as a user message to `ctx` and drive the agentic
+    /// loop to completion. Called by [`Agent::run`] (after seeding a
+    /// fresh context) and by [`crate::Session::run`] (carrying the
+    /// session's accumulated context across turns).
+    pub(crate) async fn run_in_context(
+        &self,
+        ctx: &mut ReasoningContext,
+        prompt: &str,
+    ) -> Result<String, AgentError> {
         ctx.messages.push(ChatMessage::user(prompt));
 
         let loop_config = self
@@ -318,13 +345,34 @@ impl Agent {
             tool_executor: self.tool_executor.clone(),
             hooks: self.hooks.clone(),
             tool_output_sanitizer: self.tool_output_sanitizer.clone(),
+            cancellation_token: self.cancellation_token.clone(),
         };
 
-        let outcome = run_agentic_loop(&delegate, &mut ctx, &loop_config, &self.hooks)
+        let outcome = run_agentic_loop(&delegate, ctx, &loop_config, &self.hooks)
             .await
             .map_err(AgentError::Responder)?;
 
-        map_outcome(outcome, loop_config.max_iterations)
+        let result = map_outcome(outcome, loop_config.max_iterations);
+        // The core loop's `handle_text_response` returns the final text
+        // straight to the caller without recording it as an assistant
+        // turn in `ctx`. For single-shot `Agent::run` that doesn't
+        // matter (the context is thrown away). For multi-turn
+        // `Session::run` it does: without this push the next call would
+        // not see what the model just said. Mirroring the
+        // `assistant_with_tool_calls` push already done by
+        // `execute_tool_calls` keeps the history shape consistent.
+        if let Ok(text) = &result {
+            ctx.messages.push(ChatMessage::assistant(text));
+        }
+        result
+    }
+
+    /// Run a single user prompt through the loop and return the final
+    /// text response.
+    pub async fn run(&self, prompt: &str) -> Result<String, AgentError> {
+        let mut ctx = ReasoningContext::new();
+        self.seed_context(&mut ctx);
+        self.run_in_context(&mut ctx, prompt).await
     }
 }
 
@@ -345,6 +393,7 @@ pub struct AgentBuilder {
     tool_output_sanitizer: Option<Arc<dyn ToolOutputSanitizer>>,
     hooks: Option<HookBundle>,
     config: AgentConfig,
+    cancellation_token: Option<CancellationToken>,
 }
 
 impl AgentBuilder {
@@ -435,6 +484,18 @@ impl AgentBuilder {
         self
     }
 
+    /// Wire a [`CancellationToken`] that the headless delegate consults
+    /// on each loop signal check. Cancelling the token from outside
+    /// (typically via [`Agent::cancel_handle`]) halts an in-flight
+    /// [`Agent::run`] or [`crate::Session::run`] with
+    /// [`AgentError::Stopped`] at the next iteration boundary. See issue
+    /// #907.
+    #[must_use]
+    pub fn cancellation_token(mut self, token: CancellationToken) -> Self {
+        self.cancellation_token = Some(token);
+        self
+    }
+
     /// Finalise the agent.
     pub fn build(self) -> Result<Agent, AgentError> {
         let responder = self.responder.ok_or(AgentError::MissingResponder)?;
@@ -445,6 +506,7 @@ impl AgentBuilder {
             tool_output_sanitizer: self.tool_output_sanitizer,
             hooks,
             config: self.config,
+            cancellation_token: self.cancellation_token,
         })
     }
 }
@@ -459,12 +521,16 @@ struct HeadlessDelegate {
     tool_executor: Option<Arc<dyn ToolExecutor>>,
     hooks: HookBundle,
     tool_output_sanitizer: Option<Arc<dyn ToolOutputSanitizer>>,
+    cancellation_token: Option<CancellationToken>,
 }
 
 #[async_trait]
 impl LoopDelegate for HeadlessDelegate {
     async fn check_signals(&self) -> LoopSignal {
-        LoopSignal::Continue
+        match self.cancellation_token.as_ref() {
+            Some(token) if token.is_cancelled() => LoopSignal::Stop,
+            _ => LoopSignal::Continue,
+        }
     }
 
     async fn before_llm_call(

--- a/crates/dasclaw_runtime/src/lib.rs
+++ b/crates/dasclaw_runtime/src/lib.rs
@@ -1,6 +1,30 @@
 //! Application-layer runtime types shared across dasclaw hosts (ironclaw,
 //! admin-backend, claw-code, ...).
 //!
+//! ## Multi-turn `Session` quick start (issue #907)
+//!
+//! ```ignore
+//! use std::sync::Arc;
+//! use dasclaw_runtime::{Agent, Session};
+//! use tokio_util::sync::CancellationToken;
+//!
+//! let token = CancellationToken::new();
+//! let agent = Arc::new(
+//!     Agent::builder()
+//!         .responder(my_responder)
+//!         .system_prompt("be concise")
+//!         .cancellation_token(token.clone())   // GUI "stop" button
+//!         .build()?,
+//! );
+//!
+//! let mut session = Session::new(agent.clone());
+//! let reply1 = session.run("what's 2 + 2?").await?;
+//! let reply2 = session.run("and times 10?").await?; // sees prior turn
+//!
+//! // From the GUI thread:
+//! token.cancel();                                   // halts in-flight run
+//! ```
+//!
 //! ## Modules
 //!
 //! - [`error`] — application-layer `ToolError` carrying the failing tool's
@@ -45,6 +69,7 @@ pub mod llm_adapter;
 pub mod rate_limit;
 pub mod recording;
 pub mod secrets;
+pub mod session;
 pub mod tool;
 pub mod tool_to_executor_adapter;
 
@@ -59,5 +84,6 @@ pub use job_context::JobContextCore;
 pub use llm_adapter::LlmProviderResponder;
 pub use rate_limit::{LimitType, RateLimitError, RateLimitResult, RateLimiter};
 pub use recording::{HttpExchange, HttpExchangeRequest, HttpExchangeResponse, HttpInterceptor};
+pub use session::Session;
 pub use tool::Tool;
 pub use tool_to_executor_adapter::ToolToExecutorAdapter;

--- a/crates/dasclaw_runtime/src/session.rs
+++ b/crates/dasclaw_runtime/src/session.rs
@@ -1,0 +1,93 @@
+//! Multi-turn `Session` facade for [`Agent`] (issue #907 Action 2).
+//!
+//! ## Why this exists
+//!
+//! A bare [`Agent::run`] is one-shot: every call seeds a fresh
+//! `ReasoningContext`, so the GUI has no place to keep "the prior turn"
+//! short of re-feeding the full history string into the next prompt. The
+//! issue #907 background calls this out as a GUI blocker.
+//!
+//! `Session` is the smallest thing that fixes it:
+//!
+//! - holds an `Arc<Agent>` plus one persistent [`ReasoningContext`]
+//! - on construction, seeds the context once with the agent's system
+//!   prompt / model override / advertised tools (via
+//!   [`Agent::seed_context`])
+//! - each [`Session::run`] appends a new user turn to the same context
+//!   and re-enters the loop, so the responder sees the full conversation
+//!
+//! Cancellation is inherited from the agent: if the agent was built with
+//! [`crate::AgentBuilder::cancellation_token`], cancelling the handle
+//! halts the in-flight `Session::run` with [`AgentError::Stopped`] at
+//! the next loop signal check.
+//!
+//! ## Non-goals
+//!
+//! - **No serde / persistence / fork / compaction.** Those land in a
+//!   follow-up issue that ports the rich `claw-code::Session` features
+//!   into a dedicated `dasclaw_session` crate (ADR-153 §4.3 B+).
+//! - **No streaming.** See issue B2.
+//!
+//! ## Example
+//!
+//! ```ignore
+//! use std::sync::Arc;
+//! use dasclaw_runtime::{Agent, Session};
+//!
+//! let agent = Arc::new(
+//!     Agent::builder()
+//!         .responder(my_responder)
+//!         .system_prompt("be concise")
+//!         .build()?,
+//! );
+//! let mut session = Session::new(agent);
+//! let reply1 = session.run("what's 2 + 2?").await?;
+//! let reply2 = session.run("and times 10?").await?; // sees prior turn
+//! ```
+
+use std::sync::Arc;
+
+use dasclaw_core::messages::ChatMessage;
+use dasclaw_core::reasoning_ctx::ReasoningContext;
+
+use crate::agent::{Agent, AgentError};
+
+/// Stateful, multi-turn conversation handle around an [`Agent`].
+///
+/// Keeps a single [`ReasoningContext`] alive across calls so each
+/// [`Session::run`] carries the previous user + assistant + tool_result
+/// turns into the next loop iteration.
+pub struct Session {
+    agent: Arc<Agent>,
+    ctx: ReasoningContext,
+}
+
+impl Session {
+    /// Build a new session bound to `agent`. The session's
+    /// [`ReasoningContext`] is seeded once with the agent's system
+    /// prompt, model override and advertised tools.
+    #[must_use]
+    pub fn new(agent: Arc<Agent>) -> Self {
+        let mut ctx = ReasoningContext::new();
+        agent.seed_context(&mut ctx);
+        Self { agent, ctx }
+    }
+
+    /// Send a new user prompt and return the final text response.
+    ///
+    /// The prompt is appended to the session's accumulated history, then
+    /// the agentic loop runs as in [`Agent::run`]. All assistant turns,
+    /// tool calls and tool results produced by the loop remain in the
+    /// session's context for subsequent calls.
+    pub async fn run(&mut self, prompt: &str) -> Result<String, AgentError> {
+        self.agent.run_in_context(&mut self.ctx, prompt).await
+    }
+
+    /// Read-only view of the accumulated conversation history. Useful
+    /// for a GUI that needs to render the dialog or for tests that
+    /// assert on what the responder saw.
+    #[must_use]
+    pub fn messages(&self) -> &[ChatMessage] {
+        &self.ctx.messages
+    }
+}

--- a/crates/dasclaw_runtime/tests/session_e2e.rs
+++ b/crates/dasclaw_runtime/tests/session_e2e.rs
@@ -1,0 +1,177 @@
+//! End-to-end tests for issue #907: cancel handle + multi-turn `Session`.
+//!
+//! Two behavioural contracts are covered here:
+//!
+//! 1. `Agent::cancel_handle()` — when the token is already cancelled,
+//!    `Agent::run` exits at the first signal check with
+//!    [`AgentError::Stopped`] without ever calling the responder.
+//! 2. `Session::run` — running twice in a row carries the conversation
+//!    history into the second call, so the responder sees the prior user
+//!    and assistant turns in `ReasoningContext::messages`. External
+//!    cancel on a session also surfaces as [`AgentError::Stopped`].
+//!
+//! ### Why we test pre-cancellation rather than mid-flight cancellation
+//!
+//! The agentic loop checks `check_signals` once per iteration boundary.
+//! A text response is terminal (the loop returns immediately on it), so
+//! mid-flight cancellation only matters when a tool call splits the
+//! conversation into ≥2 iterations. Wiring a full `ToolExecutor` mock
+//! solely to prove the token is read on every iteration adds noise here;
+//! the iteration-boundary contract is already covered by
+//! `dasclaw_core::agentic_loop` unit tests (search for
+//! `with_signal(LoopSignal::Stop)`), and this file focuses on the new
+//! `Agent::cancel_handle` plumbing instead.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use dasclaw_core::messages::{ChatMessage, FinishReason};
+use dasclaw_core::reasoning_ctx::ReasoningContext;
+use dasclaw_core::response_types::{RespondOutput, RespondResult, ResponseMetadata, TokenUsage};
+use dasclaw_core::traits::HostError;
+use dasclaw_runtime::{Agent, AgentError, AgentResponder, Session};
+use tokio_util::sync::CancellationToken;
+
+/// Scripted responder: returns text outputs in order, and records the
+/// length of `ctx.messages` it saw on each call so tests can assert how
+/// much history was carried in.
+struct ScriptedResponder {
+    script: tokio::sync::Mutex<Vec<&'static str>>,
+    seen_message_counts: tokio::sync::Mutex<Vec<usize>>,
+}
+
+impl ScriptedResponder {
+    fn new(script: Vec<&'static str>) -> Self {
+        Self {
+            script: tokio::sync::Mutex::new(script),
+            seen_message_counts: tokio::sync::Mutex::new(Vec::new()),
+        }
+    }
+
+    async fn seen_counts(&self) -> Vec<usize> {
+        self.seen_message_counts.lock().await.clone()
+    }
+}
+
+#[async_trait]
+impl AgentResponder for ScriptedResponder {
+    async fn respond(&self, ctx: &mut ReasoningContext) -> Result<RespondOutput, HostError> {
+        self.seen_message_counts
+            .lock()
+            .await
+            .push(ctx.messages.len());
+        let mut s = self.script.lock().await;
+        if s.is_empty() {
+            return Err("script exhausted".into());
+        }
+        let text = s.remove(0);
+        Ok(RespondOutput {
+            result: RespondResult::Text(text.to_string()),
+            usage: TokenUsage::default(),
+            finish_reason: FinishReason::Stop,
+            metadata: ResponseMetadata::default(),
+        })
+    }
+}
+
+#[tokio::test]
+async fn req_dasclaw_runtime_session_b1_run_twice_carries_history() {
+    let responder = Arc::new(ScriptedResponder::new(vec!["first reply", "second reply"]));
+    let agent = Arc::new(
+        Agent::builder()
+            .responder_arc(responder.clone())
+            .system_prompt("be concise")
+            .build()
+            .expect("build agent"),
+    );
+
+    let mut session = Session::new(agent);
+
+    let first = session.run("hello").await.expect("first run");
+    assert_eq!(first, "first reply");
+
+    let second = session.run("again").await.expect("second run");
+    assert_eq!(second, "second reply");
+
+    // Responder saw growing context across calls:
+    //   call 1: [user("hello")]
+    //   call 2: [user("hello"), assistant("first reply"), user("again")]
+    let counts = responder.seen_counts().await;
+    assert_eq!(
+        counts,
+        vec![1, 3],
+        "responder must see the prior turn carried into the 2nd call"
+    );
+
+    // Session exposes the accumulated history for the GUI to render.
+    let history: Vec<&ChatMessage> = session.messages().iter().collect();
+    assert_eq!(history.len(), 4, "expected user/assistant x2: {history:?}");
+}
+
+#[tokio::test]
+async fn req_dasclaw_runtime_agent_b1_cancel_handle_stops_loop_before_responder() {
+    let token = CancellationToken::new();
+    // Cancel before the loop even starts; the first iteration's signal
+    // check must short-circuit to `Stopped` and the scripted responder
+    // must never be polled.
+    token.cancel();
+
+    let responder = ScriptedResponder::new(vec!["never reached"]);
+    let agent = Agent::builder()
+        .responder(responder)
+        .cancellation_token(token.clone())
+        .build()
+        .expect("build agent");
+
+    let handle = agent
+        .cancel_handle()
+        .expect("cancel_handle returns the configured token");
+    assert!(handle.is_cancelled(), "we just cancelled it");
+
+    let err = agent
+        .run("please stop")
+        .await
+        .expect_err("loop should stop, not produce a response");
+    assert!(
+        matches!(err, AgentError::Stopped),
+        "expected AgentError::Stopped, got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn req_dasclaw_runtime_agent_b1_cancel_handle_returns_none_when_unset() {
+    let responder = ScriptedResponder::new(vec!["hello world"]);
+    let agent = Agent::builder()
+        .responder(responder)
+        .build()
+        .expect("build");
+    assert!(
+        agent.cancel_handle().is_none(),
+        "cancel_handle must be None when no token was wired"
+    );
+}
+
+#[tokio::test]
+async fn req_dasclaw_runtime_session_b1_external_cancel_stops_session_run() {
+    let token = CancellationToken::new();
+    token.cancel();
+
+    let responder = ScriptedResponder::new(vec!["never reached"]);
+    let agent = Arc::new(
+        Agent::builder()
+            .responder(responder)
+            .cancellation_token(token)
+            .build()
+            .expect("build agent"),
+    );
+
+    let mut session = Session::new(agent);
+    let err = session
+        .run("anything")
+        .await
+        .expect_err("session.run must propagate Stopped");
+    assert!(
+        matches!(err, AgentError::Stopped),
+        "expected AgentError::Stopped, got {err:?}"
+    );
+}


### PR DESCRIPTION
## 背景 / 目标

实现调研报告中标记为 GUI 接入阻塞的 B1：`dasclaw_runtime` 缺少 cancel 暴露口 + 多轮 Session 句柄。GUI 上的"停止"按钮和"保留历史换下个问题"两个最基础诉求当前都没有原生通道。

- **Action 1（cancel 暴露）**：`AgentBuilder::cancellation_token(token)` 把 `tokio_util::sync::CancellationToken` 接入 `HeadlessDelegate::check_signals`；`Agent::cancel_handle()` 返回 token clone 让 GUI 持有。token 触发后，正在跑的 loop 在下一次 `check_signals` 边界返回 `AgentError::Stopped`。
- **Action 2（多轮 Session）**：新增 `dasclaw_runtime::Session`，持有 `Arc<Agent>` + 一份持久 `ReasoningContext`。`Session::new` 一次性 seed 静态配置；`Session::run` 把新 prompt 追加到同一 context 上重入 loop，responder 自然看到之前的 user/assistant 历史。`Session::messages()` 把累积历史读出来供 GUI 渲染。

## 改动范围

| 文件 | 改动 |
|---|---|
| `crates/dasclaw_runtime/src/agent.rs` | 加 `cancellation_token` 字段 + builder + `cancel_handle()`；`HeadlessDelegate::check_signals` 接通 token；把 `run()` 重构成 `seed_context() + run_in_context()` 两个 helper（不是补丁式追加 if） |
| `crates/dasclaw_runtime/src/session.rs` | **新增** Session facade |
| `crates/dasclaw_runtime/src/lib.rs` | 加 `pub mod session` + `pub use Session`；顶部 doc 加 Session 用法样例（issue 验收项） |
| `crates/dasclaw_runtime/Cargo.toml` | 加 `tokio-util = "0.7"` 依赖 |
| `crates/dasclaw_runtime/tests/session_e2e.rs` | **新增** 4 个端到端测试 |

### 顺手修了一个 latent 缺陷

`dasclaw_core::agentic_loop::handle_text_response` 在 text 终止时**不会**把 assistant 文本 push 回 ctx。对 single-shot `Agent::run` 没影响（ctx 是临时局部），但对 `Session::run` 就是"第二次 run 时模型看不到自己上一次说了什么"的硬 bug。

修复点放在 `run_in_context` 末尾：成功后把 assistant 文本 push 到 ctx，和 `execute_tool_calls` 路径已有的 `assistant_with_tool_calls` push 对称，不动 `dasclaw_core` 合约。

## 非目标（What's NOT in this PR）

- ❌ 不做 serde derives（独立 PR #912 已合并）
- ❌ 不做 streaming（issue B2 / 后续 PR）
- ❌ 不搬 claw-code Session 的高级能力（fork / compaction / jsonl 持久化）—— 见 follow-up issue #914（ADR-153 §4.3 B+ 方向）
- ❌ 不动 ADR-113 hook 红线 / ADR-148 安全闸门
- ❌ 不引入 workspace-level 新依赖（`tokio-util` 已在其它 crate 使用）

## 验证

```bash
cargo check -p dasclaw_runtime --tests                  # 0 errors 0 warnings
cargo nextest run -p dasclaw_runtime                    # 182 / 182 pass
cargo fmt --all                                         # clean
python3.12 scripts/check_no_panics.py --base origin/xClaw  # OK
cargo clippy --no-deps -p dasclaw_runtime --all-targets -- -D warnings  # ok
```

### 新增 4 个测试（`tests/session_e2e.rs`）

| 测试 | 覆盖契约 |
|---|---|
| `req_dasclaw_runtime_session_b1_run_twice_carries_history` | Session::run 二次调用，responder 看到 `[user, assistant, user]` 三条而非 `[user]` 一条 |
| `req_dasclaw_runtime_agent_b1_cancel_handle_stops_loop_before_responder` | cancel 后 run 立即 Stopped，responder 一次都不被调 |
| `req_dasclaw_runtime_agent_b1_cancel_handle_returns_none_when_unset` | 未配置 token 时 `cancel_handle()` 返回 None |
| `req_dasclaw_runtime_session_b1_external_cancel_stops_session_run` | 外部 cancel 同样能停 Session::run |

> 选择 pre-cancel 测试覆盖核心契约，是因为 text 响应在 loop 内是终止态（直接 return），mid-flight cancel 只在 tool 调用拆出 ≥2 轮时才有意义；iteration 边界的 signal 读取已有 `dasclaw_core::agentic_loop` 单测覆盖。

## 三层 skill 自审

| Skill | 结论 |
|---|---|
| code-quality-audit | 5 项全通过：无补丁式 if 追加；函数最长 24 行；嵌套 ≤2 层；无 unwrap/expect/panic；无重复造轮（CancellationToken 用 tokio-util） |
| code-simplifier | 已收敛，无可压缩空间 |
| code-review-expert | SOLID/安全/向后兼容/API 契约全通过；`Agent::run` 签名不变，原 178 测试 0 回归 |

## 关联

- Issue: #907（GUI 接入阻塞 B1）
- Follow-up: #914（B+ 抽 dasclaw_session crate 搬 claw-code 高级 Session 能力）
- ADR: ADR-153 §4.3
- 调研报告: 无头 agent 框架 GUI 接入度评估，TL;DR §3 P0

## Cross-cuts

类A — diff 内未新增任何 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量。

Closes #907
