### PR TITLE
docs(repo): top-level pointer to the headless agent embedding path (P0-2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,17 @@ External content passes through multiple security layers:
 | **Workspace** | Persistent memory with hybrid search |
 | **Safety Layer** | Prompt injection defense and content sanitization |
 
+### Embed the headless agent loop in your own product
+
+The core agent loop, tool dispatch, approval gating, hook bundle and session
+store are packaged as a library — you do not need to fork IronClaw to embed an
+agent in your CLI, daemon, or backend.
+
+- Library entry point: [`crates/dasclaw_runtime`](crates/dasclaw_runtime) (start at its `README.md`)
+- Minimum runnable example: [`crates/dasclaw_cli/examples/headless_agent_starter.rs`](crates/dasclaw_cli/examples/headless_agent_starter.rs)
+- Architectural boundary and capability matrix: [`docs/plans/architecture-refactor/53-headless-agent-capability-design.md`](docs/plans/architecture-refactor/53-headless-agent-capability-design.md)
+- Three-lineage interop mapping: [`docs/INTEROP_DASCLAW.md`](docs/INTEROP_DASCLAW.md)
+
 ## Usage
 
 ```bash

--- a/docs/INTEROP_DASCLAW.md
+++ b/docs/INTEROP_DASCLAW.md
@@ -69,3 +69,11 @@ grep contract from Issue #911:
 - [`docs/plans/architecture-refactor/49-gui-readiness-assessment.md`](plans/architecture-refactor/49-gui-readiness-assessment.md)
   §5 (GUI readiness gaps) and §9 (B5 row)
 - ADR-153 §1.1 (B-series rollout for headless agent loop)
+- [`docs/plans/architecture-refactor/53-headless-agent-capability-design.md`](plans/architecture-refactor/53-headless-agent-capability-design.md)
+  (headless agent framework capability boundary; defines what is / is not part
+  of the headless library surface)
+- [`crates/dasclaw_runtime/README.md`](../crates/dasclaw_runtime/README.md)
+  (library-side getting-started for embedders) and
+  [`crates/dasclaw_cli/examples/headless_agent_starter.rs`](../crates/dasclaw_cli/examples/headless_agent_starter.rs)
+  (minimum runnable embed example covering responder + tool executor + approval
+  policy + event stream)


### PR DESCRIPTION
## 背景 / 目标

doc 53 [§4.1 / §6 PR-2](docs/plans/architecture-refactor/53-headless-agent-capability-design.md) 标的 P0-2: 让第三方开发者从仓库顶层就能发现 `dasclaw_runtime` 是一个可嵌入库, 而不是只能通过深挖架构文档才知道.

## 改动范围

19 行纯文档, 两处:

1. `README.md` Architecture 末尾加 `Embed the headless agent loop in your own product` 小节, 列出 4 个指针 (dasclaw_runtime / starter example / doc 53 / INTEROP_DASCLAW.md).
2. `docs/INTEROP_DASCLAW.md` See also 末尾加 2 条 (doc 53 + dasclaw_runtime README/example).

## 非目标

- 不动任何代码.
- 不动既有文档主体, 只在末尾追加指针.
- 不升 doc 53 为 ADR (那是 P0-3, 另开 PR).

## 验证

- 改动量 19 行, 全是 markdown.
- 所有链接均指向已存在文件 (README.md / docs/INTEROP_DASCLAW.md / doc 53 / dasclaw_runtime/README.md / starter example).
- 不触发任何编译 / 测试 / clippy 路径.

## 依赖 / 顺序

- 引用的 `dasclaw_cli/examples/headless_agent_starter.rs` 来源于 PR #945 (in flight). 本 PR 合并时若 #945 还没合, 链接也已经在 PR #945 分支可见; 待 #945 进 xClaw 后链接自动有效. 不形成 stacked PR.
- doc 53 已在 PR #948 (in flight). 同样不强依赖合并顺序.

## Sources read

- [docs/plans/architecture-refactor/53-headless-agent-capability-design.md](docs/plans/architecture-refactor/53-headless-agent-capability-design.md) §4.1 §6
- [README.md](README.md) §Architecture
- [docs/INTEROP_DASCLAW.md](docs/INTEROP_DASCLAW.md) §See also

Closes #949

Cross-cuts: 不涉及