### PR TITLE
feat(desktop): W7.4 swap chat path to runtime AgenticLoop, delete ChatDelegate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2742,6 +2742,7 @@ dependencies = [
  "tokio-stream",
  "tokio-test",
  "tokio-tungstenite 0.26.2",
+ "tokio-util",
  "toml 0.8.23",
  "tower 0.5.3",
  "tower-http 0.6.8",
@@ -12349,6 +12350,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "tokio",
 ]

--- a/desktop-client/ironclaw/Cargo.toml
+++ b/desktop-client/ironclaw/Cargo.toml
@@ -46,6 +46,7 @@ path = "src/main.rs"
 # Async runtime
 tokio = { version = "1", features = ["full"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
+tokio-util = { version = "0.7", features = ["rt"] }
 futures = "0.3"
 tokio-tungstenite = { version = "0.26", features = ["rustls-tls-native-roots"] }
 eventsource-stream = "0.2"

--- a/desktop-client/ironclaw/src/agent/desktop_responder.rs
+++ b/desktop-client/ironclaw/src/agent/desktop_responder.rs
@@ -1,15 +1,18 @@
-//! Desktop-side `AgentResponder` adapter (ADR-160 §3 L2, W7.3).
+//! Desktop-side `AgentResponder` adapter (ADR-160 §3 L2, W7.3/W7.4).
 //!
 //! Houses the LLM call pipeline (cost guard → per-user model override →
-//! streaming/non-streaming dispatch → cost record → cache monitor → DB
-//! persistence) that previously lived in `ChatDelegate::call_llm`.
+//! pre-LLM iteration setup → streaming/non-streaming dispatch → cost record →
+//! cache monitor → DB persistence) that previously lived in
+//! `ChatDelegate::call_llm` + `ChatDelegate::before_llm_call`.
 
+use std::collections::HashSet;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
 use async_trait::async_trait;
 use uuid::Uuid;
 
+use dasclaw_core::messages::ChatMessage;
 use dasclaw_core::traits::HostError;
 use dasclaw_runtime::AgentResponder;
 
@@ -20,8 +23,10 @@ use crate::observability::PromptCacheMonitor;
 
 pub(super) struct DesktopResponder {
     // Invariant: must be constructed per turn. The `model_override_applied`
-    // sentinel below is reset on each `new()`; reusing one instance across
-    // turns would silently disable per-user `selected_model` overrides.
+    // and `iteration` sentinels below are reset on each `new()`; reusing
+    // one instance across turns would silently disable per-user
+    // `selected_model` overrides and skew the iteration-driven nudge /
+    // force-text gates.
     reasoning: Reasoning,
     llm: Arc<dyn LlmProvider>,
     llm_backend: String,
@@ -31,9 +36,19 @@ pub(super) struct DesktopResponder {
     channels: Arc<ChannelManager>,
     channel: String,
     metadata: serde_json::Value,
-    // First-iteration sentinel — replaces the `iteration == 0` check that
-    // gated the per-user `selected_model` settings lookup in the previous
-    // `ChatDelegate::call_llm` body.
+    // W7.4: tool-table refresh / nudge / force-text inputs (moved from
+    // ChatDelegate::before_llm_call).
+    tools: Arc<crate::tools::ToolRegistry>,
+    active_skills: Vec<crate::skills::LoadedSkill>,
+    disabled_extensions: HashSet<String>,
+    cached_prompt: String,
+    cached_prompt_no_tools: String,
+    nudge_at: usize,
+    force_text_at: usize,
+    // Per-turn iteration counter; replaces the `iteration` parameter the
+    // old `LoopDelegate::before_llm_call` received but `AgentResponder`
+    // does not expose.
+    iteration: AtomicUsize,
     model_override_applied: AtomicBool,
 }
 
@@ -49,6 +64,13 @@ impl DesktopResponder {
         channels: Arc<ChannelManager>,
         channel: String,
         metadata: serde_json::Value,
+        tools: Arc<crate::tools::ToolRegistry>,
+        active_skills: Vec<crate::skills::LoadedSkill>,
+        disabled_extensions: HashSet<String>,
+        cached_prompt: String,
+        cached_prompt_no_tools: String,
+        nudge_at: usize,
+        force_text_at: usize,
     ) -> Self {
         Self {
             reasoning,
@@ -60,8 +82,84 @@ impl DesktopResponder {
             channels,
             channel,
             metadata,
+            tools,
+            active_skills,
+            disabled_extensions,
+            cached_prompt,
+            cached_prompt_no_tools,
+            nudge_at,
+            force_text_at,
+            iteration: AtomicUsize::new(0),
             model_override_applied: AtomicBool::new(false),
         }
+    }
+
+    /// Pre-LLM iteration setup: tool table refresh, nudge injection,
+    /// force-text gating, prompt swap, status broadcast. Moved verbatim
+    /// from the deleted `ChatDelegate::before_llm_call`.
+    async fn before_llm_call(&self, reason_ctx: &mut ReasoningContext, iteration: usize) {
+        if iteration == self.nudge_at {
+            reason_ctx.messages.push(ChatMessage::system(
+                "You are approaching the tool call limit. \
+                 Provide your best final answer on the next response \
+                 using the information you have gathered so far. \
+                 Do not call any more tools.",
+            ));
+        }
+
+        let force_text = iteration >= self.force_text_at;
+
+        let tool_defs = self
+            .tools
+            .tool_definitions_for_llm(
+                &dasclaw_governance::tool_visibility::ToolGateContextSeed::system(
+                    dasclaw_governance::tool_visibility::Env::Interactive,
+                ),
+            )
+            .await;
+        let tool_defs = super::dispatcher::filter_tools_by_disabled_extensions(
+            tool_defs,
+            &self.disabled_extensions,
+        );
+        let tool_defs = if !self.active_skills.is_empty() {
+            let result = crate::skills::attenuate_tools(&tool_defs, &self.active_skills);
+            tracing::debug!(
+                min_trust = %result.min_trust,
+                tools_available = result.tools.len(),
+                tools_removed = result.removed_tools.len(),
+                removed = ?result.removed_tools,
+                explanation = %result.explanation,
+                "Tool attenuation applied"
+            );
+            result.tools
+        } else {
+            tool_defs
+        };
+
+        reason_ctx.available_tools = tool_defs;
+        let force_text = force_text || reason_ctx.force_text;
+        reason_ctx.system_prompt = Some(if force_text {
+            self.cached_prompt_no_tools.clone()
+        } else {
+            self.cached_prompt.clone()
+        });
+        reason_ctx.force_text = force_text;
+
+        if force_text {
+            tracing::info!(
+                iteration,
+                "Forcing text-only response (iteration limit reached)"
+            );
+        }
+
+        let _ = self
+            .channels
+            .send_status(
+                &self.channel,
+                StatusUpdate::Thinking(format!("Thinking (step {iteration})...")),
+                &self.metadata,
+            )
+            .await;
     }
 
     /// Non-streaming LLM call with context-exceeded retry.
@@ -161,6 +259,9 @@ impl DesktopResponder {
 #[async_trait]
 impl AgentResponder for DesktopResponder {
     async fn respond(&self, reason_ctx: &mut ReasoningContext) -> Result<RespondOutput, HostError> {
+        let iteration = self.iteration.fetch_add(1, Ordering::Relaxed);
+        self.before_llm_call(reason_ctx, iteration).await;
+
         if let Err(limit) = self.tenant.check_cost_allowed().await {
             return Err(crate::error::LlmError::InvalidResponse {
                 provider: "agent".to_string(),

--- a/desktop-client/ironclaw/src/agent/dispatcher.rs
+++ b/desktop-client/ironclaw/src/agent/dispatcher.rs
@@ -11,17 +11,12 @@ use uuid::Uuid;
 
 use crate::agent::Agent;
 use crate::agent::session::{PendingApproval, Session, ThreadState};
-use crate::channels::{IncomingMessage, StatusUpdate};
+use crate::channels::IncomingMessage;
 use crate::error::Error;
-use async_trait::async_trait;
 use dasclaw_runtime::context::JobContext;
-use dasclaw_runtime::tool_dispatch::ToolDispatcher;
 
-use crate::agent::agentic_loop::{
-    AgenticLoopConfig, LoopDelegate, LoopOutcome, LoopSignal, TextAction,
-};
+use crate::agent::agentic_loop::{AgenticLoopConfig, LoopOutcome};
 use crate::llm::{ChatMessage, Reasoning, ReasoningContext};
-use dasclaw_core::traits::HostError;
 
 fn disabled_names_from_metadata(message: &IncomingMessage, key: &str) -> HashSet<String> {
     message
@@ -38,7 +33,7 @@ fn disabled_names_from_metadata(message: &IncomingMessage, key: &str) -> HashSet
         .unwrap_or_default()
 }
 
-fn filter_tools_by_disabled_extensions(
+pub(super) fn filter_tools_by_disabled_extensions(
     tools: Vec<crate::llm::ToolDefinition>,
     disabled_extensions: &HashSet<String>,
 ) -> Vec<crate::llm::ToolDefinition> {
@@ -250,38 +245,75 @@ impl Agent {
         let force_text_at = max_tool_iterations;
         let nudge_at = max_tool_iterations.saturating_sub(1);
 
-        let responder = Arc::new(super::desktop_responder::DesktopResponder::new(
-            reasoning,
-            self.llm().clone(),
-            self.deps.llm_backend.clone(),
-            self.deps.cache_monitor.clone(),
-            tenant.clone(),
-            thread_id,
-            self.channels.clone(),
-            message.channel.clone(),
-            message.metadata.clone(),
-        ));
+        let responder: Arc<dyn dasclaw_runtime::AgentResponder> =
+            Arc::new(super::desktop_responder::DesktopResponder::new(
+                reasoning,
+                self.llm().clone(),
+                self.deps.llm_backend.clone(),
+                self.deps.cache_monitor.clone(),
+                tenant.clone(),
+                thread_id,
+                self.channels.clone(),
+                message.channel.clone(),
+                message.metadata.clone(),
+                self.tools().clone(),
+                active_skills,
+                disabled_extensions.clone(),
+                cached_prompt.clone(),
+                cached_prompt_no_tools,
+                nudge_at,
+                force_text_at,
+            ));
 
-        let delegate = ChatDelegate {
-            agent: self,
-            session: session.clone(),
-            thread_id,
-            message: message.clone(),
-            job_ctx,
-            active_skills,
-            disabled_extensions,
-            cached_prompt,
-            cached_prompt_no_tools,
-            nudge_at,
-            force_text_at,
-            user_tz,
-            responder,
+        let dispatcher: Arc<dyn dasclaw_runtime::tool_dispatch::ToolDispatcher> =
+            Arc::new(super::desktop_dispatcher::DesktopDispatcher {
+                safety: self.safety().clone(),
+                tools: self.tools().clone(),
+                hooks: self.hooks().clone(),
+                channels: self.channels.clone(),
+                config: self.config.clone(),
+                message: message.clone(),
+                session: session.clone(),
+                thread_id,
+                job_ctx,
+                disabled_extensions,
+                user_tz,
+            });
+
+        // Bridge `ThreadState::Interrupted` (poll-based check in the old
+        // `ChatDelegate::check_signals`) onto `CancellationToken`, which is
+        // what `dasclaw_runtime::AgenticLoop` consults each iteration.
+        // A background watcher polls the session state every 100 ms and
+        // cancels the token on transition to `Interrupted`; the watcher is
+        // aborted when the loop returns.
+        let cancel_token = tokio_util::sync::CancellationToken::new();
+        let watcher_handle = {
+            let token = cancel_token.clone();
+            let session_clone = session.clone();
+            let thread_id_for_watcher = thread_id;
+            tokio::spawn(async move {
+                let mut interval = tokio::time::interval(std::time::Duration::from_millis(100));
+                interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+                loop {
+                    tokio::select! {
+                        _ = token.cancelled() => break,
+                        _ = interval.tick() => {}
+                    }
+                    let sess = session_clone.lock().await;
+                    if let Some(thread) = sess.threads.get(&thread_id_for_watcher)
+                        && thread.state == ThreadState::Interrupted
+                    {
+                        token.cancel();
+                        break;
+                    }
+                }
+            })
         };
 
         let mut reason_ctx = ReasoningContext::new()
             .with_messages(initial_messages)
             .with_tools(initial_tool_defs)
-            .with_system_prompt(delegate.cached_prompt.clone())
+            .with_system_prompt(cached_prompt)
             .with_metadata({
                 let mut m = std::collections::HashMap::new();
                 m.insert("thread_id".to_string(), thread_id.to_string());
@@ -295,39 +327,52 @@ impl Agent {
             max_tool_intent_nudges: 2,
         };
 
-        let outcome = crate::agent::agentic_loop::run_agentic_loop(
-            &delegate,
-            &mut reason_ctx,
-            &loop_config,
-            // Phase 3 Step G: SafetyLayer wired in via IronclawSafetyHook.
-            // Phase 3 Step F: SecretsStore on the tool registry now also
-            // flows into `bundle.secrets` so the agent hook layer can read
-            // user-scoped secrets without going through the tool path.
-            // Issue #73 slice D: PermissionMode threaded explicitly so the
-            // session-config layer can override per chat session.
-            // Issue #73 slice E: workspace boundary is sourced from a
-            // capability-validated `WorkspaceCapability`; `.` is the
-            // current chat session's working directory.
-            &crate::agent::agentic_loop::hook_bundle_with_safety_and_secrets(
-                self.safety().clone(),
-                &self.deps.tools,
-                &message.user_id,
-                std::sync::Arc::new(
-                    crate::agent::agentic_loop::WorkspaceCapability::open(
-                        std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from(".")),
-                    )
-                    .map_err(|e| crate::error::WorkspaceError::IoError {
-                        reason: format!("failed to open workspace capability: {e}"),
-                    })?,
-                ),
-                crate::agent::agentic_loop::PermissionMode::WorkspaceWrite,
+        // Phase 3 Step G: SafetyLayer wired in via IronclawSafetyHook.
+        // Phase 3 Step F: SecretsStore on the tool registry now also flows
+        // into `bundle.secrets` so the agent hook layer can read user-scoped
+        // secrets without going through the tool path.
+        // Issue #73 slice D/E: PermissionMode + workspace boundary threaded
+        // explicitly so the session-config layer can override per chat session.
+        let hooks = crate::agent::agentic_loop::hook_bundle_with_safety_and_secrets(
+            self.safety().clone(),
+            &self.deps.tools,
+            &message.user_id,
+            std::sync::Arc::new(
+                crate::agent::agentic_loop::WorkspaceCapability::open(
+                    std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from(".")),
+                )
+                .map_err(|e| crate::error::WorkspaceError::IoError {
+                    reason: format!("failed to open workspace capability: {e}"),
+                })?,
             ),
+            crate::agent::agentic_loop::PermissionMode::WorkspaceWrite,
+        );
+
+        let outcome = dasclaw_runtime::AgenticLoop::new(
+            responder,
+            Some(dispatcher),
+            Some(cancel_token.clone()),
+            None,
         )
+        .run(&mut reason_ctx, &loop_config, &hooks)
         .await
-        .map_err(crate::agent::agentic_loop::host_err_to_error)?;
+        .map_err(crate::agent::agentic_loop::host_err_to_error);
+
+        // Stop the watcher regardless of how the loop terminated.
+        cancel_token.cancel();
+        let _ = watcher_handle.await;
+
+        let outcome = outcome?;
 
         match outcome {
-            LoopOutcome::Response(text) => Ok(AgenticLoopResult::Response(text)),
+            LoopOutcome::Response(text) => {
+                // Strip internal "[Called tool ...]" text that can leak when
+                // provider flattening (e.g. NEAR AI) converts tool_calls to
+                // plain text and the LLM echoes it back. Previously this
+                // lived in `ChatDelegate::handle_text_response`.
+                let sanitized = strip_internal_tool_call_text(&text);
+                Ok(AgenticLoopResult::Response(sanitized))
+            }
             LoopOutcome::Stopped => Err(crate::error::JobError::ContextError {
                 id: thread_id,
                 reason: "Interrupted".to_string(),
@@ -357,170 +402,6 @@ impl Agent {
         execute_chat_tool_standalone(self.tools(), self.safety(), tool_name, params, job_ctx).await
     }
 }
-
-/// Delegate for the chat (dispatcher) context.
-///
-/// Implements `LoopDelegate` to customize the shared agentic loop for
-/// interactive chat sessions with the full 3-phase tool execution
-/// (preflight → parallel exec → post-flight), approval flow, hooks,
-/// auth intercept, and cost tracking.
-struct ChatDelegate<'a> {
-    agent: &'a Agent,
-    session: Arc<Mutex<Session>>,
-    thread_id: Uuid,
-    message: Arc<IncomingMessage>,
-    job_ctx: JobContext,
-    active_skills: Vec<crate::skills::LoadedSkill>,
-    disabled_extensions: HashSet<String>,
-    cached_prompt: String,
-    cached_prompt_no_tools: String,
-    nudge_at: usize,
-    force_text_at: usize,
-    user_tz: chrono_tz::Tz,
-    /// W7.3: LLM call + cost guard + DB persistence delegated to here.
-    responder: Arc<super::desktop_responder::DesktopResponder>,
-}
-
-#[async_trait]
-impl<'a> LoopDelegate for ChatDelegate<'a> {
-    async fn check_signals(&self) -> LoopSignal {
-        let sess = self.session.lock().await;
-        if let Some(thread) = sess.threads.get(&self.thread_id)
-            && thread.state == ThreadState::Interrupted
-        {
-            return LoopSignal::Stop;
-        }
-        LoopSignal::Continue
-    }
-
-    async fn before_llm_call(
-        &self,
-        reason_ctx: &mut ReasoningContext,
-        iteration: usize,
-    ) -> Option<LoopOutcome> {
-        // Inject a nudge message when approaching the iteration limit so the
-        // LLM is aware it should produce a final answer on the next turn.
-        if iteration == self.nudge_at {
-            reason_ctx.messages.push(ChatMessage::system(
-                "You are approaching the tool call limit. \
-                 Provide your best final answer on the next response \
-                 using the information you have gathered so far. \
-                 Do not call any more tools.",
-            ));
-        }
-
-        let force_text = iteration >= self.force_text_at;
-
-        // Refresh tool definitions each iteration so newly built tools become visible.
-        // ADR-149 / issue #485 — L2 gate; interactive agent loop.
-        let tool_defs = self
-            .agent
-            .tools()
-            .tool_definitions_for_llm(
-                &dasclaw_governance::tool_visibility::ToolGateContextSeed::system(
-                    dasclaw_governance::tool_visibility::Env::Interactive,
-                ),
-            )
-            .await;
-        let tool_defs = filter_tools_by_disabled_extensions(tool_defs, &self.disabled_extensions);
-
-        // Apply trust-based tool attenuation if skills are active.
-        let tool_defs = if !self.active_skills.is_empty() {
-            let result = crate::skills::attenuate_tools(&tool_defs, &self.active_skills);
-            tracing::debug!(
-                min_trust = %result.min_trust,
-                tools_available = result.tools.len(),
-                tools_removed = result.removed_tools.len(),
-                removed = ?result.removed_tools,
-                explanation = %result.explanation,
-                "Tool attenuation applied"
-            );
-            result.tools
-        } else {
-            tool_defs
-        };
-
-        // Update context for this iteration
-        reason_ctx.available_tools = tool_defs;
-        // Preserve force_text if already set (e.g. by truncation escalation).
-        let force_text = force_text || reason_ctx.force_text;
-        reason_ctx.system_prompt = Some(if force_text {
-            self.cached_prompt_no_tools.clone()
-        } else {
-            self.cached_prompt.clone()
-        });
-        reason_ctx.force_text = force_text;
-
-        if force_text {
-            tracing::info!(
-                iteration,
-                "Forcing text-only response (iteration limit reached)"
-            );
-        }
-
-        let _ = self
-            .agent
-            .channels
-            .send_status(
-                &self.message.channel,
-                StatusUpdate::Thinking(format!("Thinking (step {iteration})...")),
-                &self.message.metadata,
-            )
-            .await;
-
-        None
-    }
-
-    async fn call_llm(
-        &self,
-        reason_ctx: &mut ReasoningContext,
-        _iteration: usize,
-    ) -> Result<crate::llm::RespondOutput, HostError> {
-        use dasclaw_runtime::AgentResponder;
-        self.responder.respond(reason_ctx).await
-    }
-
-    async fn handle_text_response(
-        &self,
-        text: &str,
-        _metadata: crate::llm::ResponseMetadata,
-        _usage: dasclaw_core::TokenUsage,
-        _reason_ctx: &mut ReasoningContext,
-    ) -> TextAction {
-        // Strip internal "[Called tool ...]" text that can leak when
-        // provider flattening (e.g. NEAR AI) converts tool_calls to
-        // plain text and the LLM echoes it back.
-        let sanitized = strip_internal_tool_call_text(text);
-        TextAction::Return(LoopOutcome::Response(sanitized))
-    }
-
-    async fn execute_tool_calls(
-        &self,
-        tool_calls: Vec<crate::llm::ToolCall>,
-        content: Option<String>,
-        usage: dasclaw_core::TokenUsage,
-        reason_ctx: &mut ReasoningContext,
-    ) -> Result<Option<LoopOutcome>, HostError> {
-        let dispatcher = super::desktop_dispatcher::DesktopDispatcher {
-            safety: self.agent.safety().clone(),
-            tools: self.agent.tools().clone(),
-            hooks: self.agent.hooks().clone(),
-            channels: self.agent.channels.clone(),
-            config: self.agent.config.clone(),
-            message: self.message.clone(),
-            session: self.session.clone(),
-            thread_id: self.thread_id,
-            job_ctx: self.job_ctx.clone(),
-            disabled_extensions: self.disabled_extensions.clone(),
-            user_tz: self.user_tz,
-        };
-        dispatcher
-            .dispatch(tool_calls, content, usage, reason_ctx)
-            .await
-    }
-}
-
-// ── Private helpers for ChatDelegate ────────────────────────────────────
 
 /// Execute a chat tool without requiring `&Agent`.
 ///


### PR DESCRIPTION
# W7.4 — swap chat path to runtime `AgenticLoop`, delete `ChatDelegate`

Closes #967 · ADR-160 §3 L2 · Stacked on #970

## 背景 / 目标

完成 ADR-160 §3 L2 桌面端六边形化最后一步 W7.4：把 `Agent::run_agentic_loop`
的实现从本地 `ChatDelegate: LoopDelegate` 切到 `dasclaw_runtime::AgenticLoop`，
并把 `ChatDelegate` 彻底删除。至此 chat 路径完全跑在 runtime 抽象之上。

## 改动范围

- `desktop-client/ironclaw/src/agent/dispatcher.rs`
  - `Agent::run_agentic_loop` 重写为 `AgenticLoop::new(responder, dispatcher, cancel_token, None).run(...)`。
  - 删除 `struct ChatDelegate` 和 `impl LoopDelegate for ChatDelegate`（~170 行）。
  - 把 `strip_internal_tool_call_text` 从老 `handle_text_response` 移到 `LoopOutcome::Response` 出口，保证所有调用方仍拿到清洗后的文本。
  - 中断桥接：用 `tokio_util::sync::CancellationToken` + 一个 100 ms 轮询 watcher，把老的
    `ThreadState::Interrupted` 翻译成 `cancel_token.cancel()`。Watcher 在 run 返回后通过 `cancel_token.cancel()` + `watcher_handle.await` 无条件 join，错误路径同样安全。
  - `filter_tools_by_disabled_extensions` 改为 `pub(super)`，给 `DesktopResponder` 共享。

- `desktop-client/ironclaw/src/agent/desktop_responder.rs`
  - 新增私有方法 `before_llm_call(reason_ctx, iteration)`，把老 `ChatDelegate::call_llm` 的 5 个前置子行为 verbatim 搬入：nudge 注入、`force_text`、按禁用扩展+技能衰减刷新工具列表、tools/no-tools prompt 切换、`StatusUpdate::Thinking("Thinking (step N)…")`。
  - 新增 7 个字段（`tools`, `active_skills`, `disabled_extensions`, `cached_prompt`, `cached_prompt_no_tools`, `nudge_at`, `force_text_at`）+ `AtomicUsize iteration` 计数器。
  - 文档不变量更新：`DesktopResponder` **必须每个 turn 重新构造**（计数器从 0 开始）。

- `desktop-client/ironclaw/Cargo.toml`：+ `tokio-util = { version = "0.7", features = ["rt"] }`（`CancellationToken` 在 `rt` feature 下）。

净变更：4 文件，+220 / −235。

## 非目标（What's NOT in this PR）

- **不**重写 job/容器路径（`JobDelegate` / `ContainerDelegate` 仍走老路径，归属 W8）。
- **不**把 watcher 换成事件驱动（`Session::interrupt_thread` → token.cancel 信号路径属 W8）。本 PR 100 ms 轮询是 W7→W8 的显式过渡桥。
- **不**改 `AgenticLoop` 内部行为，纯 host 侧接入。

## 验证

```
cargo fmt --all                                                # OK
python3.12 scripts/check_no_panics.py --base origin/xClaw     # OK
RUSTC_WRAPPER= cargo check -p dasclaw --tests                  # OK, 5m 56s
RUSTC_WRAPPER= cargo nextest run -p dasclaw -E 'test(dispatcher)' --no-fail-fast
   → 62 tests run: 62 passed, 3015 skipped, 12.0s
RUSTC_WRAPPER= cargo clippy --no-deps -p dasclaw --all-targets -- -D warnings
   → Finished, 0 warning
```

## Sources read

- `AGENTS.md` § 必读顺序 / Skills 强制使用规范 / 复用优先
- `docs/plans/architecture-refactor/adr-160-...md` §3 L2 W7.4 任务定义
- `crates/dasclaw_runtime/src/agentic_loop.rs` L68–L86（`AgenticLoop::new` 签名）+ `LoopAdapter::check_signals`（仅检查 `token.is_cancelled()`）
- `desktop-client/ironclaw/src/agent/desktop_responder.rs`（W7.3 baseline）
- `desktop-client/ironclaw/src/agent/dispatcher.rs`（W7.3 `ChatDelegate` body for verbatim move）
- 子代理 W7.4 scope 调研报告

## Skills 自查

子代理跑 `code-quality-audit` → `code-simplifier` → `code-review-expert`，结论 **APPROVE**。
5 个目标关切（patch-style 残留 / `AtomicUsize` 生命周期不变量 / watcher 错误路径 cleanup / tool refetch 与老路径 parity / `strip_internal_tool_call_text` 出口位置）全部通过。
两个 minor：
1. `tokio-util` 的 `rt` feature 含 `CancellationToken`，可加注释防误删——后续 W8 会一起替换，本 PR 不再加注释。
2. Watcher 每 100 ms 抢 `session.lock()`——已在代码注释里标注为 W7→W8 显式过渡桥。

## Stacked PR

- base = `feat/w7.3-extract-desktop-responder`，**不是** `xClaw`
- merge 顺序：#968 → #969 → #970 → 本 PR
- 先看 #968 → #969 → #970 再看本 PR

