### PR TITLE
feat(session): add SessionSnapshot + SessionStore trait + InMemorySessionStore (#914 PR-B)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3431,6 +3431,10 @@ dependencies = [
  "async-trait",
  "dasclaw_core",
  "dasclaw_runtime",
+ "insta",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-util",
 ]

--- a/crates/dasclaw_session/Cargo.toml
+++ b/crates/dasclaw_session/Cargo.toml
@@ -11,8 +11,14 @@ dasclaw_core = { path = "../dasclaw_core" }
 # Provides `Agent`, `AgentError`, and the `seed_context` / `run_in_context`
 # support API that `Session` delegates to.
 dasclaw_runtime = { path = "../dasclaw_runtime" }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+thiserror = "1"
+async-trait = "0.1"
+tokio = { version = "1", features = ["sync"] }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync"] }
 tokio-util = "0.7"
 async-trait = "0.1"
+insta = { workspace = true }

--- a/crates/dasclaw_session/src/error.rs
+++ b/crates/dasclaw_session/src/error.rs
@@ -1,0 +1,35 @@
+//! Errors produced by the [`SessionStore`](crate::store::SessionStore)
+//! trait and the snapshot machinery.
+//!
+//! Keeps `serde_json::Error` and `std::io::Error` wrapped behind a
+//! single concrete type so callers (and future store backends like a
+//! Postgres or jsonl store) can return one error from their `save` /
+//! `load` calls without leaking dependency details to the caller.
+
+use thiserror::Error;
+
+/// Top-level error type for session storage and snapshot operations.
+#[derive(Debug, Error)]
+pub enum SessionError {
+    /// The requested session id was not present in the store.
+    #[error("session not found: {0}")]
+    NotFound(String),
+
+    /// Snapshot serialization / deserialization failed.
+    #[error("snapshot serde failed: {0}")]
+    Serde(#[from] serde_json::Error),
+
+    /// Underlying storage I/O failed (file backends, network, etc).
+    #[error("session store io failed: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// Snapshot version is newer than this build understands; bumping
+    /// [`crate::id::SESSION_VERSION`] is required to read it.
+    #[error("snapshot version {found} is newer than supported version {supported}")]
+    UnsupportedVersion {
+        /// The version embedded in the offending snapshot.
+        found: u32,
+        /// The highest version this build understands.
+        supported: u32,
+    },
+}

--- a/crates/dasclaw_session/src/id.rs
+++ b/crates/dasclaw_session/src/id.rs
@@ -1,0 +1,43 @@
+//! Session identifier generation.
+//!
+//! Mirrors the `claw-code::session::generate_session_id` strategy
+//! (`session-{unix_millis}-{counter}`) so future jsonl exports can be
+//! cross-read with claw-code if that ever becomes a goal.
+//!
+//! See `claw-code/rust/crates/runtime/src/session.rs` (function
+//! `generate_session_id`) for the reference implementation.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Wire-format version for [`SessionSnapshot`].
+///
+/// Increment when the on-disk / serialized shape of `SessionSnapshot`
+/// changes in a way that would break existing readers. Snapshot loaders
+/// must check this field and either upgrade or reject older snapshots.
+pub const SESSION_VERSION: u32 = 1;
+
+static SESSION_ID_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+/// Generate a fresh session identifier with a `session-` prefix.
+///
+/// Format: `session-{unix_millis}-{counter}`. The counter disambiguates
+/// IDs created inside the same millisecond.
+#[must_use]
+pub fn generate_session_id() -> String {
+    let millis = current_time_millis();
+    let counter = SESSION_ID_COUNTER.fetch_add(1, Ordering::Relaxed);
+    format!("session-{millis}-{counter}")
+}
+
+/// Current Unix time in milliseconds.
+///
+/// Falls back to `0` if the system clock is somehow before the Unix
+/// epoch; that is a degenerate but well-defined value (no panic).
+#[must_use]
+pub fn current_time_millis() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| u64::try_from(d.as_millis()).unwrap_or(u64::MAX))
+        .unwrap_or(0)
+}

--- a/crates/dasclaw_session/src/lib.rs
+++ b/crates/dasclaw_session/src/lib.rs
@@ -1,42 +1,39 @@
-//! Multi-turn `Session` facade for [`Agent`] (issue #907 Action 2).
+//! Multi-turn `Session` facade for [`Agent`] + persistence boundary.
 //!
