### PR TITLE
feat(desktop): W8.3 delete agent/agentic_loop.rs shim, reroute imports to dasclaw_core

### DIFF
--- a/desktop-client/ironclaw/src/agent/CLAUDE.md
+++ b/desktop-client/ironclaw/src/agent/CLAUDE.md
@@ -14,8 +14,9 @@ Core agent logic. This is the most complex subsystem — read this before workin
 | `session_manager.rs` | Lifecycle: create/lookup sessions, map external thread IDs to internal UUIDs, prune stale sessions, manage undo managers. |
 | `router.rs` | Routes explicit `/commands` to `MessageIntent`. Natural language bypasses the router entirely. |
 | `scheduler.rs` | Parallel job scheduling. Maintains `jobs` map (full LLM-driven) and `subtasks` map (tool-exec/background). |
-| *(moved to `src/worker/job.rs`)* | Per-job execution now lives in `src/worker/job.rs` as `JobDelegate`, using the shared `run_agentic_loop()` engine. |
-| `agentic_loop.rs` | Shared agentic loop engine: `run_agentic_loop()`, `LoopDelegate` trait, `LoopOutcome`, `LoopSignal`, `TextAction`. All three execution paths (chat, job, container) delegate to this. |
+| *(moved to `src/worker/job.rs`)* | Per-job execution now lives in `src/worker/job.rs`, driven by the shared engine `dasclaw_runtime::AgenticLoop`. |
+| *(removed — see `dasclaw_runtime::AgenticLoop`)* | Per ADR-160 W8, the shared agentic loop engine moved to `dasclaw_runtime`. Chat / job / container paths now implement `AgentResponder` + `ToolDispatcher` (see `dasclaw_runtime`) instead of the legacy `LoopDelegate` trait. |
+| `hook_bundle.rs` | Ironclaw-specific helpers retained after the shim was deleted: `hook_bundle_with_safety` / `..._and_permissions` / `..._and_secrets` builders and `host_err_to_error`. |
 | `compaction.rs` | Context window management: summarize old turns, write to workspace daily log, trim context. Three strategies. |
 | `context_monitor.rs` | Detects memory pressure. Suggests `CompactionStrategy` based on usage level. |
 | `self_repair.rs` | Detects stuck jobs and broken tools, attempts recovery. |
@@ -48,30 +49,21 @@ Session (per user)
 - `ThreadState` values: `Idle`, `Processing`, `AwaitingApproval`, `Completed`, `Interrupted`.
 - `SessionManager` maps `(user_id, channel, external_thread_id)` → internal UUID. Prunes idle sessions every 10 minutes (warns at 1000 sessions).
 
-## Agentic Loop (dispatcher.rs)
+## Agentic Loop (shared engine)
 
-All three execution paths (chat, job, container) now use the shared `run_agentic_loop()` engine in `agentic_loop.rs`, each providing their own `LoopDelegate` implementation:
+Per ADR-160 W8, the agentic loop engine lives in `dasclaw_runtime::AgenticLoop` (driven by the `AgentResponder` + `ToolDispatcher` traits). The previous `desktop-client/ironclaw/src/agent/agentic_loop.rs` shim and its `LoopDelegate` trait were deleted in W8.3; all three execution paths now plug into the shared engine directly:
 
-- **`ChatDelegate`** (`dispatcher.rs`) — conversational turns, tool approval, skill context injection
-- **`JobDelegate`** (`src/worker/job.rs`) — background scheduler jobs, planning support, completion detection
-- **`ContainerDelegate`** (`src/worker/container.rs`) — Docker container worker, sequential tool exec, HTTP event streaming
+- **Chat path** (`dispatcher.rs`) — conversational turns, tool approval, skill context injection.
+- **Job path** (`src/worker/job.rs`) — background scheduler jobs, planning support, completion detection.
+- **Container path** (`src/worker/container.rs`) — Docker container worker, sequential tool exec, HTTP event streaming.
 
-```
-run_agentic_loop(delegate, reasoning, reason_ctx, config)
-  1. Check signals (stop/cancel) via delegate.check_signals()
-  2. Pre-LLM hook via delegate.before_llm_call()
-  3. LLM call via delegate.call_llm()
-  4. If text response → delegate.handle_text_response() → Continue or Return
-  5. If tool calls → delegate.execute_tool_calls() → Continue or Return
-  6. Post-iteration hook via delegate.after_iteration()
-  7. Repeat until LoopOutcome returned or max_iterations reached
-```
+All three configure the engine via `dasclaw_core::agentic_loop::AgenticLoopConfig` and consume `LoopOutcome` / `LoopSignal` / `TextAction` re-exported from `dasclaw_core::agentic_loop`. Ironclaw-specific glue (hook bundle builders, `HostError` → `Error` conversion) stays in `hook_bundle.rs`.
 
