### PR TITLE
test(desktop-e2e): scenario 08 chat-stream frame lifecycle guard (#1035)

### DIFF
--- a/desktop-client/e2e-webdriver/tests/test_scenario_08_stream_protocol.py
+++ b/desktop-client/e2e-webdriver/tests/test_scenario_08_stream_protocol.py
@@ -1,0 +1,63 @@
+"""
+场景 8 — chat-stream 协议帧序验证
+
+对应：issue #1035 / PR #1036。
+
+验证：发一条能触发 thinking 的长提示词后，捕获真链路上的全部
+`chat-stream` 帧，断言：
+  1. 流必须以 `finish` 帧收尾（turn 真正结束）
+  2. 至少出现一段完整 reasoning 生命周期（require_reasoning=True）
+  3. 所有 reasoning-* 帧 id 非空、成对闭合（Start → Delta* → End）
+
+这是 PR #1036 引入的 ReasoningSessions lifecycle 的回归哨兵。修复前
+`map_status_to_stream` 对 `StatusUpdate::Thinking` 始终产出
+`ReasoningDelta { id: "" }`，Vercel AI SDK v5 严格校验会抛
+'Received reasoning-delta for missing reasoning part with ID ""'。
+
+dev hook `window.__E2E_GET_EVENTS` 在 main.tsx 的 `import.meta.env.DEV`
+分支自动安装。release bundle 不暴露该 hook——若 hook 不可达则 assert
+失败而非 skip，避免 CI 假绿。
+"""
+
+from __future__ import annotations
+
+from webdriver_client import (
+    assert_reasoning_frame_sequence,
+    clear_chat_stream_events,
+    click_send,
+    is_e2e_capture_installed,
+    type_into_composer,
+    wait_chat_stream_finish,
+    wait_composer_ready,
+)
+
+
+# 长且需推理的提示词——能可靠触发上游模型走 thinking 路径。
+# 短问答（如"你好"）几乎不会进入 reasoning，无法验证 lifecycle。
+THINKING_PROMPT = (
+    "请详细解释 Rust 的所有权（ownership）和借用（borrowing）机制，"
+    "包括它们如何在编译期防止数据竞争。请举三个最小代码示例分别说明"
+    "move 语义、可变借用排他性、以及生命周期标注的必要场景。"
+)
+
+
+def test_reasoning_frame_lifecycle_closes_with_non_empty_ids(session_id):
+    assert is_e2e_capture_installed(session_id), (
+        "dev hook __E2E_GET_EVENTS 未就绪——本场景要求 dev 构建启动："
+        "`cargo tauri dev -f webdriver`（release bundle 不暴露 hook）"
+    )
+
+    s0 = wait_composer_ready(session_id, timeout=60.0)
+    assert s0 is not None, "composer 未就绪"
+
+    clear_chat_stream_events(session_id)
+    type_into_composer(session_id, THINKING_PROMPT)
+    click_send(session_id)
+
+    events = wait_chat_stream_finish(session_id, timeout=180.0)
+    assert events is not None, (
+        "180s 内未收到 finish 帧——模型未配置 / 网络不通 / "
+        "tauri_channel.respond() 未发 finish"
+    )
+
+    assert_reasoning_frame_sequence(events, require_reasoning=True)

--- a/desktop-client/e2e-webdriver/webdriver_client.py
+++ b/desktop-client/e2e-webdriver/webdriver_client.py
@@ -303,3 +303,122 @@ def clear_pending_approval(session_id: str, timeout: float = 5.0) -> bool:
     wait_approval_decision(session_id, expected_approved=False, timeout=timeout)
     return True
 
+
+# ---------------------------------------------------------------------------
+# chat-stream 事件捕获（场景 8）
+# ---------------------------------------------------------------------------
+
+def is_e2e_capture_installed(session_id: str) -> bool:
+    """探测 dev hook `window.__E2E_GET_EVENTS` 是否就绪。"""
+    return bool(execjs(session_id, "return typeof window.__E2E_GET_EVENTS === 'function';"))
+
+
+def clear_chat_stream_events(session_id: str) -> None:
+    """清空已捕获的 chat-stream 事件缓冲（每条用例开始前调用）。"""
+    execjs(
+        session_id,
+        "if (typeof window.__E2E_CLEAR_EVENTS === 'function') window.__E2E_CLEAR_EVENTS(); return true;",
+    )
+
+
+def get_chat_stream_events(session_id: str) -> list[dict]:
+    """回读自上次 clear 起捕获到的全部 chat-stream payload。
+
+    每条结构：`{ "timestamp": <ms>, "payload": <VercelUIStream envelope> }`。
+    """
+    raw = execjs(
+        session_id,
+        "return typeof window.__E2E_GET_EVENTS === 'function' ? window.__E2E_GET_EVENTS() : [];",
+    )
+    return raw if isinstance(raw, list) else []
+
+
+def wait_chat_stream_finish(
+    session_id: str,
+    timeout: float = 180.0,
+    interval: float = 1.0,
+) -> Optional[list[dict]]:
+    """轮询直到事件流出现 `finish` 帧，返回当时已捕获的全部事件。
+
+    `finish` 是 Vercel AI SDK 协议里 turn 结束的标志（见 vercel_ui_protocol.rs::Finish）。
+    超时返回 None；调用方应据此区分"模型没回复"与"协议本身坏了"。
+    """
+
+    def _check():
+        evts = get_chat_stream_events(session_id)
+        for e in evts:
+            p = e.get("payload") if isinstance(e, dict) else None
+            if isinstance(p, dict) and p.get("type") == "finish":
+                return evts
+        return None
+
+    return poll(_check, timeout=timeout, interval=interval)
+
+
+def assert_reasoning_frame_sequence(
+    events: list[dict],
+    *,
+    require_reasoning: bool = False,
+) -> None:
+    """断言所有 reasoning 帧成对闭合（Start→Delta*→End），id 同段一致非空。
+
+    require_reasoning=False（默认）：流中没有 reasoning 帧时视为 OK，仅校验
+    存在的帧成对闭合。
+    require_reasoning=True：流中必须至少出现一段完整 reasoning 生命周期，
+    否则 AssertionError——用于显式期望 thinking 路径被触发的场景，防止
+    模型未走 reasoning 时测试假绿。
+
+    一旦出现任意 reasoning-* 帧，则必须满足：
+      1. 第一帧是 `reasoning-start`，id 非空
+      2. 同一 id 后续可有 0..N 个 `reasoning-delta`
+      3. 同一 id 必须以 `reasoning-end` 闭合
+      4. 出现 `reasoning-start` 时不能有未闭合的旧 id
+    """
+    reasoning_types = {"reasoning-start", "reasoning-delta", "reasoning-end"}
+    active_id: Optional[str] = None
+    seen_any = False
+    for idx, e in enumerate(events):
+        p = e.get("payload") if isinstance(e, dict) else None
+        if not isinstance(p, dict):
+            continue
+        t = p.get("type")
+        if t not in reasoning_types:
+            continue
+        seen_any = True
+        fid = p.get("id")
+        if not isinstance(fid, str) or not fid:
+            raise AssertionError(
+                f"reasoning 帧 #{idx} ({t}) 的 id 为空或非字符串：{p!r}"
+            )
+        if t == "reasoning-start":
+            if active_id is not None:
+                raise AssertionError(
+                    f"reasoning-start (id={fid}) 出现时仍有未闭合段 (active_id={active_id})"
+                )
+            active_id = fid
+        elif t == "reasoning-delta":
+            if active_id is None:
+                raise AssertionError(
+                    f"reasoning-delta (id={fid}) 出现在 reasoning-start 之前 —— 这正是 PR #1036 修复前的报错"
+                )
+            if fid != active_id:
+                raise AssertionError(
+                    f"reasoning-delta id={fid} 与活跃段 id={active_id} 不一致"
+                )
+        else:  # reasoning-end
+            if active_id is None:
+                raise AssertionError(f"reasoning-end (id={fid}) 出现时无活跃段")
+            if fid != active_id:
+                raise AssertionError(
+                    f"reasoning-end id={fid} 与活跃段 id={active_id} 不一致"
+                )
+            active_id = None
+    if seen_any and active_id is not None:
+        raise AssertionError(f"reasoning 段未闭合：active_id={active_id}（缺 reasoning-end）")
+    if require_reasoning and not seen_any:
+        raise AssertionError(
+            "期望至少一段 reasoning（require_reasoning=True），但流中零个 reasoning-* 帧——"
+            "可能模型未走 thinking 路径或上游协议根本未生成 reasoning 帧"
+        )
+
+

--- a/desktop-client/src/tauri_channel.rs
+++ b/desktop-client/src/tauri_channel.rs
@@ -24,12 +24,83 @@ use async_trait::async_trait;
 use ironclaw::channels::{Channel, IncomingMessage, MessageStream, OutgoingResponse, StatusUpdate};
 use ironclaw::error::ChannelError;
 use serde_json::json;
+use std::collections::HashMap;
 use std::sync::Arc;
 use tauri::{AppHandle, Emitter};
 use tokio::sync::{mpsc, Mutex};
 
 use crate::conversation_tracker::ConversationTracker;
 use crate::vercel_ui_protocol::VercelUIStream;
+
+// ---------------------------------------------------------------------------
+// Reasoning session lifecycle
+// ---------------------------------------------------------------------------
+
+/// Decision returned by [`ReasoningSessions::step`] describing which lifecycle
+/// frames need to be emitted around an incoming status.
+///
+/// AI SDK v5 拒收没有先发 `reasoning-start` 的 `reasoning-delta`，
+/// 也拒收空 `id`。该结构负责把"是否需要 Start / End / 当前 delta 用哪个 id"
+/// 一次性算清楚，调用方按顺序发帧即可。
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub(crate) struct ReasoningStep {
+    /// 若 Some，应在状态映射前发送 `ReasoningEnd { id }`（切出 reasoning 段）。
+    pub emit_end: Option<String>,
+    /// 若 Some，应在状态映射前发送 `ReasoningStart { id }`（进入新 reasoning 段）。
+    pub emit_start: Option<String>,
+    /// 若 Some，`StatusUpdate::Thinking` 映射的 `ReasoningDelta` 必须使用此 id。
+    pub delta_id: Option<String>,
+}
+
+/// 按 `thread_id` 跟踪 reasoning 段的活跃状态。
+///
+/// 状态机：
+/// - `Thinking` + 无活跃段 → 生成新 UUID，emit Start + delta_id
+/// - `Thinking` + 有活跃段 → 复用 id 作 delta_id
+/// - 其他 status + 有活跃段 → emit End，清除
+/// - 其他 status + 无活跃段 → 无动作
+#[derive(Debug, Default)]
+pub(crate) struct ReasoningSessions {
+    inner: Mutex<HashMap<String, String>>,
+}
+
+impl ReasoningSessions {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    pub(crate) async fn step(&self, thread_key: &str, is_thinking: bool) -> ReasoningStep {
+        let mut sessions = self.inner.lock().await;
+        match (sessions.get(thread_key).cloned(), is_thinking) {
+            (None, true) => {
+                let id = uuid::Uuid::new_v4().to_string();
+                sessions.insert(thread_key.to_string(), id.clone());
+                ReasoningStep {
+                    emit_start: Some(id.clone()),
+                    delta_id: Some(id),
+                    ..Default::default()
+                }
+            }
+            (Some(id), true) => ReasoningStep {
+                delta_id: Some(id),
+                ..Default::default()
+            },
+            (Some(id), false) => {
+                sessions.remove(thread_key);
+                ReasoningStep {
+                    emit_end: Some(id),
+                    ..Default::default()
+                }
+            }
+            (None, false) => ReasoningStep::default(),
+        }
+    }
+
+    /// 强制结束该 thread 的 reasoning 段（用于 turn 结束 / shutdown）。
+    pub(crate) async fn flush(&self, thread_key: &str) -> Option<String> {
+        self.inner.lock().await.remove(thread_key)
+    }
+}
 
 // ---------------------------------------------------------------------------
 // chat-stream envelope — 事件线程归属
@@ -139,6 +210,8 @@ pub struct TauriChannel {
     incoming_rx: Mutex<Option<mpsc::Receiver<IncomingMessage>>>,
     /// 对话追踪器，用于收集 Token 消耗并在对话结束时上报。
     pub conversation_tracker: Option<Arc<ConversationTracker>>,
+    /// 按 thread 维护活跃 reasoning 段，保证 Start/Delta/End 帧序与 id 一致。
+    reasoning_sessions: Arc<ReasoningSessions>,
 }
 
 impl TauriChannel {
@@ -157,6 +230,7 @@ impl TauriChannel {
             incoming_tx: tx,
             incoming_rx: Mutex::new(Some(rx)),
             conversation_tracker: None,
+            reasoning_sessions: Arc::new(ReasoningSessions::new()),
         }
     }
 
@@ -190,16 +264,74 @@ impl TauriChannel {
 
     /// 将 `StatusUpdate` 映射为 `VercelUIStream` 事件并发送。
     ///
-    /// - 工具/文本/推理事件 → 原生 Vercel AI protocol 类型
-    /// - 其他事件 → `DataCustom { data: {"type": "...", ...} }`
-    pub(crate) fn emit_status_stream(
+    /// - `Thinking` → 走 [`ReasoningSessions`] 完整 lifecycle（Start/Delta/End），需 thread_id
+    /// - 非 `Thinking` 且当前线程有活跃 reasoning 段 → 先 emit `ReasoningEnd` 切段
+    /// - 其他事件 → 走 [`map_status_to_stream`] 纯映射
+    pub(crate) async fn emit_status_stream(
         &self,
         thread_id: Option<&str>,
         status: &StatusUpdate,
         metadata: &serde_json::Value,
     ) -> Result<(), ChannelError> {
+        // Reasoning lifecycle 必须挂在 thread context 上才能保证 Start→Delta→End 闭合；
+        // 无 thread_id 的 Thinking 直接丢弃（前端没法把它归属到具体会话）。
+        if let StatusUpdate::Thinking(msg) = status {
+            let Some(tid) = thread_id else {
+                return Ok(());
+            };
+            let step = self.reasoning_sessions.step(tid, true).await;
+            if let Some(start_id) = step.emit_start {
+                self.emit_stream(
+                    thread_id,
+                    &VercelUIStream::ReasoningStart {
+                        id: start_id,
+                        provider_metadata: None,
+                    },
+                )?;
+            }
+            if let Some(delta_id) = step.delta_id {
+                self.emit_stream(
+                    thread_id,
+                    &VercelUIStream::ReasoningDelta {
+                        id: delta_id,
+                        delta: msg.clone(),
+                        provider_metadata: None,
+                    },
+                )?;
+            }
+            return Ok(());
+        }
+
+        if let Some(tid) = thread_id {
+            let step = self.reasoning_sessions.step(tid, false).await;
+            if let Some(end_id) = step.emit_end {
+                self.emit_stream(
+                    thread_id,
+                    &VercelUIStream::ReasoningEnd {
+                        id: end_id,
+                        provider_metadata: None,
+                    },
+                )?;
+            }
+        }
+
         for event in map_status_to_stream(status, metadata) {
             self.emit_stream(thread_id, &event)?;
+        }
+        Ok(())
+    }
+
+    /// 若该 thread 仍有活跃 reasoning 段，立即发送 `ReasoningEnd` 并清除。
+    /// 用于 turn 结束 / shutdown 等"自然终止点"。
+    async fn flush_reasoning(&self, thread_id: &str) -> Result<(), ChannelError> {
+        if let Some(id) = self.reasoning_sessions.flush(thread_id).await {
+            self.emit_stream(
+                Some(thread_id),
+                &VercelUIStream::ReasoningEnd {
+                    id,
+                    provider_metadata: None,
+                },
+            )?;
         }
         Ok(())
     }
@@ -209,9 +341,10 @@ impl TauriChannel {
 // 纯映射函数 — StatusUpdate → Vec<VercelUIStream>
 // ---------------------------------------------------------------------------
 
-/// 将 `StatusUpdate` + metadata 映射为 `VercelUIStream` 事件列表（纯函数）。
+/// 将非 reasoning 类 `StatusUpdate` + metadata 映射为 `VercelUIStream` 事件列表（纯函数）。
 ///
-/// 返回 0~2 个事件。测试可直接调用此函数验证映射逻辑，无需 `AppHandle`。
+/// `StatusUpdate::Thinking` 不在此处映射；由 [`TauriChannel::emit_status_stream`] 按
+/// reasoning 段 lifecycle 单独处理（确保 Start/Delta/End 帧序与 id 一致）。
 pub(crate) fn map_status_to_stream(
     status: &StatusUpdate,
     metadata: &serde_json::Value,
@@ -225,11 +358,7 @@ pub(crate) fn map_status_to_stream(
     }
 
     match status {
-        StatusUpdate::Thinking(msg) => vec![VercelUIStream::ReasoningDelta {
-            id: String::new(),
-            delta: msg.clone(),
-            provider_metadata: None,
-        }],
+        StatusUpdate::Thinking(_) => vec![],
 
         StatusUpdate::StreamChunk(content) => vec![VercelUIStream::TextDelta {
             id: String::new(),
@@ -480,6 +609,9 @@ impl Channel for TauriChannel {
             tracker.record_assistant_message(&thread_id, &response.content, None, 0, 0);
         }
 
+        // turn 终止前关闭可能仍开着的 reasoning 段，避免下一轮 Start 时残留 id
+        self.flush_reasoning(&thread_id).await?;
+
         self.emit_stream(
             Some(&thread_id),
             &VercelUIStream::DataCustom {
@@ -550,7 +682,7 @@ impl Channel for TauriChannel {
             return Ok(());
         }
 
-        self.emit_status_stream(thread_id, &status, metadata)
+        self.emit_status_stream(thread_id, &status, metadata).await
     }
 
     async fn broadcast(
@@ -719,7 +851,7 @@ mod tests {
         ];
 
         for (status, meta) in &cases {
-            let events = map_status_to_stream(&status, &meta);
+            let events = map_status_to_stream(status, meta);
             // 每个事件都应该能成功序列化
             for event in &events {
                 serde_json::to_value(event).expect("should serialize");
@@ -749,17 +881,18 @@ mod tests {
         assert_eq!(json["data"]["source"], "chat");
     }
 
-    /// 验证 reasoning-delta 事件格式。
+    /// `map_status_to_stream` 不再处理 Thinking（返回空）；Thinking 由
+    /// `emit_status_stream` 按 lifecycle 处理，详见下方 reasoning_* 系列测试。
     #[test]
-    fn test_thinking_maps_to_reasoning_delta() {
+    fn test_thinking_is_not_mapped_by_pure_function() {
         let events = map_status_to_stream(
             &StatusUpdate::Thinking("analyzing...".into()),
             &empty_meta(),
         );
-        assert_eq!(events.len(), 1);
-        let json = serde_json::to_value(&events[0]).expect("should serialize");
-        assert_eq!(json["type"], "reasoning-delta");
-        assert_eq!(json["delta"], "analyzing...");
+        assert!(
+            events.is_empty(),
+            "Thinking must not produce frames via pure mapper; lifecycle owns reasoning frames"
+        );
     }
 
     /// 验证 error 事件使用 Vercel protocol Error 类型。
@@ -867,6 +1000,90 @@ mod tests {
     }
 
     // ── Envelope 测试：chat-stream payload 注入 threadId ────────────────────
+
+    // ── ReasoningSessions 生命周期 ─────────────────────────────────────────
+
+    #[tokio::test]
+    async fn reasoning_first_thinking_emits_start_and_delta_id() {
+        let sessions = ReasoningSessions::new();
+        let step = sessions.step("t-1", true).await;
+        let start_id = step.emit_start.expect("first Thinking must emit Start");
+        assert_eq!(step.delta_id.as_deref(), Some(start_id.as_str()));
+        assert!(step.emit_end.is_none());
+        assert!(!start_id.is_empty(), "reasoning id must be non-empty");
+    }
+
+    #[tokio::test]
+    async fn reasoning_subsequent_thinking_reuses_id_without_start() {
+        let sessions = ReasoningSessions::new();
+        let first = sessions.step("t-1", true).await;
+        let second = sessions.step("t-1", true).await;
+        assert!(second.emit_start.is_none());
+        assert!(second.emit_end.is_none());
+        assert_eq!(second.delta_id, first.delta_id);
+    }
+
+    #[tokio::test]
+    async fn reasoning_transition_to_non_thinking_emits_end_once() {
+        let sessions = ReasoningSessions::new();
+        let started = sessions.step("t-1", true).await;
+        let opened_id = started.delta_id.unwrap();
+        let ended = sessions.step("t-1", false).await;
+        assert_eq!(ended.emit_end.as_deref(), Some(opened_id.as_str()));
+        assert!(ended.emit_start.is_none());
+        assert!(ended.delta_id.is_none());
+        // 再次发送非 Thinking 不应重复 End
+        let next = sessions.step("t-1", false).await;
+        assert!(next.emit_end.is_none());
+    }
+
+    #[tokio::test]
+    async fn reasoning_sessions_are_isolated_per_thread() {
+        let sessions = ReasoningSessions::new();
+        let a = sessions.step("t-A", true).await.delta_id.unwrap();
+        let b = sessions.step("t-B", true).await.delta_id.unwrap();
+        assert_ne!(a, b);
+        // 结束 A 不影响 B
+        sessions.step("t-A", false).await;
+        let b_again = sessions.step("t-B", true).await;
+        assert!(b_again.emit_start.is_none());
+        assert_eq!(b_again.delta_id, Some(b));
+    }
+
+    #[tokio::test]
+    async fn reasoning_flush_returns_active_id_and_clears() {
+        let sessions = ReasoningSessions::new();
+        let id = sessions.step("t-1", true).await.delta_id.unwrap();
+        assert_eq!(sessions.flush("t-1").await, Some(id));
+        assert_eq!(sessions.flush("t-1").await, None);
+        // flush 后再来 Thinking 应当生成新 Start
+        let next = sessions.step("t-1", true).await;
+        assert!(next.emit_start.is_some());
+    }
+
+    #[tokio::test]
+    async fn reasoning_sessions_remain_isolated_under_concurrency() {
+        let sessions = Arc::new(ReasoningSessions::new());
+        let mut handles = Vec::new();
+        for n in 0..16 {
+            let s = Arc::clone(&sessions);
+            handles.push(tokio::spawn(async move {
+                let tid = format!("t-{n}");
+                let first = s.step(&tid, true).await;
+                let id = first.delta_id.clone().expect("first step must emit id");
+                assert_eq!(first.emit_start.as_ref(), Some(&id));
+                let second = s.step(&tid, true).await;
+                assert!(
+                    second.emit_start.is_none(),
+                    "id must not reset within a turn"
+                );
+                assert_eq!(second.delta_id, Some(id));
+            }));
+        }
+        for h in handles {
+            h.await.unwrap();
+        }
+    }
 
     /// 线程专属事件：顶层应含 `threadId` 字段，type 字段保持不变。
     #[test]

--- a/desktop-client/src/tauri_channel_tests.rs
+++ b/desktop-client/src/tauri_channel_tests.rs
@@ -41,14 +41,16 @@ mod tests {
 
     #[test]
     fn test_contract_thinking_event() {
+        // AI SDK v5 拒收空 id 的 reasoning-delta；lifecycle 必须分配有效 id。
         let event = VercelUIStream::ReasoningDelta {
-            id: String::new(),
+            id: "r-42".into(),
             delta: "processing".into(),
             provider_metadata: None,
         };
         let json: serde_json::Value = serde_json::to_value(&event).unwrap();
 
         assert_eq!(json["type"], "reasoning-delta");
+        assert_eq!(json["id"], "r-42");
         assert!(json["delta"].is_string());
     }
 
@@ -460,7 +462,7 @@ mod tests {
         let empty = json!({});
 
         let cases: Vec<(StatusUpdate, &serde_json::Value)> = vec![
-            (StatusUpdate::Thinking("test".into()), &empty),
+            // Thinking 不走纯映射；由 emit_status_stream 按 lifecycle 处理，见 reasoning_* 系列测试。
             (
                 StatusUpdate::ToolStarted {
                     name: "test".into(),

--- a/desktop-client/ui/src/app/testing/e2eChatStreamCapture.ts
+++ b/desktop-client/ui/src/app/testing/e2eChatStreamCapture.ts
@@ -1,0 +1,44 @@
+/**
+ * E2E chat-stream 帧捕获 hook（仅 DEV + Tauri shell 下激活）。
+ *
+ * WebDriver 测试在 WKWebView 内执行 `window.__E2E_GET_EVENTS()` 回读真链路
+ * 帧序，用于断言 `reasoning-start → reasoning-delta → reasoning-end` 等
+ * 协议生命周期。production bundle 不会包含此模块（Vite tree-shake +
+ * 入口处 `import.meta.env.DEV` gate）。
+ */
+
+import { listen } from '@tauri-apps/api/event';
+
+interface CapturedEvent {
+  timestamp: number;
+  payload: unknown;
+}
+
+interface E2EWindow {
+  __E2E_GET_EVENTS?: () => CapturedEvent[];
+  __E2E_CLEAR_EVENTS?: () => void;
+  __E2E_EVENT_COUNT?: () => number;
+  __TAURI_INTERNALS__?: unknown;
+}
+
+export async function installE2EChatStreamCapture(): Promise<void> {
+  const win = window as unknown as E2EWindow;
+  if (!win.__TAURI_INTERNALS__) {
+    return;
+  }
+  // 幂等：HMR / 多次 bootstrap 不应叠加监听器，否则同一事件会被 push 多次
+  if (typeof win.__E2E_GET_EVENTS === 'function') {
+    return;
+  }
+
+  const events: CapturedEvent[] = [];
+  await listen<unknown>('chat-stream', (event) => {
+    events.push({ timestamp: Date.now(), payload: event.payload });
+  });
+
+  win.__E2E_GET_EVENTS = () => events.slice();
+  win.__E2E_CLEAR_EVENTS = () => {
+    events.length = 0;
+  };
+  win.__E2E_EVENT_COUNT = () => events.length;
+}

--- a/desktop-client/ui/src/main.tsx
+++ b/desktop-client/ui/src/main.tsx
@@ -8,6 +8,11 @@ async function bootstrap() {
 		setupCypressTauriMock();
 	}
 
+	if (import.meta.env.DEV) {
+		const { installE2EChatStreamCapture } = await import('./app/testing/e2eChatStreamCapture');
+		await installE2EChatStreamCapture();
+	}
+
 	createRoot(document.getElementById("root")!).render(<App />);
 }
 


### PR DESCRIPTION
## 背景 / 目标

为 issue #1035 提供 E2E 防护：捕获 WKWebView 内真链路 `chat-stream` 帧，断言 reasoning 帧成对闭合且 id 非空。这是 PR #1036 (`fix/desktop-reasoning-frame-lifecycle`) 引入的 `ReasoningSessions` 生命周期的回归哨兵——若未来有人改回 `ReasoningDelta { id: "" }` 或忘记在 turn 终止时 flush，本测试立刻 fail。

## Stacked PR

- **base**: `fix/desktop-reasoning-frame-lifecycle`（PR #1036），不是 `xClaw`
- **merge 顺序**：先 merge #1036，再 merge 本 PR
- **请先 review #1036 再看本 PR**
- 合并下层 PR 时按 AGENTS.md 路径 A 或 B 处理（保留下层分支 / 或在合并前手动把本 PR base 切到 xClaw），避免 GitHub 自动关闭本 PR

## 改动范围

| 文件 | 作用 |
|------|------|
| `desktop-client/ui/src/app/testing/e2eChatStreamCapture.ts` | 新增 dev-only listener，幂等安装 `window.__E2E_GET_EVENTS / __E2E_CLEAR_EVENTS / __E2E_EVENT_COUNT` |
| `desktop-client/ui/src/main.tsx` | bootstrap 在 `import.meta.env.DEV` 分支调用 hook 安装 |
| `desktop-client/e2e-webdriver/webdriver_client.py` | 新增 `is_e2e_capture_installed` / `clear_chat_stream_events` / `get_chat_stream_events` / `wait_chat_stream_finish` / `assert_reasoning_frame_sequence(require_reasoning=...)` |
| `desktop-client/e2e-webdriver/tests/test_scenario_08_stream_protocol.py` | 新增 E2E 场景 8 |

## 非目标（What's NOT in this PR）

- 不在本 PR 改 `StreamChunk` 的 `TextDelta.id` 同源 bug（issue 已记，独立 PR 修）
- 不增加生产 bundle 验证脚本（CI post-build grep `__E2E_GET_EVENTS` 留作 follow-up）
- 不修改 base PR #1036 的任何代码

## 关键设计决策

1. **hook 不可达 → assert 失败而非 skip**：避免 release bundle 误启动导致 CI 假绿。本 scenario 显式要求 `cargo tauri dev -f webdriver` 启动。
2. **`require_reasoning=True`**：若模型未真走 thinking 路径，立刻 fail，不让"长 prompt 但没 reasoning 帧"假绿通过。
3. **幂等性**：`installE2EChatStreamCapture` 检查 `window.__E2E_GET_EVENTS` 已存在则 noop，防止 HMR / 多次 bootstrap 叠加监听器。
4. **DEV gate**：`import.meta.env.DEV` 在 Vite production build 时为 `false`，dynamic import 被 tree-shake。release bundle 不含 `__E2E_*` 全局 API。

## 验证

```bash
# TS 类型检查（get_errors）
0 errors on testing/e2eChatStreamCapture.ts + main.tsx

# Python 语法
python3 -m py_compile webdriver_client.py tests/test_scenario_08_stream_protocol.py → OK
```

E2E 实跑需在另一终端启 `cargo tauri dev -f webdriver`，本地未自动跑（依赖真实模型）。

## Skills 自查

- `code-quality-audit`：1 项 P1（assert 重复逻辑）— 已通过把 `_assert_no_empty_reasoning_id` 合并进 `assert_reasoning_frame_sequence` 解决
- `code-review-expert`：4 项 P1
  - skip → assert：已修
  - 幂等性：已修
  - empty 流假绿：已通过 `require_reasoning=True` 修
  - DEV gate 生产验证：follow-up，未阻塞本 PR
- `code-simplifier`：N/A（新代码，无可简化的重复）
- `adr-compliance-check`：N/A（不触及 ADR 红线 / verbatim port / drift guard / starlark）

## Cross-cuts (ADR-114)

类 A：本 PR 无新增 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量。

## 后续步骤

- merge 顺序：#1036 → 本 PR
- follow-up issue：生产 bundle grep 防护 + `StreamChunk` 同源 bug 修复

Closes #1035
