### PR TITLE
feat(core): add TokenUsage + ChatMessage tool_error/usage fields (#929 step 1)

### DIFF
--- a/crates/dasclaw_core/src/lib.rs
+++ b/crates/dasclaw_core/src/lib.rs
@@ -51,8 +51,8 @@ pub use hooks::{
 };
 pub use messages::{
     ChatMessage, CompletionRequest, CompletionResponse, ContentPart, FinishReason, ImageUrl,
-    ModelMetadata, Role, ToolCall, ToolCompletionRequest, ToolCompletionResponse, ToolDefinition,
-    ToolResult, UnsupportedParam, generate_tool_call_id, sanitize_tool_messages,
+    ModelMetadata, Role, TokenUsage, ToolCall, ToolCompletionRequest, ToolCompletionResponse,
+    ToolDefinition, ToolResult, UnsupportedParam, generate_tool_call_id, sanitize_tool_messages,
     strip_unsupported_completion_params, strip_unsupported_tool_params,
 };
 pub use permissions::PermissionMode;

--- a/crates/dasclaw_core/src/messages.rs
+++ b/crates/dasclaw_core/src/messages.rs
@@ -43,6 +43,21 @@ pub struct ImageUrl {
     pub detail: Option<String>,
 }
 
+/// Token counters accumulated for a single chat completion turn.
+///
+/// Field layout mirrors `claw-code`'s `runtime::TokenUsage` exactly so the
+/// two ecosystems can share session jsonl history without lossy conversion.
+/// Also matches the per-turn fields already emitted on
+/// [`CompletionResponse`] (`input_tokens` / `output_tokens` /
+/// `cache_creation_input_tokens` / `cache_read_input_tokens`).
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TokenUsage {
+    pub input_tokens: u32,
+    pub output_tokens: u32,
+    pub cache_creation_input_tokens: u32,
+    pub cache_read_input_tokens: u32,
+}
+
 /// A message in a conversation.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ChatMessage {
@@ -63,6 +78,18 @@ pub struct ChatMessage {
     /// to appear on the assistant message preceding tool result messages).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tool_calls: Option<Vec<ToolCall>>,
+    /// Whether this tool-result message represents a tool execution error.
+    /// Only meaningful when `role == Role::Tool`. `None` means "unspecified"
+    /// (legacy callers that did not set it); `Some(false)` means success;
+    /// `Some(true)` means the tool reported an error.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_error: Option<bool>,
+    /// Token usage attributed to this assistant message, if known.
+    /// Only meaningful when `role == Role::Assistant`. Providers may fill
+    /// this in when they hand back the assistant turn so session storage
+    /// can persist per-turn cost data.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub usage: Option<TokenUsage>,
 }
 
 impl ChatMessage {
@@ -75,6 +102,8 @@ impl ChatMessage {
             tool_call_id: None,
             name: None,
             tool_calls: None,
+            tool_error: None,
+            usage: None,
         }
     }
 
@@ -87,6 +116,8 @@ impl ChatMessage {
             tool_call_id: None,
             name: None,
             tool_calls: None,
+            tool_error: None,
+            usage: None,
         }
     }
 
@@ -101,6 +132,8 @@ impl ChatMessage {
             tool_call_id: None,
             name: None,
             tool_calls: None,
+            tool_error: None,
+            usage: None,
         }
     }
 
@@ -113,6 +146,8 @@ impl ChatMessage {
             tool_call_id: None,
             name: None,
             tool_calls: None,
+            tool_error: None,
+            usage: None,
         }
     }
 
@@ -132,6 +167,8 @@ impl ChatMessage {
             } else {
                 Some(tool_calls)
             },
+            tool_error: None,
+            usage: None,
         }
     }
 
@@ -148,7 +185,31 @@ impl ChatMessage {
             tool_call_id: Some(tool_call_id.into()),
             name: Some(name.into()),
             tool_calls: None,
+            tool_error: None,
+            usage: None,
         }
