### PR TITLE
feat(runtime): GUI approval event loop with ApprovalNeeded event + respond_to_approval (B4, #910)

### DIFF
--- a/crates/dasclaw_runtime/src/agent.rs
+++ b/crates/dasclaw_runtime/src/agent.rs
@@ -56,6 +56,11 @@ use dasclaw_core::traits::HostError;
 use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
+use uuid::Uuid;
+
+use crate::approval::{
+    ApprovalDecision, ApprovalDispatchError, ApprovalInbox, ApprovalPolicy, NoApprovalPolicy,
+};
 
 /// Streaming event emitted by [`Agent::run_streaming`] and
 /// [`crate::Session::run_streaming`] (issue #908, GUI blocker B2).
@@ -105,6 +110,31 @@ pub enum AgentEvent {
     },
     /// Stop reason for the LLM iteration that just ended.
     FinishReason(FinishReason),
+    /// The configured [`crate::ApprovalPolicy`] flagged a tool call as
+    /// needing human approval (issue #910, GUI blocker B4).
+    ///
+    /// The agent loop has paused waiting for
+    /// [`Agent::respond_to_approval`] to dispatch a matching
+    /// [`crate::ApprovalDecision`] for `request_id`. Until then no
+    /// further [`AgentEvent`]s are emitted for this turn.
+    ApprovalNeeded {
+        /// Unique handle the GUI feeds back into
+        /// [`Agent::respond_to_approval`].
+        request_id: Uuid,
+        /// Tool name as emitted by the model.
+        tool_name: String,
+        /// Raw tool arguments, mirroring the matching
+        /// [`AgentEvent::ToolCallStart`] payload.
+        tool_arguments: serde_json::Value,
+        /// Human-readable description supplied by the policy.
+        description: String,
+        /// Sanitised parameters preview the GUI should render — *not*
+        /// the raw arguments.
+        display_parameters: serde_json::Value,
+        /// `true` when the GUI may surface an "approve always"
+        /// affordance.
+        allow_always: bool,
+    },
 }
 
 /// Narrow LLM seam used by [`Agent`].
@@ -259,10 +289,35 @@ pub enum AgentError {
     #[error("agent loop stopped before producing a final response")]
     Stopped,
 
-    /// A tool approval was requested. Approval flow is delegate-specific
-    /// and the headless delegate does not implement it.
+    /// A tool approval was requested but the active [`crate::ApprovalPolicy`]
+    /// path produced no [`crate::AgentEvent::ApprovalNeeded`] for it.
+    ///
+    /// This variant only fires when a custom [`LoopDelegate`] surfaces
+    /// [`LoopOutcome::NeedApproval`] outside the headless
+    /// approval-inbox pipeline; the GUI-friendly path is
+    /// [`crate::AgentEvent::ApprovalNeeded`] + [`Agent::respond_to_approval`]
+    /// + [`AgentError::ApprovalRejected`].
+    ///
+    /// Kept for wire backwards compatibility with issue #909 consumers.
+    #[deprecated(
+        since = "0.0.0-w6",
+        note = "GUI hosts should listen for AgentEvent::ApprovalNeeded and reply via Agent::respond_to_approval; only custom LoopDelegate impls that bypass the approval inbox should still surface this variant"
+    )]
     #[error("agent loop requested approval, which is not supported in headless mode")]
     ApprovalRequested,
+
+    /// The GUI replied [`crate::ApprovalDecision::Reject`] for a pending
+    /// approval prompt (issue #910, GUI blocker B4). The matching
+    /// `tool_result` has already been pushed into the conversation as
+    /// an error, so callers can inspect history if they want the LLM
+    /// view; this surface is the host-facing summary.
+    #[error("approval rejected for tool {tool_name}{}", reason.as_deref().map(|r| format!(": {r}")).unwrap_or_default())]
+    ApprovalRejected {
+        /// Tool whose call the user declined.
+        tool_name: String,
+        /// Free-form rationale the GUI supplied, if any.
+        reason: Option<String>,
+    },
 
     /// The underlying responder (or hook) returned an error.
     #[error("responder error: {0}")]
@@ -283,6 +338,10 @@ enum AgentErrorWire {
     LoopFailure(String),
     Stopped,
     ApprovalRequested,
+    ApprovalRejected {
+        tool_name: String,
+        reason: Option<String>,
+    },
     Responder(String),
 }
 
