### PR TITLE
refactor(runtime): introduce Approver trait + PolicyApprover (W6.3, stacked on #963)

### DIFF
--- a/crates/dasclaw_runtime/src/agent.rs
+++ b/crates/dasclaw_runtime/src/agent.rs
@@ -59,6 +59,7 @@ use uuid::Uuid;
 
 use crate::approval::{
     ApprovalDecision, ApprovalDispatchError, ApprovalInbox, ApprovalPolicy, NoApprovalPolicy,
+    PolicyApprover,
 };
 use crate::tool_dispatch::{
     APPROVAL_REJECTED_SENTINEL_PREFIX, RejectedPayload, SequentialDispatcher, ToolDispatcher,
@@ -872,8 +873,10 @@ impl LoopDelegate for HeadlessDelegate {
         let dispatcher = SequentialDispatcher::new(
             executor.clone(),
             self.hooks.egress.clone(),
-            self.approval_policy.clone(),
-            self.approval_inbox.clone(),
+            Arc::new(PolicyApprover::new(
+                self.approval_policy.clone(),
+                self.approval_inbox.clone(),
+            )),
             self.tool_output_sanitizer.clone(),
             self.event_tx.clone(),
         );

--- a/crates/dasclaw_runtime/src/approval.rs
+++ b/crates/dasclaw_runtime/src/approval.rs
@@ -33,8 +33,10 @@ use std::sync::Mutex;
 use async_trait::async_trait;
 use dasclaw_core::messages::ToolCall;
 use serde::{Deserialize, Serialize};
-use tokio::sync::oneshot;
+use tokio::sync::{mpsc, oneshot};
 use uuid::Uuid;
+
+use crate::AgentEvent;
 
 /// What the GUI tells the runtime once the user (dis)approves a call.
 ///
@@ -195,6 +197,107 @@ impl ApprovalInbox {
             Err(poisoned) => poisoned.into_inner(),
         };
         guard.remove(&request_id);
+    }
+}
+
+/// L5 cross-cutting seam (ADR-160 §3): outcome the runtime receives
+/// from an [`Approver`] for a single tool call.
+///
+/// Crate-internal control flow only; the GUI's wire format remains
+/// [`ApprovalDecision`].
+#[derive(Debug, PartialEq, Eq)]
+pub enum ApprovalOutcome {
+    /// No approval policy fired; continue dispatch.
+    NotRequired,
+    /// User (or default policy) said yes.
+    Approved,
+    /// User refused; the dispatcher must short-circuit the loop with
+    /// an [`crate::AgentError::ApprovalRejected`].
+    Rejected { reason: Option<String> },
+}
+
+/// L5 cross-cutting seam (ADR-160 §3): asks the host whether a tool
+/// call may proceed before the dispatcher runs the executor.
+///
+/// Implementations are responsible for emitting any user-facing
+/// approval prompts (e.g. [`crate::AgentEvent::ApprovalNeeded`]) and
+/// for blocking until the host replies. The default in-tree impl is
+/// [`PolicyApprover`], which drives an [`ApprovalPolicy`] +
+/// [`ApprovalInbox`] pair just like the pre-W6.3 inline pipeline did.
+#[async_trait]
+pub trait Approver: Send + Sync {
+    /// Inspect `call` and return the host's verdict. `event_tx` is the
+    /// loop's event channel — implementations may push
+    /// [`AgentEvent`]s through it to surface a GUI prompt.
+    async fn await_approval(
+        &self,
+        call: &ToolCall,
+        event_tx: Option<&mpsc::Sender<AgentEvent>>,
+    ) -> ApprovalOutcome;
+}
+
+/// Default in-tree [`Approver`]: drives an [`ApprovalPolicy`] +
+/// [`ApprovalInbox`] pair. Behaviour is byte-identical to the
+/// pre-W6.3 inline `SequentialDispatcher::await_approval_for`.
+pub struct PolicyApprover {
+    policy: Arc<dyn ApprovalPolicy>,
+    inbox: ApprovalInbox,
+}
+
+impl PolicyApprover {
+    /// Wire up an approver around an existing policy + inbox pair.
+    #[must_use]
+    pub fn new(policy: Arc<dyn ApprovalPolicy>, inbox: ApprovalInbox) -> Self {
+        Self { policy, inbox }
+    }
+}
+
+#[async_trait]
+impl Approver for PolicyApprover {
+    async fn await_approval(
+        &self,
+        call: &ToolCall,
+        event_tx: Option<&mpsc::Sender<AgentEvent>>,
+    ) -> ApprovalOutcome {
+        let Some(request) = self.policy.evaluate(call).await else {
+            return ApprovalOutcome::NotRequired;
+        };
+
+        let request_id = Uuid::new_v4();
+        let rx = self.inbox.register(request_id);
+
+        if let Some(tx) = event_tx {
+            // Best-effort emit; a closed receiver is not fatal.
+            let _ = tx
+                .send(AgentEvent::ApprovalNeeded {
+                    request_id,
+                    tool_name: call.name.clone(),
+                    tool_arguments: call.arguments.clone(),
+                    description: request.description,
+                    display_parameters: request.display_parameters,
+                    allow_always: request.allow_always,
+                })
+                .await;
+        }
+
+        match rx.await {
+            Ok(ApprovalDecision::Approve) | Ok(ApprovalDecision::ApproveAlways) => {
+                ApprovalOutcome::Approved
+            }
+            Ok(ApprovalDecision::Reject { reason }) => ApprovalOutcome::Rejected { reason },
+            Err(_) => {
+                // Sender dropped without dispatching: forget the entry
+                // so a late respond_to_approval call still hits
+                // ApprovalDispatchError::Unknown rather than leaking the
+                // pending request forever.
+                self.inbox.forget(request_id);
+                ApprovalOutcome::Rejected {
+                    reason: Some(String::from(
+                        "approval channel closed before the GUI replied",
+                    )),
+                }
+            }
+        }
     }
 }
 

--- a/crates/dasclaw_runtime/src/lib.rs
+++ b/crates/dasclaw_runtime/src/lib.rs
@@ -85,8 +85,8 @@ pub use agent::{
     ToolOutputSanitizer,
 };
 pub use approval::{
-    ApprovalDecision, ApprovalDispatchError, ApprovalInbox, ApprovalPolicy, ApprovalRequest,
-    NoApprovalPolicy,
+    ApprovalDecision, ApprovalDispatchError, ApprovalInbox, ApprovalOutcome, ApprovalPolicy,
+    ApprovalRequest, Approver, NoApprovalPolicy, PolicyApprover,
 };
 pub use composite_executor::{CompositeError, CompositeToolExecutor};
 pub use error::ToolError;

--- a/crates/dasclaw_runtime/src/tool_dispatch.rs
+++ b/crates/dasclaw_runtime/src/tool_dispatch.rs
@@ -27,11 +27,10 @@ use dasclaw_core::response_types::TokenUsage;
 use dasclaw_core::traits::HostError;
 use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc;
-use uuid::Uuid;
 
 use crate::AgentEvent;
 use crate::agent::{ToolExecutor, ToolOutputSanitizer};
-use crate::approval::{ApprovalDecision, ApprovalInbox, ApprovalPolicy};
+use crate::approval::{ApprovalOutcome, Approver};
 
 /// Sentinel prefix for `LoopOutcome::Failure` strings produced when an
 /// `ApprovalPolicy` flagged a tool call and the GUI replied
@@ -45,13 +44,6 @@ pub(crate) const APPROVAL_REJECTED_SENTINEL_PREFIX: &str = "headless-agent::appr
 pub(crate) struct RejectedPayload {
     pub(crate) tool_name: String,
     pub(crate) reason: Option<String>,
-}
-
-/// Outcome of `SequentialDispatcher::await_approval_for`.
-enum ApprovalOutcome {
-    NotRequired,
-    Approved,
-    Rejected { reason: Option<String> },
 }
 
 /// Best-effort emit; a closed receiver is not a loop-fatal error.
@@ -108,8 +100,7 @@ pub trait ToolDispatcher: Send + Sync {
 pub struct SequentialDispatcher {
     executor: Arc<dyn ToolExecutor>,
     egress: Arc<dyn EgressGate>,
-    approval_policy: Arc<dyn ApprovalPolicy>,
-    approval_inbox: ApprovalInbox,
+    approver: Arc<dyn Approver>,
     tool_output_sanitizer: Option<Arc<dyn ToolOutputSanitizer>>,
     event_tx: Option<mpsc::Sender<AgentEvent>>,
 }
@@ -121,16 +112,14 @@ impl SequentialDispatcher {
     pub fn new(
         executor: Arc<dyn ToolExecutor>,
         egress: Arc<dyn EgressGate>,
-        approval_policy: Arc<dyn ApprovalPolicy>,
-        approval_inbox: ApprovalInbox,
+        approver: Arc<dyn Approver>,
         tool_output_sanitizer: Option<Arc<dyn ToolOutputSanitizer>>,
         event_tx: Option<mpsc::Sender<AgentEvent>>,
     ) -> Self {
         Self {
             executor,
             egress,
-            approval_policy,
-            approval_inbox,
+            approver,
             tool_output_sanitizer,
             event_tx,
         }
@@ -161,7 +150,11 @@ impl ToolDispatcher for SequentialDispatcher {
             .await;
 
             // ADR-153 / issue #910 — GUI approval loop B4.
-            match self.await_approval_for(call).await {
+            match self
+                .approver
+                .await_approval(call, self.event_tx.as_ref())
+                .await
+            {
                 ApprovalOutcome::NotRequired | ApprovalOutcome::Approved => {}
                 ApprovalOutcome::Rejected { reason } => {
                     return Ok(Some(self.push_rejection(ctx, call, reason).await));
@@ -241,44 +234,6 @@ impl ToolDispatcher for SequentialDispatcher {
 impl SequentialDispatcher {
     async fn emit(&self, event: AgentEvent) {
         emit_event(self.event_tx.as_ref(), event).await;
-    }
-
-    async fn await_approval_for(&self, call: &ToolCall) -> ApprovalOutcome {
-        let Some(request) = self.approval_policy.evaluate(call).await else {
-            return ApprovalOutcome::NotRequired;
-        };
-
-        let request_id = Uuid::new_v4();
-        let rx = self.approval_inbox.register(request_id);
-
-        self.emit(AgentEvent::ApprovalNeeded {
-            request_id,
-            tool_name: call.name.clone(),
-            tool_arguments: call.arguments.clone(),
-            description: request.description,
-            display_parameters: request.display_parameters,
-            allow_always: request.allow_always,
-        })
-        .await;
-
-        match rx.await {
-            Ok(ApprovalDecision::Approve) | Ok(ApprovalDecision::ApproveAlways) => {
-                ApprovalOutcome::Approved
-            }
-            Ok(ApprovalDecision::Reject { reason }) => ApprovalOutcome::Rejected { reason },
-            Err(_) => {
-                // Sender dropped without dispatching: forget the entry
-                // so a late respond_to_approval call still hits
-                // ApprovalDispatchError::Unknown rather than leaking the
-                // pending request forever.
-                self.approval_inbox.forget(request_id);
-                ApprovalOutcome::Rejected {
-                    reason: Some(String::from(
-                        "approval channel closed before the GUI replied",
-                    )),
-                }
-            }
-        }
     }
 
     async fn push_rejection(


### PR DESCRIPTION
Closes #959

## 背景 / 目标

ADR-160 §3 把 IronClaw runtime 的 5 层模型固化为：L1 AgenticLoop（concrete）/ L2 ToolDispatcher（trait）/ L3 HookChain / L4 EgressGate / **L5 SessionStore + Approver（cross-cutting）**。

W6.2a（#962）抽出 `SequentialDispatcher`，W6.2b（#963）引入 `ToolDispatcher` trait。但 dispatcher 仍直接持有 `Arc<dyn ApprovalPolicy>` + `ApprovalInbox`，把"是否需要 approval / 等待用户回应"的横切关注点硬编码在 L2 内部。

**本 PR（W6.3）** 抽出 L5 接缝 `Approver` trait，把 approval 决策搬到独立 trait + 默认实现 `PolicyApprover`，让 W6.4（concrete `AgenticLoop`）可以注入替代实现（mock / headless-auto-reject / policy-routed）而不动 dispatcher 或 headless delegate。

## 改动范围（4 文件，+120 / -59）

**`crates/dasclaw_runtime/src/approval.rs`**（+105）
- 新增 `pub enum ApprovalOutcome { NotRequired, Approved, Rejected { reason } }`
- 新增 `pub trait Approver` —— 单方法 `async fn await_approval(&self, call, event_tx) -> ApprovalOutcome`
- 新增 `pub struct PolicyApprover { policy: Arc<dyn ApprovalPolicy>, inbox: ApprovalInbox }` + `pub fn new(...)`
- `impl Approver for PolicyApprover` —— **字节级搬迁**原 `SequentialDispatcher::await_approval_for` 的逻辑（policy.evaluate → inbox.register → emit `ApprovalNeeded` → rx.await → 失败时 forget）
- 头部 import 加 `tokio::sync::mpsc` + `crate::AgentEvent`

**`crates/dasclaw_runtime/src/tool_dispatch.rs`**（净 -56）
- 删除本地 `enum ApprovalOutcome`（改 use `crate::approval::ApprovalOutcome`）
- 删除 `await_approval_for` 方法（搬到 `PolicyApprover`）
- 删除字段 `approval_policy` + `approval_inbox`，新增 `approver: Arc<dyn Approver>`
- `SequentialDispatcher::new(...)` 签名：6 参 → 5 参（policy + inbox 合并为单个 approver）
- `dispatch` 内：`self.await_approval_for(call).await` → `self.approver.await_approval(call, self.event_tx.as_ref()).await`
- 清理不再使用的 import：`Uuid`、`ApprovalDecision`、`ApprovalInbox`、`ApprovalPolicy`

**`crates/dasclaw_runtime/src/agent.rs`**（+5 / -2）
- `HeadlessDelegate::execute_tool_calls` 构造 `Arc::new(PolicyApprover::new(self.approval_policy.clone(), self.approval_inbox.clone()))` 传给 `SequentialDispatcher::new`
- import 加 `PolicyApprover`
- HeadlessDelegate **仍持有** `approval_policy` + `approval_inbox` 字段（`Agent::respond_to_approval` 通过 `inbox.dispatch` 把 GUI 回应送入 oneshot 通道，必须保留）

**`crates/dasclaw_runtime/src/lib.rs`**（+2 / -1）
- re-export `ApprovalOutcome`, `Approver`, `PolicyApprover`

## 非目标（What's NOT in this PR）

- ❌ **不**改变 approval 决策的行为（policy.evaluate 路径、emit 时机、forget 语义全保留）
- ❌ **不**改 `AgentEvent::ApprovalNeeded` payload
- ❌ **不**改 `ApprovalDecision` 三个 variant 的 wire 格式
- ❌ **不**从 `HeadlessDelegate` 移除 `approval_policy` / `approval_inbox` 字段（外部 dispatch 仍要用）
- ❌ **不**提取 `AgenticLoop` concrete struct（留给 W6.4）
- ❌ **不**改 SessionStore（L5 另一半，留给后续 ADR）

## 验证

```bash
cargo check -p dasclaw_runtime --tests             # 0 errors, 0 warnings
cargo nextest run -p dasclaw_runtime               # 196/196 passed
cargo clippy --no-deps -p dasclaw_runtime --all-targets -- -D warnings  # clean
cargo fmt --all                                    # clean
python3.12 scripts/check_no_panics.py --base origin/xClaw  # OK
```

Skills 管线（并行子 agent）：
- `code-quality-audit`：5 项全部通过
- `code-simplifier`：通过（无可简化点）
- `code-review-expert`：SRP / OCP / LSP / DIP / 安全 / 错误处理 / 字节级等价全 ✓，无 P0/P1/P2

## Cross-cuts

**类 A**（与 ADR-114 `.ironclaw` → `.dasclaw` 命名迁移）：本 PR 未新增任何 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量。

## Sources read

- `docs/plans/architecture-refactor/adr-160-runtime-five-layer-model.md` §3 五层模型（L5 SessionStore + Approver）
- `crates/dasclaw_runtime/src/approval.rs`（ApprovalPolicy / ApprovalInbox / ApprovalDispatchError 现有形态）
- `crates/dasclaw_runtime/src/tool_dispatch.rs`（W6.2b 后的形态：await_approval_for 是搬迁源头）
- `crates/dasclaw_runtime/src/agent.rs`（HeadlessDelegate `respond_to_approval` 仍依赖 inbox.dispatch）
- `AGENTS.md`（本地节奏 + skills 强制管线 + stacked PR 描述要求 + 类 A 声明）

## Stacked PR 注意

- **Base 分支**：`feat/w6.2b-tool-dispatcher-trait` —— **不是** `xClaw`
- **Merge 顺序**：先 #962（W6.2a）→ 再 #963（W6.2b）→ 最后本 PR
- **请先看 #962 / #963 再看本 PR**；本 PR diff 只是 W6.3 增量（120/59 行）
- 合并下层 PR 时**不要勾选 "Delete branch"**（按 AGENTS.md 路径 A），或者提前把上层 PR base 切到 xClaw（路径 B）

## 后续

- **W6.4**：提取 `AgenticLoop` 为 concrete struct，注入 `ToolDispatcher` + `Approver`
- 后续 ADR：L5 的另一半 `SessionStore` trait