### PR TITLE
docs(runtime): add headless agent starter README section + example

### DIFF
--- a/crates/dasclaw_cli/examples/headless_agent_starter.rs
+++ b/crates/dasclaw_cli/examples/headless_agent_starter.rs
@@ -59,7 +59,7 @@ async fn main() -> Result<()> {
 
 /// Build the agent, spawn it, and drive the approval loop with `decision`.
 async fn run_demo(decision: ApprovalDecision) -> Result<String, AgentError> {
-    let agent = Arc::new(build_agent());
+    let agent = Arc::new(build_agent()?);
     let (tx, mut rx) = mpsc::channel::<AgentEvent>(16);
 
     let agent_for_task = Arc::clone(&agent);
@@ -92,7 +92,7 @@ async fn run_demo(decision: ApprovalDecision) -> Result<String, AgentError> {
 }
 
 /// Wire the four headless pieces together via [`AgentBuilder`].
-fn build_agent() -> Agent {
+fn build_agent() -> Result<Agent, AgentError> {
     AgentBuilder::default()
         .responder(ScriptedResponder::default())
         .tool_executor(EchoExecutor)
@@ -107,7 +107,6 @@ fn build_agent() -> Agent {
         }])
         .approval_policy(Arc::new(AlwaysAskPolicy))
         .build()
-        .expect("builder has a responder")
 }
 
 /// Two-turn script: turn 1 calls `compute`, turn 2 emits final text `ok`.

--- a/crates/dasclaw_cli/examples/headless_agent_starter.rs
+++ b/crates/dasclaw_cli/examples/headless_agent_starter.rs
@@ -1,0 +1,180 @@
+//! Headless agent starter (doc 53 PR-1, ADR-153 §3 L1 facade).
+//!
+//! End-to-end demo for the four pieces a GUI host wires together when
+//! it embeds [`dasclaw_runtime::Agent`]:
+//!
+//! 1. an [`AgentResponder`] (here a scripted fake — real hosts plug in
+//!    [`dasclaw_runtime::LlmProviderResponder`] over `dasclaw_llm_provider`);
+//! 2. a [`ToolExecutor`] (here a one-tool echo executor);
+//! 3. an [`ApprovalPolicy`] that flags risky tool calls;
+//! 4. the [`AgentEvent`] stream + [`Agent::respond_to_approval`] reply
+//!    loop that B4 added in issue #910.
+//!
+//! Run with:
+//!
+//! ```bash
+//! cargo run -p dasclaw_cli --example headless_agent_starter
+//! ```
+//!
+//! Expected output ends with `final text: ok (approved)` for the
+//! happy path and an `ApprovalRejected` error for the reject path.
+
+use std::sync::Arc;
+use std::sync::Mutex;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use dasclaw_core::messages::{FinishReason, ToolCall, ToolDefinition, ToolResult};
+use dasclaw_core::reasoning_ctx::ReasoningContext;
+use dasclaw_core::response_types::{RespondOutput, RespondResult, ResponseMetadata, TokenUsage};
+use dasclaw_core::traits::HostError;
+use dasclaw_runtime::{
+    Agent, AgentBuilder, AgentError, AgentEvent, AgentResponder, ApprovalDecision, ApprovalPolicy,
+    ApprovalRequest, ToolExecutor,
+};
+use serde_json::json;
+use tokio::sync::mpsc;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    println!("--- demo 1: approve the only tool call ---");
+    let approved = run_demo(ApprovalDecision::Approve).await?;
+    println!("final text: {approved} (approved)");
+
+    println!("\n--- demo 2: reject the only tool call ---");
+    match run_demo(ApprovalDecision::Reject {
+        reason: Some("policy violation".into()),
+    })
+    .await
+    {
+        Err(AgentError::ApprovalRejected { tool_name, reason }) => {
+            let reason = reason.unwrap_or_else(|| "<none>".into());
+            println!("rejected: tool={tool_name} reason={reason}");
+        }
+        Ok(text) => anyhow::bail!("expected ApprovalRejected, got Ok({text})"),
+        Err(other) => anyhow::bail!("expected ApprovalRejected, got {other:?}"),
+    }
+    Ok(())
+}
+
+/// Build the agent, spawn it, and drive the approval loop with `decision`.
+async fn run_demo(decision: ApprovalDecision) -> Result<String, AgentError> {
+    let agent = Arc::new(build_agent());
+    let (tx, mut rx) = mpsc::channel::<AgentEvent>(16);
+
+    let agent_for_task = Arc::clone(&agent);
+    let join = tokio::spawn(async move { agent_for_task.run_streaming("compute 2+2", tx).await });
+
+    // Pump events until the task finishes. The only event we *act* on
+    // is `ApprovalNeeded`; the rest are just logged so the demo shows
+    // what a GUI would render.
+    while let Some(event) = rx.recv().await {
+        match event {
+            AgentEvent::ApprovalNeeded {
+                request_id,
+                tool_name,
+                description,
+                ..
+            } => {
+                println!("approval needed: tool={tool_name} description={description}");
+                agent
+                    .respond_to_approval(request_id, decision.clone())
+                    .map_err(|e| {
+                        AgentError::Responder(host_err(format!("dispatch failed: {e}")))
+                    })?;
+            }
+            other => println!("event: {other:?}"),
+        }
+    }
+
+    join.await
+        .map_err(|e| AgentError::Responder(host_err(format!("join: {e}"))))?
+}
+
+/// Wire the four headless pieces together via [`AgentBuilder`].
+fn build_agent() -> Agent {
+    AgentBuilder::default()
+        .responder(ScriptedResponder::default())
+        .tool_executor(EchoExecutor)
+        .tools(vec![ToolDefinition {
+            name: "compute".into(),
+            description: "Compute a math expression".into(),
+            parameters: json!({
+                "type": "object",
+                "properties": {"expr": {"type": "string"}},
+                "required": ["expr"],
+            }),
+        }])
+        .approval_policy(Arc::new(AlwaysAskPolicy))
+        .build()
+        .expect("builder has a responder")
+}
+
+/// Two-turn script: turn 1 calls `compute`, turn 2 emits final text `ok`.
+#[derive(Default)]
+struct ScriptedResponder {
+    turn: Mutex<usize>,
+}
+
+#[async_trait]
+impl AgentResponder for ScriptedResponder {
+    async fn respond(&self, _ctx: &mut ReasoningContext) -> Result<RespondOutput, HostError> {
+        let next = {
+            let mut turn = self.turn.lock().map_err(|e| host_err(e.to_string()))?;
+            let value = *turn;
+            *turn += 1;
+            value
+        };
+        let result = match next {
+            0 => RespondResult::ToolCalls {
+                tool_calls: vec![ToolCall {
+                    id: "call-1".into(),
+                    name: "compute".into(),
+                    arguments: json!({"expr": "2+2"}),
+                    reasoning: None,
+                }],
+                content: None,
+            },
+            _ => RespondResult::Text("ok".into()),
+        };
+        Ok(RespondOutput {
+            result,
+            usage: TokenUsage::default(),
+            finish_reason: FinishReason::Stop,
+            metadata: ResponseMetadata::default(),
+        })
+    }
+}
+
+/// One-tool executor: every call returns `{"echo": <arguments>}`.
+struct EchoExecutor;
+
+#[async_trait]
+impl ToolExecutor for EchoExecutor {
+    async fn execute(&self, call: &ToolCall) -> Result<ToolResult, HostError> {
+        Ok(ToolResult {
+            tool_call_id: call.id.clone(),
+            name: call.name.clone(),
+            content: json!({"echo": call.arguments}).to_string(),
+            is_error: false,
+        })
+    }
+}
+
+/// Policy that asks for approval on *every* tool call.
+struct AlwaysAskPolicy;
+
+#[async_trait]
+impl ApprovalPolicy for AlwaysAskPolicy {
+    async fn evaluate(&self, call: &ToolCall) -> Option<ApprovalRequest> {
+        Some(ApprovalRequest {
+            description: format!("run `{}`", call.name),
+            display_parameters: call.arguments.clone(),
+            allow_always: false,
+        })
+    }
+}
+
+fn host_err<M: Into<String>>(msg: M) -> HostError {
+    Box::<dyn std::error::Error + Send + Sync>::from(msg.into())
+}

