### PR TITLE
feat(session): SessionCompaction + Session::compact_oldest (#914 PR-C2)

### DIFF
--- a/crates/dasclaw_session/src/jsonl.rs
+++ b/crates/dasclaw_session/src/jsonl.rs
@@ -52,7 +52,7 @@ use dasclaw_core::messages::ChatMessage;
 
 use crate::error::SessionError;
 use crate::id::SESSION_VERSION;
-use crate::snapshot::{SessionMetadata, SessionSnapshot};
+use crate::snapshot::{SessionCompaction, SessionMetadata, SessionSnapshot};
 use crate::store::SessionStore;
 
 /// Live files larger than this trigger a rotate on the next save.
@@ -204,6 +204,15 @@ struct MessageRecord<'a> {
     message: &'a ChatMessage,
 }
 
+#[derive(Debug, Serialize)]
+struct CompactionRecord<'a> {
+    #[serde(rename = "type")]
+    kind: &'a str,
+    count: u32,
+    removed_message_count: usize,
+    summary: &'a str,
+}
+
 fn render_jsonl(snapshot: &SessionSnapshot) -> Result<Vec<u8>, SessionError> {
     let meta = SessionMetaRecord {
         kind: "session_meta",
@@ -218,6 +227,16 @@ fn render_jsonl(snapshot: &SessionSnapshot) -> Result<Vec<u8>, SessionError> {
     let mut out = Vec::with_capacity(256 + snapshot.messages.len() * 128);
     serde_json::to_writer(&mut out, &meta)?;
     out.push(b'\n');
+    if let Some(compaction) = &snapshot.compaction {
+        let record = CompactionRecord {
+            kind: "compaction",
+            count: compaction.count,
+            removed_message_count: compaction.removed_message_count,
+            summary: &compaction.summary,
+        };
+        serde_json::to_writer(&mut out, &record)?;
+        out.push(b'\n');
+    }
     for message in &snapshot.messages {
         let record = MessageRecord {
             kind: "message",
@@ -240,6 +259,7 @@ fn parse_jsonl(bytes: &[u8]) -> Result<SessionSnapshot, SessionError> {
     let mut updated_at_ms = None;
     let mut workspace_root = None;
     let mut model = None;
+    let mut compaction: Option<SessionCompaction> = None;
     let mut messages: Vec<ChatMessage> = Vec::new();
 
     for (idx, raw) in text.lines().enumerate() {
@@ -321,6 +341,53 @@ fn parse_jsonl(bytes: &[u8]) -> Result<SessionSnapshot, SessionError> {
                 let msg: ChatMessage = serde_json::from_value(message_value.clone())?;
                 messages.push(msg);
             }
+            "compaction" => {
+                let count_raw = object.get("count").and_then(Value::as_u64).ok_or_else(|| {
+                    SessionError::Io(std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        format!("compaction record at line {} missing \"count\"", idx + 1),
+                    ))
+                })?;
+                let count = u32::try_from(count_raw).map_err(|_| {
+                    SessionError::Io(std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        "compaction.count out of u32 range",
+                    ))
+                })?;
+                let removed_raw = object
+                    .get("removed_message_count")
+                    .and_then(Value::as_u64)
+                    .ok_or_else(|| {
+                        SessionError::Io(std::io::Error::new(
+                            std::io::ErrorKind::InvalidData,
+                            format!(
+                                "compaction record at line {} missing \"removed_message_count\"",
+                                idx + 1
+                            ),
+                        ))
+                    })?;
+                let removed_message_count = usize::try_from(removed_raw).map_err(|_| {
+                    SessionError::Io(std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        "compaction.removed_message_count out of usize range",
+                    ))
+                })?;
+                let summary = object
+                    .get("summary")
+                    .and_then(Value::as_str)
+                    .ok_or_else(|| {
+                        SessionError::Io(std::io::Error::new(
+                            std::io::ErrorKind::InvalidData,
+                            format!("compaction record at line {} missing \"summary\"", idx + 1),
+                        ))
+                    })?
+                    .to_string();
+                compaction = Some(SessionCompaction {
+                    count,
+                    removed_message_count,
+                    summary,
+                });
+            }
             other => {
                 return Err(SessionError::Io(std::io::Error::new(
                     std::io::ErrorKind::InvalidData,
@@ -347,6 +414,7 @@ fn parse_jsonl(bytes: &[u8]) -> Result<SessionSnapshot, SessionError> {
         updated_at_ms,
         workspace_root,
         model,
+        compaction,
         messages,
     })
 }

--- a/crates/dasclaw_session/src/lib.rs
+++ b/crates/dasclaw_session/src/lib.rs
@@ -64,7 +64,7 @@ pub mod store;
 pub use error::SessionError;
 pub use id::{SESSION_VERSION, generate_session_id};
 pub use jsonl::{JsonlSessionStore, MAX_ROTATED_FILES, ROTATE_AFTER_BYTES};
-pub use snapshot::{SessionMetadata, SessionSnapshot};
+pub use snapshot::{SessionCompaction, SessionMetadata, SessionSnapshot};
 pub use store::{InMemorySessionStore, SessionStore};
 
 use std::path::PathBuf;
@@ -172,5 +172,21 @@ impl Session {
             self.state.touch();
         }
         result
+    }
+
+    /// Compact the conversation by dropping the oldest `remove_count`
+    /// messages and inserting a single summary system message at the
+    /// front. Delegates to [`SessionSnapshot::compact_oldest`];
+    /// touches `updated_at_ms` when a non-trivial pass actually runs.
+    pub fn compact_oldest<F>(&mut self, remove_count: usize, summarizer: F)
+    where
+        F: FnOnce(&[ChatMessage]) -> String,
+    {
+        let prior_pass_count = self.state.compaction.as_ref().map(|c| c.count);
+        self.state.compact_oldest(remove_count, summarizer);
+        let new_pass_count = self.state.compaction.as_ref().map(|c| c.count);
+        if prior_pass_count != new_pass_count {
+            self.state.touch();
+        }
     }
 }

--- a/crates/dasclaw_session/src/snapshot.rs
+++ b/crates/dasclaw_session/src/snapshot.rs
@@ -25,6 +25,29 @@ use serde::{Deserialize, Serialize};
 
 use crate::id::{SESSION_VERSION, current_time_millis, generate_session_id};
 
+/// Bookkeeping for a context-compaction event.
+///
+/// Each call to [`SessionSnapshot::compact_oldest`] (and therefore
+/// [`crate::Session::compact_oldest`]) replaces the in-snapshot value:
+/// `count` accumulates across calls so callers can see how many
+/// passes a session has undergone, while `removed_message_count` and
+/// `summary` describe the *most recent* pass only.
+///
+/// The on-disk JSONL record for this struct is `{"type":"compaction", …}`
+/// and is positioned between the `session_meta` line and the first
+/// `message` line — same layout as `claw-code`'s session files.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SessionCompaction {
+    /// Number of compaction passes the session has been through.
+    pub count: u32,
+    /// How many messages the *latest* pass removed.
+    pub removed_message_count: usize,
+    /// Human-readable summary the latest pass produced; this string
+    /// is also injected into the conversation as the new leading
+    /// system message.
+    pub summary: String,
+}
+
 /// Lightweight identifier + timestamps view returned from
 /// [`crate::store::SessionStore::list`].
 ///
@@ -82,6 +105,10 @@ pub struct SessionSnapshot {
     /// Optional model name the session was driven with.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model: Option<String>,
+    /// Latest compaction bookkeeping. `None` until the session has
+    /// undergone at least one [`SessionSnapshot::compact_oldest`] pass.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub compaction: Option<SessionCompaction>,
     /// Full conversation history, in turn order.
     pub messages: Vec<ChatMessage>,
 }
@@ -99,6 +126,7 @@ impl SessionSnapshot {
             updated_at_ms: now,
             workspace_root: None,
             model: None,
+            compaction: None,
             messages: Vec::new(),
         }
     }
@@ -106,5 +134,39 @@ impl SessionSnapshot {
     /// Refresh `updated_at_ms` to the current wall-clock time.
     pub fn touch(&mut self) {
         self.updated_at_ms = current_time_millis();
+    }
+
+    /// Drop the oldest `remove_count` messages and prepend a single
+    /// system message containing the summary returned by `summarizer`.
+    ///
+    /// `remove_count` is clamped to the available message count, so
+    /// passing a value larger than `self.messages.len()` removes
+    /// everything and the recorded `removed_message_count` matches
+    /// what was actually dropped. Passing `0` is a no-op: neither
+    /// the message vector nor the [`SessionCompaction`] bookkeeping
+    /// is touched, and `summarizer` is not invoked.
+    ///
+    /// On a non-trivial pass, [`SessionCompaction::count`]
+    /// monotonically increments (so callers can tell "how many
+    /// passes has this session been through"), while
+    /// `removed_message_count` and `summary` describe the latest
+    /// pass.
+    pub fn compact_oldest<F>(&mut self, remove_count: usize, summarizer: F)
+    where
+        F: FnOnce(&[ChatMessage]) -> String,
+    {
+        if remove_count == 0 || self.messages.is_empty() {
+            return;
+        }
+        let effective = remove_count.min(self.messages.len());
+        let removed: Vec<ChatMessage> = self.messages.drain(0..effective).collect();
+        let summary = summarizer(&removed);
+        let prior_count = self.compaction.as_ref().map_or(0, |c| c.count);
+        self.compaction = Some(SessionCompaction {
+            count: prior_count.saturating_add(1),
+            removed_message_count: effective,
+            summary: summary.clone(),
+        });
+        self.messages.insert(0, ChatMessage::system(summary));
     }
 }

--- a/crates/dasclaw_session/tests/compaction.rs
+++ b/crates/dasclaw_session/tests/compaction.rs
@@ -1,0 +1,123 @@
+//! Tests for [`SessionCompaction`] + [`SessionSnapshot::compaction`]
+//! plus the [`Session::compact_oldest`] API.
+//!
+//! Behavior locked here:
+//! - `compact_oldest(n, summarizer)` removes the first `n` messages
+//!   (clamped to `messages.len()`), invokes `summarizer` on those
+//!   removed messages, and prepends a `ChatMessage::system` carrying
+//!   the returned summary.
+//! - `SessionSnapshot.compaction` accumulates: a second
+//!   `compact_oldest` call bumps `count` to 2.
+//! - `compact_oldest(0, _)` is a no-op (no summarizer call, no
+//!   `compaction` field mutation).
+//! - The first system message is the summary placeholder, not a
+//!   counted "message" for protocol purposes.
+
+use std::path::PathBuf;
+
+use dasclaw_core::messages::{ChatMessage, Role};
+use dasclaw_session::{SESSION_VERSION, SessionCompaction, SessionSnapshot};
+
+fn snapshot_with_messages(messages: Vec<ChatMessage>) -> SessionSnapshot {
+    SessionSnapshot {
+        session_id: "session-test-compact".to_string(),
+        version: SESSION_VERSION,
+        created_at_ms: 1_700_000_000_000,
+        updated_at_ms: 1_700_000_000_500,
+        workspace_root: Some(PathBuf::from("/tmp/ws")),
+        model: Some("test-model".to_string()),
+        compaction: None,
+        messages,
+    }
+}
+
+#[test]
+fn req_dasclaw_session_c2_compact_oldest_removes_n_and_injects_summary() {
+    let mut snap = snapshot_with_messages(vec![
+        ChatMessage::user("m1"),
+        ChatMessage::assistant("m2"),
+        ChatMessage::user("m3"),
+        ChatMessage::assistant("m4"),
+        ChatMessage::user("m5"),
+    ]);
+
+    let mut captured = None;
+    snap.compact_oldest(3, |removed| {
+        captured = Some(removed.len());
+        "summary-of-first-three".to_string()
+    });
+
+    assert_eq!(captured, Some(3), "summarizer must see exactly 3 removed");
+    assert_eq!(snap.messages.len(), 1 + 2, "1 summary + 2 retained");
+    assert_eq!(snap.messages[0].role, Role::System);
+    assert!(snap.messages[0].content.contains("summary-of-first-three"));
+    assert_eq!(snap.messages[1].content, "m4");
+    assert_eq!(snap.messages[2].content, "m5");
+
+    let comp = snap.compaction.as_ref().expect("compaction recorded");
+    assert_eq!(comp.count, 1);
+    assert_eq!(comp.removed_message_count, 3);
+    assert_eq!(comp.summary, "summary-of-first-three");
+}
+
+#[test]
+fn req_dasclaw_session_c2_compact_oldest_accumulates_count_on_repeat() {
+    let mut snap = snapshot_with_messages(vec![
+        ChatMessage::user("a"),
+        ChatMessage::assistant("b"),
+        ChatMessage::user("c"),
+        ChatMessage::assistant("d"),
+    ]);
+    snap.compact_oldest(2, |_| "s1".to_string());
+    snap.compact_oldest(1, |_| "s2".to_string());
+
+    let comp = snap.compaction.expect("compaction recorded");
+    assert_eq!(comp.count, 2);
+    assert_eq!(comp.removed_message_count, 1, "tracks the latest pass");
+    assert_eq!(comp.summary, "s2");
+}
+
+#[test]
+fn req_dasclaw_session_c2_compact_oldest_zero_is_noop() {
+    let original = vec![ChatMessage::user("only")];
+    let mut snap = snapshot_with_messages(original.clone());
+
+    let mut called = false;
+    snap.compact_oldest(0, |_| {
+        called = true;
+        "should-not-run".to_string()
+    });
+
+    assert!(!called, "summarizer must not run when remove_count is 0");
+    assert!(snap.compaction.is_none());
+    assert_eq!(snap.messages.len(), original.len());
+}
+
+#[test]
+fn req_dasclaw_session_c2_compact_oldest_clamps_to_available() {
+    let mut snap = snapshot_with_messages(vec![ChatMessage::user("only-one")]);
+    snap.compact_oldest(99, |removed| {
+        assert_eq!(removed.len(), 1, "must clamp to available count");
+        "everything".to_string()
+    });
+
+    assert_eq!(snap.messages.len(), 1, "1 summary, 0 retained");
+    assert_eq!(snap.messages[0].role, Role::System);
+    let comp = snap.compaction.as_ref().expect("compaction recorded");
+    assert_eq!(
+        comp.removed_message_count, 1,
+        "records the actual removed count"
+    );
+}
+
+#[test]
+fn req_dasclaw_session_c2_session_compaction_serde_round_trip() {
+    let comp = SessionCompaction {
+        count: 7,
+        removed_message_count: 42,
+        summary: "previously chatted about widgets".to_string(),
+    };
+    let json = serde_json::to_string(&comp).expect("serialize");
+    let back: SessionCompaction = serde_json::from_str(&json).expect("deserialize");
+    assert_eq!(back, comp);
+}

--- a/crates/dasclaw_session/tests/jsonl_compaction.rs
+++ b/crates/dasclaw_session/tests/jsonl_compaction.rs
@@ -1,0 +1,91 @@
+//! End-to-end test: SessionCompaction survives a JsonlSessionStore
+//! round-trip and shows up between session_meta and the message
+//! records (claw-code wire-parity).
+
+use std::path::PathBuf;
+
+use dasclaw_core::messages::ChatMessage;
+use dasclaw_session::{
+    JsonlSessionStore, SESSION_VERSION, SessionCompaction, SessionSnapshot, SessionStore,
+};
+
+fn fixture() -> SessionSnapshot {
+    SessionSnapshot {
+        session_id: "session-1700000000000-0".to_string(),
+        version: SESSION_VERSION,
+        created_at_ms: 1_700_000_000_000,
+        updated_at_ms: 1_700_000_000_500,
+        workspace_root: Some(PathBuf::from("/tmp/ws")),
+        model: Some("test-model".to_string()),
+        compaction: Some(SessionCompaction {
+            count: 1,
+            removed_message_count: 3,
+            summary: "earlier discussion summarized".to_string(),
+        }),
+        messages: vec![
+            ChatMessage::system("earlier discussion summarized"),
+            ChatMessage::user("now what?"),
+        ],
+    }
+}
+
+#[tokio::test]
+async fn req_dasclaw_session_c2_jsonl_round_trip_preserves_compaction() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = JsonlSessionStore::new(dir.path().to_path_buf());
+    let snap = fixture();
+
+    store.save(&snap).await.expect("save");
+    let loaded = store
+        .load(&snap.session_id)
+        .await
+        .expect("load")
+        .expect("session present");
+
+    let comp = loaded
+        .compaction
+        .as_ref()
+        .expect("compaction must survive jsonl round trip");
+    assert_eq!(comp.count, 1);
+    assert_eq!(comp.removed_message_count, 3);
+    assert_eq!(comp.summary, "earlier discussion summarized");
+    assert_eq!(loaded.messages.len(), 2);
+}
+
+#[tokio::test]
+async fn req_dasclaw_session_c2_jsonl_wire_records_compaction_between_meta_and_messages() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = JsonlSessionStore::new(dir.path().to_path_buf());
+    let snap = fixture();
+    store.save(&snap).await.expect("save");
+
+    let bytes = tokio::fs::read(store.session_path(&snap.session_id))
+        .await
+        .expect("read");
+    let text = String::from_utf8(bytes).expect("utf8");
+    let lines: Vec<&str> = text.lines().collect();
+
+    assert!(
+        lines[0].contains(r#""type":"session_meta""#),
+        "line 1 must be session_meta, got {:?}",
+        lines.first()
+    );
+    assert!(
+        lines[1].contains(r#""type":"compaction""#),
+        "line 2 must be compaction, got {:?}",
+        lines.get(1)
+    );
+    assert!(
+        lines[1].contains(r#""count":1"#) && lines[1].contains(r#""removed_message_count":3"#),
+        "compaction record must carry its fields: {:?}",
+        lines.get(1)
+    );
+    for (i, line) in lines.iter().enumerate().skip(2) {
+        assert!(
+            line.contains(r#""type":"message""#),
+            "line {} must be a message record after compaction, got {:?}",
+            i + 1,
+            line
+        );
+    }
+}

--- a/crates/dasclaw_session/tests/jsonl_store_e2e.rs
+++ b/crates/dasclaw_session/tests/jsonl_store_e2e.rs
@@ -21,6 +21,7 @@ fn fixture_snapshot(session_id: &str, messages: Vec<ChatMessage>) -> SessionSnap
         updated_at_ms: 1_700_000_000_500,
         workspace_root: Some(PathBuf::from("/tmp/ws")),
         model: Some("test-model".to_string()),
+        compaction: None,
         messages,
     }
 }

--- a/crates/dasclaw_session/tests/jsonl_wire.rs
+++ b/crates/dasclaw_session/tests/jsonl_wire.rs
@@ -22,6 +22,7 @@ fn fixture_snapshot() -> SessionSnapshot {
         updated_at_ms: 1_700_000_000_500,
         workspace_root: Some(PathBuf::from("/tmp/ws")),
         model: Some("test-model".to_string()),
+        compaction: None,
         messages: vec![ChatMessage::user("ping"), ChatMessage::assistant("pong")],
     }
 }

--- a/crates/dasclaw_session/tests/session_e2e.rs
+++ b/crates/dasclaw_session/tests/session_e2e.rs
@@ -176,3 +176,42 @@ async fn req_dasclaw_runtime_session_b1_external_cancel_stops_session_run() {
         "expected AgentError::Stopped, got {err:?}"
     );
 }
