### PR TITLE
feat(desktop): W7.2 make DesktopDispatcher owned and impl ToolDispatcher (ADR-160 §3 L2)

### DIFF
--- a/desktop-client/ironclaw/src/agent/desktop_dispatcher.rs
+++ b/desktop-client/ironclaw/src/agent/desktop_dispatcher.rs
@@ -1,48 +1,61 @@
-//! W7.1 byte-equivalent extraction of `ChatDelegate::execute_tool_calls`
-//! (ADR-160 §3 L2 desktop dispatcher implementation).
+//! ADR-160 §3 L2 desktop dispatcher.
 //!
-//! W7.2 will let this struct `impl dasclaw_runtime::ToolDispatcher`;
-//! W7.3 will wire it through `AgenticLoop`. This slice keeps behaviour
-//! unchanged — the original method now delegates to `dispatch`.
+//! W7.1 extracted the body verbatim from `ChatDelegate::execute_tool_calls`.
+//! W7.2 makes the struct owned (no borrows) and implements
+//! `dasclaw_runtime::ToolDispatcher` so an `AgenticLoop` can drive it.
+//!
+//! Per ADR-160 §3 L2 interface segregation, the dispatcher holds only the
+//! handful of `Agent` collaborators it actually needs (safety, tools, hooks,
+//! channels, config) rather than `Arc<Agent>` — avoiding an `Arc<Self>`
+//! cascade through `process_user_input` / `process_approval`.
 
 use std::collections::HashSet;
 use std::sync::Arc;
 
+use async_trait::async_trait;
 use tokio::sync::Mutex;
 use tokio::task::JoinSet;
 use uuid::Uuid;
 
-use crate::agent::Agent;
 use crate::agent::agentic_loop::LoopOutcome;
 use crate::agent::session::{PendingApproval, Session};
-use crate::channels::{IncomingMessage, StatusUpdate};
+use crate::channels::{ChannelManager, IncomingMessage, StatusUpdate};
+use crate::config::AgentConfig;
 use crate::error::Error;
 use crate::llm::{ChatMessage, ReasoningContext};
-use crate::tools::redact_params;
+use crate::safety::SafetyLayer;
+use crate::tools::{ToolRegistry, redact_params};
 use dasclaw_core::traits::HostError;
+use dasclaw_hooks::HookRegistry;
 use dasclaw_runtime::context::JobContext;
+use dasclaw_runtime::tool_dispatch::ToolDispatcher;
 
 use super::dispatcher::{
     PreflightOutcome, check_auth_required, contextual_tool_message, execute_chat_tool_standalone,
     is_tool_disabled_by_extensions, parse_auth_result, preflight_rejection_tool_message,
 };
 
-pub(super) struct DesktopDispatcher<'a> {
-    pub(super) agent: &'a Agent,
-    pub(super) message: &'a IncomingMessage,
-    pub(super) session: &'a Arc<Mutex<Session>>,
+pub(super) struct DesktopDispatcher {
+    pub(super) safety: Arc<SafetyLayer>,
+    pub(super) tools: Arc<ToolRegistry>,
+    pub(super) hooks: Arc<HookRegistry>,
+    pub(super) channels: Arc<ChannelManager>,
+    pub(super) config: AgentConfig,
+    pub(super) message: Arc<IncomingMessage>,
+    pub(super) session: Arc<Mutex<Session>>,
     pub(super) thread_id: Uuid,
-    pub(super) job_ctx: &'a JobContext,
-    pub(super) disabled_extensions: &'a HashSet<String>,
+    pub(super) job_ctx: JobContext,
+    pub(super) disabled_extensions: HashSet<String>,
     pub(super) user_tz: chrono_tz::Tz,
 }
 
