### PR TITLE
feat(desktop-client/e2e): scenario 04 approval fail-safe

### DIFF
--- a/desktop-client/e2e-webdriver/README.md
+++ b/desktop-client/e2e-webdriver/README.md
@@ -45,4 +45,5 @@ pytest desktop-client/e2e-webdriver/tests/test_scenario_01_engine_readiness.py -
 | §1 引擎就绪与刷新韧性 | ✅ 已落地 |
 | §2 Agent 基础执行 | ✅ 已落地（需 LLM 可达） |
 | §3 工具注册与发现 | ✅ 已落地（只读工具 `list_dir` 分发链路；需 LLM 可达） |
-| §4–§7 | ⬜ 待落地（按 plan §4–§7 顺序推进） |
+| §4 工具分发与审批（Fail-Safe） | ✅ 已落地（写工具触发审批卡片 + deny 路径；approve 路径 skip，见用例说明） |
+| §5–§7 | ⬜ 待落地（按 plan §5–§7 顺序推进） |

--- a/desktop-client/e2e-webdriver/tests/test_scenario_04_approval_failsafe.py
+++ b/desktop-client/e2e-webdriver/tests/test_scenario_04_approval_failsafe.py
@@ -1,0 +1,135 @@
+"""
+场景 4 — 工具分发与审批（Fail-Safe）
+
+对应：desktop-client/docs/e2e-webdriver-test-plan.md §4
+
+验证：
+  1. 触发需审批的写操作 → 必须弹出审批卡片（**不能**静默执行，Fail-Safe）
+  2. 点击「拒绝」→ 结果横幅 `data-approved=false`
+
+为什么不断言 `AGENT_AUTO_APPROVE_TOOLS=false` 环境变量（plan §10-G3）：
+  该变量在全仓 `crates/` + `desktop-client/` 下零匹配，是文档残留的伪不变量。
+  正确的 Fail-Safe 判据是 **行为级**：写操作触发审批卡片，而不是检查某个不存在的开关。
+
+为什么 `approve` 分支被 skip：
+  审批通过后会真把 `e2e_probe.txt` 写到 desktop-client 工作目录（同一 cwd 持久化），
+  造成跨用例污染 + 需要清理逻辑。Deny 分支已经覆盖了完整的「卡片 → 决策 → 横幅」链路，
+  Approve 分支差异仅在 `data-approved=true` 这一布尔值，相对成本/价值不划算。
+  若后续要补，应优先重构成 sandbox 子目录或可清理的临时路径。
+
+测试之间用 `clear_pending_approval` 在开头清掉上一条用例可能留下的挂起卡片，
+避免共享同一 WKWebView 时的串扰。
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from webdriver_client import (
+    clear_pending_approval,
+    click_approval,
+    click_send,
+    snapshot,
+    type_into_composer,
+    wait_approval_card,
+    wait_approval_decision,
+    wait_composer_ready,
+)
+
+# 提示词照搬 plan §4，最大概率让 LLM 选择走写文件类需审批工具。
+WRITE_PROMPT = (
+    "请立即调用 write_file 工具在当前工作目录创建文件 e2e_probe.txt，"
+    "内容为字符串 hello。不要先解释，不要先用 read_file/list_dir 探查，"
+    "也不要建议我用其它方式——直接调用 write_file。"
+)
+
+# LLM 选择 + 模型推理 + 后端审批通知双发 + 前端 SDK 路由到 ToolUI 整条链路，
+# 实测在 macOS + glm-4.7-flash 一般 < 30s，给 120s 兜底应对偶发慢响应。
+CARD_TIMEOUT = 120.0
+
+
+def test_write_tool_triggers_approval_card(session_id):
+    """Fail-Safe：发"新建文件"指令 → 审批卡片出现，且不点按钮。
+
+    这是 plan §4 的核心 Fail-Safe 不变量——写操作**绝不能**绕过审批静默执行。
+    断言只要求卡片出现（`approvalCard` 为真），不点 approve/deny；点 deny 仅作为
+    tearDown 清理状态。
+    """
+    clear_pending_approval(session_id)
+
+    s0 = wait_composer_ready(session_id, timeout=60.0)
+    assert s0 is not None, "composer 未就绪"
+
+    type_into_composer(session_id, WRITE_PROMPT)
+    click_send(session_id)
+
+    s1 = wait_approval_card(session_id, timeout=CARD_TIMEOUT)
+    assert s1 is not None, (
+        f"{CARD_TIMEOUT:.0f}s 内未出现审批卡片——可能：(a) LLM 未配置/不可达；"
+        "(b) 模型没选择写文件工具（提示词不够直接）；"
+        "(c) ⚠️ Fail-Open：写操作被静默执行——这是严重安全回归。"
+        f" 末态 snapshot={snapshot(session_id)}"
+    )
+    assert s1["approvalCard"] is True, "snapshot 自相矛盾"
+
+    # 清掉挂起审批，避免污染后续用例
+    clear_pending_approval(session_id)
+
+
+def test_deny_yields_approved_false(session_id):
+    """完整链路：发指令 → 等卡片 → 点拒绝 → 等 `data-approved=false` 横幅。
+
+    覆盖前端 `ic_deny_tool` IPC → 后端 `Submission::ExecApproval` → SDK 把工具调用
+    推进到 `complete` → ApprovalResultBanner 渲染 `data-approved=false` 这条回路。
+    """
+    clear_pending_approval(session_id)
+
+    s0 = wait_composer_ready(session_id, timeout=60.0)
+    assert s0 is not None, "composer 未就绪"
+
+    type_into_composer(session_id, WRITE_PROMPT)
+    click_send(session_id)
+
+    s1 = wait_approval_card(session_id, timeout=CARD_TIMEOUT)
+    assert s1 is not None, (
+        f"{CARD_TIMEOUT:.0f}s 内未出现审批卡片，无法继续验证拒绝路径。"
+        f" 末态 snapshot={snapshot(session_id)}"
+    )
+
+    click_approval(session_id, "deny")
+
+    denied = wait_approval_decision(
+        session_id, expected_approved=False, timeout=30.0
+    )
+    assert denied, (
+        "点 deny 后 30s 内未出现 `data-approved=false` 横幅——可能："
+        "(a) ic_deny_tool IPC 未送达；(b) 后端未把虚拟工具推进到 complete；"
+        f"(c) ApprovalResultBanner 渲染失败。 末态 snapshot={snapshot(session_id)}"
+    )
+
+
+@pytest.mark.skip(
+    reason=(
+        "approve 会真把 e2e_probe.txt 写入 desktop-client 工作目录，造成跨用例污染；"
+        "deny 分支已覆盖完整链路，approve 分支差异仅 data-approved=true 这个布尔值。"
+        "若后续要补，应先把工作目录改成 sandbox 临时路径或加 teardown 清理。"
+    )
+)
+def test_approve_yields_approved_true(session_id):
+    """（保留占位）批准路径——见 skip reason。"""
+    clear_pending_approval(session_id)
+
+    s0 = wait_composer_ready(session_id, timeout=60.0)
+    assert s0 is not None
+
+    type_into_composer(session_id, WRITE_PROMPT)
+    click_send(session_id)
+
+    s1 = wait_approval_card(session_id, timeout=CARD_TIMEOUT)
+    assert s1 is not None
+
+    click_approval(session_id, "approve")
+    approved = wait_approval_decision(
+        session_id, expected_approved=True, timeout=30.0
+    )
+    assert approved

--- a/desktop-client/e2e-webdriver/webdriver_client.py
+++ b/desktop-client/e2e-webdriver/webdriver_client.py
@@ -210,3 +210,94 @@ def wait_assistant_message_count(
 
     return poll(_check, timeout=timeout, interval=interval)
 
+
+# ---------------------------------------------------------------------------
+# 审批卡片（场景 4）
+# ---------------------------------------------------------------------------
+
+def wait_approval_card(
+    session_id: str,
+    timeout: float = 120.0,
+    interval: float = 1.5,
+) -> Optional[dict]:
+    """轮询直到 `[data-testid="approval-card"]` 出现，返回当时的 snapshot。
+
+    超时返回 None。LLM 是否选择走需审批工具与模型/提示词有关——把这一判断
+    留给上层断言（含可读的诊断 message）。
+    """
+
+    def _check():
+        s = snapshot(session_id)
+        return s if s["approvalCard"] else None
+
+    return poll(_check, timeout=timeout, interval=interval)
+
+
+def click_approval(session_id: str, decision: str) -> None:
+    """点击审批卡片的 `批准` 或 `拒绝` 按钮。
+
+    decision 必须是 "approve" 或 "deny"，对应 `[data-testid="approval-approve"]`
+    / `[data-testid="approval-deny"]`（见 approval-tool-ui.tsx）。
+
+    找不到按钮时抛 RuntimeError，避免静默失败。
+    """
+    if decision not in ("approve", "deny"):
+        raise ValueError(f"decision 必须是 'approve' 或 'deny'，得到 {decision!r}")
+    testid = f"approval-{decision}"
+    script = (
+        "const [tid] = arguments;"
+        "const btn = document.querySelector(`[data-testid=\"${tid}\"]`);"
+        "if (!btn) return false;"
+        "btn.click();"
+        "return true;"
+    )
+    ok = execjs(session_id, script, [testid])
+    if not ok:
+        raise RuntimeError(f"找不到审批按钮 [data-testid=\"{testid}\"]")
+
+
+def read_approval_decision(session_id: str) -> Optional[bool]:
+    """读 `[data-testid="approval-result"]` 上的 `data-approved` 属性。
+
+    返回 True / False / None（横幅尚未出现或属性缺失）。
+    """
+    script = (
+        "const e = document.querySelector('[data-testid=\"approval-result\"]');"
+        "if (!e) return null;"
+        "const v = e.getAttribute('data-approved');"
+        "if (v === 'true') return true;"
+        "if (v === 'false') return false;"
+        "return null;"
+    )
+    return execjs(session_id, script)
+
+
+def wait_approval_decision(
+    session_id: str,
+    expected_approved: bool,
+    timeout: float = 30.0,
+    interval: float = 1.0,
+) -> bool:
+    """轮询直到 `data-approved` 等于 expected_approved，返回是否命中。"""
+
+    def _check():
+        v = read_approval_decision(session_id)
+        return True if v is expected_approved else None
+
+    return bool(poll(_check, timeout=timeout, interval=interval))
+
+
+def clear_pending_approval(session_id: str, timeout: float = 5.0) -> bool:
+    """若存在挂起的审批卡片，点 deny 把它清掉。
+
+    用例之间共享同一 WKWebView，前一条用例可能留下未点击的卡片；本函数让
+    每条用例从"无挂起审批"的干净状态开始。返回是否实际清理过。
+    """
+    s = snapshot(session_id)
+    if not s["approvalCard"]:
+        return False
+    click_approval(session_id, "deny")
+    # 等横幅出现，确保 SDK 已把状态推进，避免下一条用例还看到旧卡片
+    wait_approval_decision(session_id, expected_approved=False, timeout=timeout)
+    return True
+


### PR DESCRIPTION
## 背景 / 目标

`desktop-client/docs/e2e-webdriver-test-plan.md` §4「工具分发与审批（Fail-Safe）」的可运行落地。Stacked on #1000，先看 #1000 再看本 PR。

Closes #996

## 改动范围

| 文件 | 类型 | 内容 |
|---|---|---|
| `desktop-client/e2e-webdriver/webdriver_client.py` | 改 | +91 行，新增 5 个有名字的审批 helper：`wait_approval_card` / `click_approval(decision)` / `read_approval_decision` / `wait_approval_decision` / `clear_pending_approval`（tearDown 用） |
| `desktop-client/e2e-webdriver/tests/test_scenario_04_approval_failsafe.py` | 新 | 2 active 用例 + 1 skipped 用例 |
| `desktop-client/e2e-webdriver/README.md` | 改 | §4 状态 ⬜ → ✅ |

## 测试内容详解

`SNAPSHOT` 探针在 #997 早已暴露 `approvalCard`/`approvalResult`/`bodyHead`，本轮**只新增 helper、不改 SNAPSHOT**。每条用例开头都调 `clear_pending_approval(session_id)`——因为 `tauri-plugin-webdriver` 跨 session 共享同一个 WKWebView，上一条用例的挂起卡片会污染下一条。

- **`test_write_tool_triggers_approval_card`**（Fail-Safe 核心契约）
  - 发 `WRITE_PROMPT`（直接要求调用 `write_file` 写 `e2e_probe.txt`，禁止解释/先用 list_dir 探查）→ `wait_approval_card(timeout=120)` → 断言卡片必须出现 → tearDown 关挂起卡。
  - **只**断言「卡片出现」，不点按钮——这就是 plan §4 的 Fail-Safe 不变量：写操作绝不能绕过审批静默执行。
- **`test_deny_yields_approved_false`**（完整链路 deny 路径）
  - 发指令 → 等卡片 → `click_approval("deny")` → `wait_approval_decision(expected_approved=False, timeout=30)`。
  - 覆盖前端 `ApprovalCardView.onDeny` → `ic_deny_tool` IPC → 后端 `Submission::ExecApproval{decision:Denied}` → SDK 推进工具调用至 `complete` → `ApprovalResultBanner` 渲染 `[data-approved="false"]` 这条完整回路。
- **`test_approve_yields_approved_true`**（`@pytest.mark.skip`）
  - approve 路径会真把 `e2e_probe.txt` 写进 desktop-client 工作目录、污染后续用例。deny 分支已覆盖整条链路，approve 仅差 `data-approved=true` 这一布尔值。等 fixture 把 workspace 改成 sandbox 临时路径后再补。

### 为什么不实现 plan §10-G3 的 `AGENT_AUTO_APPROVE_TOOLS` 开关

全仓 `crates/` + `desktop-client/` 三层验证（semantic_search × grep × listCodeUsages）零匹配——是 plan 文档的「希望存在但未实现」。本轮按用户原则**不照抄写假阳测试**，改为**行为级 Fail-Safe** 断言：「受保护工具被请求时，审批卡片必须出现」。这是 `write_file::requires_approval == UnlessAutoApproved`（[crates/dasclaw_fs_tools/src/file.rs#L192-L193](crates/dasclaw_fs_tools/src/file.rs#L192-L193)）的真实可观测语义。

## 覆盖率

| § | 章节 | 状态 | 用例数 | 备注 |
|---|---|---|---|---|
| §1 | composer / send / 助手回包 | ✅ | 3 | #997 已合 |
| §2 | Agent 多轮执行 | ✅ | 1 | #998 已合 |
| §3 | tool roundtrip（read 类） | ✅ | 1 | #1000 已合 |
| §4 | **工具分发与审批（Fail-Safe）** | ✅ | 2 + 1 skipped | **本 PR** |
| §5 | hooks / policy violation 拦截 | ⬜ | — | plan 待办 |
| §6 | 长流 / 取消 | ⬜ | — | plan 待办 |
| §7 | 错误注入与恢复 | ⬜ | — | plan 待办 |

## 非目标（NOT in this PR）

- 不实现 `AGENT_AUTO_APPROVE_TOOLS` env 开关（plan §10-G3 缺口，全仓零实现）
- 不修 dashscope provider 401 / 不修 admin backend 401（基础设施问题，非本 PR scope）
- 不实现 workspace 自动导入 fixture（见下方"验证"——这是 §4 在 E2E 跑绿的真正前置）
- 不补 approve 路径（需 sandbox 临时工作目录或 teardown 清理）

## 验证

本地启 `cargo tauri dev -f webdriver` + 直跑全套 pytest：

```
3 failed, 4 passed, 1 skipped in 242.35s
```

失败用例：§2 `test_send_message_yields_assistant_reply`、§4 两条 active。失败**根因不是测试代码**：

1. 启动日志显示 `Provider switched (cross-provider) model=qwen-plus-0112 base_url=https://dashscope.aliyuncs.com/compatible-mode/v1` —— 这是 admin backend override 后的 active provider，但 admin backend 同时报 `401 Unauthorized`，状态不一致。
2. 关键证据：`Tool call failed tool=list_dir error=Cannot resolve relative path '.' — no workspace directory is set for this conversation. Please import a workspace first.` —— **E2E 启动的全新会话没导入 workspace**，write_file / list_dir 在 cwd 解析阶段就被拒，根本到不了审批环节。
3. 测试代码本身已对照 `desktop-client/ui/src/app/components/tool-ui/approval-tool-ui.tsx` 三层验证：
   - `[data-testid="approval-card"]`（line 78）
   - `[data-testid="approval-approve"]`（line 95）
   - `[data-testid="approval-deny"]`（line 105）
   - `[data-testid="approval-result"]` + `data-approved` 属性
   全部真实存在。
4. CI / 后续把「workspace 自动导入」纳入 `session_id` fixture 之后，§2 / §4 即可绿；本 PR 范围聚焦测试代码本身。失败信号本身有用——暴露了 E2E session 缺失 workspace 这个隐藏前置。

```bash
cd desktop-client && set -a && source ./.env && set +a && export MANAGED_MODE=false && export OPENAI_API_KEY="$LLM_API_KEY" && cargo tauri dev -f webdriver &
sleep 90
cd e2e-webdriver && PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -v
```

## Sources read

- `desktop-client/docs/e2e-webdriver-test-plan.md` §4 + §10-G3
- `desktop-client/ui/src/app/components/tool-ui/approval-tool-ui.tsx`（testid 三层验证）
- `desktop-client/src/lib.rs`（`ic_approve_tool` / `ic_deny_tool` 注册位）
- `desktop-client/e2e-webdriver/webdriver_client.py`（已有 helper）
- `crates/dasclaw_fs_tools/src/file.rs:192-193`（`requires_approval == UnlessAutoApproved`）
- `AGENTS.md`（stacked PR + 非目标 + Sources read）

## 关键发现

1. **plan §10-G3 `AGENT_AUTO_APPROVE_TOOLS` 全仓零匹配**——按原则换成行为级 Fail-Safe 断言。
2. **共享 WKWebView 跨 session 状态会串扰**——`clear_pending_approval` 是后续所有「触发原生交互」用例的通用前置，可考虑提升成 fixture。
3. **E2E session 缺失 workspace 导入**——所有依赖 cwd 的工具（read/write/list）当前都会在 policy 解析阶段失败。这是 §3-§7 都需要的下一步基建。
