### PR TITLE
feat(tests): W10.0 migrate StubDelegate and ParityDelegate off LoopDelegate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3323,6 +3323,7 @@ dependencies = [
  "aho-corasick",
  "async-trait",
  "dasclaw_core",
+ "dasclaw_runtime",
  "regex",
  "serde_json",
  "thiserror 2.0.18",

--- a/crates/dasclaw_safety/Cargo.toml
+++ b/crates/dasclaw_safety/Cargo.toml
@@ -35,3 +35,8 @@ egress-gate = ["dep:async-trait", "dep:dasclaw_core"]
 [dev-dependencies]
 tokio = { version = "1", features = ["rt", "macros", "sync"] }
 async-trait = "0.1"
+# W10.0 (ADR-160): integration test drives the loop via the unified
+# `AgenticLoop` + `AgentResponder` surface re-exported by `dasclaw_runtime`.
+# Always pulled in for tests; the integration test itself is gated on the
+# `egress-gate` feature (which pulls in `dasclaw_core`).
+dasclaw_runtime = { path = "../dasclaw_runtime" }

--- a/crates/dasclaw_safety/tests/egress_gate_integration.rs
+++ b/crates/dasclaw_safety/tests/egress_gate_integration.rs
@@ -1,17 +1,23 @@
-//! End-to-end contract test: `IronclawEgressGate` inside `run_agentic_loop` (ADR-148).
+//! End-to-end contract test: `IronclawEgressGate` inside the agentic
+//! loop (ADR-148).
 //!
 //! The unit tests in `src/egress_gate.rs` prove the adapter's `check`
 //! method behaves correctly per `EgressKind`. These integration tests
 //! prove the full chain: `HookBundle { egress: IronclawEgressGate, .. }`
-//! + `run_agentic_loop` actually fires the gate at the documented
-//!   insertion points (Layer B, between delegate output and downstream
-//!   actions).
+//! + `AgenticLoop` actually fires the gate at the documented insertion
+//!   points (Layer B, between responder output and downstream actions).
 //!
 //! Why this matters: per `DLP_TESTING_LESSONS_LEARNED.md`, earlier DLP
 //! regressions were caused by tests that only covered the happy path or
 //! only the adapter — the integration boundary silently shipped raw
 //! secrets. A contract test at this layer is the only place that catches
 //! "the loop was refactored and the gate stopped firing".
+//!
+//! W10.0 (ADR-160): the driver is now `dasclaw_runtime::AgenticLoop`
+//! wired with `StubResponder` (impl `AgentResponder`); no
+//! `ToolDispatcher` is needed because these scenarios never emit tool
+//! calls. The prior `StubDelegate : LoopDelegate` shape is gone in
+//! preparation for W10.1 deleting the `LoopDelegate` trait.
 //!
 //! Gated on `egress-gate` feature so this test only builds when the
 //! adapter itself is compiled in.
@@ -21,23 +27,22 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use dasclaw_core::agentic_loop::{
-    AgenticLoopConfig, LoopDelegate, LoopOutcome, LoopSignal, TextAction, run_agentic_loop,
-};
+use dasclaw_core::agentic_loop::AgenticLoopConfig;
 use dasclaw_core::messages::FinishReason;
 use dasclaw_core::reasoning_ctx::ReasoningContext;
 use dasclaw_core::response_types::{RespondOutput, RespondResult, ResponseMetadata, TokenUsage};
-use dasclaw_core::{ChatMessage, HookBundle, HostError, ToolCall};
+use dasclaw_core::{ChatMessage, HookBundle, HostError};
+use dasclaw_runtime::{AgentResponder, AgenticLoop, LoopOutcome};
 use dasclaw_safety::egress_gate::IronclawEgressGate;
 use dasclaw_safety::{SafetyConfig, SafetyLayer};
 use tokio::sync::Mutex;
 
-/// Minimal `LoopDelegate` that returns pre-canned LLM responses.
-struct StubDelegate {
+/// Minimal [`AgentResponder`] that returns pre-canned LLM responses.
+struct StubResponder {
     queued: Mutex<Vec<RespondOutput>>,
 }
 
-impl StubDelegate {
+impl StubResponder {
     fn with_text(text: impl Into<String>) -> Self {
         Self {
             queued: Mutex::new(vec![RespondOutput {
@@ -48,50 +53,22 @@ impl StubDelegate {
             }]),
         }
     }
+
+    async fn remaining(&self) -> usize {
+        self.queued.lock().await.len()
+    }
 }
 
 #[async_trait]
-impl LoopDelegate for StubDelegate {
-    async fn check_signals(&self) -> LoopSignal {
-        LoopSignal::Continue
-    }
-
-    async fn before_llm_call(
-        &self,
-        _reason_ctx: &mut ReasoningContext,
-        _iteration: usize,
-    ) -> Option<LoopOutcome> {
-        None
-    }
-
-    async fn call_llm(
-        &self,
-        _reason_ctx: &mut ReasoningContext,
-        _iteration: usize,
-    ) -> Result<RespondOutput, HostError> {
+impl AgentResponder for StubResponder {
+    async fn respond(&self, _ctx: &mut ReasoningContext) -> Result<RespondOutput, HostError> {
         let mut q = self.queued.lock().await;
-        assert!(!q.is_empty(), "StubDelegate exhausted");
-        Ok(q.remove(0))
-    }
-
-    async fn handle_text_response(
-        &self,
-        text: &str,
-        _metadata: ResponseMetadata,
-        _usage: TokenUsage,
-        _reason_ctx: &mut ReasoningContext,
-    ) -> TextAction {
-        TextAction::Return(LoopOutcome::Response(text.to_string()))
-    }
-
-    async fn execute_tool_calls(
-        &self,
-        _tool_calls: Vec<ToolCall>,
-        _content: Option<String>,
-        _usage: TokenUsage,
-        _reason_ctx: &mut ReasoningContext,
-    ) -> Result<Option<LoopOutcome>, HostError> {
-        Ok(None)
+        let next = q
+            .first()
+            .cloned()
+            .ok_or_else(|| -> HostError { "StubResponder exhausted".into() })?;
+        q.remove(0);
+        Ok(next)
     }
 }
 
@@ -108,6 +85,17 @@ fn bundle_with(layer: Arc<SafetyLayer>) -> HookBundle {
     b
 }
 
+async fn run_with(
+    responder: Arc<StubResponder>,
+    ctx: &mut ReasoningContext,
+    bundle: &HookBundle,
+) -> Result<LoopOutcome, HostError> {
+    let config = AgenticLoopConfig::default();
+    AgenticLoop::new(responder, None, None, None)
+        .run(ctx, &config, bundle)
+        .await
+}
+
 /// LLM returns a completion containing a fake OpenAI key. The outcome
 /// reaching the caller MUST NOT contain the raw secret — the egress
 /// gate fires inside the loop and scrubs (or blocks) before the
@@ -117,13 +105,12 @@ async fn run_agentic_loop_with_egress_gate_scrubs_secret_from_completion() {
     let raw_secret = format!("sk-{}", "Z".repeat(48));
     let completion = format!("here is the key: {raw_secret}");
 
-    let delegate = StubDelegate::with_text(completion.clone());
+    let responder = Arc::new(StubResponder::with_text(completion.clone()));
     let bundle = bundle_with(safety_layer());
     let mut ctx = ReasoningContext::new();
     ctx.messages.push(ChatMessage::user("give me the key"));
-    let config = AgenticLoopConfig::default();
 
-    let outcome = run_agentic_loop(&delegate, &mut ctx, &config, &bundle)
+    let outcome = run_with(responder, &mut ctx, &bundle)
         .await
         .expect("loop should not bubble HostError");
 
@@ -150,15 +137,14 @@ async fn run_agentic_loop_with_egress_gate_scrubs_secret_from_completion() {
 #[tokio::test]
 async fn run_agentic_loop_with_egress_gate_blocks_leaky_prompt() {
     let raw_secret = format!("sk-{}", "Q".repeat(48));
-    let delegate = StubDelegate::with_text("unreached");
+    let responder = Arc::new(StubResponder::with_text("unreached"));
     let bundle = bundle_with(safety_layer());
 
     let mut ctx = ReasoningContext::new();
     ctx.messages
         .push(ChatMessage::user(format!("please use {raw_secret}")));
-    let config = AgenticLoopConfig::default();
 
-    let outcome = run_agentic_loop(&delegate, &mut ctx, &config, &bundle)
+    let outcome = run_with(Arc::clone(&responder), &mut ctx, &bundle)
         .await
         .expect("Block should surface as Failure, not Err");
 
@@ -173,20 +159,19 @@ async fn run_agentic_loop_with_egress_gate_blocks_leaky_prompt() {
     }
 
     // Confirm the LLM was not dialed: the queued response is still there.
-    assert_eq!(delegate.queued.lock().await.len(), 1);
+    assert_eq!(responder.remaining().await, 1);
 }
 
 /// Clean prompt + clean completion — the gate must be transparent.
 /// Guards against a regression where the gate wrongly rewrites benign text.
 #[tokio::test]
 async fn run_agentic_loop_with_egress_gate_transparent_on_clean_input() {
-    let delegate = StubDelegate::with_text("all good");
+    let responder = Arc::new(StubResponder::with_text("all good"));
     let bundle = bundle_with(safety_layer());
     let mut ctx = ReasoningContext::new();
     ctx.messages.push(ChatMessage::user("how are things?"));
-    let config = AgenticLoopConfig::default();
 
-    let outcome = run_agentic_loop(&delegate, &mut ctx, &config, &bundle)
+    let outcome = run_with(responder, &mut ctx, &bundle)
         .await
         .expect("loop should succeed");
 

--- a/desktop-client/ironclaw/tests/parity_harness.rs
+++ b/desktop-client/ironclaw/tests/parity_harness.rs
@@ -2,7 +2,9 @@
 //!
 //! Based on claw-code's `mock_parity_harness.rs`, adapted to ironclaw's
 //! in-process architecture using `TestHarnessBuilder` + `ScriptedLlm` +
-//! a `ParityDelegate` that drives `run_agentic_loop` with real tool execution.
+//! a `ParityDelegate` test handle that drives
+//! `dasclaw_runtime::AgenticLoop` with real tool execution (W10.0,
+//! ADR-160 §3 L2).
 //!
 //! Coverage: 50 scenarios across 11 groups:
 //!   Group 1  (PS-001..006): Core tool round-trips
@@ -25,10 +27,10 @@ use serde_json::json;
 use tempfile::TempDir;
 use tokio::sync::Mutex;
 
-use dasclaw_core::agentic_loop::{
-    AgenticLoopConfig, LoopDelegate, LoopOutcome, LoopSignal, TextAction, run_agentic_loop,
-};
+use dasclaw_core::agentic_loop::AgenticLoopConfig;
 use dasclaw_runtime::context::JobContext;
+use dasclaw_runtime::tool_dispatch::ToolDispatcher;
+use dasclaw_runtime::{AgentResponder, AgenticLoop, LoopOutcome, TextAction};
 use ironclaw::config::SafetyConfig;
 use ironclaw::error::Error;
 use ironclaw::llm::{
@@ -56,13 +58,20 @@ struct ToolRecord {
 
 /// Delegate that performs real tool execution against a temp workspace,
 /// while using a ScriptedLlm for pre-programmed LLM responses.
+///
+/// W10.0 (ADR-160): this is now a test-side wiring handle. It owns the
+/// shared `Arc`s consumed by [`ParityResponder`] (the LLM seam) and
+/// [`ParityDispatcher`] (the tool seam), and drives them through the
+/// unified [`AgenticLoop`]. Post-run accessors (`recorded_tools`,
+/// `iterations`) keep the same shape as the pre-W10.0 `LoopDelegate`
+/// impl so the 50 PS/SP scenarios stay byte-identical.
 struct ParityDelegate {
     tools: Arc<ToolRegistry>,
     safety: Arc<SafetyLayer>,
     job_ctx: JobContext,
     reasoning: Arc<Reasoning>,
     tool_records: Arc<Mutex<Vec<ToolRecord>>>,
-    iterations: AtomicUsize,
+    iterations: Arc<AtomicUsize>,
 }
 
 impl ParityDelegate {
@@ -82,33 +91,54 @@ impl ParityDelegate {
             job_ctx,
             reasoning,
             tool_records: Arc::new(Mutex::new(Vec::new())),
-            iterations: AtomicUsize::new(0),
+            iterations: Arc::new(AtomicUsize::new(0)),
         }
     }
 
     async fn recorded_tools(&self) -> Vec<ToolRecord> {
         self.tool_records.lock().await.clone()
     }
+
+    /// Drive [`AgenticLoop`] with this delegate's responder/dispatcher
+    /// pair. Replaces the pre-W10.0 `run_agentic_loop(&delegate, …)`
+    /// call site without changing observable test behaviour.
+    async fn run(
+        &self,
+        ctx: &mut ReasoningContext,
+        config: &AgenticLoopConfig,
+        hooks: &dasclaw_core::HookBundle,
+    ) -> Result<LoopOutcome, dasclaw_core::HostError> {
+        let responder: Arc<dyn AgentResponder> = Arc::new(ParityResponder {
+            reasoning: Arc::clone(&self.reasoning),
+            iterations: Arc::clone(&self.iterations),
+        });
+        let dispatcher: Arc<dyn ToolDispatcher> = Arc::new(ParityDispatcher {
+            tools: Arc::clone(&self.tools),
+            safety: Arc::clone(&self.safety),
+            job_ctx: self.job_ctx.clone(),
+            tool_records: Arc::clone(&self.tool_records),
+        });
+        AgenticLoop::new(responder, Some(dispatcher), None, None)
+            .run(ctx, config, hooks)
+            .await
+    }
+}
+
+/// LLM seam: dial the scripted `Reasoning` and bump the iteration
+/// counter. Overrides `handle_text_response` so the final assistant
+/// message is *not* appended to `ctx` — the pre-W10.0 `LoopDelegate`
+/// impl returned `TextAction::Return` without pushing, and the PS/SP
+/// assertions depend on that contract.
+struct ParityResponder {
+    reasoning: Arc<Reasoning>,
+    iterations: Arc<AtomicUsize>,
 }
 
 #[async_trait]
-impl LoopDelegate for ParityDelegate {
-    async fn check_signals(&self) -> LoopSignal {
-        LoopSignal::Continue
-    }
-
-    async fn before_llm_call(
-        &self,
-        _reason_ctx: &mut ReasoningContext,
-        _iteration: usize,
-    ) -> Option<LoopOutcome> {
-        None
-    }
-
-    async fn call_llm(
+impl AgentResponder for ParityResponder {
+    async fn respond(
         &self,
         reason_ctx: &mut ReasoningContext,
-        _iteration: usize,
     ) -> Result<RespondOutput, dasclaw_core::HostError> {
         self.iterations.fetch_add(1, Ordering::SeqCst);
         self.reasoning
@@ -126,8 +156,22 @@ impl LoopDelegate for ParityDelegate {
     ) -> TextAction {
         TextAction::Return(LoopOutcome::Response(text.to_string()))
     }
+}
 
-    async fn execute_tool_calls(
+/// Tool seam: execute each call through the real registry + safety
+/// layer, record an audit row, and append the sanitized assistant
+/// message back onto `ctx`. Byte-identical port of the pre-W10.0
+/// `ParityDelegate::execute_tool_calls` body.
+struct ParityDispatcher {
+    tools: Arc<ToolRegistry>,
+    safety: Arc<SafetyLayer>,
+    job_ctx: JobContext,
+    tool_records: Arc<Mutex<Vec<ToolRecord>>>,
+}
+
+#[async_trait]
+impl ToolDispatcher for ParityDispatcher {
+    async fn dispatch(
         &self,
         tool_calls: Vec<ToolCall>,
         _content: Option<String>,
@@ -203,14 +247,10 @@ async fn run_scenario(
         max_tool_intent_nudges: 0,
     };
 
-    let outcome = run_agentic_loop(
-        &delegate,
-        &mut ctx,
-        &config,
-        &dasclaw_core::HookBundle::noop(),
-    )
-    .await
-    .expect("agentic loop should not fail");
+    let outcome = delegate
+        .run(&mut ctx, &config, &dasclaw_core::HookBundle::noop())
+        .await
+        .expect("agentic loop should not fail");
 
     let tool_records = delegate.recorded_tools().await;
     let iterations = delegate.iterations.load(Ordering::SeqCst);
@@ -261,7 +301,7 @@ async fn run_scenario_with_job_ctx(
         job_ctx,
         reasoning: Arc::clone(&reasoning),
         tool_records: Arc::new(Mutex::new(Vec::new())),
-        iterations: AtomicUsize::new(0),
+        iterations: Arc::new(AtomicUsize::new(0)),
     };
 
     let mut ctx = ReasoningContext::new();
@@ -274,14 +314,10 @@ async fn run_scenario_with_job_ctx(
         max_tool_intent_nudges: 0,
     };
 
-    let outcome = run_agentic_loop(
-        &delegate,
-        &mut ctx,
-        &config,
-        &dasclaw_core::HookBundle::noop(),
-    )
-    .await
-    .expect("agentic loop should not fail");
+    let outcome = delegate
+        .run(&mut ctx, &config, &dasclaw_core::HookBundle::noop())
+        .await
+        .expect("agentic loop should not fail");
 
     let tool_records = delegate.recorded_tools().await;
     let iterations = delegate.iterations.load(Ordering::SeqCst);
@@ -1429,14 +1465,10 @@ async fn ps_029_max_iterations_reached() {
         max_tool_intent_nudges: 0,
     };
 
-    let outcome = run_agentic_loop(
-        &delegate,
-        &mut ctx,
-        &config,
-        &dasclaw_core::HookBundle::noop(),
-    )
-    .await
-    .expect("loop should not error");
+    let outcome = delegate
+        .run(&mut ctx, &config, &dasclaw_core::HookBundle::noop())
+        .await
+        .expect("loop should not error");
 
     // Should hit MaxIterations, not Response
     match outcome {
@@ -1484,14 +1516,10 @@ async fn ps_030_token_usage_tracked() {
         max_tool_intent_nudges: 0,
     };
 
-    let outcome = run_agentic_loop(
-        &delegate,
-        &mut ctx,
-        &config,
-        &dasclaw_core::HookBundle::noop(),
-    )
-    .await
-    .expect("loop ok");
+    let outcome = delegate
+        .run(&mut ctx, &config, &dasclaw_core::HookBundle::noop())
+        .await
+        .expect("loop ok");
 
     match outcome {
         LoopOutcome::Response(text) => {


### PR DESCRIPTION
## 背景 / 目标

W10.0 — 把两个外部测试文件从遗留的 `dasclaw_core::agentic_loop::LoopDelegate` trait 迁到新的 `dasclaw_runtime::{AgenticLoop, AgentResponder, ToolDispatcher}` API。

**目的**是在下一段（W10.1，删 trait）之前**证明 `(AgentResponder, ToolDispatcher)` 表达力足够**承载现有 50+ 测试场景（含 SafetyLayer + ToolRegistry + Reasoning 全栈接线）。这是纯测试迁移，不动 production API。

`LoopDelegate` 本身在本 PR 中保留，W10.1 才会删除。

## 改动范围

| 文件 | 改动 |
|---|---|
| `crates/dasclaw_safety/tests/egress_gate_integration.rs` | `StubDelegate` → `StubResponder : AgentResponder`。本场景从不触发工具，dispatcher 传 `None`。 |
| `desktop-client/ironclaw/tests/parity_harness.rs` | `ParityDelegate` 拆为「接线 handle + `ParityResponder` + `ParityDispatcher`」三件套。`ParityResponder` 调 `Reasoning::respond_with_tools` 并自增 `iterations`；`ParityDispatcher::dispatch` 是旧 `execute_tool_calls` 函数体的逐行端口（byte-identical port）。`iterations` 从 `AtomicUsize` 升级到 `Arc<AtomicUsize>` 以便在 responder 和测试断言之间共享。 |
| `crates/dasclaw_safety/Cargo.toml` | `dev-dependencies` 新增 `dasclaw_runtime`（无环；runtime 只依赖 core）。 |
| `Cargo.lock` | 上述新依赖的锁文件刷新。 |

两个新 responder 都 override `handle_text_response` 返回 `TextAction::Return(LoopOutcome::Response(...))` 而**不**把 assistant message 推回 `ctx.messages` —— 这是为了保留 W10.0 之前 stub 的契约（默认 impl 会推，旧 stub 不推）。

## 非目标（What's NOT in this PR）

- ❌ 不删 `LoopDelegate` trait —— W10.1 干
- ❌ 不动 `dasclaw_core` / `dasclaw_runtime` 的 public API
- ❌ 不重构 tool dispatch 业务逻辑 —— `ParityDispatcher::dispatch` 是 verbatim port（per ADR-129 §1.3 跳过 `code-simplifier`）
- ❌ 不动 production code（仅 test code + 1 行 dev-dep）
- ❌ 不引入 `unwrap()` / `expect()` / `panic!()` 到生产代码

## 验证

```bash
# 1. 目标测试（功能等价性证据）
RUSTC_WRAPPER= cargo nextest run -p dasclaw_safety --features egress-gate --test egress_gate_integration
# → 3 tests run: 3 passed

RUSTC_WRAPPER= cargo nextest run -p dasclaw --test parity_harness
# → 46 tests run: 46 passed (4 skipped pre-existing)

# 2. 编译 + lint
RUSTC_WRAPPER= cargo check -p dasclaw --test parity_harness    # finished in 25.54s
cargo fmt --all
python3.12 scripts/check_no_panics.py --base origin/xClaw      # OK
RUSTC_WRAPPER= cargo clippy --no-deps -p dasclaw_safety -p dasclaw --all-targets \
  --features dasclaw_safety/egress-gate -- -D warnings         # clean

# 3. 红线自检
grep -n "impl LoopDelegate" crates/dasclaw_safety/tests/egress_gate_integration.rs \
                            desktop-client/ironclaw/tests/parity_harness.rs
# → 空（已无 trait 实现）

grep -n "LoopDelegate" crates/dasclaw_core/src/agentic_loop.rs
# → 仍有匹配（W10.1 删）
```

## Sources read

- [`crates/dasclaw_runtime/src/agentic_loop.rs`](crates/dasclaw_runtime/src/agentic_loop.rs) §`AgenticLoop::new` / `AgenticLoop::run` 签名
- [`crates/dasclaw_core/src/agentic_loop.rs`](crates/dasclaw_core/src/agentic_loop.rs) §`LoopDelegate` trait baseline + `AgenticLoopConfig::default`
- [`crates/dasclaw_core/src/traits.rs`](crates/dasclaw_core/src/traits.rs) §`HostError = Box<dyn Error + Send + Sync>` 以及 `"…".into()` 转换路径
- [`desktop-client/ironclaw/src/worker/job.rs`](desktop-client/ironclaw/src/worker/job.rs) §`JobResponder` / `JobDispatcher`（W8.2 已合的 production-side responder 拆分模板）
- [`AGENTS.md`](AGENTS.md) §PR 描述最低要求 + §会话轮换原则

## Cross-cuts

- **ADR-114**: 类A —— 本 PR diff 中**无新增** `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量。grep guard 应自动通过。

## 后续

- **W10.1**（下一个 PR）：删除 `LoopDelegate` trait + `run_agentic_loop` 自由函数，把 `agentic_loop` 模块缩到只剩 `AgenticLoopConfig` + 类型别名；`Closes #982` 在 W10.1 收尾。

Refs #982
