### PR TITLE
feat(desktop-client): e2e-webdriver scenario 02 agent execution (stacked on #997)

### DIFF
--- a/desktop-client/e2e-webdriver/README.md
+++ b/desktop-client/e2e-webdriver/README.md
@@ -43,5 +43,5 @@ pytest desktop-client/e2e-webdriver/tests/test_scenario_01_engine_readiness.py -
 | 场景 | 状态 |
 |------|------|
 | §1 引擎就绪与刷新韧性 | ✅ 已落地 |
-| §2 Agent 基础执行 | ⬜ 待落地 |
+| §2 Agent 基础执行 | ✅ 已落地（需 LLM 可达） |
 | §3–§7 | ⬜ 待落地（按 plan §1–§7 顺序推进） |

--- a/desktop-client/e2e-webdriver/tests/test_scenario_02_agent_execution.py
+++ b/desktop-client/e2e-webdriver/tests/test_scenario_02_agent_execution.py
@@ -1,0 +1,56 @@
+"""
+场景 2 — Agent 基础执行
+
+对应：desktop-client/docs/e2e-webdriver-test-plan.md §2
+
+验证：在 composer 输入一句话 + 点击发送后，60–120s 内至少出现 1 个新的助手气泡。
+
+前置条件：
+  - 场景 1 已就绪（compose 出现、boot 占位消失）
+  - 应用端已通过 admin 注入并激活模型（本地开发环境默认带 glm-4.7-flash）
+
+LLM 不通时，这条用例预期失败而非 skip——失败本身就是有用的信号，
+说明 send_chat_message 链路或模型配置出了问题。
+"""
+
+from __future__ import annotations
+
+from webdriver_client import (
+    click_send,
+    poll,
+    snapshot,
+    type_into_composer,
+)
+
+
+def _wait_composer_ready(sid: str, timeout: float = 60.0) -> dict | None:
+    def _check():
+        s = snapshot(sid)
+        return s if (s["composer"] > 0 and not s["boot"]) else None
+
+    return poll(_check, timeout=timeout, interval=1.0)
+
+
+def test_send_message_yields_assistant_reply(session_id):
+    """输入 → 发送 → 出现新助手气泡。
+
+    取发送前的 assistantMsgs 计数作为 baseline，断言之后的计数 > baseline。
+    """
+    s0 = _wait_composer_ready(session_id, timeout=60.0)
+    assert s0 is not None, "场景 1 前置：composer 未就绪"
+    baseline = s0["assistantMsgs"]
+
+    type_into_composer(session_id, "用一句话介绍你自己")
+    click_send(session_id)
+
+    def _has_new_reply():
+        s = snapshot(session_id)
+        return s if s["assistantMsgs"] > baseline else None
+
+    s1 = poll(_has_new_reply, timeout=120.0, interval=2.0)
+    assert s1 is not None, (
+        "120s 内未出现新助手气泡——可能 LLM 未配置 / send_chat_message 失败 / 网络中断"
+    )
+    assert s1["assistantMsgs"] > baseline, (
+        f"assistantMsgs 未增长（baseline={baseline}, now={s1['assistantMsgs']}）"
+    )

--- a/desktop-client/e2e-webdriver/webdriver_client.py
+++ b/desktop-client/e2e-webdriver/webdriver_client.py
@@ -114,11 +114,18 @@ def invoke(session_id: str, command: str, payload: Optional[dict] = None) -> Any
 
 
 def poll(fn: Callable[[], Any], timeout: float = 30.0, interval: float = 1.0) -> Any:
-    """轮询直到 fn() 返回真值或超时；返回最后一次结果。"""
+    """轮询直到 fn() 返回真值或超时；返回最后一次结果。
+
+    fn() 抛 `URLError` / `HTTPError` / `OSError` 视为"页面还没准备好"，
+    继续重试——典型场景是上一条用例刚 `location.reload()`，page agent 还在重启。
+    """
     last = None
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
-        last = fn()
+        try:
+            last = fn()
+        except (urllib.error.URLError, urllib.error.HTTPError, OSError):
+            last = None
         if last:
             return last
         time.sleep(interval)
@@ -146,3 +153,31 @@ return JSON.stringify({
 def snapshot(session_id: str) -> dict:
     """便捷封装：跑 SNAPSHOT 探针并解析为 dict。"""
     return json.loads(execjs(session_id, SNAPSHOT))
+
+
+# 通过原生 setter 注入文本，绕过 React 受控组件的 onChange 监听。
+_INJECT_COMPOSER = r"""
+const [text] = arguments;
+const ta = document.querySelector('textarea.aui-composer-input');
+if (!ta) return false;
+const setter = Object.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype, 'value').set;
+setter.call(ta, text);
+ta.dispatchEvent(new Event('input', { bubbles: true }));
+return true;
+"""
+
+
+def type_into_composer(session_id: str, text: str) -> None:
+    """把 text 注入 `textarea.aui-composer-input` 并触发 React 的 onChange。"""
+    ok = execjs(session_id, _INJECT_COMPOSER, [text])
+    if not ok:
+        raise RuntimeError("找不到 textarea.aui-composer-input")
+
+
+def click_send(session_id: str) -> None:
+    """点击 `button.aui-composer-send`。"""
+    execjs(
+        session_id,
+        "document.querySelector('button.aui-composer-send').click(); return true;",
+    )
+


### PR DESCRIPTION
> **⚠️ Stacked PR**：base 分支不是 `xClaw`，而是 #997（`feat/e2e-webdriver-scenario-01`）。
> **建议阅读顺序**：先看 #997，再看本 PR。
> **合并顺序**：#997 → 本 PR。

Closes #996

## 背景 / 目标

承接 #997（场景 §1 引擎就绪）。把测试计划文档 §2「Agent 基础执行」从 markdown 真正落地：
向 composer 注入一句话 → 点发送 → 60–120s 内出现新助手气泡。

## 改动范围

- `desktop-client/e2e-webdriver/webdriver_client.py`
  - 新增 `type_into_composer(sid, text)` —— 用原生 `value` setter + `input` 事件绕过 React 受控组件
  - 新增 `click_send(sid)` —— 点击 `button.aui-composer-send`
  - `poll()` 容忍 `URLError` / `HTTPError` / `OSError` —— 上一条用例 `location.reload()` 后页面重启窗口期不会再把 HTTP 500 当真失败
- `desktop-client/e2e-webdriver/tests/test_scenario_02_agent_execution.py`（新文件，单条用例 `test_send_message_yields_assistant_reply`）
  - 取发送前 `assistantMsgs` 计数作为 baseline
  - 输入「用一句话介绍你自己」+ 点击发送
  - 轮询 120s 等待 `assistantMsgs > baseline`
- `desktop-client/e2e-webdriver/README.md`：把 §2 状态从 ⬜ 改 ✅（需 LLM 可达）

## 非目标（What's NOT in this PR）

- §3 工具注册 / §4 审批 / §5 DLP / §6 持久化 / §7 prompt 注入 —— 后续独立 PR
- 把 composer / send 按钮补 `data-testid`（计划文档 §10-G1 已挂账，留产品侧确认时机）
- LLM 网络中断时的 fallback —— 用例预期失败而非 skip，**失败本身**就是有用信号
- 修改任何生产代码

## 验证

```bash
# 1. 启动 app（沿用 #997 的方法）
cd desktop-client && set -a && source ./.env && set +a
export MANAGED_MODE=false && export OPENAI_API_KEY="$LLM_API_KEY"
cargo tauri dev -f webdriver

# 2. 另起 shell 跑 pytest
cd desktop-client/e2e-webdriver && PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -v
```

实跑结果（本地 macOS 26.1 + WKWebView + glm-4.7-flash via bigmodel.cn）：

```
tests/test_scenario_01_engine_readiness.py::test_cold_boot_reaches_ready PASSED            [ 25%]
tests/test_scenario_01_engine_readiness.py::test_get_engine_status_reports_ready PASSED    [ 50%]
tests/test_scenario_01_engine_readiness.py::test_reload_remains_ready PASSED               [ 75%]
tests/test_scenario_02_agent_execution.py::test_send_message_yields_assistant_reply PASSED [100%]
============================== 4 passed in 2.54s ==============================
```

## Sources read

- [desktop-client/docs/e2e-webdriver-test-plan.md](desktop-client/docs/e2e-webdriver-test-plan.md) §2「Agent 基础执行」+ §10-G1（composer 无 data-testid 缺口说明）
- [desktop-client/src/ipc/chat.rs](desktop-client/src/ipc/chat.rs) `send_chat_message` 入口（前端 click → 这里）
- [desktop-client/ui/src/app/components/assistant-ui/thread.tsx](desktop-client/ui/src/app/components/assistant-ui/thread.tsx#L207) `aui-composer-input` / `aui-composer-send`
- [desktop-client/e2e-webdriver/webdriver_client.py](desktop-client/e2e-webdriver/webdriver_client.py)（#997 落地）—— 复用 `execjs` / `snapshot` / `poll`
- [AGENTS.md](AGENTS.md) PR 模板 / stacked PR 注明规则

## 实施过程关键发现

1. **串跑 vs 单跑差异**：§2 单跑通过，但和 §1 串跑时 §2 的第一个 `execjs` 拿 HTTP 500——根因是 §1 末尾 `test_reload_remains_ready` 触发 `location.reload()`，webview agent 重启的窗口期内 webdriver 不响应。**修复**：`poll()` 把网络 / HTTP 异常都当 "未就绪" 重试，而不是冒泡。同时这也让后续 §3-§7 任何依赖 reload 的用例直接受益。
2. **React 受控组件**：直接 `ta.value = text` 不会触发 React onChange；必须用 `Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value').set` 原生 setter，再派发 `input` 事件，与 assistant-ui 的 hook 链路一致。
