### PR TITLE
fix(desktop): #1017 fine-grained DLP ready (decouple safety_bridge from full engine init)

### DIFF
--- a/desktop-client/src/ipc/dlp.rs
+++ b/desktop-client/src/ipc/dlp.rs
@@ -112,8 +112,8 @@ pub async fn scan_user_input(
     state: State<'_, EngineState>,
     content: String,
 ) -> Result<DlpScanResponse, String> {
-    let state = state.get()?;
-    let result = state.safety_bridge.scan_user_input(&content);
+    let bridge = state.safety_bridge()?;
+    let result = bridge.scan_user_input(&content);
     Ok(DlpScanResponse::from(result))
 }
 
@@ -125,8 +125,8 @@ pub async fn scan_outbound_request(
     state: State<'_, EngineState>,
     body: String,
 ) -> Result<DlpScanResponse, String> {
-    let state = state.get()?;
-    let result = state.safety_bridge.scan_outbound(&body);
+    let bridge = state.safety_bridge()?;
+    let result = bridge.scan_outbound(&body);
     Ok(DlpScanResponse::from(result))
 }
 
@@ -138,8 +138,8 @@ pub async fn sanitize_for_storage(
     state: State<'_, EngineState>,
     content: String,
 ) -> Result<String, String> {
-    let state = state.get()?;
-    state.safety_bridge.sanitize_for_storage(&content)
+    let bridge = state.safety_bridge()?;
+    bridge.sanitize_for_storage(&content)
 }
 
 /// 检查 HTTP 请求是否包含敏感信息。
