### PR TITLE
refactor(runtime): introduce ToolDispatcher trait + expose SequentialDispatcher (W6.2b, stacked on #962)

### DIFF
--- a/crates/dasclaw_runtime/src/agent.rs
+++ b/crates/dasclaw_runtime/src/agent.rs
@@ -61,7 +61,8 @@ use crate::approval::{
     ApprovalDecision, ApprovalDispatchError, ApprovalInbox, ApprovalPolicy, NoApprovalPolicy,
 };
 use crate::tool_dispatch::{
-    APPROVAL_REJECTED_SENTINEL_PREFIX, RejectedPayload, SequentialDispatcher, emit_event,
+    APPROVAL_REJECTED_SENTINEL_PREFIX, RejectedPayload, SequentialDispatcher, ToolDispatcher,
+    emit_event,
 };
 
 /// Streaming event emitted by [`Agent::run_streaming`] and
@@ -868,14 +869,14 @@ impl LoopDelegate for HeadlessDelegate {
             )));
         };
 
-        let dispatcher = SequentialDispatcher {
-            executor: executor.clone(),
-            egress: self.hooks.egress.clone(),
-            approval_policy: self.approval_policy.clone(),
-            approval_inbox: self.approval_inbox.clone(),
-            tool_output_sanitizer: self.tool_output_sanitizer.clone(),
-            event_tx: self.event_tx.clone(),
-        };
+        let dispatcher = SequentialDispatcher::new(
+            executor.clone(),
+            self.hooks.egress.clone(),
+            self.approval_policy.clone(),
+            self.approval_inbox.clone(),
+            self.tool_output_sanitizer.clone(),
+            self.event_tx.clone(),
+        );
         dispatcher.dispatch(tool_calls, content, usage, ctx).await
     }
 }

--- a/crates/dasclaw_runtime/src/lib.rs
+++ b/crates/dasclaw_runtime/src/lib.rs
@@ -77,7 +77,7 @@ pub mod rate_limit;
 pub mod recording;
 pub mod secrets;
 pub mod tool;
-pub(crate) mod tool_dispatch;
+pub mod tool_dispatch;
 pub mod tool_to_executor_adapter;
 
 pub use agent::{

--- a/crates/dasclaw_runtime/src/tool_dispatch.rs
+++ b/crates/dasclaw_runtime/src/tool_dispatch.rs
@@ -17,6 +17,8 @@
 
 use std::sync::Arc;
 
+use async_trait::async_trait;
+use dasclaw_core::agentic_loop::LoopOutcome;
 use dasclaw_core::egress_apply::{EgressApply, apply_egress_decision};
 use dasclaw_core::hooks::{EgressGate, EgressKind};
 use dasclaw_core::messages::{ChatMessage, ToolCall};
@@ -30,7 +32,6 @@ use uuid::Uuid;
 use crate::AgentEvent;
 use crate::agent::{ToolExecutor, ToolOutputSanitizer};
 use crate::approval::{ApprovalDecision, ApprovalInbox, ApprovalPolicy};
-use dasclaw_core::agentic_loop::LoopOutcome;
 
 /// Sentinel prefix for `LoopOutcome::Failure` strings produced when an
 /// `ApprovalPolicy` flagged a tool call and the GUI replied
@@ -77,22 +78,68 @@ fn push_assistant_tool_calls(
     );
 }
 
