### PR TITLE
refactor(core): W10.1 delete LoopDelegate trait, consolidate agentic loop entry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2918,6 +2918,7 @@ dependencies = [
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
+ "tokio-util",
  "tracing",
  "uuid",
 ]

--- a/crates/dasclaw_core/Cargo.toml
+++ b/crates/dasclaw_core/Cargo.toml
@@ -32,6 +32,9 @@ rust_decimal = { version = "1", features = ["serde"] }
 ironclaw_common = { path = "../../desktop-client/ironclaw/crates/ironclaw_common", version = "0.1.0" }
 # session_manager 需要 RwLock/Mutex/spawn (fire-and-forget hooks)
 tokio = { version = "1", features = ["sync", "rt", "time"] }
+# W10.1: AgenticLoop accepts a borrowed CancellationToken so the loop can
+# short-circuit when the host cancels mid-iteration.
+tokio-util = "0.7"
 # Project doc 注入 (#59b / ADR-115): SessionManager 构建期 DI 调用
 # `LayeredProjectDocLoader` + `assemble_section`，不进 hook 系统。
 dasclaw_project_docs = { path = "../dasclaw_project_docs", version = "0.0.0-w1" }

--- a/crates/dasclaw_core/src/agentic_loop.rs
+++ b/crates/dasclaw_core/src/agentic_loop.rs
@@ -1,11 +1,17 @@
 //! Unified agentic loop engine.
 //!
-//! Ported from ironclaw `agent/agentic_loop.rs` as part of Phase 3 Step D-4.
+//! Ported from ironclaw `agent/agentic_loop.rs` as part of Phase 3 Step D-4,
+//! then collapsed in W10.1 (issue #982) onto a thinner two-seam contract:
+//! the loop drives an [`AgentResponder`] for LLM I/O and an optional
+//! [`ToolDispatcher`] for tool execution. The prior `LoopDelegate` trait
+//! that lumped both seams together is gone — see the W10 PR series for the
+//! migration trail.
 //!
 //! The engine runs the core LLM call → tool execution → result processing →
 //! context update → repeat cycle. Three consumers (chat dispatcher, job
-//! worker, container runtime) customize behavior via the [`LoopDelegate`]
-//! trait.
+//! worker, container runtime) plug in by implementing the two narrow
+//! traits and (in the desktop case) building their own `AgenticLoop`
+//! wrapper in `dasclaw_runtime`.
 //!
 //! ## Route B (scope-narrowing vs. ironclaw's pre-port version)
 //!
@@ -13,12 +19,15 @@
 //! `call_llm` invocation. That made the engine aware of ironclaw's concrete
 //! LLM engine and forced the `dasclaw_core` port to invent a trait facade.
 //!
-//! Route B removes the `reasoning` parameter entirely: each delegate owns
+//! Route B removes the `reasoning` parameter entirely: each responder owns
 //! whatever LLM engine it needs internally. The engine only sees
-//! `RespondOutput` values — it doesn't know an "LLM" exists.
+//! [`RespondOutput`] values — it doesn't know an "LLM" exists.
 
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+use uuid::Uuid;
 
 use crate::egress_apply::{EgressApply, apply_egress_decision};
 use crate::hooks::{EgressKind, HookBundle};