-**Tool approval:** Tools flagged `requires_approval` pause the loop — `ChatDelegate` returns `LoopOutcome::NeedApproval(pending)`. The web gateway stores the `PendingApproval` in session state and sends an `approval_needed` SSE event. The user's approval/deny resumes the loop.
+**Tool approval:** Tools flagged `requires_approval` pause the loop — the chat path returns `LoopOutcome::NeedApproval(pending)`. The web gateway stores the `PendingApproval` in session state and sends an `approval_needed` SSE event. The user's approval/deny resumes the loop.
 
-**Shared tool execution:** `tools/execute.rs` provides `execute_tool_with_safety()` (validate → timeout → execute → serialize) and `process_tool_result()` (sanitize → wrap → ChatMessage), used by all three delegates.
+**Shared tool execution:** `tools/execute.rs` provides `execute_tool_with_safety()` (validate → timeout → execute → serialize) and `process_tool_result()` (sanitize → wrap → ChatMessage), used by all three paths.
 
-**ChatDelegate vs JobDelegate:** `ChatDelegate` runs for user-initiated conversational turns (holds session lock, tracks turns). `JobDelegate` is spawned by the `Scheduler` for background jobs created via `CreateJob` / `/job` — it runs independently of the session and has planning support (`use_planning` flag).
+**Chat vs job path:** the chat path runs for user-initiated conversational turns (holds session lock, tracks turns). The job path is spawned by the `Scheduler` for background jobs created via `CreateJob` / `/job` — it runs independently of the session and has planning support (`use_planning` flag).
 
 ## Command Routing (router.rs)
 

--- a/desktop-client/ironclaw/src/agent/desktop_dispatcher.rs
+++ b/desktop-client/ironclaw/src/agent/desktop_dispatcher.rs
@@ -17,7 +17,6 @@ use tokio::sync::Mutex;
 use tokio::task::JoinSet;
 use uuid::Uuid;
 
-use crate::agent::agentic_loop::LoopOutcome;
 use crate::agent::session::{PendingApproval, Session};
 use crate::channels::{ChannelManager, IncomingMessage, StatusUpdate};
 use crate::config::AgentConfig;
@@ -25,6 +24,7 @@ use crate::error::Error;
 use crate::llm::{ChatMessage, ReasoningContext};
 use crate::safety::SafetyLayer;
 use crate::tools::{ToolRegistry, redact_params};
+use dasclaw_core::agentic_loop::LoopOutcome;
 use dasclaw_core::traits::HostError;
 use dasclaw_hooks::HookRegistry;
 use dasclaw_runtime::context::JobContext;

--- a/desktop-client/ironclaw/src/agent/dispatcher.rs
+++ b/desktop-client/ironclaw/src/agent/dispatcher.rs
@@ -13,9 +13,9 @@ use crate::agent::Agent;
 use crate::agent::session::{PendingApproval, Session, ThreadState};
 use crate::channels::IncomingMessage;
 use crate::error::Error;
+use dasclaw_core::agentic_loop::{AgenticLoopConfig, LoopOutcome};
 use dasclaw_runtime::context::JobContext;
 
