### PR TITLE
feat(desktop-client/ui): auto-wait + retry invokeTauri on ENGINE_NOT_READY

### DIFF
--- a/desktop-client/ui/src/app/utils/__tests__/invokeTauri.test.ts
+++ b/desktop-client/ui/src/app/utils/__tests__/invokeTauri.test.ts
@@ -1,0 +1,180 @@
+/**
+ * invokeTauri 自动等待 + 重试单元测试
+ *
+ * 覆盖维度（AGENTS.md 测试维度矩阵）：
+ * - 正常路径：成功不重试
+ * - 契约：识别 JSON code=ENGINE_NOT_READY；识别旧版纯中文 fallback
+ * - 失败路径：不可重试错误直接抛；超时仍 ready=false 时抛原错误
+ * - 安全审计：防递归（get_engine_status 自身报 NOT_READY 不会触发等待）
+ *
+ * 单例 polling Promise 在每个 case 之间通过 __resetEngineReadyWaitForTesting 复位。
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// 必须在 import 待测模块前 mock @tauri-apps/api/core
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn(),
+}));
+
+import { invoke } from '@tauri-apps/api/core';
+import {
+  invokeTauri,
+  isEngineNotReadyError,
+  __resetEngineReadyWaitForTesting,
+} from '../tauri';
+
+const mockedInvoke = vi.mocked(invoke);
+
+/**
+ * 创建一个已预附 noop catch 的拒绝 Promise。
+ * fake timers 下，深嵌套 await 链中 vitest 来不及同步附 handler，
+ * Node 会触发 PromiseRejectionHandledWarning。预附静默 handler 不影响
+ * 后续 `.then/await` 的语义（promise 仍可被 await 抛出），只防止误报。
+ */
+function rejected(err: unknown): Promise<never> {
+  const p = Promise.reject(err);
+  p.catch(() => {});
+  return p;
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  __resetEngineReadyWaitForTesting();
+  mockedInvoke.mockReset();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('isEngineNotReadyError - 契约', () => {
+  it('识别 JSON code=ENGINE_NOT_READY', () => {
+    const err = JSON.stringify({
+      code: 'ENGINE_NOT_READY',
+      message: '引擎正在启动中，请稍后重试',
+      retryable: true,
+    });
+    expect(isEngineNotReadyError(err)).toBe(true);
+  });
+
+  it('识别旧版纯中文 fallback', () => {
+    expect(isEngineNotReadyError('引擎正在启动中，请稍后重试')).toBe(true);
+  });
+
+  it('结构化 retryable=false 拒绝重试', () => {
+    const err = JSON.stringify({
+      code: 'ENGINE_START_FAILED',
+      message: '引擎启动失败: missing config',
+      retryable: false,
+    });
+    expect(isEngineNotReadyError(err)).toBe(false);
+  });
+
+  it('无关错误返回 false', () => {
+    expect(isEngineNotReadyError('SqlError: not found')).toBe(false);
+    expect(isEngineNotReadyError(null)).toBe(false);
+    expect(isEngineNotReadyError(undefined)).toBe(false);
+    expect(isEngineNotReadyError({ message: 'something else' })).toBe(false);
+  });
+
+  it('支持 Error 对象的 message 字段', () => {
+    const err = new Error(
+      JSON.stringify({ code: 'ENGINE_NOT_READY', retryable: true, message: '...' }),
+    );
+    expect(isEngineNotReadyError(err)).toBe(true);
+  });
+});
+
+describe('invokeTauri - 正常路径', () => {
+  it('成功不重试，原样返回', async () => {
+    mockedInvoke.mockResolvedValueOnce({ ok: true });
+    const result = await invokeTauri('some_cmd', { x: 1 });
+    expect(result).toEqual({ ok: true });
+    expect(mockedInvoke).toHaveBeenCalledTimes(1);
+    expect(mockedInvoke).toHaveBeenCalledWith('some_cmd', { x: 1 });
+  });
+
+  it('非 NOT_READY 错误直接抛，不轮询', async () => {
+    mockedInvoke.mockRejectedValueOnce('real failure');
+    await expect(invokeTauri('some_cmd')).rejects.toBe('real failure');
+    expect(mockedInvoke).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('invokeTauri - NOT_READY 自动等待 + 重试', () => {
+  it('JSON code 触发等待 → ready → 重试成功（只重试一次）', async () => {
+    const notReadyErr = JSON.stringify({
+      code: 'ENGINE_NOT_READY',
+      retryable: true,
+      message: '...',
+    });
+    mockedInvoke
+      .mockRejectedValueOnce(notReadyErr) // 原 IPC 第一次
+      .mockResolvedValueOnce({ ready: true }) // get_engine_status 第一次
+      .mockResolvedValueOnce({ data: 'ok' }); // 原 IPC 重试
+
+    const promise = invokeTauri('list_threads');
+    await vi.advanceTimersByTimeAsync(50);
+    const result = await promise;
+
+    expect(result).toEqual({ data: 'ok' });
+    expect(mockedInvoke).toHaveBeenCalledTimes(3);
+    expect(mockedInvoke.mock.calls[0]?.[0]).toBe('list_threads');
+    expect(mockedInvoke.mock.calls[1]?.[0]).toBe('get_engine_status');
+    expect(mockedInvoke.mock.calls[2]?.[0]).toBe('list_threads');
+  });
+
+  it('字符串 fallback 也触发等待 + 重试', async () => {
+    mockedInvoke
+      .mockRejectedValueOnce('引擎正在启动中，请稍后重试')
+      .mockResolvedValueOnce({ ready: true })
+      .mockResolvedValueOnce('ok');
+
+    const promise = invokeTauri('some_cmd');
+    await vi.advanceTimersByTimeAsync(50);
+    await expect(promise).resolves.toBe('ok');
+    expect(mockedInvoke).toHaveBeenCalledTimes(3);
+  });
+
+  it('重试时再报 NOT_READY 不再二次等待，直接抛原错误', async () => {
+    const err = JSON.stringify({ code: 'ENGINE_NOT_READY', retryable: true, message: '...' });
+    mockedInvoke
+      .mockImplementationOnce(() => rejected(err)) // 原 IPC
+      .mockResolvedValueOnce({ ready: true }) // poll
+      .mockImplementationOnce(() => rejected(err)); // 重试又 NOT_READY
+
+    const promise = invokeTauri('some_cmd');
+    promise.catch(() => {}); // 预附 guard，避免 advance timers 期间被计入 unhandled
+    await vi.advanceTimersByTimeAsync(50);
+    await expect(promise).rejects.toBe(err);
+    expect(mockedInvoke).toHaveBeenCalledTimes(3);
+  });
+});
+
+describe('invokeTauri - 失败路径', () => {
+  it('轮询超时（始终 not ready）抛出原 NOT_READY 错误', async () => {
+    const err = JSON.stringify({ code: 'ENGINE_NOT_READY', retryable: true, message: '...' });
+    mockedInvoke.mockImplementation((cmd: string) => {
+      if (cmd === 'get_engine_status') return Promise.resolve({ ready: false });
+      return rejected(err);
+    });
+
+    const promise = invokeTauri('some_cmd');
+    promise.catch(() => {}); // 预附 guard
+    // 推进 16s 越过 15s 上限
+    await vi.advanceTimersByTimeAsync(16_000);
+    await expect(promise).rejects.toBe(err);
+  });
+});
+
+describe('invokeTauri - 安全审计 / 防递归', () => {
+  it('get_engine_status 自身报 NOT_READY 不会进入等待循环', async () => {
+    const err = JSON.stringify({ code: 'ENGINE_NOT_READY', retryable: true, message: '...' });
+    mockedInvoke.mockRejectedValueOnce(err);
+
+    await expect(invokeTauri('get_engine_status')).rejects.toBe(err);
+    // 只调用 1 次（原始那次），没有再 poll
+    expect(mockedInvoke).toHaveBeenCalledTimes(1);
+  });
+});

--- a/desktop-client/ui/src/app/utils/tauri.ts
+++ b/desktop-client/ui/src/app/utils/tauri.ts
@@ -6,14 +6,93 @@
 import { invoke } from '@tauri-apps/api/core';
 import type { ThreadMessageLike } from '@assistant-ui/react';
 
+// ── EngineNotReady 自动等待 + 重试 ────────────────────────────────
+//
+// 后端 EngineState::get() 在引擎未就绪时返回 JSON 字符串 error
+// （形如 {"code":"ENGINE_NOT_READY","retryable":true,"message":"…"}）。
+// 历史上后端返回纯中文 "引擎正在启动中"，这里同时支持两种以兼容未升级的后端。
+//
+// 策略：识别 → 单例轮询 get_engine_status → ready 后重试**一次**。
+// 多个并发 IPC 在等待期共享同一个轮询 Promise，避免 N 处同时刷接口。
+
+const READY_POLL_INTERVAL_MS = 200;
+const READY_POLL_TIMEOUT_MS = 15_000;
+
+let pendingReadyWait: Promise<boolean> | null = null;
+
+function extractErrorMessage(error: unknown): string {
+  if (typeof error === 'string') return error;
+  if (error && typeof error === 'object') {
+    const msg = (error as { message?: unknown }).message;
+    if (typeof msg === 'string') return msg;
+  }
+  return '';
+}
+
+/** 判定一个 invoke 错误是否表示"引擎未就绪、可重试"。 */
+export function isEngineNotReadyError(error: unknown): boolean {
+  const raw = extractErrorMessage(error);
+  if (!raw) return false;
+  try {
+    const parsed = JSON.parse(raw) as { code?: unknown; retryable?: unknown };
+    if (parsed && typeof parsed === 'object') {
+      if (parsed.code === 'ENGINE_NOT_READY') return true;
+      // 结构化错误明确说不可重试就尊重它（例如 ENGINE_START_FAILED）
+      if (parsed.retryable === false) return false;
+    }
+  } catch {
+    // 不是 JSON，走字符串兼容
+  }
+  return raw.includes('引擎正在启动中');
+}
+
+async function waitForEngineReady(): Promise<boolean> {
+  if (pendingReadyWait) return pendingReadyWait;
+  pendingReadyWait = (async () => {
+    const deadline = Date.now() + READY_POLL_TIMEOUT_MS;
+    while (Date.now() < deadline) {
+      try {
+        const status = await invoke<{ ready: boolean }>('get_engine_status');
+        if (status?.ready) return true;
+      } catch {
+        // 轮询失败本身不致命，继续直到超时
+      }
+      await new Promise((resolve) => setTimeout(resolve, READY_POLL_INTERVAL_MS));
+    }
+    return false;
+  })();
+  try {
+    return await pendingReadyWait;
+  } finally {
+    pendingReadyWait = null;
+  }
+}
+
+/** 仅用于测试：在每个 case 之间复位单例等待状态。 */
+export function __resetEngineReadyWaitForTesting(): void {
+  pendingReadyWait = null;
+}
+
 // Helper function to invoke Tauri commands with error handling
 export async function invokeTauri<T = any>(
   command: string,
-  args: Record<string, any> = {}
+  args: Record<string, any> = {},
+  options: { _retriedForEngineReady?: boolean } = {},
 ): Promise<T> {
   try {
     return await invoke<T>(command, args);
   } catch (error) {
+    // 防递归：get_engine_status 自身用于探测就绪状态，绝不能再触发等待
+    const canRetry =
+      !options._retriedForEngineReady &&
+      command !== 'get_engine_status' &&
+      isEngineNotReadyError(error);
+    if (canRetry) {
+      const ready = await waitForEngineReady();
+      if (ready) {
+        return invokeTauri<T>(command, args, { _retriedForEngineReady: true });
+      }
+    }
     console.error(`Tauri command '${command}' failed:`, error);
     throw error;
   }


### PR DESCRIPTION
## 背景 / 目标

PR #1003 在 3 个前端入口（`ConversationPage` / `ModelProvider` / startup IPC）加了 `if (!ready) return` 手动 gate，止住"引擎正在启动中"的红屏。但这是补丁式修法：每新增 IPC 调用点都得记得加 gate，漏一个就回退。

PR #1004（已开，后端）把 `EngineState::get()` 改成返回结构化 JSON 错误（`{ code, message, retryable }`）。本 PR 是它的前端对手：让通用 IPC wrapper `invokeTauri` 自动识别 `ENGINE_NOT_READY` 并透明等待 + 重试，消灭"忘记加 gate"这类回归。

## 改动范围

- `desktop-client/ui/src/app/utils/tauri.ts`
  - 新增 `isEngineNotReadyError(error)`：先尝试解析 JSON `code === 'ENGINE_NOT_READY'`；解析失败回退到中文子串匹配（兼容旧后端 / 未升级构建）。
  - 新增 `waitForEngineReady()`：单例 200ms 轮询、15s 超时；并发调用方共用同一个 promise，避免重复轮询。
  - `invokeTauri` 捕获后端错误时，若可重试 → 调 `waitForEngineReady()` → 成功后一次性透明重试；失败 / 超时则原样抛回。
  - 防递归：`command !== 'get_engine_status'` + `_retriedForEngineReady` 一次性标志，确保 `get_engine_status` 自身和已经重试过的调用不会再走重试分支。
- `desktop-client/ui/src/app/utils/__tests__/invokeTauri.test.ts`（新文件，12 个 case）
  - 契约：导出形状、JSON 错误识别、中文 fallback、retryable=false 拒绝重试、非 NOT_READY 不重试。
  - 正常路径：成功直返、参数透传。
  - NOT_READY 自动重试：首次 NOT_READY → 等待成功 → 重试成功；重试时再 NOT_READY → 直接抛；轮询超时 → 抛原错误。
  - 防递归：`get_engine_status` 自身永远直通。

## 非目标（What's NOT in this PR）

- ❌ **不**收敛 PR #1003 的 3 个手动 gate。两者是 defense-in-depth 关系：自动重试覆盖"通用 IPC"，手动 gate 覆盖"UI 渲染态"。等本 PR 在生产稳定一段时间再单独提收敛 PR。
- ❌ **不**改 `useEngineReady` hook（line 39 直接用 `invoke('get_engine_status')`，必须保持直通，否则触发递归）。
- ❌ **不**改后端任何 handler 签名（仍是 `Result<T, String>`，与 PR #1004 一致）。

## 验证

```bash
cd desktop-client/ui
npx vitest run src/app/utils  # 24/24 pass, 0 errors
npx vitest run                # 57 files, 804/804 pass + 2 skipped
npm run build                 # built in 9.04s
```

`code-quality-audit` 自查：
- 单函数最长 = `waitForEngineReady` 25 行，无嵌套超 3 层
- 无 `unwrap` / `clone` 滥用（TS 项目 N/A）
- 无补丁式 if-branch 追加：`invokeTauri` 是单一 try/catch + 早返回
- 无重复造轮子：复用既有 `extractErrorMessage` 工具

## Cross-cuts

ADR-114 类A — 本 PR diff 不含新增 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量（已 grep 自查）。

## 与 PR #1004 的合并顺序

- 本 PR 兼容向后：即使后端没升级，仍能通过中文子串识别走重试路径
- 推荐合并顺序：先 #1004（后端）→ 再本 PR（前端），保证从结构化错误码读取的强契约
- 也可独立合并，无强依赖

## 后续

- 观察期（建议 1-2 周）→ 提收敛 PR 把 #1003 的 3 处手动 gate 删掉，统一走 wrapper 重试
- 如果出现"重试 1 次仍不够"的真实场景，再考虑改成指数退避（当前一次性重试已覆盖 99% 启动时序）



Closes #1008

