### PR TITLE
feat(runtime): W8.0 extend AgentResponder with iteration hooks for delegate migration

### DIFF
--- a/crates/dasclaw_runtime/src/agent.rs
+++ b/crates/dasclaw_runtime/src/agent.rs
@@ -44,11 +44,11 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use dasclaw_core::agentic_loop::{AgenticLoopConfig, LoopOutcome};
+use dasclaw_core::agentic_loop::{AgenticLoopConfig, LoopOutcome, LoopSignal, TextAction};
 use dasclaw_core::hooks::HookBundle;
 use dasclaw_core::messages::{ChatMessage, FinishReason, ToolCall, ToolDefinition, ToolResult};
 use dasclaw_core::reasoning_ctx::ReasoningContext;
-use dasclaw_core::response_types::{RespondOutput, RespondResult};
+use dasclaw_core::response_types::{RespondOutput, RespondResult, ResponseMetadata, TokenUsage};
 use dasclaw_core::traits::HostError;
 use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc;
@@ -182,6 +182,65 @@ pub trait AgentResponder: Send + Sync {
         }
         Ok(out)
     }
+
+    /// Per-iteration signal check (W8.0).
+    ///
+    /// Returned every loop turn before any LLM call. The default keeps
+    /// the loop running; hosts that drain a stop / cancellation channel
+    /// override this. The [`AgenticLoop`]'s own cancellation token is
+    /// honoured independently — a `Continue` here cannot override an
+    /// already-cancelled token.
+    async fn check_signals(&self) -> LoopSignal {
+        LoopSignal::Continue
+    }
+
+    /// Pre-LLM iteration setup (W8.0).
+    ///
+    /// Runs after [`Self::check_signals`] and before [`Self::respond`].
+    /// Hosts use it to mutate the context (inject prompts, swap tool
+    /// tables, force text mode) or short-circuit the loop by returning
+    /// `Some(outcome)`. The default is a no-op.
+    async fn before_llm_call(
+        &self,
+        _ctx: &mut ReasoningContext,
+        _iteration: usize,
+    ) -> Option<LoopOutcome> {
+        None
+    }
+
+    /// React to a pure-text LLM response (W8.0).
+    ///
+    /// Called when [`Self::respond`] yields a [`RespondResult::Text`]
+    /// payload. The default appends the assistant message to `ctx` and
+    /// terminates the loop with [`LoopOutcome::Response`], matching the
+    /// pre-W8.0 `LoopAdapter` behaviour. Hosts that need recovery /
+    /// completion-detection logic override this and may return
+    /// [`TextAction::Continue`] to keep iterating.
+    async fn handle_text_response(
+        &self,
+        text: &str,
+        _metadata: ResponseMetadata,
+        usage: TokenUsage,
+        ctx: &mut ReasoningContext,
+    ) -> TextAction {
+        ctx.messages
+            .push(ChatMessage::assistant(text).with_usage(usage));
+        TextAction::Return(LoopOutcome::Response(text.to_string()))
+    }
+
+    /// React to a tool-intent nudge being injected (W8.0).
+    ///
+    /// Called when the loop detects the model produced text that looked
+    /// like a tool intent and injects a corrective nudge. Default is a
+    /// no-op; hosts override to emit a UI event.
+    async fn on_tool_intent_nudge(&self, _text: &str, _ctx: &mut ReasoningContext) {}
+
+    /// End-of-iteration callback (W8.0).
+    ///
+    /// Called after every successful iteration that did not return an
+    /// outcome. Default is a no-op; hosts use it for throttling /
+    /// progress reporting.
+    async fn after_iteration(&self, _iteration: usize) {}
 }
 
 /// Narrow tool-execution seam used by [`Agent`] (ADR-153 step 2 sub-step A2).

--- a/crates/dasclaw_runtime/src/agentic_loop.rs
+++ b/crates/dasclaw_runtime/src/agentic_loop.rs
@@ -38,7 +38,7 @@ use dasclaw_core::agentic_loop::{
     AgenticLoopConfig, LoopDelegate, LoopOutcome, LoopSignal, TextAction, run_agentic_loop,
 };
 use dasclaw_core::hooks::HookBundle;
