### PR TITLE
feat(desktop): W8.1 migrate ContainerDelegate to dasclaw_runtime::AgenticLoop

### DIFF
--- a/desktop-client/ironclaw/src/worker/container.rs
+++ b/desktop-client/ironclaw/src/worker/container.rs
@@ -5,7 +5,8 @@
 //! Streams real-time events (message, tool_use, tool_result, result) through
 //! the orchestrator's job event pipeline for UI visibility.
 //!
-//! Uses the shared `AgenticLoop` engine via `ContainerDelegate`.
+//! Drives the shared `dasclaw_runtime::AgenticLoop` via `ContainerResponder`
+//! (LLM seam) and `ContainerDispatcher` (tool seam) — ADR-160 §3 L2.
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -15,12 +16,12 @@ use async_trait::async_trait;
 use tokio::sync::Mutex;
 use uuid::Uuid;
 
-use crate::agent::agentic_loop::{
-    AgenticLoopConfig, LoopDelegate, LoopOutcome, LoopSignal, TextAction, truncate_for_preview,
-};
+use crate::agent::agentic_loop::{AgenticLoopConfig, truncate_for_preview};
 use crate::config::SafetyConfig;
 use crate::error::WorkerError;
-use crate::llm::{ChatMessage, LlmProvider, Reasoning, ReasoningContext, ResponseMetadata};
+use crate::llm::{
+    ChatMessage, LlmProvider, Reasoning, ReasoningContext, RespondOutput, ResponseMetadata,
+};
 use crate::safety::SafetyLayer;
 use crate::tools::ToolRegistry;
 use crate::tools::execute::{execute_tool_simple, process_tool_result};
@@ -30,8 +31,12 @@ use crate::worker::autonomous_recovery::{
     EMPTY_TOOL_COMPLETION_NUDGE, FORCE_TEXT_RECOVERY_PROMPT,
 };
 use crate::worker::proxy_llm::ProxyLlmProvider;
+use dasclaw_core::TokenUsage;
+use dasclaw_core::messages::ToolCall;
 use dasclaw_core::traits::HostError;
 use dasclaw_runtime::context::JobContext;
+use dasclaw_runtime::tool_dispatch::ToolDispatcher;
+use dasclaw_runtime::{AgentResponder, AgenticLoop, LoopOutcome, TextAction};
 
 /// Configuration for the worker runtime.
 pub struct WorkerConfig {
@@ -196,16 +201,26 @@ Work independently to complete this job. When finished, your final message MUST 
         );
 
         // Run with timeout using the shared agentic loop
