### PR TITLE
feat(session): JsonlSessionStore with rotation + version guard (#914 PR-C1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3434,6 +3434,7 @@ dependencies = [
  "insta",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 1.0.69",
  "tokio",
  "tokio-util",

--- a/crates/dasclaw_session/Cargo.toml
+++ b/crates/dasclaw_session/Cargo.toml
@@ -22,3 +22,4 @@ tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync"] }
 tokio-util = "0.7"
 async-trait = "0.1"
 insta = { workspace = true }
+tempfile = "3.23.0"

--- a/crates/dasclaw_session/src/jsonl.rs
+++ b/crates/dasclaw_session/src/jsonl.rs
@@ -1,0 +1,500 @@
+//! On-disk [`SessionStore`] backed by one JSON-lines file per session.
+//!
+//! ## Wire format
+//!
+//! Each session lives in `<root>/<session_id>.jsonl`. The file is a
+//! sequence of newline-terminated JSON objects; the first line is the
+//! [`SessionMetaRecord`] and the rest are [`MessageRecord`] entries:
+//!
+//! ```text
+//! {"type":"session_meta","version":1,"session_id":"…","created_at_ms":…,"updated_at_ms":…,"workspace_root":"…","model":"…"}
+//! {"type":"message","message":{"role":"user","content":"ping"}}
+//! {"type":"message","message":{"role":"assistant","content":"pong"}}
+//! ```
+//!
+//! The outer framing (`type` discriminant, `session_meta` and
+//! `message` record kinds) deliberately mirrors `claw-code`'s session
+//! jsonl layout so a future migration tool can bridge the two
+//! ecosystems at the line level. The inner `message` body uses
+//! [`dasclaw_core::messages::ChatMessage`]'s serde shape, which differs
+//! from `claw-code`'s richer block-based message; full bidirectional
+//! interop is intentionally out of scope for #914 PR-C1.
+//!
+//! ## Rotation
+//!
+//! Before each [`SessionStore::save`], if the existing live file
+//! exceeds [`ROTATE_AFTER_BYTES`] it is renamed to
+//! `<session_id>.rot-<timestamp_ms>.jsonl`. After the new live file is
+//! written, the rotated history is trimmed so at most
+//! [`MAX_ROTATED_FILES`] old files remain (oldest by mtime are
+//! removed first). This mirrors `claw-code/rust/crates/runtime/src/session.rs`.
+//!
+//! ## Atomicity
+//!
+//! Saves are atomic: bytes are written to a unique temp file under
+//! the same directory and then renamed onto the live path. Concurrent
+//! readers either see the previous full snapshot or the new one,
+//! never a partial write.
+
+use std::collections::HashMap;
+use std::ffi::OsStr;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use tokio::fs;
+use tokio::io::{AsyncBufReadExt, BufReader};
+
+use dasclaw_core::messages::ChatMessage;
+
+use crate::error::SessionError;
+use crate::id::SESSION_VERSION;
+use crate::snapshot::{SessionMetadata, SessionSnapshot};
+use crate::store::SessionStore;
+
+/// Live files larger than this trigger a rotate on the next save.
+pub const ROTATE_AFTER_BYTES: u64 = 256 * 1024;
+
+/// Maximum number of rotated history files kept per session.
+pub const MAX_ROTATED_FILES: usize = 3;
+
+const FILE_EXT: &str = "jsonl";
+const ROTATED_INFIX: &str = ".rot-";
+
+/// On-disk [`SessionStore`] writing one `.jsonl` file per session
+/// under a configured root directory.
+///
+/// The root is created lazily on first save. The store holds no I/O
+/// handles between calls, so it is cheap to clone (wrap in `Arc` if
+/// shared across tasks).
+pub struct JsonlSessionStore {
+    root: PathBuf,
+    temp_counter: AtomicU64,
+}
+
+impl JsonlSessionStore {
+    /// Build a store rooted at `root`. The directory does not need to
+    /// exist yet; it will be created on the first [`SessionStore::save`].
+    #[must_use]
+    pub fn new(root: PathBuf) -> Self {
+        Self {
+            root,
+            temp_counter: AtomicU64::new(0),
+        }
+    }
+
+    /// Path the live `.jsonl` file for `session_id` would occupy.
+    /// Exposed for tests / debug; not part of the public contract.
+    #[must_use]
+    pub fn session_path(&self, session_id: &str) -> PathBuf {
+        self.root.join(format!("{session_id}.{FILE_EXT}"))
+    }
+
+    fn temp_path_for(&self, live: &Path) -> PathBuf {
+        let stem = live
+            .file_name()
+            .and_then(OsStr::to_str)
+            .unwrap_or("session");
+        let counter = self.temp_counter.fetch_add(1, Ordering::Relaxed);
+        live.with_file_name(format!("{stem}.tmp-{}-{counter}", current_time_millis()))
+    }
+}
+
+#[async_trait]
+impl SessionStore for JsonlSessionStore {
+    async fn save(&self, snapshot: &SessionSnapshot) -> Result<(), SessionError> {
+        fs::create_dir_all(&self.root).await?;
+
+        let live = self.session_path(&snapshot.session_id);
+        rotate_if_needed(&live).await?;
+
+        let rendered = render_jsonl(snapshot)?;
+        let temp = self.temp_path_for(&live);
+        fs::write(&temp, rendered).await?;
+        // tokio::fs::rename is atomic on POSIX; on Windows it falls
+        // back to MoveFileEx which is also atomic when both paths
+        // share a filesystem (the case here, since temp sits next to
+        // the live file).
+        fs::rename(&temp, &live).await?;
+
+        cleanup_rotated(&live).await?;
+        Ok(())
+    }
+
+    async fn load(&self, session_id: &str) -> Result<Option<SessionSnapshot>, SessionError> {
+        let live = self.session_path(session_id);
+        let bytes = match fs::read(&live).await {
+            Ok(bytes) => bytes,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(err) => return Err(err.into()),
+        };
+        let snap = parse_jsonl(&bytes)?;
+        Ok(Some(snap))
+    }
+
+    async fn list(&self) -> Result<Vec<SessionMetadata>, SessionError> {
+        let mut out = Vec::new();
+        let mut entries = match fs::read_dir(&self.root).await {
+            Ok(entries) => entries,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(out),
+            Err(err) => return Err(err.into()),
+        };
+        while let Some(entry) = entries.next_entry().await? {
+            let path = entry.path();
+            if !is_live_session_file(&path) {
+                continue;
+            }
+            if let Some(meta) = read_metadata_only(&path).await? {
+                out.push(meta);
+            }
+        }
+        Ok(out)
+    }
+
+    async fn delete(&self, session_id: &str) -> Result<(), SessionError> {
+        let live = self.session_path(session_id);
+        match fs::remove_file(&live).await {
+            Ok(()) => {}
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+            Err(err) => return Err(err.into()),
+        }
+        // Also remove any rotated history for this session id.
+        let stem = session_id.to_string();
+        let prefix = format!("{stem}{ROTATED_INFIX}");
+        let mut entries = match fs::read_dir(&self.root).await {
+            Ok(entries) => entries,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+            Err(err) => return Err(err.into()),
+        };
+        while let Some(entry) = entries.next_entry().await? {
+            let path = entry.path();
+            if is_rotated_for(&path, &prefix) {
+                fs::remove_file(&path).await?;
+            }
+        }
+        Ok(())
+    }
+}
+
+// -------------------------------------------------------------------
+// Wire records
+// -------------------------------------------------------------------
+
+#[derive(Debug, Serialize, Deserialize)]
+struct SessionMetaRecord<'a> {
+    #[serde(rename = "type")]
+    kind: &'a str,
+    version: u32,
+    session_id: &'a str,
+    created_at_ms: u64,
+    updated_at_ms: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    workspace_root: Option<&'a Path>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    model: Option<&'a str>,
+}
+
+#[derive(Debug, Serialize)]
+struct MessageRecord<'a> {
+    #[serde(rename = "type")]
+    kind: &'a str,
+    message: &'a ChatMessage,
+}
+
+fn render_jsonl(snapshot: &SessionSnapshot) -> Result<Vec<u8>, SessionError> {
+    let meta = SessionMetaRecord {
+        kind: "session_meta",
+        version: snapshot.version,
+        session_id: &snapshot.session_id,
+        created_at_ms: snapshot.created_at_ms,
+        updated_at_ms: snapshot.updated_at_ms,
+        workspace_root: snapshot.workspace_root.as_deref(),
+        model: snapshot.model.as_deref(),
+    };
+
+    let mut out = Vec::with_capacity(256 + snapshot.messages.len() * 128);
+    serde_json::to_writer(&mut out, &meta)?;
+    out.push(b'\n');
+    for message in &snapshot.messages {
+        let record = MessageRecord {
+            kind: "message",
+            message,
+        };
+        serde_json::to_writer(&mut out, &record)?;
+        out.push(b'\n');
+    }
+    Ok(out)
+}
+
+fn parse_jsonl(bytes: &[u8]) -> Result<SessionSnapshot, SessionError> {
+    let text = std::str::from_utf8(bytes).map_err(|err| {
+        SessionError::Io(std::io::Error::new(std::io::ErrorKind::InvalidData, err))
+    })?;
+
+    let mut version = None;
+    let mut session_id = None;
+    let mut created_at_ms = None;
+    let mut updated_at_ms = None;
+    let mut workspace_root = None;
+    let mut model = None;
+    let mut messages: Vec<ChatMessage> = Vec::new();
+
+    for (idx, raw) in text.lines().enumerate() {
+        let line = raw.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let value: Value = serde_json::from_str(line)?;
+        let object = value.as_object().ok_or_else(|| {
+            SessionError::Io(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("jsonl record at line {} must be an object", idx + 1),
+            ))
+        })?;
+        let kind = object.get("type").and_then(Value::as_str).ok_or_else(|| {
+            SessionError::Io(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("jsonl record at line {} missing \"type\"", idx + 1),
+            ))
+        })?;
+
+        match kind {
+            "session_meta" => {
+                let v = object
+                    .get("version")
+                    .and_then(Value::as_u64)
+                    .ok_or_else(|| {
+                        SessionError::Io(std::io::Error::new(
+                            std::io::ErrorKind::InvalidData,
+                            "session_meta missing \"version\"",
+                        ))
+                    })?;
+                let v = u32::try_from(v).map_err(|_| {
+                    SessionError::Io(std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        "session_meta version out of u32 range",
+                    ))
+                })?;
+                if v > SESSION_VERSION {
+                    return Err(SessionError::UnsupportedVersion {
+                        found: v,
+                        supported: SESSION_VERSION,
+                    });
+                }
+                version = Some(v);
+                session_id = Some(
+                    object
+                        .get("session_id")
+                        .and_then(Value::as_str)
+                        .ok_or_else(|| {
+                            SessionError::Io(std::io::Error::new(
+                                std::io::ErrorKind::InvalidData,
+                                "session_meta missing \"session_id\"",
+                            ))
+                        })?
+                        .to_string(),
+                );
+                created_at_ms = object.get("created_at_ms").and_then(Value::as_u64);
+                updated_at_ms = object.get("updated_at_ms").and_then(Value::as_u64);
+                workspace_root = object
+                    .get("workspace_root")
+                    .and_then(Value::as_str)
+                    .map(PathBuf::from);
+                model = object
+                    .get("model")
+                    .and_then(Value::as_str)
+                    .map(String::from);
+            }
+            "message" => {
+                let message_value = object.get("message").ok_or_else(|| {
+                    SessionError::Io(std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        format!(
+                            "jsonl message record at line {} missing \"message\"",
+                            idx + 1
+                        ),
+                    ))
+                })?;
+                let msg: ChatMessage = serde_json::from_value(message_value.clone())?;
+                messages.push(msg);
+            }
+            other => {
+                return Err(SessionError::Io(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!("unsupported jsonl record type at line {}: {other}", idx + 1),
+                )));
+            }
+        }
+    }
+
+    let session_id = session_id.ok_or_else(|| {
+        SessionError::Io(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "jsonl missing session_meta record",
+        ))
+    })?;
+    let version = version.unwrap_or(SESSION_VERSION);
+    let created_at_ms = created_at_ms.unwrap_or(0);
+    let updated_at_ms = updated_at_ms.unwrap_or(created_at_ms);
+
+    Ok(SessionSnapshot {
+        session_id,
+        version,
+        created_at_ms,
+        updated_at_ms,
+        workspace_root,
+        model,
+        messages,
+    })
+}
+
+/// Read just the first line of a session file (the `session_meta`
+/// record) and project it into a [`SessionMetadata`]. Used by
+/// [`SessionStore::list`] so the index does not pay for full message
+/// deserialization.
+async fn read_metadata_only(path: &Path) -> Result<Option<SessionMetadata>, SessionError> {
+    let file = match fs::File::open(path).await {
+        Ok(file) => file,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(err) => return Err(err.into()),
+    };
+    let mut reader = BufReader::new(file);
+    let mut first_line = String::new();
+    let bytes = reader.read_line(&mut first_line).await?;
+    if bytes == 0 {
+        return Ok(None);
+    }
+    let line = first_line.trim();
+    if line.is_empty() {
+        return Ok(None);
+    }
+    let value: HashMap<String, Value> = serde_json::from_str(line)?;
+    if value.get("type").and_then(Value::as_str) != Some("session_meta") {
+        return Ok(None);
+    }
+    let raw_version = value
+        .get("version")
+        .and_then(Value::as_u64)
+        .unwrap_or(u64::from(SESSION_VERSION));
+    let version = u32::try_from(raw_version).unwrap_or(SESSION_VERSION);
+    Ok(Some(SessionMetadata {
+        session_id: value
+            .get("session_id")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .to_string(),
+        version,
+        created_at_ms: value
+            .get("created_at_ms")
+            .and_then(Value::as_u64)
+            .unwrap_or(0),
+        updated_at_ms: value
+            .get("updated_at_ms")
+            .and_then(Value::as_u64)
+            .unwrap_or(0),
+        model: value.get("model").and_then(Value::as_str).map(String::from),
+    }))
+}
+
+// -------------------------------------------------------------------
+// Rotation helpers
+// -------------------------------------------------------------------
+
+async fn rotate_if_needed(live: &Path) -> Result<(), SessionError> {
+    let metadata = match fs::metadata(live).await {
+        Ok(metadata) => metadata,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(err) => return Err(err.into()),
+    };
+    if metadata.len() < ROTATE_AFTER_BYTES {
+        return Ok(());
+    }
+    let rotated = rotated_path_for(live);
+    fs::rename(live, rotated).await?;
+    Ok(())
+}
+
+fn rotated_path_for(live: &Path) -> PathBuf {
+    let stem = live
+        .file_stem()
+        .and_then(OsStr::to_str)
+        .unwrap_or("session");
+    live.with_file_name(format!(
+        "{stem}{ROTATED_INFIX}{}.{FILE_EXT}",
+        current_time_millis()
+    ))
+}
+
+async fn cleanup_rotated(live: &Path) -> Result<(), SessionError> {
+    let Some(parent) = live.parent() else {
+        return Ok(());
+    };
+    let stem = live
+        .file_stem()
+        .and_then(OsStr::to_str)
+        .unwrap_or("session");
+    let prefix = format!("{stem}{ROTATED_INFIX}");
+
+    let mut rotated: Vec<(PathBuf, SystemTime)> = Vec::new();
+    let mut entries = match fs::read_dir(parent).await {
+        Ok(entries) => entries,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(err) => return Err(err.into()),
+    };
+    while let Some(entry) = entries.next_entry().await? {
+        let path = entry.path();
+        if !is_rotated_for(&path, &prefix) {
+            continue;
+        }
+        let modified = entry
+            .metadata()
+            .await
+            .ok()
+            .and_then(|m| m.modified().ok())
+            .unwrap_or(UNIX_EPOCH);
+        rotated.push((path, modified));
+    }
+
+    if rotated.len() <= MAX_ROTATED_FILES {
+        return Ok(());
+    }
+    rotated.sort_by_key(|(_, mtime)| *mtime);
+    let to_remove = rotated.len() - MAX_ROTATED_FILES;
+    for (path, _) in rotated.into_iter().take(to_remove) {
+        fs::remove_file(path).await?;
+    }
+    Ok(())
+}
+
+fn is_live_session_file(path: &Path) -> bool {
+    let Some(name) = path.file_name().and_then(OsStr::to_str) else {
+        return false;
+    };
+    if name.contains(ROTATED_INFIX) {
+        return false;
+    }
+    path.extension()
+        .and_then(OsStr::to_str)
+        .is_some_and(|ext| ext.eq_ignore_ascii_case(FILE_EXT))
+}
+
+fn is_rotated_for(path: &Path, prefix: &str) -> bool {
+    let Some(name) = path.file_name().and_then(OsStr::to_str) else {
+        return false;
+    };
+    name.starts_with(prefix)
+        && path
+            .extension()
+            .and_then(OsStr::to_str)
+            .is_some_and(|ext| ext.eq_ignore_ascii_case(FILE_EXT))
+}
+
+fn current_time_millis() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| u64::try_from(d.as_millis()).unwrap_or(u64::MAX))
+        .unwrap_or(0)
+}