-//! ## Why this exists
+//! This crate is the home of the conversation-level vocabulary on top
+//! of `dasclaw_runtime`'s one-shot [`Agent::run`]:
 //!
-//! A bare [`Agent::run`] is one-shot: every call seeds a fresh
-//! `ReasoningContext`, so the GUI has no place to keep "the prior turn"
-//! short of re-feeding the full history string into the next prompt. The
-//! issue #907 background calls this out as a GUI blocker.
+//! - [`Session`] — stateful multi-turn handle around `Arc<Agent>`.
+//!   Carries a [`SessionSnapshot`] of metadata + messages across
+//!   `run()` calls so the responder always sees the prior turns.
+//! - [`SessionSnapshot`] — serializable view of everything a session
+//!   needs to survive a process restart. The wire format is locked by
+//!   an insta snapshot test.
+//! - [`SessionStore`] — async trait that store backends implement.
+//!   This crate ships [`InMemorySessionStore`]; the jsonl-on-disk
+//!   store (claw-code parity, with rotation + cleanup) lands in #914
+//!   PR-C.
+//! - [`SessionError`] — single concrete error type for all
+//!   persistence and snapshot operations.
 //!
-//! `Session` is the smallest thing that fixes it:
+//! Cancellation is inherited from the agent: if the agent was built
+//! with [`dasclaw_runtime::AgentBuilder::cancellation_token`],
+//! cancelling the handle halts the in-flight [`Session::run`] with
+//! [`AgentError::Stopped`] at the next loop signal check.
 //!
-//! - holds an `Arc<Agent>` plus one persistent [`ReasoningContext`]
-//! - on construction, seeds the context once with the agent's system
-//!   prompt / model override / advertised tools (via
-//!   [`Agent::seed_context`])
-//! - each [`Session::run`] appends a new user turn to the same context
-//!   and re-enters the loop, so the responder sees the full conversation
+//! ## Non-goals (phase 2)
 //!
-//! Cancellation is inherited from the agent: if the agent was built with
-//! [`dasclaw_runtime::AgentBuilder::cancellation_token`], cancelling the
-//! handle halts the in-flight `Session::run` with [`AgentError::Stopped`]
-//! at the next loop signal check.
-//!
-//! ## Non-goals (phase 1)
-//!
-//! This crate ships intentionally minimal so PR #913 can land the GUI
-//! blocker fix without a large new surface. The richer features land in
-//! follow-up PRs against issue #914:
-//!
-//! - **No serde / persistence / fork / compaction.** Phase 2 (#914 PR-B/C)
-//!   ports those from `claw-code::Session` (ADR-153 §4.3 B+).
-//! - **No streaming.** See issue B2.
+//! - **No fork / compaction** — see issue #914 PR-D.
+//! - **No prompt_history** — see issue #914 PR-D.
+//! - **No streaming** — see issue B2.
+//! - **No on-disk store** — see issue #914 PR-C.
 //!
 //! ## Example
 //!
 //! ```ignore
 //! use std::sync::Arc;
 //! use dasclaw_runtime::Agent;
-//! use dasclaw_session::Session;
+//! use dasclaw_session::{InMemorySessionStore, Session, SessionStore};
 //!
 //! let agent = Arc::new(
 //!     Agent::builder()
@@ -44,11 +41,31 @@
 //!         .system_prompt("be concise")
 //!         .build()?,
 //! );
-//! let mut session = Session::new(agent);
-//! let reply1 = session.run("what's 2 + 2?").await?;
-//! let reply2 = session.run("and times 10?").await?; // sees prior turn
+//!
+//! // Drive a conversation.
+//! let mut session = Session::new(agent.clone()).with_model("claude-opus");
+//! let _reply1 = session.run("what's 2 + 2?").await?;
+//! let _reply2 = session.run("and times 10?").await?;
+//!
+//! // Persist + resume.
+//! let store: Arc<dyn SessionStore> = Arc::new(InMemorySessionStore::new());
+//! store.save(session.snapshot()).await?;
+//! let snap = store.load(session.session_id()).await?.expect("stored");
+//! let resumed = Session::from_snapshot(agent, snap);
+//! assert_eq!(resumed.messages().len(), session.messages().len());
 //! ```
 
+pub mod error;
+pub mod id;
+pub mod snapshot;
+pub mod store;
+
+pub use error::SessionError;
+pub use id::{SESSION_VERSION, generate_session_id};
+pub use snapshot::{SessionMetadata, SessionSnapshot};
+pub use store::{InMemorySessionStore, SessionStore};
+
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use dasclaw_core::messages::ChatMessage;
@@ -57,40 +74,101 @@ use dasclaw_runtime::{Agent, AgentError};
 
 /// Stateful, multi-turn conversation handle around an [`Agent`].
 ///
