### PR TITLE
feat(session): claw-code message-body interop (#914 PR-D)

### DIFF
--- a/crates/dasclaw_session/src/claw_compat.rs
+++ b/crates/dasclaw_session/src/claw_compat.rs
@@ -1,0 +1,209 @@
+//! Bidirectional conversion between `dasclaw_core`'s OpenAI-shaped
+//! [`ChatMessage`] and `claw-code`'s `ConversationMessage` /
+//! `ContentBlock` shape used in its on-disk `session.jsonl`.
+//!
+//! ## Why a parallel type set
+//!
+//! Each side reflects a different upstream API contract:
+//!
+//! - `ChatMessage` mirrors OpenAI Chat Completions
+//!   (`role` + `content` string + `tool_calls` array).
+//! - claw-code stores Anthropic-style structured content blocks
+//!   (`role` + `blocks: [{ type: "text" | "tool_use" | "tool_result", ... }]`).
+//!
+//! Reusing `ChatMessage` for the claw-code wire would force its
+//! serde shape to fork, breaking every dasclaw provider. So we keep
+//! `ChatMessage` as-is and provide a `ClawMessage` whose serde shape
+//! exactly matches what `claw-code/rust/crates/runtime/src/session.rs`
+//! reads and writes.
+//!
+//! ## Lossy edges
+//!
+//! - `ChatMessage::content_parts` (multimodal `ImageUrl`) has no
+//!   counterpart in claw-code's `ContentBlock`. Conversion preserves
+//!   the text content only; images are dropped. This is documented
+//!   by `req_dasclaw_session_d1_content_parts_images_drop_to_text_only`.
+//! - `ToolCall::arguments` is a `serde_json::Value` on the dasclaw
+//!   side and a JSON-stringified field on the claw-code side. We
+//!   serialize to a JSON string on conversion and parse it back on
+//!   the return trip. Non-JSON-object arguments (rare in practice)
+//!   are serialized as their literal JSON form.
+
+use dasclaw_core::messages::{ChatMessage, Role, ToolCall};
+use serde::{Deserialize, Serialize};
+
+/// Claw-code's message-level role tag. Serializes as lowercase to
+/// match `claw-code`'s on-disk format.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ClawRole {
+    System,
+    User,
+    Assistant,
+    Tool,
+}
+
+/// Claw-code's structured content block. The `type` field is the
+/// serde tag — exactly the shape `claw-code`'s `ContentBlock::to_json`
+/// emits.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ClawContentBlock {
+    Text {
+        text: String,
+    },
+    ToolUse {
+        id: String,
+        name: String,
+        input: String,
+    },
+    ToolResult {
+        tool_use_id: String,
+        tool_name: String,
+        output: String,
+        is_error: bool,
+    },
+}
+
+/// Claw-code-shaped persisted message. Mirrors
+/// `claw-code::runtime::session::ConversationMessage` exactly on the
+/// wire, minus `usage` (token-usage fields land in
+/// [`crate::SessionSnapshot`] when we wire them up in a later PR).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ClawMessage {
+    pub role: ClawRole,
+    pub blocks: Vec<ClawContentBlock>,
+}
+
+/// Convert from the OpenAI-shaped [`ChatMessage`] to a claw-code-shaped
+/// [`ClawMessage`].
+///
+/// Mapping:
+/// - System / User text-only → single `Text` block carrying `content`
+/// - Assistant text-only → single `Text` block
+/// - Assistant with `tool_calls`: optional leading `Text` block (if
+///   `content` is non-empty) followed by one `ToolUse` block per
+///   call, with `input` = JSON-stringified `arguments`
+/// - Tool result → single `ToolResult` block reading `tool_call_id`,
+///   `name`, and `content`; `is_error` is recorded as `false` (the
+///   dasclaw `ChatMessage::tool_result` constructor does not yet
+///   surface an error flag — adding one is a forward-compatible
+///   change because `is_error` is required by the claw wire schema)
+#[must_use]
+pub fn chat_message_to_claw(message: &ChatMessage) -> ClawMessage {
+    match message.role {
+        Role::System => ClawMessage {
+            role: ClawRole::System,
+            blocks: vec![ClawContentBlock::Text {
+                text: message.content.clone(),
+            }],
+        },
+        Role::User => ClawMessage {
+            role: ClawRole::User,
+            blocks: vec![ClawContentBlock::Text {
+                text: message.content.clone(),
+            }],
+        },
+        Role::Assistant => {
+            let mut blocks: Vec<ClawContentBlock> = Vec::new();
+            if !message.content.is_empty() {
+                blocks.push(ClawContentBlock::Text {
+                    text: message.content.clone(),
+                });
+            }
+            if let Some(calls) = &message.tool_calls {
+                for call in calls {
+                    blocks.push(ClawContentBlock::ToolUse {
+                        id: call.id.clone(),
+                        name: call.name.clone(),
+                        input: call.arguments.to_string(),
+                    });
+                }
+            }
+            ClawMessage {
+                role: ClawRole::Assistant,
+                blocks,
+            }
+        }
+        Role::Tool => ClawMessage {
+            role: ClawRole::Tool,
+            blocks: vec![ClawContentBlock::ToolResult {
+                tool_use_id: message.tool_call_id.clone().unwrap_or_default(),
+                tool_name: message.name.clone().unwrap_or_default(),
+                output: message.content.clone(),
+                is_error: false,
+            }],
+        },
+    }
+}
+
+/// Convert from a claw-code-shaped [`ClawMessage`] back to the
+/// OpenAI-shaped [`ChatMessage`].
+///
+/// Mapping:
+/// - All `Text` blocks are concatenated into `content` (newline-
+///   separated). The most common case has a single block, so this
+///   collapses to the original text.
+/// - `ToolUse` blocks become entries in `tool_calls`; `input` is
+///   parsed as JSON (falling back to a JSON string if not parseable).
+/// - A single `ToolResult` block on a Tool-role message becomes a
+///   `tool_result` `ChatMessage`.
+#[must_use]
+pub fn claw_to_chat_message(message: &ClawMessage) -> ChatMessage {
+    let role: Role = match message.role {
+        ClawRole::System => Role::System,
+        ClawRole::User => Role::User,
+        ClawRole::Assistant => Role::Assistant,
+        ClawRole::Tool => Role::Tool,
+    };
+
+    // Handle Tool role with a single ToolResult block first — that's
+    // the only legal layout claw-code emits.
+    if role == Role::Tool
+        && let Some(ClawContentBlock::ToolResult {
+            tool_use_id,
+            tool_name,
+            output,
+            is_error: _,
+        }) = message.blocks.first()
+    {
+        return ChatMessage::tool_result(tool_use_id, tool_name, output);
+    }
+
+    let mut text_parts: Vec<&str> = Vec::new();
+    let mut tool_calls: Vec<ToolCall> = Vec::new();
+    for block in &message.blocks {
+        match block {
+            ClawContentBlock::Text { text } => text_parts.push(text),
+            ClawContentBlock::ToolUse { id, name, input } => {
+                let arguments: serde_json::Value = serde_json::from_str(input)
+                    .unwrap_or_else(|_| serde_json::Value::String(input.clone()));
+                tool_calls.push(ToolCall {
+                    id: id.clone(),
+                    name: name.clone(),
+                    arguments,
+                    reasoning: None,
+                });
+            }
+            ClawContentBlock::ToolResult { .. } => {
+                // tool_result on a non-Tool role is malformed claw input;
+                // drop the block silently (Fail-Safe over Fail-Open).
+            }
+        }
+    }
+
+    let content = text_parts.join("\n");
+
+    let mut msg = ChatMessage {
+        role,
+        content,
+        content_parts: Vec::new(),
+        tool_call_id: None,
+        name: None,
+        tool_calls: None,
+    };
+    if !tool_calls.is_empty() {
+        msg.tool_calls = Some(tool_calls);
+    }
+    msg
+}

