### PR TITLE
chore(desktop): split dual-bin shared main.rs into separate entry files (drop cargo warning)

### DIFF
--- a/desktop-client/ironclaw/Cargo.toml
+++ b/desktop-client/ironclaw/Cargo.toml
@@ -10,8 +10,8 @@ homepage = "https://github.com/nearai/ironclaw"
 repository = "https://github.com/nearai/ironclaw"
 # ADR-114 Ⅴ — invoke the canonical `dasclaw` binary by default. The legacy
 # `ironclaw` binary is kept as a deprecation shim that prints a warning and
-# then runs the same code path; see `[[bin]]` blocks below and the argv[0]
-# branch at the top of `fn main()` in `src/main.rs`.
+# then runs the same code path; both entry points live under `src/bin/` and
+# delegate to the shared `ironclaw::entry::run` helper.
 default-run = "dasclaw"
 
 [package.metadata.wix]
@@ -29,18 +29,12 @@ eula = false
 name = "ironclaw"
 path = "src/lib.rs"
 
-# ADR-114 Ⅴ — canonical entry point.
-[[bin]]
-name = "dasclaw"
-path = "src/main.rs"
-
-# ADR-114 Ⅴ — legacy entry point retained for one release cycle as a
-# compatibility alias. The same `src/main.rs` is compiled twice; the
-# binary detects argv[0] == "ironclaw" and emits a single deprecation
-# warning to stderr before delegating to the normal startup flow.
-[[bin]]
-name = "ironclaw"
-path = "src/main.rs"
+# ADR-114 Ⅴ — the canonical `dasclaw` and legacy `ironclaw` entry points
+# are auto-discovered from `src/bin/dasclaw.rs` and `src/bin/ironclaw.rs`
+# respectively. Each is a thin wrapper around `ironclaw::entry::run` so
+# the startup flow stays single-sourced without forcing cargo to compile
+# `src/main.rs` into two binaries (which produced a
+# "file ... found to be present in multiple build targets" warning).
 
 [dependencies]
 # Async runtime
@@ -121,7 +115,9 @@ dasclaw_core = { path = "../../crates/dasclaw_core", version = "0.1.0" }
 dasclaw_exec = { path = "../../crates/dasclaw_exec", version = "0.1.0" }
 dasclaw_sandbox = { path = "../../crates/dasclaw_sandbox", version = "0.0.0-w1" }
 # #324 sub-task 1 — pre-main hardening (disable core dumps / ptrace / dangerous
-# env vars). Wired via `#[ctor::ctor] fn pre_main()` at the top of main.rs.
+# env vars). Wired via `#[ctor::ctor] fn pre_main()` at the top of each
+# `src/bin/*.rs` so it fires only when an actual binary is invoked (not on
+# library loads from tests / downstream crates).
 # Pattern matches codex `responses-api-proxy/src/main.rs:4-7`.
 dasclaw_process_hardening = { path = "../../crates/dasclaw_process_hardening" }
 ctor = "0.2"

--- a/desktop-client/ironclaw/src/bin/dasclaw.rs
+++ b/desktop-client/ironclaw/src/bin/dasclaw.rs
@@ -1,0 +1,23 @@
+//! Canonical `dasclaw` binary entry point (ADR-114 Ⅴ).
+//!
+//! Thin wrapper around [`ironclaw::entry::run`]; all startup logic lives in
+//! `src/entry.rs` so the legacy `ironclaw` alias bin can share it without
+//! patch-style duplication.
+
+/// Pre-main process hardening hook (#324 sub-task 1).
+///
+/// Runs before `fn main()` via `#[ctor::ctor]` to disable core dumps,
+/// block ptrace attach, and scrub dangerous environment variables
+/// (`LD_PRELOAD`, `DYLD_*`, macOS malloc stack-logging controls, …).
+///
+/// Lives in each `src/bin/*.rs` rather than the library so it only fires
+/// when an actual binary is invoked, not on every library load (tests,
+/// downstream crates, etc.).
+#[ctor::ctor]
+fn pre_main() {
+    dasclaw_process_hardening::pre_main_hardening();
+}
+
+fn main() -> anyhow::Result<()> {
+    ironclaw::entry::run(None)
+}

--- a/desktop-client/ironclaw/src/bin/ironclaw.rs
+++ b/desktop-client/ironclaw/src/bin/ironclaw.rs
@@ -1,0 +1,18 @@
+//! Legacy `ironclaw` binary entry point (ADR-114 Ⅴ).
+//!
+//! Compatibility alias retained for one release cycle. Emits a single
+//! deprecation warning to stderr (via [`ironclaw::entry::run`]) before
+//! delegating to the canonical startup flow.
+
+/// Pre-main process hardening hook (#324 sub-task 1).
+///
+/// Mirrors the `dasclaw` bin so the legacy alias gets the same
+/// hardening guarantees. See `dasclaw.rs` for the full rationale.
+#[ctor::ctor]
+fn pre_main() {
+    dasclaw_process_hardening::pre_main_hardening();
+}
+
+fn main() -> anyhow::Result<()> {
+    ironclaw::entry::run(Some("ironclaw"))
+}

