### PR TITLE
feat(session): add migrate_v1_to_v2 template and MigrationError scaffolding

### DIFF
--- a/crates/dasclaw_session/src/lib.rs
+++ b/crates/dasclaw_session/src/lib.rs
@@ -27,6 +27,30 @@
 //! - **No prompt_history** — see issue #914 PR-D.
 //! - **No on-disk store** — see issue #914 PR-C.
 //!
+//! ## Extending session state without modifying `SessionSnapshot`
+//!
+//! Per ADR-160 / doc 56 §2.2, [`SessionSnapshot`] is a concrete struct,
+//! **not** an extension-slotted blob (no `extensions: serde_json::Value`,
+//! no `metadata: Map<String, Value>`). Third-party agents that need to
+//! persist extra state alongside the framework's session should use the
+//! **`WrappedSession`** pattern:
+//!
+//! ```ignore
+//! struct MyWrappedSession {
+//!     inner: SessionSnapshot,       // framework-owned, persisted via SessionStore
+//!     my_custom_state: MyState,     // wrapper-owned, persisted separately
+//! }
+//! ```
+//!
+//! The framework persists `inner` via [`SessionStore`]; the wrapper
+//! persists `my_custom_state` independently (its own JSONL file, sidecar
+//! table, etc.). When a field is meaningful to *all* agents, propose
+//! adding it to `SessionSnapshot` directly and bump [`SESSION_VERSION`]
+//! via the migration scaffolding in [`migration`].
+//!
+//! See `desktop-client/ironclaw` for a real wrapper that layers extension
+//! state on top of the framework snapshot.
+//!
 //! ## Example
 //!
 //! ```ignore
@@ -58,6 +82,7 @@ pub mod claw_compat;
 pub mod error;
 pub mod id;
 pub mod jsonl;
+pub mod migration;
 pub mod snapshot;
 pub mod store;
 
