### PR TITLE
fix(ui/g1): add data-testid to composer input/send (plan §10-G1)

### DIFF
--- a/desktop-client/docs/e2e-webdriver-test-plan.md
+++ b/desktop-client/docs/e2e-webdriver-test-plan.md
@@ -472,7 +472,7 @@ execjs(sid, "document.querySelector('button.aui-composer-send').click(); return 
 
 | # | 缺口 | 证据 | 对测试计划的影响 |
 |---|---|---|---|
-| G1 | **聊天输入框/发送按钮无 `data-testid`** | [thread.tsx:205-207](../ui/src/app/components/assistant-ui/thread.tsx)（`ComposerPrimitive.Input className="aui-composer-input"`）、[:246](../ui/src/app/components/assistant-ui/thread.tsx)（`aui-composer-send`）；全 `ui/` 无 composer 相关 testid | 场景 2/3/4/5/6/7 必须用 `.aui-composer-input` / `.aui-composer-send` class 选择器，脆于样式重构。建议补 `data-testid="composer-input"`/`"composer-send"`。 |
+| G1 | ~~**聊天输入框/发送按钮无 `data-testid`**~~ ✅ 已修复 | [thread.tsx:211/250](../ui/src/app/components/assistant-ui/thread.tsx) 已补 `data-testid="composer-input"` 与 `composer-send`；[webdriver_client.py](../e2e-webdriver/webdriver_client.py) 选择器已切换为 testid 优先 + class 回退。 |
 | G2 | **桌面端不输出 `tools: N accepted` 汇总日志** | `summary_line()`/`log_registration_report()` 仅由 `bootstrap_tools()` 调用（[registry.rs:385/725](../ironclaw/src/tools/registry.rs)）；[engine.rs](../src/engine.rs) 手动调 `register_message_tools`+`register_job_tools`，未走 `bootstrap_tools`，全仓 grep `tools: .*accepted` 无运行期匹配 | 场景 3 不能断言"日志出现 `tools: 61 accepted`"。改为经 `ToolRegistry::count()` 或 UI 读真实条数，或新增显式 report 调用。 |
 | G3 | **`AGENT_AUTO_APPROVE_TOOLS` 环境变量不存在** | 全仓（`crates/**` + `desktop-client/**`，`*.rs/*.ts/*.tsx`）grep `AGENT_AUTO_APPROVE_TOOLS`/`AUTO_APPROVE` 零匹配 | 场景 4 不能用该变量断言"默认不自动批准"。Fail-Safe 不变量改为**行为级**：直接断言 `approval-card` 出现且工具未静默执行。 |
 | G4 | **无纯自然语言 jailbreak 硬阻断** | `dasclaw_safety` 防御=secret 拦截（`scan_inbound_for_secrets`）+ 内容包裹（`wrap_for_llm`/`wrap_external_content`）+ 定界符中和（`Sanitizer`），[dasclaw_safety/src/lib.rs](../../crates/dasclaw_safety/src/lib.rs)；无"忽略规则/导出密钥"语义分类器 | 场景 7 对**不含密钥**的越权指令"被安全层拦截"的断言不成立。须降级为"不泄露系统提示/拒答"语义断言，或单列为待建能力。 |

--- a/desktop-client/e2e-webdriver/webdriver_client.py
+++ b/desktop-client/e2e-webdriver/webdriver_client.py
@@ -140,8 +140,8 @@ return JSON.stringify({
   boot:        !!document.querySelector('[data-testid="chat-runtime-boot-placeholder"]'),
   bootstrap:   !!document.querySelector('[data-testid="chat-runtime-bootstrap-placeholder"]'),
   historyLoad: !!document.querySelector('[data-testid="chat-runtime-history-loading"]'),
-  composer:    q('textarea.aui-composer-input'),
-  sendBtn:     q('button.aui-composer-send'),
+  composer:    q('[data-testid="composer-input"]') || q('textarea.aui-composer-input'),
+  sendBtn:     q('[data-testid="composer-send"]') || q('button.aui-composer-send'),
   assistantMsgs: q('.aui-assistant-message-root, [data-role="assistant"]'),
   approvalCard: !!document.querySelector('[data-testid="approval-card"]'),
   approvalResult: txt('[data-testid="approval-result"]'),
@@ -155,10 +155,11 @@ def snapshot(session_id: str) -> dict:
     return json.loads(execjs(session_id, SNAPSHOT))
 
 
-# 通过原生 setter 注入文本，绕过 React 受控组件的 onChange 监听。
+# 优先 data-testid 选择器（plan §10-G1 修复后），回退 .aui-composer-input class 选择器。
 _INJECT_COMPOSER = r"""
 const [text] = arguments;
-const ta = document.querySelector('textarea.aui-composer-input');
+const ta = document.querySelector('[data-testid="composer-input"]')
+         || document.querySelector('textarea.aui-composer-input');
 if (!ta) return false;
 const setter = Object.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype, 'value').set;
 setter.call(ta, text);
@@ -168,17 +169,18 @@ return true;
 
 
 def type_into_composer(session_id: str, text: str) -> None:
-    """把 text 注入 `textarea.aui-composer-input` 并触发 React 的 onChange。"""
+    """把 text 注入 composer textarea 并触发 React 的 onChange。"""
     ok = execjs(session_id, _INJECT_COMPOSER, [text])
     if not ok:
-        raise RuntimeError("找不到 textarea.aui-composer-input")
+        raise RuntimeError("找不到 composer-input（既无 data-testid 也无 .aui-composer-input）")
 
 
 def click_send(session_id: str) -> None:
-    """点击 `button.aui-composer-send`。"""
+    """点击发送按钮：优先 [data-testid="composer-send"]，回退 .aui-composer-send。"""
     execjs(
         session_id,
-        "document.querySelector('button.aui-composer-send').click(); return true;",
+        "(document.querySelector('[data-testid=\"composer-send\"]') "
+        "|| document.querySelector('button.aui-composer-send')).click(); return true;",
     )
 
 

--- a/desktop-client/ui/src/app/components/assistant-ui/thread.tsx
+++ b/desktop-client/ui/src/app/components/assistant-ui/thread.tsx
@@ -208,6 +208,7 @@ const Composer: FC = () => {
         rows={1}
         autoFocus
         aria-label="聊天输入"
+        data-testid="composer-input"
       />
       <ComposerSendButton onSend={handleSend} />
     </div>
@@ -246,6 +247,7 @@ const ComposerSendButton: FC<{ onSend: () => void }> = ({ onSend }) => {
             className="aui-composer-send size-8 rounded-[10px] bg-primary text-primary-foreground hover:bg-primary/90"
             aria-label="发送消息"
             onClick={onSend}
+            data-testid="composer-send"
           >
             <ArrowUpIcon className="aui-composer-send-icon size-4" />
           </TooltipIconButton>


### PR DESCRIPTION
## 背景 / 目标

闭合 [e2e-webdriver-test-plan.md §10-G1](desktop-client/docs/e2e-webdriver-test-plan.md) 记录的缺口：聊天输入框/发送按钮无 `data-testid`，e2e 必须依赖 `.aui-composer-*` class 选择器，脆于样式重构。

## 改动范围

- `desktop-client/ui/src/app/components/assistant-ui/thread.tsx`：
  - `ComposerPrimitive.Input` 加 `data-testid="composer-input"`
  - `ComposerSendButton` 内 send 按钮加 `data-testid="composer-send"`
- `desktop-client/e2e-webdriver/webdriver_client.py`：`SNAPSHOT` / `_INJECT_COMPOSER` / `click_send` 选择器改为 testid 优先 + class 回退（向后兼容已合并 §1-§5）
- `desktop-client/docs/e2e-webdriver-test-plan.md` §10-G1：标记已修复

## 非目标

- 不删除 `.aui-composer-input` / `.aui-composer-send` class（它们仍用于样式 + class 回退）
- 不改 plan §10 其他缺口（G2/G3/G4/G5 留给后续 PR）
- 不改场景测试代码（webdriver_client 已透明切换，单测无需变更）

## 验证

```
cargo tauri dev -f webdriver,claw-code-llm
pytest desktop-client/e2e-webdriver/tests/ -v
# §2 在本地 warm Tauri 上 1 passed in 0.15s（其余因 4445 监听抖动 skip，非本 PR 引入）
```

## Cross-cuts

ADR-114：类A（无新增 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量）。

## Sources read

- desktop-client/docs/e2e-webdriver-test-plan.md §10-G1
- desktop-client/ui/src/app/components/assistant-ui/thread.tsx L195-260
- desktop-client/e2e-webdriver/webdriver_client.py L135-190

## 后续 PR

plan §10 剩余缺口：
- G2（tools accepted 汇总日志）
- G3（AGENT_AUTO_APPROVE_TOOLS 不存在）— 已转为行为级断言，可能 close as won't-fix
- G4（jailbreak 分类器）— 需 ADR
- G5（tauri-plugin-webdriver 试跑态固化）

Closes #1030