@@ -153,9 +153,9 @@ pub async fn check_http_request(
     headers: Vec<(String, String)>,
     body: Option<Vec<u8>>,
 ) -> Result<(), String> {
-    let state = state.get()?;
+    let bridge = state.safety_bridge()?;
     // 扫描 URL
-    let url_result = state.safety_bridge.scan_outbound(&url);
+    let url_result = bridge.scan_outbound(&url);
     if url_result.was_blocked {
         return Err(format!(
             "URL contains sensitive data: {}",
@@ -166,7 +166,7 @@ pub async fn check_http_request(
     // 扫描 headers
     for (key, value) in &headers {
         let header_str = format!("{}: {}", key, value);
-        let header_result = state.safety_bridge.scan_outbound(&header_str);
+        let header_result = bridge.scan_outbound(&header_str);
         if header_result.was_blocked {
             return Err(format!("Header '{}' contains sensitive data", key));
         }
@@ -175,7 +175,7 @@ pub async fn check_http_request(
     // 扫描 body
     if let Some(body_bytes) = body {
         if let Ok(body_str) = String::from_utf8(body_bytes) {
-            let body_result = state.safety_bridge.scan_outbound(&body_str);
+            let body_result = bridge.scan_outbound(&body_str);
             if body_result.was_blocked {
                 return Err(format!(
                     "Request body contains sensitive data: {}",

--- a/desktop-client/src/state.rs
+++ b/desktop-client/src/state.rs
@@ -305,6 +305,10 @@ pub struct EngineState {
     inner: OnceLock<AppState>,
     /// 引擎启动失败的原因。
     failure: RwLock<Option<String>>,
+    /// 轻量级 DLP 入口：safety_bridge 在 `initialize()` 时同步填充，
+    /// 允许 DLP 命令（`scan_user_input` 等）在冷启动期间无需等待
+    /// agents/tools/sessions 等其他组件就绪。详见 issue #1017。
+    safety_bridge: OnceLock<Arc<SafetyBridge>>,
 }
 
 impl EngineState {
@@ -313,6 +317,7 @@ impl EngineState {
         Self {
             inner: OnceLock::new(),
             failure: RwLock::new(None),
+            safety_bridge: OnceLock::new(),
         }
     }
 
@@ -320,6 +325,8 @@ impl EngineState {
     ///
     /// 只能调用一次，重复调用返回 `Err`。
     pub fn initialize(&self, state: AppState) -> Result<(), String> {
+        // 先单独发布 safety_bridge，让 DLP 命令在 OnceLock 设值之间不卡住。
+        let _ = self.safety_bridge.set(Arc::clone(&state.safety_bridge));
         self.inner
             .set(state)
             .map_err(|_| "EngineState already initialized".to_string())
@@ -373,6 +380,37 @@ impl EngineState {
     pub fn is_failed(&self) -> bool {
         self.failure.read().map(|f| f.is_some()).unwrap_or(false)
     }
+
+    /// 获取 SafetyBridge 而无需等待完整引擎就绪（issue #1017）。
+    ///
+    /// DLP IPC 命令（`scan_user_input` / `scan_outbound_request` 等）只需要
+    /// safety_bridge，不依赖 agents、tools、sessions 等其他组件。
+    /// 使用此入口可在冷启动期间快速响应，避免 `get()` 的 all-or-nothing 等待。
+    ///
+    /// 返回值：
+    /// - `Ok(Arc<SafetyBridge>)` — DLP 组件就绪
+    /// - `Err(json)` — 启动失败或仍在 safety_bridge 初始化之前；payload 与 `get()` 同结构
+    pub fn safety_bridge(&self) -> Result<Arc<SafetyBridge>, String> {
+        if let Some(bridge) = self.safety_bridge.get() {
+            return Ok(Arc::clone(bridge));
+        }
+
+        if let Ok(guard) = self.failure.read() {
+            if let Some(reason) = guard.as_ref() {
+                return Err(engine_error_payload(
+                    "ENGINE_START_FAILED",
+                    &format!("引擎启动失败: {}", reason),
+                    false,
+                ));
+            }
+        }
+
+        Err(engine_error_payload(
+            "ENGINE_NOT_READY",
+            "DLP 组件正在初始化中，请稍后重试",
+            true,
+        ))
+    }
 }
 
 /// 把引擎状态错误序列化成结构化 JSON 字符串。
@@ -425,5 +463,35 @@ mod engine_state_error_tests {
             .as_str()
             .unwrap_or_default()
             .contains("config missing"));
+    }
+
+    // issue #1017: safety_bridge() 不依赖完整 engine ready
+    #[test]
+    fn safety_bridge_before_init_returns_not_ready() {
+        let state = EngineState::new();
+        let err = state
+            .safety_bridge()
+            .err()
+            .expect("uninitialized safety_bridge must return Err");
+        let v = parse(&err);
+        assert_eq!(v["code"], "ENGINE_NOT_READY");
+        assert_eq!(v["retryable"], true);
+        assert!(
+            v["message"].as_str().unwrap_or_default().contains("DLP"),
+            "safety_bridge() 失败消息应明确指向 DLP 组件，便于排障"
+        );
+    }
+
+    #[test]
+    fn safety_bridge_after_failure_returns_non_retryable() {
+        let state = EngineState::new();
+        state.set_failed("dlp init failed".to_string());
+        let err = state
+            .safety_bridge()
+            .err()
+            .expect("failed state must surface error via safety_bridge()");
+        let v = parse(&err);
+        assert_eq!(v["code"], "ENGINE_START_FAILED");
+        assert_eq!(v["retryable"], false);
     }
 }


### PR DESCRIPTION
## 背景 / 目标

DLP IPC 命令（`scan_user_input` / `scan_outbound_request` / `sanitize_for_storage` / `check_http_request`）当前通过 `state.get()` 等待完整引擎就绪，但它们其实只需要 `safety_bridge`。冷启动期间前端 DLP 扫描会被卡 60–120 秒（issue #1017、#1015），用户在引擎完全就绪前无法发送第一条消息。

§7 e2e 测试当前用 `_wait_engine_ready(timeout=120)` 兜底掩盖这个 bug —— 本 PR 是消除这种 ADAPT_TO_BUG 的真正修复。

## 改动范围

- `desktop-client/src/state.rs`
  - `EngineState` 新增 `safety_bridge: OnceLock<Arc<SafetyBridge>>` 字段
  - `initialize()` 在 `inner.set()` **之前**先发布 safety_bridge，让 DLP 路径在 OnceLock 写入间隙也能命中
  - 新增 `pub fn safety_bridge(&self) -> Result<Arc<SafetyBridge>, String>`，沿用 `get()` 的 ENGINE_NOT_READY / ENGINE_START_FAILED JSON payload 契约
- `desktop-client/src/ipc/dlp.rs`
  - 4 个命令从 `state.get()? + state.safety_bridge.X` 替换为 `state.safety_bridge()? + bridge.X`
- 新增单元测试覆盖 not-ready / failed 两条失败路径

## 非目标（What's NOT in this PR）

- 不动 `state.get()` 的其它 60+ 处调用点 —— 它们真的需要完整 AppState
- 不动 `get_dlp_config` —— 它读 `sanitization_config()` 也仅依赖 safety_bridge，但本 PR 聚焦失败路径最长的 4 个；后续可一并迁移
- 不修 #1015 e2e §6 `sleep(10)` —— 那份测试文件还在 PR #1013 上，待 #1013 合并后单独跟进
- 不删 §7 测试的 `_wait_engine_ready` workaround —— 等 #1017 合并 + §7 PR #1014 rebase 后单独清理

## 验证

```
cargo check -p desktop-client --lib --tests   # 0 错
cargo nextest run -p desktop-client --lib state::engine_state_error_tests
  # 4 passed (含新增的 safety_bridge_before_init_returns_not_ready
  #         + safety_bridge_after_failure_returns_non_retryable)
cargo fmt -p desktop-client                    # clean
python3.12 scripts/check_no_panics.py --base origin/xClaw   # OK
```

## 后续 PR / 下一步

- #1013 合并后，开 PR 把 e2e §6 的 `time.sleep(10)` + 90s polling 换成 `wait_tauri_invoke_ready` 助手（消除 #1015 的 ADAPT_TO_BUG）
- #1014 rebase 到含本 PR 的 xClaw 后，验证可以删除 `_wait_engine_ready(timeout=120)` workaround

## Sources read

- `AGENTS.md` § PR 工作流 / ADR-114 红线 / 本地快速开发节奏
- `desktop-client/src/state.rs` (EngineState 三态模型 §)
- `desktop-client/src/ipc/dlp.rs` (4 个 DLP 命令)
- issue #1017 / #1015 / #1016 body

## Cross-cuts

类A — 无新增 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量。

Closes #1017