### PR TITLE
feat(session): SessionFork + prompt_history (#914 PR-C3)

### DIFF
--- a/crates/dasclaw_session/src/jsonl.rs
+++ b/crates/dasclaw_session/src/jsonl.rs
@@ -43,7 +43,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use async_trait::async_trait;
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use serde_json::Value;
 use tokio::fs;
 use tokio::io::{AsyncBufReadExt, BufReader};
@@ -52,7 +52,9 @@ use dasclaw_core::messages::ChatMessage;
 
 use crate::error::SessionError;
 use crate::id::SESSION_VERSION;
-use crate::snapshot::{SessionCompaction, SessionMetadata, SessionSnapshot};
+use crate::snapshot::{
+    SessionCompaction, SessionFork, SessionMetadata, SessionPromptEntry, SessionSnapshot,
+};
 use crate::store::SessionStore;
 
 /// Live files larger than this trigger a rotate on the next save.
@@ -183,7 +185,7 @@ impl SessionStore for JsonlSessionStore {
 // Wire records
 // -------------------------------------------------------------------
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize)]
 struct SessionMetaRecord<'a> {
     #[serde(rename = "type")]
     kind: &'a str,
@@ -195,6 +197,8 @@ struct SessionMetaRecord<'a> {
     workspace_root: Option<&'a Path>,
     #[serde(skip_serializing_if = "Option::is_none")]
     model: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    fork: Option<&'a SessionFork>,
 }
 
 #[derive(Debug, Serialize)]
@@ -213,6 +217,14 @@ struct CompactionRecord<'a> {
     summary: &'a str,
 }
 