-use crate::agent::agentic_loop::{AgenticLoopConfig, LoopOutcome};
 use crate::llm::{ChatMessage, Reasoning, ReasoningContext};
 
 fn disabled_names_from_metadata(message: &IncomingMessage, key: &str) -> HashSet<String> {
@@ -333,19 +333,19 @@ impl Agent {
         // secrets without going through the tool path.
         // Issue #73 slice D/E: PermissionMode + workspace boundary threaded
         // explicitly so the session-config layer can override per chat session.
-        let hooks = crate::agent::agentic_loop::hook_bundle_with_safety_and_secrets(
+        let hooks = crate::agent::hook_bundle::hook_bundle_with_safety_and_secrets(
             self.safety().clone(),
             &self.deps.tools,
             &message.user_id,
             std::sync::Arc::new(
-                crate::agent::agentic_loop::WorkspaceCapability::open(
+                dasclaw_workspace_cap::WorkspaceCapability::open(
                     std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from(".")),
                 )
                 .map_err(|e| crate::error::WorkspaceError::IoError {
                     reason: format!("failed to open workspace capability: {e}"),
                 })?,
             ),
-            crate::agent::agentic_loop::PermissionMode::WorkspaceWrite,
+            dasclaw_core::permissions::PermissionMode::WorkspaceWrite,
         );
 
         let outcome = dasclaw_runtime::AgenticLoop::new(
@@ -356,7 +356,7 @@ impl Agent {
         )
         .run(&mut reason_ctx, &loop_config, &hooks)
         .await
-        .map_err(crate::agent::agentic_loop::host_err_to_error);
+        .map_err(crate::agent::hook_bundle::host_err_to_error);
 
         // Stop the watcher regardless of how the loop terminated.
         cancel_token.cancel();

--- a/desktop-client/ironclaw/src/agent/hook_bundle.rs
+++ b/desktop-client/ironclaw/src/agent/hook_bundle.rs
@@ -1,42 +1,16 @@
-//! Unified agentic loop engine — re-export shim.
+//! Ironclaw-specific `HookBundle` builders and the `HostError` → ironclaw
+//! `Error` shim.
 //!
-//! Phase 3 Step D-4.5: the real engine moved to
-//! [`dasclaw_core::agentic_loop`]. This module now only re-exports the
-//! public surface so existing `use crate::agent::agentic_loop::{...}` call
-//! sites (in [`crate::agent::dispatcher`], [`crate::worker::job`],
-//! [`crate::worker::container`]) keep resolving unchanged.
-//!
-//! Route-B: `LoopDelegate::call_llm` and `run_agentic_loop` no longer take
-//! `reasoning: &Reasoning`. Each delegate now owns a `Reasoning` engine as a
-//! field and uses `self.reasoning` directly. Error type at the trait
-//! boundary is `dasclaw_core::traits::HostError`
-//! (`Box<dyn std::error::Error + Send + Sync>`); ironclaw's internal
-//! helpers keep returning `crate::error::Error` and rely on the blanket
-//! `From<E> for Box<dyn Error + Send + Sync>` to cross the boundary via
-//! `?` or `.map_err(Into::into)`.
+//! These helpers are the only code that used to live in the now-deleted
+//! `agent/agentic_loop.rs` re-export shim. Pure re-exports of
+//! `dasclaw_core::agentic_loop::*`, `dasclaw_core::permissions::*`,
+//! `dasclaw_workspace_cap::*` and `dasclaw_hooks::*` are gone — call sites
+//! now import those names from their original crates.
 
-pub use dasclaw_core::agentic_loop::{
-    AgenticLoopConfig, LoopDelegate, LoopOutcome, LoopSignal, TextAction, run_agentic_loop,
-};
-pub use dasclaw_core::intent::truncate_for_preview;
-// Issue #73 slice D: re-export PermissionMode so call sites (dispatcher,
-// worker/job, worker/container) construct hook bundles without depending
-// directly on dasclaw_core::permissions. The session-config layer that
-// eventually decides the mode lives in this crate — agent kernel stays
-// agnostic.
-pub use dasclaw_core::permissions::PermissionMode;
-// Issue #73 slice E: workspace boundary is now sourced from a
-// capability-validated `WorkspaceCapability` instead of a raw `PathBuf`.
-// Re-exported so call sites don't have to depend on `dasclaw_workspace_cap`
-// directly.
-pub use dasclaw_workspace_cap::WorkspaceCapability;
-// ADR-152 §3 F2.2 (#626): bash permission rule context is re-exported so
-// call sites construct `BashPermissionHook` rule contexts without taking a
-// direct dependency on the `dasclaw_bash_permissions` crate. Real rule
-// ingestion (from admin-backend / session config) is Phase 2.3.
-pub use dasclaw_hooks::ToolPermissionContext;
-
+use dasclaw_core::permissions::PermissionMode;
 use dasclaw_core::traits::HostError;
+use dasclaw_hooks::ToolPermissionContext;
+use dasclaw_workspace_cap::WorkspaceCapability;
 
 /// Convert a `HostError` produced by the engine back into ironclaw's
 /// concrete [`crate::error::Error`].

--- a/desktop-client/ironclaw/src/agent/mod.rs
+++ b/desktop-client/ironclaw/src/agent/mod.rs
@@ -11,13 +11,13 @@
 //! - Context compaction for long conversations
 
 mod agent_loop;
-pub mod agentic_loop;
 mod attachments;
 mod commands;
 pub mod compaction;
 mod desktop_dispatcher;
 mod desktop_responder;
 mod dispatcher;
+pub(crate) mod hook_bundle;
 mod router;
 pub mod session;
 pub mod submission;

--- a/desktop-client/ironclaw/src/worker/container.rs
+++ b/desktop-client/ironclaw/src/worker/container.rs
@@ -16,7 +16,6 @@ use async_trait::async_trait;
 use tokio::sync::Mutex;
 use uuid::Uuid;
 
-use crate::agent::agentic_loop::{AgenticLoopConfig, truncate_for_preview};
 use crate::config::SafetyConfig;
 use crate::error::WorkerError;
 use crate::llm::{
@@ -32,6 +31,8 @@ use crate::worker::autonomous_recovery::{
 };
 use crate::worker::proxy_llm::ProxyLlmProvider;
 use dasclaw_core::TokenUsage;
+use dasclaw_core::agentic_loop::AgenticLoopConfig;
+use dasclaw_core::intent::truncate_for_preview;
 use dasclaw_core::messages::ToolCall;
 use dasclaw_core::traits::HostError;
 use dasclaw_runtime::context::JobContext;
@@ -192,7 +193,7 @@ Work independently to complete this job. When finished, your final message MUST 
         // Issue #73 slice E: open the workspace capability before the
         // timeout block so `?` propagates cleanly via this fn's error type.
         let workspace_cap = Arc::new(
-            crate::agent::agentic_loop::WorkspaceCapability::open(
+            dasclaw_workspace_cap::WorkspaceCapability::open(
                 std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from(".")),
             )
             .map_err(|e| crate::error::WorkerError::ExecutionFailed {
@@ -238,10 +239,10 @@ Work independently to complete this job. When finished, your final message MUST 
             // Issue #73 slice E: workspace boundary is capability-validated;
             // container workers run inside an isolated Docker FS so the
             // capability handle is over the in-container cwd.
-            let hooks = crate::agent::agentic_loop::hook_bundle_with_safety(
+            let hooks = crate::agent::hook_bundle::hook_bundle_with_safety(
                 self.safety.clone(),
                 workspace_cap.clone(),
-                crate::agent::agentic_loop::PermissionMode::WorkspaceWrite,
+                dasclaw_core::permissions::PermissionMode::WorkspaceWrite,
             );
 
             // ADR-160 §3 L2: drive the shared engine with responder + dispatcher.
@@ -693,7 +694,7 @@ impl ToolDispatcher for ContainerDispatcher {
 
 #[cfg(test)]
 mod tests {
-    use crate::agent::agentic_loop::truncate_for_preview;
+    use dasclaw_core::intent::truncate_for_preview;
 
     #[test]
     fn test_truncate_within_limit() {

--- a/desktop-client/ironclaw/src/worker/job.rs
+++ b/desktop-client/ironclaw/src/worker/job.rs
@@ -13,7 +13,6 @@ use tokio::sync::mpsc;
 use tokio::task::JoinSet;
 use uuid::Uuid;
 
-use crate::agent::agentic_loop::truncate_for_preview;
 use crate::channels::web::types::ToolDecisionDto;
 use crate::error::Error;
 use crate::llm::{
@@ -33,6 +32,7 @@ use crate::worker::autonomous_recovery::{
 };
 use crate::worker::job_dispatcher::WorkerMessage;
 use dasclaw_core::agentic_loop::AgenticLoopConfig;
+use dasclaw_core::intent::truncate_for_preview;
 use dasclaw_core::traits::HostError;
 use dasclaw_hooks::HookRegistry;
 use dasclaw_runtime::JobState;
@@ -468,19 +468,19 @@ Report when the job is complete or if you encounter issues you cannot resolve."#
         // workers run on user-scoped workspaces so default is
         // `WorkspaceWrite`.
         // Issue #73 slice E: workspace boundary is capability-validated.
-        let hooks = crate::agent::agentic_loop::hook_bundle_with_safety_and_secrets(
+        let hooks = crate::agent::hook_bundle::hook_bundle_with_safety_and_secrets(
             self.safety().clone(),
             self.tools(),
             &job_user_id,
             std::sync::Arc::new(
-                crate::agent::agentic_loop::WorkspaceCapability::open(
+                dasclaw_workspace_cap::WorkspaceCapability::open(
                     std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from(".")),
                 )
                 .map_err(|e| crate::error::WorkspaceError::IoError {
                     reason: format!("failed to open workspace capability: {e}"),
                 })?,
             ),
-            crate::agent::agentic_loop::PermissionMode::WorkspaceWrite,
+            dasclaw_core::permissions::PermissionMode::WorkspaceWrite,
         );
 
         // No cancellation token — `JobResponder::check_signals` already
@@ -489,7 +489,7 @@ Report when the job is complete or if you encounter issues you cannot resolve."#
         let outcome = AgenticLoop::new(Arc::new(responder), Some(Arc::new(dispatcher)), None, None)
             .run(reason_ctx, &config, &hooks)
             .await
-            .map_err(crate::agent::agentic_loop::host_err_to_error)?;
+            .map_err(crate::agent::hook_bundle::host_err_to_error)?;
 
         match outcome {
             LoopOutcome::Response(_) => {

--- a/desktop-client/ironclaw/tests/parity_harness.rs
+++ b/desktop-client/ironclaw/tests/parity_harness.rs
@@ -25,10 +25,10 @@ use serde_json::json;
 use tempfile::TempDir;
 use tokio::sync::Mutex;
 
-use dasclaw_runtime::context::JobContext;
-use ironclaw::agent::agentic_loop::{
+use dasclaw_core::agentic_loop::{
     AgenticLoopConfig, LoopDelegate, LoopOutcome, LoopSignal, TextAction, run_agentic_loop,
 };
+use dasclaw_runtime::context::JobContext;
 use ironclaw::config::SafetyConfig;
 use ironclaw::error::Error;
 use ironclaw::llm::{


### PR DESCRIPTION
## 背景 / 目标

Per [ADR-160 §W8.3](../blob/xClaw/docs/plans/architecture-refactor/adr-160-runtime-extraction.md), after W8.0 / W8.1 / W8.2 migrated `ChatDelegate`, `ContainerDelegate` and `JobDelegate` to the shared engine `dasclaw_runtime::AgenticLoop`, the 637-line shim re-export file `desktop-client/ironclaw/src/agent/agentic_loop.rs` no longer carries any unique logic beyond a handful of ironclaw-specific helpers. W8.3 removes that shim and reroutes every call site to its real source crate, completing the agent-loop verbatim port (ADR-129).

## 改动范围

- **New file** `desktop-client/ironclaw/src/agent/hook_bundle.rs` — houses the only 4 helpers the shim actually owned:
  - `pub(crate) fn host_err_to_error(HostError) -> Error`
  - `pub fn hook_bundle_with_safety`
  - `pub fn hook_bundle_with_safety_and_permissions`
  - `pub fn hook_bundle_with_safety_and_secrets`
  - The `#[cfg(test)] mod tests` block from the deleted shim is ported verbatim (ADR-129 §1.3 — no simplification on verbatim ports; `code-simplifier` skipped).
- **Delete** `desktop-client/ironclaw/src/agent/agentic_loop.rs` (637 lines, pure re-exports of `dasclaw_core::agentic_loop`, `dasclaw_core::permissions`, `dasclaw_hooks`, `dasclaw_workspace_cap`).
- **Update** `desktop-client/ironclaw/src/agent/mod.rs`: remove `pub mod agentic_loop;`, insert `pub(crate) mod hook_bundle;` in alphabetical position.
- **Reroute call sites** (all 6) to import directly from the real crates:
  - `agent/dispatcher.rs` → `dasclaw_core::agentic_loop::{AgenticLoopConfig, LoopOutcome}`, `dasclaw_core::permissions::PermissionMode`, `dasclaw_workspace_cap::WorkspaceCapability`, `crate::agent::hook_bundle::{host_err_to_error, hook_bundle_with_safety_and_secrets}`.
  - `agent/desktop_dispatcher.rs` → `dasclaw_core::agentic_loop::LoopOutcome`.
  - `worker/container.rs` → `dasclaw_core::agentic_loop::AgenticLoopConfig`, `dasclaw_core::intent::truncate_for_preview`, `dasclaw_workspace_cap::WorkspaceCapability`, `dasclaw_core::permissions::PermissionMode`, `crate::agent::hook_bundle::hook_bundle_with_safety`.
  - `worker/job.rs` → `dasclaw_core::intent::truncate_for_preview`, `dasclaw_workspace_cap::WorkspaceCapability`, `dasclaw_core::permissions::PermissionMode`, `crate::agent::hook_bundle::{host_err_to_error, hook_bundle_with_safety_and_secrets}`.
  - `tests/parity_harness.rs` → `dasclaw_core::agentic_loop::{AgenticLoopConfig, LoopDelegate, LoopOutcome, LoopSignal, TextAction, run_agentic_loop}`, `dasclaw_runtime::context::JobContext`.
- **Update** `desktop-client/ironclaw/src/agent/CLAUDE.md`: drop the `agentic_loop.rs` row from the module map, add the `hook_bundle.rs` row, and rewrite the "Agentic Loop" narrative to reflect that the shared engine lives in `dasclaw_runtime::AgenticLoop` (driven by `AgentResponder` + `ToolDispatcher` traits per W8).

Net diff: **8 files changed, 42 insertions(+), 75 deletions(-)**. Git records `agentic_loop.rs → hook_bundle.rs` as a 92%-similarity rename because the verbatim-ported test module dominates the LOC; ignore the rename label, the file's purpose is entirely different post-rename.

## 非目标（What's NOT in this PR）

- 不动 `crates/dasclaw_runtime` / `crates/dasclaw_core` 任何源码；W8.3 是纯下游 cleanup。
- 不引入新的运行时行为；所有公开类型 / 函数签名保持不变（只是导入路径改了）。
- 不动其他 desktop-client 模块的 `agentic_loop` 引用（grep 已确认无残留）。
- 不修复非 W8 范围内的既有 broken 测试（base 红线 fail-safe，本 PR 仅引入 zero new failures）。
- 不做 `code-simplifier` 收敛——`hook_bundle.rs` 的 `#[cfg(test)]` 块是 verbatim port，按 ADR-129 §1.3 禁止简化。

## 验证

```bash
RUSTC_WRAPPER= cargo check -p dasclaw --tests               # ✅ clean (1m18s)
cargo fmt --all && python3.12 scripts/check_no_panics.py --base origin/xClaw   # ✅ OK
RUSTC_WRAPPER= cargo nextest run -p dasclaw --lib           # ✅ 2522 passed (1 leaky), 2 skipped (834s)
RUSTC_WRAPPER= cargo clippy --no-deps -p dasclaw --all-targets -- -D warnings  # ✅ clean (2m00s)
```

`grep -r 'agent::agentic_loop' desktop-client/` → only a single doc-comment reference inside the new `hook_bundle.rs` explaining the historical context. No live import or symbol path resolves through the deleted module.

## Sources read

- [docs/plans/architecture-refactor/adr-160-runtime-extraction.md](../blob/xClaw/docs/plans/architecture-refactor/adr-160-runtime-extraction.md) §W8.3
- `desktop-client/ironclaw/src/agent/agentic_loop.rs` (deleted file, read in full to inventory the 4 helpers + test module)
- `crates/dasclaw_runtime/src/agentic_loop.rs` (confirm the engine is the real owner)
- `crates/dasclaw_core/src/agentic_loop.rs`, `intent.rs`, `permissions.rs`, `lib.rs` (confirm `AgenticLoopConfig`, `LoopOutcome`, `LoopSignal`, `LoopDelegate`, `TextAction`, `run_agentic_loop`, `truncate_for_preview`, `PermissionMode` all live at the rerouted paths)
- `desktop-client/ironclaw/Cargo.toml` (confirm `dasclaw_core`, `dasclaw_hooks`, `dasclaw_workspace_cap`, `dasclaw_runtime` are all present in `[dependencies]`)
- AGENTS.md §本地快速开发节奏 + §会话轮换原则 + §Skills 强制使用规范

## Cross-cuts

`类A` — 本 PR 不新增任何 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量；`scripts/check_no_new_ironclaw_literal.py` 自检通过。

## Stacking

- **Base**: `feat/w8.2-job-delegate-to-agentic-loop` (#976)
- **Review order**: #974 (W8.0) → #975 (W8.1) → #976 (W8.2) → **this PR (W8.3)**
- 请先合并 #976 再 review 本 PR。

## 后续 / 下一步

W8.3 完成后，`desktop-client/ironclaw/src/agent/` 中再无任何与 `dasclaw_runtime`/`dasclaw_core` 重复的 agent loop 代码；后续 W8.4+（若有）将聚焦 `AgentResponder` / `ToolDispatcher` 在 ironclaw 自身的精简，与本 cleanup PR 独立。

Closes #973
