### PR TITLE
feat(client-config): per-client conversation_upload_enabled toggle

### DIFF
--- a/admin-backend/migrations/029_client_conversation_upload.sql
+++ b/admin-backend/migrations/029_client_conversation_upload.sql
@@ -1,0 +1,10 @@
+-- 按客户端控制是否上报对话原文。
+--
+-- false 时, post_client_reports 仍接受 Conversation 事件,
+-- 但客户端会在打包前抹掉 message.content 和附件原文 (image_data_base64 / extracted_text),
+-- 只保留 metadata (role / model_id / token 数 / used_skills / dlp_flagged) 用于审计与计费。
+--
+-- 默认 TRUE 保持现状; 管理员可按客户端单独关闭。
+
+ALTER TABLE registered_clients
+    ADD COLUMN IF NOT EXISTS conversation_upload_enabled BOOLEAN NOT NULL DEFAULT TRUE;

--- a/admin-backend/src/routes.rs
+++ b/admin-backend/src/routes.rs
@@ -3143,6 +3143,9 @@ struct ClientConfigResponse {
     // 客户端升级提示（需求 8.9）
     #[serde(skip_serializing_if = "Option::is_none")]
     needs_upgrade: Option<bool>,
+    // 按客户端控制是否上报对话原文。None 视为 true 保持现状。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    conversation_upload_enabled: Option<bool>,
     // 私有技能注册表地址（需求 14.17）
     // 格式："{admin_base_url}/api/v1?client_token={token}"
     // ironclaw 引擎通过 CLAWHUB_REGISTRY 环境变量读取此值
@@ -3249,6 +3252,7 @@ async fn get_client_config(
                 watermark_position: None,
                 watermark_color: None,
                 needs_upgrade: None,
+                conversation_upload_enabled: None,
                 skill_registry_url: None,
             }
         }
@@ -3272,6 +3276,7 @@ async fn get_client_config(
             watermark_position: None,
             watermark_color: None,
             needs_upgrade: None,
+            conversation_upload_enabled: None,
             skill_registry_url: None,
         },
     };
@@ -3285,13 +3290,15 @@ async fn get_client_config(
         if let Ok(uuid) = Uuid::parse_str(cid) {
             if let Ok(Some(row)) = client
                 .query_opt(
-                    "SELECT user_id, needs_upgrade FROM registered_clients WHERE id = $1",
+                    "SELECT user_id, needs_upgrade, conversation_upload_enabled \
+                     FROM registered_clients WHERE id = $1",
                     &[&uuid],
                 )
                 .await
             {
                 response.backend_principal_id = row.try_get::<_, Uuid>(0).ok();
                 response.needs_upgrade = row.try_get::<_, bool>(1).ok();
+                response.conversation_upload_enabled = row.try_get::<_, bool>(2).ok();
             }
         }
     }

--- a/admin-backend/tests/integration_smoke_tests.rs
+++ b/admin-backend/tests/integration_smoke_tests.rs
@@ -179,6 +179,7 @@ async fn test_migration_all_tables_exist() {
         // 022 是 system_settings 数据插入，表已存在，通过 settings key 验证
         // 023 字段扩展验证见 test_migration_023_extensions_v2_columns
         // 028 是 code_tool_settings 数据插入（lsp_servers/git_repos），表已存在于 027
+        // 029 是 registered_clients 字段扩展，列级验证见 test_migration_029_conversation_upload_enabled_column
     ];
 
     let mut missing = Vec::new();
@@ -315,6 +316,43 @@ async fn test_migration_026_conversation_attachments_column() {
         .unwrap();
 
     assert_eq!(row.get::<_, i64>(0), 1, "026 迁移缺少 attachments 列");
+}
+
+#[tokio::test]
+async fn test_migration_029_conversation_upload_enabled_column() {
+    let pool = match try_connect_db().await {
+        Some(p) => p,
+        None => {
+            println!("⚠️  数据库不可用，跳过");
+            return;
+        }
+    };
+    let client = pool.get().await.unwrap();
+
+    let row = client
+        .query_one(
+            "SELECT column_default, is_nullable FROM information_schema.columns \
+             WHERE table_schema = 'public' AND table_name = 'registered_clients' \
+             AND column_name = 'conversation_upload_enabled'",
+            &[],
+        )
+        .await
+        .expect("029 迁移应该已加列 conversation_upload_enabled");
+
+    let default_expr: Option<String> = row.get(0);
+    let is_nullable: String = row.get(1);
+    assert_eq!(
+        is_nullable, "NO",
+        "conversation_upload_enabled 必须 NOT NULL"
+    );
+    assert!(
+        default_expr
+            .as_deref()
+            .map(|s| s.to_lowercase().contains("true"))
+            .unwrap_or(false),
+        "conversation_upload_enabled 默认值应为 TRUE，实际: {:?}",
+        default_expr
+    );
 }
 
 /// 验证 model_configs 表的列结构

