### PR TITLE
feat(runtime): expose streaming entry on Agent facade (Agent::run_streaming, GUI blocker B2)

### DIFF
--- a/crates/dasclaw_runtime/src/agent.rs
+++ b/crates/dasclaw_runtime/src/agent.rs
@@ -49,23 +49,107 @@ use dasclaw_core::agentic_loop::{
 };
 use dasclaw_core::egress_apply::{EgressApply, apply_egress_decision};
 use dasclaw_core::hooks::{EgressKind, HookBundle};
-use dasclaw_core::messages::{ChatMessage, ToolCall, ToolDefinition, ToolResult};
+use dasclaw_core::messages::{ChatMessage, FinishReason, ToolCall, ToolDefinition, ToolResult};
 use dasclaw_core::reasoning_ctx::ReasoningContext;
-use dasclaw_core::response_types::{RespondOutput, ResponseMetadata};
+use dasclaw_core::response_types::{RespondOutput, RespondResult, ResponseMetadata};
 use dasclaw_core::traits::HostError;
 use serde::{Deserialize, Serialize};
+use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
+
+/// Streaming event emitted by [`Agent::run_streaming`] and
+/// [`crate::Session::run_streaming`] (issue #908, GUI blocker B2).
+///
+/// One event per observable step in the agentic loop:
+///
+/// - [`AgentEvent::TextChunk`] — a fragment of model output as it
+///   arrives from the LLM. For providers without true token streaming
+///   the chunk arrives in a single piece; consumers should not depend
+///   on a particular chunk size.
+/// - [`AgentEvent::ToolCallStart`] — the model asked to invoke a tool;
+///   emitted before [`ToolExecutor::execute`] runs.
+/// - [`AgentEvent::ToolResult`] — the tool finished; payload is the
+///   sanitized content that the **next** LLM iteration will see in its
+///   `tool_result` block (post-egress, post-sanitizer).
+/// - [`AgentEvent::FinishReason`] — one per LLM iteration boundary,
+///   carrying the model's stop reason. Use it to render "stopped",
+///   "needs tool", etc. in a GUI.
+///
+/// Wire format is adjacent-tagged JSON
+/// (`{"kind": "text_chunk", "data": "..."}`) so a TypeScript discriminated
+/// union renders directly from `serde_json::to_string(&event)`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "kind", content = "data", rename_all = "snake_case")]
+pub enum AgentEvent {
+    /// A fragment of model text output.
+    TextChunk(String),
+    /// The model requested a tool invocation.
+    ToolCallStart {
+        /// Tool name as emitted by the model.
+        name: String,
+        /// Tool arguments as raw JSON.
+        arguments: serde_json::Value,
+    },
+    /// A tool finished; `content` is the post-sanitization payload that
+    /// is fed back into the next LLM iteration.
+    ToolResult {
+        /// Tool name as it appeared in the matching
+        /// [`AgentEvent::ToolCallStart`].
+        name: String,
+        /// Sanitized tool output that the LLM will see next iteration.
+        content: String,
+        /// `true` when the executor returned an error tool_result or the
+        /// egress gate replaced the content with a `[redacted: …]`
+        /// placeholder.
+        is_error: bool,
+    },
+    /// Stop reason for the LLM iteration that just ended.
+    FinishReason(FinishReason),
+}
 
 /// Narrow LLM seam used by [`Agent`].
 ///
 /// Adapters wrap a concrete LLM client (`dasclaw_llm_provider`, a mock,
 /// a recorder, …) and translate from the provider-native response into a
-/// [`RespondOutput`]. The runtime calls `respond` once per iteration of
-/// the agentic loop.
+/// [`RespondOutput`]. The runtime calls [`Self::respond`] once per
+/// iteration of the agentic loop in non-streaming mode, and
+/// [`Self::respond_streaming`] when the host wants token-level events.
 #[async_trait]
 pub trait AgentResponder: Send + Sync {
     /// Produce the next response for the given context.
     async fn respond(&self, ctx: &mut ReasoningContext) -> Result<RespondOutput, HostError>;
+
+    /// Streaming-aware variant used by [`Agent::run_streaming`]
+    /// (issue #908, GUI blocker B2).
+    ///
+    /// `event_tx` is the same channel the agent loop forwards
+    /// [`AgentEvent`]s on. Implementations emit one or more
+    /// [`AgentEvent::TextChunk`] events as the model produces text and
+    /// then return the final [`RespondOutput`] so the loop can dispatch
+    /// to tool execution or finish.
+    ///
+    /// The default implementation calls [`Self::respond`] and forwards
+    /// the final text (if any) as a single chunk, so every existing
+    /// adapter stays wire-compatible without code changes. Adapters
+    /// backed by streaming providers (`LlmProviderResponder`) override
+    /// this method to forward token-level deltas as they arrive.
+    ///
+    /// `ToolCallStart`, `ToolResult` and `FinishReason` events are emitted
+    /// by the agent loop itself — implementations should only emit
+    /// [`AgentEvent::TextChunk`].
+    async fn respond_streaming(
+        &self,
+        ctx: &mut ReasoningContext,
+        event_tx: mpsc::Sender<AgentEvent>,
+    ) -> Result<RespondOutput, HostError> {
+        let out = self.respond(ctx).await?;
+        if let RespondResult::Text(ref text) = out.result {
+            // Drop on closed channel is fine: the consumer hung up, but
+            // the loop still needs to return the full RespondOutput.
+            let _ = event_tx.send(AgentEvent::TextChunk(text.clone())).await;
+        }
+        Ok(out)
+    }
 }
 
 /// Narrow tool-execution seam used by [`Agent`] (ADR-153 step 2 sub-step A2).