-impl<'a> DesktopDispatcher<'a> {
-    pub(super) async fn dispatch(
+#[async_trait]
+impl ToolDispatcher for DesktopDispatcher {
+    async fn dispatch(
         &self,
-        tool_calls: Vec<crate::llm::ToolCall>,
+        tool_calls: Vec<dasclaw_core::messages::ToolCall>,
         content: Option<String>,
-        usage: dasclaw_core::TokenUsage,
+        usage: dasclaw_core::response_types::TokenUsage,
         reason_ctx: &mut ReasoningContext,
     ) -> Result<Option<LoopOutcome>, HostError> {
         // Extract and sanitize the narrative before consuming `content`.
@@ -52,7 +65,7 @@ impl<'a> DesktopDispatcher<'a> {
         let narrative = match content.as_deref().filter(|c| !c.trim().is_empty()) {
             Some(c) => {
                 let sanitized = crate::safety::egress::sanitize_tool_output_via_egress(
-                    self.agent.safety(),
+                    &self.safety,
                     "agent_narrative",
                     c,
                 )
@@ -74,7 +87,6 @@ impl<'a> DesktopDispatcher<'a> {
 
         // Execute tools and add results to context
         let _ = self
-            .agent
             .channels
             .send_status(
                 &self.message.channel,
@@ -92,7 +104,7 @@ impl<'a> DesktopDispatcher<'a> {
         for tc in tool_calls.iter() {
             if let Some(r) = tc.reasoning.as_ref() {
                 let sanitized = crate::safety::egress::sanitize_tool_output_via_egress(
-                    self.agent.safety(),
+                    &self.safety,
                     "tool_rationale",
                     r,
                 )
@@ -107,7 +119,6 @@ impl<'a> DesktopDispatcher<'a> {
         // Emit reasoning update to channels.
         if narrative.is_some() || !decisions.is_empty() {
             let _ = self
-                .agent
                 .channels
                 .send_status(
                     &self.message.channel,
@@ -124,7 +135,7 @@ impl<'a> DesktopDispatcher<'a> {
         {
             let mut redacted_args: Vec<serde_json::Value> = Vec::with_capacity(tool_calls.len());
             for tc in &tool_calls {
-                let safe = if let Some(tool) = self.agent.tools().get(&tc.name).await {
+                let safe = if let Some(tool) = self.tools.get(&tc.name).await {
                     redact_params(&tc.arguments, tool.sensitive_params())
                 } else {
                     tc.arguments.clone()
@@ -141,7 +152,7 @@ impl<'a> DesktopDispatcher<'a> {
                 let s = match tc.reasoning.as_ref() {
                     Some(r) => Some(
                         crate::safety::egress::sanitize_tool_output_via_egress(
-                            self.agent.safety(),
+                            &self.safety,
                             "tool_rationale",
                             r,
                         )
@@ -200,7 +211,7 @@ impl<'a> DesktopDispatcher<'a> {
 
             // Plan mode interception: non-readonly tools get a dry-run preview
             // instead of actual execution.
-            if is_plan_mode && let Some(tool) = self.agent.tools().get(&tc.name).await {
+            if is_plan_mode && let Some(tool) = self.tools.get(&tc.name).await {
                 let risk = tool.risk_level_for(&tc.arguments);
                 if risk > crate::tools::RiskLevel::Low {
                     preflight.push((
@@ -215,7 +226,7 @@ impl<'a> DesktopDispatcher<'a> {
                 }
             }
 
-            if is_tool_disabled_by_extensions(&tc.name, self.disabled_extensions) {
+            if is_tool_disabled_by_extensions(&tc.name, &self.disabled_extensions) {
                 preflight.push((
                     tc,
                     PreflightOutcome::Rejected(
@@ -225,7 +236,7 @@ impl<'a> DesktopDispatcher<'a> {
                 continue;
             }
 
-            let tool_opt = self.agent.tools().get(&tc.name).await;
+            let tool_opt = self.tools.get(&tc.name).await;
             let sensitive = tool_opt
                 .as_ref()
                 .map(|t| t.sensitive_params())
@@ -239,7 +250,7 @@ impl<'a> DesktopDispatcher<'a> {
                 user_id: self.message.user_id.clone(),
                 context: "chat".to_string(),
             };
-            match self.agent.hooks().run(&event).await {
+            match self.hooks.run(&event).await {
                 Err(dasclaw_hooks::HookError::Rejected { reason }) => {
                     preflight.push((
                         tc,
@@ -285,7 +296,7 @@ impl<'a> DesktopDispatcher<'a> {
             }
 
             // Check if tool requires approval
-            if !self.agent.config.auto_approve_tools
+            if !self.config.auto_approve_tools
                 && let Some(tool) = tool_opt
             {
                 use crate::tools::ApprovalRequirement;
@@ -348,7 +359,6 @@ impl<'a> DesktopDispatcher<'a> {
                     Some(&tc.arguments),
                 );
                 let _ = self
-                    .agent
                     .channels
                     .send_status(
                         &self.message.channel,
@@ -361,14 +371,18 @@ impl<'a> DesktopDispatcher<'a> {
 
                 let result = {
                     let mut job_ctx = self.job_ctx.clone();
-                    self.agent
-                        .execute_chat_tool(&tc.name, &tc.arguments, &mut job_ctx)
-                        .await
+                    execute_chat_tool_standalone(
+                        &self.tools,
+                        &self.safety,
+                        &tc.name,
+                        &tc.arguments,
+                        &mut job_ctx,
+                    )
+                    .await
                 };
 
-                let disp_tool = self.agent.tools().get(&tc.name).await;
+                let disp_tool = self.tools.get(&tc.name).await;
                 let _ = self
-                    .agent
                     .channels
                     .send_status(
                         &self.message.channel,
@@ -389,9 +403,9 @@ impl<'a> DesktopDispatcher<'a> {
 
             for (pf_idx, tc) in &runnable {
                 let pf_idx = *pf_idx;
-                let tools = self.agent.tools().clone();
-                let safety = self.agent.safety().clone();
-                let channels = self.agent.channels.clone();
+                let tools = self.tools.clone();
+                let safety = self.safety.clone();
+                let channels = self.channels.clone();
                 let job_ctx = self.job_ctx.clone();
                 let tc = tc.clone();
                 let channel = self.message.channel.clone();
@@ -478,7 +492,7 @@ impl<'a> DesktopDispatcher<'a> {
             match outcome {
                 PreflightOutcome::Rejected(error_msg) => {
                     let sanitized = preflight_rejection_tool_message(
-                        self.agent.safety(),
+                        &self.safety,
                         &tc.name,
                         &tc.id,
                         &error_msg,
@@ -525,7 +539,6 @@ impl<'a> DesktopDispatcher<'a> {
                                 );
                             } else {
                                 let _ = self
-                                    .agent
                                     .channels
                                     .send_status(
                                         &self.message.channel,
@@ -547,7 +560,7 @@ impl<'a> DesktopDispatcher<'a> {
                     // (#93): raw tool output must never reach previews or stash.
                     let is_tool_error = tool_result.is_err();
                     let sanitized = crate::tools::execute::process_tool_result(
-                        self.agent.safety(),
+                        &self.safety,
                         &tc.name,
                         &tc.id,
                         &tool_result,
@@ -561,7 +574,6 @@ impl<'a> DesktopDispatcher<'a> {
                             None,
                         );
                         let _ = self
-                            .agent
                             .channels
                             .send_status(
                                 &self.message.channel,
@@ -590,7 +602,6 @@ impl<'a> DesktopDispatcher<'a> {
                             }
                         }
                         let _ = self
-                            .agent
                             .channels
                             .send_status(
                                 &self.message.channel,

--- a/desktop-client/ironclaw/src/agent/dispatcher.rs
+++ b/desktop-client/ironclaw/src/agent/dispatcher.rs
@@ -15,6 +15,7 @@ use crate::channels::{IncomingMessage, StatusUpdate};
 use crate::error::Error;
 use async_trait::async_trait;
 use dasclaw_runtime::context::JobContext;
+use dasclaw_runtime::tool_dispatch::ToolDispatcher;
 
 use crate::agent::agentic_loop::{
     AgenticLoopConfig, LoopDelegate, LoopOutcome, LoopSignal, TextAction,
@@ -81,7 +82,7 @@ impl Agent {
     ///
     pub(super) async fn run_agentic_loop(
         &self,
-        message: &IncomingMessage,
+        message: Arc<IncomingMessage>,
         tenant: crate::tenant::TenantCtx,
         session: Arc<Mutex<Session>>,
         thread_id: Uuid,
@@ -127,8 +128,8 @@ impl Agent {
         // Select and prepare active skills (if skills system is enabled)
         let (disabled_skills, disabled_extensions) = if message.channel == "tauri" {
             (
-                disabled_names_from_metadata(message, "disabled_skills"),
-                disabled_names_from_metadata(message, "disabled_extensions"),
+                disabled_names_from_metadata(&message, "disabled_skills"),
+                disabled_names_from_metadata(&message, "disabled_extensions"),
             )
         } else {
             (
@@ -201,7 +202,7 @@ impl Agent {
                 .with_requester_id(&message.sender_id);
         job_ctx.http_interceptor = self.deps.http_interceptor.clone();
         job_ctx.user_timezone = user_tz.name().to_string();
-        job_ctx.metadata = crate::agent::agent_loop::chat_tool_execution_metadata(message);
+        job_ctx.metadata = crate::agent::agent_loop::chat_tool_execution_metadata(&message);
         // Link the job context to the current conversation so that tools like
         // CreateJobTool can pass the conversation_id to spawned background jobs,
         // enabling the frontend to navigate back to this thread when the job completes.
@@ -254,7 +255,7 @@ impl Agent {
             tenant,
             session: session.clone(),
             thread_id,
-            message,
+            message: message.clone(),
             job_ctx,
             active_skills,
             disabled_extensions,
@@ -357,7 +358,7 @@ struct ChatDelegate<'a> {
     tenant: crate::tenant::TenantCtx,
     session: Arc<Mutex<Session>>,
     thread_id: Uuid,
-    message: &'a IncomingMessage,
+    message: Arc<IncomingMessage>,
     job_ctx: JobContext,
     active_skills: Vec<crate::skills::LoadedSkill>,
     disabled_extensions: HashSet<String>,
@@ -594,12 +595,16 @@ impl<'a> LoopDelegate for ChatDelegate<'a> {
         reason_ctx: &mut ReasoningContext,
     ) -> Result<Option<LoopOutcome>, HostError> {
         let dispatcher = super::desktop_dispatcher::DesktopDispatcher {
-            agent: self.agent,
-            message: self.message,
-            session: &self.session,
+            safety: self.agent.safety().clone(),
+            tools: self.agent.tools().clone(),
+            hooks: self.agent.hooks().clone(),
+            channels: self.agent.channels.clone(),
+            config: self.agent.config.clone(),
+            message: self.message.clone(),
+            session: self.session.clone(),
             thread_id: self.thread_id,
-            job_ctx: &self.job_ctx,
-            disabled_extensions: &self.disabled_extensions,
+            job_ctx: self.job_ctx.clone(),
+            disabled_extensions: self.disabled_extensions.clone(),
             user_tz: self.user_tz,
         };
         dispatcher
@@ -2091,7 +2096,13 @@ mod tests {
         // timeout will fire and the test will fail.
         let result = tokio::time::timeout(
             Duration::from_secs(5),
-            agent.run_agentic_loop(&message, tenant, session, thread_id, initial_messages),
+            agent.run_agentic_loop(
+                Arc::new(message),
+                tenant,
+                session,
+                thread_id,
+                initial_messages,
+            ),
         )
         .await;
 
@@ -2207,7 +2218,13 @@ mod tests {
         // max_tool_iterations.
         let result = tokio::time::timeout(
             Duration::from_secs(5),
-            agent.run_agentic_loop(&message, tenant, session, thread_id, initial_messages),
+            agent.run_agentic_loop(
+                Arc::new(message),
+                tenant,
+                session,
+                thread_id,
+                initial_messages,
+            ),
         )
         .await;
 

--- a/desktop-client/ironclaw/src/agent/thread_ops.rs
+++ b/desktop-client/ironclaw/src/agent/thread_ops.rs
@@ -481,7 +481,13 @@ impl Agent {
 
         // Run the agentic tool execution loop
         let result = self
-            .run_agentic_loop(message, tenant, session.clone(), thread_id, turn_messages)
+            .run_agentic_loop(
+                Arc::new(message.clone()),
+                tenant,
+                session.clone(),
+                thread_id,
+                turn_messages,
+            )
             .await;
 
         // Re-acquire lock and check if interrupted
@@ -1679,7 +1685,7 @@ impl Agent {
             // Continue the agentic loop (a tool was already executed this turn)
             let result = self
                 .run_agentic_loop(
-                    message,
+                    Arc::new(message.clone()),
                     self.tenant_ctx(&message.user_id).await,
                     session.clone(),
                     thread_id,


### PR DESCRIPTION
## 背景 / 目标

W7 第二个切片。承接 W7.1（PR #968）把 `DesktopDispatcher` 从 `ChatDelegate::execute_tool_calls` 抽出之后，按 ADR-160 §3 L2 的要求把它接入 `dasclaw_runtime` 提供的 `ToolDispatcher` trait，让桌面端真正成为运行时框架的一个标准 dispatcher 实现，而不是借 `&Agent` 拼装出来的内部胶水。

目标：让 `DesktopDispatcher`

1. 拥有自己的全部依赖（不再持有 `&'a Agent`）；
2. 实现 `dasclaw_runtime::tool_dispatch::ToolDispatcher`；
3. 让 `ChatDelegate` 通过 trait 调用而非具体方法名调用 dispatcher。

之后 W7 后续切片可以把 `AgenticLoop` 真正改成接 `Box<dyn ToolDispatcher>`，工作量进一步降到极小。

## 改动范围

- `desktop-client/ironclaw/src/agent/desktop_dispatcher.rs`
  - 结构体去掉生命周期参数 `<'a>`，由原来的 `agent: &'a Agent` 拆为 6 个所拥有的字段：
    - `safety: Arc<SafetyLayer>`、`tools: Arc<ToolRegistry>`、`hooks: Arc<HookRegistry>`、`channels: Arc<ChannelManager>`
    - `config: AgentConfig`
    - `message: Arc<IncomingMessage>`
  - `session: Arc<Mutex<Session>>`、`thread_id`、`job_ctx`、`disabled_extensions`、`user_tz` 仍为各自所拥有的类型，与 W7.1 一致。
  - 增加 `#[async_trait] impl dasclaw_runtime::tool_dispatch::ToolDispatcher for DesktopDispatcher`，对应方法签名与 `crates/dasclaw_runtime/src/tool_dispatch.rs:82` 精确匹配。
  - 函数体里原有 `self.agent.xxx()` 全部改为直接读自有字段；原来通过 `self.agent.execute_chat_tool(...)` 走的路径替换为 `execute_chat_tool_standalone(&self.tools, &self.safety, ...)`，与运行时栈对齐。

- `desktop-client/ironclaw/src/agent/dispatcher.rs`
  - `Agent::run_agentic_loop` 的 `message` 形参类型由 `IncomingMessage` 改为 `Arc<IncomingMessage>`，所有内部读取保持引用读法不变。
  - `ChatDelegate` 内的 `message` 字段同步改为 `Arc<IncomingMessage>`（结构体仍因 `agent: &'a Agent` 而保留 `<'a>`，这属于 W7 后续切片范围）。
  - `ChatDelegate::execute_tool_calls` 不再调具体类型方法，而是构造一个 owned 的 `DesktopDispatcher` 后通过 `dispatcher.dispatch(...)` 调 trait 方法，并补 `use dasclaw_runtime::tool_dispatch::ToolDispatcher`。

- `desktop-client/ironclaw/src/agent/thread_ops.rs`
  - 两处 `run_agentic_loop` 调用站点（普通消息分支 + `process_approval` 分支）把 `message` 包成 `Arc::new(message.clone())`。

## 非目标（What's NOT in this PR）

- 不把 `AgenticLoop` 真正改成接 `Box<dyn ToolDispatcher>`（保留给后续切片）。
- 不动 `ChatDelegate` 上的 `<'a>` 生命周期（依赖于把 `Agent` 自身解耦，属于另一个独立切片）。
- 不重构 `DesktopDispatcher::dispatch` 的内部函数体长度（W7.1 是 byte-equivalent 搬迁，长度问题在 W7 后续切片里再切）。
- 不动 `AgentConfig`、`disabled_extensions` 的字段所有权形式（建议留到后续轻量 PR 改为 `Arc<AgentConfig>`）。
- 不引入 `Arc<Agent>` 级联式注入（Approach A 被显式拒绝，原因见下）。

## 方案选择说明（Approach B）

ADR-160 §3 L2 的接口隔离原则要求 dispatcher 只看见自己需要的协作者，而不是把整个 `Agent` 通过 `dasclaw_runtime` 公共面回灌。本 PR 采用按需注入的 Approach B：

- 优点：trait 边界处不暴露 `Agent` 具体类型；后续切片把桌面端整体下移到 `dasclaw_runtime::AgenticLoop` 时改动量最小。
- 代价：每次构造 dispatcher 要克隆几个 `Arc` 和一个 `AgentConfig`/`HashSet`；前者零开销，后者属于已知优化空间（写在「非目标」里）。

## 验证

本地（只测改动 crate）：

```
cargo check -p dasclaw --tests              # 通过
cargo nextest run -p dasclaw \
  -E 'test(dispatcher) | test(agentic_loop) | test(execute_tool) | test(desktop_dispatcher)'
                                            # 79 / 79 通过
cargo fmt --all                             # 已应用
python3.12 scripts/check_no_panics.py --base origin/xClaw
                                            # OK: No panic-inducing calls in changed production code.
cargo clippy --no-deps -p dasclaw --all-targets -- -D warnings
                                            # 通过
```

完整 workspace build / heavy integration 由 CI 兜底。

## Skills 自查

- `code-quality-audit`：PASS-WITH-SUGGESTIONS（已修：去掉 `&self.hooks.run(...)` 多余借用、补上 `use dasclaw_runtime::tool_dispatch::ToolDispatcher;`）。
- `code-simplifier`：PASS-WITH-SUGGESTIONS（已采纳前两条；`AgentConfig` 改 Arc / `pub(super) fn new(...)` 构造器留给后续切片，已写入「非目标」）。
- `code-review-expert`：PASS-WITH-SUGGESTIONS（trait 签名、`Send+Sync`、类型同一性、ADR-160 §3 L2 合规均确认；安全路径完整未变；无 BLOCK 级问题）。

## Stacked PR 说明

- base 分支：`feat/w7.1-extract-desktop-dispatcher`（**不是** `xClaw`）。
- merge 顺序：**先看 #968（W7.1）再看本 PR**；下层 PR 合并时按 AGENTS.md "stacked PR 路径 A"，不要勾 "Delete branch"，等本 PR 也合并后再统一清理。

## Sources read

- `AGENTS.md` §「Skills 强制使用规范」、§「GitHub PR 工作流」、§「会话轮换原则」
- `docs/plans/architecture-refactor/adr-160-*.md` §3 L2（DesktopDispatcher 接入运行时 trait 的目标态）
- `crates/dasclaw_runtime/src/tool_dispatch.rs` L82 `ToolDispatcher` trait 定义
- `desktop-client/ironclaw/src/agent/desktop_dispatcher.rs`（W7.1 产出，本 PR 基线）
- `desktop-client/ironclaw/src/agent/dispatcher.rs`（`Agent`/`ChatDelegate` 调用站点）
- `desktop-client/ironclaw/src/agent/thread_ops.rs`（`run_agentic_loop` 两处入口）
- `crates/dasclaw_core/src/messages.rs`、`response_types.rs`、`reasoning_ctx.rs`、`agentic_loop.rs`、`traits.rs`（trait 参数的规范路径来源）

Closes #967

