### PR TITLE
docs(adr-160): update L1/L2/L5 landing status + W6 slice breakdown (W6.5)

### DIFF
--- a/docs/plans/architecture-refactor/56-framework-architecture-re-review.md
+++ b/docs/plans/architecture-refactor/56-framework-architecture-re-review.md
@@ -100,11 +100,14 @@ AgenticLoop (concrete struct)
 
 ## 3. 新分层模型
 
+> **落地状态（W6.5，2026-05-29 更新）**：L1 / L2 / L5（Approver 横切）已在 `dasclaw_runtime` 落地。
+> 详见 §7 的 W6.2a/b / W6.3 / W6.4 行。L3（HookChain）/ L4（EgressGate）/ L5（SessionStore）三层原本就已是 trait，本波次不涉及。
+
 ```
-L1 AgenticLoop          concrete struct，单一实现
+L1 AgenticLoop          concrete struct，单一实现           ✅ W6.4 · PR #965
                         run loop = LLM call → tool_calls → dispatcher.dispatch → results → 继续
 
-L2 ToolDispatcher trait async fn dispatch(calls: Vec<ToolCall>, ctx: &DispatchCtx) -> Vec<ToolResult>
+L2 ToolDispatcher trait async fn dispatch(...)                ✅ W6.2a/b · PR #962 / #963
                         默认 SequentialDispatcher / ConcurrentDispatcher
                         桌面端自己写 DesktopDispatcher（含 stash 切分）
 
@@ -118,9 +121,9 @@ L5 SessionStore trait   已有 (dasclaw_session)
                         SessionSnapshot concrete + version + migration
                         不做扩展槽
 
-(横切) Approver trait   新增，替代 ApprovalInbox 直耦合
-                        async fn approve(req: ApprovalRequest) -> ApprovalDecision
-                        实现：AgentEventApprover (headless) / TauriApprover (desktop)
+(横切) Approver trait   新增，替代 ApprovalInbox 直耦合         ✅ W6.3 · PR #964
+                        async fn await_approval(...) -> ApprovalOutcome
+                        实现：PolicyApprover (默认) / 第三方 TauriApprover等
 ```
 
 ---
@@ -162,11 +165,14 @@ L5 SessionStore trait   已有 (dasclaw_session)
 
 | 阶段 | 内容 | 状态 |
 |---|---|---|
