### PR TITLE
feat(desktop-client): emit structured EngineState error payload

### DIFF
--- a/desktop-client/src/state.rs
+++ b/desktop-client/src/state.rs
@@ -338,23 +338,30 @@ impl EngineState {
     ///
     /// 返回值：
     /// - `Ok(&AppState)` — 引擎就绪
-    /// - `Err("引擎启动失败: ...")` — 引擎启动失败
-    /// - `Err("引擎正在启动中，请稍后重试")` — 引擎正在启动
+    /// - `Err(json)` — 启动失败 / 启动中；error message 是 JSON 字符串，
+    ///   形如 `{"code":"ENGINE_NOT_READY","message":"...","retryable":true}`。
+    ///   前端 `invokeTauri` wrapper 可 `JSON.parse` 拿到 `code` 后自动等待重试；
+    ///   旧调用方把它当字符串展示也无副作用（仍包含中文 message）。
     pub fn get(&self) -> Result<&AppState, String> {
-        // 优先检查是否已就绪
         if let Some(state) = self.inner.get() {
             return Ok(state);
         }
 
-        // 检查是否启动失败
         if let Ok(guard) = self.failure.read() {
             if let Some(reason) = guard.as_ref() {
-                return Err(format!("引擎启动失败: {}", reason));
+                return Err(engine_error_payload(
+                    "ENGINE_START_FAILED",
+                    &format!("引擎启动失败: {}", reason),
+                    false,
+                ));
             }
         }
 
-        // 仍在启动中
-        Err("引擎正在启动中，请稍后重试".to_string())
+        Err(engine_error_payload(
+            "ENGINE_NOT_READY",
+            "引擎正在启动中，请稍后重试",
+            true,
+        ))
     }
 
     /// 引擎是否已就绪。
@@ -365,5 +372,58 @@ impl EngineState {
     /// 引擎是否启动失败。
     pub fn is_failed(&self) -> bool {
         self.failure.read().map(|f| f.is_some()).unwrap_or(false)
+    }
+}
+
+/// 把引擎状态错误序列化成结构化 JSON 字符串。
+///
+/// IPC handler 签名是 `Result<T, String>`，把 String 内容做成 JSON 而不是引入新错误类型，
+/// 可以让前端 `invokeTauri` wrapper 用 `JSON.parse` 拿到 `code` 做自动重试，
+/// 同时保持所有 62 处 `state.get()?` handler 签名零变更。
+fn engine_error_payload(code: &str, message: &str, retryable: bool) -> String {
+    serde_json::json!({
+        "code": code,
+        "message": message,
+        "retryable": retryable,
+    })
+    .to_string()
+}
+
+#[cfg(test)]
+mod engine_state_error_tests {
+    use super::*;
+
+    fn parse(payload: &str) -> serde_json::Value {
+        serde_json::from_str(payload).expect("engine error payload must be valid JSON")
+    }
+
+    #[test]
+    fn not_ready_returns_structured_payload() {
+        let state = EngineState::new();
+        let err = state
+            .get()
+            .err()
+            .expect("uninitialized state must return Err");
+        let v = parse(&err);
+        assert_eq!(v["code"], "ENGINE_NOT_READY");
+        assert_eq!(v["retryable"], true);
+        assert!(
+            v["message"].as_str().unwrap_or_default().contains("引擎"),
+            "message 应保留中文供旧调用方降级显示"
+        );
+    }
+
+    #[test]
+    fn failed_returns_non_retryable_payload() {
+        let state = EngineState::new();
+        state.set_failed("config missing".to_string());
+        let err = state.get().err().expect("failed state must return Err");
+        let v = parse(&err);
+        assert_eq!(v["code"], "ENGINE_START_FAILED");
+        assert_eq!(v["retryable"], false);
+        assert!(v["message"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("config missing"));
     }
 }


### PR DESCRIPTION
## 背景 / 目标

`EngineState::get()` 此前返回纯中文字符串 `"引擎正在启动中，请稍后重试"` / `"引擎启动失败: ..."`，前端无法稳定区分"暂时未就绪 → 应当等待重试"和"真正失败 → 应当报错"。

直接后果是 PR #1003 不得不在 3 个 caller（`ChatTabTauriExperimental` / `AppSidebar` / `ModelProvider`）各自手动加 `useEngineReady` gate ——典型的补丁式蔓延，每加一个新挂载即调的 IPC 都得重新打补丁。

本 PR 是方案 A 的后端一半：让错误体本身结构化，配套前端 PR 在 `invokeTauri` wrapper 里识别后自动等待 + 重试。

## 改动范围

`desktop-client/src/state.rs`：

- `EngineState::get()` 的 `Err` 内容由纯文案改为 JSON 字符串：
  - `{"code":"ENGINE_NOT_READY","message":"引擎正在启动中，请稍后重试","retryable":true}`
  - `{"code":"ENGINE_START_FAILED","message":"引擎启动失败: <reason>","retryable":false}`
- 新增私有 helper `engine_error_payload(code, message, retryable)` —— 不引入新错误类型，因为 IPC handler 签名仍是 `Result<T, String>`，引入新 enum 会牵连 62 处 `state.get()?` 全部改签名
- 新增 `engine_state_error_tests` 两个单测（验证 `ENGINE_NOT_READY` retryable=true、`ENGINE_START_FAILED` retryable=false、message 仍含中文子串）

## 非目标（What's NOT in this PR）

- 不动 `error.rs` 的 `Error` enum
- 不动任何 IPC handler 签名 / 调用方
- 不动前端任何代码（前端拦截 + 重试由配套 PR 实施）
- 不收敛 PR #1003 已加的手动 gate（保留作为 defense-in-depth）

## 向后兼容

- IPC handler 签名 `Result<T, String>` 零变更
- 既有 `engine_startup_tests` 23/23 全部通过 —— 它们用 `err.contains("启动中")` / `contains("启动失败")` 断言，JSON payload 的 `message` 字段仍含这些子串
- 未升级前端把 error 当字符串展示时显示出来是 JSON，但 PR #1003 的手动 gate 仍能拦住挂载即调

## 验证

```
RUSTC_WRAPPER= cargo nextest run -p desktop-client --lib engine_state_error_tests
#   2 passed
RUSTC_WRAPPER= cargo nextest run -p desktop-client --lib engine_startup_tests
#  23 passed
cargo fmt --all                           # ✓
python3.12 scripts/check_no_panics.py --base origin/xClaw   # OK
```

Workspace clippy 由 CI 兜底；本地仅检查 `state.rs` 无新增 lint。

## Cross-cuts

- 与 ADR-114（`.ironclaw` → `.dasclaw` 命名迁移）：**类A**（无新增 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量）

## 后续

- **配套前端 PR**：增强 `desktop-client/ui/src/app/utils/tauri.ts` 的 `invokeTauri`，识别 `code: ENGINE_NOT_READY` 后轮询 `get_engine_status` 直到 ready 再重试一次。前端 PR 会先做 fallback 字符串匹配兼容未升级的后端，所以两个 PR **完全独立 / 可并行 merge**。
- 长期：观察一段时间后可考虑收敛 PR #1003 的手动 gate（前端 wrapper 已经能拦），目前先保留双保险。



Closes #1008
