### PR TITLE
feat(desktop-client): e2e-webdriver scenario 03 tool registration (stacked on #998)

### DIFF
--- a/desktop-client/e2e-webdriver/README.md
+++ b/desktop-client/e2e-webdriver/README.md
@@ -44,4 +44,5 @@ pytest desktop-client/e2e-webdriver/tests/test_scenario_01_engine_readiness.py -
 |------|------|
 | §1 引擎就绪与刷新韧性 | ✅ 已落地 |
 | §2 Agent 基础执行 | ✅ 已落地（需 LLM 可达） |
-| §3–§7 | ⬜ 待落地（按 plan §1–§7 顺序推进） |
+| §3 工具注册与发现 | ✅ 已落地（只读工具 `list_dir` 分发链路；需 LLM 可达） |
+| §4–§7 | ⬜ 待落地（按 plan §4–§7 顺序推进） |

--- a/desktop-client/e2e-webdriver/tests/test_scenario_03_tool_registration.py
+++ b/desktop-client/e2e-webdriver/tests/test_scenario_03_tool_registration.py
@@ -1,0 +1,54 @@
+"""
+场景 3 — 工具注册与发现
+
+对应：desktop-client/docs/e2e-webdriver-test-plan.md §3
+
+验证：引擎启动时注册的**只读工具**（如 `list_dir`）能被对话触发并产出助手回复，
+即整条「Prompt → LLM → ToolCall → Dispatcher → ToolResult → 助手气泡」分发链路通畅。
+
+为什么不断言 `tools: N accepted` 日志（plan §10-G2）：
+  `summary_line()` / `log_registration_report()` 只在 `bootstrap_tools()` 内触发，
+  桌面端 `engine.rs` 走的是手动 `register_message_tools` + `register_job_tools`，
+  那行 info 日志在桌面端不一定出现，断言它会假阴。改为「发对话 + 等助手回复」
+  的功能验证路线。
+
+LLM 不可达 / 模型未配置时，这条用例预期失败而非 skip——失败本身是有效信号。
+"""
+
+from __future__ import annotations
+
+from webdriver_client import (
+    click_send,
+    snapshot,
+    type_into_composer,
+    wait_assistant_message_count,
+    wait_composer_ready,
+)
+
+
+def test_only_readonly_tool_dispatch_yields_reply(session_id):
+    """触发只读工具 `list_dir` → 90s 内出现新助手气泡。
+
+    Plan §3 给的提示词照搬：「列出当前工作目录下的文件，用 list_dir 工具」。
+    断言点取「assistant 气泡数严格增长」，不去解析具体文本——LLM 输出文本不
+    稳定（中英文/换行/转义），但只要分发成功就一定有新气泡。
+    """
+    s0 = wait_composer_ready(session_id, timeout=60.0)
+    assert s0 is not None, "场景 1 前置：composer 未就绪"
+    baseline = s0["assistantMsgs"]
+
+    type_into_composer(session_id, "列出当前工作目录下的文件，用 list_dir 工具")
+    click_send(session_id)
+
+    s1 = wait_assistant_message_count(
+        session_id, baseline=baseline, timeout=90.0, interval=2.0
+    )
+
+    assert s1 is not None, (
+        "90s 内未出现新助手气泡——可能：(a) LLM 未配置或不可达；"
+        "(b) 模型没选择调用 list_dir；(c) Dispatcher 链路断（注册缺失 / 调度失败）。"
+        f" 末态 snapshot={snapshot(session_id)}"
+    )
+    assert s1["assistantMsgs"] > baseline, (
+        f"assistantMsgs 未严格增长（baseline={baseline}, now={s1['assistantMsgs']}）"
+    )

--- a/desktop-client/e2e-webdriver/webdriver_client.py
+++ b/desktop-client/e2e-webdriver/webdriver_client.py
@@ -181,3 +181,32 @@ def click_send(session_id: str) -> None:
         "document.querySelector('button.aui-composer-send').click(); return true;",
     )
 
+
+def wait_composer_ready(session_id: str, timeout: float = 60.0) -> Optional[dict]:
+    """轮询直到 composer 出现且 boot 占位消失，返回当时的 snapshot。
+
+    场景 2/3 的统一前置：发送消息前必须等聊天输入框就绪，否则 React 还没挂载
+    完毕，注入文本会找不到元素。
+    """
+
+    def _check():
+        s = snapshot(session_id)
+        return s if (s["composer"] > 0 and not s["boot"]) else None
+
+    return poll(_check, timeout=timeout, interval=1.0)
+
+
+def wait_assistant_message_count(
+    session_id: str,
+    baseline: int,
+    timeout: float = 120.0,
+    interval: float = 2.0,
+) -> Optional[dict]:
+    """轮询直到 assistantMsgs 严格大于 baseline，返回当时的 snapshot。"""
+
+    def _check():
+        s = snapshot(session_id)
+        return s if s["assistantMsgs"] > baseline else None
+
+    return poll(_check, timeout=timeout, interval=interval)
+


