### PR TITLE
feat(desktop): W8.2 migrate JobDelegate to dasclaw_runtime::AgenticLoop

### DIFF
--- a/crates/dasclaw_runtime/src/agent.rs
+++ b/crates/dasclaw_runtime/src/agent.rs
@@ -44,11 +44,11 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use dasclaw_core::agentic_loop::{AgenticLoopConfig, LoopOutcome};
+use dasclaw_core::agentic_loop::{AgenticLoopConfig, LoopOutcome, LoopSignal, TextAction};
 use dasclaw_core::hooks::HookBundle;
 use dasclaw_core::messages::{ChatMessage, FinishReason, ToolCall, ToolDefinition, ToolResult};
 use dasclaw_core::reasoning_ctx::ReasoningContext;
-use dasclaw_core::response_types::{RespondOutput, RespondResult};
+use dasclaw_core::response_types::{RespondOutput, RespondResult, ResponseMetadata, TokenUsage};
 use dasclaw_core::traits::HostError;
 use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc;
@@ -182,6 +182,65 @@ pub trait AgentResponder: Send + Sync {
         }
         Ok(out)
     }
+
+    /// Per-iteration signal check (W8.0).
+    ///
+    /// Returned every loop turn before any LLM call. The default keeps
+    /// the loop running; hosts that drain a stop / cancellation channel
+    /// override this. The [`AgenticLoop`]'s own cancellation token is
+    /// honoured independently — a `Continue` here cannot override an
+    /// already-cancelled token.
+    async fn check_signals(&self) -> LoopSignal {
+        LoopSignal::Continue
+    }
+
+    /// Pre-LLM iteration setup (W8.0).
+    ///
+    /// Runs after [`Self::check_signals`] and before [`Self::respond`].
+    /// Hosts use it to mutate the context (inject prompts, swap tool
+    /// tables, force text mode) or short-circuit the loop by returning
+    /// `Some(outcome)`. The default is a no-op.
+    async fn before_llm_call(
+        &self,
+        _ctx: &mut ReasoningContext,
+        _iteration: usize,
+    ) -> Option<LoopOutcome> {
+        None
+    }
+
+    /// React to a pure-text LLM response (W8.0).
+    ///
+    /// Called when [`Self::respond`] yields a [`RespondResult::Text`]
+    /// payload. The default appends the assistant message to `ctx` and
+    /// terminates the loop with [`LoopOutcome::Response`], matching the
+    /// pre-W8.0 `LoopAdapter` behaviour. Hosts that need recovery /
+    /// completion-detection logic override this and may return
+    /// [`TextAction::Continue`] to keep iterating.
+    async fn handle_text_response(
+        &self,
+        text: &str,
+        _metadata: ResponseMetadata,
+        usage: TokenUsage,
+        ctx: &mut ReasoningContext,
+    ) -> TextAction {
+        ctx.messages
+            .push(ChatMessage::assistant(text).with_usage(usage));
+        TextAction::Return(LoopOutcome::Response(text.to_string()))
+    }
+
+    /// React to a tool-intent nudge being injected (W8.0).
+    ///
+    /// Called when the loop detects the model produced text that looked
+    /// like a tool intent and injects a corrective nudge. Default is a
+    /// no-op; hosts override to emit a UI event.
+    async fn on_tool_intent_nudge(&self, _text: &str, _ctx: &mut ReasoningContext) {}
+
+    /// End-of-iteration callback (W8.0).
+    ///
+    /// Called after every successful iteration that did not return an
+    /// outcome. Default is a no-op; hosts use it for throttling /
+    /// progress reporting.
+    async fn after_iteration(&self, _iteration: usize) {}
 }
 
 /// Narrow tool-execution seam used by [`Agent`] (ADR-153 step 2 sub-step A2).

--- a/crates/dasclaw_runtime/src/agentic_loop.rs
+++ b/crates/dasclaw_runtime/src/agentic_loop.rs
@@ -38,7 +38,7 @@ use dasclaw_core::agentic_loop::{
     AgenticLoopConfig, LoopDelegate, LoopOutcome, LoopSignal, TextAction, run_agentic_loop,
 };
 use dasclaw_core::hooks::HookBundle;
-use dasclaw_core::messages::{ChatMessage, ToolCall};
+use dasclaw_core::messages::ToolCall;
 use dasclaw_core::reasoning_ctx::ReasoningContext;
 use dasclaw_core::response_types::{RespondOutput, ResponseMetadata, TokenUsage};
 use dasclaw_core::traits::HostError;