+/// L2 seam (ADR-160 §3): drive a single agentic-loop iteration's
+/// tool calls through whatever pipeline the host wires up.
+///
+/// The only in-tree impl today is [`SequentialDispatcher`], which
+/// preserves the ADR-153 §1.1 5-step pipeline byte-for-byte. Future
+/// `AgenticLoop`-level implementations (parallel dispatch, replay,
+/// fakes for testing) plug in here without touching
+/// `HeadlessDelegate` or `run_agentic_loop`.
+#[async_trait]
+pub trait ToolDispatcher: Send + Sync {
+    /// Execute one iteration's worth of tool calls.
+    ///
+    /// Returning `Ok(Some(outcome))` short-circuits the agentic loop
+    /// (e.g. approval rejection, fatal sandbox refusal). Returning
+    /// `Ok(None)` lets the loop run another model turn.
+    async fn dispatch(
+        &self,
+        tool_calls: Vec<ToolCall>,
+        content: Option<String>,
+        usage: TokenUsage,
+        ctx: &mut ReasoningContext,
+    ) -> Result<Option<LoopOutcome>, HostError>;
+}
+
 /// Sequential implementation of the ADR-153 §1.1 tool dispatch
 /// pipeline. Executes the supplied `tool_calls` one after another;
 /// short-circuits on approval rejection.