+#[derive(Debug, Serialize)]
+struct PromptHistoryRecord<'a> {
+    #[serde(rename = "type")]
+    kind: &'a str,
+    timestamp_ms: u64,
+    text: &'a str,
+}
+
 fn render_jsonl(snapshot: &SessionSnapshot) -> Result<Vec<u8>, SessionError> {
     let meta = SessionMetaRecord {
         kind: "session_meta",
@@ -222,6 +234,7 @@ fn render_jsonl(snapshot: &SessionSnapshot) -> Result<Vec<u8>, SessionError> {
         updated_at_ms: snapshot.updated_at_ms,
         workspace_root: snapshot.workspace_root.as_deref(),
         model: snapshot.model.as_deref(),
+        fork: snapshot.fork.as_ref(),
     };
 
     let mut out = Vec::with_capacity(256 + snapshot.messages.len() * 128);
@@ -233,6 +246,15 @@ fn render_jsonl(snapshot: &SessionSnapshot) -> Result<Vec<u8>, SessionError> {
             count: compaction.count,
             removed_message_count: compaction.removed_message_count,
             summary: &compaction.summary,
+        };
+        serde_json::to_writer(&mut out, &record)?;
+        out.push(b'\n');
+    }
+    for entry in &snapshot.prompt_history {
+        let record = PromptHistoryRecord {
+            kind: "prompt_history",
+            timestamp_ms: entry.timestamp_ms,
+            text: &entry.text,
         };
         serde_json::to_writer(&mut out, &record)?;
         out.push(b'\n');
@@ -260,6 +282,8 @@ fn parse_jsonl(bytes: &[u8]) -> Result<SessionSnapshot, SessionError> {
     let mut workspace_root = None;
     let mut model = None;
     let mut compaction: Option<SessionCompaction> = None;
+    let mut fork: Option<SessionFork> = None;
+    let mut prompt_history: Vec<SessionPromptEntry> = Vec::new();
     let mut messages: Vec<ChatMessage> = Vec::new();
 
     for (idx, raw) in text.lines().enumerate() {
@@ -327,6 +351,10 @@ fn parse_jsonl(bytes: &[u8]) -> Result<SessionSnapshot, SessionError> {
                     .get("model")
                     .and_then(Value::as_str)
                     .map(String::from);
+                fork = object
+                    .get("fork")
+                    .map(|v| serde_json::from_value::<SessionFork>(v.clone()))
+                    .transpose()?;
             }
             "message" => {
                 let message_value = object.get("message").ok_or_else(|| {
@@ -388,6 +416,34 @@ fn parse_jsonl(bytes: &[u8]) -> Result<SessionSnapshot, SessionError> {
                     summary,
                 });
             }
+            "prompt_history" => {
+                let ts = object
+                    .get("timestamp_ms")
+                    .and_then(Value::as_u64)
+                    .ok_or_else(|| {
+                        SessionError::Io(std::io::Error::new(
+                            std::io::ErrorKind::InvalidData,
+                            format!(
+                                "prompt_history record at line {} missing \"timestamp_ms\"",
+                                idx + 1
+                            ),
+                        ))
+                    })?;
+                let text = object
+                    .get("text")
+                    .and_then(Value::as_str)
+                    .ok_or_else(|| {
+                        SessionError::Io(std::io::Error::new(
+                            std::io::ErrorKind::InvalidData,
+                            format!("prompt_history record at line {} missing \"text\"", idx + 1),
+                        ))
+                    })?
+                    .to_string();
+                prompt_history.push(SessionPromptEntry {
+                    timestamp_ms: ts,
+                    text,
+                });
+            }
             other => {
                 return Err(SessionError::Io(std::io::Error::new(
                     std::io::ErrorKind::InvalidData,
@@ -415,6 +471,8 @@ fn parse_jsonl(bytes: &[u8]) -> Result<SessionSnapshot, SessionError> {
         workspace_root,
         model,
         compaction,
+        fork,
+        prompt_history,
         messages,
     })
 }

--- a/crates/dasclaw_session/src/lib.rs
+++ b/crates/dasclaw_session/src/lib.rs
@@ -64,7 +64,9 @@ pub mod store;
 pub use error::SessionError;
 pub use id::{SESSION_VERSION, generate_session_id};
 pub use jsonl::{JsonlSessionStore, MAX_ROTATED_FILES, ROTATE_AFTER_BYTES};
-pub use snapshot::{SessionCompaction, SessionMetadata, SessionSnapshot};
+pub use snapshot::{
+    SessionCompaction, SessionFork, SessionMetadata, SessionPromptEntry, SessionSnapshot,
+};
 pub use store::{InMemorySessionStore, SessionStore};
 
 use std::path::PathBuf;
@@ -187,6 +189,23 @@ impl Session {
         let new_pass_count = self.state.compaction.as_ref().map(|c| c.count);
         if prior_pass_count != new_pass_count {
             self.state.touch();
+        }
+    }
+
+    /// Record `text` as a user prompt in `prompt_history`.
+    /// Delegates to [`SessionSnapshot::record_prompt`].
+    pub fn record_prompt(&mut self, text: impl Into<String>) {
+        self.state.record_prompt(text);
+    }
+
+    /// Create a forked `Session` that shares this session's [`Agent`]
+    /// but carries an independent [`SessionSnapshot`] descended from
+    /// the current one (see [`SessionSnapshot::fork`]).
+    #[must_use]
+    pub fn fork(&self, branch_name: Option<String>) -> Self {
+        Self {
+            agent: self.agent.clone(),
+            state: self.state.fork(branch_name),
         }
     }
 }

--- a/crates/dasclaw_session/src/snapshot.rs
+++ b/crates/dasclaw_session/src/snapshot.rs
@@ -48,6 +48,33 @@ pub struct SessionCompaction {
     pub summary: String,
 }
 
+/// Provenance recorded when a session is forked off another session
+/// via [`SessionSnapshot::fork`].
+///
+/// On the JSONL wire this struct is embedded *inside* the
+/// `session_meta` record (mirroring `claw-code` layout) rather than
+/// emitted as its own line: it identifies the session, it is not an
+/// event in the conversation.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SessionFork {
+    /// `session_id` of the snapshot this child was forked from.
+    pub parent_session_id: String,
+    /// Optional human-friendly branch label (e.g. `"experiment"`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub branch_name: Option<String>,
+}
+
+/// One user prompt entered into the session, captured for audit /
+/// history rendering. Independent of `messages` so it survives
+/// [`SessionSnapshot::compact_oldest`].
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SessionPromptEntry {
+    /// Unix milliseconds the prompt was submitted.
+    pub timestamp_ms: u64,
+    /// The raw prompt text the user typed.
+    pub text: String,
+}
+
 /// Lightweight identifier + timestamps view returned from
 /// [`crate::store::SessionStore::list`].
 ///
@@ -109,6 +136,13 @@ pub struct SessionSnapshot {
     /// undergone at least one [`SessionSnapshot::compact_oldest`] pass.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub compaction: Option<SessionCompaction>,
+    /// Fork provenance. `Some` only when this snapshot was produced
+    /// by [`SessionSnapshot::fork`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fork: Option<SessionFork>,
+    /// Append-only log of user prompts. Survives `compact_oldest`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub prompt_history: Vec<SessionPromptEntry>,
     /// Full conversation history, in turn order.
     pub messages: Vec<ChatMessage>,
 }
@@ -127,6 +161,8 @@ impl SessionSnapshot {
             workspace_root: None,
             model: None,
             compaction: None,
+            fork: None,
+            prompt_history: Vec::new(),
             messages: Vec::new(),
         }
     }
@@ -134,6 +170,45 @@ impl SessionSnapshot {
     /// Refresh `updated_at_ms` to the current wall-clock time.
     pub fn touch(&mut self) {
         self.updated_at_ms = current_time_millis();
+    }
+
+    /// Append a [`SessionPromptEntry`] for `text` with the current
+    /// wall-clock timestamp and bump `updated_at_ms`.
+    pub fn record_prompt(&mut self, text: impl Into<String>) {
+        let now = current_time_millis();
+        self.prompt_history.push(SessionPromptEntry {
+            timestamp_ms: now,
+            text: text.into(),
+        });
+        self.updated_at_ms = now;
+    }
+
+    /// Create a child snapshot that diverges from `self`.
+    ///
+    /// The child gets a freshly generated `session_id` and its own
+    /// `created_at_ms` / `updated_at_ms` (= now). Messages,
+    /// `compaction`, `workspace_root`, `model`, and `prompt_history`
+    /// are cloned verbatim — forking preserves the conversation so
+    /// the child can continue exactly where the parent left off.
+    /// [`SessionFork`] records the parent identity for auditability.
+    #[must_use]
+    pub fn fork(&self, branch_name: Option<String>) -> Self {
+        let now = current_time_millis();
+        Self {
+            session_id: generate_session_id(),
+            version: self.version,
+            created_at_ms: now,
+            updated_at_ms: now,
+            workspace_root: self.workspace_root.clone(),
+            model: self.model.clone(),
+            compaction: self.compaction.clone(),
+            fork: Some(SessionFork {
+                parent_session_id: self.session_id.clone(),
+                branch_name,
+            }),
+            prompt_history: self.prompt_history.clone(),
+            messages: self.messages.clone(),
+        }
     }
 
     /// Drop the oldest `remove_count` messages and prepend a single

--- a/crates/dasclaw_session/tests/compaction.rs
+++ b/crates/dasclaw_session/tests/compaction.rs
@@ -27,6 +27,8 @@ fn snapshot_with_messages(messages: Vec<ChatMessage>) -> SessionSnapshot {
         workspace_root: Some(PathBuf::from("/tmp/ws")),
         model: Some("test-model".to_string()),
         compaction: None,
+        fork: None,
+        prompt_history: Vec::new(),
         messages,
     }
 }

--- a/crates/dasclaw_session/tests/fork_and_prompts.rs
+++ b/crates/dasclaw_session/tests/fork_and_prompts.rs
@@ -1,0 +1,190 @@
+//! Tests for [`SessionFork`] + [`SessionSnapshot::fork`] +
+//! [`SessionPromptEntry`] + [`SessionSnapshot::record_prompt`].
+//!
+//! Behavior locked here:
+//! - `fork(branch_name)` creates a fresh session_id (different from
+//!   parent), copies messages / compaction / workspace_root / model /
+//!   prompt_history verbatim, records `SessionFork { parent_session_id,
+//!   branch_name }`, and resets `created_at_ms` / `updated_at_ms` to
+//!   the current wall-clock so the child has its own provenance.
+//! - `record_prompt(text)` appends a `SessionPromptEntry` carrying
+//!   the current wall-clock and the text, and bumps `updated_at_ms`.
+//! - `compact_oldest` (from PR-C2) must NOT clear `prompt_history` —
+//!   the prompt log is the GUI's audit trail and survives every
+//!   compaction pass.
+
+use std::path::PathBuf;
+
+use dasclaw_core::messages::ChatMessage;
+use dasclaw_session::{
+    SESSION_VERSION, SessionCompaction, SessionFork, SessionPromptEntry, SessionSnapshot,
+};
+
+fn fresh_snapshot() -> SessionSnapshot {
+    SessionSnapshot {
+        session_id: "session-parent-1".to_string(),
+        version: SESSION_VERSION,
+        created_at_ms: 1_700_000_000_000,
+        updated_at_ms: 1_700_000_000_500,
+        workspace_root: Some(PathBuf::from("/tmp/ws")),
+        model: Some("test-model".to_string()),
+        compaction: None,
+        fork: None,
+        prompt_history: Vec::new(),
+        messages: vec![
+            ChatMessage::user("turn 1"),
+            ChatMessage::assistant("reply 1"),
+        ],
+    }
+}
+
+#[test]
+fn req_dasclaw_session_c3_fork_assigns_new_session_id() {
+    let parent = fresh_snapshot();
+    let child = parent.fork(Some("experiment".to_string()));
+    assert_ne!(child.session_id, parent.session_id);
+    assert!(
+        !child.session_id.is_empty(),
+        "child session_id must be non-empty"
+    );
+}
+
+#[test]
+fn req_dasclaw_session_c3_fork_records_parent_id_and_branch_name() {
+    let parent = fresh_snapshot();
+    let child = parent.fork(Some("experiment".to_string()));
+    let fork = child.fork.as_ref().expect("child must record fork");
+    assert_eq!(
+        fork,
+        &SessionFork {
+            parent_session_id: "session-parent-1".to_string(),
+            branch_name: Some("experiment".to_string()),
+        }
+    );
+}
+
+#[test]
+fn req_dasclaw_session_c3_fork_without_branch_name_keeps_none() {
+    let parent = fresh_snapshot();
+    let child = parent.fork(None);
+    assert_eq!(
+        child.fork.as_ref().expect("fork recorded").branch_name,
+        None
+    );
+}
+
+#[test]
+fn req_dasclaw_session_c3_fork_clones_messages_compaction_and_prompts() {
+    let mut parent = fresh_snapshot();
+    parent.compaction = Some(SessionCompaction {
+        count: 2,
+        removed_message_count: 4,
+        summary: "earlier summary".to_string(),
+    });
+    parent.prompt_history.push(SessionPromptEntry {
+        timestamp_ms: 1_699_999_900_000,
+        text: "first prompt".to_string(),
+    });
+
+    let child = parent.fork(None);
+    assert_eq!(child.messages.len(), parent.messages.len());
+    for (c, p) in child.messages.iter().zip(parent.messages.iter()) {
+        assert_eq!(c.role, p.role);
+        assert_eq!(c.content, p.content);
+    }
+    assert_eq!(child.compaction, parent.compaction);
+    assert_eq!(child.prompt_history, parent.prompt_history);
+    assert_eq!(child.workspace_root, parent.workspace_root);
+    assert_eq!(child.model, parent.model);
+}
+
+#[test]
+fn req_dasclaw_session_c3_fork_resets_timestamps_to_now() {
+    let parent = fresh_snapshot();
+    let before = current_ms();
+    let child = parent.fork(None);
+    let after = current_ms();
+    assert!(
+        child.created_at_ms >= before && child.created_at_ms <= after,
+        "child.created_at_ms ({}) must be wall-clock now in [{}, {}]",
+        child.created_at_ms,
+        before,
+        after
+    );
+    assert_eq!(child.updated_at_ms, child.created_at_ms);
+}
+
+#[test]
+fn req_dasclaw_session_c3_record_prompt_appends_entry_and_touches_updated_at() {
+    let mut snap = fresh_snapshot();
+    snap.updated_at_ms = 0; // pin so we can detect any forward motion
+    let before = current_ms();
+    snap.record_prompt("what's next?");
+    let after = current_ms();
+
+    assert_eq!(snap.prompt_history.len(), 1);
+    let entry = &snap.prompt_history[0];
+    assert_eq!(entry.text, "what's next?");
+    assert!(
+        entry.timestamp_ms >= before && entry.timestamp_ms <= after,
+        "prompt timestamp ({}) must be wall-clock now in [{}, {}]",
+        entry.timestamp_ms,
+        before,
+        after
+    );
+    assert!(
+        snap.updated_at_ms >= before,
+        "record_prompt must touch updated_at_ms"
+    );
+}
+
+#[test]
+fn req_dasclaw_session_c3_compact_oldest_preserves_prompt_history() {
+    let mut snap = fresh_snapshot();
+    snap.prompt_history.push(SessionPromptEntry {
+        timestamp_ms: 1_699_999_900_000,
+        text: "p1".to_string(),
+    });
+    snap.prompt_history.push(SessionPromptEntry {
+        timestamp_ms: 1_699_999_910_000,
+        text: "p2".to_string(),
+    });
+    let before = snap.prompt_history.clone();
+
+    snap.compact_oldest(2, |_| "summary".to_string());
+
+    assert_eq!(
+        snap.prompt_history, before,
+        "compact_oldest must NOT touch prompt_history"
+    );
+}
+
+#[test]
+fn req_dasclaw_session_c3_session_fork_and_prompt_entry_serde_round_trip() {
+    let fork = SessionFork {
+        parent_session_id: "session-parent-1".to_string(),
+        branch_name: Some("feature/x".to_string()),
+    };
+    let s = serde_json::to_string(&fork).expect("fork ser");
+    let back: SessionFork = serde_json::from_str(&s).expect("fork de");
+    assert_eq!(back, fork);
+
+    let entry = SessionPromptEntry {
+        timestamp_ms: 1_699_999_900_000,
+        text: "hello".to_string(),
+    };
+    let s = serde_json::to_string(&entry).expect("entry ser");
+    let back: SessionPromptEntry = serde_json::from_str(&s).expect("entry de");
+    assert_eq!(back, entry);
+}
+
+fn current_ms() -> u64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    u64::try_from(
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock before unix epoch")
+            .as_millis(),
+    )
+    .expect("ms fits in u64 for any sane wall-clock")
+}

--- a/crates/dasclaw_session/tests/jsonl_compaction.rs
+++ b/crates/dasclaw_session/tests/jsonl_compaction.rs
@@ -22,6 +22,8 @@ fn fixture() -> SessionSnapshot {
             removed_message_count: 3,
             summary: "earlier discussion summarized".to_string(),
         }),
+        fork: None,
+        prompt_history: Vec::new(),
         messages: vec![
             ChatMessage::system("earlier discussion summarized"),
             ChatMessage::user("now what?"),

--- a/crates/dasclaw_session/tests/jsonl_fork_prompts.rs
+++ b/crates/dasclaw_session/tests/jsonl_fork_prompts.rs
@@ -1,0 +1,157 @@
+//! Wire-format tests for PR-C3: fork + prompt_history must serialize
+//! and round-trip through the JsonlSessionStore the same way
+//! claw-code's `session.jsonl` lays them out:
+//!
+//! - `fork` is embedded inside the `session_meta` record (not a
+//!   separate line). Absent when `None`.
+//! - `prompt_history` entries are independent `{"type":"prompt_history",
+//!   "timestamp_ms":..., "text":...}` lines sitting between the
+//!   `compaction` record (if any) and the first `message` record.
+
+use std::path::PathBuf;
+
+use dasclaw_core::messages::ChatMessage;
+use dasclaw_session::{
+    JsonlSessionStore, SESSION_VERSION, SessionCompaction, SessionFork, SessionPromptEntry,
+    SessionSnapshot, SessionStore,
+};
+
+fn fixture() -> SessionSnapshot {
+    SessionSnapshot {
+        session_id: "session-child-1".to_string(),
+        version: SESSION_VERSION,
+        created_at_ms: 1_700_000_001_000,
+        updated_at_ms: 1_700_000_002_000,
+        workspace_root: Some(PathBuf::from("/tmp/ws")),
+        model: Some("test-model".to_string()),
+        compaction: Some(SessionCompaction {
+            count: 1,
+            removed_message_count: 3,
+            summary: "earlier discussion summarized".to_string(),
+        }),
+        fork: Some(SessionFork {
+            parent_session_id: "session-parent-1".to_string(),
+            branch_name: Some("experiment".to_string()),
+        }),
+        prompt_history: vec![
+            SessionPromptEntry {
+                timestamp_ms: 1_699_999_900_000,
+                text: "first prompt".to_string(),
+            },
+            SessionPromptEntry {
+                timestamp_ms: 1_699_999_910_000,
+                text: "second prompt".to_string(),
+            },
+        ],
+        messages: vec![
+            ChatMessage::system("earlier discussion summarized"),
+            ChatMessage::user("now what?"),
+        ],
+    }
+}
+
+#[tokio::test]
+async fn req_dasclaw_session_c3_jsonl_round_trip_preserves_fork_and_prompts() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = JsonlSessionStore::new(dir.path().to_path_buf());
+    let snap = fixture();
+    store.save(&snap).await.expect("save");
+    let loaded = store
+        .load(&snap.session_id)
+        .await
+        .expect("load")
+        .expect("session present");
+
+    assert_eq!(loaded.fork, snap.fork);
+    assert_eq!(loaded.prompt_history, snap.prompt_history);
+    assert_eq!(loaded.compaction, snap.compaction);
+    assert_eq!(loaded.messages.len(), snap.messages.len());
+    for (l, r) in loaded.messages.iter().zip(snap.messages.iter()) {
+        assert_eq!(l.role, r.role);
+        assert_eq!(l.content, r.content);
+    }
+}
+
+#[tokio::test]
+async fn req_dasclaw_session_c3_jsonl_wire_layout_matches_claw_code() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = JsonlSessionStore::new(dir.path().to_path_buf());
+    let snap = fixture();
+    store.save(&snap).await.expect("save");
+
+    let bytes = tokio::fs::read(store.session_path(&snap.session_id))
+        .await
+        .expect("read");
+    let text = String::from_utf8(bytes).expect("utf8");
+    let lines: Vec<&str> = text.lines().collect();
+
+    // Line 1: session_meta with fork embedded
+    assert!(
+        lines[0].contains(r#""type":"session_meta""#),
+        "line 1 must be session_meta: {:?}",
+        lines.first()
+    );
+    assert!(
+        lines[0].contains(r#""fork""#)
+            && lines[0].contains(r#""parent_session_id":"session-parent-1""#)
+            && lines[0].contains(r#""branch_name":"experiment""#),
+        "fork must be embedded inside session_meta, got line: {:?}",
+        lines.first()
+    );
+
+    // Line 2: compaction
+    assert!(
+        lines[1].contains(r#""type":"compaction""#),
+        "line 2 must be compaction: {:?}",
+        lines.get(1)
+    );
+
+    // Lines 3 & 4: prompt_history
+    assert!(
+        lines[2].contains(r#""type":"prompt_history""#)
+            && lines[2].contains(r#""text":"first prompt""#),
+        "line 3 must be 1st prompt_history record: {:?}",
+        lines.get(2)
+    );
+    assert!(
+        lines[3].contains(r#""type":"prompt_history""#)
+            && lines[3].contains(r#""text":"second prompt""#),
+        "line 4 must be 2nd prompt_history record: {:?}",
+        lines.get(3)
+    );
+
+    // Remaining lines: messages
+    for (i, line) in lines.iter().enumerate().skip(4) {
+        assert!(
+            line.contains(r#""type":"message""#),
+            "line {} must be a message record, got: {:?}",
+            i + 1,
+            line
+        );
+    }
+}
+
+#[tokio::test]
+async fn req_dasclaw_session_c3_jsonl_skips_absent_fork_and_empty_prompts() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let store = JsonlSessionStore::new(dir.path().to_path_buf());
+    let mut snap = fixture();
+    snap.fork = None;
+    snap.prompt_history.clear();
+    snap.compaction = None;
+    store.save(&snap).await.expect("save");
+
+    let bytes = tokio::fs::read(store.session_path(&snap.session_id))
+        .await
+        .expect("read");
+    let text = String::from_utf8(bytes).expect("utf8");
+
+    assert!(
+        !text.contains(r#""type":"prompt_history""#),
+        "empty prompt_history must not emit any records"
+    );
+    assert!(
+        !text.contains(r#""fork""#),
+        "None fork must not appear in session_meta: {text}"
+    );
+}

--- a/crates/dasclaw_session/tests/jsonl_store_e2e.rs
+++ b/crates/dasclaw_session/tests/jsonl_store_e2e.rs
@@ -22,6 +22,8 @@ fn fixture_snapshot(session_id: &str, messages: Vec<ChatMessage>) -> SessionSnap
         workspace_root: Some(PathBuf::from("/tmp/ws")),
         model: Some("test-model".to_string()),
         compaction: None,
+        fork: None,
+        prompt_history: Vec::new(),
         messages,
     }
 }

--- a/crates/dasclaw_session/tests/jsonl_wire.rs
+++ b/crates/dasclaw_session/tests/jsonl_wire.rs
@@ -23,6 +23,8 @@ fn fixture_snapshot() -> SessionSnapshot {
         workspace_root: Some(PathBuf::from("/tmp/ws")),
         model: Some("test-model".to_string()),
         compaction: None,
+        fork: None,
+        prompt_history: Vec::new(),
         messages: vec![ChatMessage::user("ping"), ChatMessage::assistant("pong")],
     }
 }

--- a/crates/dasclaw_session/tests/snapshot_wire.rs
+++ b/crates/dasclaw_session/tests/snapshot_wire.rs
@@ -22,6 +22,8 @@ fn fixture_snapshot() -> SessionSnapshot {
         workspace_root: None,
         model: Some("test-model".to_string()),
         compaction: None,
+        fork: None,
+        prompt_history: Vec::new(),
         messages: vec![ChatMessage::user("ping"), ChatMessage::assistant("pong")],
     }
 }

--- a/crates/dasclaw_session/tests/store_e2e.rs
+++ b/crates/dasclaw_session/tests/store_e2e.rs
@@ -63,6 +63,8 @@ fn sample_snapshot(session_id: &str) -> SessionSnapshot {
         workspace_root: None,
         model: Some("test-model".to_string()),
         compaction: None,
+        fork: None,
+        prompt_history: Vec::new(),
         messages: vec![
             ChatMessage::user("hi"),
             ChatMessage::assistant("hello back"),


### PR DESCRIPTION
# PR-C3: SessionFork + prompt_history

## Sources read

- AGENTS.md §1 强制阅读顺序、§3 本地管线、§4 PR 必填
- .github/copilot-instructions.md §2 红线、§3 必跑管线
- docs/plans/architecture-refactor/adr-112-compatibility-evaluation.md §wire-format-parity
- claw-code/rust/crates/runtime/src/session.rs §`SessionFork::to_json`、`SessionPromptEntry::to_jsonl_record`、`meta_record`、`render_jsonl_snapshot`、`fork()`（确认 wire 字段名与排列顺序）
- 本仓 #914 issue body §"PR-C3 — fork / prompt_history"
- crates/dasclaw_session/src/snapshot.rs §`SessionSnapshot`（PR-C2 落地后的结构）
- crates/dasclaw_session/src/jsonl.rs §`SessionMetaRecord`、`render_jsonl`、`parse_jsonl`

## 背景 / 目标

`claw-code` 的 `Session` 除了 jsonl 落盘 / 上下文压缩，还有两块功能：
- **fork**：从某条会话另开一支（保留消息历史，记录 parent_session_id）
- **prompt_history**：把用户每次输入的 prompt 单独留存为审计日志，**独立于** `messages`，并且不被 compaction 清空

`dasclaw_session` 在 PR-C1/C2 完成了 jsonl + compaction，但 fork / prompt_history 还缺。本 PR 把这两块按 claw-code 线缆字段名一比一移植过来。

## 改动范围

- `crates/dasclaw_session/src/snapshot.rs`
  - 新增 `SessionFork { parent_session_id: String, branch_name: Option<String> }`（Debug/Clone/Ser/De/PartialEq/Eq）
  - 新增 `SessionPromptEntry { timestamp_ms: u64, text: String }`
  - `SessionSnapshot` 新增 `#[serde(default, skip_serializing_if = "Option::is_none")] fork: Option<SessionFork>` + `#[serde(default, skip_serializing_if = "Vec::is_empty")] prompt_history: Vec<SessionPromptEntry>`
  - `SessionSnapshot::fork(&self, branch_name) -> Self`：生成新 session_id，timestamps 重置为 now，messages/compaction/workspace_root/model/prompt_history 全部 clone
  - `SessionSnapshot::record_prompt(&mut self, text)`：追加 entry（current_time_millis）并 touch `updated_at_ms`
  - `SessionSnapshot::fresh()` 初始化 fork: None / prompt_history: Vec::new()
- `crates/dasclaw_session/src/lib.rs`
  - 暴露 `pub use snapshot::{SessionFork, SessionPromptEntry, ...}`
  - `Session::fork(&self, branch_name) -> Session`：透传 SessionSnapshot::fork 并共享 Arc<Agent>
  - `Session::record_prompt(&mut self, text)`：透传
- `crates/dasclaw_session/src/jsonl.rs`
  - `SessionMetaRecord` 增加 `#[serde(skip_serializing_if = "Option::is_none")] fork: Option<&'a SessionFork>` 字段（claw-code parity：fork 内嵌在 session_meta 行里）
  - 新增 `PromptHistoryRecord` serde 结构（`{"type":"prompt_history", "timestamp_ms": N, "text": "..."}`）
  - `render_jsonl` 排列顺序：`session_meta(含 fork) → compaction? → prompt_history* → message*`
  - `parse_jsonl` 在 `session_meta` 分支解析内嵌的 `fork` 字段；新增 `"prompt_history"` arm；返回的 SessionSnapshot 带 fork+prompt_history
  - 移除未使用的 `Deserialize` derive（parse 路径只用 `Value` 手解，原 derive 在 PR-C2 起就是死代码）
- 测试
  - 新增 `tests/fork_and_prompts.rs`（8 个 req_ 测试：新 session_id / parent 记录 / branch_name None / messages+compaction+prompt 全 clone / 时间戳重置 / record_prompt 追加+touch / compact 不清空 prompt / SessionFork+SessionPromptEntry serde round-trip）
  - 新增 `tests/jsonl_fork_prompts.rs`（3 个测试：jsonl round-trip 保 fork+prompt / wire 顺序断言匹配 claw-code 布局 / fork=None+空 prompt 不发出记录）
  - 既有 fixture（compaction / store_e2e / jsonl_store_e2e / snapshot_wire / jsonl_wire / jsonl_compaction）追加 `fork: None, prompt_history: Vec::new()`
- **既有 insta snapshot 不变**：`skip_serializing_if` 隐藏 None / 空向量

## 非目标（What's NOT in this PR）

- **不**做与 claw-code session.jsonl **消息体格式**互读（属 PR-D）
- **不**做 prompt_history 去重 / token 计数 / GUI 渲染
- **不**做 fork 时的 partial-history snip（fork 始终拷贝完整 message history）
- **不**改 `dasclaw_runtime::Agent` API
- **不**在 `Session::run` 内自动调用 `record_prompt`（留给调用方按 UI 语义决定时机）

## 验证

```bash
cargo check -p dasclaw_session --tests        # 0 error 0 warning
cargo nextest run -p dasclaw_session          # 37 passed / 0 failed
cargo clippy --no-deps -p dasclaw_session --all-targets -- -D warnings  # clean
cargo fmt --all                                # no diff
python3.12 scripts/check_no_panics.py --base origin/xClaw  # OK
python3.12 scripts/check_blueprint_sync.py    # OK
```

3 层 skill 审查（subagent 跑 code-quality-audit → code-simplifier → code-review-expert）：

- code-quality-audit: **PASS**（一条非阻塞建议：`parse_jsonl` 的 `ok_or_else(missing field)` 模板可在后续抽 helper，但属于 PR-C2 起就有的债，不在本 PR 范围）
- code-simplifier: **PASS**
- code-review-expert: **PASS**（确认 SRP / OCP / 向后兼容 / Fail-Safe / 安全审计达标）

## 栈关系

本 PR 基于 `feat/914c2-compaction`（#923），合并顺序：#921 → #923 → 本 PR。

Refs #914
Closes #924