@@ -67,6 +92,7 @@ pub use claw_compat::{
 pub use error::SessionError;
 pub use id::{SESSION_VERSION, generate_session_id};
 pub use jsonl::{JsonlSessionStore, MAX_ROTATED_FILES, ROTATE_AFTER_BYTES};
+pub use migration::{MigrationError, migrate_to_latest, migrate_v1_to_v2};
 pub use snapshot::{
     SessionCompaction, SessionFork, SessionMetadata, SessionPromptEntry, SessionSnapshot,
 };

--- a/crates/dasclaw_session/src/migration.rs
+++ b/crates/dasclaw_session/src/migration.rs
@@ -1,0 +1,170 @@
+//! Version-to-version migration scaffolding for [`SessionSnapshot`].
+//!
+//! **Current status:** `SESSION_VERSION == 1`, so no real migration runs.
+//! This module exists as a template so that the first contributor bumping
+//! [`SESSION_VERSION`] to `2` does not have to invent the migration
+//! architecture from scratch — they copy [`migrate_v1_to_v2`], replace the
+//! `NotImplemented` body with the actual transformation, and add a new
+//! `match` arm in [`migrate_to_latest`].
+//!
+//! See ADR-160 / doc 56 §2.2 and §4 for the policy that rejects an
+//! `extensions: serde_json::Value` slot and instead requires an explicit
+//! `version` bump + migrate function per breaking change.
+
+use thiserror::Error;
+
+use crate::id::SESSION_VERSION;
+use crate::snapshot::SessionSnapshot;
+
+/// Errors produced by the migration entry points in this module.
+///
+/// Kept separate from [`crate::SessionError`] because migration is a pure,
+/// in-memory transform with no I/O or serde involvement — callers can
+/// handle "this snapshot is from a version I don't know how to read"
+/// without having to match against I/O variants.
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum MigrationError {
+    /// Reached when the migration path between two adjacent versions has
+    /// not been written yet. Currently returned by [`migrate_v1_to_v2`]
+    /// because v2 does not exist.
+    #[error("session migration {from} → {to} not implemented: {reason}")]
+    NotImplemented {
+        /// Source schema version.
+        from: u32,
+        /// Target schema version.
+        to: u32,
+        /// Human-readable reason; static so the variant stays cheap to clone.
+        reason: &'static str,
+    },
+
+    /// Returned when the snapshot's recorded `version` does not match what
+    /// the called migration function expects (e.g. caller invoked
+    /// `migrate_v1_to_v2` on a v3 snapshot), or when [`migrate_to_latest`]
+    /// sees a version it has no arm for.
+    #[error("session version {found} does not match expected migration source {expected}")]
+    VersionMismatch {
+        /// Version the migration function was prepared to consume.
+        expected: u32,
+        /// Version actually carried by the snapshot.
+        found: u32,
+    },
+}
+
+/// Migrates a v1 [`SessionSnapshot`] to v2.
+///
+/// **Status: placeholder.** v2 does not exist yet. This function exists so
+/// the first contributor bumping [`SESSION_VERSION`] to `2` has a template
+/// to copy and does not have to invent the migration architecture from
+/// scratch.
+///
+/// When v2 lands, this function will:
+///
+/// 1. Validate that `old.version == 1`, returning
+///    [`MigrationError::VersionMismatch`] otherwise.
+/// 2. Transform v1-shaped fields into their v2 equivalents.
+/// 3. Set `version = 2` on the returned snapshot.
+/// 4. Be paired with an inverse `migrate_v2_to_v1` if downgrade is
+///    supported (none of the reference implementations do — see
+///    `claw-code/rust/crates/runtime/src/session.rs` and
+///    `codex-cli-main/codex-rs/core/src/state/session.rs`, which both
+///    record `version` without offering downgrade paths).
+///
+/// See ADR-160 §2.2 and §4 for the version-bump policy.
+pub fn migrate_v1_to_v2(_old: SessionSnapshot) -> Result<SessionSnapshot, MigrationError> {
+    Err(MigrationError::NotImplemented {
+        from: 1,
+        to: 2,
+        reason: "v2 schema not yet defined; bump SESSION_VERSION and replace this stub when v2 lands",
+    })
+}
+
+/// Routes a snapshot through every known migration step until it reaches
+/// the current [`SESSION_VERSION`].
+///
+/// At v1 this function is effectively the identity: snapshots that already
+/// match the current version pass through unchanged, snapshots from a
+/// future version (loader is older than the file) or an unknown past
+/// version return [`MigrationError::VersionMismatch`].
+///
+/// When v2 ships, the future contributor adds an arm:
+///
+/// ```ignore
+/// match snapshot.version {
+///     SESSION_VERSION => Ok(snapshot),
+///     1 => migrate_v1_to_v2(snapshot).and_then(migrate_to_latest),
+///     found => Err(MigrationError::VersionMismatch { expected: SESSION_VERSION, found }),
+/// }
+/// ```
+///
+/// Recursing through `migrate_to_latest` after each step means a v1
+/// snapshot will be lifted through v1 → v2 → v3 → … → latest without the
+/// caller having to know the chain length.
+pub fn migrate_to_latest(snapshot: SessionSnapshot) -> Result<SessionSnapshot, MigrationError> {
+    match snapshot.version {
+        SESSION_VERSION => Ok(snapshot),
+        found => Err(MigrationError::VersionMismatch {
+            expected: SESSION_VERSION,
+            found,
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn snapshot_with_version(version: u32) -> SessionSnapshot {
+        let mut snap = SessionSnapshot::fresh();
+        snap.version = version;
+        snap
+    }
+
+    #[test]
+    fn migrate_v1_to_v2_returns_not_implemented() {
+        let result = migrate_v1_to_v2(snapshot_with_version(1));
+        assert_eq!(
+            result.unwrap_err(),
+            MigrationError::NotImplemented {
+                from: 1,
+                to: 2,
+                reason: "v2 schema not yet defined; bump SESSION_VERSION and replace this stub when v2 lands",
+            }
+        );
+    }
+
+    #[test]
+    fn migrate_to_latest_is_identity_on_current_version() {
+        let snap = snapshot_with_version(SESSION_VERSION);
+        let session_id = snap.session_id.clone();
+        let out = migrate_to_latest(snap).expect("identity on current version");
+        assert_eq!(out.version, SESSION_VERSION);
+        assert_eq!(out.session_id, session_id);
+    }
+
+    #[test]
+    fn migrate_to_latest_rejects_future_version() {
+        let future = SESSION_VERSION
+            .checked_add(1)
+            .expect("SESSION_VERSION leaves room for +1");
+        let result = migrate_to_latest(snapshot_with_version(future));
+        assert_eq!(
+            result.unwrap_err(),
+            MigrationError::VersionMismatch {
+                expected: SESSION_VERSION,
+                found: future,
+            }
+        );
+    }
+
+    #[test]
+    fn migrate_to_latest_rejects_unknown_old_version() {
+        let result = migrate_to_latest(snapshot_with_version(999));
+        assert_eq!(
+            result.unwrap_err(),
+            MigrationError::VersionMismatch {
+                expected: SESSION_VERSION,
+                found: 999,
+            }
+        );
+    }
+}


### PR DESCRIPTION
## 背景 / 目标

Issue #957 (W6.5 `SessionSnapshot` 版本化) 已合并 + 关闭，但 DoD 验收清单留账 2 项：

- ❌ DoD 第 2 项：`migrate_v1_to_v2` 函数模板尚未编写
- ❌ DoD 第 3 项：`WrappedSession` 扩展模式未在 crate 文档中说明

本 PR 把两项补齐。

真理来源：[ADR-160 / doc 56 §2.2 + §4](docs/plans/architecture-refactor/56-framework-architecture-re-review.md) — `SessionSnapshot` 拒绝 `extensions: serde_json::Value` 槽，改走 "concrete struct + `version: u32` + `migrate_vN_to_vM` 函数族"。

## 改动范围

新增 `crates/dasclaw_session/src/migration.rs`：

- `MigrationError { NotImplemented, VersionMismatch }` — 通过 `thiserror`（已是 crate 依赖，**未引入新 crate**）
- `migrate_v1_to_v2(_old) -> Result<SessionSnapshot, MigrationError>` — 当前返回 `NotImplemented`，v2 落地时第一个 contributor 抄此模板替换函数体
- `migrate_to_latest(snapshot) -> Result<SessionSnapshot, MigrationError>` — dispatch 入口，当前是 v1 的 identity；未来 v2/v3 加 match arm 即可
- 4 个单元测试覆盖：placeholder 返回值、当前版本 identity、未来版本拒绝、未知历史版本拒绝

修改 `crates/dasclaw_session/src/lib.rs`：

- `pub mod migration;` + flat re-export (`MigrationError`, `migrate_v1_to_v2`, `migrate_to_latest`)
- crate-level doc 新增 "Extending session state without modifying `SessionSnapshot`" 一节，给出 `WrappedSession` pattern 代码示例并指向 `desktop-client/ironclaw` 作为真实实现参考（满足 DoD 第 3 项）

## 非目标（What's NOT in this PR）

- ❌ 不改 `SESSION_VERSION = 1` 常量；v2 不是本 PR 的事
- ❌ 不写真的 v1→v2 schema 转换；v2 schema 还没定义，写了反而是猜测
- ❌ 不引入 `extensions: serde_json::Value` 扩展槽（ADR-160 §2.2 反向 DoD）
- ❌ 不引入新 crate 依赖（用 crate 已有的 `thiserror`）
- ❌ 不写 `migrate_v2_to_v1` 反向迁移（claw-code / codex 两个 reference 实现都不做 downgrade）
- ❌ 不改造 `SessionStore::load` 让它自动调 `migrate_to_latest`；那是 v2 落地时一起做的，避免现在引入未验证的语义

## 验证

```
RUSTC_WRAPPER= cargo check -p dasclaw_session --tests       # 0 错 0 警
RUSTC_WRAPPER= cargo nextest run -p dasclaw_session         # 56/56 PASS
cargo fmt --all                                              # no diff
python3.12 scripts/check_no_panics.py --base origin/xClaw   # OK
cargo clippy --no-deps -p dasclaw_session --all-targets -- -D warnings  # 0 警
```

4 个新测试：

- `migrate_v1_to_v2_returns_not_implemented`
- `migrate_to_latest_is_identity_on_current_version`
- `migrate_to_latest_rejects_future_version`
- `migrate_to_latest_rejects_unknown_old_version`

全部 PASS。52 个既有测试无回归。

## Sources read

- `gh issue view 957`（DoD 留账确认）
- `crates/dasclaw_session/src/snapshot.rs` — 全文，理解 `SessionSnapshot::fresh` / 字段布局
- `crates/dasclaw_session/src/id.rs` — `SESSION_VERSION = 1`
- `crates/dasclaw_session/src/lib.rs` — crate 公共面 + 模块声明结构
- `crates/dasclaw_session/src/error.rs` — 已有 `thiserror` 模式参考
- `crates/dasclaw_session/Cargo.toml` — 确认 `thiserror` 已是 dep
- `docs/plans/architecture-refactor/56-framework-architecture-re-review.md` §2.2 + §4 + 表格 "1 持久化 (#957)" 行 — 决策真理来源
- `claw-code/rust/crates/runtime/src/session.rs` — 确认上游也只记录 `version` 不做 downgrade
- `codex-cli-main/codex-rs/core/src/state/session.rs` — 同上
- `rg "migrate_v" crates/dasclaw_session/` — 确认无既有实现
- `rg "WrappedSession"` — 确认本 PR 是第一次落地 crate 内文档说明

## Cross-cuts

ADR-114（`.ironclaw` → `.dasclaw`）：**类A**（无新增 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量）

## 后续步骤

- v2 schema 真正需要时：抄 `migrate_v1_to_v2` 模板，替换函数体，在 `migrate_to_latest` 加 `1 => migrate_v1_to_v2(snapshot).and_then(migrate_to_latest)` arm，bump `SESSION_VERSION` 到 2，新增 `migrate_v2_to_v1`（如需 downgrade）
- 配套 `SessionStore::load` 是否要内嵌 `migrate_to_latest` 调用：留到 v2 落地时一起评估

Closes #957