--- a/desktop-client/src/admin_sync.rs
+++ b/desktop-client/src/admin_sync.rs
@@ -63,6 +63,12 @@ pub struct AdminClientConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub backend_principal_id: Option<Uuid>,
 
+    /// 是否上报对话原文。`None` 视为 `true` 保持现状；`Some(false)` 时
+    /// 客户端只上报对话 metadata（role/token/技能命中等），不携带 message.content
+    /// 与附件原文。详见 admin-backend 迁移 029。
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub conversation_upload_enabled: Option<bool>,
+
     // === 水印 ===
     /// 是否启用水印
     pub watermark_enabled: Option<bool>,
@@ -194,6 +200,7 @@ pub struct AdminConfigSync {
     current_config: Arc<RwLock<AdminClientConfig>>,
     /// 后台主身份同步出口。
     backend_user_id: Option<Arc<std::sync::RwLock<Option<Uuid>>>>,
+    upload_payload_sink: Option<Arc<std::sync::atomic::AtomicBool>>,
     /// 同步间隔（用于 run_sync_loop）
     sync_interval: Duration,
     /// 版本检查间隔（用于 run_sync_loop_with_version_check）
@@ -220,6 +227,7 @@ impl AdminConfigSync {
                 .unwrap_or_default(),
             current_config: Arc::new(RwLock::new(AdminClientConfig::default())),
             backend_user_id: None,
+            upload_payload_sink: None,
             sync_interval: Duration::from_secs(300), // 5 分钟
             version_check_interval: Duration::from_secs(30), // 30 秒
         }
@@ -230,6 +238,13 @@ impl AdminConfigSync {
         backend_user_id: Arc<std::sync::RwLock<Option<Uuid>>>,
     ) -> Self {
         self.backend_user_id = Some(backend_user_id);
+        self
+    }
+
+    /// 注入上报对话原文的开关锐导，使 ConversationTracker 进行打包前能读到最新值。
+    /// 开关默认 true；Admin Backend 返回 `Some(false)` 时切为 metadata-only。
+    pub fn with_upload_payload_sink(mut self, sink: Arc<std::sync::atomic::AtomicBool>) -> Self {
+        self.upload_payload_sink = Some(sink);
         self
     }
 
@@ -275,6 +290,7 @@ impl AdminConfigSync {
             .map_err(|e| format!("Failed to parse response: {}", e))?;
 
         self.publish_backend_principal_id(config.backend_principal_id);
+        self.publish_upload_payload_enabled(config.conversation_upload_enabled);
 
         // 更新内存缓存
         {
@@ -305,6 +321,15 @@ impl AdminConfigSync {
                     tracing::warn!(error = %error, "Failed to publish backend principal id");
                 }
             }
+        }
+    }
+
+    fn publish_upload_payload_enabled(&self, enabled: Option<bool>) {
+        if let Some(target) = &self.upload_payload_sink {
+            target.store(
+                enabled.unwrap_or(true),
+                std::sync::atomic::Ordering::Relaxed,
+            );
         }
     }
 

--- a/desktop-client/src/conversation_tracker.rs
+++ b/desktop-client/src/conversation_tracker.rs
@@ -20,6 +20,7 @@
 //! - 上报失败不影响主流程（DataReporter 有重试机制）
 
 use std::collections::{HashMap, HashSet};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 use uuid::Uuid;
@@ -72,6 +73,9 @@ pub struct ConversationTracker {
     buffers: Mutex<HashMap<String, ThreadBuffer>>,
     scope_id: String,
     backend_user_id: Arc<std::sync::RwLock<Option<Uuid>>>,
+    /// 是否上报对话原文。默认 true；Admin Backend 下发 false 时 build_report
+    /// 会抹掉 message.content 与附件原文，只保留 metadata。
+    upload_payload: Arc<AtomicBool>,
     pub idle_timeout: Duration,
 }
 
@@ -81,6 +85,7 @@ impl ConversationTracker {
             buffers: Mutex::new(HashMap::new()),
             scope_id,
             backend_user_id: Arc::new(std::sync::RwLock::new(None)),
+            upload_payload: Arc::new(AtomicBool::new(true)),
             idle_timeout: DEFAULT_IDLE_TIMEOUT,
         }
     }
