### PR TITLE
feat(desktop): W8.2 migrate JobDelegate to dasclaw_runtime::AgenticLoop

### DIFF
--- a/desktop-client/ironclaw/src/worker/job.rs
+++ b/desktop-client/ironclaw/src/worker/job.rs
@@ -1,8 +1,9 @@
 //! Job worker execution via the shared `AgenticLoop`.
 //!
-//! Replaces `src/agent/worker.rs` with a `JobDelegate` that implements
-//! `LoopDelegate`. The `Worker` struct and `WorkerDeps` remain as the
-//! public API consumed by `scheduler.rs`.
+//! Drives the shared `dasclaw_runtime::AgenticLoop` via `JobResponder`
+//! (LLM seam) and `JobDispatcher` (tool seam) — ADR-160 §3 L2. The
+//! `Worker` struct and `WorkerDeps` remain as the public API consumed
+//! by `scheduler.rs`.
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -12,10 +13,7 @@ use tokio::sync::mpsc;
 use tokio::task::JoinSet;
 use uuid::Uuid;
 
-use crate::agent::agentic_loop::{
-    AgenticLoopConfig, LoopDelegate, LoopOutcome, LoopSignal, TextAction, run_agentic_loop,
-    truncate_for_preview,
-};
+use crate::agent::agentic_loop::truncate_for_preview;
 use crate::channels::web::types::ToolDecisionDto;
 use crate::error::Error;
 use crate::llm::{
@@ -34,10 +32,13 @@ use crate::worker::autonomous_recovery::{
     EMPTY_TOOL_COMPLETION_NUDGE, FORCE_TEXT_RECOVERY_PROMPT,
 };
 use crate::worker::job_dispatcher::WorkerMessage;
+use dasclaw_core::agentic_loop::AgenticLoopConfig;
 use dasclaw_core::traits::HostError;
 use dasclaw_hooks::HookRegistry;
 use dasclaw_runtime::JobState;
 use dasclaw_runtime::context::ContextManager;
+use dasclaw_runtime::tool_dispatch::ToolDispatcher;
+use dasclaw_runtime::{AgentResponder, AgenticLoop, LoopOutcome, LoopSignal, TextAction};
 use ironclaw_common::AppEvent;
 
 /// Shared dependencies for worker execution.
@@ -264,12 +265,16 @@ impl Worker {
             Some(WorkerMessage::Ping) | Some(WorkerMessage::UserMessage(_)) => {}
         }
 
+        // ADR-160 §3 L2: wrap `Worker` in `Arc` so it can be shared between
+        // `JobResponder` and `JobDispatcher` (both run inside `AgenticLoop`).
+        let worker = Arc::new(self);
+
         // Get job context
-        let job_ctx = self.context_manager().get_context(self.job_id).await?;
+        let job_ctx = worker.context_manager().get_context(worker.job_id).await?;
 
         // Create reasoning engine
         let reasoning =
-            Reasoning::new(self.llm().clone()).with_model_name(self.llm().active_model_name());
+            Reasoning::new(worker.llm().clone()).with_model_name(worker.llm().active_model_name());
 
         // Build initial reasoning context (tool definitions refreshed each iteration in execution_loop)
         let mut reason_ctx = ReasoningContext::new().with_job(&job_ctx.description);
@@ -288,19 +293,18 @@ Report when the job is complete or if you encounter issues you cannot resolve."#
         )));
 
         // Main execution loop with timeout