-/// Keeps a single [`ReasoningContext`] alive across calls so each
-/// [`Session::run`] carries the previous user + assistant + tool_result
-/// turns into the next loop iteration.
+/// Owns a [`SessionSnapshot`] (the persistable state) plus an
+/// `Arc<Agent>` (the live executor). Each [`Session::run`] builds a
+/// fresh [`ReasoningContext`] for the agentic loop, replays the
+/// session's accumulated messages into it, appends the new prompt,
+/// runs to completion, and copies the resulting messages back into
+/// the snapshot.
+///
+/// The snapshot is the only thing a [`SessionStore`] needs to
+/// persist; the agent is reconstructed at resume time by the host.
 pub struct Session {
     agent: Arc<Agent>,
-    ctx: ReasoningContext,
+    state: SessionSnapshot,
 }
 
 impl Session {
-    /// Build a new session bound to `agent`. The session's
-    /// [`ReasoningContext`] is seeded once with the agent's system
-    /// prompt, model override and advertised tools.
+    /// Build a fresh session bound to `agent`, with a freshly
+    /// generated [`SessionSnapshot::fresh`] (new id, current time,
+    /// empty history).
     #[must_use]
     pub fn new(agent: Arc<Agent>) -> Self {
-        let mut ctx = ReasoningContext::new();
-        agent.seed_context(&mut ctx);
-        Self { agent, ctx }
+        Self {
+            agent,
+            state: SessionSnapshot::fresh(),
+        }
+    }
+
+    /// Resume a session from a previously stored snapshot. The
+    /// caller is responsible for rebuilding an `Arc<Agent>` whose
+    /// configuration matches the original session's expectations
+    /// (model, tool catalogue, etc.).
+    #[must_use]
+    pub fn from_snapshot(agent: Arc<Agent>, state: SessionSnapshot) -> Self {
+        Self { agent, state }
+    }
+
+    /// Record the model name on the snapshot. Builder-style; useful
+    /// at session construction:
+    /// `Session::new(agent).with_model("claude-opus")`.
+    #[must_use]
+    pub fn with_model(mut self, model: impl Into<String>) -> Self {
+        self.state.model = Some(model.into());
+        self
+    }
+
+    /// Record the workspace root on the snapshot. Builder-style.
+    #[must_use]
+    pub fn with_workspace_root(mut self, path: impl Into<PathBuf>) -> Self {
+        self.state.workspace_root = Some(path.into());
+        self
+    }
+
+    /// Read-only view of the persistable state. Hand this to a
+    /// [`SessionStore::save`] call.
+    #[must_use]
+    pub fn snapshot(&self) -> &SessionSnapshot {
+        &self.state
+    }
+
+    /// This session's stable identifier.
+    #[must_use]
+    pub fn session_id(&self) -> &str {
+        &self.state.session_id
+    }
+
+    /// Read-only view of the accumulated conversation history.
+    #[must_use]
+    pub fn messages(&self) -> &[ChatMessage] {
+        &self.state.messages
     }
 
     /// Send a new user prompt and return the final text response.
     ///
-    /// The prompt is appended to the session's accumulated history, then
-    /// the agentic loop runs as in [`Agent::run`]. All assistant turns,
-    /// tool calls and tool results produced by the loop remain in the
-    /// session's context for subsequent calls.
+    /// On every call this method:
+    ///
+    /// 1. builds a fresh [`ReasoningContext`] via
+    ///    [`Agent::seed_context`] so the static configuration
+    ///    (system prompt, available tools, model override) is always
+    ///    re-applied,
+    /// 2. replays the snapshot's prior messages into the context,
+    /// 3. delegates to [`Agent::run_in_context`], which appends the
+    ///    user prompt and drives the agentic loop to completion,
+    /// 4. copies the resulting messages back into the snapshot —
+    ///    even on failure, so a partial conversation is preserved,
+    /// 5. on success, advances [`SessionSnapshot::updated_at_ms`].
     pub async fn run(&mut self, prompt: &str) -> Result<String, AgentError> {
-        self.agent.run_in_context(&mut self.ctx, prompt).await
-    }
+        let mut ctx = ReasoningContext::new();
+        self.agent.seed_context(&mut ctx);
+        ctx.messages = std::mem::take(&mut self.state.messages);
 
-    /// Read-only view of the accumulated conversation history. Useful
-    /// for a GUI that needs to render the dialog or for tests that
-    /// assert on what the responder saw.
-    #[must_use]
-    pub fn messages(&self) -> &[ChatMessage] {
-        &self.ctx.messages
+        let result = self.agent.run_in_context(&mut ctx, prompt).await;
+
+        self.state.messages = std::mem::take(&mut ctx.messages);
+        if result.is_ok() {
+            self.state.touch();
+        }
+        result
     }
 }