@@ -90,6 +95,12 @@ impl ConversationTracker {
         backend_user_id: Arc<std::sync::RwLock<Option<Uuid>>>,
     ) -> Self {
         self.backend_user_id = backend_user_id;
+        self
+    }
+
+    /// 共享上报开关，使 admin_sync 能推送最新值。
+    pub fn with_upload_payload_sink(mut self, sink: Arc<AtomicBool>) -> Self {
+        self.upload_payload = sink;
         self
     }
 
@@ -239,6 +250,22 @@ impl ConversationTracker {
             .map(|user_id: Uuid| user_id.to_string())
             .unwrap_or_else(|| self.scope_id.clone());
 
+        let messages = if self.upload_payload.load(Ordering::Relaxed) {
+            buf.messages
+        } else {
+            buf.messages
+                .into_iter()
+                .map(|m| ConversationMessage {
+                    role: m.role,
+                    content: String::new(),
+                    attachments: Vec::new(),
+                    model_id: m.model_id,
+                    input_tokens: m.input_tokens,
+                    output_tokens: m.output_tokens,
+                })
+                .collect()
+        };
+
         Some(ClientReport::Conversation {
             client_conversation_id: format!("{}-{}-{}", self.scope_id, thread_id, buf.report_id),
             user_id: report_user_id,
@@ -247,7 +274,7 @@ impl ConversationTracker {
             dlp_flagged: Some(buf.dlp_flagged),
             dlp_details: None,
             used_skills,
-            messages: buf.messages,
+            messages,
         })
     }
 
@@ -490,5 +517,107 @@ mod tests {
         } else {
             panic!("Expected Conversation report");
         }
+    }
+
+    fn make_attachment() -> ConversationAttachment {
+        ConversationAttachment {
+            id: "att-1".to_string(),
+            kind: "image".to_string(),
+            mime_type: "image/png".to_string(),
+            filename: Some("shot.png".to_string()),
+            size_bytes: Some(1024),
+            extracted_text: Some("secret".to_string()),
+            image_data_base64: Some("AAAA".to_string()),
+            duration_secs: None,
+        }
+    }
+
+    #[test]
+    fn test_payload_uploaded_by_default() {
+        let tracker = make_tracker();
+        let reporter = make_reporter();
+
+        tracker.record_user_message("t-on", "secret prompt", false, &[make_attachment()]);
+        tracker.record_assistant_message("t-on", "secret reply", Some("gpt-4o"), 10, 5);
+        tracker.finish_thread("t-on", &reporter);
+
+        let reports = reporter.drain_for_test();
+        if let ClientReport::Conversation { messages, .. } = &reports[0] {
+            assert_eq!(messages[0].content, "secret prompt");
+            assert_eq!(messages[0].attachments.len(), 1);
+            assert_eq!(
+                messages[0].attachments[0].image_data_base64.as_deref(),
+                Some("AAAA")
+            );
+            assert_eq!(messages[1].content, "secret reply");
+        } else {
+            panic!("Expected Conversation report");
+        }
+    }
+
+    #[test]
+    fn test_payload_stripped_when_toggle_off() {
+        let sink = Arc::new(AtomicBool::new(false));
+        let tracker = ConversationTracker::new("scope-off".to_string())
+            .with_upload_payload_sink(Arc::clone(&sink));
+        let reporter = make_reporter();
+
+        tracker.record_user_message("t-off", "secret prompt", true, &[make_attachment()]);
+        tracker.record_assistant_message("t-off", "secret reply", Some("gpt-4o"), 11, 7);
+        tracker.finish_thread("t-off", &reporter);
+
+        let reports = reporter.drain_for_test();
+        if let ClientReport::Conversation {
+            messages,
+            dlp_flagged,
+            model_id,
+            ..
+        } = &reports[0]
+        {
+            assert_eq!(messages.len(), 2);
+            assert_eq!(messages[0].role, "user");
+            assert_eq!(messages[0].content, "");
+            assert!(messages[0].attachments.is_empty());
+            assert_eq!(messages[1].role, "assistant");
+            assert_eq!(messages[1].content, "");
+            assert_eq!(messages[1].input_tokens, 11);
+            assert_eq!(messages[1].output_tokens, 7);
+            assert_eq!(messages[1].model_id.as_deref(), Some("gpt-4o"));
+            assert_eq!(*dlp_flagged, Some(true));
+            assert_eq!(model_id.as_deref(), Some("gpt-4o"));
+        } else {
+            panic!("Expected Conversation report");
+        }
+    }
+
+    #[test]
+    fn test_toggle_flip_takes_effect_on_next_report() {
+        let sink = Arc::new(AtomicBool::new(true));
+        let tracker = ConversationTracker::new("scope-flip".to_string())
+            .with_upload_payload_sink(Arc::clone(&sink));
+        let reporter = make_reporter();
+
+        tracker.record_user_message("t-1", "first", false, &[]);
+        tracker.record_assistant_message("t-1", "reply-1", None, 1, 1);
+        tracker.finish_thread("t-1", &reporter);
+
+        sink.store(false, Ordering::Relaxed);
+
+        tracker.record_user_message("t-2", "second", false, &[]);
+        tracker.record_assistant_message("t-2", "reply-2", None, 2, 2);
+        tracker.finish_thread("t-2", &reporter);
+
+        let reports = reporter.drain_for_test();
+        let on = match &reports[0] {
+            ClientReport::Conversation { messages, .. } => messages.clone(),
+            _ => panic!("Expected Conversation report"),
+        };
+        let off = match &reports[1] {
+            ClientReport::Conversation { messages, .. } => messages.clone(),
+            _ => panic!("Expected Conversation report"),
+        };
+        assert_eq!(on[0].content, "first");
+        assert_eq!(off[0].content, "");
+        assert_eq!(off[1].content, "");
     }
 }

