### PR TITLE
feat(runtime): thread TokenUsage through agentic loop into ChatMessage.usage (#929 step 2)

### DIFF
--- a/crates/dasclaw_core/src/agentic_loop.rs
+++ b/crates/dasclaw_core/src/agentic_loop.rs
@@ -25,7 +25,7 @@ use crate::hooks::{EgressKind, HookBundle};
 use crate::intent::{TOOL_INTENT_NUDGE, TRUNCATED_TOOL_CALL_NOTICE, llm_signals_tool_intent};
 use crate::messages::{ChatMessage, FinishReason, Role, ToolCall};
 use crate::reasoning_ctx::ReasoningContext;
-use crate::response_types::{RespondOutput, RespondResult, ResponseMetadata};
+use crate::response_types::{RespondOutput, RespondResult, ResponseMetadata, TokenUsage};
 use crate::session::PendingApproval;
 use crate::traits::HostError;
 
@@ -123,19 +123,30 @@ pub trait LoopDelegate: Send + Sync {
     /// Handle a text-only response from the LLM.
     /// Return `TextAction::Return` to exit the loop, `TextAction::Continue`
     /// to proceed.
+    ///
+    /// `usage` is the per-turn token usage from the call that produced
+    /// `text`. Delegates that persist the assistant turn (e.g. to a session
+    /// transcript) MUST attach it via [`ChatMessage::with_usage`] so the
+    /// stored history matches claw-code's `ConversationMessage.usage` shape.
     async fn handle_text_response(
         &self,
         text: &str,
         metadata: ResponseMetadata,
+        usage: TokenUsage,
         reason_ctx: &mut ReasoningContext,
     ) -> TextAction;
 
     /// Execute tool calls and add results to context.
     /// Return `Some(outcome)` to break the loop (e.g. approval needed).
+    ///
+    /// `usage` is the per-turn token usage from the call that produced
+    /// `tool_calls`. Delegates that record the assistant tool-call turn
+    /// MUST attach it via [`ChatMessage::with_usage`].
     async fn execute_tool_calls(
         &self,
         tool_calls: Vec<ToolCall>,
         content: Option<String>,
+        usage: TokenUsage,
         reason_ctx: &mut ReasoningContext,
     ) -> Result<Option<LoopOutcome>, HostError>;
 
@@ -259,6 +270,7 @@ pub async fn run_agentic_loop(
 
         match output.result {
             RespondResult::Text(text) => {
+                let usage = output.usage;
                 // Tool intent nudge: if the LLM says "let me search..."
                 // without actually calling a tool, inject a nudge message.
                 if config.enable_tool_intent_nudge
@@ -273,7 +285,9 @@ pub async fn run_agentic_loop(
                         "LLM expressed tool intent without calling a tool, nudging"
                     );
                     delegate.on_tool_intent_nudge(&text, reason_ctx).await;
-                    reason_ctx.messages.push(ChatMessage::assistant(&text));
+                    reason_ctx
+                        .messages
+                        .push(ChatMessage::assistant(&text).with_usage(usage));
                     reason_ctx
                         .messages
                         .push(ChatMessage::user(TOOL_INTENT_NUDGE));
@@ -288,7 +302,7 @@ pub async fn run_agentic_loop(
                 }
 
                 match delegate
-                    .handle_text_response(&text, output.metadata, reason_ctx)
+                    .handle_text_response(&text, output.metadata, usage, reason_ctx)
                     .await
                 {
                     TextAction::Return(outcome) => return Ok(outcome),
@@ -299,6 +313,7 @@ pub async fn run_agentic_loop(
                 tool_calls,
                 content,
             } => {
+                let usage = output.usage;
                 // If the response was truncated, tool call parameters are
                 // likely incomplete. Discard them and tell the LLM to try a
                 // different approach rather than executing malformed calls.
@@ -312,7 +327,9 @@ pub async fn run_agentic_loop(
                         "Discarding truncated tool calls (finish_reason=Length)"
                     );
                     if let Some(ref text) = content {
-                        reason_ctx.messages.push(ChatMessage::assistant(text));
+                        reason_ctx
+                            .messages
+                            .push(ChatMessage::assistant(text).with_usage(usage));
                     }
                     reason_ctx
                         .messages
@@ -331,7 +348,7 @@ pub async fn run_agentic_loop(
                 truncation_count = 0;
 
                 if let Some(outcome) = delegate
-                    .execute_tool_calls(tool_calls, content, reason_ctx)
+                    .execute_tool_calls(tool_calls, content, usage, reason_ctx)
                     .await?
                 {
                     return Ok(outcome);
@@ -452,6 +469,7 @@ mod tests {
             &self,
             text: &str,
             _metadata: ResponseMetadata,
+            _usage: TokenUsage,
             _reason_ctx: &mut ReasoningContext,
         ) -> TextAction {
             TextAction::Return(LoopOutcome::Response(text.to_string()))
@@ -461,6 +479,7 @@ mod tests {
             &self,
             _tool_calls: Vec<ToolCall>,
             _content: Option<String>,
+            _usage: TokenUsage,
             reason_ctx: &mut ReasoningContext,
         ) -> Result<Option<LoopOutcome>, HostError> {
             self.tool_exec_count.fetch_add(1, Ordering::SeqCst);
@@ -598,6 +617,7 @@ mod tests {
                 &self,
                 _: &str,
                 metadata: ResponseMetadata,
+                _: TokenUsage,
                 _: &mut ReasoningContext,
             ) -> TextAction {
                 assert_eq!(metadata.anomaly, Some(ResponseAnomaly::EmptyToolCompletion));
@@ -610,6 +630,7 @@ mod tests {
                 &self,
                 _: Vec<ToolCall>,
                 _: Option<String>,
+                _: TokenUsage,
                 _: &mut ReasoningContext,
             ) -> Result<Option<LoopOutcome>, HostError> {
                 Ok(None)
@@ -659,6 +680,7 @@ mod tests {
                 &self,
                 _: &str,
                 _: ResponseMetadata,
+                _: TokenUsage,
                 ctx: &mut ReasoningContext,
             ) -> TextAction {
                 ctx.messages.push(ChatMessage::assistant("still working"));
@@ -668,6 +690,7 @@ mod tests {
                 &self,
                 _: Vec<ToolCall>,
                 _: Option<String>,
+                _: TokenUsage,
                 _: &mut ReasoningContext,
             ) -> Result<Option<LoopOutcome>, HostError> {
                 Ok(None)
@@ -994,6 +1017,7 @@ mod tests {
                 &self,
                 text: &str,
                 _: ResponseMetadata,
+                _: TokenUsage,
                 _: &mut ReasoningContext,
             ) -> TextAction {
                 TextAction::Return(LoopOutcome::Response(text.to_string()))
@@ -1002,6 +1026,7 @@ mod tests {
                 &self,
                 _: Vec<ToolCall>,
                 _: Option<String>,
+                _: TokenUsage,
                 _: &mut ReasoningContext,
             ) -> Result<Option<LoopOutcome>, HostError> {
                 Ok(None)

--- a/crates/dasclaw_core/src/messages.rs
+++ b/crates/dasclaw_core/src/messages.rs
@@ -54,8 +54,17 @@ pub struct ImageUrl {
 pub struct TokenUsage {
     pub input_tokens: u32,
     pub output_tokens: u32,
+    /// Tokens written to the provider's prompt cache (Anthropic).
     pub cache_creation_input_tokens: u32,
+    /// Tokens served from the provider's server-side prompt cache (Anthropic).
     pub cache_read_input_tokens: u32,
+}
+
+impl TokenUsage {
+    /// Sum of `input_tokens` and `output_tokens` (does not include cache fields).
+    pub fn total(&self) -> u32 {
+        self.input_tokens + self.output_tokens
+    }
 }
 
 /// A message in a conversation.

--- a/crates/dasclaw_core/src/response_types.rs
+++ b/crates/dasclaw_core/src/response_types.rs
@@ -8,24 +8,8 @@
 
 use serde::{Deserialize, Serialize};
 
+pub use crate::messages::TokenUsage;
 use crate::messages::{FinishReason, ToolCall};
-
-/// Token usage from a single LLM call.
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
-pub struct TokenUsage {
-    pub input_tokens: u32,
-    pub output_tokens: u32,
-    /// Tokens served from the provider's server-side prompt cache (Anthropic).
-    pub cache_read_input_tokens: u32,
-    /// Tokens written to the provider's prompt cache (Anthropic).
-    pub cache_creation_input_tokens: u32,
-}
-
-impl TokenUsage {
-    pub fn total(&self) -> u32 {
-        self.input_tokens + self.output_tokens
-    }
-}
 
 /// Structured anomaly classification for LLM responses.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/dasclaw_core/tests/snapshots/serde_ipc_contract__respond_output_text.snap
+++ b/crates/dasclaw_core/tests/snapshots/serde_ipc_contract__respond_output_text.snap
@@ -10,8 +10,8 @@ expression: sample
   "usage": {
     "input_tokens": 5,
     "output_tokens": 7,
-    "cache_read_input_tokens": 0,
-    "cache_creation_input_tokens": 0
+    "cache_creation_input_tokens": 0,
+    "cache_read_input_tokens": 0
   },
   "finish_reason": "stop",
   "metadata": {

--- a/crates/dasclaw_core/tests/snapshots/serde_ipc_contract__token_usage.snap
+++ b/crates/dasclaw_core/tests/snapshots/serde_ipc_contract__token_usage.snap
@@ -5,6 +5,6 @@ expression: sample
 {
   "input_tokens": 10,
   "output_tokens": 20,
-  "cache_read_input_tokens": 3,
-  "cache_creation_input_tokens": 4
+  "cache_creation_input_tokens": 4,
+  "cache_read_input_tokens": 3
 }

--- a/crates/dasclaw_runtime/src/agent.rs
+++ b/crates/dasclaw_runtime/src/agent.rs
@@ -51,7 +51,7 @@ use dasclaw_core::egress_apply::{EgressApply, apply_egress_decision};
 use dasclaw_core::hooks::{EgressKind, HookBundle};
 use dasclaw_core::messages::{ChatMessage, FinishReason, ToolCall, ToolDefinition, ToolResult};
 use dasclaw_core::reasoning_ctx::ReasoningContext;
-use dasclaw_core::response_types::{RespondOutput, RespondResult, ResponseMetadata};
+use dasclaw_core::response_types::{RespondOutput, RespondResult, ResponseMetadata, TokenUsage};
 use dasclaw_core::traits::HostError;
 use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc;
@@ -481,19 +481,14 @@ impl Agent {
             .await
             .map_err(AgentError::Responder)?;
 
-        let result = map_outcome(outcome, loop_config.max_iterations);
-        // The core loop's `handle_text_response` returns the final text
-        // straight to the caller without recording it as an assistant
-        // turn in `ctx`. For single-shot `Agent::run` that doesn't
-        // matter (the context is thrown away). For multi-turn
-        // `Session::run` it does: without this push the next call would
-        // not see what the model just said. Mirroring the
-        // `assistant_with_tool_calls` push already done by
-        // `execute_tool_calls` keeps the history shape consistent.
-        if let Ok(text) = &result {
-            ctx.messages.push(ChatMessage::assistant(text));
-        }
-        result
+        // History continuity: `HeadlessDelegate::handle_text_response`
+        // records the final assistant turn into `ctx` (with token usage
+        // attached) before returning the response text, mirroring the
+        // push that `execute_tool_calls` already performs on the
+        // tool-call branch. That keeps the next call in a multi-turn
+        // `Session::run` aware of what the model just said without
+        // requiring the caller to plumb usage out of `LoopOutcome`.
+        map_outcome(outcome, loop_config.max_iterations)
     }
 
     /// Run a single user prompt through the loop and return the final
@@ -729,8 +724,11 @@ impl LoopDelegate for HeadlessDelegate {
         &self,
         text: &str,
         _metadata: ResponseMetadata,
-        _ctx: &mut ReasoningContext,
+        usage: TokenUsage,
+        ctx: &mut ReasoningContext,
     ) -> TextAction {
+        ctx.messages
+            .push(ChatMessage::assistant(text).with_usage(usage));
         TextAction::Return(LoopOutcome::Response(text.to_string()))
     }
 
@@ -738,6 +736,7 @@ impl LoopDelegate for HeadlessDelegate {
         &self,
         tool_calls: Vec<ToolCall>,
         content: Option<String>,
+        usage: TokenUsage,
         ctx: &mut ReasoningContext,
     ) -> Result<Option<LoopOutcome>, HostError> {
         // No executor → emit the sentinel and let `map_outcome` raise
@@ -749,7 +748,7 @@ impl LoopDelegate for HeadlessDelegate {
             )));
         };
 
-        push_assistant_tool_calls(ctx, content, &tool_calls);
+        push_assistant_tool_calls(ctx, content, &tool_calls, usage);
         for call in &tool_calls {
             // Streaming hosts learn the tool name + arguments as soon as
             // the loop commits to invoking the tool, before any egress
@@ -852,11 +851,11 @@ fn push_assistant_tool_calls(
     ctx: &mut ReasoningContext,
     content: Option<String>,
     tool_calls: &[ToolCall],
+    usage: TokenUsage,
 ) {
-    ctx.messages.push(ChatMessage::assistant_with_tool_calls(
-        content,
-        tool_calls.to_vec(),
-    ));
+    ctx.messages.push(
+        ChatMessage::assistant_with_tool_calls(content, tool_calls.to_vec()).with_usage(usage),
+    );
 }
 
 /// Sentinel string emitted by [`HeadlessDelegate::execute_tool_calls`]
@@ -941,6 +940,38 @@ mod tests {
             .expect("build agent");
         let out = agent.run("hi").await.expect("run");
         assert_eq!(out, "hello world");
+    }
+
+    #[tokio::test]
+    async fn req_dasclaw_runtime_agent_929_text_branch_persists_usage_to_context() {
+        // #929 step 2: the final assistant ChatMessage recorded by
+        // HeadlessDelegate::handle_text_response must carry the per-turn
+        // TokenUsage from the LLM call that produced it, so multi-turn
+        // Session::run can persist real cost data.
+        let usage = TokenUsage {
+            input_tokens: 42,
+            output_tokens: 7,
+            cache_creation_input_tokens: 3,
+            cache_read_input_tokens: 1,
+        };
+        let mut output = text_output("done");
+        output.usage = usage;
+        let responder = ScriptedResponder::new(vec![output]);
+        let agent = Agent::builder()
+            .responder(responder)
+            .build()
+            .expect("build agent");
+        let mut ctx = ReasoningContext::new();
+        let out = agent
+            .run_in_context(&mut ctx, "ping")
+            .await
+            .expect("run_in_context");
+        assert_eq!(out, "done");
+        let last = ctx
+            .messages
+            .last()
+            .expect("ctx should contain final assistant message");
+        assert_eq!(last.usage, Some(usage));
     }
 
     #[tokio::test]

--- a/crates/dasclaw_safety/tests/egress_gate_integration.rs
+++ b/crates/dasclaw_safety/tests/egress_gate_integration.rs
@@ -78,6 +78,7 @@ impl LoopDelegate for StubDelegate {
         &self,
         text: &str,
         _metadata: ResponseMetadata,
+        _usage: TokenUsage,
         _reason_ctx: &mut ReasoningContext,
     ) -> TextAction {
         TextAction::Return(LoopOutcome::Response(text.to_string()))
@@ -87,6 +88,7 @@ impl LoopDelegate for StubDelegate {
         &self,
         _tool_calls: Vec<ToolCall>,
         _content: Option<String>,
+        _usage: TokenUsage,
         _reason_ctx: &mut ReasoningContext,
     ) -> Result<Option<LoopOutcome>, HostError> {
         Ok(None)

--- a/desktop-client/ironclaw/src/agent/dispatcher.rs
+++ b/desktop-client/ironclaw/src/agent/dispatcher.rs
@@ -575,6 +575,7 @@ impl<'a> LoopDelegate for ChatDelegate<'a> {
         &self,
         text: &str,
         _metadata: crate::llm::ResponseMetadata,
+        _usage: dasclaw_core::TokenUsage,
         _reason_ctx: &mut ReasoningContext,
     ) -> TextAction {
         // Strip internal "[Called tool ...]" text that can leak when
@@ -588,6 +589,7 @@ impl<'a> LoopDelegate for ChatDelegate<'a> {
         &self,
         tool_calls: Vec<crate::llm::ToolCall>,
         content: Option<String>,
+        usage: dasclaw_core::TokenUsage,
         reason_ctx: &mut ReasoningContext,
     ) -> Result<Option<LoopOutcome>, HostError> {
         // Extract and sanitize the narrative before consuming `content`.
@@ -613,12 +615,9 @@ impl<'a> LoopDelegate for ChatDelegate<'a> {
 
         // Add the assistant message with tool_calls to context.
         // OpenAI protocol requires this before tool-result messages.
-        reason_ctx
-            .messages
-            .push(ChatMessage::assistant_with_tool_calls(
-                content,
-                tool_calls.clone(),
-            ));
+        reason_ctx.messages.push(
+            ChatMessage::assistant_with_tool_calls(content, tool_calls.clone()).with_usage(usage),
+        );
 
         // Execute tools and add results to context
         let _ = self

--- a/desktop-client/ironclaw/src/worker/container.rs
+++ b/desktop-client/ironclaw/src/worker/container.rs
@@ -487,6 +487,7 @@ impl LoopDelegate for ContainerDelegate {
         &self,
         text: &str,
         metadata: ResponseMetadata,
+        usage: dasclaw_core::TokenUsage,
         reason_ctx: &mut ReasoningContext,
     ) -> TextAction {
         let action = {
@@ -553,7 +554,9 @@ impl LoopDelegate for ContainerDelegate {
             return TextAction::Return(LoopOutcome::Response(output));
         }
 
-        reason_ctx.messages.push(ChatMessage::assistant(text));
+        reason_ctx
+            .messages
+            .push(ChatMessage::assistant(text).with_usage(usage));
         TextAction::Continue
     }
 
@@ -561,6 +564,7 @@ impl LoopDelegate for ContainerDelegate {
         &self,
         tool_calls: Vec<crate::llm::ToolCall>,
         content: Option<String>,
+        usage: dasclaw_core::TokenUsage,
         reason_ctx: &mut ReasoningContext,
     ) -> Result<Option<LoopOutcome>, HostError> {
         {
@@ -580,12 +584,9 @@ impl LoopDelegate for ContainerDelegate {
         }
 
         // Add assistant message with tool_calls (OpenAI protocol)
-        reason_ctx
-            .messages
-            .push(ChatMessage::assistant_with_tool_calls(
-                content,
-                tool_calls.clone(),
-            ));
+        reason_ctx.messages.push(
+            ChatMessage::assistant_with_tool_calls(content, tool_calls.clone()).with_usage(usage),
+        );
 
         // Execute tools sequentially (container context — no parallel execution)
         for tc in tool_calls {

--- a/desktop-client/ironclaw/src/worker/job.rs
+++ b/desktop-client/ironclaw/src/worker/job.rs
@@ -1610,6 +1610,7 @@ impl<'a> LoopDelegate for JobDelegate<'a> {
         &self,
         text: &str,
         metadata: ResponseMetadata,
+        usage: dasclaw_core::TokenUsage,
         reason_ctx: &mut ReasoningContext,
     ) -> TextAction {
         let action = {
@@ -1705,7 +1706,9 @@ impl<'a> LoopDelegate for JobDelegate<'a> {
             .store(true, std::sync::atomic::Ordering::Relaxed);
 
         // Add assistant response to context
-        reason_ctx.messages.push(ChatMessage::assistant(&text));
+        reason_ctx
+            .messages
+            .push(ChatMessage::assistant(&text).with_usage(usage));
 
         self.worker.log_event(
             "message",
@@ -1722,6 +1725,7 @@ impl<'a> LoopDelegate for JobDelegate<'a> {
         &self,
         tool_calls: Vec<crate::llm::ToolCall>,
         content: Option<String>,
+        usage: dasclaw_core::TokenUsage,
         reason_ctx: &mut ReasoningContext,
     ) -> Result<Option<LoopOutcome>, HostError> {
         {
@@ -1786,12 +1790,9 @@ impl<'a> LoopDelegate for JobDelegate<'a> {
         }
 
         // Add assistant message with tool_calls (OpenAI protocol)
-        reason_ctx
-            .messages
-            .push(ChatMessage::assistant_with_tool_calls(
-                content,
-                tool_calls.clone(),
-            ));
+        reason_ctx.messages.push(
+            ChatMessage::assistant_with_tool_calls(content, tool_calls.clone()).with_usage(usage),
+        );
 
         // Convert to ToolSelections
         let selections: Vec<ToolSelection> = tool_calls
@@ -2464,6 +2465,7 @@ mod tests {
             .handle_text_response(
                 "Weekly review created in Notion and notification sent.",
                 ResponseMetadata::default(),
+                dasclaw_core::TokenUsage::default(),
                 &mut reason_ctx,
             )
             .await;

--- a/desktop-client/ironclaw/tests/parity_harness.rs
+++ b/desktop-client/ironclaw/tests/parity_harness.rs
@@ -121,6 +121,7 @@ impl LoopDelegate for ParityDelegate {
         &self,
         text: &str,
         _metadata: ResponseMetadata,
+        _usage: dasclaw_core::TokenUsage,
         _reason_ctx: &mut ReasoningContext,
     ) -> TextAction {
         TextAction::Return(LoopOutcome::Response(text.to_string()))
@@ -130,6 +131,7 @@ impl LoopDelegate for ParityDelegate {
         &self,
         tool_calls: Vec<ToolCall>,
         _content: Option<String>,
+        _usage: dasclaw_core::TokenUsage,
         reason_ctx: &mut ReasoningContext,
     ) -> Result<Option<LoopOutcome>, dasclaw_core::HostError> {
         for tc in &tool_calls {


### PR DESCRIPTION
## 背景/目标

#929 第二刀(N 步中的第 2 步):把 LLM 调用返回的 `RespondOutput.usage`(per-turn `TokenUsage`)无损穿过 agentic loop,落到持久化的 assistant `ChatMessage.usage` 字段上,让多轮 `Session::run` 的历史里能保留真实 token 成本。

Stacked on **PR #931** (#929 step 1)。step 1 提供 `messages::TokenUsage` + `ChatMessage.usage` + `with_usage()` builder,本 PR 在此基础上接通流向。

## Sources read

- [AGENTS.md](AGENTS.md#L1-L120)
- [crates/dasclaw_core/src/agentic_loop.rs](crates/dasclaw_core/src/agentic_loop.rs) — `LoopDelegate` trait + loop body
- [crates/dasclaw_core/src/response_types.rs](crates/dasclaw_core/src/response_types.rs) — pre-存在的 `TokenUsage` 重复定义(本 PR 修正)
- [crates/dasclaw_runtime/src/agent.rs](crates/dasclaw_runtime/src/agent.rs) — `HeadlessDelegate` + `push_assistant_tool_calls`
- [crates/dasclaw_safety/tests/egress_gate_integration.rs](crates/dasclaw_safety/tests/egress_gate_integration.rs) — `StubDelegate`
- [claw-code/rust/crates/runtime/src/usage.rs](claw-code/rust/crates/runtime/src/usage.rs) — 上游 `TokenUsage` 字段顺序(`cache_creation_input_tokens` 在前)

## 改动范围

### 类型统一(消除 step 1 引入的重复)
- `crates/dasclaw_core/src/response_types.rs`:删除本地重复 `pub struct TokenUsage` + `impl total()`,改为 `pub use crate::messages::TokenUsage;`。canonical type 在 `messages.rs`。
- `crates/dasclaw_core/src/messages.rs`:`TokenUsage` 补回 `pub fn total()` 方法。字段顺序与 claw-code 一致:`input_tokens / output_tokens / cache_creation_input_tokens / cache_read_input_tokens`。

### LoopDelegate trait
- `handle_text_response` 和 `execute_tool_calls` 新增 `usage: TokenUsage` 入参,rustdoc 明确"持久化 assistant 的 delegate 必须用 `.with_usage()` 挂上"。

### Agentic loop 主体(`crates/dasclaw_core/src/agentic_loop.rs`)
- 文本/工具调用两支各 capture `let usage = output.usage;`(`TokenUsage` 是 `Copy`)。
- nudge 路径 + 截断回滚路径的 `ChatMessage::assistant(...).push` 改为 `.with_usage(usage)`。
- 传给 `delegate.handle_text_response(...)` 与 `delegate.execute_tool_calls(...)` 的 usage 已对接。
- 4 个测试 mock delegate 全部更新签名。

### HeadlessDelegate(`crates/dasclaw_runtime/src/agent.rs`)
- `handle_text_response`:在返回前 push `ChatMessage::assistant(text).with_usage(usage)` 进 `ctx.messages`(从 `run_in_context` 末尾的事后 push 迁过来,逻辑等价)。
- `execute_tool_calls`:把 `usage` 转给 `push_assistant_tool_calls`。
- `push_assistant_tool_calls` 新增 `usage: TokenUsage` 入参,`assistant_with_tool_calls(...).with_usage(usage)`。
- `run_in_context` 末尾的"事后补 push"块删除,改由 delegate 负责;注释更新解释新归属。

### Safety
- `crates/dasclaw_safety/tests/egress_gate_integration.rs` 的 `StubDelegate` 跟随 trait 签名更新。

### Snapshot 重生成(必要,见 Non-goals 第 2 条)
- `crates/dasclaw_core/tests/snapshots/serde_ipc_contract__token_usage.snap`
- `crates/dasclaw_core/tests/snapshots/serde_ipc_contract__respond_output_text.snap`

两个快照旧字段顺序是 `cache_read` 在前(老 `response_types::TokenUsage` 写错了),新顺序与 claw-code 上游一致。

### 测试
- 新增 `req_dasclaw_runtime_agent_929_text_branch_persists_usage_to_context`:`run_in_context` 跑完后断言 `ctx.messages.last().usage == Some(non_zero_token_usage)`,守住"usage 真的落到 ChatMessage 上"的回归。

## 非目标(下一刀)

- ❌ **不改 `dasclaw_session` jsonl on-disk 形态以包含 usage 字段** —— step 3 由 #929 session bridge 那一刀完成(届时 `chat_message_to_claw` 把 `ChatMessage.tool_error` / `usage` 写进 ClawContentBlock)。本 PR 仅打通 in-memory 流向。
- ❌ **不改 LLM provider 内部 `CompletionResponse.usage` 的填充** —— 那是 `dasclaw_llm_provider` 各 adapter 自己的责任,不在 agentic loop 层。
- ❌ **不引入计费/成本业务逻辑**。

## 验证

```bash
cargo check -p dasclaw_core -p dasclaw_runtime -p dasclaw_safety --tests           # 0 错 0 警
cargo nextest run -p dasclaw_core -p dasclaw_runtime -p dasclaw_safety --no-fail-fast  # 658/658 通过
cargo clippy --no-deps -p dasclaw_core -p dasclaw_runtime -p dasclaw_safety --all-targets -- -D warnings  # 0 警
cargo fmt --all                                                                     # clean
python3.12 scripts/check_no_panics.py --base origin/xClaw                           # OK
```

3 层 skill 审查(code-quality-audit → code-simplifier → code-review-expert):**APPROVE**。Reviewer 建议补一个 "usage 真的落到 ctx" 的回归测试 —— **已在本 PR 内补齐**(`req_dasclaw_runtime_agent_929_text_branch_persists_usage_to_context`)。无 P0/P1。

## Stacked 提示

本 PR base = **`feat/929-chatmessage-tool-error-usage`** (PR #931)。
- merge 顺序:先 #931,再 rebase 本 PR 到 xClaw,再 merge 本 PR。
- 与 #927 / #930 零文件重叠,可独立 CI。

## Cross-cuts

- ADR-114 (`.ironclaw` → `.dasclaw` 命名迁移):**类A** —— 本 PR 无新增 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量。

Closes #935
Refs #929 (step 2 of 3)