--- a/crates/dasclaw_session/src/jsonl.rs
+++ b/crates/dasclaw_session/src/jsonl.rs
@@ -8,17 +8,17 @@
 //!
 //! ```text
 //! {"type":"session_meta","version":1,"session_id":"…","created_at_ms":…,"updated_at_ms":…,"workspace_root":"…","model":"…"}
-//! {"type":"message","message":{"role":"user","content":"ping"}}
-//! {"type":"message","message":{"role":"assistant","content":"pong"}}
+//! {"type":"message","message":{"role":"user","blocks":[{"type":"text","text":"ping"}]}}
+//! {"type":"message","message":{"role":"assistant","blocks":[{"type":"text","text":"pong"}]}}
 //! ```
 //!
 //! The outer framing (`type` discriminant, `session_meta` and
-//! `message` record kinds) deliberately mirrors `claw-code`'s session
-//! jsonl layout so a future migration tool can bridge the two
-//! ecosystems at the line level. The inner `message` body uses
-//! [`dasclaw_core::messages::ChatMessage`]'s serde shape, which differs
-//! from `claw-code`'s richer block-based message; full bidirectional
-//! interop is intentionally out of scope for #914 PR-C1.
+//! `message` record kinds) and the inner `message` body shape both
+//! mirror `claw-code`'s on-disk session jsonl exactly
+//! ([`crate::claw_compat`] holds the type definitions and the
+//! lossy edges of the [`ChatMessage`] bridge). Sessions written by
+//! this crate are line-level compatible with `claw-code` and vice
+//! versa.
 //!
 //! ## Rotation
 //!