--- a/desktop-client/src/data_reporter.rs
+++ b/desktop-client/src/data_reporter.rs
@@ -19,9 +19,12 @@
 //!
 //! # 安全
 //!
-//! - 不上报原始消息内容
-//! - DLP 事件只上报统计信息，不上报匹配的原始数据
-//! - 使用 HTTPS + Bearer Token 认证
+//! - 审计日志、DLP 事件、使用统计：只上报 metadata，不携带原文 / 匹配片段。
+//! - **对话事件**（`ClientReport::Conversation`）：默认上报完整 message.content
+//!   与附件原文（含截图 base64）。管理端可按客户端在 `registered_clients.
+//!   conversation_upload_enabled` 关闭，关闭后 `ConversationTracker` 会在打包
+//!   前抹掉 content 与附件、只留 role/model/token/used_skills/dlp_flagged。
+//! - 使用 HTTPS + Bearer Token 认证。
 
 use std::sync::Mutex;
 use std::time::Duration;

--- a/desktop-client/src/engine.rs
+++ b/desktop-client/src/engine.rs
@@ -116,12 +116,14 @@ pub async fn start_ironclaw_engine(app_handle: AppHandle) -> anyhow::Result<()> 
         std::env::var("ADMIN_BACKEND_URL").unwrap_or_else(|_| "http://localhost:3000".to_string());
     let client_token = std::env::var("ADMIN_AUTH_TOKEN").unwrap_or_default();
     let backend_user_id = Arc::new(std::sync::RwLock::new(None::<Uuid>));
+    let upload_payload_enabled = Arc::new(std::sync::atomic::AtomicBool::new(true));
     let admin_config_sync = if client_token.is_empty() {
         None
     } else {
         Some(
             crate::admin_sync::AdminConfigSync::new(admin_url.clone(), client_token.clone())
-                .with_backend_user_id_sink(Arc::clone(&backend_user_id)),
+                .with_backend_user_id_sink(Arc::clone(&backend_user_id))
+                .with_upload_payload_sink(Arc::clone(&upload_payload_enabled)),
         )
     };
 
@@ -133,13 +135,18 @@ pub async fn start_ironclaw_engine(app_handle: AppHandle) -> anyhow::Result<()> 
                 if let Ok(mut current) = backend_user_id.write() {
                     *current = cached.backend_principal_id;
                 }
