### PR TITLE
fix(desktop-client/ui): gate startup IPC on engine readiness

### DIFF
--- a/desktop-client/ui/src/app/components/main/AppSidebar.tsx
+++ b/desktop-client/ui/src/app/components/main/AppSidebar.tsx
@@ -93,11 +93,13 @@ export function AppSidebar({
     yesterday: true,
     older: false,
   });
-  const { readyKey } = useEngineReady();
+  const { ready, readyKey } = useEngineReady();
 
   useEffect(() => {
+    // 引擎未就绪时跳过；readyKey 初值为 0，挂载即触发会撞上 ic_list_threads 的 ready gate
+    if (!ready) return;
     loadThreads();
-  }, [refreshKey, readyKey]); // refreshKey 或引擎就绪时重新加载
+  }, [refreshKey, ready, readyKey]);
 
   const loadThreads = async () => {
     try {

--- a/desktop-client/ui/src/app/components/tabs/ChatTabTauriExperimental.tsx
+++ b/desktop-client/ui/src/app/components/tabs/ChatTabTauriExperimental.tsx
@@ -69,12 +69,15 @@ export function ChatTabTauriExperimental({
   outboundCommand,
   onOutboundCommandHandled,
 }: ChatTabTauriExperimentalProps) {
+  const { ready } = useEngineReady();
   useEffect(() => {
     TokenManager.getToken().catch((err) => console.error('Failed to load token:', err));
+    // 引擎就绪后再同步 DLP 规则；否则后端会返回"引擎正在启动中"
+    if (!ready) return;
     invoke('sync_dlp_rules_from_admin').catch((err: unknown) =>
       console.warn('DLP rules sync failed:', err),
     );
-  }, []);
+  }, [ready]);
 
   return (
     <ModelProvider

--- a/desktop-client/ui/src/app/runtime/contexts/ModelProvider.tsx
+++ b/desktop-client/ui/src/app/runtime/contexts/ModelProvider.tsx
@@ -16,6 +16,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import { ModelContext } from '../../contexts/ModelContext';
+import { useEngineReady } from '../../hooks/useEngineReady';
 import { modelApi, type ModelConfigItem } from '@utils/tauri';
 import { tracing } from '../../utils/tracing';
 
@@ -40,6 +41,7 @@ export function ModelProvider({
   const [loading, setLoading] = useState(true);
   // 用 ref 让闭包始终读到最新的选中 id，避免切换时闭包被冻结
   const selectedModelIdRef = useRef<string>(initialModelId ?? '');
+  const { ready, readyKey } = useEngineReady();
 
   const loadModels = useCallback(async () => {
     try {
@@ -65,8 +67,11 @@ export function ModelProvider({
   }, [onModelChange]);
 
   useEffect(() => {
+    // 引擎就绪前不拉模型：fetch_admin_models / query_provider_models 都需要 engine 引用，
+    // 早调会静默降级到 builtin 兜底（GPT-4o）。等 ready 翻转后由 readyKey 触发重拉。
+    if (!ready) return;
     void loadModels();
-  }, [loadModels]);
+  }, [loadModels, ready, readyKey]);
 
   const selectModel = useCallback(
     (modelId: string) => {

--- a/desktop-client/ui/src/app/runtime/contexts/__tests__/ModelProvider.test.tsx
+++ b/desktop-client/ui/src/app/runtime/contexts/__tests__/ModelProvider.test.tsx
@@ -25,6 +25,12 @@ vi.mock('@utils/tauri', async (importOriginal) => {
   };
 });
 
+// ModelProvider 现在依赖 useEngineReady，让单测默认走"已就绪"路径；
+// 就绪 gate 行为在 useEngineReady 自身的测试里覆盖。
+vi.mock('../../../hooks/useEngineReady', () => ({
+  useEngineReady: () => ({ ready: true, readyKey: 1 }),
+}));
+
 const mockModels: ModelConfigItem[] = [
   {
     model_id: 'deepseek-chat',


### PR DESCRIPTION
## 背景 / 目标

启动客户端时控制台连环报红：

```
[Error] Tauri command 'ic_list_threads' failed: – '引擎正在启动中，请稍后重试'
[Warning] DLP rules sync failed
[Error] Tauri command 'ic_list_jobs' failed
[Error] Failed to load threads: – '引擎正在启动中，请稍后重试'
```

同时模型选择浮窗一开始显示硬编码的 `GPT-4o / GPT-4o Mini`（不是 admin 后端配置的模型），刷新页面后恢复正常。

## 根因（一类问题）

后端 `EngineState::get()`（`desktop-client/src/state.rs:342-359`）对所有 IPC 做就绪门控，未初始化时返回 `"引擎正在启动中，请稍后重试"`。

前端有 3 个地方在挂载即调 IPC、不等引擎就绪：

| 文件 | 触发的 IPC | 失败表现 |
|---|---|---|
| `ChatTabTauriExperimental.tsx` | `sync_dlp_rules_from_admin` | `DLP rules sync failed` 警告 |
| `AppSidebar.tsx` | `ic_list_threads`（`loadThreads`）| 红字 `引擎正在启动中` |
| `ModelProvider.tsx` | `modelApi.getAvailableModels`（→ 后端 `fetch_admin_models` / `query_provider_models` 都需 engine 引用）| 静默降级到 builtin 兜底（GPT-4o），表现为浮窗显示错的模型；刷新就好 |

## 改动范围

复用既有的 `useEngineReady` hook 做 gate：未就绪时 `return`，`ready` 翻转后由 `readyKey` 自然触发重跑。

- `desktop-client/ui/src/app/components/tabs/ChatTabTauriExperimental.tsx`：DLP 同步加 ready gate
- `desktop-client/ui/src/app/components/main/AppSidebar.tsx`：`loadThreads` 加 ready gate
- `desktop-client/ui/src/app/runtime/contexts/ModelProvider.tsx`：模型加载加 ready gate
- `desktop-client/ui/src/app/runtime/contexts/__tests__/ModelProvider.test.tsx`：`vi.mock` `useEngineReady` 走"已就绪"路径

## 非目标（What's NOT in this PR）

- 不动后端 gate 文案 / 行为
- 不引入新的全局加载态 / Suspense 重构
- 不动 `useEngineReady` 自身实现
- 不修后端任何 `state.get()` 调用

## 验证

```
cd desktop-client/ui
npm run build                           # ✓ 8.22s
npx vitest run src/app/runtime/contexts # ✓ 28 / 28 pass（包含 ModelProvider 14 用例）
```

## Cross-cuts

- 与 ADR-114（`.ironclaw` → `.dasclaw` 命名迁移）：**类A**（无新增 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量）

## 后续

无后续 PR；这是同一类 race 的集中修复。如果后续 IPC handler 仍有"挂载即调"的，按同一模式补 `useEngineReady` gate。



Closes #1007
