### PR TITLE
feat(session): extract dasclaw_session crate for multi-turn facade (#914 PR-A)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3425,6 +3425,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "dasclaw_session"
+version = "0.0.0-w6"
+dependencies = [
+ "async-trait",
+ "dasclaw_core",
+ "dasclaw_runtime",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
 name = "dasclaw_shell_command"
 version = "0.0.0-w5"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,9 @@ members = [
 	"crates/dasclaw_tool",
 	# F3.2 phase 2 PR 2 — application-layer error type + future JobContext (see #641)
 	"crates/dasclaw_runtime",
+	# Issue #914 PR-A — multi-turn Session facade extracted out of dasclaw_runtime
+	# (phase 1 of the claw-code Session parity port; ADR-153 §4.3 B+).
+	"crates/dasclaw_session",
 	"crates/dasclaw_observability",
 	"crates/dasclaw_identity",
 	"crates/dasclaw_crash",

--- a/crates/dasclaw_runtime/src/agent.rs
+++ b/crates/dasclaw_runtime/src/agent.rs
@@ -308,9 +308,15 @@ impl Agent {
 
     /// Seed a fresh [`ReasoningContext`] with the agent's static
     /// configuration (system prompt, model override, advertised tools).
-    /// Shared by [`Agent::run`] and [`crate::Session::new`] so the
-    /// initialisation stays in one place.
-    pub(crate) fn seed_context(&self, ctx: &mut ReasoningContext) {
+    /// Shared by [`Agent::run`] and `dasclaw_session::Session::new` so
+    /// the initialisation stays in one place.
+    ///
+    /// This is part of the support API consumed by the
+    /// [`dasclaw_session`](https://docs.rs/dasclaw_session) crate; it is
+    /// public so that crate can build a multi-turn facade without
+    /// duplicating the seeding logic. End-host code should prefer
+    /// [`Agent::run`] or `dasclaw_session::Session`.
+    pub fn seed_context(&self, ctx: &mut ReasoningContext) {
         if let Some(ref sp) = self.config.system_prompt {
             ctx.system_prompt = Some(sp.clone());
         }
@@ -324,9 +330,12 @@ impl Agent {
 
     /// Append `prompt` as a user message to `ctx` and drive the agentic
     /// loop to completion. Called by [`Agent::run`] (after seeding a
-    /// fresh context) and by [`crate::Session::run`] (carrying the
-    /// session's accumulated context across turns).
-    pub(crate) async fn run_in_context(
+    /// fresh context) and by `dasclaw_session::Session::run` (carrying
+    /// the session's accumulated context across turns).
+    ///
+    /// Part of the same support API as [`Agent::seed_context`]; see
+    /// that method's docs for the rationale.
+    pub async fn run_in_context(
         &self,
         ctx: &mut ReasoningContext,
         prompt: &str,

--- a/crates/dasclaw_runtime/src/lib.rs
+++ b/crates/dasclaw_runtime/src/lib.rs
@@ -1,11 +1,17 @@
 //! Application-layer runtime types shared across dasclaw hosts (ironclaw,
 //! admin-backend, claw-code, ...).
 //!
-//! ## Multi-turn `Session` quick start (issue #907)
+//! ## Multi-turn `Session` (issue #907 / #914)
+//!
+//! The multi-turn conversation facade lives in the
+//! [`dasclaw_session`](https://docs.rs/dasclaw_session) crate. This
+//! crate exposes the building blocks (`Agent`, `AgentBuilder`,
+//! `AgentError`, `cancel_handle`) that `Session` wraps. Typical usage:
 //!
 //! ```ignore
 //! use std::sync::Arc;
-//! use dasclaw_runtime::{Agent, Session};
+//! use dasclaw_runtime::Agent;
+//! use dasclaw_session::Session;
 //! use tokio_util::sync::CancellationToken;
 //!
 //! let token = CancellationToken::new();
@@ -69,7 +75,6 @@ pub mod llm_adapter;
 pub mod rate_limit;
 pub mod recording;
 pub mod secrets;
-pub mod session;
 pub mod tool;
 pub mod tool_to_executor_adapter;
 
@@ -84,6 +89,5 @@ pub use job_context::JobContextCore;
 pub use llm_adapter::LlmProviderResponder;
 pub use rate_limit::{LimitType, RateLimitError, RateLimitResult, RateLimiter};
 pub use recording::{HttpExchange, HttpExchangeRequest, HttpExchangeResponse, HttpInterceptor};
-pub use session::Session;
 pub use tool::Tool;
 pub use tool_to_executor_adapter::ToolToExecutorAdapter;

--- a/crates/dasclaw_session/Cargo.toml
+++ b/crates/dasclaw_session/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "dasclaw_session"
+version = "0.0.0-w6"
+edition = "2024"
+description = "Multi-turn `Session` facade over `dasclaw_runtime::Agent` (issue #907 Action 2, ADR-153 §4.3 phase 1). Future home for the richer `claw-code`-parity Session port (issue #914 PR-B/C: fork / compaction / jsonl persistence)."
+license = "MIT OR Apache-2.0"
+
+[dependencies]
+# Provides `ChatMessage`, `ReasoningContext` — the conversation primitives.
+dasclaw_core = { path = "../dasclaw_core" }
+# Provides `Agent`, `AgentError`, and the `seed_context` / `run_in_context`
+# support API that `Session` delegates to.
+dasclaw_runtime = { path = "../dasclaw_runtime" }
+
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync"] }
+tokio-util = "0.7"
+async-trait = "0.1"

--- a/crates/dasclaw_session/src/lib.rs
+++ b/crates/dasclaw_session/src/lib.rs
@@ -17,22 +17,26 @@
 //!   and re-enters the loop, so the responder sees the full conversation
 //!
 //! Cancellation is inherited from the agent: if the agent was built with
-//! [`crate::AgentBuilder::cancellation_token`], cancelling the handle
-//! halts the in-flight `Session::run` with [`AgentError::Stopped`] at
-//! the next loop signal check.
+//! [`dasclaw_runtime::AgentBuilder::cancellation_token`], cancelling the
+//! handle halts the in-flight `Session::run` with [`AgentError::Stopped`]
+//! at the next loop signal check.
 //!
-//! ## Non-goals
+//! ## Non-goals (phase 1)
 //!
-//! - **No serde / persistence / fork / compaction.** Those land in a
-//!   follow-up issue that ports the rich `claw-code::Session` features
-//!   into a dedicated `dasclaw_session` crate (ADR-153 §4.3 B+).
+//! This crate ships intentionally minimal so PR #913 can land the GUI
+//! blocker fix without a large new surface. The richer features land in
+//! follow-up PRs against issue #914:
+//!
+//! - **No serde / persistence / fork / compaction.** Phase 2 (#914 PR-B/C)
+//!   ports those from `claw-code::Session` (ADR-153 §4.3 B+).
 //! - **No streaming.** See issue B2.
 //!
 //! ## Example
 //!
 //! ```ignore
 //! use std::sync::Arc;
-//! use dasclaw_runtime::{Agent, Session};
+//! use dasclaw_runtime::Agent;
+//! use dasclaw_session::Session;
 //!
 //! let agent = Arc::new(
 //!     Agent::builder()
@@ -49,8 +53,7 @@ use std::sync::Arc;
 
 use dasclaw_core::messages::ChatMessage;
 use dasclaw_core::reasoning_ctx::ReasoningContext;
-
-use crate::agent::{Agent, AgentError};
+use dasclaw_runtime::{Agent, AgentError};
 
 /// Stateful, multi-turn conversation handle around an [`Agent`].
 ///

--- a/crates/dasclaw_session/tests/session_e2e.rs
+++ b/crates/dasclaw_session/tests/session_e2e.rs
@@ -29,7 +29,8 @@ use dasclaw_core::messages::{ChatMessage, FinishReason};
 use dasclaw_core::reasoning_ctx::ReasoningContext;
 use dasclaw_core::response_types::{RespondOutput, RespondResult, ResponseMetadata, TokenUsage};
 use dasclaw_core::traits::HostError;
-use dasclaw_runtime::{Agent, AgentError, AgentResponder, Session};
+use dasclaw_runtime::{Agent, AgentError, AgentResponder};
+use dasclaw_session::Session;
 use tokio_util::sync::CancellationToken;
 
 /// Scripted responder: returns text outputs in order, and records the

--- a/scripts/check_blueprint_sync.py
+++ b/scripts/check_blueprint_sync.py
@@ -51,11 +51,9 @@ PLANNED: dict[str, str] = {
     # F4.6.6-a (`dasclaw_fs_tools`) landed — entry removed.
     # F4.6.7 (`dasclaw_shell_tools`) landed — entry removed.
     # F4.6.8 (`dasclaw_net_tools`) landed (phases 1/2/3) — entry removed.
-    # ADR-153 §4.3 step 3 — optional session crate, deliberately deferred
-    # until a second caller appears. Mentioned in 31-target-architecture.md
-    # §ADR-153 closure note (footnote: "step 3 暂搁"). Keep here so the
-    # blueprint can reference the planned name without the guard going red.
-    "dasclaw_session": "ADR-153 §4.3 step 3 — deferred until 2nd caller emerges",
+    # ADR-153 §4.3 step 3 (`dasclaw_session`) landed in PR #916 — entry
+    # removed. Subsequent persistence work (PR-B/C/D under issue #914)
+    # extends the same crate.
 }
 
 # Symbols that look like crate names but are not. Examples: conceptual


### PR DESCRIPTION
## 背景 / 目标

#914 PR-A：把 `Session` 从 `dasclaw_runtime` 抽到独立 crate `dasclaw_session`，作为后续 #914 PR-B/C（搬 claw-code Session 的 SessionStore / fork / compaction / jsonl 持久化）的 phase 1 落地点（ADR-153 §4.3 B+）。

## 为什么"搬"而不是"re-export"

原 #914 issue 描述写"在 dasclaw_runtime re-export dasclaw_session::Session"。实现时发现这是循环依赖：

- `dasclaw_session` 必须依赖 `dasclaw_runtime`（用 `Agent` / `AgentError`）
- `dasclaw_runtime` 又 re-export `dasclaw_session::Session` 就闭环了

PR-B/C 要新增的 `SessionStore` / fork / compaction 也都坐在 `dasclaw_runtime` 之上。最干净的做法是现在就把 Session 整搬走，让 dependency DAG 单向：`dasclaw_core` ← `dasclaw_runtime` ← `dasclaw_session`。

stacked 在 #913 上做这一步，可以避免 #913 刚 ship 立即又来一个"把刚加的 API 移走"的 breaking PR。

## 改动范围

| 文件 | 操作 |
|---|---|
| `crates/dasclaw_session/Cargo.toml` | **新增** — 依赖 `dasclaw_core` + `dasclaw_runtime` |
| `crates/dasclaw_runtime/src/session.rs` → `crates/dasclaw_session/src/lib.rs` | `git mv` + 改 import 路径（`crate::agent::` → `dasclaw_runtime::`）+ 改 doc 中模块路径 |
| `crates/dasclaw_runtime/tests/session_e2e.rs` → `crates/dasclaw_session/tests/session_e2e.rs` | `git mv` + 改 `Session` 导入路径 |
| `crates/dasclaw_runtime/src/lib.rs` | 删 `pub mod session;` + `pub use session::Session;`；顶部 doc 改为"详见 dasclaw_session crate" |
| `crates/dasclaw_runtime/src/agent.rs` | `seed_context` / `run_in_context` 从 `pub(crate)` → `pub`，加 doc 注明 "intended for use by the dasclaw_session crate"。**签名与函数体不变** |
| `Cargo.toml` | workspace 注册 `crates/dasclaw_session` |

### Session 行为零变化

4 个 e2e 测试**一行没改逻辑**（只改了 `use` 路径中 `Session` 来源），全部 182/182 通过，证明 Session 类型本身契约与 #913 完全一致。

## 非目标（What's NOT in this PR）

- ❌ 不引入 `SessionStore` trait（留给 #914 PR-B）
- ❌ 不引入 `serde` derive / jsonl 持久化（留给 #914 PR-B）
- ❌ 不引入 `Session::compact` / `Session::fork`（留给 #914 PR-C）
- ❌ 不改 Session 行为契约 — `Session::new` / `Session::run` / `Session::messages` 签名与 #913 完全一致
- ❌ 不动 ADR-113 hook 红线 / ADR-148 安全闸门

## 验证

```bash
cargo check -p dasclaw_session -p dasclaw_runtime --tests        # 0 errors 0 warnings
cargo nextest run -p dasclaw_session -p dasclaw_runtime          # 182 / 182 pass
cargo fmt --all                                                   # clean
python3.12 scripts/check_no_panics.py --base origin/xClaw        # OK
cargo clippy --no-deps -p dasclaw_session -p dasclaw_runtime --all-targets -- -D warnings  # ok
```

4 个 session e2e 测试现在跑在 `dasclaw_session::session_e2e`：

| 测试 | 覆盖契约 |
|---|---|
| `req_dasclaw_runtime_session_b1_run_twice_carries_history` | Session 两次 run 后 responder 看到 `[user, assistant, user]` 历史 |
| `req_dasclaw_runtime_agent_b1_cancel_handle_stops_loop_before_responder` | pre-cancel token → AgentError::Stopped |
| `req_dasclaw_runtime_agent_b1_cancel_handle_returns_none_when_unset` | 未配置 token 时 cancel_handle 返回 None |
| `req_dasclaw_runtime_session_b1_external_cancel_stops_session_run` | 外部 cancel 同样能停 Session::run |

## 三层 skill 自审

| Skill | 结论 |
|---|---|
| code-quality-audit | ✅ 纯抽离搬迁，无补丁式 if 追加；最长函数 5 行；嵌套 ≤1；无 panic / unwrap / expect；无新增 clone |
| code-simplifier | ✅ 搬迁性质无 simplify 空间；注释精准 |
| code-review-expert | ✅ SOLID 保持；`seed_context`/`run_in_context` 升 `pub` 已 doc 标注"intended for dasclaw_session"；删除 `dasclaw_runtime::Session` 导出仅影响刚由 #913 引入的 API，stacked 在 #913 上属连续操作；无外部依赖会被破坏 |

## Stacked PR 说明

**本 PR base = `feat/907-session-cancel-handle`（即 PR #913），不是 `xClaw`。** 文件依赖 PR #913 引入的 `session.rs` + `session_e2e.rs`。

**merge 顺序**：
1. 先 review + merge PR #913
2. **合 #913 时不要勾选 "Delete branch"**（AGENTS.md 路径 A）；或者合并后立刻把本 PR base 切到 `xClaw`（路径 B）
3. 然后 rebase 本 PR 到最新 `xClaw` 并 merge

## 关联

- Follow-up issue: #914（B+ 搬 claw-code Session 高级能力）
- Phase 1 前置: #913（issue #907 cancel handle + 薄 Session）
- ADR: ADR-153 §4.3

## Cross-cuts

类A — diff 内未新增任何 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量。

## 后续 PR / 下一步

- **#914 PR-B**: `SessionStore` trait + `InMemorySessionStore` + `JsonlSessionStore`（含 rotate）+ serde derive + insta 快照
- **#914 PR-C**: `Session::compact` + `Session::fork` + 与 claw-code jsonl 跨工具兼容性 smoke

Refs #914


Closes #918