+
+/// Regression for PR-C2 reviewer finding: `Session::compact_oldest`
+/// must advance `updated_at_ms` whenever a compaction pass actually
+/// runs — including the edge case where `remove_count == 1` and the
+/// post-compaction message count happens to equal the pre-compaction
+/// one (drain 1 + insert 1 summary = same length, but the snapshot
+/// has nevertheless changed).
+#[tokio::test]
+async fn req_dasclaw_session_c2_session_compact_oldest_touches_updated_at_ms() {
+    use dasclaw_session::SessionSnapshot;
+
+    let responder = ScriptedResponder::new(vec!["unused"]);
+    let agent = Arc::new(
+        Agent::builder()
+            .responder(responder)
+            .build()
+            .expect("build agent"),
+    );
+
+    let mut snap = SessionSnapshot::fresh();
+    snap.updated_at_ms = 0; // pin to a fixed value so we can detect any forward motion
+    snap.messages
+        .push(ChatMessage::user("only original message"));
+
+    let mut session = Session::from_snapshot(agent, snap);
+    let before = session.snapshot().updated_at_ms;
+
+    session.compact_oldest(1, |_removed| "summary".to_string());
+
+    let after = session.snapshot().updated_at_ms;
+    assert!(
+        after > before,
+        "updated_at_ms must advance on a real compaction pass (before={before}, after={after})"
+    );
+    assert!(
+        session.snapshot().compaction.is_some(),
+        "compaction field must be recorded"
+    );
+}