-| W6 | ADR-160 锁定。在 `dasclaw_runtime` 起 `AgenticLoop` concrete struct（旁路 `LoopDelegate`）+ `ToolDispatcher` / `Approver` trait | 待启动 |
+| W6.2a | 在 `dasclaw_runtime` 抽 `SequentialDispatcher`（5 步流水线字节级搬迁，保留 `pub(crate)`） | ✅ 已落地 · PR [#962](https://github.com/Linnanli/xClaw/pull/962) |
+| W6.2b | 引入 `pub trait ToolDispatcher`，`SequentialDispatcher` 升为 `pub` 并从 `lib.rs` 导出 | ✅ 已落地 · PR [#963](https://github.com/Linnanli/xClaw/pull/963) |
+| W6.3 | 抽 `Approver` trait + `PolicyApprover` 默认实现（横切层落地） | ✅ 已落地 · PR [#964](https://github.com/Linnanli/xClaw/pull/964) |
+| W6.4 | `AgenticLoop` 提取为 concrete struct，注入 `ToolDispatcher` + `Approver`；删除 `HeadlessDelegate` | ✅ 已落地 · PR [#965](https://github.com/Linnanli/xClaw/pull/965) |
 | W7 | `ChatDelegate` 改为基于 `AgenticLoop` 的装配。保留旧 `ChatDelegate` API 作为薄门面 | 待启动 |
-| W8 | `HeadlessDelegate` 同上 | 待启动 |
+| W8 | `HeadlessDelegate` 同上（注：W6.4 已删除 `dasclaw_runtime` 侧 `HeadlessDelegate`；W8 范围收缩为桌面端遗留 delegate） | 待启动 |
 | W9 | `LoopDelegate` 标 `#[deprecated]`，保留 1 个 release | 待启动 |
-| W10 | 删除 `LoopDelegate` 和 `HeadlessDelegate` / `ChatDelegate` 旧实现 | 待启动 |
+| W10 | 删除 `LoopDelegate` 和桌面端旧 delegate 实现 | 待启动 |
 
 每个阶段独立 PR，独立可回滚。
 
@@ -186,10 +192,11 @@ L5 SessionStore trait   已有 (dasclaw_session)
 ## 9. DoD（启用 ADR-160 的最小完成度）
 
 - [ ] 本 doc 升 ADR-160（accepted），关联 ADR-157 §2.3 改为"按 ADR-160 实施"
-- [ ] #957 / #959 issue body 改为 ADR-160 方向
-- [ ] PR #958（前置 1 RFC，原扩展槽方向）改写或关闭
-- [ ] `crates/dasclaw_runtime/src/agent.rs` 起 `AgenticLoop` concrete struct PoC
-- [ ] `crates/dasclaw_runtime/src/dispatcher/mod.rs` 起 `ToolDispatcher` trait + `SequentialDispatcher`
+- [x] #957 / #959 issue body 改为 ADR-160 方向
+- [x] PR #958（前置 1 RFC，原扩展槽方向）改写或关闭
+- [x] `crates/dasclaw_runtime/src/agentic_loop.rs` 起 `AgenticLoop` concrete struct（W6.4 · PR #965，已删除旧 `HeadlessDelegate`，非 PoC）
+- [x] `crates/dasclaw_runtime/src/tool_dispatch.rs` 起 `ToolDispatcher` trait + `SequentialDispatcher`（W6.2a/b · PR #962 / #963）
+- [x] `crates/dasclaw_runtime/src/approval.rs` 起 `Approver` trait + `PolicyApprover`（W6.3 · PR #964，横切层补充）
 
 ---
 


### PR DESCRIPTION
Closes #959

## 背景 / 目标

W6.2a/b / W6.3 / W6.4 这 4 个 stacked PR 已经把 ADR-160 §3 五分层模型的 **L1（AgenticLoop concrete struct）/ L2（ToolDispatcher trait）/ Approver 横切** 全部落地。本 PR 把这些状态写回 `docs/plans/architecture-refactor/56-framework-architecture-re-review.md`（ADR-160 draft 真理来源），让规划文档与代码状态对齐。

## 改动范围

**单一 markdown 文件**：`docs/plans/architecture-refactor/56-framework-architecture-re-review.md`（+19 / -12）

1. **§3 新分层模型**：
   - 顶部加状态横幅说明 L1/L2/L5 横切层已落地
   - L1 行注 `✅ W6.4 · PR #965`
   - L2 行注 `✅ W6.2a/b · PR #962 / #963`
   - Approver 行注 `✅ W6.3 · PR #964`
   - Approver 签名从规划期的 `async fn approve(req: ApprovalRequest) -> ApprovalDecision` 校准为实际落地的 `async fn await_approval(...) -> ApprovalOutcome`
   - 默认实现名从 `AgentEventApprover` 校准为 `PolicyApprover`

2. **§7 迁移计划**：把单行 "W6 - 待启动" 拆成 W6.2a / W6.2b / W6.3 / W6.4 四个子行，每行注明 PR 链接 + ✅ 状态。W7~W10 保持不动。W8 补一行说明：W6.4 已删除 `dasclaw_runtime::HeadlessDelegate`，W8 范围收缩到桌面端遗留 delegate。

3. **§9 DoD**：勾选 4 项已完成的（issue 方向调整 / PR #958 关闭 / AgenticLoop / ToolDispatcher + SequentialDispatcher），新增一行 Approver 落地说明。「本 doc 升 ADR-160（accepted）」仍未勾选（promotion PR #961 已 merge 到 design 分支，但还没合到 xClaw，另起 PR）。

## 非目标（What's NOT in this PR）

- 不把 doc 56 升级为正式 ADR-160 文件（promotion PR #961 已 merge 到 `design/framework-architecture-re-review`，搬到 xClaw 是另一个独立文档 PR）
- 不改任何 `crates/` 源码
- 不引入新测试

## 验证

```bash
python3.12 scripts/check_no_panics.py --base origin/xClaw  # OK
grep -E '(L1|L2|L5|W6\.[234])' docs/plans/architecture-refactor/56-framework-architecture-re-review.md  # 所有标注存在
```

纯 markdown 改动，无 build/test 影响。CI 的 `plan-docs-only` 豁免规则应该会让 closes-link 之外的检查跳过。

## Cross-cuts

**类 A**：本 PR 不引入任何新的 `.ironclaw` 字面量或 `IRONCLAW_BASE_DIR`。

## Sources read

- `docs/plans/architecture-refactor/56-framework-architecture-re-review.md` §3 / §7 / §9 全文（修改前）
- ADR-160 §3 5 层模型定义
- PR #962（W6.2a）/ #963（W6.2b）/ #964（W6.3）/ #965（W6.4）的实际落地代码 + body 摘要
- issue #959 当前状态（OPEN，本 PR `Closes` 它）

## 与 stacked PR 链的关系

- 本 PR base = `xClaw`（独立于 W6.x stacked 链）
- 与 #962 / #963 / #964 / #965 无文件冲突（它们只动 `crates/dasclaw_runtime/`，本 PR 只动 `docs/`）
- 可与 stacked 链并行 review / merge

## 后续

- 单独文档 PR：把 PR #961（doc 56 → ADR-160 正式文件）的 promotion 从 `design/framework-architecture-re-review` 搬到 xClaw
- W7 / W8：桌面端 ChatDelegate / 遗留 delegate 迁移到 AgenticLoop + 自定义 ToolDispatcher（大波次，建议独立会话）