+        let last_output = Arc::new(Mutex::new(String::new()));
+        let recovery_state = Arc::new(Mutex::new(AutonomousRecoveryState::default()));
+
         let result = tokio::time::timeout(self.config.timeout, async {
-            let delegate = ContainerDelegate {
+            let responder = ContainerResponder {
+                client: self.client.clone(),
+                tools: self.tools.clone(),
+                last_output: last_output.clone(),
+                iteration_tracker: iteration_tracker.clone(),
+                recovery_state: recovery_state.clone(),
+                reasoning,
+            };
+
+            let dispatcher = ContainerDispatcher {
                 client: self.client.clone(),
                 safety: self.safety.clone(),
                 tools: self.tools.clone(),
                 extra_env: self.extra_env.clone(),
-                last_output: Mutex::new(String::new()),
-                iteration_tracker: iteration_tracker.clone(),
-                recovery_state: Mutex::new(AutonomousRecoveryState::default()),
-                reasoning,
+                last_output: last_output.clone(),
+                recovery_state: recovery_state.clone(),
             };
 
             let config = AgenticLoopConfig {
@@ -214,26 +229,28 @@ Work independently to complete this job. When finished, your final message MUST 
                 max_tool_intent_nudges: 2,
             };
 
-            crate::agent::agentic_loop::run_agentic_loop(
-                &delegate,
-                &mut reason_ctx,
-                &config,
-                // Phase 3 Step G: SafetyLayer wired in via IronclawSafetyHook.
-                // sandbox/secrets/approval still default; container worker is
-                // already inside Docker (no nested sandbox needed) and runs
-                // unattended (auto-approve).
-                //
-                // Issue #73 slice D: PermissionMode threaded explicitly.
-                // Issue #73 slice E: workspace boundary is capability-validated;
-                // container workers run inside an isolated Docker FS so the
-                // capability handle is over the in-container cwd.
-                &crate::agent::agentic_loop::hook_bundle_with_safety(
-                    self.safety.clone(),
-                    workspace_cap.clone(),
-                    crate::agent::agentic_loop::PermissionMode::WorkspaceWrite,
-                ),
-            )
-            .await
+            // Phase 3 Step G: SafetyLayer wired in via IronclawSafetyHook.
+            // sandbox/secrets/approval still default; container worker is
+            // already inside Docker (no nested sandbox needed) and runs
+            // unattended (auto-approve).
+            //
+            // Issue #73 slice D: PermissionMode threaded explicitly.
+            // Issue #73 slice E: workspace boundary is capability-validated;
+            // container workers run inside an isolated Docker FS so the
+            // capability handle is over the in-container cwd.
+            let hooks = crate::agent::agentic_loop::hook_bundle_with_safety(
+                self.safety.clone(),
+                workspace_cap.clone(),
+                crate::agent::agentic_loop::PermissionMode::WorkspaceWrite,
+            );
+
+            // ADR-160 §3 L2: drive the shared engine with responder + dispatcher.
+            // No cancellation token — container worker lifecycle is owned by the
+            // orchestrator (check_signals always Continue). No event channel —
+            // events are streamed via WorkerHttpClient::post_event instead.
+            AgenticLoop::new(Arc::new(responder), Some(Arc::new(dispatcher)), None, None)
+                .run(&mut reason_ctx, &config, &hooks)
+                .await
         })
         .await;
 
@@ -357,36 +374,38 @@ Work independently to complete this job. When finished, your final message MUST 
     }
 }
 
-/// Container delegate: implements `LoopDelegate` for the Docker container context.
+/// Free helper so both responder and dispatcher can post job events without
+/// duplicating the small async wrapper.
+async fn post_job_event(client: &WorkerHttpClient, event_type: &str, data: serde_json::Value) {
+    client
+        .post_event(&JobEventPayload {
+            event_type: event_type.to_string(),
+            data,
+        })
+        .await;
+}
+
+/// LLM seam for the container worker — ADR-160 §3 L2.
 ///