--- a/desktop-client/ironclaw/src/entry.rs
+++ b/desktop-client/ironclaw/src/entry.rs
@@ -1,24 +1,16 @@
-//! IronClaw - Main entry point.
-
-/// #324 sub-task 1 — Pre-main process hardening hook.
-///
-/// Runs before `fn main()` (via `#[ctor::ctor]`) to disable core dumps,
-/// block ptrace attach, and scrub dangerous environment variables
-/// (`LD_PRELOAD`, `DYLD_*`, macOS malloc stack-logging controls, …).
-///
-/// Pattern mirrors codex `responses-api-proxy/src/main.rs:4-7`. Applies to
-/// both the `dasclaw` and `ironclaw` binaries (same `[[bin]] path`).
-#[ctor::ctor]
-fn pre_main() {
-    dasclaw_process_hardening::pre_main_hardening();
-}
+//! Shared synchronous + async entry point for the `dasclaw` and `ironclaw` binaries.
+//!
+//! ADR-114 Ⅴ — the package ships two binaries: `dasclaw` (canonical) and
+//! `ironclaw` (deprecated legacy alias). Each `src/bin/*.rs` is a thin
+//! wrapper that calls [`run`] with an optional deprecation marker so the
+//! actual startup flow remains single-sourced here.
 
 use std::sync::Arc;
 use std::time::Duration;
 
 use clap::Parser;
 