-use dasclaw_core::messages::{ChatMessage, ToolCall};
+use dasclaw_core::messages::ToolCall;
 use dasclaw_core::reasoning_ctx::ReasoningContext;
 use dasclaw_core::response_types::{RespondOutput, ResponseMetadata, TokenUsage};
 use dasclaw_core::traits::HostError;
@@ -117,18 +117,23 @@ impl<'a> LoopAdapter<'a> {
 #[async_trait]
 impl<'a> LoopDelegate for LoopAdapter<'a> {
     async fn check_signals(&self) -> LoopSignal {
-        match self.inner.cancellation_token.as_ref() {
-            Some(token) if token.is_cancelled() => LoopSignal::Stop,
-            _ => LoopSignal::Continue,
+        // Cancellation token short-circuits the responder hook: a
+        // cancelled token always wins even if the responder would
+        // return `Continue`.
+        if let Some(token) = self.inner.cancellation_token.as_ref()
+            && token.is_cancelled()
+        {
+            return LoopSignal::Stop;
         }
+        self.inner.responder.check_signals().await
     }
 
     async fn before_llm_call(
         &self,
-        _ctx: &mut ReasoningContext,
-        _iteration: usize,
+        ctx: &mut ReasoningContext,
+        iteration: usize,
     ) -> Option<LoopOutcome> {
-        None
+        self.inner.responder.before_llm_call(ctx, iteration).await
     }
 
     async fn call_llm(
@@ -159,13 +164,14 @@ impl<'a> LoopDelegate for LoopAdapter<'a> {
     async fn handle_text_response(
         &self,
         text: &str,
-        _metadata: ResponseMetadata,
+        metadata: ResponseMetadata,
         usage: TokenUsage,
         ctx: &mut ReasoningContext,
     ) -> TextAction {
-        ctx.messages
-            .push(ChatMessage::assistant(text).with_usage(usage));
-        TextAction::Return(LoopOutcome::Response(text.to_string()))
+        self.inner
+            .responder
+            .handle_text_response(text, metadata, usage, ctx)
+            .await
     }
 
     async fn execute_tool_calls(
@@ -184,5 +190,13 @@ impl<'a> LoopDelegate for LoopAdapter<'a> {
             )));
         };
         dispatcher.dispatch(tool_calls, content, usage, ctx).await
+    }
+
+    async fn on_tool_intent_nudge(&self, text: &str, ctx: &mut ReasoningContext) {
+        self.inner.responder.on_tool_intent_nudge(text, ctx).await;
+    }
+
+    async fn after_iteration(&self, iteration: usize) {
+        self.inner.responder.after_iteration(iteration).await;
     }
 }

--- a/crates/dasclaw_runtime/src/lib.rs
+++ b/crates/dasclaw_runtime/src/lib.rs
@@ -86,11 +86,15 @@ pub use agent::{
     ToolOutputSanitizer,
 };
 pub use agentic_loop::AgenticLoop;
+// W8.0: re-export the loop control vocabulary so AgentResponder impls
+// (and the desktop responder/dispatchers downstream) don't need a direct
+// `dasclaw_core::agentic_loop` import to spell return types.
 pub use approval::{
     ApprovalDecision, ApprovalDispatchError, ApprovalInbox, ApprovalOutcome, ApprovalPolicy,
     ApprovalRequest, Approver, NoApprovalPolicy, PolicyApprover,
 };
 pub use composite_executor::{CompositeError, CompositeToolExecutor};
+pub use dasclaw_core::agentic_loop::{LoopOutcome, LoopSignal, TextAction};
 pub use error::ToolError;
 pub use feature_flags::{SharedFeatureFlags, ToolFeatureFlags};
 pub use job::{JobState, StateTransition, TokenBudgetExceeded};

--- a/desktop-client/ironclaw/src/agent/desktop_responder.rs
+++ b/desktop-client/ironclaw/src/agent/desktop_responder.rs
@@ -7,7 +7,7 @@
 
 use std::collections::HashSet;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use async_trait::async_trait;
 use uuid::Uuid;
@@ -23,10 +23,8 @@ use crate::observability::PromptCacheMonitor;
 
 pub(super) struct DesktopResponder {
     // Invariant: must be constructed per turn. The `model_override_applied`
-    // and `iteration` sentinels below are reset on each `new()`; reusing
-    // one instance across turns would silently disable per-user
-    // `selected_model` overrides and skew the iteration-driven nudge /
-    // force-text gates.
+    // sentinel below is reset on each `new()`; reusing one instance across
+    // turns would silently disable per-user `selected_model` overrides.
     reasoning: Reasoning,
     llm: Arc<dyn LlmProvider>,
     llm_backend: String,
@@ -45,10 +43,6 @@ pub(super) struct DesktopResponder {
     cached_prompt_no_tools: String,
     nudge_at: usize,
     force_text_at: usize,
-    // Per-turn iteration counter; replaces the `iteration` parameter the
-    // old `LoopDelegate::before_llm_call` received but `AgentResponder`
-    // does not expose.
-    iteration: AtomicUsize,
     model_override_applied: AtomicBool,
 }
 
@@ -89,77 +83,8 @@ impl DesktopResponder {
             cached_prompt_no_tools,
             nudge_at,
             force_text_at,
-            iteration: AtomicUsize::new(0),
             model_override_applied: AtomicBool::new(false),
         }
-    }
-
-    /// Pre-LLM iteration setup: tool table refresh, nudge injection,
-    /// force-text gating, prompt swap, status broadcast. Moved verbatim
-    /// from the deleted `ChatDelegate::before_llm_call`.
-    async fn before_llm_call(&self, reason_ctx: &mut ReasoningContext, iteration: usize) {
-        if iteration == self.nudge_at {
-            reason_ctx.messages.push(ChatMessage::system(
-                "You are approaching the tool call limit. \
-                 Provide your best final answer on the next response \
-                 using the information you have gathered so far. \
-                 Do not call any more tools.",
-            ));
-        }
-
-        let force_text = iteration >= self.force_text_at;
-
-        let tool_defs = self
-            .tools
-            .tool_definitions_for_llm(
-                &dasclaw_governance::tool_visibility::ToolGateContextSeed::system(
-                    dasclaw_governance::tool_visibility::Env::Interactive,
-                ),
-            )
-            .await;
-        let tool_defs = super::dispatcher::filter_tools_by_disabled_extensions(
-            tool_defs,
-            &self.disabled_extensions,
-        );
-        let tool_defs = if !self.active_skills.is_empty() {
-            let result = crate::skills::attenuate_tools(&tool_defs, &self.active_skills);
-            tracing::debug!(
-                min_trust = %result.min_trust,
-                tools_available = result.tools.len(),
-                tools_removed = result.removed_tools.len(),
-                removed = ?result.removed_tools,
-                explanation = %result.explanation,
-                "Tool attenuation applied"
-            );
-            result.tools
-        } else {
-            tool_defs
-        };
-
-        reason_ctx.available_tools = tool_defs;
-        let force_text = force_text || reason_ctx.force_text;
-        reason_ctx.system_prompt = Some(if force_text {
-            self.cached_prompt_no_tools.clone()
-        } else {
-            self.cached_prompt.clone()
-        });
-        reason_ctx.force_text = force_text;
-
-        if force_text {
-            tracing::info!(
-                iteration,
-                "Forcing text-only response (iteration limit reached)"
-            );
-        }
-
-        let _ = self
-            .channels
-            .send_status(
-                &self.channel,
-                StatusUpdate::Thinking(format!("Thinking (step {iteration})...")),
-                &self.metadata,
-            )
-            .await;
     }
 
     /// Non-streaming LLM call with context-exceeded retry.
@@ -258,10 +183,81 @@ impl DesktopResponder {
 
 #[async_trait]
 impl AgentResponder for DesktopResponder {
-    async fn respond(&self, reason_ctx: &mut ReasoningContext) -> Result<RespondOutput, HostError> {
-        let iteration = self.iteration.fetch_add(1, Ordering::Relaxed);
-        self.before_llm_call(reason_ctx, iteration).await;
+    /// Pre-LLM iteration setup: tool table refresh, nudge injection,
+    /// force-text gating, prompt swap, status broadcast. Moved verbatim
+    /// from the deleted `ChatDelegate::before_llm_call`.
+    async fn before_llm_call(
+        &self,
+        reason_ctx: &mut ReasoningContext,
+        iteration: usize,
+    ) -> Option<dasclaw_runtime::LoopOutcome> {
+        if iteration == self.nudge_at {
+            reason_ctx.messages.push(ChatMessage::system(
+                "You are approaching the tool call limit. \
+                 Provide your best final answer on the next response \
+                 using the information you have gathered so far. \
+                 Do not call any more tools.",
+            ));
+        }
 
+        let force_text = iteration >= self.force_text_at;
+
+        let tool_defs = self
+            .tools
+            .tool_definitions_for_llm(
+                &dasclaw_governance::tool_visibility::ToolGateContextSeed::system(
+                    dasclaw_governance::tool_visibility::Env::Interactive,
+                ),
+            )
+            .await;
+        let tool_defs = super::dispatcher::filter_tools_by_disabled_extensions(
+            tool_defs,
+            &self.disabled_extensions,
+        );
+        let tool_defs = if !self.active_skills.is_empty() {
+            let result = crate::skills::attenuate_tools(&tool_defs, &self.active_skills);
+            tracing::debug!(
+                min_trust = %result.min_trust,
+                tools_available = result.tools.len(),
+                tools_removed = result.removed_tools.len(),
+                removed = ?result.removed_tools,
+                explanation = %result.explanation,
+                "Tool attenuation applied"
+            );
+            result.tools
+        } else {
+            tool_defs
+        };
+
+        reason_ctx.available_tools = tool_defs;
+        let force_text = force_text || reason_ctx.force_text;
+        reason_ctx.system_prompt = Some(if force_text {
+            self.cached_prompt_no_tools.clone()
+        } else {
+            self.cached_prompt.clone()
+        });
+        reason_ctx.force_text = force_text;
+
+        if force_text {
+            tracing::info!(
+                iteration,
+                "Forcing text-only response (iteration limit reached)"
+            );
+        }
+
+        let _ = self
+            .channels
+            .send_status(
+                &self.channel,
+                StatusUpdate::Thinking(format!("Thinking (step {iteration})...")),
+                &self.metadata,
+            )
+            .await;
+
+        None
+    }
+
+    async fn respond(&self, reason_ctx: &mut ReasoningContext) -> Result<RespondOutput, HostError> {
         if let Err(limit) = self.tenant.check_cost_allowed().await {
             return Err(crate::error::LlmError::InvalidResponse {
                 provider: "agent".to_string(),


### PR DESCRIPTION
## 背景 / 目标

ADR-160 §3 / §7 W8 的前置改造。W8 要把桌面端最后两个 `LoopDelegate` 实现（`ContainerDelegate` / `JobDelegate`）切到 `dasclaw_runtime::AgenticLoop`，但目前 `AgentResponder` trait 只暴露 `respond` / `respond_streaming`，而这两个 delegate 都需要 `before_llm_call` / `handle_text_response` / `check_signals` / `on_tool_intent_nudge` / `after_iteration` 五个钩子来保留 recovery / 状态上报 / 信号通道排空等行为。

本 PR 在 `AgentResponder` 上把这 5 个钩子补齐（带默认实现），并把 `LoopAdapter` 改为转发到 responder 对应方法。默认实现与原 `LoopAdapter` 行为 1:1，所有现存 16 个 `impl AgentResponder` 站点（含 4 个测试 fixture / CLI starter / 桌面端）零修改即可继续编译。

## 改动范围

- `crates/dasclaw_runtime/src/agent.rs`：`AgentResponder` 新增 5 个 trait 方法，默认实现等价于原 `LoopAdapter` 行为。
- `crates/dasclaw_runtime/src/agentic_loop.rs`：`LoopAdapter` 每个 `LoopDelegate` 方法转发到 responder 对应方法；`check_signals` 保留 "cancelled token 永远 win" 短路。
- `crates/dasclaw_runtime/src/lib.rs`：从 `dasclaw_core::agentic_loop` 重导出 `LoopOutcome` / `LoopSignal` / `TextAction`，避免下游 responder 直接 reach into core crate。
- `desktop-client/ironclaw/src/agent/desktop_responder.rs`：把 W7.4 临时塞进 `respond()` 内部的私有 `before_llm_call` 提升为 trait 方法实现；删除 `iteration: AtomicUsize` / `AtomicUsize` import / `respond()` 里的 `fetch_add` 旁路调用。

净变化：4 文件 +167 / -94。

## 非目标（What's NOT in this PR）

- ❌ 不动 `ContainerDelegate` / `JobDelegate` 本身（留给 W8.1 / W8.2 各自独立 PR）
- ❌ 不删除桌面端 `agent/agentic_loop.rs` 再导出 shim（留给 W8.3）
- ❌ 不修改任何现存 `AgentResponder` 实现（默认实现兜底，零迁移成本）
- ❌ 不调整 `LoopDelegate` trait 本身 —— 引擎 / 控制流契约保持不变

## 验证（命令 + 结果）

```bash
RUSTC_WRAPPER= cargo check -p dasclaw_runtime --tests
# Finished `dev` profile

RUSTC_WRAPPER= cargo check -p dasclaw --tests
# Finished `dev` profile

RUSTC_WRAPPER= cargo nextest run -p dasclaw_runtime
# Summary [43.0s] 196 tests run: 196 passed, 0 skipped

RUSTC_WRAPPER= cargo nextest run -p dasclaw --lib agent::dispatcher
# Summary [11.6s] 51 tests run: 51 passed, 2473 skipped

cargo fmt --all
# (clean)

python3.12 scripts/check_no_panics.py --base origin/xClaw
# OK: No panic-inducing calls in changed production code.

RUSTC_WRAPPER= cargo clippy --no-deps -p dasclaw_runtime --all-targets -- -D warnings
# Finished `dev` profile (clean)

RUSTC_WRAPPER= cargo clippy --no-deps -p dasclaw --all-targets -- -D warnings
# Finished `dev` profile (clean)
```

3-layer skill 复审：`code-quality-audit` ✅ / `code-simplifier` ✅ / `code-review-expert` ✅ APPROVE（0 阻断、0 P0/P1/P2、1 个 P3 可选文案改进）。

## Sources read

- `docs/plans/architecture-refactor/56-framework-architecture-re-review.md` §3 / §7（W8 范围澄清）
- `crates/dasclaw_runtime/src/agent.rs` L130-200（`AgentResponder` trait 定义）
- `crates/dasclaw_runtime/src/agentic_loop.rs` L1-220（`AgenticLoop` + `LoopAdapter` 完整路径）
- `desktop-client/ironclaw/src/agent/desktop_responder.rs` L1-280（W7.4 临时方案对比）
- `desktop-client/ironclaw/src/worker/container.rs` L360-660（`ContainerDelegate` 需要的钩子集 — W8.1 范围核验）
- `desktop-client/ironclaw/src/worker/job.rs` L1280-1500（`JobDelegate` 字段 + impl 起头 — W8.2 范围核验）
- `desktop-client/ironclaw/src/agent/agentic_loop.rs` L1-100（确认是 `dasclaw_core::agentic_loop` 再导出 shim — W8.3 范围核验）
- `crates/dasclaw_runtime/src/lib.rs` L80-105（re-export 清单）
- 全 workspace `grep "impl AgentResponder"`（16 个站点 — 验证默认实现兜底是必须的）

Closes #973