-pub(crate) struct SequentialDispatcher {
-    pub(crate) executor: Arc<dyn ToolExecutor>,
-    pub(crate) egress: Arc<dyn EgressGate>,
-    pub(crate) approval_policy: Arc<dyn ApprovalPolicy>,
-    pub(crate) approval_inbox: ApprovalInbox,
-    pub(crate) tool_output_sanitizer: Option<Arc<dyn ToolOutputSanitizer>>,
-    pub(crate) event_tx: Option<mpsc::Sender<AgentEvent>>,
+pub struct SequentialDispatcher {
+    executor: Arc<dyn ToolExecutor>,
+    egress: Arc<dyn EgressGate>,
+    approval_policy: Arc<dyn ApprovalPolicy>,
+    approval_inbox: ApprovalInbox,
+    tool_output_sanitizer: Option<Arc<dyn ToolOutputSanitizer>>,
+    event_tx: Option<mpsc::Sender<AgentEvent>>,
 }
 
 impl SequentialDispatcher {
-    /// Drive one iteration's worth of tool calls through the full
-    /// 5-step pipeline.
-    pub(crate) async fn dispatch(
+    /// Wire up a dispatcher with the runtime's shared collaborators.
+    /// All `Arc` handles are cheap to clone, so a fresh dispatcher
+    /// per loop iteration is acceptable.
+    pub fn new(
+        executor: Arc<dyn ToolExecutor>,
+        egress: Arc<dyn EgressGate>,
+        approval_policy: Arc<dyn ApprovalPolicy>,
+        approval_inbox: ApprovalInbox,
+        tool_output_sanitizer: Option<Arc<dyn ToolOutputSanitizer>>,
+        event_tx: Option<mpsc::Sender<AgentEvent>>,
+    ) -> Self {
+        Self {
+            executor,
+            egress,
+            approval_policy,
+            approval_inbox,
+            tool_output_sanitizer,
+            event_tx,
+        }
+    }
+}
+
+#[async_trait]
+impl ToolDispatcher for SequentialDispatcher {
+    async fn dispatch(
         &self,
         tool_calls: Vec<ToolCall>,
         content: Option<String>,
@@ -189,7 +236,9 @@ impl SequentialDispatcher {
         }
         Ok(None)
     }
+}
 
+impl SequentialDispatcher {
     async fn emit(&self, event: AgentEvent) {
         emit_event(self.event_tx.as_ref(), event).await;
     }


### PR DESCRIPTION
Closes #959

## 背景 / 目标

ADR-160 §3 把 IronClaw runtime 的 5 层模型固化为：L1 AgenticLoop（concrete）/ **L2 ToolDispatcher（trait）** / L3 HookChain / L4 EgressGate / L5 SessionStore + Approver。

#962（W6.2a，**本 PR 的 base**）已经把 `HeadlessDelegate` 内联的 173 行 5 步派发流水线抽到 `pub(crate) struct SequentialDispatcher`，但仍是 crate-private、也没有 trait 接缝。

**本 PR（W6.2b）** 引入 L2 接缝本身：把 `SequentialDispatcher` 暴露为 `pub`，并新增 `pub trait ToolDispatcher`。**`dispatch` 方法体字节级不变** —— 只是从 inherent 方法搬到 `impl ToolDispatcher for SequentialDispatcher`。

## 改动范围（3 文件，+71 / -21）

**`crates/dasclaw_runtime/src/tool_dispatch.rs`**
- 新增 `pub trait ToolDispatcher` —— 单方法 `async fn dispatch(...) -> Result<Option<LoopOutcome>, HostError>`，签名与原 inherent 方法一致
- `SequentialDispatcher` 从 `pub(crate) struct` 升为 `pub struct`，字段全部改为私有
- 新增 `pub fn SequentialDispatcher::new(executor, egress, approval_policy, approval_inbox, sanitizer, event_tx)` 构造函数（外部 crate 唯一入口）
- `dispatch` 方法搬到 `impl ToolDispatcher for SequentialDispatcher`（body 字节级不变）
- `emit` / `await_approval_for` / `push_rejection` 保留在 inherent `impl SequentialDispatcher` 块（trait 表面保持最小）

**`crates/dasclaw_runtime/src/agent.rs`**
- `HeadlessDelegate::execute_tool_calls`：把 struct literal 构造改成 `SequentialDispatcher::new(...)`
- import 加上 `ToolDispatcher`（trait 必须在 scope 才能调用其方法）

**`crates/dasclaw_runtime/src/lib.rs`**
- `pub(crate) mod tool_dispatch;` → `pub mod tool_dispatch;`

## 非目标（What's NOT in this PR）

- ❌ **不**改 dispatch body（行为字节级保持）
- ❌ **不**新增第二个 `ToolDispatcher` 实现（占位、parallel、replay 都留给后续 ADR）
- ❌ **不**抽 `Approver` trait（留给 W6.3）
- ❌ **不**提取 `AgenticLoop` concrete struct（留给 W6.4）
- ❌ **不**改公共 API、不动其他 crate

## 验证

```bash
cargo check -p dasclaw_runtime --tests             # 0 errors, 0 warnings
cargo nextest run -p dasclaw_runtime               # 196/196 passed
cargo clippy --no-deps -p dasclaw_runtime --all-targets -- -D warnings  # clean
cargo fmt --all                                    # clean
python3.12 scripts/check_no_panics.py --base origin/xClaw  # OK
```

Skills 管线：
- `code-quality-audit`：5 项全部通过
- `code-review-expert`：APPROVE（无 P0/P1；只有一条 P2 建议给 `new()` 加 doc — 已包含）

## Cross-cuts

**类 A**（与 ADR-114 `.ironclaw` → `.dasclaw` 命名迁移）：本 PR 未新增任何 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量。

## Sources read

- `docs/plans/architecture-refactor/adr-160-runtime-five-layer-model.md` §3 五层模型 / §6 W6 切片计划
- `crates/dasclaw_runtime/src/approval.rs`（`#[async_trait] pub trait ApprovalPolicy` 风格参考）
- `crates/dasclaw_runtime/src/agent.rs`（`ToolExecutor` / `ToolOutputSanitizer` trait 风格参考）
- `AGENTS.md`（本地节奏 + skills 强制管线 + stacked PR 描述要求 + 类 A 声明）

## Stacked PR 注意

- **Base 分支**：`feat/w6.2a-extract-sequential-dispatcher` —— **不是** `xClaw`
- **Merge 顺序**：先 review + merge #962（W6.2a），再 rebase 本 PR 到 `xClaw` 后 merge
- **请先看 #962** 再看本 PR；本 PR diff 只包含 W6.2b 增量（71/21 行），不包含 W6.2a 的 280/240 行
- 按 AGENTS.md：合 #962 时**不要勾选 "Delete branch"**（路径 A），等本 PR rebase + merge 后再统一清理

## 后续

- **W6.3**：抽 `Approver` trait（把 `await_approval_for` 行为也搬到独立 trait）
- **W6.4**：把 `AgenticLoop` 提取为 concrete struct，正式注入 `ToolDispatcher`