@@ -340,6 +424,41 @@ impl Agent {
         ctx: &mut ReasoningContext,
         prompt: &str,
     ) -> Result<String, AgentError> {
+        self.run_in_context_inner(ctx, prompt, None).await
+    }
+
+    /// Streaming variant of [`Agent::run_in_context`] (issue #908).
+    ///
+    /// Events are forwarded to `event_tx` in the order they happen:
+    /// [`AgentEvent::TextChunk`] from the responder, then
+    /// [`AgentEvent::FinishReason`] at each iteration boundary, with
+    /// [`AgentEvent::ToolCallStart`] / [`AgentEvent::ToolResult`]
+    /// interleaved when the model calls tools. On return the agent's
+    /// final assistant turn is also recorded in `ctx` so a
+    /// [`crate::Session`] picks up the history exactly as it does for
+    /// non-streaming runs.
+    ///
+    /// Part of the same support API as [`Agent::seed_context`].
+    pub async fn run_in_context_streaming(
+        &self,
+        ctx: &mut ReasoningContext,
+        prompt: &str,
+        event_tx: mpsc::Sender<AgentEvent>,
+    ) -> Result<String, AgentError> {
+        self.run_in_context_inner(ctx, prompt, Some(event_tx)).await
+    }
+
+    /// Shared loop driver for both streaming and non-streaming runs.
+    /// The single `event_tx: Option<...>` field on [`HeadlessDelegate`]
+    /// routes each iteration to [`AgentResponder::respond_streaming`] or
+    /// [`AgentResponder::respond`] and gates the `ToolCallStart` /
+    /// `ToolResult` / `FinishReason` emits.
+    async fn run_in_context_inner(
+        &self,
+        ctx: &mut ReasoningContext,
+        prompt: &str,
+        event_tx: Option<mpsc::Sender<AgentEvent>>,
+    ) -> Result<String, AgentError> {
         ctx.messages.push(ChatMessage::user(prompt));
 
         let loop_config = self
@@ -355,6 +474,7 @@ impl Agent {
             hooks: self.hooks.clone(),
             tool_output_sanitizer: self.tool_output_sanitizer.clone(),
             cancellation_token: self.cancellation_token.clone(),
+            event_tx,
         };
 
         let outcome = run_agentic_loop(&delegate, ctx, &loop_config, &self.hooks)
@@ -382,6 +502,24 @@ impl Agent {
         let mut ctx = ReasoningContext::new();
         self.seed_context(&mut ctx);
         self.run_in_context(&mut ctx, prompt).await
+    }
+
+    /// Streaming variant of [`Agent::run`] (issue #908, GUI blocker B2).
+    ///
+    /// Drives one user prompt through the loop while forwarding
+    /// [`AgentEvent`]s on `event_tx`. Returns the final assistant text
+    /// (the concatenation of every [`AgentEvent::TextChunk`] from the
+    /// last iteration), matching [`Agent::run`]'s contract so callers
+    /// can opt into streaming without changing their result handling.
+    pub async fn run_streaming(
+        &self,
+        prompt: &str,
+        event_tx: mpsc::Sender<AgentEvent>,
+    ) -> Result<String, AgentError> {
+        let mut ctx = ReasoningContext::new();
+        self.seed_context(&mut ctx);
+        self.run_in_context_streaming(&mut ctx, prompt, event_tx)
+            .await
     }
 }
 
