### PR TITLE
refactor(session): borrow ClawMessage in MessageRecord to align lifetime semantics

### DIFF
--- a/crates/dasclaw_session/src/jsonl.rs
+++ b/crates/dasclaw_session/src/jsonl.rs
@@ -206,7 +206,7 @@ struct SessionMetaRecord<'a> {
 struct MessageRecord<'a> {
     #[serde(rename = "type")]
     kind: &'a str,
-    message: ClawMessage,
+    message: &'a ClawMessage,
 }
 
 #[derive(Debug, Serialize)]
@@ -261,9 +261,10 @@ fn render_jsonl(snapshot: &SessionSnapshot) -> Result<Vec<u8>, SessionError> {
         out.push(b'\n');
     }
     for message in &snapshot.messages {
+        let claw_message = chat_message_to_claw(message);
         let record = MessageRecord {
             kind: "message",
-            message: chat_message_to_claw(message),
+            message: &claw_message,
         };
         serde_json::to_writer(&mut out, &record)?;
         out.push(b'\n');


### PR DESCRIPTION
## 背景 / 目标

`crates/dasclaw_session/src/jsonl.rs` 里的 `MessageRecord<'a>` 在 #914 PR-D（#927）落地时直接持有了 owned `ClawMessage`，而同文件的 `SessionMetaRecord<'a>`、`CompactionRecord<'a>`、`PromptHistoryRecord<'a>` 都持有借用引用。这是 PR #927 三层审查报告点名的生命周期语义不一致项（Issue #928）。本 PR 把 `MessageRecord` 改回借用形态，恢复结构体之间的对称性。

## 改动范围

- `crates/dasclaw_session/src/jsonl.rs`：
  - `MessageRecord<'a>::message` 由 `ClawMessage` 改为 `&'a ClawMessage`
  - `render_jsonl` 的消息循环内先把每条消息转成局部 `ClawMessage`，`MessageRecord` 再借用它

净改 3 行。

## 非目标（What's NOT in this PR）

- 不修改 `chat_message_to_claw` 签名
- 不引入新的公共 API
- 不改变 on-disk JSON wire 字节
- 不动 `claw_compat.rs` / 其他 *Record 结构

## 实现备注

Issue #928 建议先把整轮消息全部转成 `Vec<ClawMessage>` 再循环借用。本 PR 选择"每次循环单条转换 + 立刻借用"，原因：

- 语义目标一致（`MessageRecord` 持有借用引用）
- 省一份 O(n) 临时 `Vec<ClawMessage>` 内存（大会话差异可见）
- 不是补丁式分支：唯一的循环体被整体替换，没有 if/flag 切换

## 验证

```
cargo check -p dasclaw_session --tests          # Finished, 0 warning
cargo nextest run -p dasclaw_session            # 52/52 passed
cargo clippy --no-deps -p dasclaw_session --all-targets -- -D warnings   # 通过
cargo fmt --all                                 # 无 diff
python3.12 scripts/check_no_panics.py --base origin/xClaw   # OK
```

关键回归保护：`dasclaw_session::jsonl_wire jsonl_wire_format_is_stable` snapshot 通过 → 证明 on-disk wire 字节级未变。

## Sources read

- AGENTS.md §「精简检查清单」「红线」「PR 必填项」「测试纪律」
- .github/copilot-instructions.md §「强制阅读顺序」「必跑的本地管线」
- Issue #928 全文（含"建议实现方案"代码块）
- crates/dasclaw_session/src/jsonl.rs §「Wire records」`SessionMetaRecord` / `MessageRecord` / `CompactionRecord` / `PromptHistoryRecord` + `render_jsonl`
- crates/dasclaw_session/src/lib.rs 模块文档
- PR #927（PR-D）三层审查报告原文摘录

Closes #928