-use ironclaw::{
+use crate::{
     agent::{Agent, AgentDeps},
     app::{AppBuilder, AppBuilderFlags},
     channels::{
@@ -42,32 +34,26 @@ use ironclaw::{
 };
 
 #[cfg(unix)]
-use ironclaw::channels::ChannelSecretUpdater;
+use crate::channels::ChannelSecretUpdater;
 #[cfg(any(feature = "postgres", feature = "libsql"))]
-use ironclaw::setup::{SetupConfig, SetupWizard};
+use crate::setup::{SetupConfig, SetupWizard};
 
 /// Synchronous entry point. Loads `.env` files before the Tokio runtime
 /// starts so that `std::env::set_var` is safe (no worker threads yet).
-fn main() -> anyhow::Result<()> {
-    // ADR-114 Ⅴ — same `src/main.rs` is compiled into two binaries:
-    // `dasclaw` (canonical) and `ironclaw` (legacy compatibility shim).
-    // When invoked through the legacy name, emit a single deprecation
-    // warning to stderr before continuing with the normal startup flow.
-    // We inspect argv[0] (`current_exe()`) instead of a compile-time flag
-    // so that one source file backs both `[[bin]]` entries — keeping the
-    // entry point logic single-sourced (no patch-style duplication).
-    if let Ok(exe) = std::env::current_exe()
-        && let Some(stem) = exe.file_stem().and_then(|s| s.to_str())
-        && stem.eq_ignore_ascii_case("ironclaw")
-    {
+///
+/// When invoked through the legacy `ironclaw` binary, `legacy_alias`
+/// carries `Some("ironclaw")` so a single deprecation warning is emitted
+/// to stderr before the normal startup flow.
+pub fn run(legacy_alias: Option<&str>) -> anyhow::Result<()> {
+    if let Some(alias) = legacy_alias {
         eprintln!(
-            "warning: the `ironclaw` binary is deprecated and will be removed in a future \
+            "warning: the `{alias}` binary is deprecated and will be removed in a future \
              release; use `dasclaw` instead. (ADR-114 Ⅴ — Cargo package + binary rename)"
         );
     }
 
     let _ = dotenvy::dotenv();
-    ironclaw::bootstrap::load_ironclaw_env();
+    crate::bootstrap::load_ironclaw_env();
 
     let result = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
@@ -82,7 +68,7 @@ fn main() -> anyhow::Result<()> {
 
 /// Format a top-level error with color and recovery hints.
 fn format_top_level_error(err: &anyhow::Error) {
-    use ironclaw::cli::fmt;
+    use crate::cli::fmt;
     let msg = format!("{err:#}");
 
     eprintln!();
@@ -125,23 +111,20 @@ async fn async_main() -> anyhow::Result<()> {
         }
         Some(Command::Config(config_cmd)) => {
             init_cli_tracing();
-            return ironclaw::cli::run_config_command(config_cmd.clone()).await;
+            return crate::cli::run_config_command(config_cmd.clone()).await;
         }
         Some(Command::Registry(registry_cmd)) => {
             init_cli_tracing();
-            return ironclaw::cli::run_registry_command(registry_cmd.clone()).await;
+            return crate::cli::run_registry_command(registry_cmd.clone()).await;
         }
         Some(Command::Channels(channels_cmd)) => {
             init_cli_tracing();
-            return ironclaw::cli::run_channels_command(
-                channels_cmd.clone(),
-                cli.config.as_deref(),
-            )
-            .await;
+            return crate::cli::run_channels_command(channels_cmd.clone(), cli.config.as_deref())
+                .await;
         }
         Some(Command::Routines(routines_cmd)) => {
             init_cli_tracing();
-            return ironclaw::cli::run_routines_cli(routines_cmd, cli.config.as_deref()).await;
+            return crate::cli::run_routines_cli(routines_cmd, cli.config.as_deref()).await;
         }
         Some(Command::Mcp(mcp_cmd)) => {
             init_cli_tracing();
@@ -149,7 +132,7 @@ async fn async_main() -> anyhow::Result<()> {
         }
         Some(Command::Memory(mem_cmd)) => {
             init_cli_tracing();
-            return ironclaw::cli::run_memory_command(mem_cmd).await;
+            return crate::cli::run_memory_command(mem_cmd).await;
         }
         Some(Command::Pairing(pairing_cmd)) => {
             init_cli_tracing();
@@ -161,30 +144,27 @@ async fn async_main() -> anyhow::Result<()> {
         }
         Some(Command::Skills(skills_cmd)) => {
             init_cli_tracing();
-            return ironclaw::cli::run_skills_command(skills_cmd.clone(), cli.config.as_deref())
-                .await;
+            return crate::cli::run_skills_command(skills_cmd.clone(), cli.config.as_deref()).await;
         }
         Some(Command::Cert(cert_cmd)) => {
             init_cli_tracing();
-            return ironclaw::cli::run_cert_command(cert_cmd.clone());
+            return crate::cli::run_cert_command(cert_cmd.clone());
         }
         Some(Command::Hooks(hooks_cmd)) => {
             init_cli_tracing();
-            return ironclaw::cli::run_hooks_command(hooks_cmd.clone(), cli.config.as_deref())
-                .await;
+            return crate::cli::run_hooks_command(hooks_cmd.clone(), cli.config.as_deref()).await;
         }
         Some(Command::Logs(logs_cmd)) => {
             init_cli_tracing();
-            return ironclaw::cli::run_logs_command(logs_cmd.clone(), cli.config.as_deref()).await;
+            return crate::cli::run_logs_command(logs_cmd.clone(), cli.config.as_deref()).await;
         }
         Some(Command::Models(models_cmd)) => {
             init_cli_tracing();
-            return ironclaw::cli::run_models_command(models_cmd.clone(), cli.config.as_deref())
-                .await;
+            return crate::cli::run_models_command(models_cmd.clone(), cli.config.as_deref()).await;
         }
         Some(Command::Doctor) => {
             init_cli_tracing();
-            return ironclaw::cli::run_doctor_command().await;
+            return crate::cli::run_doctor_command().await;
         }
         Some(Command::Status) => {
             init_cli_tracing();
@@ -192,7 +172,7 @@ async fn async_main() -> anyhow::Result<()> {
         }
         Some(Command::Migrate(migrate_cmd)) => {
             init_cli_tracing();
-            return ironclaw::cli::run_migrate_command(migrate_cmd.clone());
+            return crate::cli::run_migrate_command(migrate_cmd.clone());
         }
         Some(Command::Completion(completion)) => {
             init_cli_tracing();
@@ -201,8 +181,8 @@ async fn async_main() -> anyhow::Result<()> {
         #[cfg(feature = "import")]
         Some(Command::Import(import_cmd)) => {
             init_cli_tracing();
-            let config = ironclaw::config::Config::from_env().await?;
-            return ironclaw::cli::run_import_command(import_cmd, &config).await;
+            let config = crate::config::Config::from_env().await?;
+            return crate::cli::run_import_command(import_cmd, &config).await;
         }
         Some(Command::Worker {
             job_id,
@@ -210,7 +190,7 @@ async fn async_main() -> anyhow::Result<()> {
             max_iterations,
         }) => {
             init_worker_tracing();
-            return ironclaw::worker::run_worker(*job_id, orchestrator_url, *max_iterations).await;
+            return crate::worker::run_worker(*job_id, orchestrator_url, *max_iterations).await;
         }
         Some(Command::ClaudeBridge {
             job_id,
@@ -219,13 +199,8 @@ async fn async_main() -> anyhow::Result<()> {
             model,
         }) => {
             init_worker_tracing();
-            return ironclaw::worker::run_claude_bridge(
-                *job_id,
-                orchestrator_url,
-                *max_turns,
-                model,
-            )
-            .await;
+            return crate::worker::run_claude_bridge(*job_id, orchestrator_url, *max_turns, model)
+                .await;
         }
         Some(Command::Login { openai_codex }) => {
             init_cli_tracing();
@@ -237,9 +212,8 @@ async fn async_main() -> anyhow::Result<()> {
                         .await
                         .map_err(|e| anyhow::anyhow!("{}", e))?;
                     config.llm.openai_codex.unwrap_or_else(|| {
-                        use ironclaw::llm::OpenAiCodexConfig;
-                        let mut cfg =
-                            OpenAiCodexConfig::new(&ironclaw::bootstrap::dasclaw_base_dir());
+                        use crate::llm::OpenAiCodexConfig;
+                        let mut cfg = OpenAiCodexConfig::new(&crate::bootstrap::dasclaw_base_dir());
                         if let Ok(v) = std::env::var("OPENAI_CODEX_AUTH_URL") {
                             cfg.auth_endpoint = v;
                         }
@@ -255,7 +229,7 @@ async fn async_main() -> anyhow::Result<()> {
                         cfg
                     })
                 };
-                let mgr = ironclaw::llm::OpenAiCodexSessionManager::new(codex_config)
+                let mgr = crate::llm::OpenAiCodexSessionManager::new(codex_config)
                     .map_err(|e| anyhow::anyhow!("{}", e))?;
                 mgr.device_code_login()
                     .await
@@ -302,14 +276,14 @@ async fn async_main() -> anyhow::Result<()> {
     }
 
     // ── PID lock (prevent multiple instances) ────────────────────────
-    let _pid_lock = match ironclaw::bootstrap::PidLock::acquire() {
+    let _pid_lock = match crate::bootstrap::PidLock::acquire() {
         Ok(lock) => Some(lock),
-        Err(ironclaw::bootstrap::PidLockError::AlreadyRunning { pid }) => {
+        Err(crate::bootstrap::PidLockError::AlreadyRunning { pid }) => {
             anyhow::bail!(
                 "Another IronClaw instance is already running (PID {}). \
                  If this is incorrect, remove the stale PID file: {}",
                 pid,
-                ironclaw::bootstrap::pid_lock_path().display()
+                crate::bootstrap::pid_lock_path().display()
             );
         }
         Err(e) => {
@@ -326,7 +300,7 @@ async fn async_main() -> anyhow::Result<()> {
     // Enhanced first-run detection
     #[cfg(any(feature = "postgres", feature = "libsql"))]
     if !cli.no_onboard
-        && let Some(reason) = ironclaw::setup::check_onboard_needed()
+        && let Some(reason) = crate::setup::check_onboard_needed()
     {
         println!("Onboarding needed: {}", reason);
         println!();
@@ -347,7 +321,7 @@ async fn async_main() -> anyhow::Result<()> {
     let toml_path = cli.config.as_deref();
     let config = match Config::from_env_with_toml(toml_path).await {
         Ok(c) => c,
-        Err(ironclaw::error::ConfigError::MissingRequired { key, hint }) => {
+        Err(crate::error::ConfigError::MissingRequired { key, hint }) => {
             anyhow::bail!(
                 "Configuration error: Missing required setting '{}'. {}. \
                  Run 'ironclaw onboard' to configure, or set the required environment variables.",
@@ -367,7 +341,7 @@ async fn async_main() -> anyhow::Result<()> {
     // Initialize tracing with a reloadable EnvFilter so the gateway can switch
     // log levels at runtime without restarting.
     let log_level_handle =
-        ironclaw::channels::web::log_layer::init_tracing(Arc::clone(&log_broadcaster));
+        crate::channels::web::log_layer::init_tracing(Arc::clone(&log_broadcaster));
 
     tracing::debug!("Starting IronClaw...");
     tracing::debug!("Loaded configuration for agent: {}", config.agent.name);
@@ -390,11 +364,11 @@ async fn async_main() -> anyhow::Result<()> {
 
     // ── Tunnel setup ───────────────────────────────────────────────────
 
-    let (config, active_tunnel) = ironclaw::tunnel::start_managed_tunnel(config).await;
+    let (config, active_tunnel) = crate::tunnel::start_managed_tunnel(config).await;
 
     // ── Orchestrator / container job manager ────────────────────────────
 
-    let orch = ironclaw::orchestrator::setup_orchestrator(
+    let orch = crate::orchestrator::setup_orchestrator(
         &config,
         &components.llm,
         components.db.as_ref(),
@@ -414,12 +388,12 @@ async fn async_main() -> anyhow::Result<()> {
 
     // Derive user-facing warning from docker_status for channel notification
     let docker_user_warning: Option<String> = match docker_status {
-        ironclaw::sandbox::DockerStatus::NotInstalled => Some(
+        crate::sandbox::DockerStatus::NotInstalled => Some(
             "Sandbox is enabled but Docker is not installed -- \
              full_job routines will fail until Docker is available."
                 .to_string(),
         ),
-        ironclaw::sandbox::DockerStatus::NotRunning => Some(
+        crate::sandbox::DockerStatus::NotRunning => Some(
             "Sandbox is enabled but Docker is not running -- \
              full_job routines will fail until Docker is started."
                 .to_string(),
@@ -464,7 +438,7 @@ async fn async_main() -> anyhow::Result<()> {
     }
 
     // Shared routine engine slot for gateway + generic webhook ingress.
-    let shared_routine_engine_slot: ironclaw::channels::web::server::RoutineEngineSlot =
+    let shared_routine_engine_slot: crate::channels::web::server::RoutineEngineSlot =
         Arc::new(tokio::sync::RwLock::new(None));
 
     // Collect webhook route fragments; a single WebhookServer hosts them all.
@@ -490,7 +464,7 @@ async fn async_main() -> anyhow::Result<()> {
         );
     }
     if config.channels.wasm_channels_enabled && config.channels.wasm_channels_dir.exists() {
-        let wasm_result = ironclaw::channels::wasm::setup_wasm_channels(
+        let wasm_result = crate::channels::wasm::setup_wasm_channels(
             &config,
             &components.secrets_store,
             components.extension_manager.as_ref(),
@@ -537,7 +511,7 @@ async fn async_main() -> anyhow::Result<()> {
     // Add HTTP channel if configured and not CLI-only mode.
     let mut webhook_server_addr: Option<std::net::SocketAddr> = None;
     #[cfg(unix)]
-    let mut http_channel_state: Option<Arc<ironclaw::channels::HttpChannelState>> = None;
+    let mut http_channel_state: Option<Arc<crate::channels::HttpChannelState>> = None;
     if !cli.cli_only
         && let Some(ref http_config) = config.channels.http
     {
@@ -613,7 +587,7 @@ async fn async_main() -> anyhow::Result<()> {
     // Lazy scheduler slot — filled after Agent::new creates the JobDispatcher.
     // Allows CreateJobTool to dispatch local jobs via the JobDispatcher even though
     // the JobDispatcher is created after tools are registered (chicken-and-egg).
-    let scheduler_slot: ironclaw::tools::builtin::JobDispatcherSlot =
+    let scheduler_slot: crate::tools::builtin::JobDispatcherSlot =
         Arc::new(tokio::sync::RwLock::new(None));
 
     // Register job tools (sandbox deps auto-injected when container_job_manager is available)
@@ -628,7 +602,7 @@ async fn async_main() -> anyhow::Result<()> {
             // create_job / list_jobs / job_status / cancel_job /
             // job_events / job_prompt entirely. The LLM never sees these
             // 6 tool definitions in Disabled mode.
-            job_config: ironclaw::tools::bootstrap::job_tools_for_mode(
+            job_config: crate::tools::bootstrap::job_tools_for_mode(
                 &config.job_runtime.mode,
                 || JobToolsConfig {
                     context_manager: Arc::clone(&components.context_manager),
@@ -654,7 +628,7 @@ async fn async_main() -> anyhow::Result<()> {
     // ── Gateway channel ────────────────────────────────────────────────
 
     let mut gateway_url: Option<String> = None;
-    let mut sse_manager: Option<std::sync::Arc<ironclaw::channels::web::sse::SseManager>> = None;
+    let mut sse_manager: Option<std::sync::Arc<crate::channels::web::sse::SseManager>> = None;
     if let Some(ref gw_config) = config.channels.gateway {
         let mut gw = GatewayChannel::new(gw_config.clone(), config.owner_id.clone());
         gw = gw.with_llm_provider(Arc::clone(&components.llm));
@@ -663,10 +637,10 @@ async fn async_main() -> anyhow::Result<()> {
         }
         // Create per-user workspace pool for multi-user mode.
         if let Some(ref db) = components.db {
-            let emb_cache_config = ironclaw::workspace::EmbeddingCacheConfig {
+            let emb_cache_config = crate::workspace::EmbeddingCacheConfig {
                 max_entries: config.embeddings.cache_size,
             };
-            let pool = Arc::new(ironclaw::channels::web::server::WorkspacePool::new(
+            let pool = Arc::new(crate::channels::web::server::WorkspacePool::new(
                 Arc::clone(db),
                 components.embeddings.clone(),
                 emb_cache_config,
@@ -704,7 +678,7 @@ async fn async_main() -> anyhow::Result<()> {
             // so the owner appears in the Users admin panel immediately.
             if let Ok(false) = d.has_any_users().await {
                 let now = chrono::Utc::now();
-                let user = ironclaw::db::UserRecord {
+                let user = crate::db::UserRecord {
                     id: config.owner_id.clone(),
                     email: None,
                     display_name: config.owner_id.clone(),
@@ -723,7 +697,7 @@ async fn async_main() -> anyhow::Result<()> {
                         tracing::warn!("Failed to bootstrap admin user: {}", e);
                     }
                 } else {
-                    use ironclaw::channels::web::auth::hash_token;
+                    use crate::channels::web::auth::hash_token;
                     let hash = hash_token(auth_token);
                     let prefix = if auth_token.len() >= 8 {
                         &auth_token[..8]
@@ -763,7 +737,7 @@ async fn async_main() -> anyhow::Result<()> {
             let active_model = components.llm.model_name().to_string();
             let mut enabled = channel_names.clone();
             enabled.push("gateway".into());
-            gw = gw.with_active_config(ironclaw::channels::web::server::ActiveConfigSnapshot {
+            gw = gw.with_active_config(crate::channels::web::server::ActiveConfigSnapshot {
                 llm_backend: config.llm.backend.to_string(),
                 llm_model: active_model,
                 enabled_channels: enabled,
@@ -838,7 +812,7 @@ async fn async_main() -> anyhow::Result<()> {
         .map(|c| c.model_name().to_string());
 
     if config.channels.cli.enabled && cli.message.is_none() {
-        let boot_info = ironclaw::boot_screen::BootInfo {
+        let boot_info = crate::boot_screen::BootInfo {
             version: env!("CARGO_PKG_VERSION").to_string(),
             agent_name: config.agent.name.clone(),
             llm_backend: config.llm.backend.to_string(),
@@ -873,7 +847,7 @@ async fn async_main() -> anyhow::Result<()> {
             tunnel_provider: active_tunnel.as_ref().map(|t| t.name().to_string()),
             startup_elapsed: Some(startup_start.elapsed()),
         };
-        ironclaw::boot_screen::print_boot_screen(&boot_info);
+        crate::boot_screen::print_boot_screen(&boot_info);
     }
 
     // ── Run the agent ──────────────────────────────────────────────────
@@ -974,10 +948,10 @@ async fn async_main() -> anyhow::Result<()> {
 
     // Capture db reference for SIGHUP handler before it's moved into AgentDeps (Unix only)
     #[cfg(unix)]
-    let sighup_settings_store: Option<Arc<dyn ironclaw::db::SettingsStore>> = components
+    let sighup_settings_store: Option<Arc<dyn crate::db::SettingsStore>> = components
         .db
         .as_ref()
-        .map(|db| Arc::clone(db) as Arc<dyn ironclaw::db::SettingsStore>);
+        .map(|db| Arc::clone(db) as Arc<dyn crate::db::SettingsStore>);
 
     let deps = AgentDeps {
         owner_id: config.owner_id.clone(),
@@ -997,35 +971,34 @@ async fn async_main() -> anyhow::Result<()> {
         job_event_sink: None,
         channels_for_jobs: None,
         http_interceptor,
-        transcription: config.transcription.create_provider().map(|p| {
-            Arc::new(ironclaw::llm::transcription::TranscriptionMiddleware::new(
-                p,
-            ))
-        }),
+        transcription: config
+            .transcription
+            .create_provider()
+            .map(|p| Arc::new(crate::llm::transcription::TranscriptionMiddleware::new(p))),
         document_extraction: Some(Arc::new(
-            ironclaw::document_extraction::DocumentExtractionMiddleware::new(),
+            crate::document_extraction::DocumentExtractionMiddleware::new(),
         )),
         sandbox_readiness: if !config.sandbox.enabled {
-            ironclaw::agent::routine_engine::SandboxReadiness::DisabledByConfig
+            crate::agent::routine_engine::SandboxReadiness::DisabledByConfig
         } else if docker_status.is_ok() {
-            ironclaw::agent::routine_engine::SandboxReadiness::Available
+            crate::agent::routine_engine::SandboxReadiness::Available
         } else {
-            ironclaw::agent::routine_engine::SandboxReadiness::DockerUnavailable
+            crate::agent::routine_engine::SandboxReadiness::DockerUnavailable
         },
         builder: components.builder,
         llm_backend: config.llm.backend.clone(),
-        tenant_rates: Arc::new(ironclaw::tenant::TenantRateRegistry::new(
+        tenant_rates: Arc::new(crate::tenant::TenantRateRegistry::new(
             config.agent.max_llm_concurrent_per_user.unwrap_or(4),
             config.agent.max_jobs_concurrent_per_user.unwrap_or(3),
         )),
         cache_monitor: {
-            let obs_config = ironclaw::observability::ObservabilityConfig {
+            let obs_config = crate::observability::ObservabilityConfig {
                 backend: "log".to_string(),
             };
-            let observer: std::sync::Arc<dyn ironclaw::observability::Observer> =
-                std::sync::Arc::from(ironclaw::observability::create_observer(&obs_config));
+            let observer: std::sync::Arc<dyn crate::observability::Observer> =
+                std::sync::Arc::from(crate::observability::create_observer(&obs_config));
             Some(std::sync::Arc::new(
-                ironclaw::observability::PromptCacheMonitor::new(observer),
+                crate::observability::PromptCacheMonitor::new(observer),
             ))
         },
     };
@@ -1116,7 +1089,7 @@ async fn async_main() -> anyhow::Result<()> {
                     {
                         // Thread-safe: Uses INJECTED_VARS mutex instead of unsafe std::env::set_var
                         // Config::from_env() will read from the overlay via optional_env()
-                        ironclaw::config::inject_single_var(
+                        crate::config::inject_single_var(
                             "HTTP_WEBHOOK_SECRET",
                             webhook_secret.expose(),
                         );
@@ -1127,9 +1100,9 @@ async fn async_main() -> anyhow::Result<()> {
                 // Reload config (now with secrets injected into environment)
                 let new_config = match &sighup_settings_store_clone {
                     Some(store) => {
-                        ironclaw::config::Config::from_db(store.as_ref(), &sighup_owner_id).await
+                        crate::config::Config::from_db(store.as_ref(), &sighup_owner_id).await
                     }
-                    None => ironclaw::config::Config::from_env().await,
+                    None => crate::config::Config::from_env().await,
                 };
 
                 let new_config = match new_config {
@@ -1245,7 +1218,7 @@ async fn async_main() -> anyhow::Result<()> {
             // 5s is generous but avoids the message being lost on slow startups.
             tokio::time::sleep(std::time::Duration::from_secs(5)).await;
             tracing::debug!("Sending sandbox-unavailable warning to connected channels");
-            let response = ironclaw::channels::OutgoingResponse {
+            let response = crate::channels::OutgoingResponse {
                 content: format!("Warning: {warning}"),
                 thread_id: None,
                 attachments: Vec::new(),

--- a/desktop-client/ironclaw/src/lib.rs
+++ b/desktop-client/ironclaw/src/lib.rs
@@ -47,6 +47,7 @@ pub mod cli;
 pub mod config;
 pub mod db;
 pub mod document_extraction;
+pub mod entry;
 pub mod error;
 pub mod estimation;
 pub mod evaluation;


### PR DESCRIPTION
## 背景 / 目标

`desktop-client/ironclaw/Cargo.toml` 通过两个显式 `[[bin]]` 段（`dasclaw` + `ironclaw`）让同一个 `src/main.rs` 同时编出两个二进制，main.rs 内部用 `argv[0]` 字符串比较运行时分流（命中 `ironclaw` 才打 ADR-114 弃用警告）。这触发了一条 cargo 警告：

```
warning: /Users/nallylin/Documents/code/x-claw/desktop-client/ironclaw/Cargo.toml: file `/Users/nallylin/Documents/code/x-claw/desktop-client/ironclaw/src/main.rs` found to be present in multiple build targets:
  * `bin` target `dasclaw`
  * `bin` target `ironclaw`
```

目标：消除该警告，同时**保持 ADR-114 Ⅴ 的两个 bin 在运行时行为 1:1 不变**（含 `ironclaw` 调用时仍发同一句 stderr 弃用警告），不引入回归。

## 改动范围

采用「方案 A：拆出 `src/bin/`，分流逻辑下沉到库 helper」。

| 文件 | 变化 |
|---|---|
| `desktop-client/ironclaw/Cargo.toml` | 删除两条手写 `[[bin]]` 段（路径都指向 `src/main.rs`），改由 `src/bin/*.rs` cargo 自动发现；刷新 3 处注释解释新结构。保留 `default-run = "dasclaw"`、`[lib] name = "ironclaw"` 不动。 |
| `desktop-client/ironclaw/src/main.rs` → `desktop-client/ironclaw/src/entry.rs` | 重命名（git 检测到 88% similarity）。移除 `argv[0]` 嗅探，新增 `pub fn run(legacy_alias: Option<&str>) -> anyhow::Result<()>`：`Some(alias)` 时打弃用警告，其余流程（dotenv → tokio 多线程 runtime → `async_main()` → 顶层错误格式化）完全不变。把原 `ironclaw::...` 路径全部改为 `crate::...`。 |
| `desktop-client/ironclaw/src/lib.rs` | 新增 `pub mod entry;`（按字母序插在 `document_extraction` 与 `error` 之间）。 |
| `desktop-client/ironclaw/src/bin/dasclaw.rs`（新增，~22 行） | `#[ctor::ctor] fn pre_main() { dasclaw_process_hardening::pre_main_hardening(); }` + `fn main() -> anyhow::Result<()> { ironclaw::entry::run(None) }`。 |
| `desktop-client/ironclaw/src/bin/ironclaw.rs`（新增，~18 行） | 与上同结构，`main()` 调 `ironclaw::entry::run(Some("ironclaw"))`，触发弃用警告分支。 |

### argv[0] 分流逻辑搬到哪

原 `main.rs` 通过 `std::env::args_os().next()` 看进程名是不是 `ironclaw` 来决定打不打弃用警告——这是「一个 main.rs 编两次」唯一的运行时差异。新方案改为**编译期分流**：每个 bin 显式把自己的身份作为参数（`None` / `Some("ironclaw")`）传给共享的 `entry::run`，由 `run` 内部统一发同一句警告。argv[0] 探测整段删除。

## 非目标（What's NOT in this PR）

- ❌ 不动 `tauri.conf.json` / bundle target name
- ❌ 不动任何前端代码
- ❌ 不改 `[lib] name = "ironclaw"`（ADR-114 Ⅴ 显式保留，仓库内 200+ 测试与 `desktop-client/` 下游全部 `use ironclaw::...` 不变）
- ❌ 不改 `default-run = "dasclaw"`
- ❌ 不动 `dasclaw_process_hardening` 的 ctor 钩子语义（仍在每个 bin 的 `src/bin/*.rs` 顶部触发，**没有**移到 lib，避免在测试 / 下游 crate 加载库时被误触发）
- ❌ 不改 `async_main()` 的任何业务逻辑、CLI 解析、channel / orchestrator / webhook 启动顺序
- ❌ 不动 ADR-114 弃用警告的措辞与时机（仍是单次 stderr，文案逐字相同）

## 验证

```bash
# 1. cargo check（0 warning，警告消失）
RUSTC_WRAPPER= cargo check -p dasclaw --all-targets
#   Finished `dev` profile in 1m 12s
#   (无任何 warning / error / multiple build targets / collision)

# 2. 两个 bin 都能编出来
RUSTC_WRAPPER= cargo build -p dasclaw --bin dasclaw --bin ironclaw
#   Finished `dev` profile in 9m 10s

# 3. 运行时 smoke：两个 bin 都能 --help，ironclaw 仍打弃用警告
target/debug/dasclaw --help
# => IronClaw is a secure AI assistant. ... Usage: dasclaw [OPTIONS] [COMMAND] ...
#    (无 deprecation warning)

target/debug/ironclaw --help
# => warning: the `ironclaw` binary is deprecated and will be removed in a future
#    release; use `dasclaw` instead. (ADR-114 Ⅴ — Cargo package + binary rename)
#    IronClaw is a secure AI assistant. ... Usage: ironclaw [OPTIONS] [COMMAND] ...

# 4. fmt + check_no_panics
cargo fmt --all
python3.12 scripts/check_no_panics.py --base origin/xClaw
# => OK: No panic-inducing calls in changed production code.

# 5. clippy（-D warnings 全绿）
RUSTC_WRAPPER= cargo clippy --no-deps -p dasclaw --all-targets -- -D warnings
#   Finished `dev` profile in 5m 22s（0 warning）
```

## Sources read

- `AGENTS.md` § "本地快速开发节奏（完整 build 下沉 CI）" / "GitHub PR 工作流" / "Skills 强制使用规范" / "ADR-114 红线"
- `.github/copilot-instructions.md` § "强制阅读顺序" / "必跑的本地管线"
- `desktop-client/ironclaw/Cargo.toml`（修改前后全文）
- `desktop-client/ironclaw/src/main.rs`（修改前全文，确认 argv[0] 分流只是单一 warning 分支，无其它分歧逻辑）
- `desktop-client/ironclaw/src/lib.rs`（修改前后）
- `docs/plans/architecture-refactor/adr-114-dasclaw-rebrand.md` § Ⅴ（Cargo package + binary rename 节奏，确认 `[lib] name = "ironclaw"` 必须保留 + `ironclaw` bin 一个 release 弃用窗口）

## Cross-cuts

- **ADR-114 类 A**：本 PR diff **没有新增 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量**。被改动的注释里出现的 `ironclaw` 是 lib crate 名与 legacy 二进制名（ADR-114 Ⅴ 显式允许保留），不属于命名空间字面量范畴。

## Skill 自查

- ✅ `code-quality-audit`：无补丁式代码（分流由参数传入 / 不在原函数尾部追加 if 分支）；每个 bin 文件 < 25 行；entry.rs `run` 入口函数 < 50 行；无新增 `unwrap()` / `panic!()`；两个 bin 的 ctor pre_main 是必要的对称（必须在 bin 而非 lib，且 ctor 不能跨 bin 共享），不算抄代码——ironclaw.rs 的 doc 注释显式 cross-reference dasclaw.rs 避免说明重复。
- ✅ `code-simplifier`：`Option<&str>` 而非 bool flag，alias 文本直接嵌进警告语，调用点自文档化；单一 `if let Some` 分支替代两端 if/else。
- ✅ `code-review-expert`：SRP 清晰（bin = 装配；entry = 流程；lib = 领域）；下一个 release 退役 legacy bin 只需 `rm src/bin/ironclaw.rs`，共享代码零修改——可逆性好；安全侧 `pre_main_hardening` 在两个 bin 都仍然第一时间触发，未被削弱。

## 后续

- 本 PR 跟进 #982 后置清单的第 1 项（dual-bin 共享 main.rs 的 cargo 警告）
- ADR-114 弃用窗口到期后，新开 PR 直接删 `src/bin/ironclaw.rs` 即可摘掉 legacy bin，无需再动 entry.rs / lib.rs



Closes #982 (cleanup checklist item 1).
