### PR TITLE
feat(session): persist ChatMessage.tool_error and usage via claw bridge (#929 step 3)

### DIFF
--- a/crates/dasclaw_core/src/agentic_loop.rs
+++ b/crates/dasclaw_core/src/agentic_loop.rs
@@ -25,7 +25,7 @@ use crate::hooks::{EgressKind, HookBundle};
 use crate::intent::{TOOL_INTENT_NUDGE, TRUNCATED_TOOL_CALL_NOTICE, llm_signals_tool_intent};
 use crate::messages::{ChatMessage, FinishReason, Role, ToolCall};
 use crate::reasoning_ctx::ReasoningContext;
-use crate::response_types::{RespondOutput, RespondResult, ResponseMetadata};
+use crate::response_types::{RespondOutput, RespondResult, ResponseMetadata, TokenUsage};
 use crate::session::PendingApproval;
 use crate::traits::HostError;
 
@@ -123,19 +123,30 @@ pub trait LoopDelegate: Send + Sync {
     /// Handle a text-only response from the LLM.
     /// Return `TextAction::Return` to exit the loop, `TextAction::Continue`
     /// to proceed.
+    ///
+    /// `usage` is the per-turn token usage from the call that produced
+    /// `text`. Delegates that persist the assistant turn (e.g. to a session
+    /// transcript) MUST attach it via [`ChatMessage::with_usage`] so the
+    /// stored history matches claw-code's `ConversationMessage.usage` shape.
     async fn handle_text_response(
         &self,
         text: &str,
         metadata: ResponseMetadata,
+        usage: TokenUsage,
         reason_ctx: &mut ReasoningContext,
     ) -> TextAction;
 
     /// Execute tool calls and add results to context.
     /// Return `Some(outcome)` to break the loop (e.g. approval needed).
+    ///
+    /// `usage` is the per-turn token usage from the call that produced
+    /// `tool_calls`. Delegates that record the assistant tool-call turn
+    /// MUST attach it via [`ChatMessage::with_usage`].
     async fn execute_tool_calls(
         &self,
         tool_calls: Vec<ToolCall>,
         content: Option<String>,
+        usage: TokenUsage,
         reason_ctx: &mut ReasoningContext,
     ) -> Result<Option<LoopOutcome>, HostError>;
 
@@ -259,6 +270,7 @@ pub async fn run_agentic_loop(
 
         match output.result {
             RespondResult::Text(text) => {
+                let usage = output.usage;
                 // Tool intent nudge: if the LLM says "let me search..."
                 // without actually calling a tool, inject a nudge message.
                 if config.enable_tool_intent_nudge
@@ -273,7 +285,9 @@ pub async fn run_agentic_loop(
                         "LLM expressed tool intent without calling a tool, nudging"
                     );
                     delegate.on_tool_intent_nudge(&text, reason_ctx).await;
-                    reason_ctx.messages.push(ChatMessage::assistant(&text));
+                    reason_ctx
+                        .messages
+                        .push(ChatMessage::assistant(&text).with_usage(usage));
                     reason_ctx
                         .messages
                         .push(ChatMessage::user(TOOL_INTENT_NUDGE));
@@ -288,7 +302,7 @@ pub async fn run_agentic_loop(
                 }
 
                 match delegate
-                    .handle_text_response(&text, output.metadata, reason_ctx)
+                    .handle_text_response(&text, output.metadata, usage, reason_ctx)
                     .await
                 {
                     TextAction::Return(outcome) => return Ok(outcome),
@@ -299,6 +313,7 @@ pub async fn run_agentic_loop(
                 tool_calls,
                 content,
             } => {
+                let usage = output.usage;
                 // If the response was truncated, tool call parameters are
                 // likely incomplete. Discard them and tell the LLM to try a
                 // different approach rather than executing malformed calls.
@@ -312,7 +327,9 @@ pub async fn run_agentic_loop(
                         "Discarding truncated tool calls (finish_reason=Length)"
                     );
                     if let Some(ref text) = content {
-                        reason_ctx.messages.push(ChatMessage::assistant(text));
+                        reason_ctx
+                            .messages
+                            .push(ChatMessage::assistant(text).with_usage(usage));
                     }
                     reason_ctx
                         .messages
@@ -331,7 +348,7 @@ pub async fn run_agentic_loop(
                 truncation_count = 0;
 
                 if let Some(outcome) = delegate
-                    .execute_tool_calls(tool_calls, content, reason_ctx)
+                    .execute_tool_calls(tool_calls, content, usage, reason_ctx)
                     .await?
                 {
                     return Ok(outcome);
@@ -452,6 +469,7 @@ mod tests {
             &self,
             text: &str,
             _metadata: ResponseMetadata,
+            _usage: TokenUsage,
             _reason_ctx: &mut ReasoningContext,
         ) -> TextAction {
             TextAction::Return(LoopOutcome::Response(text.to_string()))
@@ -461,6 +479,7 @@ mod tests {
             &self,
             _tool_calls: Vec<ToolCall>,
             _content: Option<String>,
+            _usage: TokenUsage,
             reason_ctx: &mut ReasoningContext,
         ) -> Result<Option<LoopOutcome>, HostError> {
             self.tool_exec_count.fetch_add(1, Ordering::SeqCst);
@@ -598,6 +617,7 @@ mod tests {
                 &self,
                 _: &str,
                 metadata: ResponseMetadata,
+                _: TokenUsage,
                 _: &mut ReasoningContext,
             ) -> TextAction {
                 assert_eq!(metadata.anomaly, Some(ResponseAnomaly::EmptyToolCompletion));
@@ -610,6 +630,7 @@ mod tests {
                 &self,
                 _: Vec<ToolCall>,
                 _: Option<String>,
+                _: TokenUsage,
                 _: &mut ReasoningContext,
             ) -> Result<Option<LoopOutcome>, HostError> {
                 Ok(None)
@@ -659,6 +680,7 @@ mod tests {
                 &self,
                 _: &str,
                 _: ResponseMetadata,
+                _: TokenUsage,
                 ctx: &mut ReasoningContext,
             ) -> TextAction {
                 ctx.messages.push(ChatMessage::assistant("still working"));
@@ -668,6 +690,7 @@ mod tests {
                 &self,
                 _: Vec<ToolCall>,
                 _: Option<String>,
+                _: TokenUsage,
                 _: &mut ReasoningContext,
             ) -> Result<Option<LoopOutcome>, HostError> {
                 Ok(None)
@@ -994,6 +1017,7 @@ mod tests {
                 &self,
                 text: &str,
                 _: ResponseMetadata,
+                _: TokenUsage,
                 _: &mut ReasoningContext,
             ) -> TextAction {
                 TextAction::Return(LoopOutcome::Response(text.to_string()))
@@ -1002,6 +1026,7 @@ mod tests {
                 &self,
                 _: Vec<ToolCall>,
                 _: Option<String>,
+                _: TokenUsage,
                 _: &mut ReasoningContext,
             ) -> Result<Option<LoopOutcome>, HostError> {
                 Ok(None)

--- a/crates/dasclaw_core/src/messages.rs
+++ b/crates/dasclaw_core/src/messages.rs
@@ -54,8 +54,17 @@ pub struct ImageUrl {
 pub struct TokenUsage {
     pub input_tokens: u32,
     pub output_tokens: u32,
+    /// Tokens written to the provider's prompt cache (Anthropic).
     pub cache_creation_input_tokens: u32,
+    /// Tokens served from the provider's server-side prompt cache (Anthropic).
     pub cache_read_input_tokens: u32,
+}
+
+impl TokenUsage {
+    /// Sum of `input_tokens` and `output_tokens` (does not include cache fields).
+    pub fn total(&self) -> u32 {
+        self.input_tokens + self.output_tokens
+    }
 }
 
 /// A message in a conversation.

--- a/crates/dasclaw_core/src/response_types.rs
+++ b/crates/dasclaw_core/src/response_types.rs
@@ -8,24 +8,8 @@
 
 use serde::{Deserialize, Serialize};
 
+pub use crate::messages::TokenUsage;
 use crate::messages::{FinishReason, ToolCall};
-
-/// Token usage from a single LLM call.
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
-pub struct TokenUsage {
-    pub input_tokens: u32,
-    pub output_tokens: u32,
-    /// Tokens served from the provider's server-side prompt cache (Anthropic).
-    pub cache_read_input_tokens: u32,
-    /// Tokens written to the provider's prompt cache (Anthropic).
-    pub cache_creation_input_tokens: u32,
-}
-
-impl TokenUsage {
-    pub fn total(&self) -> u32 {
-        self.input_tokens + self.output_tokens
-    }
-}
 
 /// Structured anomaly classification for LLM responses.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/dasclaw_core/tests/snapshots/serde_ipc_contract__respond_output_text.snap
+++ b/crates/dasclaw_core/tests/snapshots/serde_ipc_contract__respond_output_text.snap
@@ -10,8 +10,8 @@ expression: sample
   "usage": {
     "input_tokens": 5,
     "output_tokens": 7,
-    "cache_read_input_tokens": 0,
-    "cache_creation_input_tokens": 0
+    "cache_creation_input_tokens": 0,
+    "cache_read_input_tokens": 0
   },
   "finish_reason": "stop",
   "metadata": {

--- a/crates/dasclaw_core/tests/snapshots/serde_ipc_contract__token_usage.snap
+++ b/crates/dasclaw_core/tests/snapshots/serde_ipc_contract__token_usage.snap
@@ -5,6 +5,6 @@ expression: sample
 {
   "input_tokens": 10,
   "output_tokens": 20,
-  "cache_read_input_tokens": 3,
-  "cache_creation_input_tokens": 4
+  "cache_creation_input_tokens": 4,
+  "cache_read_input_tokens": 3
 }

--- a/crates/dasclaw_runtime/src/agent.rs
+++ b/crates/dasclaw_runtime/src/agent.rs
@@ -51,7 +51,7 @@ use dasclaw_core::egress_apply::{EgressApply, apply_egress_decision};
 use dasclaw_core::hooks::{EgressKind, HookBundle};
 use dasclaw_core::messages::{ChatMessage, FinishReason, ToolCall, ToolDefinition, ToolResult};
 use dasclaw_core::reasoning_ctx::ReasoningContext;
-use dasclaw_core::response_types::{RespondOutput, RespondResult, ResponseMetadata};
+use dasclaw_core::response_types::{RespondOutput, RespondResult, ResponseMetadata, TokenUsage};
 use dasclaw_core::traits::HostError;
 use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc;
@@ -481,19 +481,14 @@ impl Agent {
             .await
             .map_err(AgentError::Responder)?;
 
-        let result = map_outcome(outcome, loop_config.max_iterations);
-        // The core loop's `handle_text_response` returns the final text
-        // straight to the caller without recording it as an assistant
-        // turn in `ctx`. For single-shot `Agent::run` that doesn't
-        // matter (the context is thrown away). For multi-turn
-        // `Session::run` it does: without this push the next call would
-        // not see what the model just said. Mirroring the
-        // `assistant_with_tool_calls` push already done by
-        // `execute_tool_calls` keeps the history shape consistent.
-        if let Ok(text) = &result {
-            ctx.messages.push(ChatMessage::assistant(text));
-        }
-        result
+        // History continuity: `HeadlessDelegate::handle_text_response`
+        // records the final assistant turn into `ctx` (with token usage
+        // attached) before returning the response text, mirroring the
+        // push that `execute_tool_calls` already performs on the
+        // tool-call branch. That keeps the next call in a multi-turn
+        // `Session::run` aware of what the model just said without
+        // requiring the caller to plumb usage out of `LoopOutcome`.
+        map_outcome(outcome, loop_config.max_iterations)
     }
 
     /// Run a single user prompt through the loop and return the final
@@ -729,8 +724,11 @@ impl LoopDelegate for HeadlessDelegate {
         &self,
         text: &str,
         _metadata: ResponseMetadata,
-        _ctx: &mut ReasoningContext,
+        usage: TokenUsage,
+        ctx: &mut ReasoningContext,
     ) -> TextAction {
+        ctx.messages
+            .push(ChatMessage::assistant(text).with_usage(usage));
         TextAction::Return(LoopOutcome::Response(text.to_string()))
     }
 
@@ -738,6 +736,7 @@ impl LoopDelegate for HeadlessDelegate {
         &self,
         tool_calls: Vec<ToolCall>,
         content: Option<String>,
+        usage: TokenUsage,
         ctx: &mut ReasoningContext,
     ) -> Result<Option<LoopOutcome>, HostError> {
         // No executor → emit the sentinel and let `map_outcome` raise
@@ -749,7 +748,7 @@ impl LoopDelegate for HeadlessDelegate {
             )));
         };
 
-        push_assistant_tool_calls(ctx, content, &tool_calls);
+        push_assistant_tool_calls(ctx, content, &tool_calls, usage);
         for call in &tool_calls {
             // Streaming hosts learn the tool name + arguments as soon as
             // the loop commits to invoking the tool, before any egress
@@ -852,11 +851,11 @@ fn push_assistant_tool_calls(
     ctx: &mut ReasoningContext,
     content: Option<String>,
     tool_calls: &[ToolCall],
+    usage: TokenUsage,
 ) {
-    ctx.messages.push(ChatMessage::assistant_with_tool_calls(
-        content,
-        tool_calls.to_vec(),
-    ));
+    ctx.messages.push(
+        ChatMessage::assistant_with_tool_calls(content, tool_calls.to_vec()).with_usage(usage),
+    );
 }
 
 /// Sentinel string emitted by [`HeadlessDelegate::execute_tool_calls`]
@@ -941,6 +940,38 @@ mod tests {
             .expect("build agent");
         let out = agent.run("hi").await.expect("run");
         assert_eq!(out, "hello world");
+    }
+
+    #[tokio::test]
+    async fn req_dasclaw_runtime_agent_929_text_branch_persists_usage_to_context() {
+        // #929 step 2: the final assistant ChatMessage recorded by
+        // HeadlessDelegate::handle_text_response must carry the per-turn
+        // TokenUsage from the LLM call that produced it, so multi-turn
+        // Session::run can persist real cost data.
+        let usage = TokenUsage {
+            input_tokens: 42,
+            output_tokens: 7,
+            cache_creation_input_tokens: 3,
+            cache_read_input_tokens: 1,
+        };
+        let mut output = text_output("done");
+        output.usage = usage;
+        let responder = ScriptedResponder::new(vec![output]);
+        let agent = Agent::builder()
+            .responder(responder)
+            .build()
+            .expect("build agent");
+        let mut ctx = ReasoningContext::new();
+        let out = agent
+            .run_in_context(&mut ctx, "ping")
+            .await
+            .expect("run_in_context");
+        assert_eq!(out, "done");
+        let last = ctx
+            .messages
+            .last()
+            .expect("ctx should contain final assistant message");
+        assert_eq!(last.usage, Some(usage));
     }
 
     #[tokio::test]

--- a/crates/dasclaw_safety/tests/egress_gate_integration.rs
+++ b/crates/dasclaw_safety/tests/egress_gate_integration.rs
@@ -78,6 +78,7 @@ impl LoopDelegate for StubDelegate {
         &self,
         text: &str,
         _metadata: ResponseMetadata,
+        _usage: TokenUsage,
         _reason_ctx: &mut ReasoningContext,
     ) -> TextAction {
         TextAction::Return(LoopOutcome::Response(text.to_string()))
@@ -87,6 +88,7 @@ impl LoopDelegate for StubDelegate {
         &self,
         _tool_calls: Vec<ToolCall>,
         _content: Option<String>,
+        _usage: TokenUsage,
         _reason_ctx: &mut ReasoningContext,
     ) -> Result<Option<LoopOutcome>, HostError> {
         Ok(None)

--- a/crates/dasclaw_session/src/claw_compat.rs
+++ b/crates/dasclaw_session/src/claw_compat.rs
@@ -29,7 +29,7 @@
 //!   the return trip. Non-JSON-object arguments (rare in practice)
 //!   are serialized as their literal JSON form.
 
-use dasclaw_core::messages::{ChatMessage, Role, ToolCall};
+use dasclaw_core::messages::{ChatMessage, Role, TokenUsage, ToolCall};
 use serde::{Deserialize, Serialize};
 
 /// Claw-code's message-level role tag. Serializes as lowercase to
@@ -67,12 +67,18 @@ pub enum ClawContentBlock {
 
 /// Claw-code-shaped persisted message. Mirrors
 /// `claw-code::runtime::session::ConversationMessage` exactly on the
-/// wire, minus `usage` (token-usage fields land in
-/// [`crate::SessionSnapshot`] when we wire them up in a later PR).
+/// wire, including the optional per-turn `usage` field that travels
+/// with assistant messages.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ClawMessage {
     pub role: ClawRole,
     pub blocks: Vec<ClawContentBlock>,
+    /// Token usage attributed to this message. Only populated for
+    /// assistant turns when the upstream `ChatMessage` carries
+    /// `usage = Some(...)`. Skipped on the wire when absent so the
+    /// jsonl shape matches claw-code's optional layout.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub usage: Option<TokenUsage>,
 }
 
 /// Convert from the OpenAI-shaped [`ChatMessage`] to a claw-code-shaped
@@ -80,15 +86,17 @@ pub struct ClawMessage {
 ///
 /// Mapping:
 /// - System / User text-only → single `Text` block carrying `content`
-/// - Assistant text-only → single `Text` block
+/// - Assistant text-only → single `Text` block; `usage` propagates
+///   to `ClawMessage::usage` when set
 /// - Assistant with `tool_calls`: optional leading `Text` block (if
 ///   `content` is non-empty) followed by one `ToolUse` block per
-///   call, with `input` = JSON-stringified `arguments`
+///   call, with `input` = JSON-stringified `arguments`; `usage`
+///   propagates to `ClawMessage::usage`
 /// - Tool result → single `ToolResult` block reading `tool_call_id`,
-///   `name`, and `content`; `is_error` is recorded as `false` (the
-///   dasclaw `ChatMessage::tool_result` constructor does not yet
-///   surface an error flag — adding one is a forward-compatible
-///   change because `is_error` is required by the claw wire schema)
+///   `name`, and `content`. `is_error` is sourced from
+///   `ChatMessage::tool_error` (`None` flattens to `false` because
+///   the claw wire schema requires the field; `Some(b)` round-trips
+///   `b` faithfully).
 #[must_use]
 pub fn chat_message_to_claw(message: &ChatMessage) -> ClawMessage {
     match message.role {
@@ -97,12 +105,14 @@ pub fn chat_message_to_claw(message: &ChatMessage) -> ClawMessage {
             blocks: vec![ClawContentBlock::Text {
                 text: message.content.clone(),
             }],
+            usage: None,
         },
         Role::User => ClawMessage {
             role: ClawRole::User,
             blocks: vec![ClawContentBlock::Text {
                 text: message.content.clone(),
             }],
+            usage: None,
         },
         Role::Assistant => {
             let mut blocks: Vec<ClawContentBlock> = Vec::new();
@@ -123,6 +133,7 @@ pub fn chat_message_to_claw(message: &ChatMessage) -> ClawMessage {
             ClawMessage {
                 role: ClawRole::Assistant,
                 blocks,
+                usage: message.usage,
             }
         }
         Role::Tool => ClawMessage {
@@ -131,8 +142,9 @@ pub fn chat_message_to_claw(message: &ChatMessage) -> ClawMessage {
                 tool_use_id: message.tool_call_id.clone().unwrap_or_default(),
                 tool_name: message.name.clone().unwrap_or_default(),
                 output: message.content.clone(),
-                is_error: false,
+                is_error: message.tool_error.unwrap_or(false),
             }],
+            usage: None,
         },
     }
 }
@@ -164,10 +176,12 @@ pub fn claw_to_chat_message(message: &ClawMessage) -> ChatMessage {
             tool_use_id,
             tool_name,
             output,
-            is_error: _,
+            is_error,
         }) = message.blocks.first()
     {
-        return ChatMessage::tool_result(tool_use_id, tool_name, output);
+        let mut msg = ChatMessage::tool_result(tool_use_id, tool_name, output);
+        msg.tool_error = Some(*is_error);
+        return msg;
     }
 
     let mut text_parts: Vec<&str> = Vec::new();
@@ -202,7 +216,7 @@ pub fn claw_to_chat_message(message: &ClawMessage) -> ChatMessage {
         name: None,
         tool_calls: None,
         tool_error: None,
-        usage: None,
+        usage: message.usage,
     };
     if !tool_calls.is_empty() {
         msg.tool_calls = Some(tool_calls);

--- a/crates/dasclaw_session/tests/claw_compat.rs
+++ b/crates/dasclaw_session/tests/claw_compat.rs
@@ -14,7 +14,7 @@
 //!   `ContentBlock` has no image variant, so the conversion keeps
 //!   the text content only. Documented behaviour, explicitly tested.
 
-use dasclaw_core::messages::{ChatMessage, ContentPart, ImageUrl, Role, ToolCall};
+use dasclaw_core::messages::{ChatMessage, ContentPart, ImageUrl, Role, TokenUsage, ToolCall};
 use dasclaw_session::claw_compat::{
     ClawContentBlock, ClawMessage, ClawRole, chat_message_to_claw, claw_to_chat_message,
 };
@@ -231,4 +231,128 @@ fn req_dasclaw_session_d1_tool_result_claw_code_wire_parses() {
         }
         other => panic!("expected ToolResult, got {other:?}"),
     }
+}
+
+#[test]
+fn req_dasclaw_session_929_tool_error_round_trips() {
+    // #929 step 3: ChatMessage::tool_result + explicit tool_error=Some(true)
+    // must persist via ClawContentBlock::ToolResult { is_error: true } and
+    // come back with tool_error=Some(true). Defaulting to false on the way
+    // out is acceptable when the source did not set it, but a non-default
+    // value must not be silently dropped.
+    let mut original = ChatMessage::tool_result("call_err", "shell", "command not found");
+    original.tool_error = Some(true);
+
+    let claw = chat_message_to_claw(&original);
+    match &claw.blocks[..] {
+        [ClawContentBlock::ToolResult { is_error, .. }] => {
+            assert!(
+                *is_error,
+                "tool_error=Some(true) must serialize as is_error=true"
+            );
+        }
+        other => panic!("expected ToolResult, got {other:?}"),
+    }
+
+    let back = claw_to_chat_message(&claw);
+    assert_eq!(back.tool_error, Some(true));
+    assert_eq!(back.content, "command not found");
+}
+
+#[test]
+fn req_dasclaw_session_929_tool_result_unspecified_error_flattens_to_false() {
+    // When tool_error is None (legacy / unset), the claw wire schema
+    // still requires a bool, so we emit false. Round-trip then gives
+    // tool_error=Some(false) — that's a forward step, not data loss.
+    let original = ChatMessage::tool_result("call_ok", "shell", "ok");
+    assert!(original.tool_error.is_none());
+
+    let claw = chat_message_to_claw(&original);
+    match &claw.blocks[..] {
+        [ClawContentBlock::ToolResult { is_error, .. }] => assert!(!is_error),
+        other => panic!("expected ToolResult, got {other:?}"),
+    }
+
+    let back = claw_to_chat_message(&claw);
+    assert_eq!(back.tool_error, Some(false));
+}
+
+#[test]
+fn req_dasclaw_session_929_assistant_usage_round_trips() {
+    // #929 step 3: ChatMessage.usage on an assistant turn must land on
+    // ClawMessage.usage and survive the round-trip. The wire layout
+    // must use the same field names claw-code's `ConversationMessage`
+    // emits (input_tokens / output_tokens / cache_creation_input_tokens
+    // / cache_read_input_tokens).
+    let usage = TokenUsage {
+        input_tokens: 100,
+        output_tokens: 25,
+        cache_creation_input_tokens: 4,
+        cache_read_input_tokens: 2,
+    };
+    let original = ChatMessage::assistant("the answer is 42").with_usage(usage);
+
+    let claw = chat_message_to_claw(&original);
+    assert_eq!(claw.usage, Some(usage));
+
+    // Wire shape must match claw-code: usage object beside blocks,
+    // with the canonical four field names.
+    let json = serde_json::to_value(&claw).expect("ser");
+    let u = json
+        .get("usage")
+        .expect("usage emitted on assistant message");
+    assert_eq!(u["input_tokens"], 100);
+    assert_eq!(u["output_tokens"], 25);
+    assert_eq!(u["cache_creation_input_tokens"], 4);
+    assert_eq!(u["cache_read_input_tokens"], 2);
+
+    let back = claw_to_chat_message(&claw);
+    assert_eq!(back.usage, Some(usage));
+    assert_eq!(back.content, "the answer is 42");
+}
+
+#[test]
+fn req_dasclaw_session_929_assistant_without_usage_omits_field_on_wire() {
+    // Backward-compat: when assistant has no usage, the wire shape
+    // must not emit a "usage" key (claw-code's optional schema
+    // matches `skip_serializing_if = Option::is_none`).
+    let original = ChatMessage::assistant("no usage here");
+    let claw = chat_message_to_claw(&original);
+    assert!(claw.usage.is_none());
+
+    let json = serde_json::to_value(&claw).expect("ser");
+    assert!(
+        json.get("usage").is_none(),
+        "usage field must be omitted on the wire when None, got: {json}"
+    );
+}
+
+#[test]
+fn req_dasclaw_session_929_assistant_usage_wire_parses_back() {
+    // A claw-code-shaped JSON line with `usage` must parse cleanly
+    // through ClawMessage and back to ChatMessage::usage = Some(...).
+    let raw = r#"{
+        "role": "assistant",
+        "blocks": [{"type": "text", "text": "ok"}],
+        "usage": {
+            "input_tokens": 7,
+            "output_tokens": 3,
+            "cache_creation_input_tokens": 1,
+            "cache_read_input_tokens": 0
+        }
+    }"#;
+    let parsed: ClawMessage = serde_json::from_str(raw).expect("parse claw with usage");
+    assert_eq!(
+        parsed.usage,
+        Some(TokenUsage {
+            input_tokens: 7,
+            output_tokens: 3,
+            cache_creation_input_tokens: 1,
+            cache_read_input_tokens: 0,
+        })
+    );
+
+    let back = claw_to_chat_message(&parsed);
+    assert_eq!(back.role, Role::Assistant);
+    assert_eq!(back.usage.map(|u| u.input_tokens), Some(7));
 }

--- a/desktop-client/ironclaw/src/agent/dispatcher.rs
+++ b/desktop-client/ironclaw/src/agent/dispatcher.rs
@@ -575,6 +575,7 @@ impl<'a> LoopDelegate for ChatDelegate<'a> {
         &self,
         text: &str,
         _metadata: crate::llm::ResponseMetadata,
+        _usage: dasclaw_core::TokenUsage,
         _reason_ctx: &mut ReasoningContext,
     ) -> TextAction {
         // Strip internal "[Called tool ...]" text that can leak when
@@ -588,6 +589,7 @@ impl<'a> LoopDelegate for ChatDelegate<'a> {
         &self,
         tool_calls: Vec<crate::llm::ToolCall>,
         content: Option<String>,
+        usage: dasclaw_core::TokenUsage,
         reason_ctx: &mut ReasoningContext,
     ) -> Result<Option<LoopOutcome>, HostError> {
         // Extract and sanitize the narrative before consuming `content`.
@@ -613,12 +615,9 @@ impl<'a> LoopDelegate for ChatDelegate<'a> {
 
         // Add the assistant message with tool_calls to context.
         // OpenAI protocol requires this before tool-result messages.
-        reason_ctx
-            .messages
-            .push(ChatMessage::assistant_with_tool_calls(
-                content,
-                tool_calls.clone(),
-            ));
+        reason_ctx.messages.push(
+            ChatMessage::assistant_with_tool_calls(content, tool_calls.clone()).with_usage(usage),
+        );
 
         // Execute tools and add results to context
         let _ = self

--- a/desktop-client/ironclaw/src/worker/container.rs
+++ b/desktop-client/ironclaw/src/worker/container.rs
@@ -487,6 +487,7 @@ impl LoopDelegate for ContainerDelegate {
         &self,
         text: &str,
         metadata: ResponseMetadata,
+        usage: dasclaw_core::TokenUsage,
         reason_ctx: &mut ReasoningContext,
     ) -> TextAction {
         let action = {
@@ -553,7 +554,9 @@ impl LoopDelegate for ContainerDelegate {
             return TextAction::Return(LoopOutcome::Response(output));
         }
 
-        reason_ctx.messages.push(ChatMessage::assistant(text));
+        reason_ctx
+            .messages
+            .push(ChatMessage::assistant(text).with_usage(usage));
         TextAction::Continue
     }
 
@@ -561,6 +564,7 @@ impl LoopDelegate for ContainerDelegate {
         &self,
         tool_calls: Vec<crate::llm::ToolCall>,
         content: Option<String>,
+        usage: dasclaw_core::TokenUsage,
         reason_ctx: &mut ReasoningContext,
     ) -> Result<Option<LoopOutcome>, HostError> {
         {
@@ -580,12 +584,9 @@ impl LoopDelegate for ContainerDelegate {
         }
 
         // Add assistant message with tool_calls (OpenAI protocol)
-        reason_ctx
-            .messages
-            .push(ChatMessage::assistant_with_tool_calls(
-                content,
-                tool_calls.clone(),
-            ));
+        reason_ctx.messages.push(
+            ChatMessage::assistant_with_tool_calls(content, tool_calls.clone()).with_usage(usage),
+        );
 
         // Execute tools sequentially (container context — no parallel execution)
         for tc in tool_calls {

--- a/desktop-client/ironclaw/src/worker/job.rs
+++ b/desktop-client/ironclaw/src/worker/job.rs
@@ -1610,6 +1610,7 @@ impl<'a> LoopDelegate for JobDelegate<'a> {
         &self,
         text: &str,
         metadata: ResponseMetadata,
+        usage: dasclaw_core::TokenUsage,
         reason_ctx: &mut ReasoningContext,
     ) -> TextAction {
         let action = {
@@ -1705,7 +1706,9 @@ impl<'a> LoopDelegate for JobDelegate<'a> {
             .store(true, std::sync::atomic::Ordering::Relaxed);
 
         // Add assistant response to context
-        reason_ctx.messages.push(ChatMessage::assistant(&text));
+        reason_ctx
+            .messages
+            .push(ChatMessage::assistant(&text).with_usage(usage));
 
         self.worker.log_event(
             "message",
@@ -1722,6 +1725,7 @@ impl<'a> LoopDelegate for JobDelegate<'a> {
         &self,
         tool_calls: Vec<crate::llm::ToolCall>,
         content: Option<String>,
+        usage: dasclaw_core::TokenUsage,
         reason_ctx: &mut ReasoningContext,
     ) -> Result<Option<LoopOutcome>, HostError> {
         {
@@ -1786,12 +1790,9 @@ impl<'a> LoopDelegate for JobDelegate<'a> {
         }
 
         // Add assistant message with tool_calls (OpenAI protocol)
-        reason_ctx
-            .messages
-            .push(ChatMessage::assistant_with_tool_calls(
-                content,
-                tool_calls.clone(),
-            ));
+        reason_ctx.messages.push(
+            ChatMessage::assistant_with_tool_calls(content, tool_calls.clone()).with_usage(usage),
+        );
 
         // Convert to ToolSelections
         let selections: Vec<ToolSelection> = tool_calls
@@ -2464,6 +2465,7 @@ mod tests {
             .handle_text_response(
                 "Weekly review created in Notion and notification sent.",
                 ResponseMetadata::default(),
+                dasclaw_core::TokenUsage::default(),
                 &mut reason_ctx,
             )
             .await;

--- a/desktop-client/ironclaw/tests/parity_harness.rs
+++ b/desktop-client/ironclaw/tests/parity_harness.rs
@@ -121,6 +121,7 @@ impl LoopDelegate for ParityDelegate {
         &self,
         text: &str,
         _metadata: ResponseMetadata,
+        _usage: dasclaw_core::TokenUsage,
         _reason_ctx: &mut ReasoningContext,
     ) -> TextAction {
         TextAction::Return(LoopOutcome::Response(text.to_string()))
@@ -130,6 +131,7 @@ impl LoopDelegate for ParityDelegate {
         &self,
         tool_calls: Vec<ToolCall>,
         _content: Option<String>,
+        _usage: dasclaw_core::TokenUsage,
         reason_ctx: &mut ReasoningContext,
     ) -> Result<Option<LoopOutcome>, dasclaw_core::HostError> {
         for tc in &tool_calls {


### PR DESCRIPTION
## 背景/目标

#929 收官刀(step 3 of 3):把 `ChatMessage.tool_error` 和 `ChatMessage.usage` 真正写到 claw-code 兼容的 `session.jsonl` 落盘形态上。在此之前 `claw_compat::chat_message_to_claw` 把 `is_error` 硬编码为 `false`,反向转换里 `is_error: _` 直接丢弃,`usage` 字段则根本不在 `ClawMessage` 上 —— 这一刀把这三个洞同时补上。

Stacked on **PR #931** (#929 step 1)。与并行的 PR #932 (#929 step 2) 零文件重叠。

## Sources read

- [AGENTS.md](AGENTS.md)
- [crates/dasclaw_session/src/claw_compat.rs](crates/dasclaw_session/src/claw_compat.rs) — 桥接现状(`is_error: false`、`is_error: _`、缺 `usage`)
- [crates/dasclaw_session/tests/claw_compat.rs](crates/dasclaw_session/tests/claw_compat.rs) — 已有 D1 round-trip 套件
- [crates/dasclaw_core/src/messages.rs](crates/dasclaw_core/src/messages.rs) — step 1 落地的 `ChatMessage.tool_error` / `usage` / `TokenUsage` 字段顺序
- [claw-code/rust/crates/runtime/src/session.rs](claw-code/rust/crates/runtime/src/session.rs) — 上游 `ConversationMessage.to_json` / `usage_to_json` 字段集与命名
- [crates/dasclaw_session/tests/jsonl_wire.rs](crates/dasclaw_session/tests/jsonl_wire.rs) + snapshot — 现有 jsonl wire 锁定

## 改动范围

### `crates/dasclaw_session/src/claw_compat.rs`
- 导入新增 `dasclaw_core::messages::TokenUsage`。
- `ClawMessage` 新增 `pub usage: Option<TokenUsage>`,带 `#[serde(default, skip_serializing_if = "Option::is_none")]`,wire 形态对齐上游 `ConversationMessage` 的可选 `usage` 字段(同名同字段集)。
- `chat_message_to_claw`:
  - Assistant 两支(纯文本 / 带 tool_calls)都把 `message.usage` 透传到 `ClawMessage.usage`。
  - System / User / Tool 强制 `usage: None`(语义上不属于这些 role)。
  - Tool 支的 `is_error` 改为 `message.tool_error.unwrap_or(false)` —— `None` 时 Fail-Safe 落 `false`(claw wire schema 必填 bool),`Some(b)` 忠实保留。
- `claw_to_chat_message`:
  - Tool 支:不再 `is_error: _` 丢弃,改为 `msg.tool_error = Some(*is_error)`。
  - 其他支:`usage: message.usage`,复用上游记录的 token 数。
- rustdoc 同步更新,把"is_error 当前固定 false"那段陈年 TODO 删掉。

### `crates/dasclaw_session/tests/claw_compat.rs`
新增 5 个 #929 round-trip / wire 兼容测试:
- `req_dasclaw_session_929_tool_error_round_trips` —— `Some(true)` 全程无损。
- `req_dasclaw_session_929_tool_result_unspecified_error_flattens_to_false` —— 显式记录"`None → false` 落盘 → 读回为 `Some(false)`"是前进了一步而非数据丢失。
- `req_dasclaw_session_929_assistant_usage_round_trips` —— 顺手断言 wire 上 `usage` 对象用的是 claw-code 那 4 个字段名(`input_tokens` / `output_tokens` / `cache_creation_input_tokens` / `cache_read_input_tokens`)。
- `req_dasclaw_session_929_assistant_without_usage_omits_field_on_wire` —— 反向证明 `skip_serializing_if` 生效,旧 session 文件 wire 形态不变(向后兼容)。
- `req_dasclaw_session_929_assistant_usage_wire_parses_back` —— 手写 claw-code 形态 JSON 能解析回 `ClawMessage.usage`。

### 不动的东西
- 现有 `jsonl_wire__jsonl_wire_format_is_stable.snap` 快照**无需更新** —— 该 fixture 用的 `ChatMessage::user("ping")` / `ChatMessage::assistant("pong")` 都没碰 `usage` / `tool_error`,新增字段 `skip_if_none`,wire 字节级零变化。本地已验证 50/50 测试通过。

## 非目标

- ❌ 不改 jsonl session 文件的 `session_meta` / `message` 框架(record discriminants 不变)。
- ❌ 不修改 `SessionSnapshot` 字段集(顶层无 cumulative usage 字段,沿用 claw-code 上游"usage 挂在每条 message 上"的做法)。
- ❌ 不动 LLM provider adapter —— `CompletionResponse.usage` 已在 step 2 (#932) 流通过 agentic loop。
- ❌ 不引入 cost / billing 业务逻辑。

## 验证

```bash
cargo check -p dasclaw_session --tests                                          # 0 错 0 警
cargo nextest run -p dasclaw_session --no-fail-fast                             # 50/50 通过(含原 jsonl_wire 快照不变)
cargo clippy --no-deps -p dasclaw_session --all-targets -- -D warnings          # 0 警
cargo fmt --all                                                                  # clean
python3.12 scripts/check_no_panics.py --base origin/xClaw                        # OK
```

3 层 skill 审查(code-quality-audit → code-simplifier → code-review-expert):**APPROVE**,无 P0 / P1 / P2,wire 与上游 `ConversationMessage` 字段集逐项核对一致。

## Stacked 提示

本 PR base = **`feat/929-chatmessage-tool-error-usage`** (PR #931)。
- merge 顺序建议:#931 → #932 → 本 PR(三者全部 stacked on #931;本 PR 与 #932 零文件重叠,可独立 review)。
- #931 已 rebase 到最新 xClaw(包含 #927 的 `claw_compat.rs`),force-with-lease push 完成。

## Cross-cuts

- ADR-114(`.ironclaw` → `.dasclaw` 命名迁移):**类A** —— 本 PR 无新增 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量。

Closes #936
Closes #929
Refs #929 (step 3 of 3, closes the loop)