-/// Tools execute sequentially. Events are posted to the orchestrator via HTTP.
-/// Completion is detected via `llm_signals_completion()`.
-struct ContainerDelegate {
+/// Owns the `Reasoning` engine and the autonomous-recovery decisions taken on
+/// each iteration / text response. Shares `last_output` and `recovery_state`
+/// with `ContainerDispatcher` via `Arc<Mutex<_>>`.
+struct ContainerResponder {
     client: Arc<WorkerHttpClient>,
-    safety: Arc<SafetyLayer>,
     tools: Arc<ToolRegistry>,
-    extra_env: Arc<HashMap<String, String>>,
-    /// Tracks the last successful tool output for the final response.
-    last_output: Mutex<String>,
+    /// Last successful tool output — read here to back-fill the final response
+    /// when the model signals completion with an empty text body.
+    last_output: Arc<Mutex<String>>,
     /// Tracks the current iteration — shared with the outer `run` method so
     /// `CompletionReport` can include accurate iteration counts.
     iteration_tracker: Arc<Mutex<u32>>,
-    recovery_state: Mutex<AutonomousRecoveryState>,
-    /// Route-B (D-4.5): the delegate owns the LLM reasoning engine instead
-    /// of receiving it as a loop parameter.
+    /// Shared with `ContainerDispatcher` (Arc<Mutex>): responder runs
+    /// `begin_iteration` + `on_text_response`, dispatcher runs `on_valid_tool_call`.
+    recovery_state: Arc<Mutex<AutonomousRecoveryState>>,
     reasoning: Reasoning,
 }
 
-impl ContainerDelegate {
-    async fn post_event(&self, event_type: &str, data: serde_json::Value) {
-        self.client
-            .post_event(&JobEventPayload {
-                event_type: event_type.to_string(),
-                data,
-            })
-            .await;
-    }
-
+impl ContainerResponder {
     /// Poll the orchestrator for a follow-up prompt. If one is available,
     /// inject it as a user message into the reasoning context.
     async fn poll_and_inject_prompt(&self, reason_ctx: &mut ReasoningContext) {
@@ -396,7 +415,8 @@ impl ContainerDelegate {
                     "Received follow-up prompt: {}",
                     truncate_for_preview(&prompt.content, 100)
                 );
-                self.post_event(
+                post_job_event(
+                    &self.client,
                     "message",
                     serde_json::json!({
                         "role": "user",
@@ -415,12 +435,7 @@ impl ContainerDelegate {
 }
 
 #[async_trait]
-impl LoopDelegate for ContainerDelegate {
-    async fn check_signals(&self) -> LoopSignal {
-        // Container runtime has no stop signals — the orchestrator manages lifecycle.
-        LoopSignal::Continue
-    }
-
+impl AgentResponder for ContainerResponder {
     async fn before_llm_call(
         &self,
         reason_ctx: &mut ReasoningContext,
@@ -471,11 +486,7 @@ impl LoopDelegate for ContainerDelegate {
         None
     }
 
-    async fn call_llm(
-        &self,
-        reason_ctx: &mut ReasoningContext,
-        _iteration: usize,
-    ) -> Result<crate::llm::RespondOutput, HostError> {
+    async fn respond(&self, reason_ctx: &mut ReasoningContext) -> Result<RespondOutput, HostError> {
         // Container uses respond_with_tools (which may return either text or tool calls)
         self.reasoning
             .respond_with_tools(reason_ctx)
@@ -487,7 +498,7 @@ impl LoopDelegate for ContainerDelegate {
         &self,
         text: &str,
         metadata: ResponseMetadata,
-        usage: dasclaw_core::TokenUsage,
+        usage: TokenUsage,
         reason_ctx: &mut ReasoningContext,
     ) -> TextAction {
         let action = {
@@ -497,7 +508,8 @@ impl LoopDelegate for ContainerDelegate {
         match action {
             AutonomousRecoveryAction::ToolModeNudge => {
                 tracing::warn!("Malformed empty tool completion detected; retrying in tool mode");
-                self.post_event(
+                post_job_event(
+                    &self.client,
                     "status",
                     serde_json::json!({
                         "message": "Model returned an empty tool-completion response; retrying with a stronger tool-use nudge.",
@@ -513,7 +525,8 @@ impl LoopDelegate for ContainerDelegate {
                 tracing::warn!(
                     "Repeated malformed tool completions detected; switching to text-only recovery"
                 );
-                self.post_event(
+                post_job_event(
+                    &self.client,
                     "status",
                     serde_json::json!({
                         "message": "Model returned repeated empty tool-completion responses; requesting a final status update without tools.",
@@ -534,7 +547,8 @@ impl LoopDelegate for ContainerDelegate {
             AutonomousRecoveryAction::Continue => {}
         }
 
-        self.post_event(
+        post_job_event(
+            &self.client,
             "message",
             serde_json::json!({
                 "role": "assistant",
@@ -560,11 +574,46 @@ impl LoopDelegate for ContainerDelegate {
         TextAction::Continue
     }
 
-    async fn execute_tool_calls(
+    async fn on_tool_intent_nudge(&self, text: &str, _reason_ctx: &mut ReasoningContext) {
+        post_job_event(
+            &self.client,
+            "message",
+            serde_json::json!({
+                "role": "assistant",
+                "content": truncate_for_preview(text, 2000),
+                "nudge": true,
+            }),
+        )
+        .await;
+    }
+
+    async fn after_iteration(&self, _iteration: usize) {
+        // Brief pause between iterations
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
+/// Tool seam for the container worker — ADR-160 §3 L2.
+///
+/// Executes tools sequentially (no parallel execution in container context)
+/// and streams `tool_use` / `tool_result` events back to the orchestrator.
+/// Shares `last_output` and `recovery_state` with `ContainerResponder`.
+struct ContainerDispatcher {
+    client: Arc<WorkerHttpClient>,
+    safety: Arc<SafetyLayer>,
+    tools: Arc<ToolRegistry>,
+    extra_env: Arc<HashMap<String, String>>,
+    last_output: Arc<Mutex<String>>,
+    recovery_state: Arc<Mutex<AutonomousRecoveryState>>,
+}
+
+#[async_trait]
+impl ToolDispatcher for ContainerDispatcher {
+    async fn dispatch(
         &self,
-        tool_calls: Vec<crate::llm::ToolCall>,
+        tool_calls: Vec<ToolCall>,
         content: Option<String>,
-        usage: dasclaw_core::TokenUsage,
+        usage: TokenUsage,
         reason_ctx: &mut ReasoningContext,
     ) -> Result<Option<LoopOutcome>, HostError> {
         {
@@ -573,7 +622,8 @@ impl LoopDelegate for ContainerDelegate {
         }
 
         if let Some(ref text) = content {
-            self.post_event(
+            post_job_event(
+                &self.client,
                 "message",
                 serde_json::json!({
                     "role": "assistant",
@@ -590,7 +640,8 @@ impl LoopDelegate for ContainerDelegate {
 
         // Execute tools sequentially (container context — no parallel execution)
         for tc in tool_calls {
-            self.post_event(
+            post_job_event(
+                &self.client,
                 "tool_use",
                 serde_json::json!({
                     "tool_name": tc.name,
@@ -613,7 +664,8 @@ impl LoopDelegate for ContainerDelegate {
             )
             .await;
 
-            self.post_event(
+            post_job_event(
+                &self.client,
                 "tool_result",
                 serde_json::json!({
                     "tool_name": tc.name,
@@ -636,23 +688,6 @@ impl LoopDelegate for ContainerDelegate {
         }
 
         Ok(None)
-    }
-
-    async fn on_tool_intent_nudge(&self, text: &str, _reason_ctx: &mut ReasoningContext) {
-        self.post_event(
-            "message",
-            serde_json::json!({
-                "role": "assistant",
-                "content": truncate_for_preview(text, 2000),
-                "nudge": true,
-            }),
-        )
-        .await;
-    }
-
-    async fn after_iteration(&self, _iteration: usize) {
-        // Brief pause between iterations
-        tokio::time::sleep(Duration::from_millis(100)).await;
     }
 }
 


### PR DESCRIPTION
## 背景 / 目标

ADR-160 §3 L2 — `desktop-client/ironclaw/src/worker/container.rs` 的 `ContainerDelegate` 仍在使用本地 `LoopDelegate` trait，与 W7.x 已落地的 desktop chat path 不对齐。本 PR 把 container worker 切到统一的 `dasclaw_runtime::AgenticLoop`，把单一 delegate 拆成 `ContainerResponder`（LLM 半段，impl `dasclaw_runtime::AgentResponder`）+ `ContainerDispatcher`（工具半段，impl `dasclaw_runtime::tool_dispatch::ToolDispatcher`）。

Closes #973。

## 改动范围

仅一个文件：`desktop-client/ironclaw/src/worker/container.rs`（+125 / −90）。

- 删除 `LoopDelegate for ContainerDelegate` impl 及 `ContainerDelegate` 自身
- 新增 `ContainerResponder`（owns `Reasoning`、`iteration_tracker`、`last_output`、`recovery_state`、`tools`、`client`）
- 新增 `ContainerDispatcher`（owns `safety`、`extra_env`、`last_output`、`recovery_state`、`tools`、`client`）
- 共享可变状态（`last_output: String`、`recovery_state: AutonomousRecoveryState`）从 `Mutex<_>` 升级为 `Arc<Mutex<_>>`
- 重复的 `post_event` 方法抽取成自由函数 `post_job_event`，避免两半各拿一份拷贝
- `WorkerRuntime::run` 调用点切换：本地 `AgenticLoop::with_delegate(...)` → `dasclaw_runtime::AgenticLoop::new(Arc::new(responder), Some(Arc::new(dispatcher)), None, None).run(...)`
  - `cancellation_token = None`：container worker 没有取消信号，原 `check_signals` 永远返回 `Continue`
  - `event_tx = None`：事件已通过 `WorkerHttpClient::post_event` 向 orchestrator 推送

行为 1:1 保留 —— 包括 `before_llm_call` 的每 5 轮 status 上报 / poll-and-inject prompt / `recovery.begin_iteration()` 处理；`handle_text_response` 的 ToolModeNudge / ForceTextRecovery / Fail / Continue 四分支；`llm_signals_completion` 时优先用 `last_output` 回填；`on_tool_intent_nudge` 推送 `"nudge": true`；`after_iteration` 100ms sleep。

## 非目标（What's NOT in this PR）

- 不动 `dasclaw_runtime` 任何代码（W8.0 已落地于栈底）
- 不动 worker 模块以外任何文件
- 不做行为变更 / 不重命名 / 不简化 recovery 逻辑（verbatim port）
- 不新增 / 不豁免 `.ironclaw` 或 `IRONCLAW_BASE_DIR` 字面量

## 验证

```bash
# 编译
RUSTC_WRAPPER= cargo check -p dasclaw --tests
# → Finished `dev` profile in 1m 07s, 0 errors

# 单元测试
RUSTC_WRAPPER= cargo nextest run -p dasclaw --lib worker::container
# → 4/4 PASS: test_truncate_within_limit / test_truncate_at_limit
#            / test_truncate_beyond_limit / test_truncate_multibyte_safe

# Worker 集成 E2E
RUSTC_WRAPPER= cargo nextest run -p dasclaw --test e2e_worker_coverage
# → 7/7 PASS: simple_echo_flow / iteration_limit / invalid_tool_params
#            / tool_error_feedback / rate_limit_cascade / parallel_three_tools
#            / unknown_tool_name

# 格式化 + 面板代码 panic 守护
cargo fmt --all
python3.12 scripts/check_no_panics.py --base origin/xClaw
# → OK: No panic-inducing calls in changed production code.

# Clippy（被改 crate）
RUSTC_WRAPPER= cargo clippy --no-deps -p dasclaw --all-targets -- -D warnings
# → Finished `dev` profile in 1m 57s, 0 warnings
```

## Sources read

- `docs/plans/architecture-refactor/adr-160-unify-loops-and-tool-dispatch.md` §3 L2（responder + dispatcher 拆法）
- `crates/dasclaw_runtime/src/agent.rs`（`AgentResponder` trait，W8.0 扩展后的 default-impl 钩子）
- `crates/dasclaw_runtime/src/tool_dispatch.rs`（`ToolDispatcher::dispatch` 签名）
- `crates/dasclaw_runtime/src/agentic_loop.rs`（`AgenticLoop::new` / `run` / `LoopOutcome`）
- `desktop-client/ironclaw/src/agent/desktop_responder.rs`、`desktop_dispatcher.rs`（W7.3 / W7.4 模板）
- `desktop-client/ironclaw/src/agent/dispatcher.rs` L260-400（W7.4 调用点模板）
- `desktop-client/ironclaw/src/worker/container.rs`（改前全文）
- `crates/dasclaw_llm_provider/src/provider/mod.rs` L76-78、`provider/reasoning.rs` L29（类型 re-export 链验证）

## Cross-cuts

类A — 本 PR 不新增 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量。

## Stacked PR

- Base: `feat/w8.0-extend-agent-responder-iteration-hooks`（PR #974）
- 请先 review / merge #974 再看本 PR；本 PR 用到 W8.0 在 `AgentResponder` 上新增的 `before_llm_call` / `handle_text_response` / `on_tool_intent_nudge` / `after_iteration` default-impl 钩子。

## 后续 PR / 下一步

W8.2 — 删除 `desktop-client/ironclaw/src/agent/agentic_loop.rs` 里旧的 `LoopDelegate` trait 定义本身（待 W7.x + W8.1 全部 merge 后即可移除）。