@@ -525,12 +663,29 @@ impl AgentBuilder {
 /// context with the user prompt, system prompt, model override and
 /// advertised tools before the loop starts, so the delegate only needs
 /// the responder and an optional tool executor.
+///
+/// When `event_tx` is `Some`, the delegate routes each iteration through
+/// [`AgentResponder::respond_streaming`] and forwards
+/// [`AgentEvent::ToolCallStart`], [`AgentEvent::ToolResult`] and
+/// [`AgentEvent::FinishReason`] events to the host (issue #908, GUI
+/// blocker B2). When `None`, the delegate behaves exactly like the
+/// pre-#908 non-streaming path.
 struct HeadlessDelegate {
     responder: Arc<dyn AgentResponder>,
     tool_executor: Option<Arc<dyn ToolExecutor>>,
     hooks: HookBundle,
     tool_output_sanitizer: Option<Arc<dyn ToolOutputSanitizer>>,
     cancellation_token: Option<CancellationToken>,
+    event_tx: Option<mpsc::Sender<AgentEvent>>,
+}
+
+impl HeadlessDelegate {
+    /// Best-effort emit; a closed receiver is not a loop-fatal error.
+    async fn emit(&self, event: AgentEvent) {
+        if let Some(tx) = self.event_tx.as_ref() {
+            let _ = tx.send(event).await;
+        }
+    }
 }
 
 #[async_trait]
@@ -555,7 +710,19 @@ impl LoopDelegate for HeadlessDelegate {
         ctx: &mut ReasoningContext,
         _iteration: usize,
     ) -> Result<RespondOutput, HostError> {
-        self.responder.respond(ctx).await
+        // Streaming and non-streaming routes split at the responder
+        // seam: when an event channel is wired we go through
+        // `respond_streaming`, which the default trait impl falls back
+        // to `respond` for adapters that don't override it. Either way
+        // we forward the trailing `FinishReason` so a GUI knows the
+        // iteration boundary even when the model emitted no text.
+        let output = match self.event_tx.as_ref() {
+            Some(tx) => self.responder.respond_streaming(ctx, tx.clone()).await?,
+            None => self.responder.respond(ctx).await?,
+        };
+        self.emit(AgentEvent::FinishReason(output.finish_reason))
+            .await;
+        Ok(output)
     }
 
     async fn handle_text_response(
@@ -584,6 +751,18 @@ impl LoopDelegate for HeadlessDelegate {
 
         push_assistant_tool_calls(ctx, content, &tool_calls);
         for call in &tool_calls {
+            // Streaming hosts learn the tool name + arguments as soon as
+            // the loop commits to invoking the tool, before any egress
+            // gate runs. The post-egress sanitized payload is forwarded
+            // in the matching `ToolResult` event below, so a redacted
+            // arguments preview stays consistent with what the LLM sees
+            // next iteration.
+            self.emit(AgentEvent::ToolCallStart {
+                name: call.name.clone(),
+                arguments: call.arguments.clone(),
+            })
+            .await;
+
             // ADR-148 Layer B + ADR-153 §1.1 e8/A2:
             // Pre-execute egress gate scans serialised tool arguments.
             // `Block` → executor is never invoked; an is_error
@@ -606,10 +785,17 @@ impl LoopDelegate for HeadlessDelegate {
                 let error_body = format!("Error: {reason}");
                 ctx.messages
                     .push(ChatMessage::tool_result(&call.id, &call.name, &error_body));
+                self.emit(AgentEvent::ToolResult {
+                    name: call.name.clone(),
+                    content: error_body,
+                    is_error: true,
+                })
+                .await;
                 continue;
             }
 
             let result = executor.execute(call).await?;
+            let executor_is_error = result.is_error;
 
             // ADR-148 Layer B + ADR-153 §1.1 e15/A9:
             // Post-execute egress gate sanitises tool output before it
@@ -623,15 +809,15 @@ impl LoopDelegate for HeadlessDelegate {
                 .egress
                 .check(&EgressKind::UserDisplay, &content_buf)
                 .await;
-            let post_gate_content = match apply_egress_decision(
+            let (post_gate_content, gate_halted) = match apply_egress_decision(
                 decision,
                 &mut content_buf,
                 &post_label,
             ) {
-                EgressApply::Continue => content_buf,
+                EgressApply::Continue => (content_buf, false),
                 EgressApply::Halt(reason) => {
                     tracing::warn!(tool = %result.name, %reason, "egress gate blocked tool output");
-                    format!("[redacted: {reason}]")
+                    (format!("[redacted: {reason}]"), true)
                 }
             };
 
@@ -649,6 +835,12 @@ impl LoopDelegate for HeadlessDelegate {
                 &result.name,
                 &pushed_content,
             ));
+            self.emit(AgentEvent::ToolResult {
+                name: result.name.clone(),
+                content: pushed_content,
+                is_error: executor_is_error || gate_halted,
+            })
+            .await;
         }
         Ok(None)
     }
@@ -934,5 +1126,212 @@ mod tests {
             .expect("build");
         let err = agent.run("hi").await.unwrap_err();
         assert!(matches!(err, AgentError::ToolsNotSupported), "got {err:?}");
+    }
+
+    // -----------------------------------------------------------------
+    // Issue #908 — Agent::run_streaming (GUI blocker B2)
+    // -----------------------------------------------------------------
+
+    /// Responder that emits a fixed list of text chunks via
+    /// `respond_streaming` and returns the concatenation as the final
+    /// `RespondOutput`. Mirrors how `LlmProviderResponder` will forward
+    /// real provider chunks at the seam.
+    struct ChunkedResponder {
+        chunks: Vec<String>,
+    }
+
+    #[async_trait]
+    impl AgentResponder for ChunkedResponder {
+        async fn respond(&self, _ctx: &mut ReasoningContext) -> Result<RespondOutput, HostError> {
+            Ok(text_output(&self.chunks.concat()))
+        }
+
+        async fn respond_streaming(
+            &self,
+            _ctx: &mut ReasoningContext,
+            event_tx: mpsc::Sender<AgentEvent>,
+        ) -> Result<RespondOutput, HostError> {
+            for chunk in &self.chunks {
+                event_tx
+                    .send(AgentEvent::TextChunk(chunk.clone()))
+                    .await
+                    .expect("event_rx alive");
+            }
+            Ok(text_output(&self.chunks.concat()))
+        }
+    }
+
+    #[tokio::test]
+    async fn req_dasclaw_runtime_agent_b2_run_streaming_orders_chunks_and_finish() {
+        let responder = ChunkedResponder {
+            chunks: ["Hel", "lo, ", "wor", "ld", "!"]
+                .into_iter()
+                .map(String::from)
+                .collect(),
+        };
+        let agent = Agent::builder()
+            .responder(responder)
+            .build()
+            .expect("build");
+
+        let (tx, mut rx) = mpsc::channel::<AgentEvent>(16);
+        let final_text = agent.run_streaming("hi", tx).await.expect("run");
+
+        let mut events = Vec::new();
+        while let Some(ev) = rx.recv().await {
+            events.push(ev);
+        }
+
+        assert_eq!(events.len(), 6, "5 TextChunk + 1 FinishReason: {events:?}");
+        let chunks: Vec<&str> = events
+            .iter()
+            .filter_map(|e| match e {
+                AgentEvent::TextChunk(s) => Some(s.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(chunks, vec!["Hel", "lo, ", "wor", "ld", "!"]);
+        assert!(
+            matches!(
+                events.last(),
+                Some(AgentEvent::FinishReason(FinishReason::Stop))
+            ),
+            "last must be FinishReason::Stop: {events:?}"
+        );
+        assert_eq!(final_text, chunks.join(""));
+    }
+
+    #[tokio::test]
+    async fn req_dasclaw_runtime_agent_b2_run_streaming_default_impl_falls_back_to_respond() {
+        // A responder that doesn't override `respond_streaming` must
+        // still surface its final text as a single `TextChunk`
+        // courtesy of the default trait impl. This is what guarantees
+        // pre-#908 adapters keep working untouched.
+        let responder = ScriptedResponder::new(vec![text_output("one shot")]);
+        let agent = Agent::builder()
+            .responder(responder)
+            .build()
+            .expect("build");
+
+        let (tx, mut rx) = mpsc::channel::<AgentEvent>(4);
+        let final_text = agent.run_streaming("hi", tx).await.expect("run");
+
+        let mut events = Vec::new();
+        while let Some(ev) = rx.recv().await {
+            events.push(ev);
+        }
+        assert_eq!(
+            events,
+            vec![
+                AgentEvent::TextChunk("one shot".to_string()),
+                AgentEvent::FinishReason(FinishReason::Stop),
+            ]
+        );
+        assert_eq!(final_text, "one shot");
+    }
+
+    #[tokio::test]
+    async fn req_dasclaw_runtime_agent_b2_run_streaming_emits_tool_events_in_order() {
+        // First iteration → tool call; second iteration → final text.
+        // Expected event order:
+        //   FinishReason::ToolUse        (iter 1 LLM)
+        //   ToolCallStart { name=echo }  (loop wires tool)
+        //   ToolResult   { name=echo }   (executor finished)
+        //   TextChunk("all done")        (iter 2 LLM streaming chunk)
+        //   FinishReason::Stop           (iter 2 LLM)
+        let responder = ScriptedResponder::new(vec![
+            tool_call_output_named("echo", "call_1"),
+            text_output("all done"),
+        ]);
+        let executor = ScriptedExecutor::new("echo result");
+        let agent = Agent::builder()
+            .responder(responder)
+            .tool_executor(executor)
+            .tools(vec![ToolDefinition {
+                name: "echo".into(),
+                description: "echo".into(),
+                parameters: serde_json::json!({"type": "object"}),
+            }])
+            .build()
+            .expect("build");
+
+        let (tx, mut rx) = mpsc::channel::<AgentEvent>(16);
+        let final_text = agent.run_streaming("call echo", tx).await.expect("run");
+
+        let mut events = Vec::new();
+        while let Some(ev) = rx.recv().await {
+            events.push(ev);
+        }
+
+        assert!(
+            matches!(
+                events.first(),
+                Some(AgentEvent::FinishReason(FinishReason::ToolUse))
+            ),
+            "first event = ToolUse FinishReason: {events:?}"
+        );
+        let tool_start_idx = events
+            .iter()
+            .position(|e| matches!(e, AgentEvent::ToolCallStart { name, .. } if name == "echo"))
+            .expect("ToolCallStart missing");
+        let tool_result_idx = events
+            .iter()
+            .position(|e| matches!(e, AgentEvent::ToolResult { name, content, is_error: false } if name == "echo" && content == "echo result"))
+            .expect("ToolResult missing");
+        assert!(
+            tool_start_idx < tool_result_idx,
+            "ToolCallStart must precede ToolResult: {events:?}"
+        );
+        assert!(
+            matches!(
+                events.last(),
+                Some(AgentEvent::FinishReason(FinishReason::Stop))
+            ),
+            "last event = Stop FinishReason: {events:?}"
+        );
+        assert_eq!(final_text, "all done");
+    }
+
+    #[tokio::test]
+    async fn req_dasclaw_runtime_agent_b2_run_streaming_serializes_to_adjacent_tagged_json() {
+        // Wire format guard: AgentEvent uses adjacent-tagged JSON so a
+        // TypeScript discriminated union renders directly. Pin the
+        // four variants so we notice if anything reshapes the wire.
+        let chunks = vec![
+            AgentEvent::TextChunk("hi".into()),
+            AgentEvent::ToolCallStart {
+                name: "echo".into(),
+                arguments: serde_json::json!({"x": 1}),
+            },
+            AgentEvent::ToolResult {
+                name: "echo".into(),
+                content: "ok".into(),
+                is_error: false,
+            },
+            AgentEvent::FinishReason(FinishReason::Stop),
+        ];
+        let json: Vec<String> = chunks
+            .iter()
+            .map(|c| serde_json::to_string(c).expect("serialize"))
+            .collect();
+        assert_eq!(json[0], r#"{"kind":"text_chunk","data":"hi"}"#);
+        assert!(
+            json[1].starts_with(r#"{"kind":"tool_call_start","data":{"name":"echo""#),
+            "got {}",
+            json[1]
+        );
+        assert!(
+            json[2].contains(r#""kind":"tool_result""#) && json[2].contains(r#""is_error":false"#),
+            "got {}",
+            json[2]
+        );
+        assert_eq!(json[3], r#"{"kind":"finish_reason","data":"stop"}"#);
+
+        // Round-trip every variant.
+        for original in chunks {
+            let s = serde_json::to_string(&original).expect("ser");
+            let back: AgentEvent = serde_json::from_str(&s).expect("de");
+            assert_eq!(back, original);
+        }
     }
 }

--- a/crates/dasclaw_runtime/src/lib.rs
+++ b/crates/dasclaw_runtime/src/lib.rs
@@ -79,7 +79,8 @@ pub mod tool;
 pub mod tool_to_executor_adapter;
 
 pub use agent::{
-    Agent, AgentBuilder, AgentConfig, AgentError, AgentResponder, ToolExecutor, ToolOutputSanitizer,
+    Agent, AgentBuilder, AgentConfig, AgentError, AgentEvent, AgentResponder, ToolExecutor,
+    ToolOutputSanitizer,
 };
 pub use composite_executor::{CompositeError, CompositeToolExecutor};
 pub use error::ToolError;

--- a/crates/dasclaw_runtime/src/llm_adapter.rs
+++ b/crates/dasclaw_runtime/src/llm_adapter.rs
@@ -36,8 +36,9 @@ use dasclaw_core::reasoning_ctx::ReasoningContext;
 use dasclaw_core::response_types::{RespondOutput, RespondResult, ResponseMetadata, TokenUsage};
 use dasclaw_core::traits::HostError;
 use dasclaw_llm_provider::provider::provider::LlmProvider;
+use tokio::sync::mpsc;
 
-use crate::agent::AgentResponder;
+use crate::agent::{AgentEvent, AgentResponder};
 
 /// Adapt any [`LlmProvider`] into an [`AgentResponder`].
 ///
@@ -62,20 +63,72 @@ impl<P: LlmProvider> LlmProviderResponder<P> {
 #[async_trait]
 impl<P: LlmProvider + 'static> AgentResponder for LlmProviderResponder<P> {
     async fn respond(&self, ctx: &mut ReasoningContext) -> Result<RespondOutput, HostError> {
-        let mut messages = ctx.messages.clone();
-        sanitize_tool_messages(&mut messages);
-
-        let mut request = ToolCompletionRequest::new(messages, ctx.available_tools.clone());
-        if let Some(model) = ctx.model_override.as_ref() {
-            request = request.with_model(model);
-        }
-        if !ctx.metadata.is_empty() {
-            request.metadata = ctx.metadata.clone();
-        }
-
+        let request = build_request(ctx);
         let response = self.provider.complete_with_tools(request).await?;
         Ok(map_to_respond_output(response))
     }
+
+    /// Forward token-level text deltas to `event_tx` while the
+    /// underlying provider streams the response (issue #908).
+    ///
+    /// We bridge the provider's `UnboundedSender<String>` chunk channel
+    /// onto the agent-level `mpsc::Sender<AgentEvent>` via a forwarder
+    /// task: the LLM call only finishes once the provider closes its
+    /// chunk sender, so the forwarder always drains to completion. A
+    /// closed `event_tx` (consumer hung up) is treated as best-effort —
+    /// we keep draining the LLM chunks to avoid stalling the provider's
+    /// underlying SSE stream.
+    async fn respond_streaming(
+        &self,
+        ctx: &mut ReasoningContext,
+        event_tx: mpsc::Sender<AgentEvent>,
+    ) -> Result<RespondOutput, HostError> {
+        let request = build_request(ctx);
+        let (chunk_tx, mut chunk_rx) = mpsc::unbounded_channel::<String>();
+
+        // Forwarder runs concurrently with `complete_with_tools_stream`:
+        // the provider call won't return until it closes `chunk_tx`, at
+        // which point `chunk_rx` yields `None` and the forwarder exits.
+        let forwarder = tokio::spawn(async move {
+            while let Some(chunk) = chunk_rx.recv().await {
+                if event_tx.send(AgentEvent::TextChunk(chunk)).await.is_err() {
+                    // Consumer hung up — drain the rest silently so
+                    // the provider stream isn't back-pressured.
+                    while chunk_rx.recv().await.is_some() {}
+                    break;
+                }
+            }
+        });
+
+        let response = self
+            .provider
+            .complete_with_tools_stream(request, chunk_tx)
+            .await;
+        // Whether the call succeeded or failed, wait for the forwarder
+        // to drain so all already-sent chunks reach `event_tx` before
+        // the caller observes the FinishReason event in `call_llm`.
+        let _ = forwarder.await;
+        Ok(map_to_respond_output(response?))
+    }
+}
+
+/// Build a [`ToolCompletionRequest`] from the agent's reasoning context.
+///
+/// Extracted out of [`AgentResponder::respond`] so the streaming
+/// variant produces a byte-identical request — keeping the two paths in
+/// sync without duplicating the message-sanitisation rules.
+fn build_request(ctx: &ReasoningContext) -> ToolCompletionRequest {
+    let mut messages = ctx.messages.clone();
+    sanitize_tool_messages(&mut messages);
+
+    let mut request = ToolCompletionRequest::new(messages, ctx.available_tools.clone());
+    if let Some(model) = ctx.model_override.as_ref() {
+        request = request.with_model(model);
+    }
+    if !ctx.metadata.is_empty() {
+        request.metadata = ctx.metadata.clone();
+    }
+    request
 }
 
 /// Translate a provider [`ToolCompletionResponse`] into the
@@ -262,5 +315,80 @@ mod tests {
             _ => panic!("expected ToolCalls"),
         }
         assert_eq!(output.finish_reason, FinishReason::ToolUse);
+    }
+
+    /// Provider that overrides the streaming entry point with a real
+    /// chunked emission so we can verify the adapter forwards every
+    /// chunk on `event_tx` and still returns the full `RespondOutput`.
+    struct StreamingMockProvider {
+        chunks: Vec<String>,
+    }
+
+    #[async_trait]
+    impl LlmProvider for StreamingMockProvider {
+        fn model_name(&self) -> &str {
+            "mock-stream"
+        }
+
+        fn cost_per_token(&self) -> (Decimal, Decimal) {
+            (Decimal::ZERO, Decimal::ZERO)
+        }
+
+        async fn complete(
+            &self,
+            _request: CompletionRequest,
+        ) -> Result<CompletionResponse, LlmError> {
+            unreachable!()
+        }
+
+        async fn complete_with_tools(
+            &self,
+            _request: ToolCompletionRequest,
+        ) -> Result<ToolCompletionResponse, LlmError> {
+            unreachable!("streaming path should be exercised")
+        }
+
+        fn supports_streaming(&self) -> bool {
+            true
+        }
+
+        async fn complete_with_tools_stream(
+            &self,
+            _request: ToolCompletionRequest,
+            chunk_tx: tokio::sync::mpsc::UnboundedSender<String>,
+        ) -> Result<ToolCompletionResponse, LlmError> {
+            for chunk in &self.chunks {
+                // A closed receiver shouldn't block real providers either.
+                let _ = chunk_tx.send(chunk.clone());
+            }
+            Ok(text_response(&self.chunks.concat()))
+        }
+    }
+
+    #[tokio::test]
+    async fn req_dasclaw_runtime_agent_b2_adapter_respond_streaming_forwards_chunks() {
+        let provider = Arc::new(StreamingMockProvider {
+            chunks: vec!["foo ".into(), "bar ".into(), "baz".into()],
+        });
+        let responder = LlmProviderResponder::new(Arc::clone(&provider));
+        let mut ctx = ReasoningContext::new();
+        ctx.messages.push(ChatMessage::user("hi"));
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<crate::AgentEvent>(16);
+        let output = responder.respond_streaming(&mut ctx, tx).await.unwrap();
+
+        let mut got = Vec::new();
+        while let Some(ev) = rx.recv().await {
+            match ev {
+                crate::AgentEvent::TextChunk(s) => got.push(s),
+                other => panic!("unexpected event from adapter: {other:?}"),
+            }
+        }
+        assert_eq!(got, vec!["foo ", "bar ", "baz"]);
+
+        match output.result {
+            RespondResult::Text(t) => assert_eq!(t, "foo bar baz"),
+            _ => panic!("expected Text"),
+        }
     }
 }

--- a/crates/dasclaw_session/src/lib.rs
+++ b/crates/dasclaw_session/src/lib.rs
@@ -25,7 +25,6 @@
 //!
 //! - **No fork / compaction** — see issue #914 PR-D.
 //! - **No prompt_history** — see issue #914 PR-D.
-//! - **No streaming** — see issue B2.
 //! - **No on-disk store** — see issue #914 PR-C.
 //!
 //! ## Example
@@ -78,7 +77,8 @@ use std::sync::Arc;
 
 use dasclaw_core::messages::ChatMessage;
 use dasclaw_core::reasoning_ctx::ReasoningContext;
-use dasclaw_runtime::{Agent, AgentError};
+use dasclaw_runtime::{Agent, AgentError, AgentEvent};
+use tokio::sync::mpsc;
 
 /// Stateful, multi-turn conversation handle around an [`Agent`].
 ///
@@ -172,6 +172,35 @@ impl Session {
         ctx.messages = std::mem::take(&mut self.state.messages);
 
         let result = self.agent.run_in_context(&mut ctx, prompt).await;
+
+        self.state.messages = std::mem::take(&mut ctx.messages);
+        if result.is_ok() {
+            self.state.touch();
+        }
+        result
+    }
+
+    /// Streaming variant of [`Session::run`] (issue #908, GUI blocker
+    /// B2). Replays the session's prior messages into a fresh
+    /// [`ReasoningContext`] and delegates to
+    /// [`Agent::run_in_context_streaming`], forwarding [`AgentEvent`]s
+    /// on `event_tx` as the agentic loop progresses. The final
+    /// assistant text is appended to the session snapshot on success,
+    /// matching [`Session::run`]'s history-shape contract so callers
+    /// can mix streaming and non-streaming turns freely.
+    pub async fn run_streaming(
+        &mut self,
+        prompt: &str,
+        event_tx: mpsc::Sender<AgentEvent>,
+    ) -> Result<String, AgentError> {
+        let mut ctx = ReasoningContext::new();
+        self.agent.seed_context(&mut ctx);
+        ctx.messages = std::mem::take(&mut self.state.messages);
+
+        let result = self
+            .agent
+            .run_in_context_streaming(&mut ctx, prompt, event_tx)
+            .await;
 
         self.state.messages = std::mem::take(&mut ctx.messages);
         if result.is_ok() {

--- a/crates/dasclaw_session/tests/session_streaming.rs
+++ b/crates/dasclaw_session/tests/session_streaming.rs
@@ -1,0 +1,144 @@
+//! End-to-end tests for issue #908 / GUI blocker B2 on the
+//! [`Session::run_streaming`] facade.
+//!
+//! Coverage:
+//!
+//! 1. `Session::run_streaming` forwards every [`AgentEvent::TextChunk`]
+//!    the responder emits, in order, followed by exactly one
+//!    [`AgentEvent::FinishReason`], and returns the concatenated text
+//!    as the final reply.
+//! 2. The streaming turn is recorded in the session history exactly
+//!    like a non-streaming turn, so a follow-up `Session::run` sees
+//!    the prior assistant message.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use dasclaw_core::messages::FinishReason;
+use dasclaw_core::reasoning_ctx::ReasoningContext;
+use dasclaw_core::response_types::{RespondOutput, RespondResult, ResponseMetadata, TokenUsage};
+use dasclaw_core::traits::HostError;
+use dasclaw_runtime::{Agent, AgentEvent, AgentResponder};
+use dasclaw_session::Session;
+use tokio::sync::mpsc;
+
+/// Responder that emits a fixed list of chunks on the streaming path
+/// and the concatenation on the non-streaming path.
+struct ChunkedResponder {
+    chunks: Vec<&'static str>,
+}
+
+#[async_trait]
+impl AgentResponder for ChunkedResponder {
+    async fn respond(&self, _ctx: &mut ReasoningContext) -> Result<RespondOutput, HostError> {
+        Ok(RespondOutput {
+            result: RespondResult::Text(self.chunks.concat()),
+            usage: TokenUsage::default(),
+            finish_reason: FinishReason::Stop,
+            metadata: ResponseMetadata::default(),
+        })
+    }
+
+    async fn respond_streaming(
+        &self,
+        _ctx: &mut ReasoningContext,
+        event_tx: mpsc::Sender<AgentEvent>,
+    ) -> Result<RespondOutput, HostError> {
+        for chunk in &self.chunks {
+            event_tx
+                .send(AgentEvent::TextChunk((*chunk).to_string()))
+                .await
+                .expect("event_rx alive");
+        }
+        Ok(RespondOutput {
+            result: RespondResult::Text(self.chunks.concat()),
+            usage: TokenUsage::default(),
+            finish_reason: FinishReason::Stop,
+            metadata: ResponseMetadata::default(),
+        })
+    }
+}
+
+#[tokio::test]
+async fn req_dasclaw_session_b2_run_streaming_orders_chunks_and_finish() {
+    let agent = Arc::new(
+        Agent::builder()
+            .responder(ChunkedResponder {
+                chunks: vec!["He", "llo", ", ", "wor", "ld"],
+            })
+            .build()
+            .expect("build agent"),
+    );
+
+    let mut session = Session::new(agent);
+    let (tx, mut rx) = mpsc::channel::<AgentEvent>(16);
+    let reply = session
+        .run_streaming("greet me", tx)
+        .await
+        .expect("run_streaming");
+
+    let mut events = Vec::new();
+    while let Some(ev) = rx.recv().await {
+        events.push(ev);
+    }
+
+    let chunks: Vec<&str> = events
+        .iter()
+        .filter_map(|e| match e {
+            AgentEvent::TextChunk(s) => Some(s.as_str()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(chunks, vec!["He", "llo", ", ", "wor", "ld"]);
+    assert_eq!(events.len(), 6, "5 chunks + 1 finish_reason: {events:?}");
+    assert!(
+        matches!(
+            events.last(),
+            Some(AgentEvent::FinishReason(FinishReason::Stop))
+        ),
+        "last event must be FinishReason::Stop: {events:?}"
+    );
+    assert_eq!(reply, "Hello, world");
+}
+
+#[tokio::test]
+async fn req_dasclaw_session_b2_run_streaming_records_assistant_turn_in_history() {
+    // After a streaming turn, a follow-up non-streaming `run` must see
+    // the prior user prompt + assistant reply in the conversation
+    // history — same shape as two back-to-back `run` calls.
+    let agent = Arc::new(
+        Agent::builder()
+            .responder(ChunkedResponder {
+                chunks: vec!["hi", " there"],
+            })
+            .build()
+            .expect("build agent"),
+    );
+
+    let mut session = Session::new(agent);
+    let (tx, mut rx) = mpsc::channel::<AgentEvent>(8);
+    let first = session
+        .run_streaming("hello", tx)
+        .await
+        .expect("streaming run");
+    // Drain any remaining events so the channel closes cleanly.
+    while rx.recv().await.is_some() {}
+    assert_eq!(first, "hi there");
+
+    // Session history must now hold the user prompt + the streamed
+    // assistant reply. `Session::messages()` is a read-only view of the
+    // accumulated history.
+    let history_after_first = session.messages().len();
+    assert_eq!(
+        history_after_first, 2,
+        "expected 1 user + 1 assistant message after streaming turn"
+    );
+
+    let second = session.run("what did you say?").await.expect("follow-up");
+    assert_eq!(second, "hi there"); // ChunkedResponder is deterministic.
+    assert!(
+        session.messages().len() >= history_after_first + 2,
+        "follow-up turn must extend history: have {} messages",
+        session.messages().len()
+    );
+}


### PR DESCRIPTION
## 背景 / 目标

GUI blocker B2 from ADR-153 step 2：在 headless `Agent` facade 上暴露流式入口，让 desktop client / admin-backend UI 能渲染增量 LLM 输出，不再依赖 legacy session 层。

Closes #908

## 改动范围

- `crates/dasclaw_runtime/src/agent.rs`
  - 新增 `AgentEvent` 枚举（adjacent-tagged JSON：`TextChunk` / `ToolCallStart` / `ToolResult` / `FinishReason`），方便 TypeScript discriminated union 直接消费 `serde_json::to_string` 输出
  - `AgentResponder` 新增 `respond_streaming` 方法，默认实现 fallback 到 `respond()` 并 emit 一个 `TextChunk`（向后兼容，不强制下游实现）
  - 重构 loop driver 为单一 `run_in_context_inner`，通过 `HeadlessDelegate.event_tx: Option<mpsc::Sender>` 单字段路由，**没有 scattered if-streaming 分支**
  - 新增 `Agent::run_streaming` / `Agent::run_in_context_streaming`
- `crates/dasclaw_runtime/src/llm_adapter.rs`
  - 提取 `build_request` helper（让 streaming / 非 streaming 路径请求构造一致）
  - `LlmProviderResponder::respond_streaming` override：spawn forwarder task 把 provider 的 `UnboundedReceiver<String>` 转发为 `AgentEvent::TextChunk`；provider 调用返回后 `forwarder.await` 保证 chunk 在 `FinishReason` 之前到达
- `crates/dasclaw_runtime/src/lib.rs`：re-export `AgentEvent`
- `crates/dasclaw_session/src/lib.rs`：新增 `Session::run_streaming`，历史持久化规则与非流式 `run` 一致
- 测试
  - runtime: 4 个新测试（chunk + finish 顺序、default-impl fallback、tool-call 事件顺序、AgentEvent serde round-trip）
  - runtime adapter: 1 个新测试（`StreamingMockProvider` 验证 chunk 转发）
  - session: 2 个新测试（chunk + finish 顺序、流式回合的历史持久化）

## 非目标（What's NOT in this PR）

- 不修改任何 `LlmProvider` 实现（OpenAI / Anthropic 等保持原状）
- 不暴露 streaming usage / metadata 增量事件（issue #908 只要求 `TextChunk` + `FinishReason` 两个核心事件，tool 事件作为附赠）
- 不在 admin-backend / desktop-client 接线（后续 PR）

## 验证

- `cargo nextest run -p dasclaw_runtime` → 183/183 PASS
- `cargo nextest run -p dasclaw_session` → 47/47 PASS
- `cargo clippy --no-deps -p dasclaw_runtime -p dasclaw_session --all-targets -- -D warnings` → clean
- `cargo fmt --all` → clean
- `python3.12 scripts/check_no_panics.py --base origin/xClaw` → `OK: No panic-inducing calls in changed production code.`

## Cross-cuts

- ADR-114 **类A**：本 PR 未新增 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量

## 后续步骤

- desktop-client / admin-backend 接 `Agent::run_streaming` 替换 legacy session 流式路径
- 评估 streaming usage / metadata 增量事件是否纳入 `AgentEvent`

## Sources read

- AGENTS.md（任务启动 4 问、Skills 强制使用规范、PR 工作流、ADR-114 红线）
- docs/plans/architecture-refactor/adr-153-headless-agent-facade.md §4.2（GUI blocker B2 acceptance）
- crates/dasclaw_runtime/src/agent.rs 既有 `Agent` / `AgentResponder` / `HeadlessDelegate` 实现
- crates/dasclaw_runtime/src/llm_adapter.rs 既有 `LlmProviderResponder` 实现
- crates/dasclaw_session/src/lib.rs 既有 `Session::run` 历史持久化语义
- crates/dasclaw_llm_provider/ `LlmProvider::supports_streaming` / `complete_with_tools_stream` 流式 API