### PR TITLE
refactor(session): align MessageRecord lifetime with other *Record types (#928)

### DIFF
--- a/crates/dasclaw_session/src/jsonl.rs
+++ b/crates/dasclaw_session/src/jsonl.rs
@@ -206,7 +206,7 @@ struct SessionMetaRecord<'a> {
 struct MessageRecord<'a> {
     #[serde(rename = "type")]
     kind: &'a str,
-    message: ClawMessage,
+    message: &'a ClawMessage,
 }
 
 #[derive(Debug, Serialize)]
@@ -260,10 +260,12 @@ fn render_jsonl(snapshot: &SessionSnapshot) -> Result<Vec<u8>, SessionError> {
         serde_json::to_writer(&mut out, &record)?;
         out.push(b'\n');
     }
-    for message in &snapshot.messages {
+    let claw_messages: Vec<ClawMessage> =
+        snapshot.messages.iter().map(chat_message_to_claw).collect();
+    for message in &claw_messages {
         let record = MessageRecord {
             kind: "message",
-            message: chat_message_to_claw(message),
+            message,
         };
         serde_json::to_writer(&mut out, &record)?;
         out.push(b'\n');


### PR DESCRIPTION
## 背景 / 目标

#927 (PR-D) 简化把 `MessageWireFormat` 枚举删掉之后,`crates/dasclaw_session/src/jsonl.rs` 里的 `MessageRecord<'a>` 留下一个 owned 字段 `message: ClawMessage`,与同文件其他 `*Record<'a>` 持有借用引用的模式不一致(`SessionMetaRecord` / `CompactionRecord` / `PromptHistoryRecord` 等都是 `&'a ...`)。

本 PR 把 `MessageRecord` 也改回借用,统一 jsonl 模块内所有 `*Record` 的生命周期语义。

**Sources read**
- [crates/dasclaw_session/src/jsonl.rs PR-D 简化后的 MessageRecord 定义](crates/dasclaw_session/src/jsonl.rs)
- [crates/dasclaw_session/src/claw_compat.rs `chat_message_to_claw` 签名](crates/dasclaw_session/src/claw_compat.rs)
- AGENTS.md "PR 描述最低要求" + "Skills 强制使用规范"

## 改动范围

只动 `crates/dasclaw_session/src/jsonl.rs` 一个文件,2 处微调:

1. `MessageRecord<'a>` 字段 `message: ClawMessage` → `message: &'a ClawMessage`
2. `render_jsonl` 的 message 序列化循环前置一行 `let claw_messages: Vec<ClawMessage> = snapshot.messages.iter().map(chat_message_to_claw).collect();`,然后循环里借用引用

```rust
let claw_messages: Vec<ClawMessage> = snapshot.messages.iter().map(chat_message_to_claw).collect();
for message in &claw_messages {
    let record = MessageRecord { kind: "message", message };
    serde_json::to_writer(&mut out, &record)?;
    out.push(b'\n');
}
```

## 非目标 (What's NOT in this PR)

- ❌ 不修 #929 提到的 `ChatMessage::tool_result` 缺 `is_error` 字段的有损边
- ❌ 不引入 `usage: Option<TokenUsage>` 字段映射(也是 #929 范围)
- ❌ 不动 wire format(字节级一致,无需 `SESSION_VERSION` bump)
- ❌ 不优化 `claw_messages` 的内存分配模式(SmallVec / pool 等过早优化,留待性能需要时再做)

## 验证

```bash
cargo check -p dasclaw_session --tests          # 0 错 0 警
cargo nextest run -p dasclaw_session             # 45/45 通过
cargo clippy --no-deps -p dasclaw_session --all-targets -- -D warnings  # 0 警
cargo fmt --all                                  # clean
python3.12 scripts/check_no_panics.py --base origin/xClaw  # OK
```

**关键回归检查**:`jsonl_wire__jsonl_wire_format_is_stable.snap` 字节级未变(insta 自动校验),证明 on-disk wire format 完全一致。

3 层 skill 审查(code-quality-audit → code-simplifier → code-review-expert):**APPROVE**,无阻塞项。
- 额外 `Vec<ClawMessage>` 分配可接受(典型 session 10-50 条消息,<10KB),换回结构一致性+缓存局部性
- 类型系统覆盖完整,无安全/并发风险
- 测试 45/45 通过

## Stacked 提示

本 PR base 是 **`feat/914d-claw-msg-compat`** (PR #927),不是 `xClaw`。
- merge 顺序:先 merge #927,再 rebase 本 PR 到 xClaw,再 merge 本 PR
- 或:本 PR 等 #927 合后我会 rebase 到 xClaw

## Cross-cuts

- ADR-114 (`.ironclaw` → `.dasclaw` 命名迁移):**类A** —— 本 PR 无新增 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量

Closes #928