+    }
+
+    /// Attach a tool-error flag to a tool-result message and return `self`.
+    ///
+    /// Convenience for `Self::tool_result(...).with_tool_error(is_error)`.
+    /// `is_error: false` is recorded explicitly (not erased to `None`) so
+    /// round-trips with `claw-code`'s `ContentBlock::ToolResult.is_error`
+    /// preserve the original signal.
+    #[must_use]
+    pub fn with_tool_error(mut self, is_error: bool) -> Self {
+        self.tool_error = Some(is_error);
+        self
+    }
+
+    /// Attach token usage to an assistant message and return `self`.
+    ///
+    /// Convenience for providers that want to record per-turn token counts
+    /// on the assistant message so the session store can persist them.
+    #[must_use]
+    pub fn with_usage(mut self, usage: TokenUsage) -> Self {
+        self.usage = Some(usage);
+        self
     }
 }
 
@@ -699,5 +760,66 @@ mod tests {
         strip_unsupported_tool_params(&unsupported, &mut req);
 
         assert!(req.stop_sequences.is_none()); // safety: test assertion for explicit strip behavior
+    }
+
+    #[test]
+    fn req_dasclaw_core_929_chat_message_tool_error_defaults_to_none() {
+        let msg = ChatMessage::tool_result("call-1", "shell", "ok");
+        assert!(msg.tool_error.is_none());
+    }
+
+    #[test]
+    fn req_dasclaw_core_929_with_tool_error_records_explicit_flag() {
+        let ok = ChatMessage::tool_result("call-1", "shell", "ok").with_tool_error(false);
+        let err = ChatMessage::tool_result("call-2", "shell", "boom").with_tool_error(true);
+        assert_eq!(ok.tool_error, Some(false));
+        assert_eq!(err.tool_error, Some(true));
+    }
+
+    #[test]
+    fn req_dasclaw_core_929_chat_message_usage_defaults_to_none() {
+        let msg = ChatMessage::assistant("hi");
+        assert!(msg.usage.is_none());
+    }
+
+    #[test]
+    fn req_dasclaw_core_929_with_usage_records_token_counts() {
+        let usage = TokenUsage {
+            input_tokens: 100,
+            output_tokens: 50,
+            cache_creation_input_tokens: 10,
+            cache_read_input_tokens: 20,
+        };
+        let msg = ChatMessage::assistant("hi").with_usage(usage);
+        assert_eq!(msg.usage, Some(usage));
+    }
+
+    #[test]
+    fn req_dasclaw_core_929_legacy_chat_message_json_round_trips_without_new_fields() {
+        // Pre-#929 callers serialized ChatMessage with no `tool_error` / `usage` keys;
+        // those wire payloads must still deserialize and re-serialize cleanly.
+        let legacy = serde_json::json!({
+            "role": "assistant",
+            "content": "hello",
+        });
+        let parsed: ChatMessage = serde_json::from_value(legacy.clone()).expect("legacy parse");
+        assert!(parsed.tool_error.is_none());
+        assert!(parsed.usage.is_none());
+        let reserialized = serde_json::to_value(&parsed).expect("reserialize");
+        assert!(reserialized.get("tool_error").is_none());
+        assert!(reserialized.get("usage").is_none());
+    }
+
+    #[test]
+    fn req_dasclaw_core_929_token_usage_round_trips_through_serde() {
+        let usage = TokenUsage {
+            input_tokens: 1,
+            output_tokens: 2,
+            cache_creation_input_tokens: 3,
+            cache_read_input_tokens: 4,
+        };
+        let json = serde_json::to_value(usage).expect("serialize");
+        let back: TokenUsage = serde_json::from_value(json).expect("deserialize");
+        assert_eq!(back, usage);
     }
 }

--- a/crates/dasclaw_llm_provider/src/provider/claw_code_provider.rs
+++ b/crates/dasclaw_llm_provider/src/provider/claw_code_provider.rs
@@ -590,6 +590,8 @@ mod tests {
             tool_call_id: None,
             name: None,
             tool_calls: None,
+            tool_error: None,
+            usage: None,
         }
     }
 
@@ -657,6 +659,8 @@ mod tests {
             tool_call_id: None,
             name: None,
             tool_calls: None,
+            tool_error: None,
+            usage: None,
         };
         let im = map_user_message(&m);
         assert_eq!(im.content.len(), 2);
@@ -678,6 +682,8 @@ mod tests {
                 arguments: json!({"cmd": "ls"}),
                 reasoning: None,
             }]),
+            tool_error: None,
+            usage: None,
         };
         let im = map_assistant_message(&m);
         assert_eq!(im.content.len(), 2);
