### PR TITLE
ci(desktop-client): add grep guard rejecting ungated tauri_plugin_webdriver in production bundle

### DIFF
--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -176,6 +176,20 @@ jobs:
         BASE="${{ github.event.pull_request.base.sha }}"
         python3 scripts/check_no_new_ironclaw_literal.py --base "$BASE" --head HEAD
 
+  e2e-hooks-bundle-check:
+    name: E2E hook bundle guard (tauri_plugin_webdriver gated)
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v6
+      with:
+        submodules: recursive
+    - uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+    - name: Reject ungated E2E hook references in desktop-client/src
+      run: python3 scripts/check_e2e_hooks_not_in_bundle.py
+
   codex-execpolicy-drift:
     name: ADR-132 verbatim drift guard (codex execpolicy)
     runs-on: ubuntu-latest
@@ -394,7 +408,7 @@ jobs:
     name: Code Style (fmt + clippy + deny)
     runs-on: ubuntu-latest
     if: always()
-    needs: [format, clippy, clippy-windows, deny-check, no-panics, claw-code-readonly, no-new-ironclaw-literal, blueprint-sync, codex-execpolicy-drift, codex-process-hardening-drift, codex-shell-command-drift, codex-protocol-drift, codex-utils-home-dir-drift, codex-utils-rustls-provider-drift, codex-net-proxy-drift, codex-async-utils-drift, codex-utils-string-drift, codex-utils-cache-drift, codex-utils-image-drift, codex-sandboxing-drift, codex-linux-sandbox-drift, codex-sandbox-windows-drift]
+    needs: [format, clippy, clippy-windows, deny-check, no-panics, claw-code-readonly, no-new-ironclaw-literal, e2e-hooks-bundle-check, blueprint-sync, codex-execpolicy-drift, codex-process-hardening-drift, codex-shell-command-drift, codex-protocol-drift, codex-utils-home-dir-drift, codex-utils-rustls-provider-drift, codex-net-proxy-drift, codex-async-utils-drift, codex-utils-string-drift, codex-utils-cache-drift, codex-utils-image-drift, codex-sandboxing-drift, codex-linux-sandbox-drift, codex-sandbox-windows-drift]
     steps:
       - run: |
           if [[ "${{ needs.format.result }}" != "success" || "${{ needs.clippy.result }}" != "success" || "${{ needs.deny-check.result }}" != "success" || "${{ needs.no-panics.result }}" != "success" || "${{ needs.claw-code-readonly.result }}" != "success" || "${{ needs.codex-execpolicy-drift.result }}" != "success" ]]; then
@@ -404,6 +418,10 @@ jobs:
           # no-new-ironclaw-literal is skipped on adr-114-class-b PRs (by design); skipped is acceptable but failure is not
           if [[ "${{ needs.no-new-ironclaw-literal.result }}" != "success" && "${{ needs.no-new-ironclaw-literal.result }}" != "skipped" ]]; then
             echo "ADR-114 grep guard failed: ${{ needs.no-new-ironclaw-literal.result }}"
+            exit 1
+          fi
+          if [[ "${{ needs.e2e-hooks-bundle-check.result }}" != "success" ]]; then
+            echo "E2E hook bundle guard failed: ${{ needs.e2e-hooks-bundle-check.result }}"
             exit 1
           fi
           if [[ "${{ needs.codex-process-hardening-drift.result }}" != "success" ]]; then

