### PR TITLE
refactor(runtime): extract concrete AgenticLoop struct (W6.4, stacked on #964)

### DIFF
--- a/crates/dasclaw_runtime/src/agent.rs
+++ b/crates/dasclaw_runtime/src/agent.rs
@@ -44,26 +44,24 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use dasclaw_core::agentic_loop::{
-    AgenticLoopConfig, LoopDelegate, LoopOutcome, LoopSignal, TextAction, run_agentic_loop,
-};
+use dasclaw_core::agentic_loop::{AgenticLoopConfig, LoopOutcome};
 use dasclaw_core::hooks::HookBundle;
 use dasclaw_core::messages::{ChatMessage, FinishReason, ToolCall, ToolDefinition, ToolResult};
 use dasclaw_core::reasoning_ctx::ReasoningContext;
-use dasclaw_core::response_types::{RespondOutput, RespondResult, ResponseMetadata, TokenUsage};
+use dasclaw_core::response_types::{RespondOutput, RespondResult};
 use dasclaw_core::traits::HostError;
 use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
+use crate::agentic_loop::AgenticLoop;
 use crate::approval::{
     ApprovalDecision, ApprovalDispatchError, ApprovalInbox, ApprovalPolicy, NoApprovalPolicy,
     PolicyApprover,
 };
 use crate::tool_dispatch::{
     APPROVAL_REJECTED_SENTINEL_PREFIX, RejectedPayload, SequentialDispatcher, ToolDispatcher,
-    emit_event,
 };
 
 /// Streaming event emitted by [`Agent::run_streaming`] and
@@ -553,10 +551,11 @@ impl Agent {
     }
 
     /// Shared loop driver for both streaming and non-streaming runs.
-    /// The single `event_tx: Option<...>` field on [`HeadlessDelegate`]
-    /// routes each iteration to [`AgentResponder::respond_streaming`] or
-    /// [`AgentResponder::respond`] and gates the `ToolCallStart` /
-    /// `ToolResult` / `FinishReason` emits.
+    /// The optional `event_tx` is forwarded to the
+    /// [`AgenticLoop`] which routes each iteration to
+    /// [`AgentResponder::respond_streaming`] or [`AgentResponder::respond`]
+    /// and gates the `ToolCallStart` / `ToolResult` / `FinishReason`
+    /// emits.
     async fn run_in_context_inner(
         &self,
         ctx: &mut ReasoningContext,
@@ -572,26 +571,41 @@ impl Agent {
             .map(clone_loop_config)
             .unwrap_or_default();
 
-        let delegate = HeadlessDelegate {
-            responder: Arc::clone(&self.responder),
-            tool_executor: self.tool_executor.clone(),
-            hooks: self.hooks.clone(),
-            tool_output_sanitizer: self.tool_output_sanitizer.clone(),
-            cancellation_token: self.cancellation_token.clone(),
-            event_tx,
-            approval_policy: Arc::clone(&self.approval_policy),
-            approval_inbox: self.approval_inbox.clone(),
-        };
+        // Build the L2 dispatcher once for the lifetime of this run
+        // (pre-W6.4 rebuilt it on every iteration inside
+        // `HeadlessDelegate::execute_tool_calls`). When no executor is
+        // wired, leave the dispatcher unset so the loop emits the
+        // `TOOLS_NOT_SUPPORTED_REASON` sentinel just like before.
+        let dispatcher: Option<Arc<dyn ToolDispatcher>> = self.tool_executor.as_ref().map(|exec| {
+            Arc::new(SequentialDispatcher::new(
+                Arc::clone(exec),
+                Arc::clone(&self.hooks.egress),
+                Arc::new(PolicyApprover::new(
+                    Arc::clone(&self.approval_policy),
+                    self.approval_inbox.clone(),
+                )),
+                self.tool_output_sanitizer.clone(),
+                event_tx.clone(),
+            )) as Arc<dyn ToolDispatcher>
+        });
 
-        let outcome = run_agentic_loop(&delegate, ctx, &loop_config, &self.hooks)
+        let agentic_loop = AgenticLoop::new(
+            Arc::clone(&self.responder),
+            dispatcher,
+            self.cancellation_token.clone(),
+            event_tx,
+        );
+
+        let outcome = agentic_loop
+            .run(ctx, &loop_config, &self.hooks)
             .await
             .map_err(AgentError::Responder)?;
 
-        // History continuity: `HeadlessDelegate::handle_text_response`
-        // records the final assistant turn into `ctx` (with token usage
-        // attached) before returning the response text, mirroring the
-        // push that `execute_tool_calls` already performs on the
-        // tool-call branch. That keeps the next call in a multi-turn
+        // History continuity: the agentic loop records the final
+        // assistant turn into `ctx` (with token usage attached) before
+        // returning the response text, mirroring the push that
+        // `SequentialDispatcher` already performs on the tool-call
+        // branch. That keeps the next call in a multi-turn
         // `Session::run` aware of what the model just said without
         // requiring the caller to plumb usage out of `LoopOutcome`.
         map_outcome(outcome, loop_config.max_iterations)
@@ -775,118 +789,10 @@ impl AgentBuilder {
     }
 }
 
-/// Internal `LoopDelegate` that bridges the agentic loop to a single
-/// [`AgentResponder`]. The agent has already seeded the reasoning
-/// context with the user prompt, system prompt, model override and
-/// advertised tools before the loop starts, so the delegate only needs
-/// the responder and an optional tool executor.
-///
-/// When `event_tx` is `Some`, the delegate routes each iteration through
-/// [`AgentResponder::respond_streaming`] and forwards
-/// [`AgentEvent::ToolCallStart`], [`AgentEvent::ToolResult`] and
-/// [`AgentEvent::FinishReason`] events to the host (issue #908, GUI
-/// blocker B2). When `None`, the delegate behaves exactly like the
-/// pre-#908 non-streaming path.
-struct HeadlessDelegate {
-    responder: Arc<dyn AgentResponder>,
-    tool_executor: Option<Arc<dyn ToolExecutor>>,
-    hooks: HookBundle,
-    tool_output_sanitizer: Option<Arc<dyn ToolOutputSanitizer>>,
-    cancellation_token: Option<CancellationToken>,
-    event_tx: Option<mpsc::Sender<AgentEvent>>,
-    approval_policy: Arc<dyn ApprovalPolicy>,
-    approval_inbox: ApprovalInbox,
-}
-
-impl HeadlessDelegate {
-    /// Best-effort emit; a closed receiver is not a loop-fatal error.
-    async fn emit(&self, event: AgentEvent) {
-        emit_event(self.event_tx.as_ref(), event).await;
-    }
-}
-
-#[async_trait]
-impl LoopDelegate for HeadlessDelegate {
-    async fn check_signals(&self) -> LoopSignal {
-        match self.cancellation_token.as_ref() {
-            Some(token) if token.is_cancelled() => LoopSignal::Stop,
-            _ => LoopSignal::Continue,
-        }
-    }
-
-    async fn before_llm_call(
-        &self,
-        _ctx: &mut ReasoningContext,
-        _iteration: usize,
-    ) -> Option<LoopOutcome> {
-        None
-    }
-
-    async fn call_llm(
-        &self,
-        ctx: &mut ReasoningContext,
-        _iteration: usize,
-    ) -> Result<RespondOutput, HostError> {
-        // Streaming and non-streaming routes split at the responder
-        // seam: when an event channel is wired we go through
-        // `respond_streaming`, which the default trait impl falls back
-        // to `respond` for adapters that don't override it. Either way
-        // we forward the trailing `FinishReason` so a GUI knows the
-        // iteration boundary even when the model emitted no text.
-        let output = match self.event_tx.as_ref() {
-            Some(tx) => self.responder.respond_streaming(ctx, tx.clone()).await?,
-            None => self.responder.respond(ctx).await?,
-        };
-        self.emit(AgentEvent::FinishReason(output.finish_reason))
-            .await;
-        Ok(output)
-    }
-
-    async fn handle_text_response(
-        &self,
-        text: &str,
-        _metadata: ResponseMetadata,
-        usage: TokenUsage,
-        ctx: &mut ReasoningContext,
-    ) -> TextAction {
-        ctx.messages
-            .push(ChatMessage::assistant(text).with_usage(usage));
-        TextAction::Return(LoopOutcome::Response(text.to_string()))
-    }
-
-    async fn execute_tool_calls(
-        &self,
-        tool_calls: Vec<ToolCall>,
-        content: Option<String>,
-        usage: TokenUsage,
-        ctx: &mut ReasoningContext,
-    ) -> Result<Option<LoopOutcome>, HostError> {
-        // No executor → emit the sentinel and let `map_outcome` raise
-        // `AgentError::ToolsNotSupported`. This keeps the A1 contract
-        // intact when callers use text-only agents.
-        let Some(executor) = self.tool_executor.as_ref() else {
-            return Ok(Some(LoopOutcome::Failure(
-                TOOLS_NOT_SUPPORTED_REASON.to_string(),
-            )));
-        };
-
-        let dispatcher = SequentialDispatcher::new(
-            executor.clone(),
-            self.hooks.egress.clone(),
-            Arc::new(PolicyApprover::new(
-                self.approval_policy.clone(),
-                self.approval_inbox.clone(),
-            )),
-            self.tool_output_sanitizer.clone(),
-            self.event_tx.clone(),
-        );
-        dispatcher.dispatch(tool_calls, content, usage, ctx).await
-    }
-}
-
-/// Sentinel string emitted by [`HeadlessDelegate::execute_tool_calls`]
-/// and re-mapped to [`AgentError::ToolsNotSupported`] by [`map_outcome`].
-const TOOLS_NOT_SUPPORTED_REASON: &str = "headless-agent::tools-not-supported";
+/// Sentinel string emitted by [`AgenticLoop`]'s tool-call branch when
+/// no [`ToolDispatcher`] is wired, then re-mapped to
+/// [`AgentError::ToolsNotSupported`] by [`map_outcome`].
+pub(crate) const TOOLS_NOT_SUPPORTED_REASON: &str = "headless-agent::tools-not-supported";
 
 fn map_outcome(outcome: LoopOutcome, max_iterations: usize) -> Result<String, AgentError> {
     match outcome {
@@ -924,7 +830,7 @@ fn map_outcome(outcome: LoopOutcome, max_iterations: usize) -> Result<String, Ag
 mod tests {
     use super::*;
     use dasclaw_core::messages::{FinishReason, ToolCall};
-    use dasclaw_core::response_types::{RespondResult, TokenUsage};
+    use dasclaw_core::response_types::{RespondResult, ResponseMetadata, TokenUsage};
 
     /// Mock responder driven by a fixed sequence of pre-built outputs.
     struct ScriptedResponder {

--- a/crates/dasclaw_runtime/src/agentic_loop.rs
+++ b/crates/dasclaw_runtime/src/agentic_loop.rs
@@ -1,0 +1,188 @@
+//! ADR-160 §3 L1: `AgenticLoop` as a concrete struct (W6.4).
+//!
+//! Wraps [`dasclaw_core::agentic_loop::run_agentic_loop`] behind a
+//! struct that owns the seams the loop needs at runtime: the LLM
+//! responder, an optional [`ToolDispatcher`] (L2 seam), a cancellation
+//! token, and a streaming event channel. The struct is the new
+//! single-entry point that [`crate::Agent`] drives; the prior
+//! private `HeadlessDelegate` is now an internal adapter
+//! ([`LoopAdapter`]) whose `LoopDelegate` impl is a byte-identical
+//! move of the pre-W6.4 inline implementation.
+//!
+//! ## Why a struct, not a free function
+//!
+//! The pre-W6.4 path built a fresh `HeadlessDelegate` per
+//! `run_in_context_inner` call and re-constructed
+//! [`SequentialDispatcher`] inside `execute_tool_calls` on **every
+//! iteration**. The struct gives us:
+//!
+//! - one place that owns the dispatcher for the lifetime of the run
+//!   (built once at `Agent::run_in_context_inner`, not per iteration);
+//! - a stable injection point for fakes / parallel dispatchers /
+//!   replay engines without touching the agentic-loop crate;
+//! - the L1 seam ADR-160 §3 asks for, so future hosts can build
+//!   loops without going through `Agent` at all.
+//!
+//! ## Scope (W6.4)
+//!
+//! - Byte-equivalent behaviour with the pre-W6.4 `HeadlessDelegate`.
+//! - No public-API churn for `Agent` / `AgentBuilder` callers.
+//! - `desktop-client/ironclaw` delegates (ChatDelegate / JobDelegate /
+//!   ContainerDelegate) are untouched — they keep calling
+//!   `run_agentic_loop` directly.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use dasclaw_core::agentic_loop::{
+    AgenticLoopConfig, LoopDelegate, LoopOutcome, LoopSignal, TextAction, run_agentic_loop,
+};
+use dasclaw_core::hooks::HookBundle;
+use dasclaw_core::messages::{ChatMessage, ToolCall};
+use dasclaw_core::reasoning_ctx::ReasoningContext;
+use dasclaw_core::response_types::{RespondOutput, ResponseMetadata, TokenUsage};
+use dasclaw_core::traits::HostError;
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+
+use crate::agent::{AgentEvent, AgentResponder, TOOLS_NOT_SUPPORTED_REASON};
+use crate::tool_dispatch::{ToolDispatcher, emit_event};
+
+/// L1 seam (ADR-160 §3): concrete agentic-loop driver.
+///
+/// Owns the per-run collaborators (`responder`, `dispatcher`,
+/// `cancellation_token`, `event_tx`) and forwards to
+/// [`run_agentic_loop`] via an internal [`LoopAdapter`]. Hosts that
+/// don't need a [`crate::Agent`] facade can build an `AgenticLoop`
+/// directly.
+pub struct AgenticLoop {
+    responder: Arc<dyn AgentResponder>,
+    dispatcher: Option<Arc<dyn ToolDispatcher>>,
+    cancellation_token: Option<CancellationToken>,
+    event_tx: Option<mpsc::Sender<AgentEvent>>,
+}
+
+impl AgenticLoop {
+    /// Wire up a loop with the runtime's shared collaborators.
+    ///
+    /// Pass `dispatcher = None` to keep the agent in text-only mode;
+    /// any model-emitted tool call then resolves to the
+    /// [`TOOLS_NOT_SUPPORTED_REASON`] sentinel, matching the pre-W6.4
+    /// `HeadlessDelegate` contract.
+    #[must_use]
+    pub fn new(
+        responder: Arc<dyn AgentResponder>,
+        dispatcher: Option<Arc<dyn ToolDispatcher>>,
+        cancellation_token: Option<CancellationToken>,
+        event_tx: Option<mpsc::Sender<AgentEvent>>,
+    ) -> Self {
+        Self {
+            responder,
+            dispatcher,
+            cancellation_token,
+            event_tx,
+        }
+    }
+
+    /// Drive the agentic loop to completion.
+    ///
+    /// `ctx` must already be seeded with the system prompt, advertised
+    /// tools and the latest user message (the [`crate::Agent`] facade
+    /// does this for callers).
+    pub async fn run(
+        &self,
+        ctx: &mut ReasoningContext,
+        loop_config: &AgenticLoopConfig,
+        hooks: &HookBundle,
+    ) -> Result<LoopOutcome, HostError> {
+        let adapter = LoopAdapter { inner: self };
+        run_agentic_loop(&adapter, ctx, loop_config, hooks).await
+    }
+}
+
+/// Internal `LoopDelegate` adapter. Byte-identical move of the
+/// pre-W6.4 `HeadlessDelegate::LoopDelegate` impl, refactored to
+/// borrow its dependencies from an enclosing [`AgenticLoop`].
+struct LoopAdapter<'a> {
+    inner: &'a AgenticLoop,
+}
+
+impl<'a> LoopAdapter<'a> {
+    /// Best-effort emit; a closed receiver is not a loop-fatal error.
+    async fn emit(&self, event: AgentEvent) {
+        emit_event(self.inner.event_tx.as_ref(), event).await;
+    }
+}
+
+#[async_trait]
+impl<'a> LoopDelegate for LoopAdapter<'a> {
+    async fn check_signals(&self) -> LoopSignal {
+        match self.inner.cancellation_token.as_ref() {
+            Some(token) if token.is_cancelled() => LoopSignal::Stop,
+            _ => LoopSignal::Continue,
+        }
+    }
+
+    async fn before_llm_call(
+        &self,
+        _ctx: &mut ReasoningContext,
+        _iteration: usize,
+    ) -> Option<LoopOutcome> {
+        None
+    }
+
+    async fn call_llm(
+        &self,
+        ctx: &mut ReasoningContext,
+        _iteration: usize,
+    ) -> Result<RespondOutput, HostError> {
+        // Streaming and non-streaming routes split at the responder
+        // seam: when an event channel is wired we go through
+        // `respond_streaming`, which the default trait impl falls back
+        // to `respond` for adapters that don't override it. Either way
+        // we forward the trailing `FinishReason` so a GUI knows the
+        // iteration boundary even when the model emitted no text.
+        let output = match self.inner.event_tx.as_ref() {
+            Some(tx) => {
+                self.inner
+                    .responder
+                    .respond_streaming(ctx, tx.clone())
+                    .await?
+            }
+            None => self.inner.responder.respond(ctx).await?,
+        };
+        self.emit(AgentEvent::FinishReason(output.finish_reason))
+            .await;
+        Ok(output)
+    }
+
+    async fn handle_text_response(
+        &self,
+        text: &str,
+        _metadata: ResponseMetadata,
+        usage: TokenUsage,
+        ctx: &mut ReasoningContext,
+    ) -> TextAction {
+        ctx.messages
+            .push(ChatMessage::assistant(text).with_usage(usage));
+        TextAction::Return(LoopOutcome::Response(text.to_string()))
+    }
+
+    async fn execute_tool_calls(
+        &self,
+        tool_calls: Vec<ToolCall>,
+        content: Option<String>,
+        usage: TokenUsage,
+        ctx: &mut ReasoningContext,
+    ) -> Result<Option<LoopOutcome>, HostError> {
+        // No dispatcher wired → emit the sentinel and let `map_outcome`
+        // raise `AgentError::ToolsNotSupported`. This keeps the A1
+        // contract intact when callers use text-only agents.
+        let Some(dispatcher) = self.inner.dispatcher.as_ref() else {
+            return Ok(Some(LoopOutcome::Failure(
+                TOOLS_NOT_SUPPORTED_REASON.to_string(),
+            )));
+        };
+        dispatcher.dispatch(tool_calls, content, usage, ctx).await
+    }
+}

--- a/crates/dasclaw_runtime/src/lib.rs
+++ b/crates/dasclaw_runtime/src/lib.rs
@@ -65,6 +65,7 @@
 //! [`ToolError::from_tool_impl`].
 
 pub mod agent;
+pub mod agentic_loop;
 pub mod approval;
 pub mod composite_executor;
 pub mod context;
@@ -84,6 +85,7 @@ pub use agent::{
     Agent, AgentBuilder, AgentConfig, AgentError, AgentEvent, AgentResponder, ToolExecutor,
     ToolOutputSanitizer,
 };
+pub use agentic_loop::AgenticLoop;
 pub use approval::{
     ApprovalDecision, ApprovalDispatchError, ApprovalInbox, ApprovalOutcome, ApprovalPolicy,
     ApprovalRequest, Approver, NoApprovalPolicy, PolicyApprover,


### PR DESCRIPTION
Closes #959

## 背景 / 目标

完成 **ADR-160 §3 5 层模型的 L1 提取**：把 dasclaw_runtime 这一侧的「agentic loop」从一个**每次调用就内联构造 `HeadlessDelegate` + 每次 iteration 再重构造 `SequentialDispatcher`** 的补丁式实现，重构成一个 concrete `AgenticLoop` struct，注入 `ToolDispatcher`（W6.2b 引入的 L2 seam）+ 其他 per-run 协作者。

完成本 PR 后，ADR-160 §3 的 L1（AgenticLoop）/ L2（ToolDispatcher）/ L5（Approver）三个 seam 全部在 dasclaw_runtime 落地。

## 改动范围

### 新文件 `crates/dasclaw_runtime/src/agentic_loop.rs`（+188）

- `pub struct AgenticLoop`：字段 `responder` / `dispatcher: Option<Arc<dyn ToolDispatcher>>` / `cancellation_token` / `event_tx`
- `pub fn new(...)` + `pub async fn run(ctx, loop_config, hooks) -> Result<LoopOutcome, HostError>`
- 内部 `struct LoopAdapter<'a> { inner: &'a AgenticLoop }`，实现 `LoopDelegate`：**字节级搬迁** 原 `HeadlessDelegate` 的 5 个方法（check_signals / before_llm_call / call_llm / handle_text_response / execute_tool_calls）

### 修改 `crates/dasclaw_runtime/src/agent.rs`（+27 / -153）

- `run_in_context_inner`：把 `HeadlessDelegate { ... }` + `run_agentic_loop(&delegate, ...)` 改成
  - 先构造 `dispatcher: Option<Arc<dyn ToolDispatcher>>`（**一次 run 只构造一次**，取代以前每个 iteration 重新构造）
  - 再 `AgenticLoop::new(...)` + `.run(...)`
- 删除 `struct HeadlessDelegate` + `impl HeadlessDelegate` + `impl LoopDelegate for HeadlessDelegate`（一共约 100 行）
- `TOOLS_NOT_SUPPORTED_REASON` 改为 `pub(crate)`，让 `agentic_loop.rs` 引用
- 调整 imports：删除 `LoopDelegate / LoopSignal / TextAction / run_agentic_loop / ResponseMetadata / emit_event`，加入 `AgenticLoop`

### 修改 `crates/dasclaw_runtime/src/lib.rs`（+2 / -0）

- `pub mod agentic_loop;`
- `pub use agentic_loop::AgenticLoop;`

**Diff 统计**：3 files changed, +233 / -137

## 非目标（What's NOT in this PR）

- 不动 `Agent` / `AgentBuilder` 的公共 API；外部调用方完全无感
- 不动 `desktop-client/ironclaw` 里的 3 个 `LoopDelegate` 实现（ChatDelegate / JobDelegate / ContainerDelegate）——它们继续直接调 `run_agentic_loop`
- 不引入新测试：行为字节等价，现有 196 个测试已覆盖
- 不涉及 ADR-160 §3 的 L3 (HookChain) / L4 (EgressGate 已是 trait) 进一步重构

## 验证

```bash
cargo check -p dasclaw_runtime --tests           # 0 errors, 0 warnings
cargo nextest run -p dasclaw_runtime             # 196/196 passed (136s)
cargo clippy --no-deps -p dasclaw_runtime --all-targets -- -D warnings  # clean
cargo fmt --all                                   # clean
python3.12 scripts/check_no_panics.py --base origin/xClaw  # OK
```

完整 `cargo build` / workspace clippy / heavy integration 由 PR CI 兜底。

## Skills 自审（三层全 PASS）

- **code-quality-audit**：5 项全过（无补丁式 / 函数长度合理 / 无 unwrap / 无重复轮子 / 字节等价性验证通过）
- **code-simplifier**：no changes needed（命名 / 注释 / imports / 嵌套均已最简）
- **code-review-expert**：SRP/DIP ✓、生命周期安全 ✓、`Option<dispatcher>` 在 None 时仍走 sentinel 路径 ✓、API 兼容性 ✓，无 P0/P1/P2

## Cross-cuts

- **类 A**：本 PR 不引入任何新的 `.ironclaw` 字面量或 `IRONCLAW_BASE_DIR`

## Sources read

- `docs/plans/architecture-refactor/adr-160-runtime-architecture-decisions.md` §3 5-layer model（L1 = AgenticLoop concrete struct）
- `crates/dasclaw_core/src/agentic_loop.rs` L101-188（LoopDelegate trait + run_agentic_loop signature）
- `crates/dasclaw_runtime/src/agent.rs` L555-600 + L786-976（原 HeadlessDelegate 实现）
- `crates/dasclaw_runtime/src/tool_dispatch.rs` L82-129（ToolDispatcher trait + SequentialDispatcher）
- `crates/dasclaw_runtime/src/approval.rs` L228-286（Approver trait + PolicyApprover）

## Stacked PR 说明

- **Base 分支不是 `xClaw`**，而是 `feat/w6.3-approver-trait`（PR #964）
- **Merge 顺序**：#962 (W6.2a) → #963 (W6.2b) → #964 (W6.3) → **本 PR (W6.4)**
- **请先 review/merge 前面的 stacked PR 再看本 PR**
- 合并下层时**不要勾选 "Delete branch"**（AGENTS.md 路径 A），等所有 stacked 上层 PR 全部 merge 后统一清理

## 后续

- W6.5（如有）：考虑把 dasclaw_core 的 LoopDelegate 标 deprecated，长期让 desktop-client 4 个 delegate 也迁移到 AgenticLoop + 自定义 ToolDispatcher 的形态（大改，独立波次）
- 把 ADR-160 §3 的「L1/L2/L5 已落地」状态写回 ADR 自身（独立文档 PR）