@@ -50,6 +50,7 @@ use tokio::io::{AsyncBufReadExt, BufReader};
 
 use dasclaw_core::messages::ChatMessage;
 
+use crate::claw_compat::{ClawMessage, chat_message_to_claw, claw_to_chat_message};
 use crate::error::SessionError;
 use crate::id::SESSION_VERSION;
 use crate::snapshot::{
@@ -205,7 +206,7 @@ struct SessionMetaRecord<'a> {
 struct MessageRecord<'a> {
     #[serde(rename = "type")]
     kind: &'a str,
-    message: &'a ChatMessage,
+    message: ClawMessage,
 }
 
 #[derive(Debug, Serialize)]
@@ -262,7 +263,7 @@ fn render_jsonl(snapshot: &SessionSnapshot) -> Result<Vec<u8>, SessionError> {
     for message in &snapshot.messages {
         let record = MessageRecord {
             kind: "message",
-            message,
+            message: chat_message_to_claw(message),
         };
         serde_json::to_writer(&mut out, &record)?;
         out.push(b'\n');
@@ -366,8 +367,8 @@ fn parse_jsonl(bytes: &[u8]) -> Result<SessionSnapshot, SessionError> {
                         ),
                     ))
                 })?;
-                let msg: ChatMessage = serde_json::from_value(message_value.clone())?;
-                messages.push(msg);
+                let claw: ClawMessage = serde_json::from_value(message_value.clone())?;
+                messages.push(claw_to_chat_message(&claw));
             }
             "compaction" => {
                 let count_raw = object.get("count").and_then(Value::as_u64).ok_or_else(|| {

--- a/crates/dasclaw_session/src/lib.rs
+++ b/crates/dasclaw_session/src/lib.rs
@@ -55,12 +55,16 @@
 //! assert_eq!(resumed.messages().len(), session.messages().len());
 //! ```
 
+pub mod claw_compat;
 pub mod error;
 pub mod id;
 pub mod jsonl;
 pub mod snapshot;
 pub mod store;
 
+pub use claw_compat::{
+    ClawContentBlock, ClawMessage, ClawRole, chat_message_to_claw, claw_to_chat_message,
+};
 pub use error::SessionError;
 pub use id::{SESSION_VERSION, generate_session_id};
 pub use jsonl::{JsonlSessionStore, MAX_ROTATED_FILES, ROTATE_AFTER_BYTES};

--- a/crates/dasclaw_session/tests/claw_compat.rs
+++ b/crates/dasclaw_session/tests/claw_compat.rs
@@ -1,0 +1,234 @@
+//! Tests for `claw_compat`: bidirectional conversion between
+//! `dasclaw_core::messages::ChatMessage` (OpenAI Chat Completions
+//! shape) and the `ClawMessage` / `ClawContentBlock` shape that
+//! `claw-code`'s `session.jsonl` writes.
+//!
+//! Roundtrip rules:
+//! - text-only system / user / assistant messages survive verbatim
+//! - assistant + tool_calls survives: tool_calls become `tool_use`
+//!   blocks (input serialized as JSON string), content stays as a
+//!   leading `text` block when non-empty
+//! - tool result survives: stored as `ToolResult { tool_use_id,
+//!   tool_name, output, is_error: false }`
+//! - `content_parts` (images) currently lossy: claw-code's
+//!   `ContentBlock` has no image variant, so the conversion keeps
+//!   the text content only. Documented behaviour, explicitly tested.
+
+use dasclaw_core::messages::{ChatMessage, ContentPart, ImageUrl, Role, ToolCall};
+use dasclaw_session::claw_compat::{
+    ClawContentBlock, ClawMessage, ClawRole, chat_message_to_claw, claw_to_chat_message,
+};
+
+#[test]
+fn req_dasclaw_session_d1_system_text_round_trip() {
+    let original = ChatMessage::system("be concise");
+    let claw = chat_message_to_claw(&original);
+    assert_eq!(claw.role, ClawRole::System);
+    assert_eq!(
+        claw.blocks,
+        vec![ClawContentBlock::Text {
+            text: "be concise".to_string()
+        }]
+    );
+
+    let back = claw_to_chat_message(&claw);
+    assert_eq!(back.role, Role::System);
+    assert_eq!(back.content, "be concise");
+    assert!(back.tool_calls.is_none());
+    assert!(back.tool_call_id.is_none());
+}
+
+#[test]
+fn req_dasclaw_session_d1_user_and_assistant_text_round_trip() {
+    let user = ChatMessage::user("hello");
+    let assistant = ChatMessage::assistant("hi back");
+
+    let user_claw = chat_message_to_claw(&user);
+    let asst_claw = chat_message_to_claw(&assistant);
+    assert_eq!(user_claw.role, ClawRole::User);
+    assert_eq!(asst_claw.role, ClawRole::Assistant);
+
+    let user_back = claw_to_chat_message(&user_claw);
+    let asst_back = claw_to_chat_message(&asst_claw);
+    assert_eq!(user_back.content, "hello");
+    assert_eq!(asst_back.content, "hi back");
+}
+
+#[test]
+fn req_dasclaw_session_d1_assistant_with_tool_calls_round_trip() {
+    let calls = vec![
+        ToolCall {
+            id: "call_1".to_string(),
+            name: "list_files".to_string(),
+            arguments: serde_json::json!({"path": "/tmp"}),
+            reasoning: None,
+        },
+        ToolCall {
+            id: "call_2".to_string(),
+            name: "read_file".to_string(),
+            arguments: serde_json::json!({"path": "/tmp/x", "limit": 100}),
+            reasoning: None,
+        },
+    ];
+    let original = ChatMessage::assistant_with_tool_calls(Some("thinking...".to_string()), calls);
+
+    let claw = chat_message_to_claw(&original);
+    assert_eq!(claw.role, ClawRole::Assistant);
+    // expect: [Text(thinking...), ToolUse(call_1), ToolUse(call_2)]
+    assert_eq!(claw.blocks.len(), 3);
+    matches!(claw.blocks[0], ClawContentBlock::Text { .. });
+    match &claw.blocks[1] {
+        ClawContentBlock::ToolUse { id, name, input } => {
+            assert_eq!(id, "call_1");
+            assert_eq!(name, "list_files");
+            // input must be a JSON string of the arguments
+            let parsed: serde_json::Value = serde_json::from_str(input).expect("input is JSON");
+            assert_eq!(parsed, serde_json::json!({"path": "/tmp"}));
+        }
+        other => panic!("expected ToolUse, got {other:?}"),
+    }
+
+    let back = claw_to_chat_message(&claw);
+    assert_eq!(back.role, Role::Assistant);
+    assert_eq!(back.content, "thinking...");
+    let back_calls = back.tool_calls.as_ref().expect("tool_calls preserved");
+    assert_eq!(back_calls.len(), 2);
+    assert_eq!(back_calls[0].id, "call_1");
+    assert_eq!(back_calls[0].name, "list_files");
+    assert_eq!(back_calls[0].arguments, serde_json::json!({"path": "/tmp"}));
+    assert_eq!(back_calls[1].id, "call_2");
+}
+
+#[test]
+fn req_dasclaw_session_d1_assistant_tool_calls_only_no_text_round_trip() {
+    // assistant with empty content but tool_calls — leading text block
+    // must NOT appear in claw output (empty text is meaningless).
+    let calls = vec![ToolCall {
+        id: "call_x".to_string(),
+        name: "noop".to_string(),
+        arguments: serde_json::json!({}),
+        reasoning: None,
+    }];
+    let original = ChatMessage::assistant_with_tool_calls(None, calls);
+    assert_eq!(original.content, ""); // sanity
+
+    let claw = chat_message_to_claw(&original);
+    assert_eq!(claw.blocks.len(), 1, "no leading empty Text block expected");
+    matches!(claw.blocks[0], ClawContentBlock::ToolUse { .. });
+
+    let back = claw_to_chat_message(&claw);
+    assert!(back.tool_calls.is_some());
+    assert_eq!(back.content, "");
+}
+
+#[test]
+fn req_dasclaw_session_d1_tool_result_round_trip() {
+    let original = ChatMessage::tool_result("call_1", "list_files", "a.txt\nb.txt");
+    let claw = chat_message_to_claw(&original);
+    assert_eq!(claw.role, ClawRole::Tool);
+    match &claw.blocks[..] {
+        [
+            ClawContentBlock::ToolResult {
+                tool_use_id,
+                tool_name,
+                output,
+                is_error,
+            },
+        ] => {
+            assert_eq!(tool_use_id, "call_1");
+            assert_eq!(tool_name, "list_files");
+            assert_eq!(output, "a.txt\nb.txt");
+            assert!(!is_error);
+        }
+        other => panic!("expected single ToolResult, got {other:?}"),
+    }
+
+    let back = claw_to_chat_message(&claw);
+    assert_eq!(back.role, Role::Tool);
+    assert_eq!(back.tool_call_id.as_deref(), Some("call_1"));
+    assert_eq!(back.name.as_deref(), Some("list_files"));
+    assert_eq!(back.content, "a.txt\nb.txt");
+}
+
+#[test]
+fn req_dasclaw_session_d1_content_parts_images_drop_to_text_only() {
+    // claw-code's ContentBlock has no image variant; convert is lossy
+    // on the image side but text content survives.
+    let original = ChatMessage::user_with_parts(
+        "describe this",
+        vec![ContentPart::ImageUrl {
+            image_url: ImageUrl {
+                url: "https://example/x.png".to_string(),
+                detail: None,
+            },
+        }],
+    );
+    let claw = chat_message_to_claw(&original);
+    assert_eq!(claw.blocks.len(), 1);
+    match &claw.blocks[0] {
+        ClawContentBlock::Text { text } => assert_eq!(text, "describe this"),
+        other => panic!("expected Text only, got {other:?}"),
+    }
+}
+
+#[test]
+fn req_dasclaw_session_d1_claw_message_serde_matches_claw_code_wire() {
+    // Hand-crafted claw-code-shaped JSON must parse via ClawMessage.
+    let raw = r#"{
+        "role": "assistant",
+        "blocks": [
+            {"type": "text", "text": "let me check"},
+            {"type": "tool_use", "id": "call_a", "name": "ls", "input": "{\"path\":\"/\"}"}
+        ]
+    }"#;
+    let parsed: ClawMessage = serde_json::from_str(raw).expect("parse claw wire");
+    assert_eq!(parsed.role, ClawRole::Assistant);
+    assert_eq!(parsed.blocks.len(), 2);
+
+    // And our re-serialize must produce a value claw-code can read
+    // back (type tag preserved, field names preserved).
+    let again = serde_json::to_value(&parsed).expect("ser");
+    assert_eq!(
+        again["blocks"][0]["type"].as_str(),
+        Some("text"),
+        "block type tag must be \"text\""
+    );
+    assert_eq!(
+        again["blocks"][1]["type"].as_str(),
+        Some("tool_use"),
+        "block type tag must be \"tool_use\""
+    );
+    assert_eq!(again["role"].as_str(), Some("assistant"));
+}
+
+#[test]
+fn req_dasclaw_session_d1_tool_result_claw_code_wire_parses() {
+    let raw = r#"{
+        "role": "tool",
+        "blocks": [{
+            "type": "tool_result",
+            "tool_use_id": "call_a",
+            "tool_name": "ls",
+            "output": "x\ny",
+            "is_error": false
+        }]
+    }"#;
+    let parsed: ClawMessage = serde_json::from_str(raw).expect("parse claw tool result wire");
+    assert_eq!(parsed.role, ClawRole::Tool);
+    match &parsed.blocks[..] {
+        [
+            ClawContentBlock::ToolResult {
+                tool_use_id,
+                tool_name,
+                output,
+                is_error,
+            },
+        ] => {
+            assert_eq!(tool_use_id, "call_a");
+            assert_eq!(tool_name, "ls");
+            assert_eq!(output, "x\ny");
+            assert!(!is_error);
+        }
+        other => panic!("expected ToolResult, got {other:?}"),
+    }
+}

--- a/crates/dasclaw_session/tests/snapshots/jsonl_wire__jsonl_wire_format_is_stable.snap
+++ b/crates/dasclaw_session/tests/snapshots/jsonl_wire__jsonl_wire_format_is_stable.snap
@@ -3,5 +3,5 @@ source: crates/dasclaw_session/tests/jsonl_wire.rs
 expression: text
 ---
 {"type":"session_meta","version":1,"session_id":"session-1700000000000-0","created_at_ms":1700000000000,"updated_at_ms":1700000000500,"workspace_root":"/tmp/ws","model":"test-model"}
-{"type":"message","message":{"role":"user","content":"ping"}}
-{"type":"message","message":{"role":"assistant","content":"pong"}}
+{"type":"message","message":{"role":"user","blocks":[{"type":"text","text":"ping"}]}}
+{"type":"message","message":{"role":"assistant","blocks":[{"type":"text","text":"pong"}]}}


### PR DESCRIPTION
## 背景 / 目标

把 `dasclaw_session` 的 jsonl `message` 记录体切换成 claw-code 的 `role + blocks` 形态，作为 #914 整体 port 的最后一刀。

**Sources read**
- [docs/plans/architecture-refactor/adr-112-compatibility-evaluation.md §3 verbatim 范围](docs/plans/architecture-refactor/adr-112-compatibility-evaluation.md)
- [claw-code/rust/crates/runtime/src/session.rs `ConversationMessage` / `ContentBlock` / `MessageRole`](claw-code/rust/crates/runtime/src/session.rs)
- [crates/dasclaw_session/src/jsonl.rs PR-C1 既有 wire 形态](crates/dasclaw_session/src/jsonl.rs)
- [crates/dasclaw_core/src/messages.rs `ChatMessage` / `ToolCall`](crates/dasclaw_core/src/messages.rs)
- AGENTS.md "PR 描述最低要求" + "Skills 强制使用规范"

## 改动范围

**重要**:相对最初 PR 版本,本 PR 已删除 `MessageWireFormat::{Native, ClawCompat}` 二选一 opt-in 兼容层 —— 因为 x-claw 尚未发布第一个版本,没有 on-disk session 需要兼容 PR-C1 旧形态,所以 opt-in 是死重。现在 claw 的 blocks 形态是 jsonl `message` 记录体的**唯一**形态。

- `crates/dasclaw_session/src/jsonl.rs`
  - 删 `MessageWireFormat` 枚举 + `with_message_format` builder + `message_format()` getter + 字段
  - 删旧 `MessageRecord<'a>`(借 ChatMessage), 把 `ClawMessageRecord<'a>` 改名为 `MessageRecord<'a>`
  - `render_jsonl` / `parse_jsonl` 去掉 format 参数 + 内部 match,永远走 `chat_message_to_claw` / `claw_to_chat_message`
  - 模块 rustdoc 同步:wire 例子改为 blocks 形态,删除"out of scope for PR-C1"那句
- `crates/dasclaw_session/src/lib.rs` re-export 行去掉 `MessageWireFormat`
- `crates/dasclaw_session/src/claw_compat.rs` 新增(沿用 PR-D 已加好的内容)
  - `ClawRole` / `ClawContentBlock` / `ClawMessage` 三件套,serde 形态与 claw-code 1:1
  - `chat_message_to_claw` / `claw_to_chat_message` 双向桥接,含已记录的有损边(ToolResult.is_error 硬编码 false)
- `crates/dasclaw_session/tests/claw_compat.rs` 新增 8 个纯类型转换测试
- `crates/dasclaw_session/tests/jsonl_claw_compat.rs` 整文件**删除**(单一形态下"default vs compat"对比测试没意义)
- `crates/dasclaw_session/tests/snapshots/jsonl_wire__jsonl_wire_format_is_stable.snap` **重生**: `"content":"ping"` → `"blocks":[{"type":"text","text":"ping"}]`

## 非目标 (What's NOT in this PR)

- ❌ 不维护 PR-C1 旧 `content:String` 形态的向后读兼容 —— pre-release 无既有数据
- ❌ 不修 `ChatMessage::tool_result` 缺 `is_error` 字段的有损边 —— 待 follow-up issue
- ❌ 不引入 `usage: Option<TokenUsage>` 字段 —— claw-code 有,dasclaw 暂时不映射,后续 issue 跟进
- ❌ 不统一 `MessageRecord` 与其他 `*Record` 结构的 owned/borrowed 生命周期语义 —— P3 follow-up

## 验证

```bash
cargo check -p dasclaw_session --tests          # 0 错 0 警
cargo nextest run -p dasclaw_session             # 45/45 通过
cargo clippy --no-deps -p dasclaw_session --all-targets -- -D warnings  # 0 警
cargo fmt --all                                  # clean
python3.12 scripts/check_no_panics.py --base origin/xClaw  # OK
```

3 层 skill 审查(code-quality-audit → code-simplifier → code-review-expert)结论:**APPROVE**,无 P0/P1 阻塞,1 项 P3 follow-up(MessageRecord 生命周期统一)。

## Cross-cuts

- ADR-114 (`.ironclaw` → `.dasclaw` 命名迁移):**类A** —— 本 PR 无新增 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量

Closes #914
