### PR TITLE
fix(tests): update req_110_dual_bin_targets_present after #986 src/bin/ split

### DIFF
--- a/desktop-client/ironclaw/tests/req_110_cargo_metadata.rs
+++ b/desktop-client/ironclaw/tests/req_110_cargo_metadata.rs
@@ -8,12 +8,14 @@
 //!   downstream wrappers invoke the canonical binary.
 //! * `[lib].name` MUST stay `"ironclaw"` so the 200+ `use ironclaw::…`
 //!   imports across the workspace continue to resolve unchanged.
-//! * Two `[[bin]]` entries MUST exist — `dasclaw` (canonical) and
-//!   `ironclaw` (deprecation shim) — both pointing at `src/main.rs`.
+//! * The two binary entry points MUST exist on disk under `src/bin/` —
+//!   `dasclaw.rs` (canonical) and `ironclaw.rs` (deprecation shim) — and
+//!   are auto-discovered by Cargo, so `Cargo.toml` MUST NOT carry stale
+//!   explicit `[[bin]]` entries pointing at the old `src/main.rs`.
 //!
-//! The test is a pure string-level scan of `Cargo.toml`. It does not pull
-//! in `toml` or `cargo_metadata` to keep the dev-dep surface small and
-//! the test fast (< 5 ms).
+//! The test is a pure file-system + string scan. It does not pull in
+//! `toml` or `cargo_metadata` to keep the dev-dep surface small and the
+//! test fast (< 5 ms).
 
 use std::fs;
 use std::path::PathBuf;
@@ -59,21 +61,25 @@ fn req_110_lib_name_preserved_as_ironclaw() {
 
 #[test]
 fn req_110_dual_bin_targets_present() {
-    let text = cargo_toml_text();
-    let dasclaw_bin = text.contains("[[bin]]")
-        && text
-            .split("[[bin]]")
-            .any(|s| s.contains("name = \"dasclaw\"") && s.contains("path = \"src/main.rs\""));
-    let ironclaw_bin = text
-        .split("[[bin]]")
-        .any(|s| s.contains("name = \"ironclaw\"") && s.contains("path = \"src/main.rs\""));
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let dasclaw_bin = manifest_dir.join("src/bin/dasclaw.rs");
+    let ironclaw_bin = manifest_dir.join("src/bin/ironclaw.rs");
     assert!(
-        dasclaw_bin,
-        "req_110: missing [[bin]] dasclaw → src/main.rs (canonical entry)"
+        dasclaw_bin.is_file(),
+        "req_110: missing src/bin/dasclaw.rs (canonical entry, auto-discovered)"
     );
     assert!(
-        ironclaw_bin,
-        "req_110: missing [[bin]] ironclaw → src/main.rs (deprecation shim)"
+        ironclaw_bin.is_file(),
+        "req_110: missing src/bin/ironclaw.rs (deprecation shim, auto-discovered)"
+    );
+    // Guard against accidental reintroduction of an explicit [[bin]] entry
+    // pointing at the deleted `src/main.rs`, which would resurrect the
+    // "file present in multiple build targets" warning the split fixed.
+    let text = cargo_toml_text();
+    assert!(
+        !text.contains("path = \"src/main.rs\""),
+        "req_110: stale path = \"src/main.rs\" found in Cargo.toml; \
+         both bins must stay auto-discovered from src/bin/"
     );
 }
 


### PR DESCRIPTION
Closes #986 (post-merge fix).

## 背景 / 目标

#986 把 `desktop-client/ironclaw` 的两个二进制目标从「都指向 `src/main.rs`」拆成 `src/bin/dasclaw.rs` + `src/bin/ironclaw.rs`（由 Cargo 自动发现），消除了 `file present in multiple build targets` 警告。

但 `desktop-client/ironclaw/tests/req_110_cargo_metadata.rs::req_110_dual_bin_targets_present` 这条 req-test 没有跟着更新，仍在断言 `Cargo.toml` 里有两条 `[[bin]]` 显式条目且都指向 `src/main.rs`。结果是主分支这一条测试持续失败，所有基于 xClaw 开出的 dependabot rebase 都因此 CI 红。

## 改动范围

只改 `desktop-client/ironclaw/tests/req_110_cargo_metadata.rs`：

- `req_110_dual_bin_targets_present` 重写为：
  - 验证 `src/bin/dasclaw.rs` 和 `src/bin/ironclaw.rs` 文件存在（auto-discovery 契约）
  - 额外断言 `Cargo.toml` 里**不再**出现 `path = "src/main.rs"`（防止未来不慎回退到双入口指同一文件的写法，再次触发 cargo 警告）
- 顶部 doc 注释同步更新到新契约

## 非目标

- 不动 `Cargo.toml`
- 不动 `src/bin/*.rs` 或 `src/entry.rs`
- 不动其他 4 条 `req_110_*` 测试（它们本来就在过）
- 不改 dependabot PR；让它们自己 rebase 上来即可

## 验证

```
cargo nextest run -p dasclaw --test req_110_cargo_metadata
# Summary: 5 tests run: 5 passed, 0 skipped
```

`req_110_dual_bin_targets_present` 现已通过；其他 4 条保持通过。

## Sources read

- `desktop-client/ironclaw/Cargo.toml` §1–45：确认 `[lib].name = "ironclaw"`、`default-run = "dasclaw"`、无显式 `[[bin]]` 条目（auto-discovery 由顶部 doc 注释明确）
- `desktop-client/ironclaw/src/bin/dasclaw.rs` / `ironclaw.rs`：确认两个文件存在
- `desktop-client/ironclaw/tests/req_110_cargo_metadata.rs` 全文：确认仅一条测试需要重写，其他 4 条契约未变
- ADR-114 Ⅴ（Cargo package + binary rename）：契约未变，本 PR 仅同步测试到 #986 落地的真实结构