@@ -709,6 +715,8 @@ mod tests {
                 arguments: json!({"q": "rust"}),
                 reasoning: None,
             }]),
+            tool_error: None,
+            usage: None,
         };
         let im = map_assistant_message(&m);
         assert_eq!(im.content.len(), 1);
@@ -1017,6 +1025,8 @@ mod tests {
                     arguments: json!({"cmd": "ls /"}),
                     reasoning: None,
                 }]),
+                tool_error: None,
+                usage: None,
             },
             ChatMessage::tool_result("call-1", "shell", "bin\netc\nusr"),
         ];

--- a/crates/dasclaw_llm_provider/src/providers/openai_compat.rs
+++ b/crates/dasclaw_llm_provider/src/providers/openai_compat.rs
@@ -1009,13 +1009,13 @@ impl StreamState {
         }
 
         for state in self.tool_calls.values_mut() {
-            if !state.started {
-                if let Some(start_event) = state.start_event() {
-                    state.started = true;
-                    events.push(StreamEvent::ContentBlockStart(start_event));
-                    if let Some(delta_event) = state.delta_event() {
-                        events.push(StreamEvent::ContentBlockDelta(delta_event));
-                    }
+            if !state.started
+                && let Some(start_event) = state.start_event()
+            {
+                state.started = true;
+                events.push(StreamEvent::ContentBlockStart(start_event));
+                if let Some(delta_event) = state.delta_event() {
+                    events.push(StreamEvent::ContentBlockDelta(delta_event));
                 }
             }
             if state.started && !state.stopped {

--- a/crates/dasclaw_llm_provider/src/testing.rs
+++ b/crates/dasclaw_llm_provider/src/testing.rs
@@ -7,7 +7,6 @@
 //! provider crate's unit tests can run standalone, without pulling ironclaw
 //! into the provider crate's dependency graph.
 
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 
 use async_trait::async_trait;
@@ -103,11 +102,6 @@ impl Default for StubLlm {
     fn default() -> Self {
         Self::new("OK")
     }
-}
-
-/// Helper for cheaply constructing a shared stub.
-pub fn stub(response: impl Into<String>) -> Arc<StubLlm> {
-    Arc::new(StubLlm::new(response))
 }
 
 #[async_trait]

--- a/crates/dasclaw_llm_provider/tests/openai_compat_streaming.rs
+++ b/crates/dasclaw_llm_provider/tests/openai_compat_streaming.rs
@@ -248,10 +248,10 @@ async fn stream_dispatch_through_provider_client_returns_same_events() {
 
     let mut text = String::new();
     while let Some(event) = stream.next_event().await.expect("next ok") {
-        if let StreamEvent::ContentBlockDelta(delta) = event {
-            if let ContentBlockDelta::TextDelta { text: chunk } = delta.delta {
-                text.push_str(&chunk);
-            }
+        if let StreamEvent::ContentBlockDelta(delta) = event
+            && let ContentBlockDelta::TextDelta { text: chunk } = delta.delta
+        {
+            text.push_str(&chunk);
         }
     }
     assert_eq!(text, "hi");

--- a/crates/dasclaw_session/src/claw_compat.rs
+++ b/crates/dasclaw_session/src/claw_compat.rs
@@ -201,6 +201,8 @@ pub fn claw_to_chat_message(message: &ClawMessage) -> ChatMessage {
         tool_call_id: None,
         name: None,
         tool_calls: None,
+        tool_error: None,
+        usage: None,
     };
     if !tool_calls.is_empty() {
         msg.tool_calls = Some(tool_calls);

--- a/desktop-client/ironclaw/src/channels/web/openai_compat.rs
+++ b/desktop-client/ironclaw/src/channels/web/openai_compat.rs
@@ -249,6 +249,8 @@ pub fn convert_messages(messages: &[OpenAiMessage]) -> Result<Vec<ChatMessage>, 
                     tool_call_id: None,
                     name: m.name.clone(),
                     tool_calls: None,
+                    tool_error: None,
+                    usage: None,
                 }),
             }
         })

--- a/desktop-client/ironclaw/tests/claw_code_real_llm_tests.rs
+++ b/desktop-client/ironclaw/tests/claw_code_real_llm_tests.rs
@@ -356,6 +356,8 @@ async fn test_qwen_full_tool_round_trip_with_final_answer() {
         tool_call_id: None,
         name: None,
         tool_calls: Some(first_resp.tool_calls.clone()),
+        tool_error: None,
+        usage: None,
     };
     history.push(assistant_msg);
 


### PR DESCRIPTION
## 背景/目标

第一刀实现 #929 (P2 跨 crate):为 `ChatMessage` 与 `TokenUsage` 引入数据载体,让后续 provider 与 session bridge 能够无损携带 claw-code 的 `ContentBlock::ToolResult.is_error` 和 `ConversationMessage.usage` 信号。

本 PR 是 **N 步中的第 1 步**,只新增类型/字段/builder/单元测试,不动 provider、不动 session 桥接。

## Sources read

- [AGENTS.md](AGENTS.md#L1-L120) — PR body / cross-cuts / 局部验证规范
- [crates/dasclaw_core/src/messages.rs](crates/dasclaw_core/src/messages.rs) — `ChatMessage` / `CompletionResponse` 现状
- [crates/dasclaw_core/src/lib.rs](crates/dasclaw_core/src/lib.rs#L50-L60) — 公共 re-export 列表
- `claw-code/rust/crates/runtime/src/usage.rs` — `TokenUsage` 字段命名与排列(逐字段对齐)
- [crates/dasclaw_session/src/claw_compat.rs](crates/dasclaw_session/src/claw_compat.rs) (PR #927) — 当前 `chat_message_to_claw` 硬编码 `is_error: false` 的有损边

## 改动范围

- `crates/dasclaw_core/src/messages.rs`:
  - 新增 `TokenUsage` 结构体(4 个 `u32`:`input_tokens` / `output_tokens` / `cache_creation_input_tokens` / `cache_read_input_tokens`),字段排布与 claw-code 一致
  - `ChatMessage` 新增两个可选字段:`tool_error: Option<bool>` 和 `usage: Option<TokenUsage>`,均带 `#[serde(default, skip_serializing_if = "Option::is_none")]`
  - 6 个 `ChatMessage` 构造器全部初始化新字段为 `None`
  - 新增 2 个 builder:`with_tool_error(bool)` 与 `with_usage(TokenUsage)`,标 `#[must_use]`
  - 新增 6 个 `req_dasclaw_core_929_*` 单元测试,覆盖默认值/builder/serde 兼容/legacy JSON 反序列化
- `crates/dasclaw_core/src/lib.rs`:`TokenUsage` 加入 re-export(在 `Role` 与 `ToolCall` 之间,保持字母序)

## 非目标(后续 PR)

- ❌ **不接入 LLM provider 用量映射**(`CompletionResponse` → `ChatMessage.usage`)—— #929 step 2
- ❌ **不修 session 桥接的 `is_error` 硬编码**(`dasclaw_session::claw_compat::chat_message_to_claw` 现在仍写 `false`)—— #929 step 3
- ❌ **不改 jsonl on-disk wire 形态**(新字段 None 时不出现在 wire 上,旧 jsonl 反序列化继续工作,字节级零变化)
- ❌ **不引入计费/成本业务逻辑**

## 验证

```bash
cargo check -p dasclaw_core --tests          # 0 错 0 警
cargo nextest run -p dasclaw_core             # 291/291 通过(含 6 个新增 req_dasclaw_core_929_*)
cargo clippy --no-deps -p dasclaw_core --all-targets -- -D warnings  # 0 警
cargo fmt --all                               # clean
python3.12 scripts/check_no_panics.py --base origin/xClaw  # OK
```

3 层 skill 审查(code-quality-audit → code-simplifier → code-review-expert)结论:**APPROVE**,无 P0/P1/P2/P3 issue。

## 与并行 PR 的关系

本 PR 与 #927 / #930 **零文件重叠**,可独立 rebase / merge:
- #927 / #930 改 `crates/dasclaw_session/src/jsonl.rs` + `claw_compat.rs` + tests
- 本 PR 只动 `crates/dasclaw_core/src/{messages.rs, lib.rs}`

待 #927 与本 PR 都合入 xClaw 后,step 3(session bridge 用 `ChatMessage.tool_error` 替换硬编码 `false`)就可以无冲突地动笔。

## Cross-cuts

- ADR-114 (`.ironclaw` → `.dasclaw` 命名迁移):**类A** —— 本 PR 无新增 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量

Closes #934
Refs #929 (step 1 of 3)

