### PR TITLE
fix(desktop-client/ui): align @tauri-apps/api to ^2.11.0

### DIFF
--- a/desktop-client/ui/package-lock.json
+++ b/desktop-client/ui/package-lock.json
@@ -46,7 +46,7 @@
         "@radix-ui/react-toggle": "1.1.2",
         "@radix-ui/react-toggle-group": "1.1.2",
         "@radix-ui/react-tooltip": "1.1.8",
-        "@tauri-apps/api": "^2.0",
+        "@tauri-apps/api": "^2.11.0",
         "@tauri-apps/plugin-dialog": "^2.7.0",
         "@tauri-apps/plugin-fs": "^2.5.0",
         "ai": "^4.0.0",
@@ -5683,9 +5683,9 @@
       }
     },
     "node_modules/@tauri-apps/api": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmmirror.com/@tauri-apps/api/-/api-2.10.1.tgz",
-      "integrity": "sha512-hKL/jWf293UDSUN09rR69hrToyIXBb8CjGaWC7gfinvnQrBVvnLr08FeFi38gxtugAVyVcTa5/FD/Xnkb1siBw==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.11.0.tgz",
+      "integrity": "sha512-7CinYODhky9lmO23xHnUFv0Xt43fbtWMyxZcLcRBlFkcgXKuEirBvHpmtJ89YMhyeGcq20Wuc47Fa4XjyniywA==",
       "license": "Apache-2.0 OR MIT",
       "funding": {
         "type": "opencollective",

--- a/desktop-client/ui/package.json
+++ b/desktop-client/ui/package.json
@@ -54,7 +54,7 @@
     "@radix-ui/react-toggle": "1.1.2",
     "@radix-ui/react-toggle-group": "1.1.2",
     "@radix-ui/react-tooltip": "1.1.8",
-    "@tauri-apps/api": "^2.0",
+    "@tauri-apps/api": "^2.11.0",
     "@tauri-apps/plugin-dialog": "^2.7.0",
     "@tauri-apps/plugin-fs": "^2.5.0",
     "ai": "^4.0.0",


### PR DESCRIPTION
## 背景 / 目标
启动 desktop-client 时 Tauri 报版本对齐警告：
```
Error Found version mismatched Tauri packages.
tauri (v2.11.1) : @tauri-apps/api (v2.10.1)
```
Rust crate 已升到 2.11.1，但 `package.json` 仍写 `^2.0`，导致 lockfile 把 `@tauri-apps/api` 钉在 2.10.1，与 Rust 端 minor 版本不一致。

## 改动范围
- `desktop-client/ui/package.json`：`@tauri-apps/api` 从 `^2.0` 改 `^2.11.0`
- `desktop-client/ui/package-lock.json`：`@tauri-apps/api` 由 2.10.1 升到 2.11.0

## 非目标
- 不动 `@tauri-apps/plugin-dialog` / `plugin-fs`（minor 版与 Rust 端一致）
- 不升 Tauri Rust crate 版本
- 不修其他独立问题（模型选择浮窗 / 引擎就绪竞态，将在另一个 PR 处理）

## 验证
- `npm install` → lockfile 落地 2.11.0
- `npm run build` ✅ `built in 10.08s`
- 既有 TS 错误是 base 既有遗留（cypressTauriMock / tracing / react-dom 等），与本 PR 无关

## Cross-cuts
类A（无 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量新增）


Closes #1006