@@ -117,18 +117,23 @@ impl<'a> LoopAdapter<'a> {
 #[async_trait]
 impl<'a> LoopDelegate for LoopAdapter<'a> {
     async fn check_signals(&self) -> LoopSignal {
-        match self.inner.cancellation_token.as_ref() {
-            Some(token) if token.is_cancelled() => LoopSignal::Stop,
-            _ => LoopSignal::Continue,
+        // Cancellation token short-circuits the responder hook: a
+        // cancelled token always wins even if the responder would
+        // return `Continue`.
+        if let Some(token) = self.inner.cancellation_token.as_ref()
+            && token.is_cancelled()
+        {
+            return LoopSignal::Stop;
         }
+        self.inner.responder.check_signals().await
     }
 
     async fn before_llm_call(
         &self,
-        _ctx: &mut ReasoningContext,
-        _iteration: usize,
+        ctx: &mut ReasoningContext,
+        iteration: usize,
     ) -> Option<LoopOutcome> {
-        None
+        self.inner.responder.before_llm_call(ctx, iteration).await
     }
 
     async fn call_llm(
@@ -159,13 +164,14 @@ impl<'a> LoopDelegate for LoopAdapter<'a> {
     async fn handle_text_response(
         &self,
         text: &str,
-        _metadata: ResponseMetadata,
+        metadata: ResponseMetadata,
         usage: TokenUsage,
         ctx: &mut ReasoningContext,
     ) -> TextAction {
-        ctx.messages
-            .push(ChatMessage::assistant(text).with_usage(usage));
-        TextAction::Return(LoopOutcome::Response(text.to_string()))
+        self.inner
+            .responder
+            .handle_text_response(text, metadata, usage, ctx)
+            .await
     }
 
     async fn execute_tool_calls(
@@ -184,5 +190,13 @@ impl<'a> LoopDelegate for LoopAdapter<'a> {
             )));
         };
         dispatcher.dispatch(tool_calls, content, usage, ctx).await
+    }
+
+    async fn on_tool_intent_nudge(&self, text: &str, ctx: &mut ReasoningContext) {
+        self.inner.responder.on_tool_intent_nudge(text, ctx).await;
+    }
+
+    async fn after_iteration(&self, iteration: usize) {
+        self.inner.responder.after_iteration(iteration).await;
     }
 }

--- a/crates/dasclaw_runtime/src/lib.rs
+++ b/crates/dasclaw_runtime/src/lib.rs
@@ -86,11 +86,15 @@ pub use agent::{
     ToolOutputSanitizer,
 };
 pub use agentic_loop::AgenticLoop;
+// W8.0: re-export the loop control vocabulary so AgentResponder impls
+// (and the desktop responder/dispatchers downstream) don't need a direct
+// `dasclaw_core::agentic_loop` import to spell return types.
 pub use approval::{
     ApprovalDecision, ApprovalDispatchError, ApprovalInbox, ApprovalOutcome, ApprovalPolicy,
     ApprovalRequest, Approver, NoApprovalPolicy, PolicyApprover,
 };
 pub use composite_executor::{CompositeError, CompositeToolExecutor};
+pub use dasclaw_core::agentic_loop::{LoopOutcome, LoopSignal, TextAction};
 pub use error::ToolError;
 pub use feature_flags::{SharedFeatureFlags, ToolFeatureFlags};
 pub use job::{JobState, StateTransition, TokenBudgetExceeded};

--- a/desktop-client/ironclaw/src/agent/desktop_responder.rs
+++ b/desktop-client/ironclaw/src/agent/desktop_responder.rs
@@ -7,7 +7,7 @@
 
 use std::collections::HashSet;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use async_trait::async_trait;
 use uuid::Uuid;
@@ -23,10 +23,8 @@ use crate::observability::PromptCacheMonitor;
 
 pub(super) struct DesktopResponder {
     // Invariant: must be constructed per turn. The `model_override_applied`
-    // and `iteration` sentinels below are reset on each `new()`; reusing
-    // one instance across turns would silently disable per-user
-    // `selected_model` overrides and skew the iteration-driven nudge /
-    // force-text gates.
+    // sentinel below is reset on each `new()`; reusing one instance across
+    // turns would silently disable per-user `selected_model` overrides.
     reasoning: Reasoning,
     llm: Arc<dyn LlmProvider>,
     llm_backend: String,
@@ -45,10 +43,6 @@ pub(super) struct DesktopResponder {
     cached_prompt_no_tools: String,
     nudge_at: usize,
     force_text_at: usize,
-    // Per-turn iteration counter; replaces the `iteration` parameter the
-    // old `LoopDelegate::before_llm_call` received but `AgentResponder`
-    // does not expose.
-    iteration: AtomicUsize,
     model_override_applied: AtomicBool,
 }
 
@@ -89,77 +83,8 @@ impl DesktopResponder {
             cached_prompt_no_tools,
             nudge_at,
             force_text_at,
-            iteration: AtomicUsize::new(0),
             model_override_applied: AtomicBool::new(false),
         }
-    }
-
-    /// Pre-LLM iteration setup: tool table refresh, nudge injection,
-    /// force-text gating, prompt swap, status broadcast. Moved verbatim
-    /// from the deleted `ChatDelegate::before_llm_call`.
-    async fn before_llm_call(&self, reason_ctx: &mut ReasoningContext, iteration: usize) {
-        if iteration == self.nudge_at {
-            reason_ctx.messages.push(ChatMessage::system(
-                "You are approaching the tool call limit. \
-                 Provide your best final answer on the next response \
-                 using the information you have gathered so far. \
-                 Do not call any more tools.",
-            ));
-        }
-
-        let force_text = iteration >= self.force_text_at;
-
-        let tool_defs = self
-            .tools
-            .tool_definitions_for_llm(
-                &dasclaw_governance::tool_visibility::ToolGateContextSeed::system(
-                    dasclaw_governance::tool_visibility::Env::Interactive,
-                ),
-            )
-            .await;
-        let tool_defs = super::dispatcher::filter_tools_by_disabled_extensions(
-            tool_defs,
-            &self.disabled_extensions,
-        );
-        let tool_defs = if !self.active_skills.is_empty() {
-            let result = crate::skills::attenuate_tools(&tool_defs, &self.active_skills);
-            tracing::debug!(
-                min_trust = %result.min_trust,
-                tools_available = result.tools.len(),
-                tools_removed = result.removed_tools.len(),
-                removed = ?result.removed_tools,
-                explanation = %result.explanation,
-                "Tool attenuation applied"
-            );
-            result.tools
-        } else {
-            tool_defs
-        };
-
-        reason_ctx.available_tools = tool_defs;
-        let force_text = force_text || reason_ctx.force_text;
-        reason_ctx.system_prompt = Some(if force_text {
-            self.cached_prompt_no_tools.clone()
-        } else {
-            self.cached_prompt.clone()
-        });
-        reason_ctx.force_text = force_text;
-
-        if force_text {
-            tracing::info!(
-                iteration,
-                "Forcing text-only response (iteration limit reached)"
-            );
-        }
-
-        let _ = self
-            .channels
-            .send_status(
-                &self.channel,
-                StatusUpdate::Thinking(format!("Thinking (step {iteration})...")),
-                &self.metadata,
-            )
-            .await;
     }
 
     /// Non-streaming LLM call with context-exceeded retry.
@@ -258,10 +183,81 @@ impl DesktopResponder {
 
 #[async_trait]
 impl AgentResponder for DesktopResponder {
-    async fn respond(&self, reason_ctx: &mut ReasoningContext) -> Result<RespondOutput, HostError> {
-        let iteration = self.iteration.fetch_add(1, Ordering::Relaxed);
-        self.before_llm_call(reason_ctx, iteration).await;
+    /// Pre-LLM iteration setup: tool table refresh, nudge injection,
+    /// force-text gating, prompt swap, status broadcast. Moved verbatim
+    /// from the deleted `ChatDelegate::before_llm_call`.
+    async fn before_llm_call(
+        &self,
+        reason_ctx: &mut ReasoningContext,
+        iteration: usize,
+    ) -> Option<dasclaw_runtime::LoopOutcome> {
+        if iteration == self.nudge_at {
+            reason_ctx.messages.push(ChatMessage::system(
+                "You are approaching the tool call limit. \
+                 Provide your best final answer on the next response \
+                 using the information you have gathered so far. \
+                 Do not call any more tools.",
+            ));
+        }
 
+        let force_text = iteration >= self.force_text_at;
+
+        let tool_defs = self
+            .tools
+            .tool_definitions_for_llm(
+                &dasclaw_governance::tool_visibility::ToolGateContextSeed::system(
+                    dasclaw_governance::tool_visibility::Env::Interactive,
+                ),
+            )
+            .await;
+        let tool_defs = super::dispatcher::filter_tools_by_disabled_extensions(
+            tool_defs,
+            &self.disabled_extensions,
+        );
+        let tool_defs = if !self.active_skills.is_empty() {
+            let result = crate::skills::attenuate_tools(&tool_defs, &self.active_skills);
+            tracing::debug!(
+                min_trust = %result.min_trust,
+                tools_available = result.tools.len(),
+                tools_removed = result.removed_tools.len(),
+                removed = ?result.removed_tools,
+                explanation = %result.explanation,
+                "Tool attenuation applied"
+            );
+            result.tools
+        } else {
+            tool_defs
+        };
+
+        reason_ctx.available_tools = tool_defs;
+        let force_text = force_text || reason_ctx.force_text;
+        reason_ctx.system_prompt = Some(if force_text {
+            self.cached_prompt_no_tools.clone()
+        } else {
+            self.cached_prompt.clone()
+        });
+        reason_ctx.force_text = force_text;
+
+        if force_text {
+            tracing::info!(
+                iteration,
+                "Forcing text-only response (iteration limit reached)"
+            );
+        }
+
+        let _ = self
+            .channels
+            .send_status(
+                &self.channel,
+                StatusUpdate::Thinking(format!("Thinking (step {iteration})...")),
+                &self.metadata,
+            )
+            .await;
+
+        None
+    }
+
+    async fn respond(&self, reason_ctx: &mut ReasoningContext) -> Result<RespondOutput, HostError> {
         if let Err(limit) = self.tenant.check_cost_allowed().await {
             return Err(crate::error::LlmError::InvalidResponse {
                 provider: "agent".to_string(),

--- a/desktop-client/ironclaw/src/worker/container.rs
+++ b/desktop-client/ironclaw/src/worker/container.rs
@@ -5,7 +5,8 @@
 //! Streams real-time events (message, tool_use, tool_result, result) through
 //! the orchestrator's job event pipeline for UI visibility.
 //!
-//! Uses the shared `AgenticLoop` engine via `ContainerDelegate`.
+//! Drives the shared `dasclaw_runtime::AgenticLoop` via `ContainerResponder`
+//! (LLM seam) and `ContainerDispatcher` (tool seam) — ADR-160 §3 L2.
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -15,12 +16,12 @@ use async_trait::async_trait;
 use tokio::sync::Mutex;
 use uuid::Uuid;
 
-use crate::agent::agentic_loop::{
-    AgenticLoopConfig, LoopDelegate, LoopOutcome, LoopSignal, TextAction, truncate_for_preview,
-};
+use crate::agent::agentic_loop::{AgenticLoopConfig, truncate_for_preview};
 use crate::config::SafetyConfig;
 use crate::error::WorkerError;
-use crate::llm::{ChatMessage, LlmProvider, Reasoning, ReasoningContext, ResponseMetadata};
+use crate::llm::{
+    ChatMessage, LlmProvider, Reasoning, ReasoningContext, RespondOutput, ResponseMetadata,
+};
 use crate::safety::SafetyLayer;
 use crate::tools::ToolRegistry;
 use crate::tools::execute::{execute_tool_simple, process_tool_result};
@@ -30,8 +31,12 @@ use crate::worker::autonomous_recovery::{
     EMPTY_TOOL_COMPLETION_NUDGE, FORCE_TEXT_RECOVERY_PROMPT,
 };
 use crate::worker::proxy_llm::ProxyLlmProvider;
+use dasclaw_core::TokenUsage;
+use dasclaw_core::messages::ToolCall;
 use dasclaw_core::traits::HostError;
 use dasclaw_runtime::context::JobContext;
+use dasclaw_runtime::tool_dispatch::ToolDispatcher;
+use dasclaw_runtime::{AgentResponder, AgenticLoop, LoopOutcome, TextAction};
 
 /// Configuration for the worker runtime.
 pub struct WorkerConfig {
@@ -196,16 +201,26 @@ Work independently to complete this job. When finished, your final message MUST 
         );
 
         // Run with timeout using the shared agentic loop
+        let last_output = Arc::new(Mutex::new(String::new()));
+        let recovery_state = Arc::new(Mutex::new(AutonomousRecoveryState::default()));
+
         let result = tokio::time::timeout(self.config.timeout, async {
-            let delegate = ContainerDelegate {
+            let responder = ContainerResponder {
+                client: self.client.clone(),
+                tools: self.tools.clone(),
+                last_output: last_output.clone(),
+                iteration_tracker: iteration_tracker.clone(),
+                recovery_state: recovery_state.clone(),
+                reasoning,
+            };
+
+            let dispatcher = ContainerDispatcher {
                 client: self.client.clone(),
                 safety: self.safety.clone(),
                 tools: self.tools.clone(),
                 extra_env: self.extra_env.clone(),
-                last_output: Mutex::new(String::new()),
-                iteration_tracker: iteration_tracker.clone(),
-                recovery_state: Mutex::new(AutonomousRecoveryState::default()),
-                reasoning,
+                last_output: last_output.clone(),
+                recovery_state: recovery_state.clone(),
             };
 
             let config = AgenticLoopConfig {
@@ -214,26 +229,28 @@ Work independently to complete this job. When finished, your final message MUST 
                 max_tool_intent_nudges: 2,
             };
 
-            crate::agent::agentic_loop::run_agentic_loop(
-                &delegate,
-                &mut reason_ctx,
-                &config,
-                // Phase 3 Step G: SafetyLayer wired in via IronclawSafetyHook.
-                // sandbox/secrets/approval still default; container worker is
-                // already inside Docker (no nested sandbox needed) and runs
-                // unattended (auto-approve).
-                //
-                // Issue #73 slice D: PermissionMode threaded explicitly.
-                // Issue #73 slice E: workspace boundary is capability-validated;
-                // container workers run inside an isolated Docker FS so the
-                // capability handle is over the in-container cwd.
-                &crate::agent::agentic_loop::hook_bundle_with_safety(
-                    self.safety.clone(),
-                    workspace_cap.clone(),
-                    crate::agent::agentic_loop::PermissionMode::WorkspaceWrite,
-                ),
-            )
-            .await
+            // Phase 3 Step G: SafetyLayer wired in via IronclawSafetyHook.
+            // sandbox/secrets/approval still default; container worker is
+            // already inside Docker (no nested sandbox needed) and runs
+            // unattended (auto-approve).
+            //
+            // Issue #73 slice D: PermissionMode threaded explicitly.
+            // Issue #73 slice E: workspace boundary is capability-validated;
+            // container workers run inside an isolated Docker FS so the
+            // capability handle is over the in-container cwd.
+            let hooks = crate::agent::agentic_loop::hook_bundle_with_safety(
+                self.safety.clone(),
+                workspace_cap.clone(),
+                crate::agent::agentic_loop::PermissionMode::WorkspaceWrite,
+            );
+
+            // ADR-160 §3 L2: drive the shared engine with responder + dispatcher.
+            // No cancellation token — container worker lifecycle is owned by the
+            // orchestrator (check_signals always Continue). No event channel —
+            // events are streamed via WorkerHttpClient::post_event instead.
+            AgenticLoop::new(Arc::new(responder), Some(Arc::new(dispatcher)), None, None)
+                .run(&mut reason_ctx, &config, &hooks)
+                .await
         })
         .await;
 
@@ -357,36 +374,38 @@ Work independently to complete this job. When finished, your final message MUST 
     }
 }
 
-/// Container delegate: implements `LoopDelegate` for the Docker container context.
+/// Free helper so both responder and dispatcher can post job events without
+/// duplicating the small async wrapper.
+async fn post_job_event(client: &WorkerHttpClient, event_type: &str, data: serde_json::Value) {
+    client
+        .post_event(&JobEventPayload {
+            event_type: event_type.to_string(),
+            data,
+        })
+        .await;
+}
+
+/// LLM seam for the container worker — ADR-160 §3 L2.
 ///
-/// Tools execute sequentially. Events are posted to the orchestrator via HTTP.
-/// Completion is detected via `llm_signals_completion()`.
-struct ContainerDelegate {
+/// Owns the `Reasoning` engine and the autonomous-recovery decisions taken on
+/// each iteration / text response. Shares `last_output` and `recovery_state`
+/// with `ContainerDispatcher` via `Arc<Mutex<_>>`.
+struct ContainerResponder {
     client: Arc<WorkerHttpClient>,
-    safety: Arc<SafetyLayer>,
     tools: Arc<ToolRegistry>,
-    extra_env: Arc<HashMap<String, String>>,
-    /// Tracks the last successful tool output for the final response.
-    last_output: Mutex<String>,
+    /// Last successful tool output — read here to back-fill the final response
+    /// when the model signals completion with an empty text body.
+    last_output: Arc<Mutex<String>>,
     /// Tracks the current iteration — shared with the outer `run` method so
     /// `CompletionReport` can include accurate iteration counts.
     iteration_tracker: Arc<Mutex<u32>>,
-    recovery_state: Mutex<AutonomousRecoveryState>,
-    /// Route-B (D-4.5): the delegate owns the LLM reasoning engine instead
-    /// of receiving it as a loop parameter.
+    /// Shared with `ContainerDispatcher` (Arc<Mutex>): responder runs
+    /// `begin_iteration` + `on_text_response`, dispatcher runs `on_valid_tool_call`.
+    recovery_state: Arc<Mutex<AutonomousRecoveryState>>,
     reasoning: Reasoning,
 }
 
-impl ContainerDelegate {
-    async fn post_event(&self, event_type: &str, data: serde_json::Value) {
-        self.client
-            .post_event(&JobEventPayload {
-                event_type: event_type.to_string(),
-                data,
-            })
-            .await;
-    }
-
+impl ContainerResponder {
     /// Poll the orchestrator for a follow-up prompt. If one is available,
     /// inject it as a user message into the reasoning context.
     async fn poll_and_inject_prompt(&self, reason_ctx: &mut ReasoningContext) {
@@ -396,7 +415,8 @@ impl ContainerDelegate {
                     "Received follow-up prompt: {}",
                     truncate_for_preview(&prompt.content, 100)
                 );
-                self.post_event(
+                post_job_event(
+                    &self.client,
                     "message",
                     serde_json::json!({
                         "role": "user",
@@ -415,12 +435,7 @@ impl ContainerDelegate {
 }
 
 #[async_trait]
-impl LoopDelegate for ContainerDelegate {
-    async fn check_signals(&self) -> LoopSignal {
-        // Container runtime has no stop signals — the orchestrator manages lifecycle.
-        LoopSignal::Continue
-    }
-
+impl AgentResponder for ContainerResponder {
     async fn before_llm_call(
         &self,
         reason_ctx: &mut ReasoningContext,
@@ -471,11 +486,7 @@ impl LoopDelegate for ContainerDelegate {
         None
     }
 
-    async fn call_llm(
-        &self,
-        reason_ctx: &mut ReasoningContext,
-        _iteration: usize,
-    ) -> Result<crate::llm::RespondOutput, HostError> {
+    async fn respond(&self, reason_ctx: &mut ReasoningContext) -> Result<RespondOutput, HostError> {
         // Container uses respond_with_tools (which may return either text or tool calls)
         self.reasoning
             .respond_with_tools(reason_ctx)
@@ -487,7 +498,7 @@ impl LoopDelegate for ContainerDelegate {
         &self,
         text: &str,
         metadata: ResponseMetadata,
-        usage: dasclaw_core::TokenUsage,
+        usage: TokenUsage,
         reason_ctx: &mut ReasoningContext,
     ) -> TextAction {
         let action = {
@@ -497,7 +508,8 @@ impl LoopDelegate for ContainerDelegate {
         match action {
             AutonomousRecoveryAction::ToolModeNudge => {
                 tracing::warn!("Malformed empty tool completion detected; retrying in tool mode");
-                self.post_event(
+                post_job_event(
+                    &self.client,
                     "status",
                     serde_json::json!({
                         "message": "Model returned an empty tool-completion response; retrying with a stronger tool-use nudge.",
@@ -513,7 +525,8 @@ impl LoopDelegate for ContainerDelegate {
                 tracing::warn!(
                     "Repeated malformed tool completions detected; switching to text-only recovery"
                 );
-                self.post_event(
+                post_job_event(
+                    &self.client,
                     "status",
                     serde_json::json!({
                         "message": "Model returned repeated empty tool-completion responses; requesting a final status update without tools.",
@@ -534,7 +547,8 @@ impl LoopDelegate for ContainerDelegate {
             AutonomousRecoveryAction::Continue => {}
         }
 
-        self.post_event(
+        post_job_event(
+            &self.client,
             "message",
             serde_json::json!({
                 "role": "assistant",
@@ -560,11 +574,46 @@ impl LoopDelegate for ContainerDelegate {
         TextAction::Continue
     }
 
-    async fn execute_tool_calls(
+    async fn on_tool_intent_nudge(&self, text: &str, _reason_ctx: &mut ReasoningContext) {
+        post_job_event(
+            &self.client,
+            "message",
+            serde_json::json!({
+                "role": "assistant",
+                "content": truncate_for_preview(text, 2000),
+                "nudge": true,
+            }),
+        )
+        .await;
+    }
+
+    async fn after_iteration(&self, _iteration: usize) {
+        // Brief pause between iterations
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
+/// Tool seam for the container worker — ADR-160 §3 L2.
+///
+/// Executes tools sequentially (no parallel execution in container context)
+/// and streams `tool_use` / `tool_result` events back to the orchestrator.
+/// Shares `last_output` and `recovery_state` with `ContainerResponder`.
+struct ContainerDispatcher {
+    client: Arc<WorkerHttpClient>,
+    safety: Arc<SafetyLayer>,
+    tools: Arc<ToolRegistry>,
+    extra_env: Arc<HashMap<String, String>>,
+    last_output: Arc<Mutex<String>>,
+    recovery_state: Arc<Mutex<AutonomousRecoveryState>>,
+}
+
+#[async_trait]
+impl ToolDispatcher for ContainerDispatcher {
+    async fn dispatch(
         &self,
-        tool_calls: Vec<crate::llm::ToolCall>,
+        tool_calls: Vec<ToolCall>,
         content: Option<String>,
-        usage: dasclaw_core::TokenUsage,
+        usage: TokenUsage,
         reason_ctx: &mut ReasoningContext,
     ) -> Result<Option<LoopOutcome>, HostError> {
         {
@@ -573,7 +622,8 @@ impl LoopDelegate for ContainerDelegate {
         }
 
         if let Some(ref text) = content {
-            self.post_event(
+            post_job_event(
+                &self.client,
                 "message",
                 serde_json::json!({
                     "role": "assistant",
@@ -590,7 +640,8 @@ impl LoopDelegate for ContainerDelegate {
 
         // Execute tools sequentially (container context — no parallel execution)
         for tc in tool_calls {
-            self.post_event(
+            post_job_event(
+                &self.client,
                 "tool_use",
                 serde_json::json!({
                     "tool_name": tc.name,
@@ -613,7 +664,8 @@ impl LoopDelegate for ContainerDelegate {
             )
             .await;
 
-            self.post_event(
+            post_job_event(
+                &self.client,
                 "tool_result",
                 serde_json::json!({
                     "tool_name": tc.name,
@@ -636,23 +688,6 @@ impl LoopDelegate for ContainerDelegate {
         }
 
         Ok(None)
-    }
-
-    async fn on_tool_intent_nudge(&self, text: &str, _reason_ctx: &mut ReasoningContext) {
-        self.post_event(
-            "message",
-            serde_json::json!({
-                "role": "assistant",
-                "content": truncate_for_preview(text, 2000),
-                "nudge": true,
-            }),
-        )
-        .await;
-    }
-
-    async fn after_iteration(&self, _iteration: usize) {
-        // Brief pause between iterations
-        tokio::time::sleep(Duration::from_millis(100)).await;
     }
 }
 

--- a/desktop-client/ironclaw/src/worker/job.rs
+++ b/desktop-client/ironclaw/src/worker/job.rs
@@ -1,8 +1,9 @@
 //! Job worker execution via the shared `AgenticLoop`.
 //!
-//! Replaces `src/agent/worker.rs` with a `JobDelegate` that implements
-//! `LoopDelegate`. The `Worker` struct and `WorkerDeps` remain as the
-//! public API consumed by `scheduler.rs`.
+//! Drives the shared `dasclaw_runtime::AgenticLoop` via `JobResponder`
+//! (LLM seam) and `JobDispatcher` (tool seam) — ADR-160 §3 L2. The
+//! `Worker` struct and `WorkerDeps` remain as the public API consumed
+//! by `scheduler.rs`.
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -12,10 +13,7 @@ use tokio::sync::mpsc;
 use tokio::task::JoinSet;
 use uuid::Uuid;
 
-use crate::agent::agentic_loop::{
-    AgenticLoopConfig, LoopDelegate, LoopOutcome, LoopSignal, TextAction, run_agentic_loop,
-    truncate_for_preview,
-};
+use crate::agent::agentic_loop::truncate_for_preview;
 use crate::channels::web::types::ToolDecisionDto;
 use crate::error::Error;
 use crate::llm::{
@@ -34,10 +32,13 @@ use crate::worker::autonomous_recovery::{
     EMPTY_TOOL_COMPLETION_NUDGE, FORCE_TEXT_RECOVERY_PROMPT,
 };
 use crate::worker::job_dispatcher::WorkerMessage;
+use dasclaw_core::agentic_loop::AgenticLoopConfig;
 use dasclaw_core::traits::HostError;
 use dasclaw_hooks::HookRegistry;
 use dasclaw_runtime::JobState;
 use dasclaw_runtime::context::ContextManager;
+use dasclaw_runtime::tool_dispatch::ToolDispatcher;
+use dasclaw_runtime::{AgentResponder, AgenticLoop, LoopOutcome, LoopSignal, TextAction};
 use ironclaw_common::AppEvent;
 
 /// Shared dependencies for worker execution.
@@ -264,12 +265,16 @@ impl Worker {
             Some(WorkerMessage::Ping) | Some(WorkerMessage::UserMessage(_)) => {}
         }
 
+        // ADR-160 §3 L2: wrap `Worker` in `Arc` so it can be shared between
+        // `JobResponder` and `JobDispatcher` (both run inside `AgenticLoop`).
+        let worker = Arc::new(self);
+
         // Get job context
-        let job_ctx = self.context_manager().get_context(self.job_id).await?;
+        let job_ctx = worker.context_manager().get_context(worker.job_id).await?;
 
         // Create reasoning engine
         let reasoning =
-            Reasoning::new(self.llm().clone()).with_model_name(self.llm().active_model_name());
+            Reasoning::new(worker.llm().clone()).with_model_name(worker.llm().active_model_name());
 
         // Build initial reasoning context (tool definitions refreshed each iteration in execution_loop)
         let mut reason_ctx = ReasoningContext::new().with_job(&job_ctx.description);
@@ -288,19 +293,18 @@ Report when the job is complete or if you encounter issues you cannot resolve."#
         )));
 
         // Main execution loop with timeout
-        let result = tokio::time::timeout(self.timeout(), async {
-            self.execution_loop(&mut rx, &reasoning, &mut reason_ctx)
-                .await
+        let result = tokio::time::timeout(worker.timeout(), async {
+            worker.execution_loop(rx, reasoning, &mut reason_ctx).await
         })
         .await;
 
         match result {
             Ok(Ok(())) => {
-                tracing::info!("Worker for job {} completed successfully", self.job_id);
+                tracing::info!("Worker for job {} completed successfully", worker.job_id);
                 // Only mark completed if still in an active, non-stuck state.
-                let current_state = self
+                let current_state = worker
                     .context_manager()
-                    .get_context(self.job_id)
+                    .get_context(worker.job_id)
                     .await
                     .map(|ctx| ctx.state);
                 match current_state {
@@ -309,27 +313,27 @@ Report when the job is complete or if you encounter issues you cannot resolve."#
                     Ok(JobState::Stuck) => {
                         tracing::info!(
                             "Job {} returned Ok but is Stuck — leaving for self-repair",
-                            self.job_id
+                            worker.job_id
                         );
                     }
                     Ok(_) => {
-                        self.mark_completed().await?;
+                        worker.mark_completed().await?;
                     }
                     Err(e) => {
                         tracing::warn!(
-                            job_id = %self.job_id,
+                            job_id = %worker.job_id,
                             "Failed to get job context, cannot mark as completed: {}", e
                         );
                     }
                 }
             }
             Ok(Err(e)) => {
-                tracing::error!("Worker for job {} failed: {}", self.job_id, e);
-                self.mark_failed(&e.to_string()).await?;
+                tracing::error!("Worker for job {} failed: {}", worker.job_id, e);
+                worker.mark_failed(&e.to_string()).await?;
             }
             Err(_) => {
-                tracing::warn!("Worker for job {} timed out", self.job_id);
-                self.mark_stuck("Execution timeout").await?;
+                tracing::warn!("Worker for job {} timed out", worker.job_id);
+                worker.mark_stuck("Execution timeout").await?;
             }
         }
 
@@ -337,9 +341,9 @@ Report when the job is complete or if you encounter issues you cannot resolve."#
     }
 
     async fn execution_loop(
-        &self,
-        rx: &mut mpsc::Receiver<WorkerMessage>,
-        reasoning: &Reasoning,
+        self: &Arc<Self>,
+        mut rx: mpsc::Receiver<WorkerMessage>,
+        reasoning: Reasoning,
         reason_ctx: &mut ReasoningContext,
     ) -> Result<(), Error> {
         const MAX_WORKER_ITERATIONS: usize = 500;
@@ -411,7 +415,8 @@ Report when the job is complete or if you encounter issues you cannot resolve."#
 
         // If we have a plan, execute it.
         if let Some(ref plan) = plan {
-            self.execute_plan(rx, reasoning, reason_ctx, plan).await?;
+            self.execute_plan(&mut rx, &reasoning, reason_ctx, plan)
+                .await?;
 
             if let Ok(ctx) = self.context_manager().get_context(self.job_id).await
                 && (ctx.state.is_terminal()
@@ -422,14 +427,21 @@ Report when the job is complete or if you encounter issues you cannot resolve."#
             }
         }
 
-        // Build the delegate and run the shared agentic loop
-        let delegate = JobDelegate {
-            worker: self,
+        // ADR-160 §3 L2: drive the shared engine via responder + dispatcher.
+        // `recovery_state` is shared so the responder runs `begin_iteration` /
+        // `on_text_response` while the dispatcher runs `on_valid_tool_call`.
+        let recovery_state = Arc::new(tokio::sync::Mutex::new(AutonomousRecoveryState::default()));
+        let responder = JobResponder {
+            worker: Arc::clone(self),
             rx: tokio::sync::Mutex::new(rx),
-            consecutive_rate_limits: std::sync::atomic::AtomicUsize::new(0),
-            recovery_state: tokio::sync::Mutex::new(AutonomousRecoveryState::default()),
-            has_text_response: std::sync::atomic::AtomicBool::new(false),
             reasoning,
+            consecutive_rate_limits: std::sync::atomic::AtomicUsize::new(0),
+            recovery_state: Arc::clone(&recovery_state),
+            has_text_response: std::sync::atomic::AtomicBool::new(false),
+        };
+        let dispatcher = JobDispatcher {
+            worker: Arc::clone(self),
+            recovery_state,
         };
 
         let config = AgenticLoopConfig {
@@ -449,34 +461,35 @@ Report when the job is complete or if you encounter issues you cannot resolve."#
             .map(|ctx| ctx.user_id.clone())
             .unwrap_or_else(|_| "unknown".to_string());
 
-        let outcome = run_agentic_loop(
-            &delegate,
-            reason_ctx,
-            &config,
-            // Phase 3 Step G: SafetyLayer wired in via IronclawSafetyHook.
-            // Phase 3 Step F: SecretsStore wired in via AgentSecrets,
-            // scoped to the job owner (resolved just above).
-            // Issue #73 slice D: PermissionMode threaded explicitly; job
-            // workers run on user-scoped workspaces so default is
-            // `WorkspaceWrite`.
-            // Issue #73 slice E: workspace boundary is capability-validated.
-            &crate::agent::agentic_loop::hook_bundle_with_safety_and_secrets(
-                self.safety().clone(),
-                self.tools(),
-                &job_user_id,
-                std::sync::Arc::new(
-                    crate::agent::agentic_loop::WorkspaceCapability::open(
-                        std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from(".")),
-                    )
-                    .map_err(|e| crate::error::WorkspaceError::IoError {
-                        reason: format!("failed to open workspace capability: {e}"),
-                    })?,
-                ),
-                crate::agent::agentic_loop::PermissionMode::WorkspaceWrite,
+        // Phase 3 Step G: SafetyLayer wired in via IronclawSafetyHook.
+        // Phase 3 Step F: SecretsStore wired in via AgentSecrets,
+        // scoped to the job owner (resolved just above).
+        // Issue #73 slice D: PermissionMode threaded explicitly; job
+        // workers run on user-scoped workspaces so default is
+        // `WorkspaceWrite`.
+        // Issue #73 slice E: workspace boundary is capability-validated.
+        let hooks = crate::agent::agentic_loop::hook_bundle_with_safety_and_secrets(
+            self.safety().clone(),
+            self.tools(),
+            &job_user_id,
+            std::sync::Arc::new(
+                crate::agent::agentic_loop::WorkspaceCapability::open(
+                    std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from(".")),
+                )
+                .map_err(|e| crate::error::WorkspaceError::IoError {
+                    reason: format!("failed to open workspace capability: {e}"),
+                })?,
             ),
-        )
-        .await
-        .map_err(crate::agent::agentic_loop::host_err_to_error)?;
+            crate::agent::agentic_loop::PermissionMode::WorkspaceWrite,
+        );
+
+        // No cancellation token — `JobResponder::check_signals` already
+        // observes the `WorkerMessage::Stop` channel signal. No event
+        // channel — events are streamed via `Worker::log_event` instead.
+        let outcome = AgenticLoop::new(Arc::new(responder), Some(Arc::new(dispatcher)), None, None)
+            .run(reason_ctx, &config, &hooks)
+            .await
+            .map_err(crate::agent::agentic_loop::host_err_to_error)?;
 
         match outcome {
             LoopOutcome::Response(_) => {
@@ -1278,7 +1291,6 @@ fn store_fallback_in_metadata(
     }
 }
 
-/// Job delegate: implements `LoopDelegate` for the background job context.
 /// Whether an LLM error represents a completion-eligible empty response.
 ///
 /// Only `EmptyResponse` (provider returned no choices/content) qualifies.
@@ -1288,26 +1300,30 @@ fn is_completion_eligible_error(error: &crate::error::LlmError) -> bool {
     matches!(error, crate::error::LlmError::EmptyResponse { .. })
 }
 
+/// LLM-seam delegate (ADR-160 §3 L2): drives the agentic loop's
+/// `AgentResponder` side.
 ///
-/// Handles: signal channel (stop/ping/user messages), cancellation checks,
-/// rate-limit retry, parallel tool execution, DB persistence, SSE broadcasting.
-struct JobDelegate<'a> {
-    worker: &'a Worker,
-    rx: tokio::sync::Mutex<&'a mut mpsc::Receiver<WorkerMessage>>,
+/// Handles signal channel draining (stop/ping/user messages),
+/// rate-limit retry/back-off, autonomous-recovery iteration hooks,
+/// and the completion-on-text path. Tool dispatch lives on
+/// [`JobDispatcher`] so both sides can share `recovery_state`.
+struct JobResponder {
+    worker: Arc<Worker>,
+    rx: tokio::sync::Mutex<mpsc::Receiver<WorkerMessage>>,
     /// Tracks consecutive rate-limit errors to fail fast instead of burning iterations.
     consecutive_rate_limits: std::sync::atomic::AtomicUsize,
-    recovery_state: tokio::sync::Mutex<AutonomousRecoveryState>,
+    recovery_state: Arc<tokio::sync::Mutex<AutonomousRecoveryState>>,
     /// Whether a substantive (non-empty) text response has been produced.
     /// When true, an empty follow-up response is treated as job completion
     /// rather than a retry signal (prevents spurious failures in routines).
     has_text_response: std::sync::atomic::AtomicBool,
-    /// Route-B (D-4.5): the delegate borrows the LLM reasoning engine
-    /// instead of receiving it as a loop parameter. Borrowed because
-    /// `execution_loop` needs `&reasoning` both before and during the loop.
-    reasoning: &'a Reasoning,
+    /// Owned LLM reasoning engine for this job run. Owned (not borrowed)
+    /// because the responder lives inside `Arc<dyn AgentResponder>` for
+    /// the entire `AgenticLoop::run` call.
+    reasoning: Reasoning,
 }
 
-impl<'a> JobDelegate<'a> {
+impl JobResponder {
     const MAX_CONSECUTIVE_RATE_LIMITS: usize = 10;
 
     /// Handle a rate-limit error: back off, increment counter, and fail fast
@@ -1359,7 +1375,9 @@ impl<'a> JobDelegate<'a> {
         })
     }
 
-    /// Mark the job as completed, logging a warning on failure.
+    /// Mark the job as completed, logging a warning instead of returning the
+    /// error if the transition fails. Used in completion-on-text paths where
+    /// the loop has already produced a final response.
     async fn mark_completed_or_warn(&self, context: &str) {
         if let Err(e) = self.worker.mark_completed().await {
             tracing::warn!(
@@ -1409,7 +1427,7 @@ impl<'a> JobDelegate<'a> {
 }
 
 #[async_trait]
-impl<'a> LoopDelegate for JobDelegate<'a> {
+impl AgentResponder for JobResponder {
     async fn check_signals(&self) -> LoopSignal {
         // Drain the entire message channel, prioritizing Stop over user messages.
         // Scope the lock so it's dropped before any .await below.
@@ -1527,12 +1545,11 @@ impl<'a> LoopDelegate for JobDelegate<'a> {
         None
     }
 
-    async fn call_llm(
+    async fn respond(
         &self,
         reason_ctx: &mut ReasoningContext,
-        _iteration: usize,
     ) -> Result<crate::llm::RespondOutput, HostError> {
-        let reasoning = self.reasoning;
+        let reasoning = &self.reasoning;
         // Try select_tools first, fall back to respond_with_tools
         match reasoning.select_tools(reason_ctx).await {
             Ok(s) if !s.is_empty() => {
@@ -1721,9 +1738,41 @@ impl<'a> LoopDelegate for JobDelegate<'a> {
         TextAction::Return(LoopOutcome::Response(text))
     }
 
-    async fn execute_tool_calls(
+    async fn on_tool_intent_nudge(&self, text: &str, _reason_ctx: &mut ReasoningContext) {
+        self.worker.log_event(
+            "message",
+            serde_json::json!({
+                "role": "assistant",
+                "content": truncate_for_preview(text, 2000),
+                "nudge": true,
+            }),
+        );
+    }
+
+    async fn after_iteration(&self, _iteration: usize) {
+        // Small delay between iterations
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
+/// Tool-seam delegate (ADR-160 §3 L2): drives the agentic loop's
+/// `ToolDispatcher` side.
+///
+/// Receives validated tool-call batches from the loop, broadcasts the
+/// accompanying narrative/reasoning, executes the tools (in parallel
+/// when the batch has more than one), and records the results back into
+/// the reasoning context. Shares `recovery_state` with [`JobResponder`]
+/// so a successful tool call resets the malformed-completion counter.
+struct JobDispatcher {
+    worker: Arc<Worker>,
+    recovery_state: Arc<tokio::sync::Mutex<AutonomousRecoveryState>>,
+}
+
+#[async_trait]
+impl ToolDispatcher for JobDispatcher {
+    async fn dispatch(
         &self,
-        tool_calls: Vec<crate::llm::ToolCall>,
+        tool_calls: Vec<ToolCall>,
         content: Option<String>,
         usage: dasclaw_core::TokenUsage,
         reason_ctx: &mut ReasoningContext,
@@ -1826,22 +1875,6 @@ impl<'a> LoopDelegate for JobDelegate<'a> {
         }
 
         Ok(None)
-    }
-
-    async fn on_tool_intent_nudge(&self, text: &str, _reason_ctx: &mut ReasoningContext) {
-        self.worker.log_event(
-            "message",
-            serde_json::json!({
-                "role": "assistant",
-                "content": truncate_for_preview(text, 2000),
-                "nudge": true,
-            }),
-        );
-    }
-
-    async fn after_iteration(&self, _iteration: usize) {
-        // Small delay between iterations
-        tokio::time::sleep(Duration::from_millis(100)).await;
     }
 }
 
@@ -2447,21 +2480,22 @@ mod tests {
             .unwrap() // safety: test
             .unwrap(); // safety: test
 
-        let (_, mut rx) = tokio::sync::mpsc::channel(1);
+        let (_, rx) = tokio::sync::mpsc::channel(1);
         let reasoning = Reasoning::new(worker.llm().clone());
-        let delegate = JobDelegate {
-            worker: &worker,
-            rx: tokio::sync::Mutex::new(&mut rx),
+        let worker = Arc::new(worker);
+        let responder = JobResponder {
+            worker: Arc::clone(&worker),
+            rx: tokio::sync::Mutex::new(rx),
             consecutive_rate_limits: std::sync::atomic::AtomicUsize::new(0),
-            recovery_state: tokio::sync::Mutex::new(AutonomousRecoveryState::default()),
+            recovery_state: Arc::new(tokio::sync::Mutex::new(AutonomousRecoveryState::default())),
             has_text_response: std::sync::atomic::AtomicBool::new(false),
-            reasoning: &reasoning,
+            reasoning,
         };
 
         let mut reason_ctx = ReasoningContext::new();
 
         // Text that a real LLM would produce but doesn't match llm_signals_completion
-        let action = delegate
+        let action = responder
             .handle_text_response(
                 "Weekly review created in Notion and notification sent.",
                 ResponseMetadata::default(),


### PR DESCRIPTION
## 背景 / 目标

ADR-160 §3 L2 第三步：把 `desktop-client/ironclaw/src/worker/job.rs`
里的 `JobDelegate<'a>`（自定义 `LoopDelegate`）拆成
`JobResponder`（实现 `dasclaw_runtime::AgentResponder`，负责 LLM 一侧）
和 `JobDispatcher`（实现 `dasclaw_runtime::tool_dispatch::ToolDispatcher`，
负责工具一侧），并改由共享的 `dasclaw_runtime::AgenticLoop` 驱动。

这是 W8 系列的第三个切片：W8.0 (#974) 为 `AgentResponder` 加了默认 hooks，
W8.1 (#975) 把 `ContainerDelegate` 迁过去，本 PR 完成 `JobDelegate` 的迁移。

Closes #973

## 改动范围

唯一文件：`desktop-client/ironclaw/src/worker/job.rs`（+134 / -100）。

- 删除 `struct JobDelegate<'a>` 及其 `impl<'a> LoopDelegate for JobDelegate<'a>`。
- 新增 `struct JobResponder`（owned 字段：`Arc<Worker>` / `Mutex<mpsc::Receiver>`
  / `Reasoning` / `AtomicUsize` / `Arc<Mutex<AutonomousRecoveryState>>` /
  `AtomicBool`）与 `#[async_trait] impl AgentResponder for JobResponder`，
  实现 `check_signals` / `before_llm_call` / `respond` / `handle_text_response`
  / `on_tool_intent_nudge` / `after_iteration`。
- 新增 `struct JobDispatcher`（持 `Arc<Worker>` + 与 responder 共享的
  `Arc<Mutex<AutonomousRecoveryState>>`）与
  `#[async_trait] impl ToolDispatcher for JobDispatcher`，实现 `dispatch`。
- 在 `Worker::run` 内把 `self` 包成 `Arc::new(self)`，让 responder/dispatcher
  共享同一份 `Worker`；外部 `Worker::run(self, rx)` 签名不变，
  `worker/job_dispatcher.rs` 那里的 `tokio::spawn(async move { worker.run(rx).await })`
  无需任何改动。
- `execution_loop` 签名改为 `self: &Arc<Self>`，并以
  `AgenticLoop::new(Arc::new(responder), Some(Arc::new(dispatcher)), None, None)
  .run(reason_ctx, &config, &hooks)` 调用引擎。
- 辅助函数 `handle_rate_limit` / `mark_completed_or_warn` /
  `try_complete_on_error` 完全 verbatim 从旧 `impl<'a> JobDelegate<'a>` 搬到
  `impl JobResponder`。
- 更新唯一受影响的 unit test
  `test_text_response_terminates_loop_without_explicit_completion_phrase`，
  改为构造 `JobResponder` 后直接调用 `handle_text_response` 验证
  `TextAction::Return` + `JobState::Completed`。

## 非目标（What's NOT in this PR）

- 不改 `dasclaw_runtime` 公共 API（`AgentResponder` / `ToolDispatcher` /
  `AgenticLoop` 形状保持 #974 / #975 后的状态）。
- 不改 `execute_plan` / `execute_tool_calls` 内部业务逻辑——所有 hooks 都是
  调用同名 helper / 重新组合 ADR-160 §3 L2 规约里要求的 seam 边界，
  不调整功能行为。
- 不动 `selections_to_tool_calls` / `selections_to_text` / 自动恢复算法。
- 不删除 / 不重命名 `Worker::run` / `Worker::execution_loop` 之外的任何外部 API。
- 不引入新的 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量。
- 不动 CI、不动 ADR 红线脚本、不动 starlark pin。

## 验证

本地（按 AGENTS.md "本地快速开发节奏"）：

```bash
RUSTC_WRAPPER= cargo check -p dasclaw --tests
# → Finished `dev` profile in 1m 15s, 0 错 0 警

RUSTC_WRAPPER= cargo nextest run -p dasclaw --lib worker::job
# → 31 tests run: 31 passed, 2493 skipped
#   含 test_text_response_terminates_loop_without_explicit_completion_phrase

cargo fmt --all
python3.12 scripts/check_no_panics.py --base origin/xClaw
# → OK: No panic-inducing calls in changed production code.

RUSTC_WRAPPER= cargo clippy --no-deps -p dasclaw --all-targets -- -D warnings
# → Finished `dev` profile in 1m 58s, 0 警告
```

完整 workspace clippy / 全集 nextest / heavy integration 由 CI 兜底。

## Sources read

- `AGENTS.md` § 沟通规则、本地快速开发节奏、GitHub PR 工作流、Skills 强制使用规范、ADR-114 红线
- `.github/copilot-instructions.md` § 不要碰的红线、必跑的本地管线、PR 必填项
- `docs/plans/architecture-refactor/adr-160-cli-engine-unification.md` §3 L2（AgentResponder + ToolDispatcher seam）
- `crates/dasclaw_runtime/src/agent.rs` L51,L150-L244（trait 形状 + 默认 hooks）
- `crates/dasclaw_runtime/src/tool_dispatch.rs` L82-L95（`ToolDispatcher::dispatch` 签名）
- `crates/dasclaw_runtime/src/lib.rs` L84-L106（re-exports）
- `desktop-client/ironclaw/src/worker/container.rs` L20-L41 / L204-L251 / L438 / L611（W8.1 ContainerDelegate 模板）
- `desktop-client/ironclaw/src/agent/agentic_loop.rs` L49（`host_err_to_error` shim）
- `desktop-client/ironclaw/src/worker/job_dispatcher.rs` L361-L365（spawn 站点，确认 `Worker::run` 外部签名不能变）

## Cross-cuts

类 A —— 本 PR diff 没有新增 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量，
也没有触发 ADR-114 类 B 集中工程豁免。

## Stack 说明

- Base: `feat/w8.1-container-delegate-to-agentic-loop`（#975），
  非 `xClaw`。
- 完整 stack 顺序：`xClaw` ← #974 (W8.0) ← #975 (W8.1) ← **本 PR (W8.2)**。
- 请按 **#974 → #975 → 本 PR** 的顺序合并；review 也建议按此顺序看。

## Skills 自查

- `code-quality-audit`：无补丁式追加分支，无 copy-paste 实现（所有 helper / hook 逻辑
  都是 verbatim port，仅做"trait 边界匹配"必要的最小重组），无 flag 切换大块代码，
  没有新增 `unwrap` / `expect` / `panic!`（已被 `scripts/check_no_panics.py` 验过）。
- `code-simplifier`：本 PR 属于 verbatim port，按 AGENTS.md "verbatim port 场景必须跳过"
  的规则不做"简化"，保留与原 `JobDelegate` 逐行对应的形态以便审阅 diff。
- `code-review-expert`：trait 边界完全对齐 W8.1 `ContainerDelegate`，
  `recovery_state: Arc<Mutex<_>>` 双侧持有、`Worker: Arc<_>` 双侧持有，
  无生命周期借用穿透；`cancel_token=None` 的理由（`check_signals` 已经在
  `WorkerMessage` 通道上观察 `Stop`）和 `event_tx=None` 的理由
  （事件经 `Worker::log_event` 走自有 SSE 总线）已写在调用点的内联注释里。

## 后续 PR / 下一步

W8.2 之后，W8 系列剩余 verbatim 迁移的候选 delegate（如 routine /
sub-agent 路径）以 ADR-160 §3 L2 后续切片继续推进，沿用本 PR + #975
确立的 `AgentResponder` + `ToolDispatcher` + `Arc<Mutex<_>>` 共享状态模式。