--- a/crates/dasclaw_session/src/lib.rs
+++ b/crates/dasclaw_session/src/lib.rs
@@ -57,11 +57,13 @@
 
 pub mod error;
 pub mod id;
+pub mod jsonl;
 pub mod snapshot;
 pub mod store;
 
 pub use error::SessionError;
 pub use id::{SESSION_VERSION, generate_session_id};
+pub use jsonl::{JsonlSessionStore, MAX_ROTATED_FILES, ROTATE_AFTER_BYTES};
 pub use snapshot::{SessionMetadata, SessionSnapshot};
 pub use store::{InMemorySessionStore, SessionStore};
 

--- a/crates/dasclaw_session/tests/jsonl_store_e2e.rs
+++ b/crates/dasclaw_session/tests/jsonl_store_e2e.rs
@@ -1,0 +1,222 @@
+//! End-to-end tests for [`dasclaw_session::JsonlSessionStore`].
+//!
+//! Covers the four `SessionStore` contracts plus the rotation /
+//! version-rejection requirements from issue #914 PR-C1.
+
+use std::fs;
+use std::path::PathBuf;
+
+use dasclaw_core::messages::ChatMessage;
+use dasclaw_session::{
+    JsonlSessionStore, ROTATE_AFTER_BYTES, SESSION_VERSION, SessionError, SessionSnapshot,
+    SessionStore,
+};
+use tempfile::TempDir;
+
+fn fixture_snapshot(session_id: &str, messages: Vec<ChatMessage>) -> SessionSnapshot {
+    SessionSnapshot {
+        session_id: session_id.to_string(),
+        version: SESSION_VERSION,
+        created_at_ms: 1_700_000_000_000,
+        updated_at_ms: 1_700_000_000_500,
+        workspace_root: Some(PathBuf::from("/tmp/ws")),
+        model: Some("test-model".to_string()),
+        messages,
+    }
+}
+
+fn chat(role: &str, content: &str) -> ChatMessage {
+    match role {
+        "user" => ChatMessage::user(content),
+        "assistant" => ChatMessage::assistant(content),
+        "system" => ChatMessage::system(content),
+        other => panic!("unsupported test role: {other}"),
+    }
+}
+
+#[tokio::test]
+async fn req_dasclaw_session_c1_jsonl_round_trip_preserves_snapshot() {
+    let dir = TempDir::new().expect("tempdir");
+    let store = JsonlSessionStore::new(dir.path().to_path_buf());
+
+    let snap = fixture_snapshot(
+        "session-c1-rt",
+        vec![chat("user", "ping"), chat("assistant", "pong")],
+    );
+
+    store.save(&snap).await.expect("save");
+    let loaded = store
+        .load(&snap.session_id)
+        .await
+        .expect("load")
+        .expect("session present");
+
+    assert_eq!(loaded.session_id, snap.session_id);
+    assert_eq!(loaded.version, snap.version);
+    assert_eq!(loaded.created_at_ms, snap.created_at_ms);
+    assert_eq!(loaded.updated_at_ms, snap.updated_at_ms);
+    assert_eq!(loaded.model, snap.model);
+    assert_eq!(loaded.workspace_root, snap.workspace_root);
+    assert_eq!(loaded.messages.len(), snap.messages.len());
+    for (l, r) in loaded.messages.iter().zip(snap.messages.iter()) {
+        assert_eq!(l.role, r.role);
+        assert_eq!(l.content, r.content);
+    }
+}
+
+#[tokio::test]
+async fn req_dasclaw_session_c1_jsonl_list_returns_metadata_without_full_load() {
+    let dir = TempDir::new().expect("tempdir");
+    let store = JsonlSessionStore::new(dir.path().to_path_buf());
+
+    for (id, model) in [("session-a", "m1"), ("session-b", "m2")] {
+        let mut snap = fixture_snapshot(id, vec![chat("user", "hi")]);
+        snap.model = Some(model.to_string());
+        store.save(&snap).await.expect("save");
+    }
+
+    let mut entries = store.list().await.expect("list");
+    entries.sort_by(|a, b| a.session_id.cmp(&b.session_id));
+
+    assert_eq!(entries.len(), 2);
+    assert_eq!(entries[0].session_id, "session-a");
+    assert_eq!(entries[0].model.as_deref(), Some("m1"));
+    assert_eq!(entries[0].version, SESSION_VERSION);
+    assert_eq!(entries[1].session_id, "session-b");
+    assert_eq!(entries[1].model.as_deref(), Some("m2"));
+}
+
+#[tokio::test]
+async fn req_dasclaw_session_c1_jsonl_missing_session_load_returns_none() {
+    let dir = TempDir::new().expect("tempdir");
+    let store = JsonlSessionStore::new(dir.path().to_path_buf());
+
+    let res = store.load("session-does-not-exist").await.expect("load");
+    assert!(res.is_none());
+}
+
+#[tokio::test]
+async fn req_dasclaw_session_c1_jsonl_delete_is_idempotent() {
+    let dir = TempDir::new().expect("tempdir");
+    let store = JsonlSessionStore::new(dir.path().to_path_buf());
+
+    let snap = fixture_snapshot("session-del", vec![chat("user", "hi")]);
+    store.save(&snap).await.expect("save");
+
+    store.delete(&snap.session_id).await.expect("first delete");
+    store
+        .delete(&snap.session_id)
+        .await
+        .expect("second delete is idempotent");
+
+    assert!(store.load(&snap.session_id).await.expect("load").is_none());
+}
+
+#[tokio::test]
+async fn req_dasclaw_session_c1_jsonl_future_version_is_rejected() {
+    let dir = TempDir::new().expect("tempdir");
+    let store = JsonlSessionStore::new(dir.path().to_path_buf());
+
+    let mut snap = fixture_snapshot("session-fv", vec![chat("user", "hi")]);
+    snap.version = SESSION_VERSION + 99;
+
+    // The store is allowed to either reject on save or on load; the
+    // contract is that callers never see a snapshot they cannot
+    // interpret. We exercise the load path because that's what hits
+    // mismatched-version files written by a future binary.
+    let path = dir.path().join(format!("{}.jsonl", snap.session_id));
+    let line = format!(
+        "{{\"type\":\"session_meta\",\"version\":{},\"session_id\":\"{}\",\"created_at_ms\":1,\"updated_at_ms\":1}}\n",
+        snap.version, snap.session_id
+    );
+    fs::write(&path, line).expect("write fixture");
+
+    let err = store
+        .load(&snap.session_id)
+        .await
+        .expect_err("future version must be rejected");
+    match err {
+        SessionError::UnsupportedVersion { found, supported } => {
+            assert_eq!(found, SESSION_VERSION + 99);
+            assert_eq!(supported, SESSION_VERSION);
+        }
+        other => panic!("expected UnsupportedVersion, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn req_dasclaw_session_c1_jsonl_rotates_after_threshold() {
+    let dir = TempDir::new().expect("tempdir");
+    let store = JsonlSessionStore::new(dir.path().to_path_buf());
+
+    // Build a snapshot large enough that a single save exceeds the
+    // rotation threshold. We pad message content with a known string.
+    let pad = "x".repeat(2048);
+    let mut messages = Vec::new();
+    while (messages.len() as u64) * (pad.len() as u64 + 64) < ROTATE_AFTER_BYTES + 8 * 1024 {
+        messages.push(chat("user", &pad));
+    }
+    let snap = fixture_snapshot("session-rot", messages);
+
+    // First save creates the file.
+    store.save(&snap).await.expect("first save");
+    // Second save must observe the existing oversized file and rotate
+    // it before writing.
+    store
+        .save(&snap)
+        .await
+        .expect("second save triggers rotate");
+
+    let entries: Vec<_> = fs::read_dir(dir.path())
+        .expect("readdir")
+        .filter_map(Result::ok)
+        .map(|e| e.file_name().to_string_lossy().to_string())
+        .collect();
+
+    let rotated: Vec<&String> = entries
+        .iter()
+        .filter(|n| n.starts_with("session-rot.rot-") && n.ends_with(".jsonl"))
+        .collect();
+    assert!(
+        !rotated.is_empty(),
+        "expected at least one rotated file in {entries:?}"
+    );
+    assert!(
+        entries.iter().any(|n| n == "session-rot.jsonl"),
+        "live session file should still exist in {entries:?}"
+    );
+}
+
+#[tokio::test]
+async fn req_dasclaw_session_c1_jsonl_caps_rotated_history_at_three() {
+    use dasclaw_session::MAX_ROTATED_FILES;
+
+    let dir = TempDir::new().expect("tempdir");
+    let store = JsonlSessionStore::new(dir.path().to_path_buf());
+
+    let pad = "y".repeat(4096);
+    let mut messages = Vec::new();
+    while (messages.len() as u64) * (pad.len() as u64 + 64) < ROTATE_AFTER_BYTES + 8 * 1024 {
+        messages.push(chat("user", &pad));
+    }
+    let snap = fixture_snapshot("session-cap", messages);
+
+    // Repeated saves should trigger multiple rotations but the on-disk
+    // rotated file count must never exceed `MAX_ROTATED_FILES`.
+    for _ in 0..(MAX_ROTATED_FILES + 3) {
+        store.save(&snap).await.expect("save");
+    }
+
+    let rotated_count = fs::read_dir(dir.path())
+        .expect("readdir")
+        .filter_map(Result::ok)
+        .filter(|e| {
+            let name = e.file_name().to_string_lossy().to_string();
+            name.starts_with("session-cap.rot-") && name.ends_with(".jsonl")
+        })
+        .count();
+    assert!(
+        rotated_count <= MAX_ROTATED_FILES,
+        "rotated history should be capped at {MAX_ROTATED_FILES}, got {rotated_count}"
+    );
+}

--- a/crates/dasclaw_session/tests/jsonl_wire.rs
+++ b/crates/dasclaw_session/tests/jsonl_wire.rs
@@ -1,0 +1,42 @@
+//! Wire-format snapshot test for the on-disk JSONL session file.
+//!
+//! Locks the line-by-line framing produced by
+//! [`JsonlSessionStore`] so any change to record discriminants
+//! (`session_meta` / `message`), field order or field set forces a
+//! deliberate `cargo insta review` and a [`SESSION_VERSION`] bump.
+//!
+//! The fixture is fully literal (no clocks, no temp dirs) so the
+//! snapshot diff stays focused on the wire shape.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use dasclaw_core::messages::ChatMessage;
+use dasclaw_session::{JsonlSessionStore, SESSION_VERSION, SessionSnapshot, SessionStore};
+
+fn fixture_snapshot() -> SessionSnapshot {
+    SessionSnapshot {
+        session_id: "session-1700000000000-0".to_string(),
+        version: SESSION_VERSION,
+        created_at_ms: 1_700_000_000_000,
+        updated_at_ms: 1_700_000_000_500,
+        workspace_root: Some(PathBuf::from("/tmp/ws")),
+        model: Some("test-model".to_string()),
+        messages: vec![ChatMessage::user("ping"), ChatMessage::assistant("pong")],
+    }
+}
+
+#[tokio::test]
+async fn jsonl_wire_format_is_stable() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = Arc::new(JsonlSessionStore::new(dir.path().to_path_buf()));
+    let snap = fixture_snapshot();
+    store.save(&snap).await.expect("save");
+
+    let bytes = tokio::fs::read(store.session_path(&snap.session_id))
+        .await
+        .expect("read jsonl");
+    let text = String::from_utf8(bytes).expect("utf8");
+
+    insta::assert_snapshot!(text);
+}

--- a/crates/dasclaw_session/tests/snapshots/jsonl_wire__jsonl_wire_format_is_stable.snap
+++ b/crates/dasclaw_session/tests/snapshots/jsonl_wire__jsonl_wire_format_is_stable.snap
@@ -1,0 +1,7 @@
+---
+source: crates/dasclaw_session/tests/jsonl_wire.rs
+expression: text
+---
+{"type":"session_meta","version":1,"session_id":"session-1700000000000-0","created_at_ms":1700000000000,"updated_at_ms":1700000000500,"workspace_root":"/tmp/ws","model":"test-model"}
+{"type":"message","message":{"role":"user","content":"ping"}}
+{"type":"message","message":{"role":"assistant","content":"pong"}}


### PR DESCRIPTION
# 背景 / 目标

落地 #914 Action 3（jsonl 部分）+ Action 5（wire 稳定性）的最小可用切片：把 `dasclaw_session` 从内存版升级到**真的能关机重开**——给 CLI / 桌面端补齐一个文件存档器，外加一道版本兼容闸门。

PR-A #916 把 crate 拆出来；PR-B #917 落了 SessionSnapshot + SessionStore trait + InMemorySessionStore；本 PR 是这段的第三步。

## Sources read

- AGENTS.md §"红线" / §"复用优先于新建" / §"PR 必填项"
- #914 epic body — Action 3（SessionStore + jsonl rotate）+ Action 5（serde 稳定性）+ 拆 PR 建议（PR-C 段）
- docs/plans/architecture-refactor/adr-153-headless-agent-framework-draft.md §4.3（dasclaw_session crate 规划）
- claw-code/rust/crates/runtime/src/session.rs（jsonl framing + rotation 参考实现，行 1-13 / 200-340 / 400-600 / 1060-1170）
- crates/dasclaw_session/src/{lib.rs,store.rs,snapshot.rs,error.rs,id.rs}（PR-B 已落地的现状）
- scripts/check_no_panics.py（确认测试目录不在禁区）
- scripts/check_blueprint_sync.py（确认 dasclaw_session 已不在 PLANNED）

# 改动范围

| 文件 | 改动 |
|---|---|
| `crates/dasclaw_session/src/jsonl.rs` | **新增**。`JsonlSessionStore` 实现 `SessionStore`，含 wire 渲染、解析、旋转、原子写、清理 |
| `crates/dasclaw_session/src/lib.rs` | 追加 `pub mod jsonl;` + `pub use jsonl::{JsonlSessionStore, MAX_ROTATED_FILES, ROTATE_AFTER_BYTES};` |
| `crates/dasclaw_session/Cargo.toml` | 追加 1 行 dev-dep `tempfile = "3.23.0"` |
| `crates/dasclaw_session/tests/jsonl_store_e2e.rs` | **新增**。7 个 tokio 测试 |
| `crates/dasclaw_session/tests/jsonl_wire.rs` + `snapshots/jsonl_wire__jsonl_wire_format_is_stable.snap` | **新增**。insta 锁定 jsonl 行格式 |

## Wire 格式（已锁定 snapshot）

```
{"type":"session_meta","version":1,"session_id":"…","created_at_ms":…,"updated_at_ms":…,"workspace_root":"…","model":"…"}
{"type":"message","message":{"role":"user","content":"ping"}}
{"type":"message","message":{"role":"assistant","content":"pong"}}
```

外层 framing（`type=session_meta` + `type=message`）刻意与 `claw-code/rust/crates/runtime/src/session.rs` 对齐，方便未来跨工具迁移工具按行级合流；内层 `message` 体使用 `dasclaw_core::messages::ChatMessage` 的 serde shape。

## 旋转 / 清理

- `ROTATE_AFTER_BYTES = 256 KiB`，`MAX_ROTATED_FILES = 3`（与 claw-code 同参，issue 明确要求）
- 旋转文件名：`<session_id>.rot-<ms>.jsonl`
- save 顺序：`create_dir_all` → `rotate_if_needed` → 写 `<live>.tmp-<ms>-<n>` → `rename` 上 live → `cleanup_rotated`（按 mtime 删最旧的若干份直到 ≤ 3）

## 版本协议

- load 路径：若 `session_meta.version > SESSION_VERSION` → `SessionError::UnsupportedVersion { found, supported }`
- 不做静默截断、不做隐式降级

# 非目标（What's NOT in this PR）

- ❌ `compact()` / `SessionCompaction` —— 留给 PR-C2
- ❌ `fork()` / `SessionFork` —— 留给 PR-C3
- ❌ `prompt_history` 持久化 —— 待 PR-D
- ❌ 完整的 claw-code `ConversationMessage` ↔ dasclaw `ChatMessage` shim（双向 round-trip）—— 在本 PR 显式记录为未来工作
- ❌ 不动 ADR-113（hook 红线）/ ADR-148（安全闸门）/ ADR-153 红线
- ❌ 不改 dasclaw_runtime re-export

# 验证（命令 + 结果）

```bash
cargo check -p dasclaw_session --tests       # 0 errors / 0 warnings
cargo nextest run -p dasclaw_session         # 18 tests pass (1 leaky tempdir bg cleanup, false positive)
cargo clippy --no-deps -p dasclaw_session --all-targets -- -D warnings  # clean
cargo fmt --all
python3.12 scripts/check_no_panics.py --base origin/xClaw   # OK
python3.12 scripts/check_blueprint_sync.py                  # OK: 49 crates on disk, 2 planned
```

测试覆盖：
- `req_dasclaw_session_c1_jsonl_round_trip_preserves_snapshot`
- `req_dasclaw_session_c1_jsonl_list_returns_metadata_without_full_load`
- `req_dasclaw_session_c1_jsonl_missing_session_load_returns_none`
- `req_dasclaw_session_c1_jsonl_delete_is_idempotent`
- `req_dasclaw_session_c1_jsonl_future_version_is_rejected`
- `req_dasclaw_session_c1_jsonl_rotates_after_threshold`
- `req_dasclaw_session_c1_jsonl_caps_rotated_history_at_three`
- `jsonl_wire_format_is_stable`（insta 行格式锁）

## 三层 skill 自查

`code-quality-audit` / `code-simplifier` / `code-review-expert` 全部 PASS。

`code-review-expert` 记录一个**非阻塞**观察：`rotated_path_for` 用毫秒命名 rotated 文件，同毫秒内连续两次 rotate 会让第二次覆盖第一次的旋转文件（这与 claw-code 参考实现同质，issue 也只要求"对齐 claw-code"）；测试断言用 `<= MAX_ROTATED_FILES` 不会受影响。若 PR-C2/D 阶段决定加 `AtomicU64` nonce 增强，再做。

Closes #920
Refs #914
