### PR TITLE
docs(arch): add doc 56 — framework architecture re-review (ADR-160 draft)

### DIFF
--- a/docs/plans/architecture-refactor/56-framework-architecture-re-review.md
+++ b/docs/plans/architecture-refactor/56-framework-architecture-re-review.md
@@ -1,0 +1,213 @@
+# doc 56 — 框架架构重审：砍 LoopDelegate 上帝接口、取消 Session 扩展槽
+
+> 状态：**draft**（候选 ADR-160）
+> 范围：`dasclaw_runtime` / `dasclaw_session` / `dasclaw_hooks` / `dasclaw_safety` 4 个 crate 的边界
+> 关联：ADR-157（无头 agent 框架能力边界）、ADR-148（EgressGate）、ADR-113（hooks event-only）
+> 取代 / 修订：ADR-157 §2.3 三前置条件的实现方向（不取消"做"，但取消"加补丁"的做法）
+
+---
+
+## 1. 背景
+
+ADR-157 §2.3 列出"桌面端 `ChatDelegate` 迁到 `Agent` 门面"的 3 个前置条件：
+
+1. 持久化标准统一（issue #957）
+2. 可插拔 3 阶段派发器（issue #959）
+3. 审批统一到 ApprovalInbox（B4 部分推进）
+
+起草前置 1 / 2 RFC 时发现：**三件事都在给同一棵歪树打补丁**，根因不在 RFC 写得不够细，而在 `LoopDelegate` 这个 trait 本身的层次切错了。
+
+### 1.1 当前问题
+
+[`crates/dasclaw_runtime/src/agent.rs`](../../../crates/dasclaw_runtime/src/agent.rs) 的 `LoopDelegate` trait 把以下职责揉在一个 trait 里：
+
+- 事件循环驱动
+- 工具批次调度（并发 / 顺序）
+- 审批门控
+- 出口消毒（DLP）
+- 会话持久化时机
+
+结果：
+
+- [`HeadlessDelegate::execute_tool_calls`](../../../crates/dasclaw_runtime/src/agent.rs#L855)（约 170 行）
+- [`ChatDelegate::execute_tool_calls`](../../../desktop-client/ironclaw/src/agent/dispatcher.rs#L586)（约 600 行）
+
+**不是同一接口的两个实现，是两份各自独立的事件循环代码**。共性逻辑（事件发射、ApprovalInbox 等待、EgressGate 调用、ChatMessage 追加）在两边复制；想给桌面端加并发只能改一边、headless 无法受益，反之亦然。
+
+### 1.2 行业参照（已核验）
+
+派子 agent 调研 `codex-cli-main` 与 `claw-code` 两个参照实现：
+
+| 维度 | claw-code | codex |
+|---|---|---|
+| Session 类型 | 单一 concrete struct，12 字段（[session.rs:90](../../../claw-code/rust/crates/runtime/src/session.rs#L90)） | 单一 concrete struct，12 字段（codex-rs/core/src/state/session.rs:1-35） |
+| 扩展槽 | **无** | **无** |
+| 第三方扩展 | 改源码 + 版本迁移 | 改源码 + 版本迁移 |
+| 持久化格式 | JSONL 即时追加 | JSONL 后台 mpsc 异步、延迟物化 |
+| 派发器 trait | `ToolExecutor` trait，**1 个方法** `execute(name, input)`（[conversation.rs:57-60](../../../claw-code/rust/crates/runtime/src/conversation.rs#L57)） | `ToolOrchestrator`（单工具粒度） |
+| 派发器层次 | 单工具粒度 | 单工具粒度 |
+| 批工具调度 | conversation.rs 顺序 for 循环（具体代码、无 trait） | turn 内具体代码 |
+
+**关键启示**：业界两个 reference 实现都不做"框架公共扩展槽"。"框架核心字段 vs 业务扩展字段"是个**伪需求**——它把"框架不知道字段含义"的责任甩给使用者，最后人人都往 `serde_json::Value` 里塞 blob，没法 query / migrate / 校验。
+
+---
+
+## 2. 决策
+
+### 2.1 砍 `LoopDelegate` 上帝接口
+
+`LoopDelegate` 进入废弃路径。换为：
+
+```
+AgenticLoop (concrete struct)
+    ├── tool_dispatcher : Box<dyn ToolDispatcher>   ← L2 新增 trait
+    ├── hooks           : HookChain                  ← L3 已有 (event-only)
+    ├── egress_gate     : Arc<dyn EgressGate>        ← L4 已有 (ADR-148)
+    ├── session_store   : Arc<dyn SessionStore>      ← L5 已有 (dasclaw_session)
+    ├── approver        : Box<dyn Approver>          ← 替代 ApprovalInbox 直耦合
+    └── (其他不变的依赖)
+```
+
+`AgenticLoop::run()` 是**所有 agent 共用的同一份**事件循环代码，不再是 trait method。差异点全部通过注入的 trait 表达。
+
+### 2.2 取消 Session 扩展槽
+
+`SessionSnapshot` 保持 concrete struct。新增：
+
+- `version: u32` 字段
+- `migrate_vN_to_vM` 函数族
+- **不**引入 `extensions: serde_json::Value` 或 `metadata: Map<String, Value>`
+
+第三方需要扩展 session 状态？两条路：
+
+| 路径 | 适用场景 |
+|---|---|
+| **WrappedSession** | 第三方自己定义 `MyWrappedSession { inner: SessionSnapshot, my_state: Foo }`，各自管各自的存储 |
+| **推动主线加字段** | 字段对所有 agent 都有意义时，走版本迁移加进 SessionSnapshot |
+
+### 2.3 `HeadlessDelegate` / `ChatDelegate` 走废弃路径
+
+不再是 `LoopDelegate` 的两个实现。改为 `AgenticLoop` 的两套装配：
+
+| 当前类型 | 重构后等价物 |
+|---|---|
+| `HeadlessDelegate` | `AgenticLoop::new(SequentialDispatcher, StandardHookChain, IronclawEgressGate, JsonlSessionStore, AgentEventApprover)` |
+| `ChatDelegate` | `AgenticLoop::new(DesktopDispatcher, DesktopHookChain, DesktopEgressGate, DesktopSessionStore, TauriApprover)` |
+
+桌面端 `tool_output_stash` 双轨切分写成 `DesktopDispatcher`（包 `ConcurrentDispatcher` + 自己的后置逻辑）—— 是桌面端的实现策略，不进框架公共面。
+
+---
+
+## 3. 新分层模型
+
+```
+L1 AgenticLoop          concrete struct，单一实现
+                        run loop = LLM call → tool_calls → dispatcher.dispatch → results → 继续
+
+L2 ToolDispatcher trait async fn dispatch(calls: Vec<ToolCall>, ctx: &DispatchCtx) -> Vec<ToolResult>
+                        默认 SequentialDispatcher / ConcurrentDispatcher
+                        桌面端自己写 DesktopDispatcher（含 stash 切分）
+
+L3 HookChain            纯事件通知 (ADR-113 event-only red line)
+                        不改控制流；改控制流的需求走 L2 的自定义 dispatcher 或 L4 的 EgressGate
+
+L4 EgressGate trait     已有 (ADR-148)
+                        消毒 / DLP / 闸门
+
+L5 SessionStore trait   已有 (dasclaw_session)
+                        SessionSnapshot concrete + version + migration
+                        不做扩展槽
+
+(横切) Approver trait   新增，替代 ApprovalInbox 直耦合
+                        async fn approve(req: ApprovalRequest) -> ApprovalDecision
+                        实现：AgentEventApprover (headless) / TauriApprover (desktop)
+```
+
+---
+
+## 4. 对前置 1/2/3 的影响
+
+| 前置 | 原 RFC 方向 | ADR-160 方向 |
+|---|---|---|
+| **1 持久化 (#957)** | `SessionSnapshot` 加 `extensions: serde_json::Value` 槽 | **取消扩展槽**。`version` + `migrate_vN_to_vM`。第三方走 `WrappedSession` |
+| **2 派发器 (#959)** | 在 `LoopDelegate` 旁加 `ToolDispatcher` trait | **直接砍 `LoopDelegate`**。`AgenticLoop` concrete + 注入 `ToolDispatcher` |
+| **3 审批** | 把 `ApprovalRequest` 全走 `ApprovalInbox` | 引入 `Approver` trait，`AgentEventApprover` 包 `ApprovalInbox`，桌面端用 `TauriApprover` |
+
+净结果：代码量大概率**减少**，因为消除了 `HeadlessDelegate` / `ChatDelegate` 两份 600+170 行的循环代码重复。
+
+---
+
+## 5. 不做什么（显式排除）
+
+- ❌ **不立刻重写** `ChatDelegate` / `HeadlessDelegate`。走废弃路径，给桌面端 / 第三方迁移时间（建议 1 个 release cycle）
+- ❌ **不改** `EgressGate` / `SessionStore` / `dasclaw_safety` 的公共面
+- ❌ **不破坏**现有桌面端行为（tool_output_stash / DLP 双轨切分 / Tauri 直推审批保持原样，只是换实现位置）
+- ❌ **不引入**新 crate（在 `dasclaw_runtime` 内部完成）
+- ❌ **不**强制第三方迁。`LoopDelegate` 标 deprecated 后保留至少 1 个 release
+
+---
+
+## 6. 替代方案（必须列出）
+
+| 方案 | 描述 | 评价 |
+|---|---|---|
+| **A. 维持现状，走原 §2.3 三补丁** | 按 #957 / #959 / 审批统一各加一层补丁 | ❌ 拒绝。补的是歪树枝，根问题不解 |
+| **B. 给 `LoopDelegate` 加 default method** | trait method 给默认实现，子类按需 override | ❌ 拒绝。不解决上帝接口本质——默认 method 仍然在调上帝接口的其他 method，循环耦合 |
+| **C. 本方案（5 分层 + 装配）** | 砍 `LoopDelegate`，引入 `AgenticLoop` concrete + 4 个注入 trait | ✅ 推荐 |
+| **D. 完全废弃 `dasclaw_runtime`，第三方直接用 `dasclaw_core`** | 不给"通用 agent 框架"承诺，每家自己拼 | ❌ 拒绝。ADR-157 已承诺通用 agent 能力 |
+
+---
+
+## 7. 迁移计划（草案）
+
+| 阶段 | 内容 | 状态 |
+|---|---|---|
+| W6 | ADR-160 锁定。在 `dasclaw_runtime` 起 `AgenticLoop` concrete struct（旁路 `LoopDelegate`）+ `ToolDispatcher` / `Approver` trait | 待启动 |
+| W7 | `ChatDelegate` 改为基于 `AgenticLoop` 的装配。保留旧 `ChatDelegate` API 作为薄门面 | 待启动 |
+| W8 | `HeadlessDelegate` 同上 | 待启动 |
+| W9 | `LoopDelegate` 标 `#[deprecated]`，保留 1 个 release | 待启动 |
+| W10 | 删除 `LoopDelegate` 和 `HeadlessDelegate` / `ChatDelegate` 旧实现 | 待启动 |
+
+每个阶段独立 PR，独立可回滚。
+
+---
+
+## 8. 风险
+
+| 风险 | 缓解 |
+|---|---|
+| `ChatDelegate` 当前 15 字段，迁到装配模式切片复杂 | W7 分多个 sub-PR：先抽 `DesktopDispatcher`，再抽 `DesktopHookChain`，最后切 `AgenticLoop::new` |
+| 第三方已 impl `LoopDelegate`（**目前没人，但 W3-A Phase 0 后可能有**） | 兼容 shim：保留 `LoopDelegate` blanket impl for `AgenticLoop`-with-defaults |
+| `tool_output_stash` 抽到 `DesktopDispatcher` 后是否还能让 `json` 工具回查 | stash 本来就是桌面端业务，迁移时随实现迁移，不入框架公共面 |
+| 桌面端 W3-A migration 已进行中，重叠风险 | ADR-160 不要求与 W3-A 同步推进；W3-A 完成后再启 W6 |
+
+---
+
+## 9. DoD（启用 ADR-160 的最小完成度）
+
+- [ ] 本 doc 升 ADR-160（accepted），关联 ADR-157 §2.3 改为"按 ADR-160 实施"
+- [ ] #957 / #959 issue body 改为 ADR-160 方向
+- [ ] PR #958（前置 1 RFC，原扩展槽方向）改写或关闭
+- [ ] `crates/dasclaw_runtime/src/agent.rs` 起 `AgenticLoop` concrete struct PoC
+- [ ] `crates/dasclaw_runtime/src/dispatcher/mod.rs` 起 `ToolDispatcher` trait + `SequentialDispatcher`
+
+---
+
+## 10. Sources read
+
+- [ADR-157 §2.3](adr-157-headless-agent-framework-capability-boundary.md#23-不做的事)
+- [doc 53 §4.3](53-headless-agent-capability-design.md)
+- [doc 54（前置 1 RFC，扩展槽方向）](54-session-extensible-snapshot-rfc.md)
+- [ADR-148（EgressGate）](adr-148-egress-gate.md)
+- [ADR-113（hooks event-only）](adr-113-hook-engine-unification.md)
+- `crates/dasclaw_runtime/src/agent.rs` L807-979（`HeadlessDelegate::execute_tool_calls` 完整 5 步，亲自核验）
+- `desktop-client/ironclaw/src/agent/dispatcher.rs` L586-1200（`ChatDelegate` 三阶段，亲自核验）
+- `claw-code/rust/crates/runtime/src/session.rs` L90-105（`Session` struct 12 字段）
+- `claw-code/rust/crates/runtime/src/conversation.rs` L57-60（`ToolExecutor` trait 1 个方法）
+- `crates/dasclaw_safety/src/lib.rs` L1-60（`SafetyLayer` 已是完整 DLP）
+- `crates/dasclaw_safety/src/egress_gate.rs`（`IronclawEgressGate` 适配器）
+- codex `codex-rs/core/src/state/session.rs` L1-35（`SessionState` 12 字段 concrete，无扩展槽）—— 子 agent 报告引用，未亲自核验
+
+## 11. Cross-cuts
+
+无新增 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量。


### PR DESCRIPTION
## 背景 / 目标

起草 [doc 56](docs/plans/architecture-refactor/56-framework-architecture-re-review.md)（候选 ADR-160），**重审 agent 框架架构**。

调研 codex 与 claw-code 两个参照实现后发现：ADR-157 §2.3 列的 3 个前置条件（持久化标准 #957 / 派发器 #959 / 审批统一）都在给 `LoopDelegate` 这棵歪树打补丁。真问题不在 RFC 写得不细，而在 `LoopDelegate` 本身是个"上帝接口"反模式。

## 改动范围

- ✅ 新增 [`docs/plans/architecture-refactor/56-framework-architecture-re-review.md`](docs/plans/architecture-refactor/56-framework-architecture-re-review.md) 213 行
- ❌ 无代码改动
- ❌ 无脚本 / CI / 配置改动

## 核心决策（doc 56 §2 摘要）

1. **砍 `LoopDelegate` 上帝接口**。换为 `AgenticLoop` concrete struct + 注入 5 个 trait：`ToolDispatcher` / `HookChain` / `EgressGate` / `SessionStore` / `Approver`
2. **取消 Session 扩展槽**。`SessionSnapshot` 保持 concrete struct + `version` + `migrate_vN_to_vM`；第三方扩展走 `WrappedSession` 模式（codex / claw-code 都这么做）
3. **`HeadlessDelegate` / `ChatDelegate` 走废弃路径**。变成 `AgenticLoop` 的两套装配，不再是 `LoopDelegate` 的两个独立 800 行实现

## 对前置 1/2/3 的影响

| 前置 | 原方向 | ADR-160 方向 |
|---|---|---|
| 1 持久化 (#957) | 加 `extensions: serde_json::Value` 槽 | **取消扩展槽**，version + migration |
| 2 派发器 (#959) | 在 `LoopDelegate` 旁加 `ToolDispatcher` | **直接砍 `LoopDelegate`** |
| 3 审批 | 统一到 `ApprovalInbox` | 引入 `Approver` trait 注入 |

#957 / #959 issue body 已同步改为新方向。**#958（前置 1 原扩展槽方向 RFC）将被本 PR 超越，需关闭或重写**——本 PR merge 前会先在 #958 加 comment 说明。

## 非目标（What's NOT in this PR）

- ❌ **不**立刻砍 `LoopDelegate`（走废弃路径，W9 加 deprecated、W10 删除）
- ❌ **不**重写 `ChatDelegate` / `HeadlessDelegate`（W7-W8 分独立 PR）
- ❌ **不**改任何代码（纯架构 ADR 草案）
- ❌ **不**强制第三方迁

## 验证

```bash
# 纯文档 PR，无代码验证
cargo fmt --all  # 0 改动
python3.12 scripts/check_no_panics.py --base origin/xClaw  # 跳过（无 .rs 改动）
```

## Sources read

- [ADR-157 §2.3 不做的事](docs/plans/architecture-refactor/adr-157-headless-agent-framework-capability-boundary.md)
- [ADR-148 EgressGate](docs/plans/architecture-refactor/adr-148-egress-gate.md)
- [ADR-113 hooks event-only](docs/plans/architecture-refactor/adr-113-hook-engine-unification.md)
- [doc 53 §4.3](docs/plans/architecture-refactor/53-headless-agent-capability-design.md)
- [doc 54（被超越的扩展槽 RFC）](docs/plans/architecture-refactor/54-session-extensible-snapshot-rfc.md)
- `crates/dasclaw_runtime/src/agent.rs` L807-979（`HeadlessDelegate::execute_tool_calls`，亲自核验）
- `desktop-client/ironclaw/src/agent/dispatcher.rs` L586-1200（`ChatDelegate` 三阶段，亲自核验）
- `claw-code/rust/crates/runtime/src/session.rs` L90-105 + `conversation.rs` L57-60
- `crates/dasclaw_safety/src/lib.rs` + `egress_gate.rs`（已有完整 DLP + EgressGate 适配器）

## Cross-cuts

类 A：本 PR 无新增 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量。

## 后续步骤

1. 本 PR 锁定 doc 56 → ADR-160 accepted（独立 promotion PR）
2. 处理 PR #958（关闭或重写）
3. 启动 W6：在 `dasclaw_runtime` 起 `AgenticLoop` concrete struct + `ToolDispatcher` trait PoC（不破坏现有 `HeadlessDelegate`）