--- a/crates/dasclaw_session/src/snapshot.rs
+++ b/crates/dasclaw_session/src/snapshot.rs
@@ -1,0 +1,110 @@
+//! Serializable, agent-independent snapshot of a [`Session`](crate::Session).
+//!
+//! `Session` itself holds an `Arc<Agent>` (live trait objects, futures,
+//! mutex state) that cannot be serialized. Persistence and `SessionStore`
+//! backends operate on the [`SessionSnapshot`] view, which carries only
+//! the conversation history plus identifying metadata.
+//!
+//! Round-trip is:
+//!
+//! ```text
+//! Session ──snapshot()──▶ SessionSnapshot ──serde──▶ bytes
+//!   ▲                                                  │
+//!   └──── Session::from_snapshot(agent, snap) ◀────────┘
+//! ```
+//!
+//! The wire format is locked by an insta snapshot test
+//! (`tests/snapshot_wire.rs`) so any accidental field rename or shape
+//! change shows up as a review-time diff and forces a deliberate
+//! [`crate::id::SESSION_VERSION`] bump.
+
+use std::path::PathBuf;
+
+use dasclaw_core::messages::ChatMessage;
+use serde::{Deserialize, Serialize};
+
+use crate::id::{SESSION_VERSION, current_time_millis, generate_session_id};
+
+/// Lightweight identifier + timestamps view returned from
+/// [`crate::store::SessionStore::list`].
+///
+/// Carrying the full `messages` vector through `list()` would force
+/// every store backend to deserialize entire conversations just to
+/// build the index; this view stays cheap.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SessionMetadata {
+    /// Unique session identifier.
+    pub session_id: String,
+    /// Wire-format version of the underlying snapshot.
+    pub version: u32,
+    /// Unix milliseconds when the session was created.
+    pub created_at_ms: u64,
+    /// Unix milliseconds of the last write.
+    pub updated_at_ms: u64,
+    /// Optional model name that drove this session (for resume UX).
+    pub model: Option<String>,
+}
+
+impl From<&SessionSnapshot> for SessionMetadata {
+    fn from(snap: &SessionSnapshot) -> Self {
+        Self {
+            session_id: snap.session_id.clone(),
+            version: snap.version,
+            created_at_ms: snap.created_at_ms,
+            updated_at_ms: snap.updated_at_ms,
+            model: snap.model.clone(),
+        }
+    }
+}
+
+/// All state that `Session` needs to persist across process restarts.
+///
+/// Field layout follows the `claw-code::session::Session` core fields
+/// (session_id / version / timestamps / workspace_root / model /
+/// messages) so a future jsonl store (#914 PR-C) can match its
+/// `session_meta` record shape.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionSnapshot {
+    /// Unique session identifier; see [`crate::id::generate_session_id`].
+    pub session_id: String,
+    /// Wire-format version. Loaders reject snapshots newer than the
+    /// supported [`crate::id::SESSION_VERSION`].
+    pub version: u32,
+    /// Unix milliseconds at session creation.
+    pub created_at_ms: u64,
+    /// Unix milliseconds of the last mutation. Updated by
+    /// [`crate::Session::run`] on successful completion.
+    pub updated_at_ms: u64,
+    /// Optional bound workspace; recorded for the UI / future
+    /// concurrency guards. Not interpreted by the snapshot logic.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workspace_root: Option<PathBuf>,
+    /// Optional model name the session was driven with.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    /// Full conversation history, in turn order.
+    pub messages: Vec<ChatMessage>,
+}
+
+impl SessionSnapshot {
+    /// Build a fresh snapshot with a generated id and current time.
+    /// Used by [`crate::Session::new`].
+    #[must_use]
+    pub fn fresh() -> Self {
+        let now = current_time_millis();
+        Self {
+            session_id: generate_session_id(),
+            version: SESSION_VERSION,
+            created_at_ms: now,
+            updated_at_ms: now,
+            workspace_root: None,
+            model: None,
+            messages: Vec::new(),
+        }
+    }
+
+    /// Refresh `updated_at_ms` to the current wall-clock time.
+    pub fn touch(&mut self) {
+        self.updated_at_ms = current_time_millis();
+    }
+}