-        let result = tokio::time::timeout(self.timeout(), async {
-            self.execution_loop(&mut rx, &reasoning, &mut reason_ctx)
-                .await
+        let result = tokio::time::timeout(worker.timeout(), async {
+            worker.execution_loop(rx, reasoning, &mut reason_ctx).await
         })
         .await;
 
         match result {
             Ok(Ok(())) => {
-                tracing::info!("Worker for job {} completed successfully", self.job_id);
+                tracing::info!("Worker for job {} completed successfully", worker.job_id);
                 // Only mark completed if still in an active, non-stuck state.
-                let current_state = self
+                let current_state = worker
                     .context_manager()
-                    .get_context(self.job_id)
+                    .get_context(worker.job_id)
                     .await
                     .map(|ctx| ctx.state);
                 match current_state {
@@ -309,27 +313,27 @@ Report when the job is complete or if you encounter issues you cannot resolve."#
                     Ok(JobState::Stuck) => {
                         tracing::info!(
                             "Job {} returned Ok but is Stuck — leaving for self-repair",
-                            self.job_id
+                            worker.job_id
                         );
                     }
                     Ok(_) => {
-                        self.mark_completed().await?;
+                        worker.mark_completed().await?;
                     }
                     Err(e) => {
                         tracing::warn!(
-                            job_id = %self.job_id,
+                            job_id = %worker.job_id,
                             "Failed to get job context, cannot mark as completed: {}", e
                         );
                     }
                 }
             }
             Ok(Err(e)) => {
-                tracing::error!("Worker for job {} failed: {}", self.job_id, e);
-                self.mark_failed(&e.to_string()).await?;
+                tracing::error!("Worker for job {} failed: {}", worker.job_id, e);
+                worker.mark_failed(&e.to_string()).await?;
             }
             Err(_) => {
-                tracing::warn!("Worker for job {} timed out", self.job_id);
-                self.mark_stuck("Execution timeout").await?;
+                tracing::warn!("Worker for job {} timed out", worker.job_id);
+                worker.mark_stuck("Execution timeout").await?;
             }
         }
 
@@ -337,9 +341,9 @@ Report when the job is complete or if you encounter issues you cannot resolve."#
     }
 
     async fn execution_loop(
-        &self,
-        rx: &mut mpsc::Receiver<WorkerMessage>,
-        reasoning: &Reasoning,
+        self: &Arc<Self>,
+        mut rx: mpsc::Receiver<WorkerMessage>,
+        reasoning: Reasoning,
         reason_ctx: &mut ReasoningContext,
     ) -> Result<(), Error> {
         const MAX_WORKER_ITERATIONS: usize = 500;
@@ -411,7 +415,8 @@ Report when the job is complete or if you encounter issues you cannot resolve."#
 
         // If we have a plan, execute it.
         if let Some(ref plan) = plan {
-            self.execute_plan(rx, reasoning, reason_ctx, plan).await?;
+            self.execute_plan(&mut rx, &reasoning, reason_ctx, plan)
+                .await?;
 
             if let Ok(ctx) = self.context_manager().get_context(self.job_id).await
                 && (ctx.state.is_terminal()
@@ -422,14 +427,21 @@ Report when the job is complete or if you encounter issues you cannot resolve."#
             }
         }
 
-        // Build the delegate and run the shared agentic loop
-        let delegate = JobDelegate {
-            worker: self,
+        // ADR-160 §3 L2: drive the shared engine via responder + dispatcher.
+        // `recovery_state` is shared so the responder runs `begin_iteration` /
+        // `on_text_response` while the dispatcher runs `on_valid_tool_call`.
+        let recovery_state = Arc::new(tokio::sync::Mutex::new(AutonomousRecoveryState::default()));
+        let responder = JobResponder {
+            worker: Arc::clone(self),
             rx: tokio::sync::Mutex::new(rx),
-            consecutive_rate_limits: std::sync::atomic::AtomicUsize::new(0),
-            recovery_state: tokio::sync::Mutex::new(AutonomousRecoveryState::default()),
-            has_text_response: std::sync::atomic::AtomicBool::new(false),
             reasoning,
+            consecutive_rate_limits: std::sync::atomic::AtomicUsize::new(0),
+            recovery_state: Arc::clone(&recovery_state),
+            has_text_response: std::sync::atomic::AtomicBool::new(false),
+        };
+        let dispatcher = JobDispatcher {
+            worker: Arc::clone(self),
+            recovery_state,
         };
 
         let config = AgenticLoopConfig {
@@ -449,34 +461,35 @@ Report when the job is complete or if you encounter issues you cannot resolve."#
             .map(|ctx| ctx.user_id.clone())
             .unwrap_or_else(|_| "unknown".to_string());
 
-        let outcome = run_agentic_loop(
-            &delegate,
-            reason_ctx,
-            &config,
-            // Phase 3 Step G: SafetyLayer wired in via IronclawSafetyHook.
-            // Phase 3 Step F: SecretsStore wired in via AgentSecrets,
-            // scoped to the job owner (resolved just above).
-            // Issue #73 slice D: PermissionMode threaded explicitly; job
-            // workers run on user-scoped workspaces so default is
-            // `WorkspaceWrite`.
-            // Issue #73 slice E: workspace boundary is capability-validated.
-            &crate::agent::agentic_loop::hook_bundle_with_safety_and_secrets(
-                self.safety().clone(),
-                self.tools(),
-                &job_user_id,
-                std::sync::Arc::new(
-                    crate::agent::agentic_loop::WorkspaceCapability::open(
-                        std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from(".")),
-                    )
-                    .map_err(|e| crate::error::WorkspaceError::IoError {
-                        reason: format!("failed to open workspace capability: {e}"),
-                    })?,
-                ),
-                crate::agent::agentic_loop::PermissionMode::WorkspaceWrite,
+        // Phase 3 Step G: SafetyLayer wired in via IronclawSafetyHook.
+        // Phase 3 Step F: SecretsStore wired in via AgentSecrets,
+        // scoped to the job owner (resolved just above).
+        // Issue #73 slice D: PermissionMode threaded explicitly; job
+        // workers run on user-scoped workspaces so default is
+        // `WorkspaceWrite`.
+        // Issue #73 slice E: workspace boundary is capability-validated.
+        let hooks = crate::agent::agentic_loop::hook_bundle_with_safety_and_secrets(
+            self.safety().clone(),
+            self.tools(),
+            &job_user_id,
+            std::sync::Arc::new(
+                crate::agent::agentic_loop::WorkspaceCapability::open(
+                    std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from(".")),
+                )
+                .map_err(|e| crate::error::WorkspaceError::IoError {
+                    reason: format!("failed to open workspace capability: {e}"),
+                })?,
             ),
-        )
-        .await
-        .map_err(crate::agent::agentic_loop::host_err_to_error)?;
+            crate::agent::agentic_loop::PermissionMode::WorkspaceWrite,
+        );
+
+        // No cancellation token — `JobResponder::check_signals` already
+        // observes the `WorkerMessage::Stop` channel signal. No event
+        // channel — events are streamed via `Worker::log_event` instead.
+        let outcome = AgenticLoop::new(Arc::new(responder), Some(Arc::new(dispatcher)), None, None)
+            .run(reason_ctx, &config, &hooks)
+            .await
+            .map_err(crate::agent::agentic_loop::host_err_to_error)?;
 
         match outcome {
             LoopOutcome::Response(_) => {
@@ -1278,7 +1291,6 @@ fn store_fallback_in_metadata(
     }
 }
 
-/// Job delegate: implements `LoopDelegate` for the background job context.
 /// Whether an LLM error represents a completion-eligible empty response.
 ///
 /// Only `EmptyResponse` (provider returned no choices/content) qualifies.
@@ -1288,26 +1300,30 @@ fn is_completion_eligible_error(error: &crate::error::LlmError) -> bool {
     matches!(error, crate::error::LlmError::EmptyResponse { .. })
 }
 
+/// LLM-seam delegate (ADR-160 §3 L2): drives the agentic loop's
+/// `AgentResponder` side.
 ///
-/// Handles: signal channel (stop/ping/user messages), cancellation checks,
-/// rate-limit retry, parallel tool execution, DB persistence, SSE broadcasting.
-struct JobDelegate<'a> {
-    worker: &'a Worker,
-    rx: tokio::sync::Mutex<&'a mut mpsc::Receiver<WorkerMessage>>,
+/// Handles signal channel draining (stop/ping/user messages),
+/// rate-limit retry/back-off, autonomous-recovery iteration hooks,
+/// and the completion-on-text path. Tool dispatch lives on
+/// [`JobDispatcher`] so both sides can share `recovery_state`.
+struct JobResponder {
+    worker: Arc<Worker>,
+    rx: tokio::sync::Mutex<mpsc::Receiver<WorkerMessage>>,
     /// Tracks consecutive rate-limit errors to fail fast instead of burning iterations.
     consecutive_rate_limits: std::sync::atomic::AtomicUsize,
-    recovery_state: tokio::sync::Mutex<AutonomousRecoveryState>,
+    recovery_state: Arc<tokio::sync::Mutex<AutonomousRecoveryState>>,
     /// Whether a substantive (non-empty) text response has been produced.
     /// When true, an empty follow-up response is treated as job completion
     /// rather than a retry signal (prevents spurious failures in routines).
     has_text_response: std::sync::atomic::AtomicBool,
-    /// Route-B (D-4.5): the delegate borrows the LLM reasoning engine
-    /// instead of receiving it as a loop parameter. Borrowed because
-    /// `execution_loop` needs `&reasoning` both before and during the loop.
-    reasoning: &'a Reasoning,
+    /// Owned LLM reasoning engine for this job run. Owned (not borrowed)
+    /// because the responder lives inside `Arc<dyn AgentResponder>` for
+    /// the entire `AgenticLoop::run` call.
+    reasoning: Reasoning,
 }
 
-impl<'a> JobDelegate<'a> {
+impl JobResponder {
     const MAX_CONSECUTIVE_RATE_LIMITS: usize = 10;
 
     /// Handle a rate-limit error: back off, increment counter, and fail fast
@@ -1359,7 +1375,9 @@ impl<'a> JobDelegate<'a> {
         })
     }
 
-    /// Mark the job as completed, logging a warning on failure.
+    /// Mark the job as completed, logging a warning instead of returning the
+    /// error if the transition fails. Used in completion-on-text paths where
+    /// the loop has already produced a final response.
     async fn mark_completed_or_warn(&self, context: &str) {
         if let Err(e) = self.worker.mark_completed().await {
             tracing::warn!(
@@ -1409,7 +1427,7 @@ impl<'a> JobDelegate<'a> {
 }
 
 #[async_trait]
-impl<'a> LoopDelegate for JobDelegate<'a> {
+impl AgentResponder for JobResponder {
     async fn check_signals(&self) -> LoopSignal {
         // Drain the entire message channel, prioritizing Stop over user messages.
         // Scope the lock so it's dropped before any .await below.
@@ -1527,12 +1545,11 @@ impl<'a> LoopDelegate for JobDelegate<'a> {
         None
     }
 
-    async fn call_llm(
+    async fn respond(
         &self,
         reason_ctx: &mut ReasoningContext,
-        _iteration: usize,
     ) -> Result<crate::llm::RespondOutput, HostError> {
-        let reasoning = self.reasoning;
+        let reasoning = &self.reasoning;
         // Try select_tools first, fall back to respond_with_tools
         match reasoning.select_tools(reason_ctx).await {
             Ok(s) if !s.is_empty() => {
@@ -1721,9 +1738,41 @@ impl<'a> LoopDelegate for JobDelegate<'a> {
         TextAction::Return(LoopOutcome::Response(text))
     }
 
-    async fn execute_tool_calls(
+    async fn on_tool_intent_nudge(&self, text: &str, _reason_ctx: &mut ReasoningContext) {
+        self.worker.log_event(
+            "message",
+            serde_json::json!({
+                "role": "assistant",
+                "content": truncate_for_preview(text, 2000),
+                "nudge": true,
+            }),
+        );
+    }
+
+    async fn after_iteration(&self, _iteration: usize) {
+        // Small delay between iterations
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
+/// Tool-seam delegate (ADR-160 §3 L2): drives the agentic loop's
+/// `ToolDispatcher` side.
+///
+/// Receives validated tool-call batches from the loop, broadcasts the
+/// accompanying narrative/reasoning, executes the tools (in parallel
+/// when the batch has more than one), and records the results back into
+/// the reasoning context. Shares `recovery_state` with [`JobResponder`]
+/// so a successful tool call resets the malformed-completion counter.
+struct JobDispatcher {
+    worker: Arc<Worker>,
+    recovery_state: Arc<tokio::sync::Mutex<AutonomousRecoveryState>>,
+}
+
+#[async_trait]
+impl ToolDispatcher for JobDispatcher {
+    async fn dispatch(
         &self,
-        tool_calls: Vec<crate::llm::ToolCall>,
+        tool_calls: Vec<ToolCall>,
         content: Option<String>,
         usage: dasclaw_core::TokenUsage,
         reason_ctx: &mut ReasoningContext,
@@ -1826,22 +1875,6 @@ impl<'a> LoopDelegate for JobDelegate<'a> {
         }
 
         Ok(None)
-    }
-
-    async fn on_tool_intent_nudge(&self, text: &str, _reason_ctx: &mut ReasoningContext) {
-        self.worker.log_event(
-            "message",
-            serde_json::json!({
-                "role": "assistant",
-                "content": truncate_for_preview(text, 2000),
-                "nudge": true,
-            }),
-        );
-    }
-
-    async fn after_iteration(&self, _iteration: usize) {
-        // Small delay between iterations
-        tokio::time::sleep(Duration::from_millis(100)).await;
     }
 }
 
@@ -2447,21 +2480,22 @@ mod tests {
             .unwrap() // safety: test
             .unwrap(); // safety: test
 
-        let (_, mut rx) = tokio::sync::mpsc::channel(1);
+        let (_, rx) = tokio::sync::mpsc::channel(1);
         let reasoning = Reasoning::new(worker.llm().clone());
-        let delegate = JobDelegate {
-            worker: &worker,
-            rx: tokio::sync::Mutex::new(&mut rx),
+        let worker = Arc::new(worker);
+        let responder = JobResponder {
+            worker: Arc::clone(&worker),
+            rx: tokio::sync::Mutex::new(rx),
             consecutive_rate_limits: std::sync::atomic::AtomicUsize::new(0),
-            recovery_state: tokio::sync::Mutex::new(AutonomousRecoveryState::default()),
+            recovery_state: Arc::new(tokio::sync::Mutex::new(AutonomousRecoveryState::default())),
             has_text_response: std::sync::atomic::AtomicBool::new(false),
-            reasoning: &reasoning,
+            reasoning,
         };
 
         let mut reason_ctx = ReasoningContext::new();
 
         // Text that a real LLM would produce but doesn't match llm_signals_completion
-        let action = delegate
+        let action = responder
             .handle_text_response(
                 "Weekly review created in Notion and notification sent.",
                 ResponseMetadata::default(),


### PR DESCRIPTION
## 背景 / 目标

ADR-160 §3 L2 第三步：把 `desktop-client/ironclaw/src/worker/job.rs`
里的 `JobDelegate<'a>`（自定义 `LoopDelegate`）拆成
`JobResponder`（实现 `dasclaw_runtime::AgentResponder`，负责 LLM 一侧）
和 `JobDispatcher`（实现 `dasclaw_runtime::tool_dispatch::ToolDispatcher`，
负责工具一侧），并改由共享的 `dasclaw_runtime::AgenticLoop` 驱动。

这是 W8 系列的第三个切片：W8.0 (#974) 为 `AgentResponder` 加了默认 hooks，
W8.1 (#975) 把 `ContainerDelegate` 迁过去，本 PR 完成 `JobDelegate` 的迁移。

Closes #973

## 改动范围

唯一文件：`desktop-client/ironclaw/src/worker/job.rs`（+134 / -100）。

- 删除 `struct JobDelegate<'a>` 及其 `impl<'a> LoopDelegate for JobDelegate<'a>`。
- 新增 `struct JobResponder`（owned 字段：`Arc<Worker>` / `Mutex<mpsc::Receiver>`
  / `Reasoning` / `AtomicUsize` / `Arc<Mutex<AutonomousRecoveryState>>` /
  `AtomicBool`）与 `#[async_trait] impl AgentResponder for JobResponder`，
  实现 `check_signals` / `before_llm_call` / `respond` / `handle_text_response`
  / `on_tool_intent_nudge` / `after_iteration`。
- 新增 `struct JobDispatcher`（持 `Arc<Worker>` + 与 responder 共享的
  `Arc<Mutex<AutonomousRecoveryState>>`）与
  `#[async_trait] impl ToolDispatcher for JobDispatcher`，实现 `dispatch`。
- 在 `Worker::run` 内把 `self` 包成 `Arc::new(self)`，让 responder/dispatcher
  共享同一份 `Worker`；外部 `Worker::run(self, rx)` 签名不变，
  `worker/job_dispatcher.rs` 那里的 `tokio::spawn(async move { worker.run(rx).await })`
  无需任何改动。
- `execution_loop` 签名改为 `self: &Arc<Self>`，并以
  `AgenticLoop::new(Arc::new(responder), Some(Arc::new(dispatcher)), None, None)
  .run(reason_ctx, &config, &hooks)` 调用引擎。
- 辅助函数 `handle_rate_limit` / `mark_completed_or_warn` /
  `try_complete_on_error` 完全 verbatim 从旧 `impl<'a> JobDelegate<'a>` 搬到
  `impl JobResponder`。
- 更新唯一受影响的 unit test
  `test_text_response_terminates_loop_without_explicit_completion_phrase`，
  改为构造 `JobResponder` 后直接调用 `handle_text_response` 验证
  `TextAction::Return` + `JobState::Completed`。

## 非目标（What's NOT in this PR）

- 不改 `dasclaw_runtime` 公共 API（`AgentResponder` / `ToolDispatcher` /
  `AgenticLoop` 形状保持 #974 / #975 后的状态）。
- 不改 `execute_plan` / `execute_tool_calls` 内部业务逻辑——所有 hooks 都是
  调用同名 helper / 重新组合 ADR-160 §3 L2 规约里要求的 seam 边界，
  不调整功能行为。
- 不动 `selections_to_tool_calls` / `selections_to_text` / 自动恢复算法。
- 不删除 / 不重命名 `Worker::run` / `Worker::execution_loop` 之外的任何外部 API。
- 不引入新的 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量。
- 不动 CI、不动 ADR 红线脚本、不动 starlark pin。

## 验证

本地（按 AGENTS.md "本地快速开发节奏"）：

```bash
RUSTC_WRAPPER= cargo check -p dasclaw --tests
# → Finished `dev` profile in 1m 15s, 0 错 0 警

RUSTC_WRAPPER= cargo nextest run -p dasclaw --lib worker::job
# → 31 tests run: 31 passed, 2493 skipped
#   含 test_text_response_terminates_loop_without_explicit_completion_phrase

cargo fmt --all
python3.12 scripts/check_no_panics.py --base origin/xClaw
# → OK: No panic-inducing calls in changed production code.

RUSTC_WRAPPER= cargo clippy --no-deps -p dasclaw --all-targets -- -D warnings
# → Finished `dev` profile in 1m 58s, 0 警告
```

完整 workspace clippy / 全集 nextest / heavy integration 由 CI 兜底。

## Sources read

- `AGENTS.md` § 沟通规则、本地快速开发节奏、GitHub PR 工作流、Skills 强制使用规范、ADR-114 红线
- `.github/copilot-instructions.md` § 不要碰的红线、必跑的本地管线、PR 必填项
- `docs/plans/architecture-refactor/adr-160-cli-engine-unification.md` §3 L2（AgentResponder + ToolDispatcher seam）
- `crates/dasclaw_runtime/src/agent.rs` L51,L150-L244（trait 形状 + 默认 hooks）
- `crates/dasclaw_runtime/src/tool_dispatch.rs` L82-L95（`ToolDispatcher::dispatch` 签名）
- `crates/dasclaw_runtime/src/lib.rs` L84-L106（re-exports）
- `desktop-client/ironclaw/src/worker/container.rs` L20-L41 / L204-L251 / L438 / L611（W8.1 ContainerDelegate 模板）
- `desktop-client/ironclaw/src/agent/agentic_loop.rs` L49（`host_err_to_error` shim）
- `desktop-client/ironclaw/src/worker/job_dispatcher.rs` L361-L365（spawn 站点，确认 `Worker::run` 外部签名不能变）

## Cross-cuts

类 A —— 本 PR diff 没有新增 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量，
也没有触发 ADR-114 类 B 集中工程豁免。

## Stack 说明

- Base: `feat/w8.1-container-delegate-to-agentic-loop`（#975），
  非 `xClaw`。
- 完整 stack 顺序：`xClaw` ← #974 (W8.0) ← #975 (W8.1) ← **本 PR (W8.2)**。
- 请按 **#974 → #975 → 本 PR** 的顺序合并；review 也建议按此顺序看。

## Skills 自查

- `code-quality-audit`：无补丁式追加分支，无 copy-paste 实现（所有 helper / hook 逻辑
  都是 verbatim port，仅做"trait 边界匹配"必要的最小重组），无 flag 切换大块代码，
  没有新增 `unwrap` / `expect` / `panic!`（已被 `scripts/check_no_panics.py` 验过）。
- `code-simplifier`：本 PR 属于 verbatim port，按 AGENTS.md "verbatim port 场景必须跳过"
  的规则不做"简化"，保留与原 `JobDelegate` 逐行对应的形态以便审阅 diff。
- `code-review-expert`：trait 边界完全对齐 W8.1 `ContainerDelegate`，
  `recovery_state: Arc<Mutex<_>>` 双侧持有、`Worker: Arc<_>` 双侧持有，
  无生命周期借用穿透；`cancel_token=None` 的理由（`check_signals` 已经在
  `WorkerMessage` 通道上观察 `Stop`）和 `event_tx=None` 的理由
  （事件经 `Worker::log_event` 走自有 SSE 总线）已写在调用点的内联注释里。

## 后续 PR / 下一步

W8.2 之后，W8 系列剩余 verbatim 迁移的候选 delegate（如 routine /
sub-agent 路径）以 ADR-160 §3 L2 后续切片继续推进，沿用本 PR + #975
确立的 `AgentResponder` + `ToolDispatcher` + `Arc<Mutex<_>>` 共享状态模式。

