### PR TITLE
fix(desktop-client): emit AI SDK v5 text-* lifecycle frames in TauriChannel

### DIFF
--- a/desktop-client/src/tauri_channel.rs
+++ b/desktop-client/src/tauri_channel.rs
@@ -7,8 +7,8 @@
 //!
 //! 统一使用 `chat-stream` 通道，发送 `VercelUIStream` 事件：
 //! - 工具事件 → `ToolInputStart/Available`, `ToolOutputAvailable/Error`
-//! - 文本流 → `TextDelta`
-//! - 思考链 → `ReasoningDelta`
+//! - 文本流 → `TextStart` → `TextDelta`... → `TextEnd`（lifecycle，参见 [`TextSessions`]）
+//! - 思考链 → `ReasoningStart` → `ReasoningDelta`... → `ReasoningEnd`（lifecycle，参见 [`ReasoningSessions`]）
 //! - 非标准事件 → `DataCustom { data: {"type": "...", ...} }`
 //!
 //! ```text
@@ -97,6 +97,66 @@ impl ReasoningSessions {
     }
 
     /// 强制结束该 thread 的 reasoning 段（用于 turn 结束 / shutdown）。
+    pub(crate) async fn flush(&self, thread_key: &str) -> Option<String> {
+        self.inner.lock().await.remove(thread_key)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Text session lifecycle
+// ---------------------------------------------------------------------------
+
+/// Decision returned by [`TextSessions::step`] describing which lifecycle
+/// frames need to be emitted around an incoming text chunk.
+///
+/// 与 [`ReasoningStep`] 同形：AI SDK v5 拒收没有先发 `text-start` 的 `text-delta`，
+/// 也拒收空 `id`。
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub(crate) struct TextStep {
+    /// 若 Some，应在 delta 前发送 `TextStart { id }`（进入新 text 段）。
+    pub emit_start: Option<String>,
+    /// 若 Some，`StatusUpdate::StreamChunk` 映射的 `TextDelta` 必须使用此 id。
+    pub delta_id: Option<String>,
+}
+
+/// 按 `thread_id` 跟踪 text 段的活跃状态。
+///
+/// 与 [`ReasoningSessions`] 同构，但状态机退化更简单——StreamChunk 没有
+/// "对立信号"主动闭合段（reasoning 用任何非 Thinking 事件闭合），text 段的
+/// 自然终止点是 `respond()`，由调用方显式 [`flush`](Self::flush)。
+///
+/// 状态机：
+/// - `StreamChunk` + 无活跃段 → 生成新 UUID，emit Start + delta_id
+/// - `StreamChunk` + 有活跃段 → 复用 id 作 delta_id
+#[derive(Debug, Default)]
+pub(crate) struct TextSessions {
+    inner: Mutex<HashMap<String, String>>,
+}
+
+impl TextSessions {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    pub(crate) async fn step(&self, thread_key: &str) -> TextStep {
+        let mut sessions = self.inner.lock().await;
+        match sessions.get(thread_key).cloned() {
+            None => {
+                let id = uuid::Uuid::new_v4().to_string();
+                sessions.insert(thread_key.to_string(), id.clone());
+                TextStep {
+                    emit_start: Some(id.clone()),
+                    delta_id: Some(id),
+                }
+            }
+            Some(id) => TextStep {
+                emit_start: None,
+                delta_id: Some(id),
+            },
+        }
+    }
+
+    /// 强制结束该 thread 的 text 段，返回活跃 id（用于 `respond()` 决定如何收尾）。
     pub(crate) async fn flush(&self, thread_key: &str) -> Option<String> {
         self.inner.lock().await.remove(thread_key)
     }
@@ -212,6 +272,8 @@ pub struct TauriChannel {
     pub conversation_tracker: Option<Arc<ConversationTracker>>,
     /// 按 thread 维护活跃 reasoning 段，保证 Start/Delta/End 帧序与 id 一致。
     reasoning_sessions: Arc<ReasoningSessions>,
+    /// 按 thread 维护活跃 text 段，保证 Start/Delta/End 帧序与 id 一致。
+    text_sessions: Arc<TextSessions>,
 }
 
 impl TauriChannel {
@@ -231,6 +293,7 @@ impl TauriChannel {
             incoming_rx: Mutex::new(Some(rx)),
             conversation_tracker: None,
             reasoning_sessions: Arc::new(ReasoningSessions::new()),
+            text_sessions: Arc::new(TextSessions::new()),
         }
     }
 
@@ -265,7 +328,8 @@ impl TauriChannel {
     /// 将 `StatusUpdate` 映射为 `VercelUIStream` 事件并发送。
     ///
     /// - `Thinking` → 走 [`ReasoningSessions`] 完整 lifecycle（Start/Delta/End），需 thread_id
-    /// - 非 `Thinking` 且当前线程有活跃 reasoning 段 → 先 emit `ReasoningEnd` 切段
+    /// - `StreamChunk` → 走 [`TextSessions`] lifecycle（Start/Delta），End 由 `respond()` 触发，需 thread_id
+    /// - 非 `Thinking` 事件且当前线程有活跃 reasoning 段 → 先 emit `ReasoningEnd` 切段
     /// - 其他事件 → 走 [`map_status_to_stream`] 纯映射
     pub(crate) async fn emit_status_stream(
         &self,
@@ -295,6 +359,35 @@ impl TauriChannel {
                     &VercelUIStream::ReasoningDelta {
                         id: delta_id,
                         delta: msg.clone(),
+                        provider_metadata: None,
+                    },
+                )?;
+            }
+            return Ok(());
+        }
+
+        // Text streaming：与 Reasoning 同形，但 End 由 respond() 显式触发
+        // （StreamChunk 没有对立信号能告诉我们 "流结束了"）。
+        if let StatusUpdate::StreamChunk(content) = status {
+            let Some(tid) = thread_id else {
+                return Ok(());
+            };
+            let step = self.text_sessions.step(tid).await;
+            if let Some(start_id) = step.emit_start {
+                self.emit_stream(
+                    thread_id,
+                    &VercelUIStream::TextStart {
+                        id: start_id,
+                        provider_metadata: None,
+                    },
+                )?;
+            }
+            if let Some(delta_id) = step.delta_id {
+                self.emit_stream(
+                    thread_id,
+                    &VercelUIStream::TextDelta {
+                        id: delta_id,
+                        delta: content.clone(),
                         provider_metadata: None,
                     },
                 )?;
@@ -335,6 +428,74 @@ impl TauriChannel {
         }
         Ok(())
     }
+
+    /// 若该 thread 仍有活跃 text 段，返回其 id 供调用方决定 end 时机。
+    /// 与 `flush_reasoning` 不同：text 段必须由 `respond()` 显式收尾，不能在这里就 emit End，
+    /// 因为 `respond()` 还要根据 "是否有活跃 streaming" 决定是否补 TextStart/Delta（non-streaming 路径）。
+    async fn take_active_text_id(&self, thread_id: &str) -> Option<String> {
+        self.text_sessions.flush(thread_id).await
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 纯函数 — 构造 respond() 的 wire 帧序列
+// ---------------------------------------------------------------------------
+
+/// 决定 `respond()` 应发送的 wire 帧序列（纯函数，便于单元测试）。
+///
+/// 协议契约（AI SDK v5 + 向后兼容）：
+/// - **streaming 路径**（`active_text_id = Some(_)`）：streaming chunks 已通过 `TextDelta` 把
+///   `response.content` 累积完整，此处只需 `TextEnd` 闭合段；DataCustom + Finish 紧随。
+/// - **non-streaming 路径**（`active_text_id = None`）：发完整 `TextStart` → `TextDelta(content)`
+///   → `TextEnd` 三段（id 复用 `msg_id`），再 DataCustom + Finish。
+///
+/// 保留 `DataCustom { type: "response" }` 是为了向后兼容 legacy `useAiChatTauri` hook，
+/// 它仍消费该事件（assistant-ui / `TauriChatTransport` 走 text-* 标准帧）。
+pub(crate) fn build_respond_frames(
+    active_text_id: Option<String>,
+    msg_id: &str,
+    content: &str,
+    source: &str,
+    thread_id: &str,
+) -> Vec<VercelUIStream> {
+    let mut frames = Vec::with_capacity(5);
+    match active_text_id {
+        Some(id) => {
+            frames.push(VercelUIStream::TextEnd {
+                id,
+                provider_metadata: None,
+            });
+        }
+        None => {
+            frames.push(VercelUIStream::TextStart {
+                id: msg_id.to_string(),
+                provider_metadata: None,
+            });
+            frames.push(VercelUIStream::TextDelta {
+                id: msg_id.to_string(),
+                delta: content.to_string(),
+                provider_metadata: None,
+            });
+            frames.push(VercelUIStream::TextEnd {
+                id: msg_id.to_string(),
+                provider_metadata: None,
+            });
+        }
+    }
+    frames.push(VercelUIStream::DataCustom {
+        id: None,
+        data: json!({
+            "type": "response",
+            "message_id": msg_id,
+            "content": content,
+            "thread_id": thread_id,
+            "source": source,
+        }),
+    });
+    frames.push(VercelUIStream::Finish {
+        id: msg_id.to_string(),
+    });
+    frames
 }
 
 // ---------------------------------------------------------------------------
@@ -358,13 +519,9 @@ pub(crate) fn map_status_to_stream(
     }
 
     match status {
-        StatusUpdate::Thinking(_) => vec![],
-
-        StatusUpdate::StreamChunk(content) => vec![VercelUIStream::TextDelta {
-            id: String::new(),
-            delta: content.clone(),
-            provider_metadata: None,
-        }],
+        // Thinking 和 StreamChunk 都不在此处映射——它们由
+        // `emit_status_stream` 按 lifecycle 处理（保证 Start/Delta/End 帧序与 id 一致）。
+        StatusUpdate::Thinking(_) | StatusUpdate::StreamChunk(_) => vec![],
 
         StatusUpdate::ToolStarted { name } => {
             let tcid = tool_call_id(metadata);
@@ -603,6 +760,7 @@ impl Channel for TauriChannel {
         response: OutgoingResponse,
     ) -> Result<(), ChannelError> {
         let thread_id = msg.thread_id.clone().unwrap_or_default();
+        let msg_id = msg.id.to_string();
 
         // 记录 assistant 消息到对话追踪器（Token 数在后续 TokenUsage 事件中更新）
         if let Some(tracker) = &self.conversation_tracker {
@@ -612,25 +770,19 @@ impl Channel for TauriChannel {
         // turn 终止前关闭可能仍开着的 reasoning 段，避免下一轮 Start 时残留 id
         self.flush_reasoning(&thread_id).await?;
 
-        self.emit_stream(
-            Some(&thread_id),
-            &VercelUIStream::DataCustom {
-                id: None,
-                data: json!({
-                    "type": "response",
-                    "message_id": msg.id.to_string(),
-                    "content": response.content,
-                    "thread_id": thread_id,
-                    "source": "chat",
-                }),
-            },
-        )?;
-        self.emit_stream(
-            Some(&thread_id),
-            &VercelUIStream::Finish {
-                id: msg.id.to_string(),
-            },
-        )
+        // 取走活跃 text 段 id（streaming 路径），交给纯函数决定帧序
+        let active_text_id = self.take_active_text_id(&thread_id).await;
+        let frames = build_respond_frames(
+            active_text_id,
+            &msg_id,
+            &response.content,
+            "chat",
+            &thread_id,
+        );
+        for frame in &frames {
+            self.emit_stream(Some(&thread_id), frame)?;
+        }
+        Ok(())
     }
 
     async fn send_status(
@@ -881,17 +1033,26 @@ mod tests {
         assert_eq!(json["data"]["source"], "chat");
     }
 
-    /// `map_status_to_stream` 不再处理 Thinking（返回空）；Thinking 由
-    /// `emit_status_stream` 按 lifecycle 处理，详见下方 reasoning_* 系列测试。
+    /// `map_status_to_stream` 不再处理 Thinking / StreamChunk（返回空）；他们由
+    /// `emit_status_stream` 按 lifecycle 处理，详见下方 reasoning_* / text_* 系列测试。
     #[test]
-    fn test_thinking_is_not_mapped_by_pure_function() {
-        let events = map_status_to_stream(
+    fn test_lifecycle_owned_statuses_are_not_mapped_by_pure_function() {
+        let thinking = map_status_to_stream(
             &StatusUpdate::Thinking("analyzing...".into()),
             &empty_meta(),
         );
         assert!(
-            events.is_empty(),
-            "Thinking must not produce frames via pure mapper; lifecycle owns reasoning frames"
+            thinking.is_empty(),
+            "Thinking must not produce frames via pure mapper; reasoning lifecycle owns it"
+        );
+
+        let stream_chunk = map_status_to_stream(
+            &StatusUpdate::StreamChunk("hello world".into()),
+            &empty_meta(),
+        );
+        assert!(
+            stream_chunk.is_empty(),
+            "StreamChunk must not produce frames via pure mapper; text lifecycle owns it (regression: empty-id TextDelta bug)"
         );
     }
 
@@ -1083,6 +1244,148 @@ mod tests {
         for h in handles {
             h.await.unwrap();
         }
+    }
+
+    // ── TextSessions 生命周期 ──────────────────────────────────
+
+    #[tokio::test]
+    async fn text_first_chunk_emits_start_and_nonempty_delta_id() {
+        let sessions = TextSessions::new();
+        let step = sessions.step("t-1").await;
+        let start_id = step.emit_start.expect("first StreamChunk must emit Start");
+        assert_eq!(step.delta_id.as_deref(), Some(start_id.as_str()));
+        assert!(
+            !start_id.is_empty(),
+            "text id must be non-empty (regression: AI SDK v5 rejects empty id)"
+        );
+    }
+
+    #[tokio::test]
+    async fn text_subsequent_chunks_reuse_id_without_start() {
+        let sessions = TextSessions::new();
+        let first = sessions.step("t-1").await;
+        let second = sessions.step("t-1").await;
+        assert!(second.emit_start.is_none());
+        assert_eq!(second.delta_id, first.delta_id);
+    }
+
+    #[tokio::test]
+    async fn text_sessions_are_isolated_per_thread() {
+        let sessions = TextSessions::new();
+        let a = sessions.step("t-A").await.delta_id.unwrap();
+        let b = sessions.step("t-B").await.delta_id.unwrap();
+        assert_ne!(a, b);
+    }
+
+    #[tokio::test]
+    async fn text_flush_returns_active_id_and_clears() {
+        let sessions = TextSessions::new();
+        let id = sessions.step("t-1").await.delta_id.unwrap();
+        assert_eq!(sessions.flush("t-1").await, Some(id));
+        assert_eq!(sessions.flush("t-1").await, None);
+        // flush 后再来 StreamChunk 应当生成新 Start
+        let next = sessions.step("t-1").await;
+        assert!(next.emit_start.is_some());
+    }
+
+    #[tokio::test]
+    async fn text_sessions_remain_isolated_under_concurrency() {
+        let sessions = Arc::new(TextSessions::new());
+        let mut handles = Vec::new();
+        for n in 0..16 {
+            let s = Arc::clone(&sessions);
+            handles.push(tokio::spawn(async move {
+                let tid = format!("t-{n}");
+                let first = s.step(&tid).await;
+                let id = first.delta_id.clone().expect("first step must emit id");
+                assert_eq!(first.emit_start.as_ref(), Some(&id));
+                let second = s.step(&tid).await;
+                assert!(
+                    second.emit_start.is_none(),
+                    "id must not reset within a turn"
+                );
+                assert_eq!(second.delta_id, Some(id));
+            }));
+        }
+        for h in handles {
+            h.await.unwrap();
+        }
+    }
+
+    // ── build_respond_frames 纯函数 ──────────────────────────────
+
+    /// streaming 路径：TextDelta 已累积完整内容，只需 TextEnd 闭合 + DataCustom + Finish。
+    #[test]
+    fn respond_with_active_text_session_only_closes_text() {
+        let frames = build_respond_frames(
+            Some("text-id-xyz".into()),
+            "msg-1",
+            "hello world",
+            "chat",
+            "t-1",
+        );
+        assert_eq!(
+            frames.len(),
+            3,
+            "streaming path: TextEnd + DataCustom + Finish"
+        );
+        assert!(matches!(
+            &frames[0],
+            VercelUIStream::TextEnd { id, .. } if id == "text-id-xyz"
+        ));
+        assert!(matches!(&frames[1], VercelUIStream::DataCustom { .. }));
+        assert!(matches!(
+            &frames[2],
+            VercelUIStream::Finish { id } if id == "msg-1"
+        ));
+    }
+
+    /// non-streaming 路径：没有任何 streaming chunks，需完整发
+    /// TextStart → TextDelta(content) → TextEnd → DataCustom → Finish。
+    /// id 使用 msg_id 以便前端关联 message part。
+    #[test]
+    fn respond_without_active_text_session_emits_full_text_lifecycle() {
+        let frames = build_respond_frames(None, "msg-1", "hello", "chat", "t-1");
+        assert_eq!(
+            frames.len(),
+            5,
+            "non-streaming path: TextStart + TextDelta + TextEnd + DataCustom + Finish"
+        );
+        assert!(matches!(
+            &frames[0],
+            VercelUIStream::TextStart { id, .. } if id == "msg-1"
+        ));
+        assert!(matches!(
+            &frames[1],
+            VercelUIStream::TextDelta { id, delta, .. } if id == "msg-1" && delta == "hello"
+        ));
+        assert!(matches!(
+            &frames[2],
+            VercelUIStream::TextEnd { id, .. } if id == "msg-1"
+        ));
+        assert!(matches!(&frames[3], VercelUIStream::DataCustom { .. }));
+        assert!(matches!(
+            &frames[4],
+            VercelUIStream::Finish { id } if id == "msg-1"
+        ));
+    }
+
+    /// 向后兼容：DataCustom { type: "response" } 字段保持不变，供 legacy `useAiChatTauri` hook 消费。
+    #[test]
+    fn respond_frames_preserve_data_custom_response_for_legacy_hook() {
+        let frames = build_respond_frames(None, "msg-9", "body", "chat", "t-9");
+        let custom = frames
+            .iter()
+            .find_map(|f| match f {
+                VercelUIStream::DataCustom { data, .. } => Some(data.clone()),
+                _ => None,
+            })
+            .expect("DataCustom must be present for legacy compat");
+        assert_eq!(custom["type"], "response");
+        assert_eq!(custom["message_id"], "msg-9");
+        assert_eq!(custom["content"], "body");
+        assert_eq!(custom["thread_id"], "t-9");
+        assert_eq!(custom["source"], "chat");
     }
 
     /// 线程专属事件：顶层应含 `threadId` 字段，type 字段保持不变。

--- a/desktop-client/src/tauri_channel_tests.rs
+++ b/desktop-client/src/tauri_channel_tests.rs
@@ -494,7 +494,7 @@ mod tests {
                 },
                 &meta,
             ),
-            (StatusUpdate::StreamChunk("test".into()), &empty),
+            // StreamChunk 不走纯映射；由 emit_status_stream 按 TextSessions lifecycle 处理，见 text_* 系列测试。
             (StatusUpdate::Status("test".into()), &empty),
             (
                 StatusUpdate::JobStarted {


### PR DESCRIPTION
Closes #1043

## 背景 / 目标

Tauri 桌面端「对话消息一直显示 loading 中」根因：`TauriChannel::respond()` 只发了
`DataCustom { type: "response" }` + `Finish`，缺少 Vercel AI SDK v5 `assistant-ui`
渲染必需的 `text-start { id }` → `text-delta { id, delta }` → `text-end { id }`
三段帧序，因此前端 runtime 永远拿不到完整的 assistant text part，气泡不会渲染、
loading 状态永不退出。

附带修一个二级 bug：流式 LLM 路径下 `map_status_to_stream` 把
`StatusUpdate::StreamChunk` 直接映射为 `TextDelta { id: String::new(), .. }`，
而 AI SDK v5 会拒绝空 id 的 delta。

## 改动范围（仅 1 个生产文件 + 1 个契约测试）

- `desktop-client/src/tauri_channel.rs`
  - 新增 `TextSessions` —— 镜像 `ReasoningSessions` 的三段生命周期管理
    （Start / Delta(*N) / End），每个 `thread_id` 一个活动 text id，
    `Mutex<HashMap<String, String>>`。
  - 在 `emit_status_stream` 的 `StatusUpdate::StreamChunk` 分支按生命周期
    发出 `TextStart`（首次）+ `TextDelta`（非空 id）。
  - 抽出纯函数 `build_respond_frames(active_text_id, msg_id, content, source, thread_id)`：
    - 有活动 text 会话：`[TextEnd(id), DataCustom(legacy), Finish(msg_id)]`（3 帧，流式路径）
    - 无活动会话：`[TextStart, TextDelta, TextEnd, DataCustom(legacy), Finish]`（5 帧，非流式路径）
  - `respond()` 改写为 `take_active_text_id` + `build_respond_frames` 组合，
    **完整保留** `DataCustom { type: "response" }` 以兼容遗留 `useAiChatTauri.ts` hook。
  - `map_status_to_stream`：`Thinking | StreamChunk => vec![]`（两者均归 lifecycle 管理，
    修掉空 id bug）。
  - 新增 9 个测试，覆盖 TextSessions 生命周期 / 并发隔离 / `build_respond_frames`
    两条路径（3 帧 vs 5 帧）/ DataCustom 兼容性 / lifecycle-owned 状态不再被纯映射器映射。

- `desktop-client/src/tauri_channel_tests.rs`
  - 既有契约测试 `test_all_status_updates_produce_valid_stream_events` 同步更新：
    `StreamChunk` 从纯映射期望集合中移除，加注释指向 `text_*` 系列测试。

## 非目标（What's NOT in this PR）

- **不**把协议转换下沉到 `dasclaw_*` / ironclaw 框架。已与 codex（TUI `StreamController` →
  `ratatui::Line`）、claude-code（CLI `ccrClient` pass-through）架构对比后确认：
  Vercel AI SDK v5 是 **Tauri 桌面端的渲染格式**，应由 adapter 拥有，
  framework 必须保持协议无关。
- 不动 `useAiChatTauri.ts` 遗留 hook —— `DataCustom { type: "response" }` 已完整保留。
- 不动 `TauriChatTransport.ts` —— 它收到正确的 text-* 帧后自然工作。
- 不动那 24 个预存在的 clippy 错误（`dlp/security_tests.rs`、`safety_bridge.rs` 等），
  与本 PR 无关，留给独立 PR。

## 验证

| 命令 | 结果 |
|---|---|
| `cargo check -p desktop-client --tests` | PASS（54.80s） |
| `cargo nextest run -p desktop-client --lib tauri_channel` | **52/52 PASS** |
| `cargo nextest run -p desktop-client --no-fail-fast` | 825/825 PASS（修契约测试后） |
| `cargo fmt --all` | clean |
| `python3.12 scripts/check_no_panics.py --base origin/xClaw` | OK: No panic-inducing calls |
| `cargo clippy --no-deps -p desktop-client --all-targets` 对 `tauri_channel.rs` | 0 warnings |

完整 workspace clippy / build / heavy integration 交由 CI。

## Sources read

- `AGENTS.md` §「禁止补丁式代码」「测试纪律」「复用优先于新建」
- `.github/copilot-instructions.md` §「强制阅读顺序」「PR 必填项」
- `desktop-client/src/tauri_channel.rs:36-100`（既有 `ReasoningSessions` 模式作为镜像参考）
- `desktop-client/src/tauri_channel.rs:respond / emit_status_stream / map_status_to_stream`（修改前的状态）
- `desktop-client/ui/src/app/runtime/TauriChatTransport.ts` §`chat-stream` 消费路径
- `desktop-client/ui/src/app/hooks/useAiChatTauri.ts` §`DataCustom { data.type: "response" }` 遗留路径
- `desktop-client/src/tauri_channel_tests.rs:test_all_status_updates_produce_valid_stream_events`
- codex-cli-main `codex-rs/tui` `StreamController` / claude-code-main `ccrClient`（架构对比，验证「adapter 拥有协议转换」结论）