### PR DESCRIPTION
> **⚠️ Stacked PR**：base 分支不是 `xClaw`，而是 #998（`feat/e2e-webdriver-scenario-02`）。
> **建议阅读顺序**：先看 #997 → #998 → 本 PR。
> **合并顺序**：#997 → #998 → 本 PR。

Closes #996

## 背景 / 目标

承接 #998（场景 §2 Agent 执行）。把测试计划文档 §3「工具注册与发现」从 markdown 落地：对话触发只读工具 `list_dir` → 90s 内出现新助手气泡 = 整条「Prompt → LLM → ToolCall → Dispatcher → ToolResult → Thread 渲染」分发链路通畅。

## 改动范围

- `desktop-client/e2e-webdriver/tests/test_scenario_03_tool_registration.py`（新文件，单条用例 `test_only_readonly_tool_dispatch_yields_reply`）
  - 用 plan §3 原话「列出当前工作目录下的文件，用 list_dir 工具」做 prompt
  - 取发送前 `assistantMsgs` 计数为 baseline，断言 90s 内严格 > baseline
  - **不**断言 `tools: N accepted` 日志（见下方"实施过程关键发现"#1）
- `desktop-client/e2e-webdriver/webdriver_client.py`
  - 新增 `wait_composer_ready(sid, timeout)` —— 等聊天框就绪并返回 snapshot
  - 新增 `wait_assistant_message_count(sid, baseline, timeout, interval)` —— 等助手气泡严格增长
  - 避免在每个 test 文件里写小循环；后续 §4-§7 直接复用
- `desktop-client/e2e-webdriver/README.md`：§3 状态 ⬜ → ✅（需 LLM 可达）

## 非目标（What's NOT in this PR）

- §4 审批 / §5 DLP / §6 持久化 / §7 prompt 注入 —— 留独立 PR
- **不**收敛 §2 的 `_wait_composer_ready` 私有 helper 到新的公共 `wait_composer_ready`：保留重复以降低 §2 回归风险，后续 §4 PR 顺手合并
- **不**断言工具注册的具体条数：plan §10-G2 已挂账，注册条数应通过 UI / 命令读真实计数，未来 PR 处理
- 修改任何生产代码

## 验证

```bash
# 1. 启动 app（沿用 #997 方法）
cd desktop-client && set -a && source ./.env && set +a
export MANAGED_MODE=false && export OPENAI_API_KEY="$LLM_API_KEY"
cargo tauri dev -f webdriver

# 2. 另起 shell 跑 pytest
cd desktop-client/e2e-webdriver && PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -v
```

实跑结果（本地 macOS 26.1 + WKWebView + glm-4.7-flash via bigmodel.cn）：

```
tests/test_scenario_01_engine_readiness.py::test_cold_boot_reaches_ready PASSED            [ 20%]
tests/test_scenario_01_engine_readiness.py::test_get_engine_status_reports_ready PASSED    [ 40%]
tests/test_scenario_01_engine_readiness.py::test_reload_remains_ready PASSED               [ 60%]
tests/test_scenario_02_agent_execution.py::test_send_message_yields_assistant_reply PASSED [ 80%]
tests/test_scenario_03_tool_registration.py::test_only_readonly_tool_dispatch_yields_reply PASSED [100%]
============================== 5 passed in 3.48s ==============================
```

## Sources read

- [desktop-client/docs/e2e-webdriver-test-plan.md](desktop-client/docs/e2e-webdriver-test-plan.md) §3「工具注册与发现」+ §10-G2「`tools: N accepted` 日志在 desktop-client 不一定出现」
- [desktop-client/src/engine.rs](desktop-client/src/engine.rs) Phase 7 手动 `register_message_tools` + `register_job_tools`
- 子 agent 用 grep_search + read_file 三层验证了 `list_dir` 工具在 ironclaw / dasclaw 的真实定义
- [desktop-client/e2e-webdriver/webdriver_client.py](desktop-client/e2e-webdriver/webdriver_client.py)（#997 / #998 落地的基础）
- [AGENTS.md](AGENTS.md) PR 模板 / stacked PR 规则

## 实施过程关键发现

1. **plan §10-G2 已挂账的日志缺口实测确认**：`tools: 61 accepted` 这行 info 由 `ToolRegistrationReport::summary_line()` → `log_registration_report()` 产出，但 desktop-client 的 `engine.rs` 在 Phase 7 手动调 `register_message_tools` / `register_job_tools`，**不**走 `bootstrap_tools()`，因此该日志在桌面端**不一定出现**。本 PR 测试因此走"功能验证"而非"日志条数验证"路线——发对话 + 等助手气泡。
2. **`assistantMsgs > baseline` 是稳定断言点**：助手回复文本会因模型 / 提示词不同而变（中英文、是否真用 list_dir、转义），但只要 dispatch 链路通，就一定有新的 assistant root 节点。和 §2 一致。
3. **断言失败的可读性**：失败 message 列了 3 个怀疑方向（LLM 不可达 / 模型没选 list_dir / Dispatcher 链路断）+ 末态 snapshot，给后来者快速定位。