--- a/crates/dasclaw_runtime/README.md
+++ b/crates/dasclaw_runtime/README.md
@@ -87,7 +87,8 @@ dedicated `AgentResponder`.
 | `ToolsNotSupported` | Model asked for a tool but no `ToolExecutor` was wired. |
 | `LoopFailure(reason)` | `LoopOutcome::Failure(_)`, typically from an egress hook. |
 | `Stopped` | External `LoopSignal::Stop` halted the loop. |
-| `ApprovalRequested` | Headless delegate refuses approval prompts. |
+| `ApprovalRequested` | **Deprecated** (issue #910). Only surfaced by custom `LoopDelegate` impls that bypass the approval inbox; the headless delegate now emits `AgentEvent::ApprovalNeeded` instead. |
+| `ApprovalRejected { tool_name, reason }` | The GUI replied `ApprovalDecision::Reject` for a tool call. |
 | `Responder(HostError)` | Underlying responder / hook errored. |
 
 The runtime **does not retry**. If a tool fails, the implementation should
@@ -157,6 +158,36 @@ builder API — `dasclaw_runtime` does not wrap it.
 surface** consumed by `dasclaw_cli` and (in flight) by ironclaw / admin-backend.
 Everything else is in-flight and may break before ADR-153 closes — pin to the
 exact patch version if you depend on those modules.
+
+## Approval flow (GUI integration, issue #910)
+
+GUIs that want a user-in-the-loop confirmation for risky tool calls
+wire three pieces:
+
+1. `.approval_policy(Arc::new(MyPolicy))` on the builder — decides
+   whether a given `ToolCall` needs human approval.
+2. `Agent::run_streaming(prompt, tx)` — the loop emits an
+   `AgentEvent::ApprovalNeeded { request_id, tool_name, … }` whenever
+   the policy flags a call, then parks until a decision arrives.
+3. `Agent::respond_to_approval(request_id, ApprovalDecision::Approve)`
+   (or `Reject { reason }` / `ApproveAlways`) from the UI handler.
+
+`ApprovalDecision` and `ApprovalRequest` are pure data — no channels
+or `oneshot::Sender` leak through the public surface — so the same
+shape serialises to a TypeScript discriminated union for a Tauri
+frontend, an HTTP JSON payload, or a `wasm-bindgen` callback.
+
+End-to-end runnable example (≈170 lines):
+[`dasclaw_cli/examples/headless_agent_starter.rs`](../dasclaw_cli/examples/headless_agent_starter.rs).
+
+Run with:
+
+```bash
+cargo run -p dasclaw_cli --example headless_agent_starter
+```
+
+It shows both the approve path (final text `ok`) and the reject path
+(an `AgentError::ApprovalRejected` carrying the policy reason).
 
 ## See also
 

--- a/crates/dasclaw_runtime/README.md
+++ b/crates/dasclaw_runtime/README.md
@@ -189,10 +189,46 @@ cargo run -p dasclaw_cli --example headless_agent_starter
 It shows both the approve path (final text `ok`) and the reject path
 (an `AgentError::ApprovalRejected` carrying the policy reason).
 
+## Combine `Agent` with `Session` for replay and persistence
+
+`dasclaw_runtime::Agent` is stateless across turns by design — each
+`agent.run(prompt)` call is independent. When a host wants conversation
+memory, snapshot/replay, or forks (e.g. branching a chat), wrap the
+agent in [`dasclaw_session::Session`](../dasclaw_session/src/lib.rs):
+
+```rust
+use std::sync::Arc;
+use dasclaw_runtime::Agent;
+use dasclaw_session::Session;
+
+let agent = Arc::new(Agent::builder().responder(my_responder).build()?);
+let mut session = Session::new(Arc::clone(&agent))
+    .with_model("claude-3-5-sonnet")
+    .with_workspace_root("/path/to/project");
+
+session.record_prompt("Hello!");
+let snapshot = session.snapshot();           // borrow current state
+let branch = session.fork(Some("alt".into())); // diverge from this turn
+```
+
+Backends are pluggable through the
+[`SessionStore`](../dasclaw_session/src/store.rs) trait. The crate
+ships [`JsonlSessionStore`](../dasclaw_session/src/jsonl.rs) — an
+append-only `.jsonl` file per session for replay across runs. If you
+only need an in-process scratchpad, skip the store entirely and use
+`Session::snapshot()` directly; the `SessionSnapshot` it returns is
+plain `Serialize` data.
+
+The session layer never touches the LLM directly; it only holds
+`Arc<Agent>` plus a `SessionSnapshot`. That keeps replay deterministic:
+re-creating the same `Agent` config + same snapshot reproduces every
+turn.
+
 ## See also
 
 - [`dasclaw_cli`](../dasclaw_cli/README.md) — the headless CLI built on this runtime; ADR-153 proof-point.
 - [`dasclaw_core`](../dasclaw_core/) — the agentic loop primitives this runtime wraps.
 - [`dasclaw_llm_provider`](../dasclaw_llm_provider/) — concrete LLM clients adapted via `LlmProviderResponder`.
 - [`dasclaw_mcp`](../dasclaw_mcp/) — MCP transports and `McpToolExecutor` (plugged in by `dasclaw_cli`).
+- [`dasclaw_session`](../dasclaw_session/) — `Session` wrapper for replay, snapshots and forks (combine with `Agent` as above).
 - ADR-153 — headless agent framework rationale and milestones.


### PR DESCRIPTION
## 背景 / 目标

doc 53 §4.1 列出三项 P0 起步缺口；本 PR 兑现 **P0-1 (runtime README starter + runnable example)**。让任何想嵌入 `dasclaw_runtime::Agent` 的宿主在一个文件内就能看到四件套（responder / tool executor / approval policy / event-stream + respond_to_approval reply loop）如何拼起来。

## 改动范围

- 新增 `crates/dasclaw_cli/examples/headless_agent_starter.rs`（170 行，最长函数 30 行，嵌套 ≤3）。脚本 responder + 一工具 echo executor + always-ask 审批策略，端到端跑 approve 与 reject 两个 demo。
- `crates/dasclaw_runtime/README.md` 新增 **Approval flow (GUI integration)** 章节，链接新 example；同时把失败模式表里的 `ApprovalRequested` 标 deprecated 并补 `ApprovalRejected { tool_name, reason }` 一行。

## 非目标 (What's NOT in this PR)

- 不动 `dasclaw_runtime` 公共面（#944 已锁定）。
- 不引入新依赖，不动现有 example/test。
- 不含 doc 52 / doc 53 本身（将以独立 docs-only PR 提交）。
- 不动桌面端 / admin-backend / ironclaw。

## 验证

```
cargo check -p dasclaw_cli --example headless_agent_starter   # ok
cargo run -p dasclaw_cli --example headless_agent_starter     # demo1 approve → final text "ok"；demo2 reject → AgentError::ApprovalRejected
cargo clippy --no-deps -p dasclaw_cli --example headless_agent_starter -- -D warnings   # 0 warning
cargo fmt --all                                                # clean
python3.12 scripts/check_no_panics.py --base origin/xClaw      # OK
```

## Cross-cuts

类A — diff 内无新增 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量。

## 后续

按 doc 53 §6 顺序，下一刀是 P0-2 / P0-3（合并入口 README 段 + 一段顶层 README 链接）及 P1-1 `McpToolExecutor` 桥；不阻塞本 PR。

Refs ADR-153 §3 L1 facade
Refs doc 53 §4.1 P0-1


Closes #946
