### PR TITLE
feat(desktop): W7.3 extract DesktopResponder (impl AgentResponder) from ChatDelegate::call_llm

### DIFF
--- a/desktop-client/ironclaw/src/agent/desktop_responder.rs
+++ b/desktop-client/ironclaw/src/agent/desktop_responder.rs
@@ -1,0 +1,250 @@
+//! Desktop-side `AgentResponder` adapter (ADR-160 §3 L2, W7.3).
+//!
+//! Houses the LLM call pipeline (cost guard → per-user model override →
+//! streaming/non-streaming dispatch → cost record → cache monitor → DB
+//! persistence) that previously lived in `ChatDelegate::call_llm`.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use async_trait::async_trait;
+use uuid::Uuid;
+
+use dasclaw_core::traits::HostError;
+use dasclaw_runtime::AgentResponder;
+
+use crate::channels::{ChannelManager, StatusUpdate};
+use crate::error::Error;
+use crate::llm::{LlmProvider, Reasoning, ReasoningContext, RespondOutput};
+use crate::observability::PromptCacheMonitor;
+
+pub(super) struct DesktopResponder {
+    // Invariant: must be constructed per turn. The `model_override_applied`
+    // sentinel below is reset on each `new()`; reusing one instance across
+    // turns would silently disable per-user `selected_model` overrides.
+    reasoning: Reasoning,
+    llm: Arc<dyn LlmProvider>,
+    llm_backend: String,
+    cache_monitor: Option<Arc<PromptCacheMonitor>>,
+    tenant: crate::tenant::TenantCtx,
+    thread_id: Uuid,
+    channels: Arc<ChannelManager>,
+    channel: String,
+    metadata: serde_json::Value,
+    // First-iteration sentinel — replaces the `iteration == 0` check that
+    // gated the per-user `selected_model` settings lookup in the previous
+    // `ChatDelegate::call_llm` body.
+    model_override_applied: AtomicBool,
+}
+
+impl DesktopResponder {
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn new(
+        reasoning: Reasoning,
+        llm: Arc<dyn LlmProvider>,
+        llm_backend: String,
+        cache_monitor: Option<Arc<PromptCacheMonitor>>,
+        tenant: crate::tenant::TenantCtx,
+        thread_id: Uuid,
+        channels: Arc<ChannelManager>,
+        channel: String,
+        metadata: serde_json::Value,
+    ) -> Self {
+        Self {
+            reasoning,
+            llm,
+            llm_backend,
+            cache_monitor,
+            tenant,
+            thread_id,
+            channels,
+            channel,
+            metadata,
+            model_override_applied: AtomicBool::new(false),
+        }
+    }
+
+    /// Non-streaming LLM call with context-exceeded retry.
+    async fn call_llm_non_streaming(
+        &self,
+        reason_ctx: &mut ReasoningContext,
+    ) -> Result<RespondOutput, Error> {
+        let reasoning = &self.reasoning;
+        match reasoning.respond_with_tools(reason_ctx).await {
+            Ok(output) => Ok(output),
+            Err(crate::error::LlmError::ContextLengthExceeded { used, limit }) => {
+                tracing::warn!(
+                    used,
+                    limit,
+                    "Context length exceeded, compacting messages and retrying"
+                );
+                reason_ctx.messages =
+                    super::dispatcher::compact_messages_for_retry(&reason_ctx.messages);
+                if reason_ctx.force_text {
+                    reason_ctx.available_tools.clear();
+                }
+                reasoning
+                    .respond_with_tools(reason_ctx)
+                    .await
+                    .map_err(|retry_err| {
+                        tracing::error!(
+                            original_used = used,
+                            original_limit = limit,
+                            retry_error = %retry_err,
+                            "Retry after auto-compaction also failed"
+                        );
+                        crate::error::Error::from(retry_err)
+                    })
+            }
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    /// Streaming LLM call: forwards text chunks to the channel while the
+    /// response is being generated, with context-exceeded retry fallback.
+    async fn call_llm_streaming(
+        &self,
+        reason_ctx: &mut ReasoningContext,
+    ) -> Result<RespondOutput, Error> {
+        let reasoning = &self.reasoning;
+        let (chunk_tx, mut chunk_rx) = tokio::sync::mpsc::unbounded_channel::<String>();
+
+        let channels = self.channels.clone();
+        let channel_name = self.channel.clone();
+        let metadata = self.metadata.clone();
+
+        let forward_handle = tokio::spawn(async move {
+            while let Some(chunk) = chunk_rx.recv().await {
+                let _ = channels
+                    .send_status(&channel_name, StatusUpdate::StreamChunk(chunk), &metadata)
+                    .await;
+            }
+        });
+
+        let result = reasoning
+            .respond_with_tools_streaming(reason_ctx, chunk_tx)
+            .await;
+
+        let _ = forward_handle.await;
+
+        match result {
+            Ok(output) => Ok(output),
+            Err(crate::error::LlmError::ContextLengthExceeded { used, limit }) => {
+                tracing::warn!(
+                    used,
+                    limit,
+                    "Context length exceeded (streaming), compacting and retrying non-streaming"
+                );
+                reason_ctx.messages =
+                    super::dispatcher::compact_messages_for_retry(&reason_ctx.messages);
+                if reason_ctx.force_text {
+                    reason_ctx.available_tools.clear();
+                }
+                reasoning
+                    .respond_with_tools(reason_ctx)
+                    .await
+                    .map_err(|retry_err| {
+                        tracing::error!(
+                            original_used = used,
+                            original_limit = limit,
+                            retry_error = %retry_err,
+                            "Retry after auto-compaction also failed (streaming)"
+                        );
+                        crate::error::Error::from(retry_err)
+                    })
+            }
+            Err(e) => Err(e.into()),
+        }
+    }
+}
+
+#[async_trait]
+impl AgentResponder for DesktopResponder {
+    async fn respond(&self, reason_ctx: &mut ReasoningContext) -> Result<RespondOutput, HostError> {
+        if let Err(limit) = self.tenant.check_cost_allowed().await {
+            return Err(crate::error::LlmError::InvalidResponse {
+                provider: "agent".to_string(),
+                reason: limit.to_string(),
+            }
+            .into());
+        }
+
+        // Per-user model override from settings. Only applied on the first
+        // call within this responder instance — `DesktopResponder` is built
+        // once per turn, so this matches the prior `iteration == 0` gate.
+        if !self.model_override_applied.swap(true, Ordering::AcqRel)
+            && let Some(store) = self.tenant.store()
+            && let Ok(Some(value)) = store.get_setting("selected_model").await
+            && let Some(model) = value.as_str()
+        {
+            let model = model.trim();
+            if !model.is_empty() {
+                reason_ctx.model_override = Some(model.to_string());
+            }
+        }
+
+        let use_streaming = self.llm.supports_streaming();
+        let output = if use_streaming {
+            self.call_llm_streaming(reason_ctx).await?
+        } else {
+            self.call_llm_non_streaming(reason_ctx).await?
+        };
+
+        let model_name = self
+            .llm
+            .effective_model_name(reason_ctx.model_override.as_deref());
+        let cost_per_token = if reason_ctx.model_override.is_some() {
+            None
+        } else {
+            Some(self.llm.cost_per_token())
+        };
+        let read_discount = self.llm.cache_read_discount();
+        let write_multiplier = self.llm.cache_write_multiplier();
+        let call_cost = self
+            .tenant
+            .record_llm_call(
+                &model_name,
+                output.usage.input_tokens,
+                output.usage.output_tokens,
+                output.usage.cache_read_input_tokens,
+                output.usage.cache_creation_input_tokens,
+                read_discount,
+                write_multiplier,
+                cost_per_token,
+            )
+            .await;
+        tracing::debug!(
+            "LLM call used {} input + {} output tokens (${:.6})",
+            output.usage.input_tokens,
+            output.usage.output_tokens,
+            call_cost,
+        );
+
+        if let Some(ref monitor) = self.cache_monitor {
+            monitor.record(
+                output.usage.input_tokens,
+                output.usage.cache_read_input_tokens,
+                output.usage.cache_creation_input_tokens,
+                false,
+            );
+        }
+
+        if let Some(store) = self.tenant.store() {
+            let record = crate::history::LlmCallRecord {
+                job_id: None,
+                conversation_id: Some(self.thread_id),
+                provider: &self.llm_backend,
+                model: &model_name,
+                input_tokens: output.usage.input_tokens,
+                output_tokens: output.usage.output_tokens,
+                cost: call_cost,
+                purpose: Some("chat"),
+            };
+            if let Err(e) = store.record_llm_call(&record).await {
+                tracing::warn!("Failed to persist LLM call to DB: {}", e);
+            }
+        }
+
+        Ok(output)
+    }
+}

--- a/desktop-client/ironclaw/src/agent/dispatcher.rs
+++ b/desktop-client/ironclaw/src/agent/dispatcher.rs
@@ -250,9 +250,20 @@ impl Agent {
         let force_text_at = max_tool_iterations;
         let nudge_at = max_tool_iterations.saturating_sub(1);
 
+        let responder = Arc::new(super::desktop_responder::DesktopResponder::new(
+            reasoning,
+            self.llm().clone(),
+            self.deps.llm_backend.clone(),
+            self.deps.cache_monitor.clone(),
+            tenant.clone(),
+            thread_id,
+            self.channels.clone(),
+            message.channel.clone(),
+            message.metadata.clone(),
+        ));
+
         let delegate = ChatDelegate {
             agent: self,
-            tenant,
             session: session.clone(),
             thread_id,
             message: message.clone(),
@@ -264,7 +275,7 @@ impl Agent {
             nudge_at,
             force_text_at,
             user_tz,
-            reasoning,
+            responder,
         };
 
         let mut reason_ctx = ReasoningContext::new()
@@ -355,7 +366,6 @@ impl Agent {
 /// auth intercept, and cost tracking.
 struct ChatDelegate<'a> {
     agent: &'a Agent,
-    tenant: crate::tenant::TenantCtx,
     session: Arc<Mutex<Session>>,
     thread_id: Uuid,
     message: Arc<IncomingMessage>,
@@ -367,11 +377,8 @@ struct ChatDelegate<'a> {
     nudge_at: usize,
     force_text_at: usize,
     user_tz: chrono_tz::Tz,
-    /// Route-B (D-4.5): the delegate owns the LLM reasoning engine instead
-    /// of receiving it as a loop parameter. Inherent helpers
-    /// (`call_llm_non_streaming` / `call_llm_streaming`) still take
-    /// `reasoning: &Reasoning` and are invoked with `&self.reasoning`.
-    reasoning: Reasoning,
+    /// W7.3: LLM call + cost guard + DB persistence delegated to here.
+    responder: Arc<super::desktop_responder::DesktopResponder>,
 }
 
 #[async_trait]
@@ -467,110 +474,10 @@ impl<'a> LoopDelegate for ChatDelegate<'a> {
     async fn call_llm(
         &self,
         reason_ctx: &mut ReasoningContext,
-        iteration: usize,
+        _iteration: usize,
     ) -> Result<crate::llm::RespondOutput, HostError> {
-        let reasoning = &self.reasoning;
-        // Enforce cost guardrails before the LLM call (global + per-user)
-        if let Err(limit) = self.tenant.check_cost_allowed().await {
-            return Err(crate::error::LlmError::InvalidResponse {
-                provider: "agent".to_string(),
-                reason: limit.to_string(),
-            }
-            .into());
-        }
-
-        // Apply per-user model override from settings (first iteration only
-        // to avoid repeated DB lookups within the same agentic loop).
-        // Uses "selected_model" — the same key the /model command persists to
-        // via SettingsStore (per-user scoped via TenantScope).
-        if iteration == 0
-            && let Some(store) = self.tenant.store()
-            && let Ok(Some(value)) = store.get_setting("selected_model").await
-            && let Some(model) = value.as_str()
-        {
-            let model = model.trim();
-            if !model.is_empty() {
-                reason_ctx.model_override = Some(model.to_string());
-            }
-        }
-
-        let use_streaming = self.agent.llm().supports_streaming();
-        let output = if use_streaming {
-            self.call_llm_streaming(reasoning, reason_ctx, iteration)
-                .await?
-        } else {
-            self.call_llm_non_streaming(reasoning, reason_ctx, iteration)
-                .await?
-        };
-
-        // Record cost and track token usage (global + per-user).
-        // Use the provider's effective_model_name so cost attribution matches
-        // the model that actually served the request. When the override is
-        // honoured (e.g. NearAI), this returns the override name; when the
-        // provider ignores overrides (e.g. Rig-based), it returns the active
-        // model, keeping attribution accurate in both cases.
-        let model_name = self
-            .agent
-            .llm()
-            .effective_model_name(reason_ctx.model_override.as_deref());
-        let cost_per_token = if reason_ctx.model_override.is_some() {
-            // Override may use different pricing; let CostGuard fall back to
-            // costs::model_cost() for the effective model.
-            None
-        } else {
-            Some(self.agent.llm().cost_per_token())
-        };
-        let read_discount = self.agent.llm().cache_read_discount();
-        let write_multiplier = self.agent.llm().cache_write_multiplier();
-        let call_cost = self
-            .tenant
-            .record_llm_call(
-                &model_name,
-                output.usage.input_tokens,
-                output.usage.output_tokens,
-                output.usage.cache_read_input_tokens,
-                output.usage.cache_creation_input_tokens,
-                read_discount,
-                write_multiplier,
-                cost_per_token,
-            )
-            .await;
-        tracing::debug!(
-            "LLM call used {} input + {} output tokens (${:.6})",
-            output.usage.input_tokens,
-            output.usage.output_tokens,
-            call_cost,
-        );
-
-        // Record cache metrics for the prompt cache monitor.
-        if let Some(ref monitor) = self.agent.deps.cache_monitor {
-            monitor.record(
-                output.usage.input_tokens,
-                output.usage.cache_read_input_tokens,
-                output.usage.cache_creation_input_tokens,
-                false,
-            );
-        }
-
-        // Persist LLM call to DB so usage stats survive restarts.
-        // Chat turns don't create agent_jobs, so job_id is None.
-        if let Some(store) = self.tenant.store() {
-            let record = crate::history::LlmCallRecord {
-                job_id: None,
-                conversation_id: Some(self.thread_id),
-                provider: &self.agent.deps.llm_backend,
-                model: &model_name,
-                input_tokens: output.usage.input_tokens,
-                output_tokens: output.usage.output_tokens,
-                cost: call_cost,
-                purpose: Some("chat"),
-            };
-            if let Err(e) = store.record_llm_call(&record).await {
-                tracing::warn!("Failed to persist LLM call to DB: {}", e);
-            }
-        }
-
-        Ok(output)
+        use dasclaw_runtime::AgentResponder;
+        self.responder.respond(reason_ctx).await
     }
 
     async fn handle_text_response(
@@ -614,109 +521,6 @@ impl<'a> LoopDelegate for ChatDelegate<'a> {
 }
 
 // ── Private helpers for ChatDelegate ────────────────────────────────────
-
-impl<'a> ChatDelegate<'a> {
-    /// Non-streaming LLM call with context-exceeded retry.
-    async fn call_llm_non_streaming(
-        &self,
-        reasoning: &Reasoning,
-        reason_ctx: &mut ReasoningContext,
-        iteration: usize,
-    ) -> Result<crate::llm::RespondOutput, Error> {
-        match reasoning.respond_with_tools(reason_ctx).await {
-            Ok(output) => Ok(output),
-            Err(crate::error::LlmError::ContextLengthExceeded { used, limit }) => {
-                tracing::warn!(
-                    used,
-                    limit,
-                    iteration,
-                    "Context length exceeded, compacting messages and retrying"
-                );
-                reason_ctx.messages = compact_messages_for_retry(&reason_ctx.messages);
-                if reason_ctx.force_text {
-                    reason_ctx.available_tools.clear();
-                }
-                reasoning
-                    .respond_with_tools(reason_ctx)
-                    .await
-                    .map_err(|retry_err| {
-                        tracing::error!(
-                            original_used = used,
-                            original_limit = limit,
-                            retry_error = %retry_err,
-                            "Retry after auto-compaction also failed"
-                        );
-                        crate::error::Error::from(retry_err)
-                    })
-            }
-            Err(e) => Err(e.into()),
-        }
-    }
-
-    /// Streaming LLM call: forwards text chunks to the channel while the
-    /// response is being generated, with context-exceeded retry fallback.
-    async fn call_llm_streaming(
-        &self,
-        reasoning: &Reasoning,
-        reason_ctx: &mut ReasoningContext,
-        iteration: usize,
-    ) -> Result<crate::llm::RespondOutput, Error> {
-        let (chunk_tx, mut chunk_rx) = tokio::sync::mpsc::unbounded_channel::<String>();
-
-        let channels = self.agent.channels.clone();
-        let channel_name = self.message.channel.clone();
-        let metadata = self.message.metadata.clone();
-
-        // Spawn a task that drains text chunks and forwards them as
-        // StatusUpdate::StreamChunk to the frontend.
-        let forward_handle = tokio::spawn(async move {
-            while let Some(chunk) = chunk_rx.recv().await {
-                let _ = channels
-                    .send_status(&channel_name, StatusUpdate::StreamChunk(chunk), &metadata)
-                    .await;
-            }
-        });
-
-        let result = reasoning
-            .respond_with_tools_streaming(reason_ctx, chunk_tx)
-            .await;
-
-        // Wait for the forwarding task to finish draining queued chunks
-        // before returning to the caller.
-        let _ = forward_handle.await;
-
-        match result {
-            Ok(output) => Ok(output),
-            Err(crate::error::LlmError::ContextLengthExceeded { used, limit }) => {
-                tracing::warn!(
-                    used,
-                    limit,
-                    iteration,
-                    "Context length exceeded (streaming), compacting and retrying non-streaming"
-                );
-                reason_ctx.messages = compact_messages_for_retry(&reason_ctx.messages);
-                if reason_ctx.force_text {
-                    reason_ctx.available_tools.clear();
-                }
-                // Retry falls back to non-streaming to avoid creating another
-                // forwarding task for a likely-small compacted context.
-                reasoning
-                    .respond_with_tools(reason_ctx)
-                    .await
-                    .map_err(|retry_err| {
-                        tracing::error!(
-                            original_used = used,
-                            original_limit = limit,
-                            retry_error = %retry_err,
-                            "Retry after auto-compaction also failed (streaming)"
-                        );
-                        crate::error::Error::from(retry_err)
-                    })
-            }
-            Err(e) => Err(e.into()),
-        }
-    }
-}
 
 /// Execute a chat tool without requiring `&Agent`.
 ///
@@ -836,7 +640,7 @@ pub(super) fn contextual_tool_message(tool_calls: &[crate::llm::ToolCall]) -> St
 /// finds the last `User` message, and retains it plus every subsequent message
 /// (the current turn's assistant tool calls and tool results). A short note is
 /// inserted so the LLM knows earlier history was dropped.
-fn compact_messages_for_retry(messages: &[ChatMessage]) -> Vec<ChatMessage> {
+pub(super) fn compact_messages_for_retry(messages: &[ChatMessage]) -> Vec<ChatMessage> {
     use crate::llm::Role;
 
     let mut compacted = Vec::new();

--- a/desktop-client/ironclaw/src/agent/mod.rs
+++ b/desktop-client/ironclaw/src/agent/mod.rs
@@ -16,6 +16,7 @@ mod attachments;
 mod commands;
 pub mod compaction;
 mod desktop_dispatcher;
+mod desktop_responder;
 mod dispatcher;
 mod router;
 pub mod session;


### PR DESCRIPTION
## 背景 / 目标

ADR-160 §3 L2 W7.3：从 `desktop-client/ironclaw/src/agent/dispatcher.rs::ChatDelegate::call_llm` 抽出独立 `DesktopResponder`，实现 `dasclaw_runtime::AgentResponder` trait，为 W7.4（让桌面端复用 `dasclaw_runtime::AgenticLoop`）做铺垫。

Closes #967

## 改动范围

- 新增 `desktop-client/ironclaw/src/agent/desktop_responder.rs`（~250 行）
  - `pub(super) struct DesktopResponder` 持有 `reasoning / llm / llm_backend / cache_monitor / tenant / thread_id / channels / channel / metadata`
  - `#[async_trait] impl AgentResponder for DesktopResponder`：cost guard → per-user `selected_model` 覆写 → streaming/non-streaming 分派 → cost 记录 → cache monitor → DB 持久化（行为与原 `call_llm` body 等价）
  - 私有 helper `call_llm_non_streaming` / `call_llm_streaming` 一并迁入
  - 用 `AtomicBool model_override_applied` sentinel 取代原 `iteration == 0` gate（`AgentResponder::respond` 不接收 `iteration` 参数）
- 修改 `desktop-client/ironclaw/src/agent/dispatcher.rs`
  - `ChatDelegate` 删除 `reasoning` 与 `tenant` 字段，新增 `responder: Arc<DesktopResponder>` 字段
  - 构造点先组装 `responder`，再写入 `ChatDelegate`
  - `ChatDelegate::call_llm` 退化为一行：`self.responder.respond(reason_ctx).await`
  - 原 `impl<'a> ChatDelegate<'a>` 中的两个 helper 已迁走删除
  - `compact_messages_for_retry` 由 `fn` 改为 `pub(super) fn`（被新模块复用）
- 修改 `desktop-client/ironclaw/src/agent/mod.rs`：新增 `mod desktop_responder;`

## 非目标（What's NOT in this PR）

- 不动 `JobDelegate` / `ContainerDelegate`（W8 任务）
- 不切到 `dasclaw_runtime::AgenticLoop::new`（W7.4）
- 不动 `unbounded_channel` 流式背压（与原行为一致）
- 不重构 `call_llm_streaming` / `non_streaming` 的相似分支（属预存重复，本 PR 仅做搬迁）

## 验证

本地（仅改动 crate）：

```bash
RUSTC_WRAPPER= cargo check -p dasclaw --tests            # ✅ 通过
RUSTC_WRAPPER= cargo nextest run -p dasclaw \
  -E 'test(dispatcher) | test(test_dispatcher_terminates) | test(test_context_length_recovery)'
# ✅ 62/62 通过
cargo fmt --all                                           # ✅
python3.12 scripts/check_no_panics.py --base origin/xClaw # ✅ No panic-inducing calls
RUSTC_WRAPPER= cargo clippy --no-deps -p dasclaw --all-targets -- -D warnings  # ✅
```

完整 workspace build / clippy 由 CI 兜底。

## Sources read

- AGENTS.md（仓库根）
- docs/plans/architecture-refactor/adr-160（W7 切片说明）§3 L2
- docs/plans/architecture-refactor/56-... ChatDelegate convergence 设计
- crates/dasclaw_runtime/src/agent.rs（AgentResponder trait 定义 L149-L153）
- crates/dasclaw_runtime/src/agentic_loop.rs（W6.4 已统一的 loop 装配）
- desktop-client/ironclaw/src/agent/dispatcher.rs 改动前完整体（ChatDelegate / call_llm）
- desktop-client/ironclaw/src/observability.rs（PromptCacheMonitor 路径确认）

## Skills 自查

子 agent 跑了 code-quality-audit + code-simplifier + code-review-expert 三层：

- code-quality-audit：未引入新 unwrap/expect/panic；DB / channel 错误用 tracing::warn! 静默处理，与原行为一致。
- code-simplifier：`call_llm` 退化为单行 delegate，符合"消除冗余抽象"；`ChatDelegate` 删除两个不再使用的字段（`reasoning`、`tenant`）。
- code-review-expert：唯一 SHOULD-FIX 已修——`DesktopResponder` struct 补充了"必须 per-turn 构造"的 invariant 注释，避免未来误用导致 `selected_model` override 静默失效。

## Stacked PR

- base = `feat/w7.2-impl-tooldispatcher-for-desktop`（非 xClaw）
- merge 顺序：先 #968（W7.1）→ 再 #969（W7.2）→ 最后本 PR
- 复审建议：先看 #968 → #969 → 本 PR