--- a/scripts/check_e2e_hooks_not_in_bundle.py
+++ b/scripts/check_e2e_hooks_not_in_bundle.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3.12
+"""
+E2E hook bundle guard: ensure tauri_plugin_webdriver (and future E2E-only
+plugins) is only referenced behind the established debug-only feature gate
+``cfg(all(debug_assertions, feature = "webdriver"))``.
+
+Why this guard exists
+---------------------
+PR #1037 introduced a WebDriver automation plugin for E2E testing. The plugin
+must NEVER ship in production releases. We rely on three layers of defense:
+
+  1. Cargo.toml: ``tauri-plugin-webdriver`` is ``optional = true`` and only
+     pulled in when ``webdriver`` feature is enabled.
+  2. main.rs: the plugin is registered inside
+     ``#[cfg(all(debug_assertions, feature = "webdriver"))]``.
+  3. **This grep guard** (CI): rejects any source file under
+     ``desktop-client/src/`` that mentions ``tauri_plugin_webdriver`` without
+     the cfg gate immediately preceding the line.
+
+Scope
+-----
+Scans ``desktop-client/src/**/*.rs`` only (production crate sources). Test
+files under ``desktop-client/tests/`` and dev-only modules are out of scope —
+they never ship in the bundle.
+
+Rule
+----
+For every line in scope containing the literal ``tauri_plugin_webdriver``,
+one of the **preceding 5 lines** must contain ``debug_assertions`` AND
+``feature = "webdriver"``. Otherwise it's a violation.
+
+Local usage
+-----------
+::
+
+    python3.12 scripts/check_e2e_hooks_not_in_bundle.py
+
+CI usage
+--------
+::
+
+    python3 scripts/check_e2e_hooks_not_in_bundle.py
+
+Exit codes: 0 = clean; 1 = at least one violation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+import unittest
+from dataclasses import dataclass
+from pathlib import Path
+
+
+# Hooks that must never ship in production bundle without proper cfg gate.
+# Keep this list narrow — only true E2E-only crates belong here.
+HOOK_PATTERNS: tuple[str, ...] = ("tauri_plugin_webdriver",)
+
+# Required cfg gate signals (BOTH must appear in the same window above the
+# hook reference).
+REQUIRED_GATE_SIGNALS: tuple[str, ...] = ("debug_assertions", 'feature = "webdriver"')
+
+# Look back this many lines for the cfg gate. Accounts for the gate attribute
+# itself plus a few lines of doc comments or formatting between gate and hook
+# use. See desktop-client/src/main.rs:60-63 for the canonical pattern.
+GATE_WINDOW = 5
+
+# Files scanned (relative to repo root). Glob patterns.
+SCAN_GLOBS: tuple[str, ...] = ("desktop-client/src/**/*.rs",)
+
+# Whitelist: this script itself + workflow yml that mentions the hook name.
+PATH_WHITELIST: tuple[str, ...] = (
+    "scripts/check_e2e_hooks_not_in_bundle.py",
+    ".github/workflows/code_style.yml",
+)
+
+
+@dataclass(frozen=True)
+class Violation:
+    path: str
+    line_no: int
+    hook: str
+    snippet: str
+
+
+def is_whitelisted(path: str) -> bool:
+    return path in PATH_WHITELIST
+
+
+def find_violations_in_text(path: str, text: str) -> list[Violation]:
+    lines = text.splitlines()
+    violations: list[Violation] = []
+    for idx, line in enumerate(lines):
+        for hook in HOOK_PATTERNS:
+            if hook not in line:
+                continue
+            # Look back GATE_WINDOW lines for the required cfg gate.
+            window_start = max(0, idx - GATE_WINDOW)
+            window = "\n".join(lines[window_start:idx])
+            if all(sig in window for sig in REQUIRED_GATE_SIGNALS):
+                continue
+            # Allow the same line to also contain the gate (single-line cfg).
+            if all(sig in line for sig in REQUIRED_GATE_SIGNALS):
+                continue
+            violations.append(
+                Violation(
+                    path=path,
+                    line_no=idx + 1,
+                    hook=hook,
+                    snippet=line.rstrip(),
+                )
+            )
+    return violations
+
+
+def collect_violations(repo_root: Path) -> list[Violation]:
+    violations: list[Violation] = []
+    for glob in SCAN_GLOBS:
+        for file_path in sorted(repo_root.glob(glob)):
+            rel = file_path.relative_to(repo_root).as_posix()
+            if is_whitelisted(rel):
+                continue
+            try:
+                text = file_path.read_text(encoding="utf-8")
+            except (OSError, UnicodeDecodeError):
+                continue
+            violations.extend(find_violations_in_text(rel, text))
+    return violations
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repo-root",
+        default=".",
+        help="repository root (default: cwd)",
+    )
+    parser.add_argument(
+        "--self-test",
+        action="store_true",
+        help="run inline unittests instead of scanning the tree",
+    )
+    args = parser.parse_args(argv)
+
+    if args.self_test:
+        return _run_self_test()
+
+    violations = collect_violations(Path(args.repo_root).resolve())
+    if not violations:
+        print("OK: No ungated E2E hook references found in production bundle sources.")
+        return 0
+
+    print("::error::E2E hook bundle guard hit: references to E2E-only plugins")
+    print("must be gated by cfg(all(debug_assertions, feature = \"webdriver\")).")
+    print("")
+    for v in violations[:20]:
+        print(f"{v.path}:{v.line_no}: [{v.hook}] {v.snippet}")
+    print("")
+    print(f"Total: {len(violations)} violation(s)")
+    return 1
+
+
+# ---------------------------------------------------------------------------
+# Inline tests: python3.12 scripts/check_e2e_hooks_not_in_bundle.py --self-test
+# ---------------------------------------------------------------------------
+
+
+def _run_self_test() -> int:
+    suite = unittest.TestLoader().loadTestsFromTestCase(_GuardTests)
+    runner = unittest.TextTestRunner(verbosity=2)
+    return 0 if runner.run(suite).wasSuccessful() else 1
+
+
+class _GuardTests(unittest.TestCase):
+    def test_properly_gated_passes(self) -> None:
+        src = (
+            "    #[cfg(all(debug_assertions, feature = \"webdriver\"))]\n"
+            "    let builder = builder.plugin(tauri_plugin_webdriver::init());\n"
+        )
+        self.assertEqual(find_violations_in_text("main.rs", src), [])
+
+    def test_ungated_use_fails(self) -> None:
+        src = "let b = b.plugin(tauri_plugin_webdriver::init());\n"
+        v = find_violations_in_text("main.rs", src)
+        self.assertEqual(len(v), 1)
+        self.assertEqual(v[0].hook, "tauri_plugin_webdriver")
+
+    def test_gate_missing_debug_assertions_fails(self) -> None:
+        src = (
+            "#[cfg(feature = \"webdriver\")]\n"
+            "let b = b.plugin(tauri_plugin_webdriver::init());\n"
+        )
+        v = find_violations_in_text("main.rs", src)
+        self.assertEqual(len(v), 1)
+
+    def test_gate_missing_feature_fails(self) -> None:
+        src = (
+            "#[cfg(debug_assertions)]\n"
+            "let b = b.plugin(tauri_plugin_webdriver::init());\n"
+        )
+        v = find_violations_in_text("main.rs", src)
+        self.assertEqual(len(v), 1)
+
+    def test_gate_far_above_fails(self) -> None:
+        # Cfg gate 10 lines above (outside GATE_WINDOW=5) doesn't count.
+        prefix = "#[cfg(all(debug_assertions, feature = \"webdriver\"))]\n"
+        body = "\n".join(["// blank"] * 10) + "\n"
+        src = prefix + body + "let b = b.plugin(tauri_plugin_webdriver::init());\n"
+        v = find_violations_in_text("main.rs", src)
+        self.assertEqual(len(v), 1)
+
+    def test_gate_within_window_passes(self) -> None:
+        # 4-line gap is within GATE_WINDOW=5.
+        prefix = "#[cfg(all(debug_assertions, feature = \"webdriver\"))]\n"
+        body = "\n".join(["// blank"] * 3) + "\n"
+        src = prefix + body + "let b = b.plugin(tauri_plugin_webdriver::init());\n"
+        self.assertEqual(find_violations_in_text("main.rs", src), [])
+
+    def test_single_line_gate_passes(self) -> None:
+        # Defensive: same-line gate also accepted (rare style).
+        src = "#[cfg(all(debug_assertions, feature = \"webdriver\"))] tauri_plugin_webdriver::init();\n"
+        self.assertEqual(find_violations_in_text("main.rs", src), [])
+
+    def test_whitelist(self) -> None:
+        self.assertTrue(is_whitelisted("scripts/check_e2e_hooks_not_in_bundle.py"))
+        self.assertTrue(is_whitelisted(".github/workflows/code_style.yml"))
+        self.assertFalse(is_whitelisted("desktop-client/src/main.rs"))
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## 背景 / 目标

`tauri_plugin_webdriver` 是 E2E-only Tauri plugin（暴露 :4445 WebDriver HTTP server 给 WKWebView 自动化），绝不能进 release bundle。

当前已有两层防御：
1. `desktop-client/Cargo.toml`：`tauri-plugin-webdriver` 为 optional dep，挂 `webdriver` feature
2. `desktop-client/src/main.rs:60-63`：注册点用 `#[cfg(all(debug_assertions, feature = "webdriver"))]` 双门 gate（release build 与 missing feature 都会被剥除）

**缺第三层 CI grep guard**：未来 PR 若在 `desktop-client/src/**/*.rs` 别处新增未 gate 的 `tauri_plugin_webdriver::init()` 调用，没人拦得住。本 PR 补上。

## 改动范围

- 新增 `scripts/check_e2e_hooks_not_in_bundle.py`（~220 行，stdlib only）
  - 扫描 `desktop-client/src/**/*.rs`
  - 对 `HOOK_PATTERNS = ("tauri_plugin_webdriver",)` 每个匹配，要求前 5 行窗口（或同行）同时出现 `debug_assertions` 与 `feature = "webdriver"`
  - 白名单：脚本自身 + `.github/workflows/code_style.yml`（meta 自指）
  - 8 个内联 unittest（`--self-test` flag）覆盖：正常 gate / 无 gate / 缺 debug_assertions / 缺 feature / gate 太远（>5 行）/ gate 在窗口内 / 同行 gate / 白名单
- `.github/workflows/code_style.yml`：
  - 新增 `e2e-hooks-bundle-check` job（与 `no-new-ironclaw-literal` 同款骨架）
  - 加入 `code-style` rollup 的 `needs:` 列表
  - 加入 rollup 的 failure-check stanza

模仿 `scripts/check_no_new_ironclaw_literal.py`（ADR-114 grep guard）的成熟模式。

## 非目标（What's NOT in this PR）

- 不修改 `desktop-client/src/main.rs` 或 `Cargo.toml`（两层已有防御保留不动）
- 不引入新 Python 依赖（stdlib only）
- 不扩展到 `admin-backend/` 或其他 crate（当前仅 `desktop-client/src/`，未来可加 GLOB）
- 不处理其它 E2E-only crate（如未来出现可往 `HOOK_PATTERNS` 加）

## 验证（命令 + 结果）

```bash
# 1. 内联 self-tests（8/8 pass）
$ python3.12 scripts/check_e2e_hooks_not_in_bundle.py --self-test
Ran 8 tests in 0.002s
OK

# 2. 真实代码扫描（clean）
$ python3.12 scripts/check_e2e_hooks_not_in_bundle.py
OK: No ungated E2E hook references found in production bundle sources.

# 3. workflow YAML 解析（24 jobs，含新 job）
$ python3 -c "import yaml; d=yaml.safe_load(open('.github/workflows/code_style.yml')); \
    assert 'e2e-hooks-bundle-check' in d['jobs']; print('OK')"
OK
```

## Skills 自审

- `code-quality-audit`：PASS（无补丁代码 / 函数最长 32 行 / 嵌套 ≤ 2 / 无重复逻辑 / stdlib only）
- `code-review-expert`：PASS，0 P0 / 0 P1 / 3 P2（已采纳 GATE_WINDOW 说明，其余为可选优化）
- `code-simplifier`：skip（脚本本身已直白，无嵌套需收敛）
- `adr-compliance-check`：N/A（未触及 ADR 红线 / verbatim port / `.ironclaw` 字面量 / drift guard）

## Cross-cuts

类 A（无新增 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量；本 PR 仅新增 E2E hook guard，与 ADR-114 命名迁移正交）。

## 后续

- 若未来引入更多 E2E-only Tauri plugin（如 `tauri-plugin-mockserver` 之类），加进 `HOOK_PATTERNS` 即可
- 若 desktop-client 拆分多 crate，更新 `SCAN_GLOBS`

Closes #1041