--- a/crates/dasclaw_session/tests/snapshot_wire.rs
+++ b/crates/dasclaw_session/tests/snapshot_wire.rs
@@ -21,6 +21,7 @@ fn fixture_snapshot() -> SessionSnapshot {
         updated_at_ms: 1_700_000_000_500,
         workspace_root: None,
         model: Some("test-model".to_string()),
+        compaction: None,
         messages: vec![ChatMessage::user("ping"), ChatMessage::assistant("pong")],
     }
 }

--- a/crates/dasclaw_session/tests/store_e2e.rs
+++ b/crates/dasclaw_session/tests/store_e2e.rs
@@ -62,6 +62,7 @@ fn sample_snapshot(session_id: &str) -> SessionSnapshot {
         updated_at_ms: 1_700_000_000_500,
         workspace_root: None,
         model: Some("test-model".to_string()),
+        compaction: None,
         messages: vec![
             ChatMessage::user("hi"),
             ChatMessage::assistant("hello back"),


### PR DESCRIPTION
# PR-C2: SessionCompaction 上下文压缩

## Sources read

- AGENTS.md §1（强制阅读顺序）、§3（本地管线）、§4（PR 必填）
- .github/copilot-instructions.md §2 红线、§3 必跑管线
- docs/plans/architecture-refactor/adr-112-compatibility-evaluation.md §wire-format-parity
- docs/plans/architecture-refactor/adr-113-hook-engine-unification.md（无直接影响，仅扫读确认）
- claw-code/rust/crates/runtime/src/session.rs §`SessionCompaction::to_jsonl_record`（确认线缆字段名）
- 本仓 #914 issue body §"PR-C2 — SessionCompaction"
- crates/dasclaw_session/src/lib.rs §`Session::run` / `from_snapshot`（上下文压缩需保持的状态机）

## 背景 / 目标

`dasclaw_session` 在 PR-C1 之后已能把会话以 jsonl 落盘。但长会话注定撑爆模型上下文窗口，
`claw-code` 用 **SessionCompaction** 解决：丢掉最旧的 N 条消息，由调用方提供一句概要，
把概要塞回会话首条系统消息位置；并在 jsonl 文件中、`session_meta` 和 `message` 之间记一行
`{"type":"compaction", "count":N, "removed_message_count":N, "summary":"…"}` 用于回放与统计。

目标：在 `dasclaw_session` 端等价复刻该机制，给后续接入 LLM-side summarizer / 自动压缩
留好接口。

## 改动范围

- `crates/dasclaw_session/src/snapshot.rs`
  - 新增 `pub struct SessionCompaction { count: u32, removed_message_count: usize, summary: String }`
  - 给 `SessionSnapshot` 增加 `#[serde(default, skip_serializing_if = "Option::is_none")] pub compaction: Option<SessionCompaction>` 字段
  - 新增 `SessionSnapshot::compact_oldest<F: FnOnce(&[ChatMessage]) -> String>(&mut self, remove_count, summarizer)`
    - `remove_count == 0` 或 messages 为空 → 静默 no-op，不触发 summarizer
    - `remove_count` 自动 clamp 到 `messages.len()`
    - 删除最旧的 N 条 → 调用 summarizer 拿到摘要 → 用 `ChatMessage::system(summary)` 前插
    - `compaction.count` 累积 +1，`removed_message_count` 与 `summary` 记录本轮值
- `crates/dasclaw_session/src/lib.rs`
  - 暴露 `pub use snapshot::SessionCompaction`
  - 给 `Session` 新增 `compact_oldest` 透传方法；仅在真实发生压缩（`compaction.count` 改变）时 `touch()` `updated_at_ms`
- `crates/dasclaw_session/src/jsonl.rs`
  - 新增 `CompactionRecord<'a>` serde 写盘结构
  - `render_jsonl` 在 meta 之后、message 之前写出 compaction 行（`None` 时跳过）
  - `parse_jsonl` 新增 `"compaction"` 分支，按 claw-code 字段名解析回 `SessionCompaction`
- 测试
  - 新增 `tests/compaction.rs`（5 个 req_ 测试，覆盖 inject / 累积 count / 0 no-op / clamp / serde 闭环）
  - 新增 `tests/jsonl_compaction.rs`（2 个测试：jsonl 端到端 round-trip + 线缆顺序断言）
  - `tests/session_e2e.rs` 增 `req_dasclaw_session_c2_session_compact_oldest_touches_updated_at_ms`，覆盖 review-expert 找到的 `remove_count=1` 时 `updated_at_ms` 不推进的回归点
  - 其余既有 fixture 加 `compaction: None` 以适配字段变化（snapshot_wire / jsonl_wire / jsonl_store_e2e / store_e2e）
- **既有 insta snapshot 不变**：`compaction: Option` 用 `skip_serializing_if = "Option::is_none"` 屏蔽，PR-C1 锁定的 wire 保持兼容

## 非目标（What's NOT in this PR）

- **不**接入任何具体的 LLM summarizer（PR-C2 只暴露闭包入口，summarizer 由更高层装配）
- **不**做 `prompt_history` / fork 字段（留给 PR-C3）
- **不**做自动按 token 阈值触发压缩的策略（留给后续 runtime PR）
- **不**改 `dasclaw_runtime::Agent` 任何 API
- **不**做与 claw-code session.jsonl 100% 字段级互操作（仅 compaction 这一段对齐；message 体保留 ChatMessage serde 形状，互操作整体属 PR-D 范围）

## 验证

```bash
cargo check -p dasclaw_session --tests        # 0 error 0 warning
cargo nextest run -p dasclaw_session          # 26 passed / 0 failed
cargo clippy --no-deps -p dasclaw_session --all-targets -- -D warnings  # clean
cargo fmt --all                                # no diff
python3.12 scripts/check_no_panics.py --base origin/xClaw  # OK
python3.12 scripts/check_blueprint_sync.py    # OK
```

3 层 skill 审查（subagent 跑 code-quality-audit → code-simplifier → code-review-expert）：

- code-quality-audit: **PASS**
- code-simplifier: **PASS**
- code-review-expert: 第一轮 NEEDS_CHANGES（指出 `Session::compact_oldest` 用 `messages.len()` 差值判 touch 在 `remove_count=1` 时会漏判 `updated_at_ms` 推进） → 已改为按 `compaction.count` 差值判定 + 增补 `req_dasclaw_session_c2_session_compact_oldest_touches_updated_at_ms` 回归测试 → **PASS**

## 栈关系

本 PR 基于 `feat/914c1-jsonl-store`（#921），合并顺序：先 #921，再本 PR。

Refs #914
Closes #922