--- a/crates/dasclaw_session/src/store.rs
+++ b/crates/dasclaw_session/src/store.rs
@@ -1,0 +1,88 @@
+//! Storage abstraction over [`SessionSnapshot`].
+//!
+//! A `SessionStore` is the persistence boundary for sessions. This
+//! crate ships one in-memory implementation; a jsonl-on-disk store
+//! (claw-code parity, rotation + cleanup) will land in #914 PR-C, and
+//! database-backed stores (Postgres, libsql) can be implemented by
+//! downstream hosts behind the same trait.
+//!
+//! The trait is async because realistic backends (filesystem, DB,
+//! remote) need to be; the in-memory implementation simply awaits an
+//! `RwLock`.
+
+use std::collections::HashMap;
+
+use async_trait::async_trait;
+use tokio::sync::RwLock;
+
+use crate::error::SessionError;
+use crate::snapshot::{SessionMetadata, SessionSnapshot};
+
+/// Persistence boundary for sessions.
+///
+/// All methods are `async` so realistic backends (filesystem, DB) can
+/// be implemented without blocking the reactor. Backends must be
+/// `Send + Sync` so they can be shared across tasks (`Arc<dyn
+/// SessionStore>` is the expected usage).
+#[async_trait]
+pub trait SessionStore: Send + Sync {
+    /// Insert or replace the snapshot, keyed by `snapshot.session_id`.
+    async fn save(&self, snapshot: &SessionSnapshot) -> Result<(), SessionError>;
+
+    /// Return the snapshot for `session_id`, or `Ok(None)` if absent.
+    async fn load(&self, session_id: &str) -> Result<Option<SessionSnapshot>, SessionError>;
+
+    /// Cheap index of stored sessions; does not load full message
+    /// vectors.
+    async fn list(&self) -> Result<Vec<SessionMetadata>, SessionError>;
+
+    /// Remove the snapshot if present. Returns `Ok(())` whether or not
+    /// the id existed (idempotent).
+    async fn delete(&self, session_id: &str) -> Result<(), SessionError>;
+}
+
+/// In-process [`SessionStore`] backed by a `HashMap` under an
+/// `RwLock`. Suited for tests, GUI prototypes and headless reuse
+/// where session durability across process restarts is not required.
+#[derive(Default)]
+pub struct InMemorySessionStore {
+    inner: RwLock<HashMap<String, SessionSnapshot>>,
+}
+
+impl InMemorySessionStore {
+    /// Create an empty store.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+#[async_trait]
+impl SessionStore for InMemorySessionStore {
+    async fn save(&self, snapshot: &SessionSnapshot) -> Result<(), SessionError> {
+        self.inner
+            .write()
+            .await
+            .insert(snapshot.session_id.clone(), snapshot.clone());
+        Ok(())
+    }
+
+    async fn load(&self, session_id: &str) -> Result<Option<SessionSnapshot>, SessionError> {
+        Ok(self.inner.read().await.get(session_id).cloned())
+    }
+
+    async fn list(&self) -> Result<Vec<SessionMetadata>, SessionError> {
+        Ok(self
+            .inner
+            .read()
+            .await
+            .values()
+            .map(SessionMetadata::from)
+            .collect())
+    }
+
+    async fn delete(&self, session_id: &str) -> Result<(), SessionError> {
+        self.inner.write().await.remove(session_id);
+        Ok(())
+    }
+}

--- a/crates/dasclaw_session/tests/snapshot_wire.rs
+++ b/crates/dasclaw_session/tests/snapshot_wire.rs
@@ -1,0 +1,38 @@
+//! Wire-format snapshot test for [`SessionSnapshot`].
+//!
+//! Locks the on-disk JSON shape produced by `serde_json` so any
+//! accidental field rename, reorder or addition surfaces as a diff in
+//! `cargo insta review`. Bumping the shape on purpose requires both an
+//! intentional snapshot review **and** a [`SESSION_VERSION`] bump.
+//!
+//! Timestamps and session ids are non-deterministic in real life, so
+//! we construct a fully literal `SessionSnapshot` value rather than
+//! redacting fields from a freshly created one. This keeps the
+//! snapshot diff focused on shape, not on test scaffolding.
+
+use dasclaw_core::messages::ChatMessage;
+use dasclaw_session::{SESSION_VERSION, SessionMetadata, SessionSnapshot};
+
+fn fixture_snapshot() -> SessionSnapshot {
+    SessionSnapshot {
+        session_id: "session-1700000000000-0".to_string(),
+        version: SESSION_VERSION,
+        created_at_ms: 1_700_000_000_000,
+        updated_at_ms: 1_700_000_000_500,
+        workspace_root: None,
+        model: Some("test-model".to_string()),
+        messages: vec![ChatMessage::user("ping"), ChatMessage::assistant("pong")],
+    }
+}
+
+#[test]
+fn session_snapshot_wire_format_is_stable() {
+    let snap = fixture_snapshot();
+    insta::assert_json_snapshot!(snap);
+}
+
+#[test]
+fn session_metadata_wire_format_is_stable() {
+    let meta = SessionMetadata::from(&fixture_snapshot());
+    insta::assert_json_snapshot!(meta);
+}

--- a/crates/dasclaw_session/tests/snapshots/snapshot_wire__session_metadata_wire_format_is_stable.snap
+++ b/crates/dasclaw_session/tests/snapshots/snapshot_wire__session_metadata_wire_format_is_stable.snap
@@ -1,0 +1,11 @@
+---
+source: crates/dasclaw_session/tests/snapshot_wire.rs
+expression: meta
+---
+{
+  "session_id": "session-1700000000000-0",
+  "version": 1,
+  "created_at_ms": 1700000000000,
+  "updated_at_ms": 1700000000500,
+  "model": "test-model"
+}

--- a/crates/dasclaw_session/tests/snapshots/snapshot_wire__session_snapshot_wire_format_is_stable.snap
+++ b/crates/dasclaw_session/tests/snapshots/snapshot_wire__session_snapshot_wire_format_is_stable.snap
@@ -1,0 +1,21 @@
+---
+source: crates/dasclaw_session/tests/snapshot_wire.rs
+expression: snap
+---
+{
+  "session_id": "session-1700000000000-0",
+  "version": 1,
+  "created_at_ms": 1700000000000,
+  "updated_at_ms": 1700000000500,
+  "model": "test-model",
+  "messages": [
+    {
+      "role": "user",
+      "content": "ping"
+    },
+    {
+      "role": "assistant",
+      "content": "pong"
+    }
+  ]
+}

--- a/crates/dasclaw_session/tests/store_e2e.rs
+++ b/crates/dasclaw_session/tests/store_e2e.rs
@@ -1,0 +1,148 @@
+//! End-to-end tests for the [`SessionStore`] persistence boundary
+//! introduced in #914 PR-B.
+//!
+//! Three contracts are covered here:
+//!
+//! 1. `InMemorySessionStore` round-trips: `save` → `load` → `delete`
+//!    behave correctly, and `list` returns a lightweight metadata
+//!    view that mirrors what was saved.
+//! 2. `Session` ↔ `SessionSnapshot`: a live session can be snapshotted,
+//!    the snapshot can be stored, reloaded, and used to rebuild a
+//!    new `Session` whose `messages()` exactly matches the original.
+//! 3. `generate_session_id` is monotonic enough that two consecutive
+//!    calls never collide, even in tight loops.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use dasclaw_core::messages::{ChatMessage, FinishReason};
+use dasclaw_core::reasoning_ctx::ReasoningContext;
+use dasclaw_core::response_types::{RespondOutput, RespondResult, ResponseMetadata, TokenUsage};
+use dasclaw_core::traits::HostError;
+use dasclaw_runtime::{Agent, AgentResponder};
+use dasclaw_session::{
+    InMemorySessionStore, SESSION_VERSION, Session, SessionSnapshot, SessionStore,
+    generate_session_id,
+};
+
+/// Minimal responder that returns a single scripted text turn. Same
+/// pattern as `session_e2e.rs`, kept local so the two test files do not
+/// share a test-utility module yet.
+struct OneShotResponder {
+    reply: &'static str,
+}
+
+#[async_trait]
+impl AgentResponder for OneShotResponder {
+    async fn respond(&self, _ctx: &mut ReasoningContext) -> Result<RespondOutput, HostError> {
+        Ok(RespondOutput {
+            result: RespondResult::Text(self.reply.to_string()),
+            usage: TokenUsage::default(),
+            finish_reason: FinishReason::Stop,
+            metadata: ResponseMetadata::default(),
+        })
+    }
+}
+
+fn build_agent(reply: &'static str) -> Arc<Agent> {
+    Arc::new(
+        Agent::builder()
+            .responder(OneShotResponder { reply })
+            .system_prompt("be concise")
+            .build()
+            .expect("build agent"),
+    )
+}
+
+fn sample_snapshot(session_id: &str) -> SessionSnapshot {
+    SessionSnapshot {
+        session_id: session_id.to_string(),
+        version: SESSION_VERSION,
+        created_at_ms: 1_700_000_000_000,
+        updated_at_ms: 1_700_000_000_500,
+        workspace_root: None,
+        model: Some("test-model".to_string()),
+        messages: vec![
+            ChatMessage::user("hi"),
+            ChatMessage::assistant("hello back"),
+        ],
+    }
+}
+
+#[tokio::test]
+async fn req_dasclaw_session_b2_in_memory_store_round_trip() {
+    let store = InMemorySessionStore::new();
+    let snap = sample_snapshot("session-test-1");
+
+    store.save(&snap).await.expect("save");
+
+    let loaded = store
+        .load("session-test-1")
+        .await
+        .expect("load ok")
+        .expect("session present");
+    assert_eq!(loaded.session_id, snap.session_id);
+    assert_eq!(loaded.version, SESSION_VERSION);
+    assert_eq!(loaded.messages.len(), 2);
+    assert_eq!(loaded.model.as_deref(), Some("test-model"));
+
+    let metas = store.list().await.expect("list");
+    assert_eq!(metas.len(), 1);
+    assert_eq!(metas[0].session_id, "session-test-1");
+    assert_eq!(metas[0].model.as_deref(), Some("test-model"));
+
+    store.delete("session-test-1").await.expect("delete");
+    let after = store.load("session-test-1").await.expect("load ok");
+    assert!(after.is_none(), "session should be gone after delete");
+}
+
+#[tokio::test]
+async fn req_dasclaw_session_b2_missing_session_returns_none() {
+    let store = InMemorySessionStore::new();
+    let loaded = store.load("does-not-exist").await.expect("load ok");
+    assert!(loaded.is_none());
+
+    // Deleting an absent id is idempotent, not an error.
+    store.delete("does-not-exist").await.expect("delete absent");
+}
+
+#[tokio::test]
+async fn req_dasclaw_session_b2_session_snapshot_round_trip_preserves_history() {
+    let agent = build_agent("the answer is 4");
+    let mut session = Session::new(agent.clone()).with_model("scripted");
+
+    let original_id = session.session_id().to_string();
+    let _ = session.run("2 + 2?").await.expect("run");
+    assert_eq!(session.messages().len(), 2);
+
+    let store = InMemorySessionStore::new();
+    store.save(session.snapshot()).await.expect("save");
+
+    let loaded = store
+        .load(&original_id)
+        .await
+        .expect("load ok")
+        .expect("present");
+    let resumed = Session::from_snapshot(agent, loaded);
+
+    assert_eq!(resumed.session_id(), original_id);
+    assert_eq!(resumed.messages().len(), session.messages().len());
+    assert_eq!(
+        resumed.snapshot().model.as_deref(),
+        Some("scripted"),
+        "builder-style model should be preserved"
+    );
+}
+
+#[test]
+fn req_dasclaw_session_b2_session_id_is_unique_under_tight_loop() {
+    // 1k iterations is plenty to flush out a missing counter without
+    // making the test slow. Same-millisecond collisions would surface
+    // here if the counter were ever removed.
+    let mut ids = std::collections::HashSet::new();
+    for _ in 0..1000 {
+        let id = generate_session_id();
+        assert!(ids.insert(id.clone()), "duplicate session id: {id}");
+        assert!(id.starts_with("session-"));
+    }
+}


### PR DESCRIPTION
## 背景 / 目标

PR-B of the #914 session-port stack. Builds on **#916 (PR-A)** which extracted `Session` out of `dasclaw_runtime` into the new `dasclaw_session` crate. This PR introduces the persistence boundary (`SessionSnapshot` + `SessionStore` trait + in-memory backend) without yet shipping a disk-backed store.

## 改动范围

- **`SessionSnapshot`** — serializable view of session state: `session_id`, `version`, `created_at_ms`, `updated_at_ms`, optional `workspace_root`, optional `model`, `messages`. Wire format locked by an insta snapshot test (`tests/snapshot_wire.rs`).
- **`SessionMetadata`** — lightweight index view returned by `SessionStore::list` so backends don't have to deserialize full conversations for list views.
- **`SessionStore`** async trait — `save` / `load` / `list` / `delete`. Send + Sync so it can be wrapped in `Arc<dyn SessionStore>` and shared across tasks.
- **`InMemorySessionStore`** — process-local backend backed by `RwLock<HashMap<String, SessionSnapshot>>`. Suited for tests, GUI prototypes, headless reuse.
- **`SessionError`** — single concrete error type via `thiserror`, wrapping `serde_json::Error` and `std::io::Error` so future store backends don't leak their dependencies.
- **`generate_session_id()` + `SESSION_VERSION = 1`** — `session-{unix_millis}-{counter}` id generator (claw-code parity).
- **`Session` internal repr change**: `ctx: ReasoningContext` (PR-A) → `state: SessionSnapshot`. `Session::run` now builds a fresh `ReasoningContext` each call, replays accumulated messages via `std::mem::take`, runs the loop, and copies messages back into the snapshot. Failures preserve the partial conversation; success advances `updated_at_ms`.
- **Builder-style accessors**: `with_model` / `with_workspace_root` / `from_snapshot` / `snapshot()` / `session_id()`. Existing `new` / `run` / `messages` signatures unchanged so PR-A's 4 `session_e2e` tests pass untouched.

## 非目标 (What's NOT in this PR)

- ❌ **No on-disk jsonl store** (rotation + cleanup) — deferred to **#914 PR-C**.
- ❌ **No fork** — deferred to **#914 PR-D**.
- ❌ **No compaction** — deferred to **#914 PR-D**.
- ❌ **No prompt_history** — deferred to **#914 PR-D**.
- ❌ **No streaming** — see issue B2.
- ❌ No cross-tool compatibility with claude-code's JSONL — per `claw-code/PARITY.md` L175 the two are already incompatible.

## 验证

```bash
cargo check -p dasclaw_session --tests              # 0 errors / 0 warnings
cargo nextest run -p dasclaw_session                # 10/10 passed
cargo fmt --all
cargo clippy --no-deps -p dasclaw_session --all-targets -- -D warnings
python3.12 scripts/check_no_panics.py --base origin/feat/914a-session-crate
```

Test breakdown:
- `session_e2e.rs` (4 tests from PR-A): all still pass — `Session::run` public behaviour unchanged.
- `store_e2e.rs` (4 new tests): in-memory CRUD round-trip, missing-id returns `None`, full `Session → SessionSnapshot → store → load → Session` round-trip preserves history, `generate_session_id` is collision-free under 1k tight-loop iterations.
- `snapshot_wire.rs` (2 new tests): insta locks JSON wire format for both `SessionSnapshot` and `SessionMetadata`.

## 三层 Skill 自审

- **code-quality-audit**: no `unwrap`/`expect`/`panic!`; longest function `Session::run` at 11 LOC; max nesting depth 2; `.clone()` only where required (in-memory store copies on save/load); no patch-code / no flag-controlled blocks.
- **code-simplifier**: `SessionSnapshot::touch()` centralises the `updated_at_ms` write; `impl From<&SessionSnapshot> for SessionMetadata` centralises metadata derivation; `Session::run` uses `std::mem::take` for zero-copy message transfer instead of `.clone()`.
- **code-review-expert**: SRP clean (`id` / `snapshot` / `store` / `session` modules with single responsibilities each); `SessionStore: Send + Sync` async trait properly covers future fs / DB backends; `SessionError` wraps lower-level errors via `thiserror`'s `#[from]` without leaking implementation details; failure path preserves partial conversation rather than discarding it.

## Cross-cuts

**类A** — no new `.ironclaw` / `IRONCLAW_BASE_DIR` literals introduced.

## Stacked PR

- **Base branch**: `feat/914a-session-crate` (PR #916), **NOT `xClaw`**.
- **Merge order**: #913 (#907 cancel handle) → #916 (#914 PR-A extract) → **this PR (#914 PR-B)** → future #914 PR-C (jsonl store) → future #914 PR-D (fork + compaction).
- **Please review PR #916 first**; this PR's diff against `xClaw` would otherwise include the entire PR-A move.
- **When merging #916, do NOT delete the `feat/914a-session-crate` branch** until this PR's base is rebased onto `xClaw`; otherwise GitHub will auto-close this PR (实证教训: PR #816 / #817).

Refs #914

Closes #919