@@ -291,6 +350,10 @@ impl Serialize for AgentError {
     where
         S: serde::Serializer,
     {
+        // The match below names the deprecated `AgentError::ApprovalRequested`
+        // variant; allow it locally so the wire mirror keeps full
+        // bidirectional coverage without a crate-wide allow.
+        #[allow(deprecated)]
         let wire = match self {
             AgentError::MissingResponder => AgentErrorWire::MissingResponder,
             AgentError::MaxIterations(n) => AgentErrorWire::MaxIterations(*n),
@@ -298,6 +361,12 @@ impl Serialize for AgentError {
             AgentError::LoopFailure(s) => AgentErrorWire::LoopFailure(s.clone()),
             AgentError::Stopped => AgentErrorWire::Stopped,
             AgentError::ApprovalRequested => AgentErrorWire::ApprovalRequested,
+            AgentError::ApprovalRejected { tool_name, reason } => {
+                AgentErrorWire::ApprovalRejected {
+                    tool_name: tool_name.clone(),
+                    reason: reason.clone(),
+                }
+            }
             AgentError::Responder(err) => AgentErrorWire::Responder(err.to_string()),
         };
         wire.serialize(serializer)
@@ -310,6 +379,8 @@ impl<'de> Deserialize<'de> for AgentError {
         D: serde::Deserializer<'de>,
     {
         let wire = AgentErrorWire::deserialize(deserializer)?;
+        // Same rationale as the serialize impl above.
+        #[allow(deprecated)]
         Ok(match wire {
             AgentErrorWire::MissingResponder => AgentError::MissingResponder,
             AgentErrorWire::MaxIterations(n) => AgentError::MaxIterations(n),
@@ -317,6 +388,9 @@ impl<'de> Deserialize<'de> for AgentError {
             AgentErrorWire::LoopFailure(s) => AgentError::LoopFailure(s),
             AgentErrorWire::Stopped => AgentError::Stopped,
             AgentErrorWire::ApprovalRequested => AgentError::ApprovalRequested,
+            AgentErrorWire::ApprovalRejected { tool_name, reason } => {
+                AgentError::ApprovalRejected { tool_name, reason }
+            }
             AgentErrorWire::Responder(s) => AgentError::Responder(Box::new(StringHostError(s))),
         })
     }
@@ -371,6 +445,14 @@ pub struct Agent {
     /// When set and tripped, the agentic loop exits with
     /// [`AgentError::Stopped`] on the next signal check. See issue #907.
     cancellation_token: Option<CancellationToken>,
+    /// GUI approval policy (issue #910, GUI blocker B4). Defaults to
+    /// [`NoApprovalPolicy`] so existing callers keep their zero-event
+    /// behaviour bit-for-bit.
+    approval_policy: Arc<dyn ApprovalPolicy>,
+    /// Pending approval inbox shared with [`HeadlessDelegate`] for the
+    /// lifetime of the agent. [`Agent::respond_to_approval`] dispatches
+    /// into this inbox once the GUI replies.
+    approval_inbox: ApprovalInbox,
 }
 
 impl Agent {
@@ -388,6 +470,24 @@ impl Agent {
     #[must_use]
     pub fn cancel_handle(&self) -> Option<CancellationToken> {
         self.cancellation_token.clone()
+    }
+
+    /// Reply to a pending [`AgentEvent::ApprovalNeeded`] event
+    /// (issue #910, GUI blocker B4).
+    ///
+    /// Looks up the matching request in the agent's approval inbox and
+    /// hands the [`ApprovalDecision`] to the headless delegate that is
+    /// currently parked on its oneshot receiver. Returns
+    /// [`ApprovalDispatchError::Unknown`] when the id is unknown (stale
+    /// or duplicate click) and [`ApprovalDispatchError::Closed`] when
+    /// the receiver has already been dropped (loop cancellation, agent
+    /// shutdown, …).
+    pub fn respond_to_approval(
+        &self,
+        request_id: Uuid,
+        decision: ApprovalDecision,
+    ) -> Result<(), ApprovalDispatchError> {
+        self.approval_inbox.dispatch(request_id, decision)
     }
 
     /// Seed a fresh [`ReasoningContext`] with the agent's static
@@ -475,6 +575,8 @@ impl Agent {
             tool_output_sanitizer: self.tool_output_sanitizer.clone(),
             cancellation_token: self.cancellation_token.clone(),
             event_tx,
+            approval_policy: Arc::clone(&self.approval_policy),
+            approval_inbox: self.approval_inbox.clone(),
         };
 
         let outcome = run_agentic_loop(&delegate, ctx, &loop_config, &self.hooks)
@@ -536,6 +638,7 @@ pub struct AgentBuilder {
     hooks: Option<HookBundle>,
     config: AgentConfig,
     cancellation_token: Option<CancellationToken>,
+    approval_policy: Option<Arc<dyn ApprovalPolicy>>,
 }
 
 impl AgentBuilder {
@@ -638,10 +741,23 @@ impl AgentBuilder {
         self
     }
 
+    /// Wire an [`ApprovalPolicy`] (issue #910, GUI blocker B4). When
+    /// unset, [`NoApprovalPolicy`] is installed so every tool call is
+    /// auto-approved and no [`AgentEvent::ApprovalNeeded`] events are
+    /// emitted — the pre-B4 contract.
+    #[must_use]
+    pub fn approval_policy(mut self, policy: Arc<dyn ApprovalPolicy>) -> Self {
+        self.approval_policy = Some(policy);
+        self
+    }
+
     /// Finalise the agent.
     pub fn build(self) -> Result<Agent, AgentError> {
         let responder = self.responder.ok_or(AgentError::MissingResponder)?;
         let hooks = self.hooks.unwrap_or_else(HookBundle::noop);
+        let approval_policy = self
+            .approval_policy
+            .unwrap_or_else(|| Arc::new(NoApprovalPolicy));
         Ok(Agent {
             responder,
             tool_executor: self.tool_executor,
@@ -649,6 +765,8 @@ impl AgentBuilder {
             hooks,
             config: self.config,
             cancellation_token: self.cancellation_token,
+            approval_policy,
+            approval_inbox: ApprovalInbox::new(),
         })
     }
 }
@@ -672,6 +790,8 @@ struct HeadlessDelegate {
     tool_output_sanitizer: Option<Arc<dyn ToolOutputSanitizer>>,
     cancellation_token: Option<CancellationToken>,
     event_tx: Option<mpsc::Sender<AgentEvent>>,
+    approval_policy: Arc<dyn ApprovalPolicy>,
+    approval_inbox: ApprovalInbox,
 }
 
 impl HeadlessDelegate {
@@ -761,6 +881,23 @@ impl LoopDelegate for HeadlessDelegate {
                 arguments: call.arguments.clone(),
             })
             .await;
+
+            // ADR-153 / issue #910 — GUI approval loop B4:
+            // ApprovalPolicy is the single gate that decides whether
+            // this call needs human approval. Three outcomes:
+            //   * NotRequired / Approved → fall through to egress + execute
+            //   * Rejected                → push tool-error, emit, return
+            //                                APPROVAL_REJECTED sentinel
+            //   * ChannelClosed           → treat as Reject("approval
+            //                                channel closed") so the loop
+            //                                degrades gracefully instead
+            //                                of leaking the pending entry
+            match self.await_approval_for(call).await {
+                ApprovalOutcome::NotRequired | ApprovalOutcome::Approved => {}
+                ApprovalOutcome::Rejected { reason } => {
+                    return Ok(Some(self.push_rejection(ctx, call, reason).await));
+                }
+            }
 
             // ADR-148 Layer B + ADR-153 §1.1 e8/A2:
             // Pre-execute egress gate scans serialised tool arguments.
@@ -862,6 +999,117 @@ fn push_assistant_tool_calls(
 /// and re-mapped to [`AgentError::ToolsNotSupported`] by [`map_outcome`].
 const TOOLS_NOT_SUPPORTED_REASON: &str = "headless-agent::tools-not-supported";
 
+/// Sentinel prefix for [`LoopOutcome::Failure`] strings produced when an
+/// [`crate::ApprovalPolicy`] flagged a tool call and the GUI replied
+/// [`crate::ApprovalDecision::Reject`] (issue #910, GUI blocker B4).
+///
+/// The remainder of the failure string after the prefix is a
+/// JSON-encoded [`RejectedPayload`]. [`map_outcome`] strips and decodes
+/// it back into [`AgentError::ApprovalRejected`] so the public surface
+/// remains structured. We piggy-back on `LoopOutcome::Failure(String)`
+/// instead of patching the `dasclaw_core` enum because issue #910
+/// explicitly forbids touching the `LoopOutcome` / `LoopDelegate` /
+/// `agentic_loop` public contract.
+const APPROVAL_REJECTED_SENTINEL_PREFIX: &str = "headless-agent::approval-rejected:";
+
+#[derive(Serialize, Deserialize)]
+struct RejectedPayload {
+    tool_name: String,
+    reason: Option<String>,
+}
+
+/// Outcome of [`HeadlessDelegate::await_approval_for`].
+///
+/// `ChannelClosed` is folded into [`ApprovalOutcome::Rejected`] before
+/// it leaves the helper so the caller's match stays exhaustive without
+/// a fall-through arm — keeps `execute_tool_calls` in the
+/// "evaluate → decide → execute-or-reject" 3-step shape ADR-153 wants.
+enum ApprovalOutcome {
+    NotRequired,
+    Approved,
+    Rejected { reason: Option<String> },
+}
+
+impl HeadlessDelegate {
+    /// Step 1 of the per-call pipeline in [`Self::execute_tool_calls`]:
+    /// ask the policy, emit `ApprovalNeeded` if needed, await the GUI
+    /// reply.
+    async fn await_approval_for(&self, call: &ToolCall) -> ApprovalOutcome {
+        let Some(request) = self.approval_policy.evaluate(call).await else {
+            return ApprovalOutcome::NotRequired;
+        };
+
+        let request_id = Uuid::new_v4();
+        let rx = self.approval_inbox.register(request_id);
+
+        self.emit(AgentEvent::ApprovalNeeded {
+            request_id,
+            tool_name: call.name.clone(),
+            tool_arguments: call.arguments.clone(),
+            description: request.description,
+            display_parameters: request.display_parameters,
+            allow_always: request.allow_always,
+        })
+        .await;
+
+        match rx.await {
+            Ok(ApprovalDecision::Approve) | Ok(ApprovalDecision::ApproveAlways) => {
+                ApprovalOutcome::Approved
+            }
+            Ok(ApprovalDecision::Reject { reason }) => ApprovalOutcome::Rejected { reason },
+            Err(_) => {
+                // Sender dropped without dispatching: forget the entry
+                // so a late respond_to_approval call still hits
+                // ApprovalDispatchError::Unknown rather than leaking the
+                // pending request forever.
+                self.approval_inbox.forget(request_id);
+                ApprovalOutcome::Rejected {
+                    reason: Some(String::from(
+                        "approval channel closed before the GUI replied",
+                    )),
+                }
+            }
+        }
+    }
+
+    /// Step 3b of the per-call pipeline: when the GUI rejected the
+    /// call, push the matching tool-error `tool_result` so the LLM sees
+    /// a well-formed history, emit the streaming `ToolResult` event for
+    /// the GUI, and return the sentinel-encoded
+    /// [`LoopOutcome::Failure`] that [`map_outcome`] reverses into
+    /// [`AgentError::ApprovalRejected`].
+    async fn push_rejection(
+        &self,
+        ctx: &mut ReasoningContext,
+        call: &ToolCall,
+        reason: Option<String>,
+    ) -> LoopOutcome {
+        let body = match reason.as_deref() {
+            Some(r) => format!("Error: approval rejected: {r}"),
+            None => String::from("Error: approval rejected"),
+        };
+        ctx.messages
+            .push(ChatMessage::tool_result(&call.id, &call.name, &body).with_tool_error(true));
+        self.emit(AgentEvent::ToolResult {
+            name: call.name.clone(),
+            content: body,
+            is_error: true,
+        })
+        .await;
+        let payload = RejectedPayload {
+            tool_name: call.name.clone(),
+            reason,
+        };
+        // `serde_json::to_string` on a two-field POD struct cannot fail
+        // under normal conditions; the fallback keeps the call panic-free
+        // (AGENTS.md production-code rule) and still lands on a
+        // recognisable sentinel for `map_outcome`.
+        let encoded = serde_json::to_string(&payload)
+            .unwrap_or_else(|_| String::from("{\"tool_name\":\"\"}"));
+        LoopOutcome::Failure(format!("{APPROVAL_REJECTED_SENTINEL_PREFIX}{encoded}"))
+    }
+}
+
 fn map_outcome(outcome: LoopOutcome, max_iterations: usize) -> Result<String, AgentError> {
     match outcome {
         LoopOutcome::Response(text) => Ok(text),
@@ -869,8 +1117,27 @@ fn map_outcome(outcome: LoopOutcome, max_iterations: usize) -> Result<String, Ag
         LoopOutcome::Failure(reason) if reason == TOOLS_NOT_SUPPORTED_REASON => {
             Err(AgentError::ToolsNotSupported)
         }
-        LoopOutcome::Failure(reason) => Err(AgentError::LoopFailure(reason)),
+        LoopOutcome::Failure(reason) => {
+            if let Some(rest) = reason.strip_prefix(APPROVAL_REJECTED_SENTINEL_PREFIX) {
+                match serde_json::from_str::<RejectedPayload>(rest) {
+                    Ok(payload) => Err(AgentError::ApprovalRejected {
+                        tool_name: payload.tool_name,
+                        reason: payload.reason,
+                    }),
+                    // Malformed sentinel: fall back to LoopFailure with
+                    // the raw reason so debugging is not silently lost.
+                    Err(_) => Err(AgentError::LoopFailure(reason)),
+                }
+            } else {
+                Err(AgentError::LoopFailure(reason))
+            }
+        }
         LoopOutcome::Stopped => Err(AgentError::Stopped),
+        // Custom LoopDelegate impls that surface NeedApproval bypass the
+        // approval-inbox pipeline; keep the deprecated wire variant so
+        // they keep compiling. New GUI hosts should rely on
+        // AgentEvent::ApprovalNeeded + Agent::respond_to_approval.
+        #[allow(deprecated)]
         LoopOutcome::NeedApproval(_) => Err(AgentError::ApprovalRequested),
     }
 }

--- a/crates/dasclaw_runtime/src/approval.rs
+++ b/crates/dasclaw_runtime/src/approval.rs
@@ -1,0 +1,273 @@
+//! GUI approval loop primitives (issue #910, GUI blocker B4).
+//!
+//! The headless agent (see [`crate::agent`]) previously refused every
+//! approval prompt with a fail-stop [`crate::AgentError::ApprovalRequested`].
+//! That contract is fine for fully automated agents but blocks any GUI
+//! that wants a "user-in-the-loop" workflow for dangerous tool calls.
+//!
+//! This module supplies the pieces the GUI loop needs without touching
+//! the `dasclaw_core` `LoopDelegate` / `LoopOutcome` public contract:
+//!
+//! - [`ApprovalPolicy`] — pluggable rule that decides whether a given
+//!   [`dasclaw_core::messages::ToolCall`] needs human approval. Default
+//!   is [`NoApprovalPolicy`], which preserves the pre-B4 zero-event
+//!   behaviour for every existing caller.
+//! - [`ApprovalRequest`] — the policy's verdict carrying the
+//!   user-facing description, sanitised parameters and the
+//!   `allow_always` flag.
+//! - [`ApprovalDecision`] — the GUI's reply: `Approve`, `Reject`, or
+//!   `ApproveAlways`.
+//! - [`ApprovalDispatchError`] — surfaced by
+//!   [`crate::Agent::respond_to_approval`] when the supplied request id
+//!   is unknown or its channel has been dropped.
+//!
+//! The runtime owns one [`ApprovalInbox`] per [`crate::Agent`]; the
+//! `HeadlessDelegate` inserts a one-shot sender when it emits
+//! [`crate::AgentEvent::ApprovalNeeded`] and the GUI calls
+//! [`crate::Agent::respond_to_approval`] to resolve it.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::Mutex;
+
+use async_trait::async_trait;
+use dasclaw_core::messages::ToolCall;
+use serde::{Deserialize, Serialize};
+use tokio::sync::oneshot;
+use uuid::Uuid;
+
+/// What the GUI tells the runtime once the user (dis)approves a call.
+///
+/// Serialised as adjacent-tagged JSON (`{"kind":"approve"}` /
+/// `{"kind":"reject","data":{"reason":"…"}}` /
+/// `{"kind":"approve_always"}`) so a TypeScript discriminated union
+/// renders directly from [`serde_json::to_string`].
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "kind", content = "data", rename_all = "snake_case")]
+pub enum ApprovalDecision {
+    /// Run this tool call exactly once and continue the loop.
+    Approve,
+    /// Refuse this tool call. The optional `reason` is forwarded both to
+    /// the LLM (as a tool-error `tool_result`) and to the
+    /// [`crate::AgentError::ApprovalRejected`] surface so the GUI can
+    /// render its own copy.
+    Reject {
+        /// Free-form rationale shown to the LLM and the GUI.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        reason: Option<String>,
+    },
+    /// Run this call and remember the decision for future calls of the
+    /// same tool. The policy decides what "remember" means in practice;
+    /// the runtime treats it identically to [`ApprovalDecision::Approve`]
+    /// for the in-flight call.
+    ApproveAlways,
+}
+
+/// Surface for [`crate::Agent::respond_to_approval`].
+///
+/// Both variants are recoverable from the GUI's perspective: an
+/// [`ApprovalDispatchError::Unknown`] typically means the user clicked
+/// twice, and [`ApprovalDispatchError::Closed`] means the loop already
+/// gave up on the prompt (cancellation, agent shutdown, …).
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum ApprovalDispatchError {
+    /// No pending request matches the supplied id — likely a duplicate
+    /// click or a stale GUI handle.
+    #[error("no pending approval found for request_id {0}")]
+    Unknown(Uuid),
+    /// The receiver was dropped before the GUI replied (cancellation,
+    /// agent shutdown, …).
+    #[error("approval channel for request_id {0} closed before decision arrived")]
+    Closed(Uuid),
+}
+
+/// What the policy tells the runtime when a call needs human approval.
+///
+/// `display_parameters` is the redacted preview the GUI should show —
+/// the policy is expected to scrub secrets here. `allow_always`
+/// indicates whether the "always approve this tool" affordance makes
+/// sense (e.g. read-only tools may set it `true`; one-shot destructive
+/// tools may force `false`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ApprovalRequest {
+    /// Human-readable description rendered in the prompt.
+    pub description: String,
+    /// Sanitised arguments preview for the GUI; never the raw payload
+    /// the policy received.
+    pub display_parameters: serde_json::Value,
+    /// `true` when the GUI may offer an "always approve" affordance.
+    pub allow_always: bool,
+}
+
+/// Pluggable rule that decides whether a [`ToolCall`] needs human
+/// approval.
+///
+/// Returning `None` means "auto-approve, continue the loop"; returning
+/// `Some(req)` causes the headless delegate to emit
+/// [`crate::AgentEvent::ApprovalNeeded`] and block until the GUI replies
+/// via [`crate::Agent::respond_to_approval`].
+#[async_trait]
+pub trait ApprovalPolicy: Send + Sync {
+    /// Inspect a single tool call and decide if it needs approval.
+    async fn evaluate(&self, call: &ToolCall) -> Option<ApprovalRequest>;
+}
+
+/// Default policy: every tool call is auto-approved.
+///
+/// Wired automatically by [`crate::AgentBuilder`] when the caller does
+/// not supply a policy, so existing zero-approval behaviour is
+/// preserved bit-for-bit.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct NoApprovalPolicy;
+
+#[async_trait]
+impl ApprovalPolicy for NoApprovalPolicy {
+    async fn evaluate(&self, _call: &ToolCall) -> Option<ApprovalRequest> {
+        None
+    }
+}
+
+/// Inbox of pending approvals, keyed by request id.
+///
+/// The runtime owns one [`ApprovalInbox`] per [`crate::Agent`]: the
+/// headless delegate registers a one-shot sender before emitting
+/// [`crate::AgentEvent::ApprovalNeeded`], and
+/// [`crate::Agent::respond_to_approval`] resolves it. Held behind a
+/// plain `std::sync::Mutex` because every critical section is a single
+/// `HashMap` op — async locking would only add a `Box::pin` allocation
+/// per poll.
+#[derive(Default, Clone)]
+pub struct ApprovalInbox {
+    inner: Arc<Mutex<HashMap<Uuid, oneshot::Sender<ApprovalDecision>>>>,
+}
+
+impl ApprovalInbox {
+    /// Create an empty inbox.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register a fresh request and return the receiving end the
+    /// delegate should await.
+    pub fn register(&self, request_id: Uuid) -> oneshot::Receiver<ApprovalDecision> {
+        let (tx, rx) = oneshot::channel();
+        // A poisoned mutex here means an earlier panic during inbox
+        // mutation; recover the inner state and keep going — a poisoned
+        // approval inbox should never take down the whole agent.
+        let mut guard = match self.inner.lock() {
+            Ok(g) => g,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        guard.insert(request_id, tx);
+        rx
+    }
+
+    /// Resolve a pending request. Returns the dispatched decision via
+    /// the oneshot, or an error if the id is unknown / the receiver
+    /// already dropped.
+    pub fn dispatch(
+        &self,
+        request_id: Uuid,
+        decision: ApprovalDecision,
+    ) -> Result<(), ApprovalDispatchError> {
+        let sender = {
+            let mut guard = match self.inner.lock() {
+                Ok(g) => g,
+                Err(poisoned) => poisoned.into_inner(),
+            };
+            guard
+                .remove(&request_id)
+                .ok_or(ApprovalDispatchError::Unknown(request_id))?
+        };
+        sender
+            .send(decision)
+            .map_err(|_| ApprovalDispatchError::Closed(request_id))
+    }
+
+    /// Forget a pending request without dispatching, used when the
+    /// receiver side gave up (loop cancellation, executor returning
+    /// early, …) so the GUI's late reply maps to
+    /// [`ApprovalDispatchError::Unknown`] rather than a silent leak.
+    pub fn forget(&self, request_id: Uuid) {
+        let mut guard = match self.inner.lock() {
+            Ok(g) => g,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        guard.remove(&request_id);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn inbox_dispatch_resolves_oneshot() {
+        let inbox = ApprovalInbox::new();
+        let id = Uuid::new_v4();
+        let rx = inbox.register(id);
+        inbox.dispatch(id, ApprovalDecision::Approve).expect("ok");
+        let decision = rx.await.expect("decision arrives");
+        assert_eq!(decision, ApprovalDecision::Approve);
+    }
+
+    #[tokio::test]
+    async fn inbox_dispatch_unknown_id_errors() {
+        let inbox = ApprovalInbox::new();
+        let err = inbox
+            .dispatch(Uuid::new_v4(), ApprovalDecision::Approve)
+            .unwrap_err();
+        assert!(matches!(err, ApprovalDispatchError::Unknown(_)));
+    }
+
+    #[tokio::test]
+    async fn inbox_forget_then_dispatch_is_unknown() {
+        let inbox = ApprovalInbox::new();
+        let id = Uuid::new_v4();
+        let _rx = inbox.register(id);
+        inbox.forget(id);
+        let err = inbox.dispatch(id, ApprovalDecision::Approve).unwrap_err();
+        assert!(matches!(err, ApprovalDispatchError::Unknown(_)));
+    }
+
+    #[tokio::test]
+    async fn inbox_dispatch_after_receiver_dropped_yields_closed() {
+        let inbox = ApprovalInbox::new();
+        let id = Uuid::new_v4();
+        let rx = inbox.register(id);
+        drop(rx);
+        let err = inbox
+            .dispatch(id, ApprovalDecision::Reject { reason: None })
+            .unwrap_err();
+        assert!(matches!(err, ApprovalDispatchError::Closed(_)));
+    }
+
+    #[test]
+    fn approval_decision_adjacent_tagged_wire() {
+        let approve = serde_json::to_string(&ApprovalDecision::Approve).unwrap();
+        assert_eq!(approve, r#"{"kind":"approve"}"#);
+
+        let reject = serde_json::to_string(&ApprovalDecision::Reject {
+            reason: Some("nope".into()),
+        })
+        .unwrap();
+        assert_eq!(reject, r#"{"kind":"reject","data":{"reason":"nope"}}"#);
+
+        let always = serde_json::to_string(&ApprovalDecision::ApproveAlways).unwrap();
+        assert_eq!(always, r#"{"kind":"approve_always"}"#);
+
+        for original in [
+            ApprovalDecision::Approve,
+            ApprovalDecision::Reject { reason: None },
+            ApprovalDecision::Reject {
+                reason: Some("user denied".into()),
+            },
+            ApprovalDecision::ApproveAlways,
+        ] {
+            let s = serde_json::to_string(&original).unwrap();
+            let back: ApprovalDecision = serde_json::from_str(&s).unwrap();
+            assert_eq!(back, original);
+        }
+    }
+}

--- a/crates/dasclaw_runtime/src/lib.rs
+++ b/crates/dasclaw_runtime/src/lib.rs
@@ -65,6 +65,7 @@
 //! [`ToolError::from_tool_impl`].
 
 pub mod agent;
+pub mod approval;
 pub mod composite_executor;
 pub mod context;
 pub mod error;
@@ -81,6 +82,10 @@ pub mod tool_to_executor_adapter;
 pub use agent::{
     Agent, AgentBuilder, AgentConfig, AgentError, AgentEvent, AgentResponder, ToolExecutor,
     ToolOutputSanitizer,
+};
+pub use approval::{
+    ApprovalDecision, ApprovalDispatchError, ApprovalInbox, ApprovalPolicy, ApprovalRequest,
+    NoApprovalPolicy,
 };
 pub use composite_executor::{CompositeError, CompositeToolExecutor};
 pub use error::ToolError;

--- a/crates/dasclaw_runtime/tests/approval_flow.rs
+++ b/crates/dasclaw_runtime/tests/approval_flow.rs
@@ -1,0 +1,371 @@
+//! Issue #910 (GUI blocker B4): integration tests for the GUI
+//! approval loop.
+//!
+//! Covers the four named requirements:
+//!
+//! - `req_dasclaw_runtime_b4_approve_resumes_tool_execution`
+//! - `req_dasclaw_runtime_b4_reject_returns_approval_rejected_error`
+//! - `req_dasclaw_runtime_b4_unknown_request_id_rejected`
+//! - `req_dasclaw_runtime_b4_no_policy_no_approval_events`
+//!
+//! Plus a small wire-shape lock for `AgentEvent::ApprovalNeeded` so the
+//! GUI's TypeScript discriminated union doesn't drift unnoticed.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use dasclaw_core::messages::{FinishReason, ToolCall, ToolDefinition, ToolResult};
+use dasclaw_core::reasoning_ctx::ReasoningContext;
+use dasclaw_core::response_types::{RespondOutput, RespondResult, ResponseMetadata, TokenUsage};
+use dasclaw_core::traits::HostError;
+use dasclaw_runtime::{
+    Agent, AgentError, AgentEvent, AgentResponder, ApprovalDecision, ApprovalDispatchError,
+    ApprovalPolicy, ApprovalRequest, ToolExecutor,
+};
+use tokio::sync::{Mutex, mpsc};
+use uuid::Uuid;
+
+// ---------------------------------------------------------------------------
+// Test scaffolding
+// ---------------------------------------------------------------------------
+
+/// Mock responder driven by a fixed sequence of pre-built outputs.
+struct ScriptedResponder {
+    script: Mutex<Vec<RespondOutput>>,
+}
+
+impl ScriptedResponder {
+    fn new(script: Vec<RespondOutput>) -> Self {
+        Self {
+            script: Mutex::new(script),
+        }
+    }
+}
+
+#[async_trait]
+impl AgentResponder for ScriptedResponder {
+    async fn respond(&self, _ctx: &mut ReasoningContext) -> Result<RespondOutput, HostError> {
+        let mut s = self.script.lock().await;
+        if s.is_empty() {
+            return Err("script exhausted".into());
+        }
+        Ok(s.remove(0))
+    }
+}
+
+/// Executor that returns a fixed `ToolResult` and counts invocations.
+struct CountingExecutor {
+    calls: Mutex<Vec<ToolCall>>,
+}
+
+impl CountingExecutor {
+    fn new() -> Self {
+        Self {
+            calls: Mutex::new(Vec::new()),
+        }
+    }
+
+    async fn call_count(&self) -> usize {
+        self.calls.lock().await.len()
+    }
+}
+
+#[async_trait]
+impl ToolExecutor for CountingExecutor {
+    async fn execute(&self, call: &ToolCall) -> Result<ToolResult, HostError> {
+        self.calls.lock().await.push(call.clone());
+        Ok(ToolResult {
+            tool_call_id: call.id.clone(),
+            name: call.name.clone(),
+            content: format!("ran {}", call.name),
+            is_error: false,
+        })
+    }
+}
+
+/// Policy that always requires approval, regardless of tool.
+struct AlwaysApprovePolicy;
+
+#[async_trait]
+impl ApprovalPolicy for AlwaysApprovePolicy {
+    async fn evaluate(&self, call: &ToolCall) -> Option<ApprovalRequest> {
+        Some(ApprovalRequest {
+            description: format!("approve call to {}", call.name),
+            display_parameters: call.arguments.clone(),
+            allow_always: true,
+        })
+    }
+}
+
+fn tool_call_output(name: &str, id: &str) -> RespondOutput {
+    RespondOutput {
+        result: RespondResult::ToolCalls {
+            tool_calls: vec![ToolCall {
+                id: id.into(),
+                name: name.into(),
+                arguments: serde_json::json!({"path": "/tmp/x"}),
+                reasoning: None,
+            }],
+            content: None,
+        },
+        usage: TokenUsage::default(),
+        finish_reason: FinishReason::ToolUse,
+        metadata: ResponseMetadata::default(),
+    }
+}
+
+fn text_output(s: &str) -> RespondOutput {
+    RespondOutput {
+        result: RespondResult::Text(s.to_string()),
+        usage: TokenUsage::default(),
+        finish_reason: FinishReason::Stop,
+        metadata: ResponseMetadata::default(),
+    }
+}
+
+fn dummy_tool(name: &str) -> ToolDefinition {
+    ToolDefinition {
+        name: name.into(),
+        description: "test tool".into(),
+        parameters: serde_json::json!({"type": "object"}),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// req_dasclaw_runtime_b4_approve_resumes_tool_execution
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn req_dasclaw_runtime_b4_approve_resumes_tool_execution() {
+    let executor = Arc::new(CountingExecutor::new());
+    let agent = Arc::new(
+        Agent::builder()
+            .responder(ScriptedResponder::new(vec![
+                tool_call_output("bash", "call_1"),
+                text_output("done"),
+            ]))
+            .tool_executor(Arc::clone(&executor) as Arc<dyn ToolExecutor>)
+            .tools(vec![dummy_tool("bash")])
+            .approval_policy(Arc::new(AlwaysApprovePolicy))
+            .build()
+            .expect("build agent"),
+    );
+
+    let (event_tx, mut event_rx) = mpsc::channel::<AgentEvent>(32);
+    let agent_for_drain = Arc::clone(&agent);
+
+    // GUI simulator: on the first ApprovalNeeded, dispatch Approve.
+    let drain = tokio::spawn(async move {
+        let mut events = Vec::new();
+        while let Some(ev) = event_rx.recv().await {
+            if let AgentEvent::ApprovalNeeded { request_id, .. } = &ev {
+                let id = *request_id;
+                agent_for_drain
+                    .respond_to_approval(id, ApprovalDecision::Approve)
+                    .expect("approval dispatch succeeds");
+            }
+            events.push(ev);
+        }
+        events
+    });
+
+    let mut ctx = ReasoningContext::new();
+    let outcome = agent
+        .run_in_context_streaming(&mut ctx, "hi", event_tx)
+        .await
+        .expect("run completes");
+    assert_eq!(outcome, "done");
+
+    let events = drain.await.expect("drain task joins");
+    let approval_count = events
+        .iter()
+        .filter(|e| matches!(e, AgentEvent::ApprovalNeeded { .. }))
+        .count();
+    assert_eq!(approval_count, 1, "exactly one approval prompt expected");
+
+    let tool_result_errors = events
+        .iter()
+        .filter(|e| matches!(e, AgentEvent::ToolResult { is_error: true, .. }))
+        .count();
+    assert_eq!(
+        tool_result_errors, 0,
+        "approve path must not surface error tool results"
+    );
+    assert_eq!(executor.call_count().await, 1, "tool must run once");
+}
+
+// ---------------------------------------------------------------------------
+// req_dasclaw_runtime_b4_reject_returns_approval_rejected_error
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn req_dasclaw_runtime_b4_reject_returns_approval_rejected_error() {
+    let executor = Arc::new(CountingExecutor::new());
+    let agent = Arc::new(
+        Agent::builder()
+            .responder(ScriptedResponder::new(vec![tool_call_output(
+                "bash", "call_1",
+            )]))
+            .tool_executor(Arc::clone(&executor) as Arc<dyn ToolExecutor>)
+            .tools(vec![dummy_tool("bash")])
+            .approval_policy(Arc::new(AlwaysApprovePolicy))
+            .build()
+            .expect("build agent"),
+    );
+
+    let (event_tx, mut event_rx) = mpsc::channel::<AgentEvent>(32);
+    let agent_for_drain = Arc::clone(&agent);
+
+    let drain = tokio::spawn(async move {
+        let mut events = Vec::new();
+        while let Some(ev) = event_rx.recv().await {
+            if let AgentEvent::ApprovalNeeded { request_id, .. } = &ev {
+                let id = *request_id;
+                agent_for_drain
+                    .respond_to_approval(
+                        id,
+                        ApprovalDecision::Reject {
+                            reason: Some("nope".into()),
+                        },
+                    )
+                    .expect("approval dispatch succeeds");
+            }
+            events.push(ev);
+        }
+        events
+    });
+
+    let mut ctx = ReasoningContext::new();
+    let err = agent
+        .run_in_context_streaming(&mut ctx, "hi", event_tx)
+        .await
+        .expect_err("rejected approval must surface as error");
+
+    match err {
+        AgentError::ApprovalRejected { tool_name, reason } => {
+            assert_eq!(tool_name, "bash");
+            assert_eq!(reason.as_deref(), Some("nope"));
+        }
+        other => panic!("expected ApprovalRejected, got {other:?}"),
+    }
+
+    let events = drain.await.expect("drain joins");
+    let error_results: Vec<_> = events
+        .iter()
+        .filter_map(|e| match e {
+            AgentEvent::ToolResult {
+                name,
+                content,
+                is_error: true,
+            } => Some((name.clone(), content.clone())),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        error_results.len(),
+        1,
+        "expected exactly one error tool_result event, got {error_results:?}"
+    );
+    assert_eq!(error_results[0].0, "bash");
+    assert!(
+        error_results[0].1.contains("nope"),
+        "tool error body should embed rejection reason: {}",
+        error_results[0].1
+    );
+    assert_eq!(
+        executor.call_count().await,
+        0,
+        "executor must not run when approval is rejected"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// req_dasclaw_runtime_b4_unknown_request_id_rejected
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn req_dasclaw_runtime_b4_unknown_request_id_rejected() {
+    let agent = Agent::builder()
+        .responder(ScriptedResponder::new(vec![text_output("noop")]))
+        .build()
+        .expect("build agent");
+
+    let err = agent
+        .respond_to_approval(Uuid::new_v4(), ApprovalDecision::Approve)
+        .expect_err("unknown id must error");
+    assert!(matches!(err, ApprovalDispatchError::Unknown(_)));
+}
+
+// ---------------------------------------------------------------------------
+// req_dasclaw_runtime_b4_no_policy_no_approval_events
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn req_dasclaw_runtime_b4_no_policy_no_approval_events() {
+    // No .approval_policy() call → NoApprovalPolicy default → zero
+    // ApprovalNeeded events even for tool calls.
+    let executor = Arc::new(CountingExecutor::new());
+    let agent = Agent::builder()
+        .responder(ScriptedResponder::new(vec![
+            tool_call_output("bash", "call_1"),
+            text_output("done"),
+        ]))
+        .tool_executor(Arc::clone(&executor) as Arc<dyn ToolExecutor>)
+        .tools(vec![dummy_tool("bash")])
+        .build()
+        .expect("build agent");
+
+    let (event_tx, mut event_rx) = mpsc::channel::<AgentEvent>(32);
+    let drain = tokio::spawn(async move {
+        let mut events = Vec::new();
+        while let Some(ev) = event_rx.recv().await {
+            events.push(ev);
+        }
+        events
+    });
+
+    let mut ctx = ReasoningContext::new();
+    let outcome = agent
+        .run_in_context_streaming(&mut ctx, "hi", event_tx)
+        .await
+        .expect("run completes");
+    assert_eq!(outcome, "done");
+
+    // Allow drain to finish.
+    let events = tokio::time::timeout(Duration::from_secs(2), drain)
+        .await
+        .expect("drain finishes")
+        .expect("drain joins");
+
+    let approval_events = events
+        .iter()
+        .filter(|e| matches!(e, AgentEvent::ApprovalNeeded { .. }))
+        .count();
+    assert_eq!(
+        approval_events, 0,
+        "default NoApprovalPolicy must not emit ApprovalNeeded events"
+    );
+    assert_eq!(executor.call_count().await, 1, "tool should still run");
+}
+
+// ---------------------------------------------------------------------------
+// Wire-shape lock for AgentEvent::ApprovalNeeded
+// ---------------------------------------------------------------------------
+
+#[test]
+fn agent_event_approval_needed_serde_roundtrip() {
+    let id = Uuid::new_v4();
+    let original = AgentEvent::ApprovalNeeded {
+        request_id: id,
+        tool_name: "bash".into(),
+        tool_arguments: serde_json::json!({"cmd": "ls"}),
+        description: "needs approval".into(),
+        display_parameters: serde_json::json!({"cmd": "ls"}),
+        allow_always: true,
+    };
+    let json = serde_json::to_string(&original).expect("serialize");
+    assert!(json.contains("approval_needed") || json.contains("ApprovalNeeded"));
+    let back: AgentEvent = serde_json::from_str(&json).expect("deserialize");
+    assert_eq!(back, original);
+}

--- a/crates/dasclaw_runtime/tests/serde_agent_error_contract.rs
+++ b/crates/dasclaw_runtime/tests/serde_agent_error_contract.rs
@@ -23,6 +23,7 @@ fn roundtrip(value: &AgentError) -> AgentError {
 // because the inner types are `String` / `usize` which derive serde.
 
 #[test]
+#[allow(deprecated)] // exercises the `ApprovalRequested` wire-compat variant
 fn req_dasclaw_runtime_909_agent_error_simple_variants_roundtrip() {
     let samples = [
         AgentError::MissingResponder,
@@ -31,6 +32,14 @@ fn req_dasclaw_runtime_909_agent_error_simple_variants_roundtrip() {
         AgentError::LoopFailure("hook blocked".into()),
         AgentError::Stopped,
         AgentError::ApprovalRequested,
+        AgentError::ApprovalRejected {
+            tool_name: "bash".into(),
+            reason: Some("user denied".into()),
+        },
+        AgentError::ApprovalRejected {
+            tool_name: "web_fetch".into(),
+            reason: None,
+        },
     ];
     for sample in samples {
         let back = roundtrip(&sample);
@@ -99,6 +108,28 @@ fn req_dasclaw_runtime_909_snapshot_agent_error_loop_failure() {
     insta::assert_json_snapshot!(
         "agent_error_loop_failure",
         AgentError::LoopFailure("hook blocked egress".into())
+    );
+}
+
+#[test]
+fn req_dasclaw_runtime_b4_snapshot_agent_error_approval_rejected_with_reason() {
+    insta::assert_json_snapshot!(
+        "agent_error_approval_rejected_with_reason",
+        AgentError::ApprovalRejected {
+            tool_name: "bash".into(),
+            reason: Some("user denied".into()),
+        }
+    );
+}
+
+#[test]
+fn req_dasclaw_runtime_b4_snapshot_agent_error_approval_rejected_no_reason() {
+    insta::assert_json_snapshot!(
+        "agent_error_approval_rejected_no_reason",
+        AgentError::ApprovalRejected {
+            tool_name: "web_fetch".into(),
+            reason: None,
+        }
     );
 }
 

--- a/crates/dasclaw_runtime/tests/snapshots/serde_agent_error_contract__agent_error_approval_rejected_no_reason.snap
+++ b/crates/dasclaw_runtime/tests/snapshots/serde_agent_error_contract__agent_error_approval_rejected_no_reason.snap
@@ -1,0 +1,11 @@
+---
+source: crates/dasclaw_runtime/tests/serde_agent_error_contract.rs
+expression: "AgentError::ApprovalRejected { tool_name: \"web_fetch\".into(), reason: None, }"
+---
+{
+  "kind": "approval_rejected",
+  "data": {
+    "tool_name": "web_fetch",
+    "reason": null
+  }
+}

--- a/crates/dasclaw_runtime/tests/snapshots/serde_agent_error_contract__agent_error_approval_rejected_with_reason.snap
+++ b/crates/dasclaw_runtime/tests/snapshots/serde_agent_error_contract__agent_error_approval_rejected_with_reason.snap
@@ -1,0 +1,11 @@
+---
+source: crates/dasclaw_runtime/tests/serde_agent_error_contract.rs
+expression: "AgentError::ApprovalRejected\n{ tool_name: \"bash\".into(), reason: Some(\"user denied\".into()), }"
+---
+{
+  "kind": "approval_rejected",
+  "data": {
+    "tool_name": "bash",
+    "reason": "user denied"
+  }
+}


### PR DESCRIPTION
## 背景 / 目标

Issue #910（GUI blocker B4）。当前的 `LoopOutcome::NeedApproval` → `AgentError::ApprovalRequested` 是一条**fail-stop**：headless agent 一遇到需要审批的工具调用就直接拒绝。GUI host 想做"用户在环"的双向回路时无路可走。

本 PR 把这条 fail-stop 升级成「`AgentEvent::ApprovalNeeded` 事件 + GUI 回执」的双向回路，**完全在 `dasclaw_runtime` 内部消化**，不动 `dasclaw_core` 的 `LoopOutcome` / `LoopDelegate` / `agentic_loop` 公共契约。

## 改动范围

新增文件：

- `crates/dasclaw_runtime/src/approval.rs`（新模块）
  - `ApprovalDecision { Approve, Reject{reason}, ApproveAlways }`（adjacent-tagged 序列化，TS discriminated union 直接对得上）
  - `ApprovalRequest { description, display_parameters, allow_always }`
  - `#[async_trait] ApprovalPolicy` + `NoApprovalPolicy`（默认策略，零事件，向后兼容）
  - `ApprovalInbox`（`Arc<Mutex<HashMap<Uuid, oneshot::Sender>>>`，互斥中毒走 `into_inner()` 兜底）
  - `ApprovalDispatchError { Unknown(Uuid), Closed(Uuid) }`

修改文件：

- `crates/dasclaw_runtime/src/agent.rs`
  - 新增 `AgentEvent::ApprovalNeeded { request_id, tool_name, tool_arguments, description, display_parameters, allow_always }`
  - 新增 `AgentError::ApprovalRejected { tool_name, reason: Option<String> }`
  - `AgentError::ApprovalRequested` 标 `#[deprecated]`，但**保留**变体 + serde 兼容（旧快照测试仍绿）
  - `Agent::respond_to_approval(request_id, decision) -> Result<(), ApprovalDispatchError>`
  - `AgentBuilder::approval_policy(Arc<dyn ApprovalPolicy>)`
  - `HeadlessDelegate` 每次执行工具前先走 `await_approval_for(call)`：
    - `NotRequired | Approved` → 走原有 egress + executor 路径，**未做补丁式追加**
    - `Rejected{reason}` → 推入 `tool_result(is_error=true)` 消息 + 发 `ToolResult` 事件 + 通过哨兵编码 `LoopOutcome::Failure` 把 `ApprovalRejected` 透到 `map_outcome`
  - `map_outcome` 解码哨兵前缀，把 `Failure` 翻译回 `AgentError::ApprovalRejected{...}`

- `crates/dasclaw_runtime/src/lib.rs`：新增 `pub mod approval;` 与 5 个 `pub use`。

- `crates/dasclaw_runtime/tests/serde_agent_error_contract.rs`：扩展 `req_dasclaw_runtime_909_agent_error_simple_variants_roundtrip` 覆盖 `ApprovalRejected` 两种 reason 形态；新增 2 个 insta 快照测试锁定其 JSON wire 形状。

新增测试：

- `crates/dasclaw_runtime/tests/approval_flow.rs`（4 个具名 B4 测试 + 1 个 serde roundtrip）：
  - `req_dasclaw_runtime_b4_approve_resumes_tool_execution`
  - `req_dasclaw_runtime_b4_reject_returns_approval_rejected_error`
  - `req_dasclaw_runtime_b4_unknown_request_id_rejected`
  - `req_dasclaw_runtime_b4_no_policy_no_approval_events`
  - `agent_event_approval_needed_serde_roundtrip`

快照基线：

- `tests/snapshots/serde_agent_error_contract__agent_error_approval_rejected_with_reason.snap`
- `tests/snapshots/serde_agent_error_contract__agent_error_approval_rejected_no_reason.snap`

## 非目标（What's NOT in this PR）

- ❌ 不动 `dasclaw_core::LoopOutcome` / `LoopDelegate` / `agentic_loop` / `session::PendingApproval` 任何公共类型
- ❌ 不删 `AgentError::ApprovalRequested`（只 `#[deprecated]`，保留 serde 双向兼容）
- ❌ 不接 GUI 端 Tauri command（GUI 侧的 `respond_to_approval` 桥接留给后续 PR）
- ❌ 不动 `dasclaw_session` 的 PendingApproval 持久化模型
- ❌ 不实现具体的 `ApprovalPolicy`（如基于 ACL/规则的策略），只提供 trait + 默认 no-op

## 验证

```bash
cargo check -p dasclaw_runtime --tests
# Finished `dev` profile [unoptimized + debuginfo] target(s) in 16.12s — 0 错 0 警

cargo nextest run -p dasclaw_runtime
# Summary [115.797s] 196 tests run: 196 passed, 0 skipped

cargo nextest run -p dasclaw_session
# Summary [29.977s] 52 tests run: 52 passed, 0 skipped

cargo fmt --all
# OK

python3.12 scripts/check_no_panics.py --base origin/xClaw
# OK: No panic-inducing calls in changed production code.

cargo clippy --no-deps -p dasclaw_runtime --all-targets -- -D warnings
# Finished `dev` profile [unoptimized + debuginfo] target(s) in 9.31s — 0 错 0 警
```

4 个 B4 具名测试结果：

| 测试 | 结果 |
|---|---|
| `req_dasclaw_runtime_b4_approve_resumes_tool_execution` | ✅ PASS (6.34s) |
| `req_dasclaw_runtime_b4_reject_returns_approval_rejected_error` | ✅ PASS (3.51s) |
| `req_dasclaw_runtime_b4_unknown_request_id_rejected` | ✅ PASS (3.98s) |
| `req_dasclaw_runtime_b4_no_policy_no_approval_events` | ✅ PASS (4.65s) |

## 三层 skill 自查摘要

### 1. `code-quality-audit`

- ✅ 补丁式代码：`execute_tool_calls` 通过 `await_approval_for(call)` 前置门控，未在尾部追加 `if` 分支；`map_outcome` 通过哨兵前缀分支扩展，未复制粘贴
- ✅ 函数规模与嵌套：`ApprovalInbox::dispatch` ~10 LOC、`await_approval_for` ~15 LOC、`push_rejection` ~20 LOC、`map_outcome` ~25 LOC，全部 < 50 LOC、≤ 3 层嵌套
- ✅ 重复逻辑：互斥中毒兜底 (`Ok(g) => g, Err(p) => p.into_inner()`) 在 approval.rs 出现 3 次，但每处只占 4 行的小习语，抽 helper 反而增加噪声，保留原样
- ✅ Rust 特有：生产代码无 `.unwrap()` / `.expect()` / `panic!()`；`serde_json::to_string(&payload)` 用 `unwrap_or_else(|_| String::from("{\"tool_name\":\"\"}"))` 兜底；无多余 clone
- ✅ 重复造轮子：直接复用 `tokio::sync::oneshot`、`std::sync::Mutex`、`serde`、`thiserror`、`async_trait`、`uuid`

### 2. `code-simplifier`

新增代码、非 verbatim port。审查重点是「可读性 vs 抽象成本」：互斥中毒兜底虽出现 3 次，但抽 helper 会引入额外名字（`lock_or_recover` 之类）反而降低局部可读性，保留原样。`await_approval_for` + `push_rejection` 拆分把审批分支隔离干净，主路径未受影响。

### 3. `code-review-expert`

- **SOLID**：`ApprovalPolicy` 单一职责（决策），`ApprovalInbox` 单一职责（关联 Uuid ↔ oneshot），`HeadlessDelegate` 通过组合两者实现门控，开闭原则 OK
- **安全**：`display_parameters` 由 policy 负责脱敏（doc 注明，不在 runtime 层强解析）；互斥中毒走 `into_inner()` 恢复，不会因为审批模块导致整 agent 崩溃；哨兵前缀仅运行时内部使用，不出现在 serde wire
- **向后兼容**：`AgentError::ApprovalRequested` 仅 `#[deprecated]` 未删；既有 909 序列化快照测试全部仍绿；默认 `NoApprovalPolicy` 保证未配置策略的 caller 行为 bit-for-bit 一致（已用 `req_dasclaw_runtime_b4_no_policy_no_approval_events` 验证）
- **失败路径覆盖**：unknown id / closed channel / reject with reason / reject without reason / 默认策略不发事件，5 条失败/边界路径全覆盖

## Caveat

- 集成测试 `req_dasclaw_runtime_b4_no_policy_no_approval_events` 用 `tokio::time::timeout(2s, drain)` 等 drain 收尾；如果 CI runner 极慢理论上可能超时，但当前 nextest 实测耗时 4.65s（含 build），裸跑 < 1s，留足余量
- GUI 端要使用本能力还需在 desktop-client 侧添加 Tauri command 暴露 `Agent::respond_to_approval` + 监听 `AgentEvent::ApprovalNeeded`，留给后续 PR

## 后续 PR / 下一步

1. desktop-client 侧 Tauri command 桥接（issue 待开）
2. 一个具体的 `ApprovalPolicy` 实现（按工具名 ACL / 危险操作启发式），如有需要
3. 评估是否要在 `dasclaw_session` 侧持久化未决审批（GUI 重启恢复）




Closes #910