@@ -29,7 +38,7 @@ use crate::response_types::{RespondOutput, RespondResult, ResponseMetadata, Toke
 use crate::session::PendingApproval;
 use crate::traits::HostError;
 
-/// Signal from the delegate indicating how the loop should proceed.
+/// Signal from the responder indicating how the loop should proceed.
 pub enum LoopSignal {
     /// Continue normally.
     Continue,
@@ -80,89 +89,247 @@ impl Default for AgenticLoopConfig {
     }
 }
 
-/// Strategy trait — each consumer implements this to customize I/O and
-/// lifecycle.
+/// Sentinel surfaced as `LoopOutcome::Failure` when the model emits a
+/// tool call but no [`ToolDispatcher`] was wired up. The runtime maps
+/// this back to `AgentError::ToolsNotSupported` (see
+/// `dasclaw_runtime::AgentError`).
+pub const TOOLS_NOT_SUPPORTED_REASON: &str = "headless-agent::tools-not-supported";
+
+/// Streaming event emitted by the loop and forwarded to GUI / CLI hosts
+/// (issue #908, GUI blocker B2).
 ///
-/// The shared loop calls these methods at well-defined points. Consumers
-/// implement only the behavior that differs between chat, job, and
-/// container contexts. The loop itself handles the common logic: tool
-/// intent nudge, iteration counting, truncation handling, and the
-/// respond → execute → process cycle.
+/// One event per observable step in the agentic loop:
+///
+/// - `TextChunk` — a fragment of model output as it arrives from the LLM.
+///   For providers without true token streaming the chunk arrives in a
+///   single piece; consumers should not depend on a particular chunk size.
+/// - `ToolCallStart` — the model asked to invoke a tool; emitted before
+///   tool execution.
+/// - `ToolResult` — the tool finished; payload is the sanitized content
+///   that the **next** LLM iteration will see in its `tool_result` block
+///   (post-egress, post-sanitizer).
+/// - `FinishReason` — one per LLM iteration boundary, carrying the
+///   model's stop reason. Use it to render "stopped", "needs tool", etc.
+///   in a GUI.
+/// - `ApprovalNeeded` — the configured approval policy flagged a tool
+///   call as needing human approval; the loop has paused until the host
+///   replies with a matching decision.
+///
+/// Wire format is adjacent-tagged JSON
+/// (`{"kind": "text_chunk", "data": "..."}`) so a TypeScript discriminated
+/// union renders directly from `serde_json::to_string(&event)`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "kind", content = "data", rename_all = "snake_case")]
+pub enum AgentEvent {
+    /// A fragment of model text output.
+    TextChunk(String),
+    /// The model requested a tool invocation.
+    ToolCallStart {
+        /// Tool name as emitted by the model.
+        name: String,
+        /// Tool arguments as raw JSON.
+        arguments: serde_json::Value,
+    },
+    /// A tool finished; `content` is the post-sanitization payload that
+    /// is fed back into the next LLM iteration.
+    ToolResult {
+        /// Tool name as it appeared in the matching `ToolCallStart`.
+        name: String,
+        /// Sanitized tool output that the LLM will see next iteration.
+        content: String,
+        /// `true` when the executor returned an error tool_result or the
+        /// egress gate replaced the content with a `[redacted: …]`
+        /// placeholder.
+        is_error: bool,
+    },
+    /// Stop reason for the LLM iteration that just ended.
+    FinishReason(FinishReason),
+    /// The configured approval policy flagged a tool call as needing
+    /// human approval (issue #910, GUI blocker B4).
+    ///
+    /// The agent loop has paused waiting for the host to dispatch a
+    /// matching approval decision for `request_id`. Until then no
+    /// further [`AgentEvent`]s are emitted for this turn.
+    ApprovalNeeded {
+        /// Unique handle the GUI feeds back into the approval inbox.
+        request_id: Uuid,
+        /// Tool name as emitted by the model.
+        tool_name: String,
+        /// Raw tool arguments, mirroring the matching `ToolCallStart`
+        /// payload.
+        tool_arguments: serde_json::Value,
+        /// Human-readable description supplied by the policy.
+        description: String,
+        /// Sanitised parameters preview the GUI should render — *not*
+        /// the raw arguments.
+        display_parameters: serde_json::Value,
+        /// `true` when the GUI may surface an "approve always"
+        /// affordance.
+        allow_always: bool,
+    },
+}
+
+/// Best-effort emit; a closed receiver is not a loop-fatal error.
+async fn emit_event(tx: Option<&mpsc::Sender<AgentEvent>>, event: AgentEvent) {
+    if let Some(tx) = tx {
+        let _ = tx.send(event).await;
+    }
+}
+
+/// Narrow LLM seam driven by [`run_agentic_loop`].
+///
+/// Adapters wrap a concrete LLM client (`dasclaw_llm_provider`, a mock,
+/// a recorder, …) and translate from the provider-native response into a
+/// [`RespondOutput`]. The loop calls [`Self::respond`] once per iteration
+/// in non-streaming mode, and [`Self::respond_streaming`] when the host
+/// wired up an event channel for token-level streaming.
+///
+/// The remaining methods replace the old `LoopDelegate` lifecycle hooks
+/// (`check_signals` / `before_llm_call` / `handle_text_response` /
+/// `on_tool_intent_nudge` / `after_iteration`). All have defaults so a
+/// minimal "headless agent" responder only has to implement
+/// [`Self::respond`].
 ///
 /// # `Send + Sync` requirement
 ///
 /// This trait requires `Send + Sync` because the loop accepts
-/// `&dyn LoopDelegate`. Delegates using borrowed references (e.g.
-/// `ChatDelegate<'a>`) must ensure all borrowed fields are `Send + Sync`.
-/// This is a load-bearing constraint: if a delegate needs to be spawned
-/// into a detached task, it must use `Arc`-based ownership instead of
-/// borrows.
+/// `&dyn AgentResponder`. Responders using borrowed references (e.g.
+/// scoped `ChatResponder<'a>`) must ensure all borrowed fields are
+/// `Send + Sync`. This is load-bearing: a responder that needs to be
+/// spawned into a detached task must use `Arc`-based ownership instead
+/// of borrows.
 #[async_trait]
-pub trait LoopDelegate: Send + Sync {
-    /// Called at the start of each iteration. Check for external signals
-    /// (cancellation, user messages, stop requests).
-    async fn check_signals(&self) -> LoopSignal;
+pub trait AgentResponder: Send + Sync {
+    /// Produce the next response for the given context.
+    async fn respond(&self, ctx: &mut ReasoningContext) -> Result<RespondOutput, HostError>;
 
-    /// Called before the LLM call. Allows the delegate to refresh tool
-    /// definitions, enforce cost guards, or inject messages.
-    /// Return `Some(outcome)` to break the loop early.
+    /// Streaming-aware variant used when the host wired up an event
+    /// channel (issue #908, GUI blocker B2).
+    ///
+    /// `event_tx` is the same channel the agent loop forwards
+    /// [`AgentEvent`]s on. Implementations emit one or more
+    /// [`AgentEvent::TextChunk`] events as the model produces text and
+    /// then return the final [`RespondOutput`] so the loop can dispatch
+    /// to tool execution or finish.
+    ///
+    /// The default implementation calls [`Self::respond`] and forwards
+    /// the final text (if any) as a single chunk, so every existing
+    /// adapter stays wire-compatible without code changes. Adapters
+    /// backed by streaming providers override this method to forward
+    /// token-level deltas as they arrive.
+    ///
+    /// `ToolCallStart`, `ToolResult` and `FinishReason` events are emitted
+    /// by the agent loop itself — implementations should only emit
+    /// [`AgentEvent::TextChunk`].
+    async fn respond_streaming(
+        &self,
+        ctx: &mut ReasoningContext,
+        event_tx: mpsc::Sender<AgentEvent>,
+    ) -> Result<RespondOutput, HostError> {
+        let out = self.respond(ctx).await?;
+        if let RespondResult::Text(ref text) = out.result {
+            // Drop on closed channel is fine: the consumer hung up, but
+            // the loop still needs to return the full RespondOutput.
+            let _ = event_tx.send(AgentEvent::TextChunk(text.clone())).await;
+        }
+        Ok(out)
+    }
+
+    /// Per-iteration signal check.
+    ///
+    /// Returned every loop turn before any LLM call. The default keeps
+    /// the loop running; hosts that drain a stop / cancellation channel
+    /// override this. The loop's own cancellation token (passed to
+    /// [`run_agentic_loop`]) is honoured independently — a `Continue`
+    /// here cannot override an already-cancelled token.
+    async fn check_signals(&self) -> LoopSignal {
+        LoopSignal::Continue
+    }
+
+    /// Pre-LLM iteration setup.
+    ///
+    /// Runs after [`Self::check_signals`] and before [`Self::respond`].
+    /// Hosts use it to mutate the context (inject prompts, swap tool
+    /// tables, force text mode) or short-circuit the loop by returning
+    /// `Some(outcome)`. The default is a no-op.
     async fn before_llm_call(
         &self,
-        reason_ctx: &mut ReasoningContext,
-        iteration: usize,
-    ) -> Option<LoopOutcome>;
+        _ctx: &mut ReasoningContext,
+        _iteration: usize,
+    ) -> Option<LoopOutcome> {
+        None
+    }
 
-    /// Call the LLM and return the result. Delegates own the LLM engine
-    /// themselves — the loop doesn't care what produces `RespondOutput`.
-    async fn call_llm(
-        &self,
-        reason_ctx: &mut ReasoningContext,
-        iteration: usize,
-    ) -> Result<RespondOutput, HostError>;
-
-    /// Handle a text-only response from the LLM.
-    /// Return `TextAction::Return` to exit the loop, `TextAction::Continue`
-    /// to proceed.
+    /// React to a pure-text LLM response.
     ///
-    /// `usage` is the per-turn token usage from the call that produced
-    /// `text`. Delegates that persist the assistant turn (e.g. to a session
-    /// transcript) MUST attach it via [`ChatMessage::with_usage`] so the
-    /// stored history matches claw-code's `ConversationMessage.usage` shape.
+    /// Called when [`Self::respond`] yields a [`RespondResult::Text`]
+    /// payload. The default appends the assistant message to `ctx` and
+    /// terminates the loop with [`LoopOutcome::Response`], matching the
+    /// pre-W10 headless-agent behaviour. Hosts that need recovery /
+    /// completion-detection logic override this and may return
+    /// [`TextAction::Continue`] to keep iterating.
     async fn handle_text_response(
         &self,
         text: &str,
-        metadata: ResponseMetadata,
+        _metadata: ResponseMetadata,
         usage: TokenUsage,
-        reason_ctx: &mut ReasoningContext,
-    ) -> TextAction;
+        ctx: &mut ReasoningContext,
+    ) -> TextAction {
+        ctx.messages
+            .push(ChatMessage::assistant(text).with_usage(usage));
+        TextAction::Return(LoopOutcome::Response(text.to_string()))
+    }
 
-    /// Execute tool calls and add results to context.
-    /// Return `Some(outcome)` to break the loop (e.g. approval needed).
+    /// React to a tool-intent nudge being injected.
     ///
-    /// `usage` is the per-turn token usage from the call that produced
-    /// `tool_calls`. Delegates that record the assistant tool-call turn
-    /// MUST attach it via [`ChatMessage::with_usage`].
-    async fn execute_tool_calls(
+    /// Called when the loop detects the model produced text that looked
+    /// like a tool intent and injects a corrective nudge. Default is a
+    /// no-op; hosts override to emit a UI event.
+    async fn on_tool_intent_nudge(&self, _text: &str, _ctx: &mut ReasoningContext) {}
+
+    /// End-of-iteration callback.
+    ///
+    /// Called after every successful iteration that did not return an
+    /// outcome. Default is a no-op; hosts use it for throttling /
+    /// progress reporting.
+    async fn after_iteration(&self, _iteration: usize) {}
+}
+
+/// Narrow tool-execution seam driven by [`run_agentic_loop`].
+///
+/// Wraps a concrete tool-dispatch pipeline (ADR-153 §1.1 5-step pipeline,
+/// a parallel dispatcher, a replay engine, a mock, …) and drives a
+/// single iteration's worth of tool calls. The loop calls
+/// [`Self::dispatch`] once per iteration that produced tool calls;
+/// dispatchers that need to record the assistant tool-call turn into
+/// the context must do so themselves before executing.
+///
+/// When no dispatcher is wired and the model still emits a tool call,
+/// the loop ends with [`LoopOutcome::Failure`] carrying
+/// [`TOOLS_NOT_SUPPORTED_REASON`].
+#[async_trait]
+pub trait ToolDispatcher: Send + Sync {
+    /// Execute one iteration's worth of tool calls.
+    ///
+    /// Returning `Ok(Some(outcome))` short-circuits the agentic loop
+    /// (e.g. approval rejection, fatal sandbox refusal). Returning
+    /// `Ok(None)` lets the loop run another model turn.
+    async fn dispatch(
         &self,
         tool_calls: Vec<ToolCall>,
         content: Option<String>,
         usage: TokenUsage,
-        reason_ctx: &mut ReasoningContext,
+        ctx: &mut ReasoningContext,
     ) -> Result<Option<LoopOutcome>, HostError>;
-
-    /// Called when the LLM expresses tool intent without actually calling a
-    /// tool. Delegates can use this to emit events or log the nudge for
-    /// observability.
-    async fn on_tool_intent_nudge(&self, _text: &str, _reason_ctx: &mut ReasoningContext) {}
-
-    /// Called after each successful iteration (no error, no early return).
-    async fn after_iteration(&self, _iteration: usize) {}
 }
 
 /// Run the unified agentic loop.
 ///
-/// This is the single implementation used by all consumers. The `delegate`
-/// provides consumer-specific behavior via the [`LoopDelegate`] trait.
+/// `responder` provides LLM I/O and per-iteration lifecycle hooks.
+/// `dispatcher` is optional: when `None`, tool calls from the model
+/// surface as [`LoopOutcome::Failure`] with [`TOOLS_NOT_SUPPORTED_REASON`].
+/// `cancellation_token` and `event_tx` are also optional — passing both
+/// `None` yields the minimum "headless" loop.
 ///
 /// `hooks` is the environment bundle ([`HookBundle`]). The loop itself
 /// calls two of the four hooks directly:
@@ -172,17 +339,18 @@ pub trait LoopDelegate: Send + Sync {
 ///   `LoopOutcome::Failure`. A `Redact` swaps the message content with
 ///   the sanitized payload.
 /// - `egress.check(EgressKind::UserDisplay, …)` on text-only LLM responses
-///   before the delegate sees them. `Redact` swaps the text in place so
+///   before the responder sees them. `Redact` swaps the text in place so
 ///   downstream UI sees the sanitized version.
 ///
-/// Tool-level egress (`EgressKind::ToolExecution`) and
-///
-/// Tool-level egress (`EgressKind::ToolExecution`) and
-/// `ApprovalGate::request` are the responsibility of the
-/// [`LoopDelegate::execute_tool_calls`] implementation. Delegates typically
-/// clone the same `Arc<HookBundle>` at construction time.
+/// Tool-level egress (`EgressKind::ToolExecution`) and approval gating
+/// are the responsibility of the [`ToolDispatcher`] implementation.
+/// Dispatchers typically clone the same `Arc<HookBundle>` at
+/// construction time.
 pub async fn run_agentic_loop(
-    delegate: &dyn LoopDelegate,
+    responder: &dyn AgentResponder,
+    dispatcher: Option<&dyn ToolDispatcher>,
+    cancellation_token: Option<&CancellationToken>,
+    event_tx: Option<&mpsc::Sender<AgentEvent>>,
     reason_ctx: &mut ReasoningContext,
     config: &AgenticLoopConfig,
     hooks: &HookBundle,
@@ -193,8 +361,15 @@ pub async fn run_agentic_loop(
     let mut truncation_count: u32 = 0;
 
     for iteration in 1..=config.max_iterations {
-        // Check for external signals (stop, cancellation, user messages)
-        match delegate.check_signals().await {
+        // Check for external signals (stop, cancellation, user messages).
+        // A cancelled token always wins even if the responder would
+        // return `Continue`.
+        let signal = if cancellation_token.is_some_and(CancellationToken::is_cancelled) {
+            LoopSignal::Stop
+        } else {
+            responder.check_signals().await
+        };
+        match signal {
             LoopSignal::Continue => {}
             LoopSignal::Stop => return Ok(LoopOutcome::Stopped),
             LoopSignal::InjectMessage(msg) => {
@@ -204,7 +379,7 @@ pub async fn run_agentic_loop(
 
         // Pre-LLM call hook (cost guard, tool refresh, iteration limit
         // nudge)
-        if let Some(outcome) = delegate.before_llm_call(reason_ctx, iteration).await {
+        if let Some(outcome) = responder.before_llm_call(reason_ctx, iteration).await {
             return Ok(outcome);
         }
 
@@ -228,13 +403,19 @@ pub async fn run_agentic_loop(
             }
         }
 
-        // Call LLM
-        let mut output = delegate.call_llm(reason_ctx, iteration).await?;
+        // Call LLM (streaming when an event channel is wired, plain
+        // otherwise). Forward the trailing `FinishReason` so a GUI knows
+        // the iteration boundary even when the model emitted no text.
+        let mut output = match event_tx {
+            Some(tx) => responder.respond_streaming(reason_ctx, tx.clone()).await?,
+            None => responder.respond(reason_ctx).await?,
+        };
+        emit_event(event_tx, AgentEvent::FinishReason(output.finish_reason)).await;
 
         // EgressGate (ADR-148 Layer B): scan / redact text completions
-        // before the delegate (and ultimately the user UI) sees them.
-        // Tool-call responses skip this gate; delegates apply the
-        // tool-level egress themselves inside `execute_tool_calls`.
+        // before the responder (and ultimately the user UI) sees them.
+        // Tool-call responses skip this gate; dispatchers apply the
+        // tool-level egress themselves inside `dispatch`.
         if let RespondResult::Text(ref mut text) = output.result {
             let decision = hooks.egress.check(&EgressKind::UserDisplay, text).await;
             if let EgressApply::Halt(reason) = apply_egress_decision(decision, text, "UserDisplay")
@@ -284,14 +465,14 @@ pub async fn run_agentic_loop(
                         iteration,
                         "LLM expressed tool intent without calling a tool, nudging"
                     );
-                    delegate.on_tool_intent_nudge(&text, reason_ctx).await;
+                    responder.on_tool_intent_nudge(&text, reason_ctx).await;
                     reason_ctx
                         .messages
                         .push(ChatMessage::assistant(&text).with_usage(usage));
                     reason_ctx
                         .messages
                         .push(ChatMessage::user(TOOL_INTENT_NUDGE));
-                    delegate.after_iteration(iteration).await;
+                    responder.after_iteration(iteration).await;
                     continue;
                 }
 
@@ -301,7 +482,7 @@ pub async fn run_agentic_loop(
                     consecutive_tool_intent_nudges = 0;
                 }
 
-                match delegate
+                match responder
                     .handle_text_response(&text, output.metadata, usage, reason_ctx)
                     .await
                 {
@@ -340,23 +521,26 @@ pub async fn run_agentic_loop(
                     if truncation_count >= 3 {
                         reason_ctx.force_text = true;
                     }
-                    delegate.after_iteration(iteration).await;
+                    responder.after_iteration(iteration).await;
                     continue;
                 }
 
                 consecutive_tool_intent_nudges = 0;
                 truncation_count = 0;
 
-                if let Some(outcome) = delegate
-                    .execute_tool_calls(tool_calls, content, usage, reason_ctx)
-                    .await?
-                {
+                // No dispatcher wired → emit the sentinel and let the
+                // host map it back to `AgentError::ToolsNotSupported`.
+                let outcome_opt = match dispatcher {
+                    Some(d) => d.dispatch(tool_calls, content, usage, reason_ctx).await?,
+                    None => Some(LoopOutcome::Failure(TOOLS_NOT_SUPPORTED_REASON.to_string())),
+                };
+                if let Some(outcome) = outcome_opt {
                     return Ok(outcome);
                 }
             }
         }
 
-        delegate.after_iteration(iteration).await;
+        responder.after_iteration(iteration).await;
     }
 
     Ok(LoopOutcome::MaxIterations)
@@ -367,6 +551,7 @@ mod tests {
     use super::*;
     use crate::messages::{Role, ToolCall, ToolDefinition};
     use crate::response_types::{ResponseAnomaly, TokenUsage};
+    use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use tokio::sync::Mutex;
 
@@ -395,24 +580,34 @@ mod tests {
         }
     }
 
-    /// Configurable mock delegate for testing `run_agentic_loop`.
-    struct MockDelegate {
+    /// Default invocation: run with no dispatcher / cancellation / event
+    /// channel, matching the legacy `run_agentic_loop(&delegate, …)`
+    /// shape used by the pre-W10.1 tests.
+    async fn run_with(
+        responder: &dyn AgentResponder,
+        ctx: &mut ReasoningContext,
+        config: &AgenticLoopConfig,
+        hooks: &HookBundle,
+    ) -> Result<LoopOutcome, HostError> {
+        run_agentic_loop(responder, None, None, None, ctx, config, hooks).await
+    }
+
+    /// Configurable mock responder + dispatcher pair for driving
+    /// `run_agentic_loop`. Splits the old `MockDelegate` cleanly along the
+    /// new trait boundary.
+    struct MockResponder {
         signal: Mutex<LoopSignal>,
         llm_responses: Mutex<Vec<RespondOutput>>,
-        tool_exec_count: AtomicUsize,
-        tool_exec_outcome: Mutex<Option<LoopOutcome>>,
         iterations_seen: Mutex<Vec<usize>>,
         early_exit: Mutex<Option<(usize, LoopOutcome)>>,
         nudge_count: AtomicUsize,
     }
 
-    impl MockDelegate {
+    impl MockResponder {
         fn new(responses: Vec<RespondOutput>) -> Self {
             Self {
                 signal: Mutex::new(LoopSignal::Continue),
                 llm_responses: Mutex::new(responses),
-                tool_exec_count: AtomicUsize::new(0),
-                tool_exec_outcome: Mutex::new(None),
                 iterations_seen: Mutex::new(Vec::new()),
                 early_exit: Mutex::new(None),
                 nudge_count: AtomicUsize::new(0),
@@ -431,7 +626,16 @@ mod tests {
     }
 
     #[async_trait]
-    impl LoopDelegate for MockDelegate {
+    impl AgentResponder for MockResponder {
+        async fn respond(&self, _ctx: &mut ReasoningContext) -> Result<RespondOutput, HostError> {
+            let mut responses = self.llm_responses.lock().await;
+            assert!(
+                !responses.is_empty(),
+                "MockResponder: no more LLM responses queued"
+            );
+            Ok(responses.remove(0))
+        }
+
         async fn check_signals(&self) -> LoopSignal {
             let mut sig = self.signal.lock().await;
             std::mem::replace(&mut *sig, LoopSignal::Continue)
@@ -439,7 +643,7 @@ mod tests {
 
         async fn before_llm_call(
             &self,
-            _reason_ctx: &mut ReasoningContext,
+            _ctx: &mut ReasoningContext,
             iteration: usize,
         ) -> Option<LoopOutcome> {
             let mut guard = self.early_exit.lock().await;
@@ -453,44 +657,19 @@ mod tests {
             }
         }
 
-        async fn call_llm(
-            &self,
-            _reason_ctx: &mut ReasoningContext,
-            _iteration: usize,
-        ) -> Result<RespondOutput, HostError> {
-            let mut responses = self.llm_responses.lock().await;
-            if responses.is_empty() {
-                panic!("MockDelegate: no more LLM responses queued");
-            }
-            Ok(responses.remove(0))
-        }
-
         async fn handle_text_response(
             &self,
             text: &str,
             _metadata: ResponseMetadata,
             _usage: TokenUsage,
-            _reason_ctx: &mut ReasoningContext,
+            _ctx: &mut ReasoningContext,
         ) -> TextAction {
+            // Override the default (which appends + Returns) so the
+            // assertion shape of the pre-W10 tests carries over unchanged.
             TextAction::Return(LoopOutcome::Response(text.to_string()))
         }
 
-        async fn execute_tool_calls(
-            &self,
-            _tool_calls: Vec<ToolCall>,
-            _content: Option<String>,
-            _usage: TokenUsage,
-            reason_ctx: &mut ReasoningContext,
-        ) -> Result<Option<LoopOutcome>, HostError> {
-            self.tool_exec_count.fetch_add(1, Ordering::SeqCst);
-            reason_ctx
-                .messages
-                .push(ChatMessage::user("tool result stub"));
-            let outcome = self.tool_exec_outcome.lock().await.take();
-            Ok(outcome)
-        }
-
-        async fn on_tool_intent_nudge(&self, _text: &str, _reason_ctx: &mut ReasoningContext) {
+        async fn on_tool_intent_nudge(&self, _text: &str, _ctx: &mut ReasoningContext) {
             self.nudge_count.fetch_add(1, Ordering::SeqCst);
         }
 
@@ -499,23 +678,52 @@ mod tests {
         }
     }
 
+    struct MockDispatcher {
+        tool_exec_count: AtomicUsize,
+        tool_exec_outcome: Mutex<Option<LoopOutcome>>,
+    }
+
+    impl MockDispatcher {
+        fn new() -> Self {
+            Self {
+                tool_exec_count: AtomicUsize::new(0),
+                tool_exec_outcome: Mutex::new(None),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl ToolDispatcher for MockDispatcher {
+        async fn dispatch(
+            &self,
+            _tool_calls: Vec<ToolCall>,
+            _content: Option<String>,
+            _usage: TokenUsage,
+            ctx: &mut ReasoningContext,
+        ) -> Result<Option<LoopOutcome>, HostError> {
+            self.tool_exec_count.fetch_add(1, Ordering::SeqCst);
+            ctx.messages.push(ChatMessage::user("tool result stub"));
+            Ok(self.tool_exec_outcome.lock().await.take())
+        }
+    }
+
     // --- Tests ---
 
     #[tokio::test]
     async fn test_text_response_returns_immediately() {
-        let delegate = MockDelegate::new(vec![text_output("Hello, world!")]);
+        let responder = MockResponder::new(vec![text_output("Hello, world!")]);
         let mut ctx = ReasoningContext::new();
         let config = AgenticLoopConfig::default();
 
-        let outcome = run_agentic_loop(&delegate, &mut ctx, &config, &HookBundle::noop())
+        let outcome = run_with(&responder, &mut ctx, &config, &HookBundle::noop())
             .await
-            .unwrap();
+            .expect("loop completes");
 
         match outcome {
             LoopOutcome::Response(text) => assert_eq!(text, "Hello, world!"),
-            _ => panic!("Expected LoopOutcome::Response"),
+            other => panic!("expected LoopOutcome::Response, got {other:?}-ish"),
         }
-        assert!(delegate.iterations_seen.lock().await.is_empty());
+        assert!(responder.iterations_seen.lock().await.is_empty());
     }
 
     #[tokio::test]
@@ -526,50 +734,104 @@ mod tests {
             arguments: serde_json::json!({}),
             reasoning: None,
         };
-        let delegate = MockDelegate::new(vec![
+        let responder = MockResponder::new(vec![
             tool_calls_output(vec![tool_call]),
             text_output("Done!"),
         ]);
+        let dispatcher = MockDispatcher::new();
         let mut ctx = ReasoningContext::new();
         let config = AgenticLoopConfig::default();
 
-        let outcome = run_agentic_loop(&delegate, &mut ctx, &config, &HookBundle::noop())
-            .await
-            .unwrap();
+        let outcome = run_agentic_loop(
+            &responder,
+            Some(&dispatcher),
+            None,
+            None,
+            &mut ctx,
+            &config,
+            &HookBundle::noop(),
+        )
+        .await
+        .expect("loop completes");
 
         match outcome {
             LoopOutcome::Response(text) => assert_eq!(text, "Done!"),
-            _ => panic!("Expected LoopOutcome::Response"),
+            other => panic!("expected LoopOutcome::Response, got {other:?}-ish"),
         }
-        assert_eq!(delegate.tool_exec_count.load(Ordering::SeqCst), 1);
-        assert_eq!(*delegate.iterations_seen.lock().await, vec![1]);
+        assert_eq!(dispatcher.tool_exec_count.load(Ordering::SeqCst), 1);
+        assert_eq!(*responder.iterations_seen.lock().await, vec![1]);
+    }
+
+    #[tokio::test]
+    async fn test_tool_call_without_dispatcher_yields_tools_not_supported() {
+        let tool_call = ToolCall {
+            id: "call_1".to_string(),
+            name: "echo".to_string(),
+            arguments: serde_json::json!({}),
+            reasoning: None,
+        };
+        let responder = MockResponder::new(vec![tool_calls_output(vec![tool_call])]);
+        let mut ctx = ReasoningContext::new();
+        let config = AgenticLoopConfig::default();
+
+        let outcome = run_with(&responder, &mut ctx, &config, &HookBundle::noop())
+            .await
+            .expect("loop completes");
+
+        match outcome {
+            LoopOutcome::Failure(reason) => assert_eq!(reason, TOOLS_NOT_SUPPORTED_REASON),
+            other => panic!("expected Failure(tools_not_supported), got {other:?}-ish"),
+        }
     }
 
     #[tokio::test]
     async fn test_stop_signal_exits_immediately() {
-        let delegate =
-            MockDelegate::new(vec![text_output("unreachable")]).with_signal(LoopSignal::Stop);
+        let responder =
+            MockResponder::new(vec![text_output("unreachable")]).with_signal(LoopSignal::Stop);
         let mut ctx = ReasoningContext::new();
         let config = AgenticLoopConfig::default();
 
-        let outcome = run_agentic_loop(&delegate, &mut ctx, &config, &HookBundle::noop())
+        let outcome = run_with(&responder, &mut ctx, &config, &HookBundle::noop())
             .await
-            .unwrap();
+            .expect("loop completes");
 
         assert!(matches!(outcome, LoopOutcome::Stopped));
-        assert!(delegate.iterations_seen.lock().await.is_empty());
+        assert!(responder.iterations_seen.lock().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_cancellation_token_short_circuits() {
+        let responder = MockResponder::new(vec![text_output("unreachable")]);
+        let token = CancellationToken::new();
+        token.cancel();
+        let mut ctx = ReasoningContext::new();
+        let config = AgenticLoopConfig::default();
+
+        let outcome = run_agentic_loop(
+            &responder,
+            None,
+            Some(&token),
+            None,
+            &mut ctx,
+            &config,
+            &HookBundle::noop(),
+        )
+        .await
+        .expect("loop completes");
+
+        assert!(matches!(outcome, LoopOutcome::Stopped));
     }
 
     #[tokio::test]
     async fn test_inject_message_adds_user_message() {
-        let delegate = MockDelegate::new(vec![text_output("Got it")])
+        let responder = MockResponder::new(vec![text_output("Got it")])
             .with_signal(LoopSignal::InjectMessage("injected prompt".to_string()));
         let mut ctx = ReasoningContext::new();
         let config = AgenticLoopConfig::default();
 
-        let outcome = run_agentic_loop(&delegate, &mut ctx, &config, &HookBundle::noop())
+        let outcome = run_with(&responder, &mut ctx, &config, &HookBundle::noop())
             .await
-            .unwrap();
+            .expect("loop completes");
 
         assert!(matches!(outcome, LoopOutcome::Response(_)));
         assert!(
@@ -585,24 +847,8 @@ mod tests {
         struct FailOnMalformedResponse;
 
         #[async_trait]
-        impl LoopDelegate for FailOnMalformedResponse {
-            async fn check_signals(&self) -> LoopSignal {
-                LoopSignal::Continue
-            }
-
-            async fn before_llm_call(
-                &self,
-                _: &mut ReasoningContext,
-                _: usize,
-            ) -> Option<LoopOutcome> {
-                None
-            }
-
-            async fn call_llm(
-                &self,
-                _: &mut ReasoningContext,
-                _: usize,
-            ) -> Result<RespondOutput, HostError> {
+        impl AgentResponder for FailOnMalformedResponse {
+            async fn respond(&self, _: &mut ReasoningContext) -> Result<RespondOutput, HostError> {
                 Ok(RespondOutput {
                     result: RespondResult::Text("fallback".to_string()),
                     usage: zero_usage(),
@@ -625,28 +871,18 @@ mod tests {
                     "malformed tool completion".to_string(),
                 ))
             }
-
-            async fn execute_tool_calls(
-                &self,
-                _: Vec<ToolCall>,
-                _: Option<String>,
-                _: TokenUsage,
-                _: &mut ReasoningContext,
-            ) -> Result<Option<LoopOutcome>, HostError> {
-                Ok(None)
-            }
         }
 
-        let delegate = FailOnMalformedResponse;
+        let responder = FailOnMalformedResponse;
         let mut ctx = ReasoningContext::new();
-        let outcome = run_agentic_loop(
-            &delegate,
+        let outcome = run_with(
+            &responder,
             &mut ctx,
             &AgenticLoopConfig::default(),
             &HookBundle::noop(),
         )
         .await
-        .unwrap();
+        .expect("loop completes");
 
         assert!(
             matches!(outcome, LoopOutcome::Failure(ref reason) if reason == "malformed tool completion")
@@ -655,25 +891,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_max_iterations_reached() {
-        struct ContinueDelegate;
+        struct ContinueResponder;
 
         #[async_trait]
-        impl LoopDelegate for ContinueDelegate {
-            async fn check_signals(&self) -> LoopSignal {
-                LoopSignal::Continue
-            }
-            async fn before_llm_call(
-                &self,
-                _: &mut ReasoningContext,
-                _: usize,
-            ) -> Option<LoopOutcome> {
-                None
-            }
-            async fn call_llm(
-                &self,
-                _: &mut ReasoningContext,
-                _: usize,
-            ) -> Result<RespondOutput, HostError> {
+        impl AgentResponder for ContinueResponder {
+            async fn respond(&self, _: &mut ReasoningContext) -> Result<RespondOutput, HostError> {
                 Ok(text_output("still working"))
             }
             async fn handle_text_response(
@@ -686,27 +908,18 @@ mod tests {
                 ctx.messages.push(ChatMessage::assistant("still working"));
                 TextAction::Continue
             }
-            async fn execute_tool_calls(
-                &self,
-                _: Vec<ToolCall>,
-                _: Option<String>,
-                _: TokenUsage,
-                _: &mut ReasoningContext,
-            ) -> Result<Option<LoopOutcome>, HostError> {
-                Ok(None)
-            }
         }
 
-        let delegate = ContinueDelegate;
+        let responder = ContinueResponder;
         let mut ctx = ReasoningContext::new();
         let config = AgenticLoopConfig {
             max_iterations: 3,
             ..Default::default()
         };
 
-        let outcome = run_agentic_loop(&delegate, &mut ctx, &config, &HookBundle::noop())
+        let outcome = run_with(&responder, &mut ctx, &config, &HookBundle::noop())
             .await
-            .unwrap();
+            .expect("loop completes");
 
         assert!(matches!(outcome, LoopOutcome::MaxIterations));
         let assistant_count = ctx
@@ -719,7 +932,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_tool_intent_nudge_fires_and_caps() {
-        let delegate = MockDelegate::new(vec![
+        let responder = MockResponder::new(vec![
             text_output("Let me search for that file"),
             text_output("Let me search for that file"),
             text_output("Let me search for that file"),
@@ -736,12 +949,12 @@ mod tests {
             max_tool_intent_nudges: 2,
         };
 
-        let outcome = run_agentic_loop(&delegate, &mut ctx, &config, &HookBundle::noop())
+        let outcome = run_with(&responder, &mut ctx, &config, &HookBundle::noop())
             .await
-            .unwrap();
+            .expect("loop completes");
 
         assert!(matches!(outcome, LoopOutcome::Response(_)));
-        assert_eq!(delegate.nudge_count.load(Ordering::SeqCst), 2);
+        assert_eq!(responder.nudge_count.load(Ordering::SeqCst), 2);
         let nudge_messages = ctx
             .messages
             .iter()
@@ -757,17 +970,17 @@ mod tests {
 
     #[tokio::test]
     async fn test_before_llm_call_early_exit() {
-        let delegate = MockDelegate::new(vec![text_output("unreachable")])
+        let responder = MockResponder::new(vec![text_output("unreachable")])
             .with_early_exit(1, LoopOutcome::Stopped);
         let mut ctx = ReasoningContext::new();
         let config = AgenticLoopConfig::default();
 
-        let outcome = run_agentic_loop(&delegate, &mut ctx, &config, &HookBundle::noop())
+        let outcome = run_with(&responder, &mut ctx, &config, &HookBundle::noop())
             .await
-            .unwrap();
+            .expect("loop completes");
 
         assert!(matches!(outcome, LoopOutcome::Stopped));
-        assert!(delegate.iterations_seen.lock().await.is_empty());
+        assert!(responder.iterations_seen.lock().await.is_empty());
     }
 
     #[tokio::test]
@@ -787,18 +1000,27 @@ mod tests {
             finish_reason: FinishReason::Length,
             metadata: ResponseMetadata::default(),
         };
-        let delegate = MockDelegate::new(vec![truncated_output, text_output("Summarized it.")]);
+        let responder = MockResponder::new(vec![truncated_output, text_output("Summarized it.")]);
+        let dispatcher = MockDispatcher::new();
         let mut ctx = ReasoningContext::new();
         let config = AgenticLoopConfig {
             max_iterations: 5,
             ..Default::default()
         };
 
-        let outcome = run_agentic_loop(&delegate, &mut ctx, &config, &HookBundle::noop())
-            .await
-            .unwrap();
+        let outcome = run_agentic_loop(
+            &responder,
+            Some(&dispatcher),
+            None,
+            None,
+            &mut ctx,
+            &config,
+            &HookBundle::noop(),
+        )
+        .await
+        .expect("loop completes");
 
-        assert_eq!(delegate.tool_exec_count.load(Ordering::SeqCst), 0);
+        assert_eq!(dispatcher.tool_exec_count.load(Ordering::SeqCst), 0);
         assert!(matches!(outcome, LoopOutcome::Response(ref t) if t == "Summarized it."));
         assert!(
             ctx.messages
@@ -830,24 +1052,33 @@ mod tests {
             finish_reason: FinishReason::Length,
             metadata: ResponseMetadata::default(),
         };
-        let delegate = MockDelegate::new(vec![
+        let responder = MockResponder::new(vec![
             make_truncated(),
             make_truncated(),
             make_truncated(),
             text_output("Gave up on tool calls."),
         ]);
+        let dispatcher = MockDispatcher::new();
         let mut ctx = ReasoningContext::new();
         let config = AgenticLoopConfig {
             max_iterations: 5,
             ..Default::default()
         };
 
-        let outcome = run_agentic_loop(&delegate, &mut ctx, &config, &HookBundle::noop())
-            .await
-            .unwrap();
+        let outcome = run_agentic_loop(
+            &responder,
+            Some(&dispatcher),
+            None,
+            None,
+            &mut ctx,
+            &config,
+            &HookBundle::noop(),
+        )
+        .await
+        .expect("loop completes");
 
         assert!(matches!(outcome, LoopOutcome::Response(_)));
-        assert_eq!(delegate.tool_exec_count.load(Ordering::SeqCst), 0);
+        assert_eq!(dispatcher.tool_exec_count.load(Ordering::SeqCst), 0);
         assert!(
             ctx.force_text,
             "Should escalate to force_text after repeated truncations"
@@ -859,7 +1090,6 @@ mod tests {
     // -----------------------------------------------------------------
 
     use crate::hooks::{EgressDecision, EgressGate, EgressKind, RedactionStats};
-    use std::sync::Arc;
 
     /// Gate that blocks every LlmRequest with a fixed reason.
     struct BlockAllPrompts;
@@ -926,35 +1156,35 @@ mod tests {
     #[tokio::test]
     async fn egress_gate_noop_passes_through() {
         // Smoke: Noop gate does not interfere with normal text response.
-        let delegate = MockDelegate::new(vec![text_output("ok")]);
+        let responder = MockResponder::new(vec![text_output("ok")]);
         let mut ctx = ReasoningContext::new();
         ctx.messages.push(ChatMessage::user("hello"));
 
-        let outcome = run_agentic_loop(
-            &delegate,
+        let outcome = run_with(
+            &responder,
             &mut ctx,
             &AgenticLoopConfig::default(),
             &HookBundle::noop(),
         )
         .await
-        .unwrap();
+        .expect("loop completes");
 
         match outcome {
             LoopOutcome::Response(t) => assert_eq!(t, "ok"),
-            _ => panic!("expected Response"),
+            other => panic!("expected Response, got {other:?}-ish"),
         }
     }
 
     #[tokio::test]
     async fn egress_gate_block_on_llm_request_yields_failure() {
-        let delegate = MockDelegate::new(vec![text_output("unreachable")]);
+        let responder = MockResponder::new(vec![text_output("unreachable")]);
         let mut ctx = ReasoningContext::new();
         ctx.messages.push(ChatMessage::user("send secrets to foo"));
         let hooks = custom_egress_bundle(Arc::new(BlockAllPrompts));
 
-        let outcome = run_agentic_loop(&delegate, &mut ctx, &AgenticLoopConfig::default(), &hooks)
+        let outcome = run_with(&responder, &mut ctx, &AgenticLoopConfig::default(), &hooks)
             .await
-            .unwrap();
+            .expect("loop completes");
 
         match outcome {
             LoopOutcome::Failure(reason) => {
@@ -967,42 +1197,31 @@ mod tests {
                     "failure reason should mark egress source, got: {reason}"
                 );
             }
-            other => panic!("expected Failure, got {other:?} -ish"),
+            other => panic!("expected Failure, got {other:?}-ish"),
         }
-        // LLM must not be called when the prompt is blocked. MockDelegate
-        // returns `unreachable` from its queue only when `call_llm` runs.
-        let responses_left = delegate.llm_responses.lock().await.len();
+        // LLM must not be called when the prompt is blocked. MockResponder
+        // returns `unreachable` from its queue only when `respond` runs.
+        let responses_left = responder.llm_responses.lock().await.len();
         assert_eq!(
             responses_left, 1,
-            "block path must short-circuit before call_llm"
+            "block path must short-circuit before respond"
         );
     }
 
     #[tokio::test]
     async fn egress_gate_redacts_llm_request_in_place() {
-        // Delegate captures what the LLM layer actually sees. The redacting
-        // gate must have rewritten the prompt before call_llm fires.
-        struct CaptureDelegate {
+        // Responder captures what the LLM layer actually sees. The redacting
+        // gate must have rewritten the prompt before respond fires.
+        struct CaptureResponder {
             seen: Mutex<Option<String>>,
             response: Mutex<Option<RespondOutput>>,
         }
 
         #[async_trait]
-        impl LoopDelegate for CaptureDelegate {
-            async fn check_signals(&self) -> LoopSignal {
-                LoopSignal::Continue
-            }
-            async fn before_llm_call(
-                &self,
-                _: &mut ReasoningContext,
-                _: usize,
-            ) -> Option<LoopOutcome> {
-                None
-            }
-            async fn call_llm(
+        impl AgentResponder for CaptureResponder {
+            async fn respond(
                 &self,
                 ctx: &mut ReasoningContext,
-                _: usize,
             ) -> Result<RespondOutput, HostError> {
                 let last_user = ctx
                     .messages
@@ -1011,8 +1230,14 @@ mod tests {
                     .find(|m| m.role == Role::User)
                     .map(|m| m.content.clone());
                 *self.seen.lock().await = last_user;
-                Ok(self.response.lock().await.take().expect("one response"))
+                Ok(self
+                    .response
+                    .lock()
+                    .await
+                    .take()
+                    .expect("one response queued"))
             }
+
             async fn handle_text_response(
                 &self,
                 text: &str,
@@ -1022,18 +1247,9 @@ mod tests {
             ) -> TextAction {
                 TextAction::Return(LoopOutcome::Response(text.to_string()))
             }
-            async fn execute_tool_calls(
-                &self,
-                _: Vec<ToolCall>,
-                _: Option<String>,
-                _: TokenUsage,
-                _: &mut ReasoningContext,
-            ) -> Result<Option<LoopOutcome>, HostError> {
-                Ok(None)
-            }
         }
 
-        let delegate = CaptureDelegate {
+        let responder = CaptureResponder {
             seen: Mutex::new(None),
             response: Mutex::new(Some(text_output("raw completion"))),
         };
@@ -1042,21 +1258,26 @@ mod tests {
             .push(ChatMessage::user("please use token sk-secret now"));
         let hooks = custom_egress_bundle(Arc::new(RedactingGate));
 
-        let outcome = run_agentic_loop(&delegate, &mut ctx, &AgenticLoopConfig::default(), &hooks)
+        let outcome = run_with(&responder, &mut ctx, &AgenticLoopConfig::default(), &hooks)
             .await
-            .unwrap();
+            .expect("loop completes");
 
         match outcome {
             LoopOutcome::Response(t) => {
                 assert_eq!(
                     t, "raw completion [scanned]",
-                    "UserDisplay Redact must mutate the text before the delegate returns"
+                    "UserDisplay Redact must mutate the text before the responder returns"
                 );
             }
-            _ => panic!("expected Response"),
+            other => panic!("expected Response, got {other:?}-ish"),
         }
 
-        let seen = delegate.seen.lock().await.clone().unwrap();
+        let seen = responder
+            .seen
+            .lock()
+            .await
+            .clone()
+            .expect("respond saw a user message");
         assert!(
             !seen.contains("sk-secret"),
             "LlmRequest Redact must rewrite the payload; LLM saw: {seen}"
@@ -1066,13 +1287,11 @@ mod tests {
             "redaction token must be present; LLM saw: {seen}"
         );
 
-        // Redacted content must persist in ctx.messages so the next
-        // iteration also sees the clean text.
         let stored = ctx
             .messages
             .iter()
             .find(|m| m.role == Role::User)
-            .unwrap()
+            .expect("ctx still has the user message")
             .content
             .clone();
         assert!(
@@ -1085,12 +1304,12 @@ mod tests {
     async fn egress_gate_internal_error_translates_to_failure() {
         // ADR-148: fail-closed contract — internal errors surface as Block,
         // not panics or HostError. The loop converts Block into Failure.
-        let delegate = MockDelegate::new(vec![text_output("unreachable")]);
+        let responder = MockResponder::new(vec![text_output("unreachable")]);
         let mut ctx = ReasoningContext::new();
         ctx.messages.push(ChatMessage::user("anything"));
         let hooks = custom_egress_bundle(Arc::new(FailingGate));
 
-        let outcome = run_agentic_loop(&delegate, &mut ctx, &AgenticLoopConfig::default(), &hooks)
+        let outcome = run_with(&responder, &mut ctx, &AgenticLoopConfig::default(), &hooks)
             .await
             .expect("FailingGate must NOT bubble HostError — fail-closed translates to Failure");
 
@@ -1101,7 +1320,7 @@ mod tests {
                     "failure reason should preserve inner cause, got: {reason}"
                 );
             }
-            other => panic!("expected Failure, got {other:?}"),
+            other => panic!("expected Failure, got {other:?}-ish"),
         }
     }
 }

--- a/crates/dasclaw_core/src/hooks.rs
+++ b/crates/dasclaw_core/src/hooks.rs
@@ -348,14 +348,14 @@ impl ApprovalGate for DenyAllGate {
 /// `egress.check(EgressKind::UserDisplay, …)` directly (ADR-148).
 /// Tool-level egress (`EgressKind::ToolExecution`) and
 /// `ApprovalGate::request` are the responsibility of the
-/// [`LoopDelegate::execute_tool_calls`](crate::agentic_loop::LoopDelegate)
-/// implementation — delegates typically hold their own `Arc<HookBundle>`
+/// [`ToolDispatcher::dispatch`](crate::agentic_loop::ToolDispatcher)
+/// implementation — dispatchers typically hold their own `Arc<HookBundle>`
 /// and call into it during tool iteration.
 ///
-/// Keeping tool-level egress out of the loop avoids forcing every delegate
-/// to re-express the tool execution contract through the loop signature.
-/// The runtime stays narrow; delegates stay in charge of their own
-/// tool dispatch.
+/// Keeping tool-level egress out of the loop avoids forcing every
+/// dispatcher to re-express the tool execution contract through the loop
+/// signature. The runtime stays narrow; dispatchers stay in charge of
+/// their own tool dispatch.
 #[derive(Clone)]
 pub struct HookBundle {
     /// ADR-148 Layer B egress gate (replaces former `safety: Arc<dyn SafetyHook>`).

--- a/crates/dasclaw_runtime/README.md
+++ b/crates/dasclaw_runtime/README.md
@@ -66,10 +66,10 @@ The two **traits you actually have to implement** to integrate a new host are
 
 ### Why two narrow traits instead of one fat one
 
-`AgentResponder` mirrors `LoopDelegate::call_llm` one-to-one and is a single
-method. `ToolExecutor` is likewise single-method. Splitting along the LLM ↔
-tool seam means an adapter author only implements the side they care about, and
-the runtime never has to construct a no-op tool executor for text-only flows.
+`AgentResponder` is the LLM seam and is a single method.  `ToolExecutor` is
+likewise single-method. Splitting along the LLM ↔ tool seam means an adapter
+author only implements the side they care about, and the runtime never has to
+construct a no-op tool executor for text-only flows.
 
 `dasclaw_core::traits::LlmCompleter` exists too but is **text-only** — it
 returns `String`, not `RespondOutput`, so it cannot carry tool calls or finish
@@ -87,7 +87,7 @@ dedicated `AgentResponder`.
 | `ToolsNotSupported` | Model asked for a tool but no `ToolExecutor` was wired. |
 | `LoopFailure(reason)` | `LoopOutcome::Failure(_)`, typically from an egress hook. |
 | `Stopped` | External `LoopSignal::Stop` halted the loop. |
-| `ApprovalRequested` | **Deprecated** (issue #910). Only surfaced by custom `LoopDelegate` impls that bypass the approval inbox; the headless delegate now emits `AgentEvent::ApprovalNeeded` instead. |
+| `ApprovalRequested` | **Deprecated** (issue #910). Only surfaced by custom tool-dispatch paths that bypass the approval inbox; the built-in `SequentialDispatcher` emits `AgentEvent::ApprovalNeeded` instead. |
 | `ApprovalRejected { tool_name, reason }` | The GUI replied `ApprovalDecision::Reject` for a tool call. |
 | `Responder(HostError)` | Underlying responder / hook errored. |
 
@@ -138,7 +138,7 @@ builder API — `dasclaw_runtime` does not wrap it.
 
 | Module | Sketch |
 |---|---|
-| [`agent`](src/agent.rs) | `Agent`, `AgentBuilder`, `AgentResponder`, `ToolExecutor`, `AgentError`, `AgentConfig`, internal `HeadlessDelegate`. |
+| [`agent`](src/agent.rs) | `Agent`, `AgentBuilder`, re-exports `AgentResponder` from core, `ToolExecutor`, `AgentError`, `AgentConfig`. |
 | [`composite_executor`](src/composite_executor.rs) | `CompositeToolExecutor` + `CompositeError`. |
 | [`context`](src/context/) | Per-job context object & helpers. |
 | [`error`](src/error.rs) | App-layer `ToolError`. |

--- a/crates/dasclaw_runtime/src/agent.rs
+++ b/crates/dasclaw_runtime/src/agent.rs
@@ -17,10 +17,10 @@
 //! ## Scope (A1 + A2)
 //!
 //! - **A1** — public shape (`Agent`, `AgentBuilder`, `AgentConfig`,
-//!   `AgentError`), wraps [`dasclaw_core::agentic_loop::run_agentic_loop`]
-//!   with an internal `HeadlessDelegate` and a configurable `HookBundle`.
-//!   The narrow [`AgentResponder`] trait is the single seam where any LLM
-//!   adapter plugs in.
+//!   `AgentError`), wraps the [`AgenticLoop`] runtime engine with a
+//!   configurable [`HookBundle`]. The narrow [`AgentResponder`] trait
+//!   (re-exported from [`dasclaw_core::agentic_loop`]) is the single
+//!   seam where any LLM adapter plugs in.
 //! - **A2** — tool execution wiring. A second narrow trait
 //!   [`ToolExecutor`] lets callers plug in a real tool runner. When wired,
 //!   the loop dispatches each tool call through the executor and feeds the
@@ -37,18 +37,19 @@
 //! intended for compaction summaries and similar one-shot helpers — it
 //! returns a `String`, not a `RespondOutput`, so it cannot carry tool
 //! calls or finish reasons. The agent loop fundamentally needs
-//! `RespondOutput`, so the seam here mirrors `LoopDelegate::call_llm`'s
-//! signature one-to-one and stays single-method to keep the wire-up cost
-//! for adapter authors trivial.
+//! `RespondOutput`, so the [`AgentResponder`] seam is a dedicated
+//! single-method trait — adapter authors only ever need to implement
+//! `respond` (and optionally `respond_streaming` for token streaming).
 
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use dasclaw_core::agentic_loop::{AgenticLoopConfig, LoopOutcome, LoopSignal, TextAction};
+pub(crate) use dasclaw_core::agentic_loop::TOOLS_NOT_SUPPORTED_REASON;
+pub use dasclaw_core::agentic_loop::{AgentEvent, AgentResponder};
+use dasclaw_core::agentic_loop::{AgenticLoopConfig, LoopOutcome};
 use dasclaw_core::hooks::HookBundle;
-use dasclaw_core::messages::{ChatMessage, FinishReason, ToolCall, ToolDefinition, ToolResult};
+use dasclaw_core::messages::{ChatMessage, ToolCall, ToolDefinition, ToolResult};
 use dasclaw_core::reasoning_ctx::ReasoningContext;
-use dasclaw_core::response_types::{RespondOutput, RespondResult, ResponseMetadata, TokenUsage};
 use dasclaw_core::traits::HostError;
 use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc;
@@ -63,185 +64,6 @@ use crate::approval::{
 use crate::tool_dispatch::{
     APPROVAL_REJECTED_SENTINEL_PREFIX, RejectedPayload, SequentialDispatcher, ToolDispatcher,
 };
-
-/// Streaming event emitted by [`Agent::run_streaming`] and
-/// [`crate::Session::run_streaming`] (issue #908, GUI blocker B2).
-///
-/// One event per observable step in the agentic loop:
-///
-/// - [`AgentEvent::TextChunk`] — a fragment of model output as it
-///   arrives from the LLM. For providers without true token streaming
-///   the chunk arrives in a single piece; consumers should not depend
-///   on a particular chunk size.
-/// - [`AgentEvent::ToolCallStart`] — the model asked to invoke a tool;
-///   emitted before [`ToolExecutor::execute`] runs.
-/// - [`AgentEvent::ToolResult`] — the tool finished; payload is the
-///   sanitized content that the **next** LLM iteration will see in its
-///   `tool_result` block (post-egress, post-sanitizer).
-/// - [`AgentEvent::FinishReason`] — one per LLM iteration boundary,
-///   carrying the model's stop reason. Use it to render "stopped",
-///   "needs tool", etc. in a GUI.
-///
-/// Wire format is adjacent-tagged JSON
-/// (`{"kind": "text_chunk", "data": "..."}`) so a TypeScript discriminated
-/// union renders directly from `serde_json::to_string(&event)`.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(tag = "kind", content = "data", rename_all = "snake_case")]
-pub enum AgentEvent {
-    /// A fragment of model text output.
-    TextChunk(String),
-    /// The model requested a tool invocation.
-    ToolCallStart {
-        /// Tool name as emitted by the model.
-        name: String,
-        /// Tool arguments as raw JSON.
-        arguments: serde_json::Value,
-    },
-    /// A tool finished; `content` is the post-sanitization payload that
-    /// is fed back into the next LLM iteration.
-    ToolResult {
-        /// Tool name as it appeared in the matching
-        /// [`AgentEvent::ToolCallStart`].
-        name: String,
-        /// Sanitized tool output that the LLM will see next iteration.
-        content: String,
-        /// `true` when the executor returned an error tool_result or the
-        /// egress gate replaced the content with a `[redacted: …]`
-        /// placeholder.
-        is_error: bool,
-    },
-    /// Stop reason for the LLM iteration that just ended.
-    FinishReason(FinishReason),
-    /// The configured [`crate::ApprovalPolicy`] flagged a tool call as
-    /// needing human approval (issue #910, GUI blocker B4).
-    ///
-    /// The agent loop has paused waiting for
-    /// [`Agent::respond_to_approval`] to dispatch a matching
-    /// [`crate::ApprovalDecision`] for `request_id`. Until then no
-    /// further [`AgentEvent`]s are emitted for this turn.
-    ApprovalNeeded {
-        /// Unique handle the GUI feeds back into
-        /// [`Agent::respond_to_approval`].
-        request_id: Uuid,
-        /// Tool name as emitted by the model.
-        tool_name: String,
-        /// Raw tool arguments, mirroring the matching
-        /// [`AgentEvent::ToolCallStart`] payload.
-        tool_arguments: serde_json::Value,
-        /// Human-readable description supplied by the policy.
-        description: String,
-        /// Sanitised parameters preview the GUI should render — *not*
-        /// the raw arguments.
-        display_parameters: serde_json::Value,
-        /// `true` when the GUI may surface an "approve always"
-        /// affordance.
-        allow_always: bool,
-    },
-}
-
-/// Narrow LLM seam used by [`Agent`].
-///
-/// Adapters wrap a concrete LLM client (`dasclaw_llm_provider`, a mock,
-/// a recorder, …) and translate from the provider-native response into a
-/// [`RespondOutput`]. The runtime calls [`Self::respond`] once per
-/// iteration of the agentic loop in non-streaming mode, and
-/// [`Self::respond_streaming`] when the host wants token-level events.
-#[async_trait]
-pub trait AgentResponder: Send + Sync {
-    /// Produce the next response for the given context.
-    async fn respond(&self, ctx: &mut ReasoningContext) -> Result<RespondOutput, HostError>;
-
-    /// Streaming-aware variant used by [`Agent::run_streaming`]
-    /// (issue #908, GUI blocker B2).
-    ///
-    /// `event_tx` is the same channel the agent loop forwards
-    /// [`AgentEvent`]s on. Implementations emit one or more
-    /// [`AgentEvent::TextChunk`] events as the model produces text and
-    /// then return the final [`RespondOutput`] so the loop can dispatch
-    /// to tool execution or finish.
-    ///
-    /// The default implementation calls [`Self::respond`] and forwards
-    /// the final text (if any) as a single chunk, so every existing
-    /// adapter stays wire-compatible without code changes. Adapters
-    /// backed by streaming providers (`LlmProviderResponder`) override
-    /// this method to forward token-level deltas as they arrive.
-    ///
-    /// `ToolCallStart`, `ToolResult` and `FinishReason` events are emitted
-    /// by the agent loop itself — implementations should only emit
-    /// [`AgentEvent::TextChunk`].
-    async fn respond_streaming(
-        &self,
-        ctx: &mut ReasoningContext,
-        event_tx: mpsc::Sender<AgentEvent>,
-    ) -> Result<RespondOutput, HostError> {
-        let out = self.respond(ctx).await?;
-        if let RespondResult::Text(ref text) = out.result {
-            // Drop on closed channel is fine: the consumer hung up, but
-            // the loop still needs to return the full RespondOutput.
-            let _ = event_tx.send(AgentEvent::TextChunk(text.clone())).await;
-        }
-        Ok(out)
-    }
-
-    /// Per-iteration signal check (W8.0).
-    ///
-    /// Returned every loop turn before any LLM call. The default keeps
-    /// the loop running; hosts that drain a stop / cancellation channel
-    /// override this. The [`AgenticLoop`]'s own cancellation token is
-    /// honoured independently — a `Continue` here cannot override an
-    /// already-cancelled token.
-    async fn check_signals(&self) -> LoopSignal {
-        LoopSignal::Continue
-    }
-
-    /// Pre-LLM iteration setup (W8.0).
-    ///
-    /// Runs after [`Self::check_signals`] and before [`Self::respond`].
-    /// Hosts use it to mutate the context (inject prompts, swap tool
-    /// tables, force text mode) or short-circuit the loop by returning
-    /// `Some(outcome)`. The default is a no-op.
-    async fn before_llm_call(
-        &self,
-        _ctx: &mut ReasoningContext,
-        _iteration: usize,
-    ) -> Option<LoopOutcome> {
-        None
-    }
-
-    /// React to a pure-text LLM response (W8.0).
-    ///
-    /// Called when [`Self::respond`] yields a [`RespondResult::Text`]
-    /// payload. The default appends the assistant message to `ctx` and
-    /// terminates the loop with [`LoopOutcome::Response`], matching the
-    /// pre-W8.0 `LoopAdapter` behaviour. Hosts that need recovery /
-    /// completion-detection logic override this and may return
-    /// [`TextAction::Continue`] to keep iterating.
-    async fn handle_text_response(
-        &self,
-        text: &str,
-        _metadata: ResponseMetadata,
-        usage: TokenUsage,
-        ctx: &mut ReasoningContext,
-    ) -> TextAction {
-        ctx.messages
-            .push(ChatMessage::assistant(text).with_usage(usage));
-        TextAction::Return(LoopOutcome::Response(text.to_string()))
-    }
-
-    /// React to a tool-intent nudge being injected (W8.0).
-    ///
-    /// Called when the loop detects the model produced text that looked
-    /// like a tool intent and injects a corrective nudge. Default is a
-    /// no-op; hosts override to emit a UI event.
-    async fn on_tool_intent_nudge(&self, _text: &str, _ctx: &mut ReasoningContext) {}
-
-    /// End-of-iteration callback (W8.0).
-    ///
-    /// Called after every successful iteration that did not return an
-    /// outcome. Default is a no-op; hosts use it for throttling /
-    /// progress reporting.
-    async fn after_iteration(&self, _iteration: usize) {}
-}
 
 /// Narrow tool-execution seam used by [`Agent`] (ADR-153 step 2 sub-step A2).
 ///
@@ -353,7 +175,7 @@ pub enum AgentError {
     /// A tool approval was requested but the active [`crate::ApprovalPolicy`]
     /// path produced no [`crate::AgentEvent::ApprovalNeeded`] for it.
     ///
-    /// This variant only fires when a custom [`LoopDelegate`] surfaces
+    /// This variant only fires when the agent loop surfaces
     /// [`LoopOutcome::NeedApproval`] outside the headless
     /// approval-inbox pipeline; the GUI-friendly path is
     /// [`crate::AgentEvent::ApprovalNeeded`] + [`Agent::respond_to_approval`]
@@ -362,7 +184,7 @@ pub enum AgentError {
     /// Kept for wire backwards compatibility with issue #909 consumers.
     #[deprecated(
         since = "0.0.0-w6",
-        note = "GUI hosts should listen for AgentEvent::ApprovalNeeded and reply via Agent::respond_to_approval; only custom LoopDelegate impls that bypass the approval inbox should still surface this variant"
+        note = "GUI hosts should listen for AgentEvent::ApprovalNeeded and reply via Agent::respond_to_approval; only custom tool-dispatch paths that bypass the approval inbox should still surface this variant"
     )]
     #[error("agent loop requested approval, which is not supported in headless mode")]
     ApprovalRequested,
@@ -502,7 +324,8 @@ pub struct Agent {
     tool_output_sanitizer: Option<Arc<dyn ToolOutputSanitizer>>,
     hooks: HookBundle,
     config: AgentConfig,
-    /// Optional cancellation token wired through [`HeadlessDelegate::check_signals`].
+    /// Optional cancellation token forwarded to
+    /// [`dasclaw_core::agentic_loop::run_agentic_loop`].
     /// When set and tripped, the agentic loop exits with
     /// [`AgentError::Stopped`] on the next signal check. See issue #907.
     cancellation_token: Option<CancellationToken>,
@@ -510,9 +333,10 @@ pub struct Agent {
     /// [`NoApprovalPolicy`] so existing callers keep their zero-event
     /// behaviour bit-for-bit.
     approval_policy: Arc<dyn ApprovalPolicy>,
-    /// Pending approval inbox shared with [`HeadlessDelegate`] for the
-    /// lifetime of the agent. [`Agent::respond_to_approval`] dispatches
-    /// into this inbox once the GUI replies.
+    /// Pending approval inbox shared with the internal
+    /// `SequentialDispatcher` for the lifetime of the agent.
+    /// [`Agent::respond_to_approval`] dispatches into this inbox once
+    /// the GUI replies.
     approval_inbox: ApprovalInbox,
 }
 
@@ -630,11 +454,9 @@ impl Agent {
             .map(clone_loop_config)
             .unwrap_or_default();
 
-        // Build the L2 dispatcher once for the lifetime of this run
-        // (pre-W6.4 rebuilt it on every iteration inside
-        // `HeadlessDelegate::execute_tool_calls`). When no executor is
-        // wired, leave the dispatcher unset so the loop emits the
-        // `TOOLS_NOT_SUPPORTED_REASON` sentinel just like before.
+        // Build the L2 dispatcher once for the lifetime of this run.
+        // When no executor is wired, leave the dispatcher unset so the
+        // loop emits the `TOOLS_NOT_SUPPORTED_REASON` sentinel.
         let dispatcher: Option<Arc<dyn ToolDispatcher>> = self.tool_executor.as_ref().map(|exec| {
             Arc::new(SequentialDispatcher::new(
                 Arc::clone(exec),
@@ -848,11 +670,6 @@ impl AgentBuilder {
     }
 }
 
-/// Sentinel string emitted by [`AgenticLoop`]'s tool-call branch when
-/// no [`ToolDispatcher`] is wired, then re-mapped to
-/// [`AgentError::ToolsNotSupported`] by [`map_outcome`].
-pub(crate) const TOOLS_NOT_SUPPORTED_REASON: &str = "headless-agent::tools-not-supported";
-
 fn map_outcome(outcome: LoopOutcome, max_iterations: usize) -> Result<String, AgentError> {
     match outcome {
         LoopOutcome::Response(text) => Ok(text),
@@ -876,7 +693,7 @@ fn map_outcome(outcome: LoopOutcome, max_iterations: usize) -> Result<String, Ag
             }
         }
         LoopOutcome::Stopped => Err(AgentError::Stopped),
-        // Custom LoopDelegate impls that surface NeedApproval bypass the
+        // Custom tool-dispatch paths that surface NeedApproval bypass the
         // approval-inbox pipeline; keep the deprecated wire variant so
         // they keep compiling. New GUI hosts should rely on
         // AgentEvent::ApprovalNeeded + Agent::respond_to_approval.
@@ -889,7 +706,9 @@ fn map_outcome(outcome: LoopOutcome, max_iterations: usize) -> Result<String, Ag
 mod tests {
     use super::*;
     use dasclaw_core::messages::{FinishReason, ToolCall};
-    use dasclaw_core::response_types::{RespondResult, ResponseMetadata, TokenUsage};
+    use dasclaw_core::response_types::{
+        RespondOutput, RespondResult, ResponseMetadata, TokenUsage,
+    };
 
     /// Mock responder driven by a fixed sequence of pre-built outputs.
     struct ScriptedResponder {
@@ -954,8 +773,8 @@ mod tests {
 
     #[tokio::test]
     async fn req_dasclaw_runtime_agent_929_text_branch_persists_usage_to_context() {
-        // #929 step 2: the final assistant ChatMessage recorded by
-        // HeadlessDelegate::handle_text_response must carry the per-turn
+        // #929 step 2: the final assistant ChatMessage recorded on the
+        // text branch of run_agentic_loop must carry the per-turn
         // TokenUsage from the LLM call that produced it, so multi-turn
         // Session::run can persist real cost data.
         let usage = TokenUsage {

--- a/crates/dasclaw_runtime/src/agentic_loop.rs
+++ b/crates/dasclaw_runtime/src/agentic_loop.rs
@@ -1,60 +1,30 @@
-//! ADR-160 §3 L1: `AgenticLoop` as a concrete struct (W6.4).
+//! ADR-160 §3 L1: `AgenticLoop` as a concrete struct (W6.4; updated W10.1).
 //!
-//! Wraps [`dasclaw_core::agentic_loop::run_agentic_loop`] behind a
-//! struct that owns the seams the loop needs at runtime: the LLM
-//! responder, an optional [`ToolDispatcher`] (L2 seam), a cancellation
-//! token, and a streaming event channel. The struct is the new
-//! single-entry point that [`crate::Agent`] drives; the prior
-//! private `HeadlessDelegate` is now an internal adapter
-//! ([`LoopAdapter`]) whose `LoopDelegate` impl is a byte-identical
-//! move of the pre-W6.4 inline implementation.
-//!
-//! ## Why a struct, not a free function
-//!
-//! The pre-W6.4 path built a fresh `HeadlessDelegate` per
-//! `run_in_context_inner` call and re-constructed
-//! [`SequentialDispatcher`] inside `execute_tool_calls` on **every
-//! iteration**. The struct gives us:
-//!
-//! - one place that owns the dispatcher for the lifetime of the run
-//!   (built once at `Agent::run_in_context_inner`, not per iteration);
-//! - a stable injection point for fakes / parallel dispatchers /
-//!   replay engines without touching the agentic-loop crate;
-//! - the L1 seam ADR-160 §3 asks for, so future hosts can build
-//!   loops without going through `Agent` at all.
-//!
-//! ## Scope (W6.4)
-//!
-//! - Byte-equivalent behaviour with the pre-W6.4 `HeadlessDelegate`.
-//! - No public-API churn for `Agent` / `AgentBuilder` callers.
-//! - `desktop-client/ironclaw` delegates (ChatDelegate / JobDelegate /
-//!   ContainerDelegate) are untouched — they keep calling
-//!   `run_agentic_loop` directly.
+//! W10.1 collapsed the prior `LoopDelegate` adapter — the new
+//! [`dasclaw_core::agentic_loop::run_agentic_loop`] takes the same four
+//! seams ([`AgentResponder`], [`ToolDispatcher`], cancellation token,
+//! event channel) directly, so the `LoopAdapter` shim is gone. This
+//! struct now exists purely as the L1 façade hosts that don't need a
+//! [`crate::Agent`] facade can target, and to own the per-run
+//! collaborators for as long as the run is in flight.
 
 use std::sync::Arc;
 
-use async_trait::async_trait;
 use dasclaw_core::agentic_loop::{
-    AgenticLoopConfig, LoopDelegate, LoopOutcome, LoopSignal, TextAction, run_agentic_loop,
+    AgentEvent, AgentResponder, AgenticLoopConfig, LoopOutcome, ToolDispatcher, run_agentic_loop,
 };
 use dasclaw_core::hooks::HookBundle;
-use dasclaw_core::messages::ToolCall;
 use dasclaw_core::reasoning_ctx::ReasoningContext;
-use dasclaw_core::response_types::{RespondOutput, ResponseMetadata, TokenUsage};
 use dasclaw_core::traits::HostError;
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
-
-use crate::agent::{AgentEvent, AgentResponder, TOOLS_NOT_SUPPORTED_REASON};
-use crate::tool_dispatch::{ToolDispatcher, emit_event};
 
 /// L1 seam (ADR-160 §3): concrete agentic-loop driver.
 ///
 /// Owns the per-run collaborators (`responder`, `dispatcher`,
 /// `cancellation_token`, `event_tx`) and forwards to
-/// [`run_agentic_loop`] via an internal [`LoopAdapter`]. Hosts that
-/// don't need a [`crate::Agent`] facade can build an `AgenticLoop`
-/// directly.
+/// [`run_agentic_loop`]. Hosts that don't need a [`crate::Agent`]
+/// facade can build an `AgenticLoop` directly.
 pub struct AgenticLoop {
     responder: Arc<dyn AgentResponder>,
     dispatcher: Option<Arc<dyn ToolDispatcher>>,
@@ -67,8 +37,8 @@ impl AgenticLoop {
     ///
     /// Pass `dispatcher = None` to keep the agent in text-only mode;
     /// any model-emitted tool call then resolves to the
-    /// [`TOOLS_NOT_SUPPORTED_REASON`] sentinel, matching the pre-W6.4
-    /// `HeadlessDelegate` contract.
+    /// `TOOLS_NOT_SUPPORTED_REASON` sentinel, matching the pre-W6.4
+    /// pre-W10.1 `HeadlessDelegate` contract.
     #[must_use]
     pub fn new(
         responder: Arc<dyn AgentResponder>,
@@ -95,108 +65,15 @@ impl AgenticLoop {
         loop_config: &AgenticLoopConfig,
         hooks: &HookBundle,
     ) -> Result<LoopOutcome, HostError> {
-        let adapter = LoopAdapter { inner: self };
-        run_agentic_loop(&adapter, ctx, loop_config, hooks).await
-    }
-}
-
-/// Internal `LoopDelegate` adapter. Byte-identical move of the
-/// pre-W6.4 `HeadlessDelegate::LoopDelegate` impl, refactored to
-/// borrow its dependencies from an enclosing [`AgenticLoop`].
-struct LoopAdapter<'a> {
-    inner: &'a AgenticLoop,
-}
-
-impl<'a> LoopAdapter<'a> {
-    /// Best-effort emit; a closed receiver is not a loop-fatal error.
-    async fn emit(&self, event: AgentEvent) {
-        emit_event(self.inner.event_tx.as_ref(), event).await;
-    }
-}
-
-#[async_trait]
-impl<'a> LoopDelegate for LoopAdapter<'a> {
-    async fn check_signals(&self) -> LoopSignal {
-        // Cancellation token short-circuits the responder hook: a
-        // cancelled token always wins even if the responder would
-        // return `Continue`.
-        if let Some(token) = self.inner.cancellation_token.as_ref()
-            && token.is_cancelled()
-        {
-            return LoopSignal::Stop;
-        }
-        self.inner.responder.check_signals().await
-    }
-
-    async fn before_llm_call(
-        &self,
-        ctx: &mut ReasoningContext,
-        iteration: usize,
-    ) -> Option<LoopOutcome> {
-        self.inner.responder.before_llm_call(ctx, iteration).await
-    }
-
-    async fn call_llm(
-        &self,
-        ctx: &mut ReasoningContext,
-        _iteration: usize,
-    ) -> Result<RespondOutput, HostError> {
-        // Streaming and non-streaming routes split at the responder
-        // seam: when an event channel is wired we go through
-        // `respond_streaming`, which the default trait impl falls back
-        // to `respond` for adapters that don't override it. Either way
-        // we forward the trailing `FinishReason` so a GUI knows the
-        // iteration boundary even when the model emitted no text.
-        let output = match self.inner.event_tx.as_ref() {
-            Some(tx) => {
-                self.inner
-                    .responder
-                    .respond_streaming(ctx, tx.clone())
-                    .await?
-            }
-            None => self.inner.responder.respond(ctx).await?,
-        };
-        self.emit(AgentEvent::FinishReason(output.finish_reason))
-            .await;
-        Ok(output)
-    }
-
-    async fn handle_text_response(
-        &self,
-        text: &str,
-        metadata: ResponseMetadata,
-        usage: TokenUsage,
-        ctx: &mut ReasoningContext,
-    ) -> TextAction {
-        self.inner
-            .responder
-            .handle_text_response(text, metadata, usage, ctx)
-            .await
-    }
-
-    async fn execute_tool_calls(
-        &self,
-        tool_calls: Vec<ToolCall>,
-        content: Option<String>,
-        usage: TokenUsage,
-        ctx: &mut ReasoningContext,
-    ) -> Result<Option<LoopOutcome>, HostError> {
-        // No dispatcher wired → emit the sentinel and let `map_outcome`
-        // raise `AgentError::ToolsNotSupported`. This keeps the A1
-        // contract intact when callers use text-only agents.
-        let Some(dispatcher) = self.inner.dispatcher.as_ref() else {
-            return Ok(Some(LoopOutcome::Failure(
-                TOOLS_NOT_SUPPORTED_REASON.to_string(),
-            )));
-        };
-        dispatcher.dispatch(tool_calls, content, usage, ctx).await
-    }
-
-    async fn on_tool_intent_nudge(&self, text: &str, ctx: &mut ReasoningContext) {
-        self.inner.responder.on_tool_intent_nudge(text, ctx).await;
-    }
-
-    async fn after_iteration(&self, iteration: usize) {
-        self.inner.responder.after_iteration(iteration).await;
+        run_agentic_loop(
+            self.responder.as_ref(),
+            self.dispatcher.as_deref(),
+            self.cancellation_token.as_ref(),
+            self.event_tx.as_ref(),
+            ctx,
+            loop_config,
+            hooks,
+        )
+        .await
     }
 }

--- a/crates/dasclaw_runtime/src/approval.rs
+++ b/crates/dasclaw_runtime/src/approval.rs
@@ -6,7 +6,8 @@
 //! that wants a "user-in-the-loop" workflow for dangerous tool calls.
 //!
 //! This module supplies the pieces the GUI loop needs without touching
-//! the `dasclaw_core` `LoopDelegate` / `LoopOutcome` public contract:
+//! the `dasclaw_core` `AgentResponder` / `ToolDispatcher` / `LoopOutcome`
+//! public contract:
 //!
 //! - [`ApprovalPolicy`] — pluggable rule that decides whether a given
 //!   [`dasclaw_core::messages::ToolCall`] needs human approval. Default
@@ -22,8 +23,8 @@
 //!   is unknown or its channel has been dropped.
 //!
 //! The runtime owns one [`ApprovalInbox`] per [`crate::Agent`]; the
-//! `HeadlessDelegate` inserts a one-shot sender when it emits
-//! [`crate::AgentEvent::ApprovalNeeded`] and the GUI calls
+//! internal `SequentialDispatcher` inserts a one-shot sender when it
+//! emits [`crate::AgentEvent::ApprovalNeeded`] and the GUI calls
 //! [`crate::Agent::respond_to_approval`] to resolve it.
 
 use std::collections::HashMap;

--- a/crates/dasclaw_runtime/src/tool_dispatch.rs
+++ b/crates/dasclaw_runtime/src/tool_dispatch.rs
@@ -1,24 +1,20 @@
-//! Sequential tool dispatcher extracted from `HeadlessDelegate`.
+//! Sequential tool dispatcher (ADR-153 §1.1 5-step pipeline).
 //!
-//! Encapsulates the per-iteration 5-step pipeline ADR-153 §1.1 locks
-//! in (emit `ToolCallStart` → approval gate → pre-execute egress →
-//! `ToolExecutor::execute` → post-execute egress + sanitizer + emit
-//! `ToolResult`) so that:
+//! Encapsulates the per-iteration pipeline (emit `ToolCallStart` →
+//! approval gate → pre-execute egress → `ToolExecutor::execute` →
+//! post-execute egress + sanitizer + emit `ToolResult`) so that the
+//! agentic loop's tool-execution branch reduces to a one-shot
+//! `SequentialDispatcher::dispatch` call via the
+//! [`ToolDispatcher`](dasclaw_core::agentic_loop::ToolDispatcher) trait
+//! re-exported below.
 //!
-//! * `HeadlessDelegate::execute_tool_calls` reduces to a one-shot
-//!   `SequentialDispatcher::dispatch` call, and
-//! * a future `AgenticLoop` (ADR-160 §3 L1) can reuse the same
-//!   implementation by injecting a `ToolDispatcher` trait whose
-//!   default impl is this struct.
-//!
-//! This module is a pure refactor: behaviour is byte-identical to the
-//! pre-extraction inline pipeline. The `agent.rs` tests cover the
-//! shape end-to-end.
+//! The `agent.rs` tests cover the shape end-to-end.
 
 use std::sync::Arc;
 
 use async_trait::async_trait;
 use dasclaw_core::agentic_loop::LoopOutcome;
+pub use dasclaw_core::agentic_loop::ToolDispatcher;
 use dasclaw_core::egress_apply::{EgressApply, apply_egress_decision};
 use dasclaw_core::hooks::{EgressGate, EgressKind};
 use dasclaw_core::messages::{ChatMessage, ToolCall};
@@ -48,9 +44,10 @@ pub(crate) struct RejectedPayload {
 
 /// Best-effort emit; a closed receiver is not a loop-fatal error.
 ///
-/// Shared between the `HeadlessDelegate` (which emits `FinishReason`
-/// outside the tool pipeline) and `SequentialDispatcher` so the two
-/// sites cannot drift.
+/// Used by [`SequentialDispatcher`] for `ToolCallStart` / `ToolResult`
+/// events. The core agentic loop has its own private `emit_event` for
+/// `FinishReason` emission; keeping a runtime-side copy avoids
+/// publishing helper internals from `dasclaw_core`.
 pub(crate) async fn emit_event(tx: Option<&mpsc::Sender<AgentEvent>>, event: AgentEvent) {
     if let Some(tx) = tx {
         let _ = tx.send(event).await;
@@ -70,29 +67,11 @@ fn push_assistant_tool_calls(
     );
 }
 
-/// L2 seam (ADR-160 §3): drive a single agentic-loop iteration's
-/// tool calls through whatever pipeline the host wires up.
-///
-/// The only in-tree impl today is [`SequentialDispatcher`], which
-/// preserves the ADR-153 §1.1 5-step pipeline byte-for-byte. Future
-/// `AgenticLoop`-level implementations (parallel dispatch, replay,
-/// fakes for testing) plug in here without touching
-/// `HeadlessDelegate` or `run_agentic_loop`.
-#[async_trait]
-pub trait ToolDispatcher: Send + Sync {
-    /// Execute one iteration's worth of tool calls.
-    ///
-    /// Returning `Ok(Some(outcome))` short-circuits the agentic loop
-    /// (e.g. approval rejection, fatal sandbox refusal). Returning
-    /// `Ok(None)` lets the loop run another model turn.
-    async fn dispatch(
-        &self,
-        tool_calls: Vec<ToolCall>,
-        content: Option<String>,
-        usage: TokenUsage,
-        ctx: &mut ReasoningContext,
-    ) -> Result<Option<LoopOutcome>, HostError>;
-}
+// `ToolDispatcher` itself now lives in `dasclaw_core::agentic_loop`
+// (re-exported above) so that downstream tool dispatchers and the
+// core loop share the exact same trait object. The only in-tree impl
+// today is `SequentialDispatcher` (below), which preserves the
+// ADR-153 §1.1 5-step pipeline byte-for-byte.
 
 /// Sequential implementation of the ADR-153 §1.1 tool dispatch
 /// pipeline. Executes the supplied `tool_calls` one after another;

--- a/crates/dasclaw_safety/tests/egress_gate_integration.rs
+++ b/crates/dasclaw_safety/tests/egress_gate_integration.rs
@@ -13,11 +13,9 @@
 //! secrets. A contract test at this layer is the only place that catches
 //! "the loop was refactored and the gate stopped firing".
 //!
-//! W10.0 (ADR-160): the driver is now `dasclaw_runtime::AgenticLoop`
-//! wired with `StubResponder` (impl `AgentResponder`); no
-//! `ToolDispatcher` is needed because these scenarios never emit tool
-//! calls. The prior `StubDelegate : LoopDelegate` shape is gone in
-//! preparation for W10.1 deleting the `LoopDelegate` trait.
+//! W10.1 (ADR-160): the driver is `dasclaw_runtime::AgenticLoop` wired
+//! with `StubResponder` (impl `AgentResponder`); no `ToolDispatcher`
+//! is needed because these scenarios never emit tool calls.
 //!
 //! Gated on `egress-gate` feature so this test only builds when the
 //! adapter itself is compiled in.


### PR DESCRIPTION
Closes #982

## 背景 / 目标

W10.0 (#983) 把 `StubDelegate` / `ParityDelegate` 等所有外部 `LoopDelegate` 实现都迁离了旧契约。本 PR 完成 W10.1：**彻底删除** `dasclaw_core::agentic_loop::{LoopDelegate, run_agentic_loop}` 旧契约。删完后整个 workspace 只剩 `dasclaw_runtime::AgenticLoop::run` 一个 agentic loop 入口（产品未发布，按 AGENTS.md 直接删除：不留 `#[deprecated]`、不留 type alias、不留 deprecated re-export）。

## 改动范围（Option A：把 trait 下沉到 core）

把 `AgentEvent` / `AgentResponder` / `ToolDispatcher` / `TOOLS_NOT_SUPPORTED_REASON` 从 `dasclaw_runtime` 下沉到 `dasclaw_core::agentic_loop`，新版 `run_agentic_loop` 直接收 7 个参数（responder, dispatcher, cancellation_token, event_tx, ctx, config, hooks），把原 `LoopAdapter` 的内联逻辑吸收进去。

- `crates/dasclaw_core/Cargo.toml`: 新增 `tokio-util = "0.7"`（CancellationToken 需要）
- `crates/dasclaw_core/src/agentic_loop.rs` (+462 / -148): 成为 `AgentEvent` / `AgentResponder` / `ToolDispatcher` / `TOOLS_NOT_SUPPORTED_REASON` 的权威定义点；新版 `run_agentic_loop` 内联旧 `LoopAdapter` 的全部分支；14 个单元测试
- `crates/dasclaw_runtime/src/agent.rs` (-237): 删除本地 trait/enum/const，改 `pub use` 自 core；重写模块顶 doc 第 "Scope" 节；重写 `AgentError::ApprovalRequested` 的 `#[deprecated(note = …)]` 文案；重写 `map_outcome` 注释
- `crates/dasclaw_runtime/src/agentic_loop.rs` (-169 → 80 行 thin façade): `AgenticLoop::run` 内体直接调 `run_agentic_loop`，`LoopAdapter` struct + impl 全删
- `crates/dasclaw_runtime/src/tool_dispatch.rs`: 删除本地 `pub trait ToolDispatcher`，改 `pub use` 自 core；`SequentialDispatcher` 实现保持不变
- 文档跟随更新：`crates/dasclaw_core/src/hooks.rs`、`crates/dasclaw_runtime/src/approval.rs`、`crates/dasclaw_runtime/README.md`、`crates/dasclaw_safety/tests/egress_gate_integration.rs`

净改动：10 文件，+644 / -747（净 -103 行）。

## 非目标（What's NOT in this PR）

- ❌ 不改 `dasclaw_runtime::AgenticLoop` 的对外 API（仅 `LoopAdapter` 私有 shim 被删）
- ❌ 不改 hook 契约（ADR-113 / ADR-148 红线）
- ❌ 不改 ADR-112 五层架构（L1 = AgenticLoop in runtime；L2 = ToolDispatcher seam now in core）
- ❌ 不引入新 crate
- ❌ 不动 `desktop-client/ironclaw/src/agent/dispatcher.rs:78` 的 `pub(super) async fn run_agentic_loop`（局部方法名同名碰撞，与 core entry 无关）

## 验证

```
RUSTC_WRAPPER= cargo check -p dasclaw_core --tests          # 0 warn 0 err (44.07s)
RUSTC_WRAPPER= cargo check -p dasclaw_runtime --tests       # 0 warn 0 err
RUSTC_WRAPPER= cargo check -p dasclaw_safety -p dasclaw --tests  # 0 warn 0 err
RUSTC_WRAPPER= cargo nextest run -p dasclaw_core -p dasclaw_runtime -p dasclaw_safety
                                                            # 678/678 pass (178s)
cargo fmt --all                                             # clean
python3.12 scripts/check_no_panics.py --base origin/xClaw   # clean
RUSTC_WRAPPER= cargo clippy --no-deps -p dasclaw_core -p dasclaw_runtime \
   --all-targets -- -D warnings                             # clean
grep -r 'LoopDelegate\|HeadlessDelegate' crates/**/*.rs desktop-client/**/*.rs   # 仅剩 //! 历史注释
```

## Sources read

- `AGENTS.md` §"GitHub PR 工作流"、§"会话轮换原则"、§"Rust 开发规范"、§"测试规则"
- `docs/plans/architecture-refactor/adr-160-agentic-loop-five-layers.md` §3 (L1/L2 边界)
- `docs/plans/architecture-refactor/adr-148-egress-gate.md` §EgressGate::check 返回类型
- 历史 PR #983 (W10.0) — `StubDelegate` / `ParityDelegate` 迁离 LoopDelegate
- `crates/dasclaw_core/src/agentic_loop.rs` 第 349 行新 `run_agentic_loop` 7 参数签名（本 PR 落地）

## Stacked PR

- **Base**: `feat/w10.0-migrate-external-loop-delegate-tests` (PR #983)，不是 `xClaw`
- **Merge 顺序**: 先 merge #983，再 merge 本 PR
- **W8 #975/#976/#977 教训**：合 #983 时要么**不勾 "Delete branch"**（路径 A，推荐），要么**在删 #983 分支之前**先把本 PR 的 base retarget 到 `xClaw`（路径 B）。两条都不做会让本 PR 被 GitHub 自动关闭且无法 reopen，被迫重开 PR 编号。

## Cross-cuts

类 A：本 PR 无新增 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量。