+                upload_payload_enabled.store(
+                    cached.conversation_upload_enabled.unwrap_or(true),
+                    std::sync::atomic::Ordering::Relaxed,
+                );
             }
         }
     }
 
     let tracker = Arc::new(
         crate::conversation_tracker::ConversationTracker::new(scope_id.clone())
-            .with_backend_user_id_sink(Arc::clone(&backend_user_id)),
+            .with_backend_user_id_sink(Arc::clone(&backend_user_id))
+            .with_upload_payload_sink(Arc::clone(&upload_payload_enabled)),
     );
     let reporter = Arc::new(crate::data_reporter::DataReporter::new(
         admin_url.clone(),


### PR DESCRIPTION
## 背景 / 目标

`desktop-client/src/data_reporter.rs` 的 `ClientReport::Conversation` 默认会把 `message.content` 与附件原文（含截图 base64、提取文本）整包上传到 admin-backend，目前没有按客户端关闭的开关；文件顶部安全注释还写着 "不上报原始消息内容"，与实现漂移。

本 PR 加一个 per-client 开关，默认 `TRUE` 保持现状；关闭后客户端会在 `ConversationTracker::build_report` 阶段抹掉 content + 附件原文，只保留 metadata（role / model_id / token / used_skills / dlp_flagged），仍走原有上报路径，所以 admin 端的审计、计费、DLP 命中统计链路保持不变。

## 改动范围（7 文件）

**admin-backend**
- 新增迁移 `029_client_conversation_upload.sql`：`registered_clients` 加 `conversation_upload_enabled BOOLEAN NOT NULL DEFAULT TRUE`
- `routes.rs` `ClientConfigResponse` 加 `conversation_upload_enabled: Option<bool>` 字段；`get_client_config` 把 SELECT 列表从 `user_id, needs_upgrade` 扩成三列
- `tests/integration_smoke_tests.rs` 加 `test_migration_029_conversation_upload_enabled_column`（列级 NOT NULL + 默认值 TRUE 双断言）

**desktop-client**
- `admin_sync.rs` `AdminClientConfig` 加 `conversation_upload_enabled` 字段；`AdminConfigSync` 加 `upload_payload_sink: Option<Arc<AtomicBool>>` + `with_upload_payload_sink` builder + `publish_upload_payload_enabled`（按既有 `backend_user_id_sink` 模式做，无新轮子）
- `conversation_tracker.rs` 加 `upload_payload: Arc<AtomicBool>`（默认 true）；`build_report` 拦截关闭情况，逐条把 content 置空、attachments 清空、保留 metadata
- `engine.rs` 串接 sink：本地 cache fallback 也同步读 `cached.conversation_upload_enabled.unwrap_or(true)`
- `data_reporter.rs` 顶部安全注释改成准确描述

## 非目标（What's NOT in this PR）

- 不做 admin UI（拆到 #954；目前要切只能手动 UPDATE 数据库）
- 不做对话原文导出/备份能力（拆到 #955）
- 不改 audit / DLP / usage 三类事件的上报行为（它们本来就只 metadata）
- 不改 libsql 本地存储
- 不动 `conversation_messages` 表结构（关闭只影响客户端打包，admin 后端字段不变）

## 验证

```bash
cargo check -p desktop-client --tests    # 5m57s 通过 0 错
cargo check -p admin-backend --tests     # 3m30s 通过 0 错
cargo nextest run -p desktop-client --lib conversation_tracker   # 14/14 通过
cargo fmt --all                          # 已 fmt
python3.12 scripts/check_no_panics.py --base origin/xClaw   # OK: No panic
cargo clippy --no-deps -p desktop-client --all-targets      # 0 error（既有 warning 与本 PR 无关）
cargo clippy --no-deps -p admin-backend --all-targets       # 本 PR 改动区零警告；既有 lint 在 routes.rs L2304/L2609 等老代码上，CI 兜底
```

完整 build / workspace clippy / smoke 集成测试由 CI 兑现。

## 测试覆盖

- `test_payload_uploaded_by_default`：默认 sink 不注入或 sink=true 时 content + 附件原文都保留
- `test_payload_stripped_when_toggle_off`：sink=false 时 content 全空、attachments 全空、token/model_id/role/dlp_flagged 保留
- `test_toggle_flip_takes_effect_on_next_report`：运行期翻 sink 立刻对下一份报告生效
- `test_migration_029_conversation_upload_enabled_column`：列级 NOT NULL + DEFAULT TRUE

## 关联

- Closes #953
- 跟踪 issue #954（admin UI）+ #955（libsql 导出/备份）

## Cross-cuts

不涉及 ADR-114（无新增 `.ironclaw` 或 `IRONCLAW_BASE_DIR` 字面量）。

## Sources read

- AGENTS.md §代码质量规范、§GitHub PR 工作流、§ADR-114 红线、§本地快速开发节奏
- desktop-client/src/{admin_sync.rs, conversation_tracker.rs, data_reporter.rs, engine.rs}
- admin-backend/src/routes.rs (L3115-L3320 ClientConfigResponse + get_client_config)
- admin-backend/migrations/009_client_management.sql (registered_clients schema)
- admin-backend/tests/integration_smoke_tests.rs (smoke 列级验证模板)