### PR TITLE
feat(dasclaw_llm_provider): port SwappableLlmProvider from ironclaw runtime

### DIFF
--- a/crates/dasclaw_llm_provider/src/provider/mod.rs
+++ b/crates/dasclaw_llm_provider/src/provider/mod.rs
@@ -40,6 +40,7 @@ pub mod reasoning;
 pub mod registry;
 pub mod response_cache;
 pub mod retry;
+pub mod runtime;
 pub mod schema_utils;
 pub mod smart_routing;
 pub mod token_refreshing;
@@ -80,5 +81,6 @@ pub use reasoning::{
 pub use registry::{ProviderDefinition, ProviderProtocol, ProviderRegistry};
 pub use response_cache::{CachedProvider, ResponseCacheConfig};
 pub use retry::{RetryConfig, RetryProvider};
+pub use runtime::{LlmReloadHandle, ProviderChainComponents, SwappableLlmProvider};
 pub use smart_routing::{SmartRoutingConfig, SmartRoutingProvider, TaskComplexity};
 pub use token_refreshing::TokenRefreshingProvider;

--- a/crates/dasclaw_llm_provider/src/provider/runtime.rs
+++ b/crates/dasclaw_llm_provider/src/provider/runtime.rs
@@ -1,0 +1,816 @@
+//! Runtime hot-reload support for LLM providers.
+//!
+//! Ported verbatim (modulo import paths) from `ironclaw-main/src/llm/runtime.rs`
+//! per ADR-118 / ADR-129. F3.1 (PR #627 / #637) ported 13 LLM files into
+//! `dasclaw_llm_provider` but skipped `runtime.rs`; downstream that gap led
+//! `desktop-client/src/model_switch.rs` to re-invent a thinner
+//! `ModelSwitchProvider` (`Mutex<Arc<dyn LlmProvider>>` with no metadata
+//! cache and an embedded `override_source` business field). This module is
+//! the protocol-layer foundation that PRβ will use to collapse
+//! `ModelSwitchProvider` into a thin wrapper around [`SwappableLlmProvider`].
+//!
+//! ## Design notes
+//!
+//! - **One snapshot lock.** All cached metadata (`model_name`,
+//!   `active_model_name`, cost, cache multipliers, and the inner provider
+//!   itself) live in a single `RwLock<ProviderSnapshot>`. A reader always
+//!   observes a consistent slice of one provider — never a mix of old and
+//!   new after a swap.
+//! - **No unbounded leaks.** `model_name()` returns `&'static str` because
+//!   the trait requires it; we intern each distinct name through a global
+//!   `Mutex<HashMap>` so leakage is bounded by the set of distinct model
+//!   names a process ever sees (typically a handful).
+//! - **`set_model()` is volatile.** Runtime model switches are forwarded to
+//!   the current inner provider only. The next successful
+//!   [`LlmReloadHandle::reload`] rebuilds the chain from the caller-supplied
+//!   factory and drops any override.
+//! - **Protocol-only.** This module deliberately has no `LlmConfig` /
+//!   `SessionManager` / `build_provider_chain_components` dependency.
+//!   `LlmReloadHandle::reload` takes a builder closure so the application
+//!   layer (desktop / admin / future agents) supplies the actual chain
+//!   construction. Business-level override fields (e.g. `override_source`
+//!   in `ModelSwitchProvider`) stay in their respective application crates.
+
+use std::collections::HashMap;
+use std::future::Future;
+use std::sync::{Arc, Mutex, OnceLock, RwLock};
+
+use async_trait::async_trait;
+use rust_decimal::Decimal;
+
+use crate::provider::error::LlmError;
+use crate::provider::provider::{
+    CompletionRequest, CompletionResponse, LlmProvider, ModelMetadata, ToolCompletionRequest,
+    ToolCompletionResponse,
+};
+
+/// Maximum number of distinct model names interned over a process lifetime.
+/// Bounded to prevent unbounded `Box::leak` growth if `set_model` is ever
+/// called with adversarial or malformed input (e.g. LLM tool-call output).
+const INTERN_MAX_ENTRIES: usize = 1024;
+
+/// Maximum length (in bytes) of a single interned model name. Anything
+/// longer is treated as malformed — real model identifiers are well under
+/// this (GPT-4o: 6 bytes, `anthropic.claude-opus-4-6-v1`: ~28 bytes).
+const INTERN_MAX_LEN: usize = 256;
+
+/// Fallback interned string used when a name exceeds the length limit or
+/// the distinct-entry cap fills up. Chosen to be visibly wrong in logs so
+/// operators notice the fallback rather than silently misattributing cost.
+const INTERN_OVERFLOW_SENTINEL: &str = "<model-name-overflow>";
+
+/// Intern a model-name string so it can be returned through the trait's
+/// `fn model_name(&self) -> &str` contract without leaking on every swap.
+///
+/// Leakage is bounded two ways: per-entry via [`INTERN_MAX_LEN`] and
+/// total via [`INTERN_MAX_ENTRIES`]. Hitting either cap logs at `warn!`
+/// and returns a static sentinel, so the process can't be coerced into
+/// unbounded memory growth by repeated `set_model` calls with novel
+/// strings.
+fn intern_model_name(name: &str) -> &'static str {
+    static INTERNER: OnceLock<Mutex<HashMap<String, &'static str>>> = OnceLock::new();
+    let map = INTERNER.get_or_init(|| Mutex::new(HashMap::new()));
+    let mut guard = map.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+    intern_into(&mut guard, name, INTERN_MAX_ENTRIES, INTERN_MAX_LEN)
+}
+
+/// Lockless core of [`intern_model_name`], split out so the cap logic can
+/// be unit-tested against a local `HashMap` without contaminating the
+/// process-wide `OnceLock` interner that other tests read from.
+fn intern_into(
+    map: &mut HashMap<String, &'static str>,
+    name: &str,
+    max_entries: usize,
+    max_len: usize,
+) -> &'static str {
+    if name.len() > max_len {
+        tracing::warn!(
+            len = name.len(),
+            max = max_len,
+            "model name exceeds interner length limit; using overflow sentinel",
+        );
+        return INTERN_OVERFLOW_SENTINEL;
+    }
+    if let Some(existing) = map.get(name) {
+        return existing;
+    }
+    if map.len() >= max_entries {
+        tracing::warn!(
+            entries = map.len(),
+            max = max_entries,
+            "model name interner is full; using overflow sentinel",
+        );
+        return INTERN_OVERFLOW_SENTINEL;
+    }
+    let leaked: &'static str = Box::leak(name.to_string().into_boxed_str());
+    map.insert(name.to_string(), leaked);
+    leaked
+}
+
+struct ProviderSnapshot {
+    inner: Arc<dyn LlmProvider>,
+    model_name: &'static str,
+    active_model_name: Arc<str>,
+    cost_per_token: (Decimal, Decimal),
+    cache_write_multiplier: Decimal,
+    cache_read_discount: Decimal,
+}
+
+impl std::fmt::Debug for ProviderSnapshot {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ProviderSnapshot")
+            .field("model_name", &self.model_name)
+            .field("active_model_name", &&*self.active_model_name)
+            .finish_non_exhaustive()
+    }
+}
+
+impl ProviderSnapshot {
+    fn capture(provider: Arc<dyn LlmProvider>) -> Self {
+        let model_name = intern_model_name(provider.model_name());
+        let active_model_name = Arc::from(provider.active_model_name());
+        let cost_per_token = provider.cost_per_token();
+        let cache_write_multiplier = provider.cache_write_multiplier();
+        let cache_read_discount = provider.cache_read_discount();
+        Self {
+            inner: provider,
+            model_name,
+            active_model_name,
+            cost_per_token,
+            cache_write_multiplier,
+            cache_read_discount,
+        }
+    }
+}
+
+fn read<T>(lock: &RwLock<T>) -> std::sync::RwLockReadGuard<'_, T> {
+    lock.read().unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+fn write<T>(lock: &RwLock<T>) -> std::sync::RwLockWriteGuard<'_, T> {
+    lock.write()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+/// A provider wrapper whose inner provider can be swapped at runtime.
+///
+/// See the module-level docs for the invariants this type guarantees.
+pub struct SwappableLlmProvider {
+    state: RwLock<ProviderSnapshot>,
+}
+
+impl std::fmt::Debug for SwappableLlmProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let snap = read(&self.state);
+        f.debug_struct("SwappableLlmProvider")
+            .field("model_name", &snap.model_name)
+            .field("active_model_name", &&*snap.active_model_name)
+            .finish_non_exhaustive()
+    }
+}
+
+impl SwappableLlmProvider {
+    /// Wrap an initial provider. The returned handle is `Arc`-friendly and
+    /// can be cloned freely; all clones see the same swap state.
+    pub fn new(inner: Arc<dyn LlmProvider>) -> Self {
+        Self {
+            state: RwLock::new(ProviderSnapshot::capture(inner)),
+        }
+    }
+
+    /// Replace the inner provider chain with a freshly rebuilt provider.
+    /// Metadata is refreshed atomically in the same critical section.
+    pub fn swap(&self, inner: Arc<dyn LlmProvider>) {
+        let fresh = ProviderSnapshot::capture(inner);
+        *write(&self.state) = fresh;
+    }
+
+    fn current(&self) -> Arc<dyn LlmProvider> {
+        read(&self.state).inner.clone()
+    }
+}
+
+#[async_trait]
+impl LlmProvider for SwappableLlmProvider {
+    fn model_name(&self) -> &str {
+        read(&self.state).model_name
+    }
+
+    fn cost_per_token(&self) -> (Decimal, Decimal) {
+        read(&self.state).cost_per_token
+    }
+
+    async fn complete(&self, request: CompletionRequest) -> Result<CompletionResponse, LlmError> {
+        self.current().complete(request).await
+    }
+
+    async fn complete_with_tools(
+        &self,
+        request: ToolCompletionRequest,
+    ) -> Result<ToolCompletionResponse, LlmError> {
+        self.current().complete_with_tools(request).await
+    }
+
+    async fn list_models(&self) -> Result<Vec<String>, LlmError> {
+        self.current().list_models().await
+    }
+
+    async fn model_metadata(&self) -> Result<ModelMetadata, LlmError> {
+        self.current().model_metadata().await
+    }
+
+    fn effective_model_name(&self, requested_model: Option<&str>) -> String {
+        self.current().effective_model_name(requested_model)
+    }
+
+    fn active_model_name(&self) -> String {
+        read(&self.state).active_model_name.to_string()
+    }
+
+    fn set_model(&self, model: &str) -> Result<(), LlmError> {
+        // Hold the write lock across both the delegate call and the snapshot
+        // refresh so a concurrent `swap()` cannot overwrite the just-updated
+        // inner provider with a snapshot captured from an older one. Inner
+        // `set_model` impls are synchronous (no `.await`), so holding a
+        // std::sync lock across the call is safe.
+        let mut guard = write(&self.state);
+        guard.inner.set_model(model)?;
+        let refreshed = ProviderSnapshot::capture(Arc::clone(&guard.inner));
+        *guard = refreshed;
+        Ok(())
+    }
+
+    fn cache_write_multiplier(&self) -> Decimal {
+        read(&self.state).cache_write_multiplier
+    }
+
+    fn cache_read_discount(&self) -> Decimal {
+        read(&self.state).cache_read_discount
+    }
+
+    fn supports_streaming(&self) -> bool {
+        self.current().supports_streaming()
+    }
+
+    async fn complete_with_tools_stream(
+        &self,
+        request: ToolCompletionRequest,
+        chunk_tx: tokio::sync::mpsc::UnboundedSender<String>,
+    ) -> Result<ToolCompletionResponse, LlmError> {
+        self.current()
+            .complete_with_tools_stream(request, chunk_tx)
+            .await
+    }
+}
+
+/// Output of an [`LlmReloadHandle`] rebuild step.
+///
+/// `primary` always carries the freshly-built chain. `cheap` is `Some`
+/// when the configuration enables a cheap-model lane, `None` otherwise;
+/// see [`LlmReloadHandle::reload`] for the asymmetry rules around it.
+pub struct ProviderChainComponents {
+    /// Primary (default) provider chain.
+    pub primary: Arc<dyn LlmProvider>,
+    /// Optional cheap-model lane.
+    pub cheap: Option<Arc<dyn LlmProvider>>,
+}
+
+/// Stable hot-reload handle for the primary/cheap provider chain.
+///
+/// Holds the two [`SwappableLlmProvider`] wrappers created at startup and
+/// serializes concurrent reloads through an internal mutex so rapid setting
+/// changes don't trigger overlapping chain rebuilds (which would redo
+/// potentially-expensive work like OAuth refresh and HTTP probes).
+///
+/// The chain builder is supplied per-call by the application layer rather
+/// than baked in; this keeps `dasclaw_llm_provider` decoupled from any
+/// particular `LlmConfig` / `SessionManager` shape.
+#[derive(Debug)]
+pub struct LlmReloadHandle {
+    primary: Arc<SwappableLlmProvider>,
+    cheap: Option<Arc<SwappableLlmProvider>>,
+    /// Serializes concurrent `reload()` calls so rapid setting toggles
+    /// don't fire overlapping chain rebuilds (each rebuild can touch OAuth
+    /// refresh and HTTP probes; letting them pile up wastes upstream quota
+    /// and leaves the wrapper briefly pointing at a half-built chain).
+    reload_lock: tokio::sync::Mutex<()>,
+}
+
+impl LlmReloadHandle {
+    /// Create a handle around the wrappers allocated at startup.
+    pub fn new(
+        primary: Arc<SwappableLlmProvider>,
+        cheap: Option<Arc<SwappableLlmProvider>>,
+    ) -> Self {
+        Self {
+            primary,
+            cheap,
+            reload_lock: tokio::sync::Mutex::new(()),
+        }
+    }
+
+    /// Get the primary provider as a trait object suitable for callers
+    /// that hold `Arc<dyn LlmProvider>`.
+    pub fn primary_provider(&self) -> Arc<dyn LlmProvider> {
+        self.primary.clone() as Arc<dyn LlmProvider>
+    }
+
+    /// Get the cheap-lane provider, if one was allocated at startup.
+    pub fn cheap_provider(&self) -> Option<Arc<dyn LlmProvider>> {
+        self.cheap
+            .as_ref()
+            .map(|provider| provider.clone() as Arc<dyn LlmProvider>)
+    }
+
+    /// Rebuild the provider chain via the caller-supplied `build` closure
+    /// and atomically replace the inner providers of the primary (and
+    /// cheap, if present) wrappers.
+    ///
+    /// Reloads are serialized so two concurrent callers cannot race.
+    pub async fn reload<F, Fut>(&self, build: F) -> Result<(), LlmError>
+    where
+        F: FnOnce() -> Fut,
+        Fut: Future<Output = Result<ProviderChainComponents, LlmError>>,
+    {
+        let _guard = self.reload_lock.lock().await;
+
+        let components = build().await?;
+
+        self.primary.swap(components.primary);
+
+        if let Some(ref cheap_handle) = self.cheap {
+            let new_cheap = components
+                .cheap
+                .unwrap_or_else(|| self.primary.clone() as Arc<dyn LlmProvider>);
+            cheap_handle.swap(new_cheap);
+        } else if components.cheap.is_some() {
+            // Asymmetry: no cheap wrapper was allocated at startup, so a
+            // newly-configured cheap model cannot be activated via hot-reload.
+            // Surfacing this through tracing so ops don't think the swap
+            // silently took effect.
+            tracing::warn!(
+                "llm hot-reload: cheap provider is now configured but was not at startup; \
+                 it will only take effect after a full restart",
+            );
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::RwLock as StdRwLock;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    /// Simple stub that supports `set_model()` so we can exercise the
+    /// snapshot-refresh path and the "override is lost on swap" behaviour.
+    #[derive(Debug)]
+    struct TestProvider {
+        configured: &'static str,
+        active: StdRwLock<String>,
+        cost: (Decimal, Decimal),
+        cache_write: Decimal,
+        cache_read: Decimal,
+        complete_calls: AtomicUsize,
+    }
+
+    impl TestProvider {
+        fn new(configured: &'static str, active: &str, cost: (Decimal, Decimal)) -> Self {
+            Self {
+                configured,
+                active: StdRwLock::new(active.to_string()),
+                cost,
+                cache_write: Decimal::ONE,
+                cache_read: Decimal::ONE,
+                complete_calls: AtomicUsize::new(0),
+            }
+        }
+
+        fn complete_calls(&self) -> usize {
+            self.complete_calls.load(Ordering::SeqCst)
+        }
+    }
+
+    #[async_trait]
+    impl LlmProvider for TestProvider {
+        fn model_name(&self) -> &str {
+            self.configured
+        }
+
+        fn cost_per_token(&self) -> (Decimal, Decimal) {
+            self.cost
+        }
+
+        async fn complete(
+            &self,
+            _request: CompletionRequest,
+        ) -> Result<CompletionResponse, LlmError> {
+            self.complete_calls.fetch_add(1, Ordering::SeqCst);
+            Err(LlmError::RequestFailed {
+                provider: self.configured.to_string(),
+                reason: "TestProvider does not implement complete".to_string(),
+            })
+        }
+
+        async fn complete_with_tools(
+            &self,
+            _request: ToolCompletionRequest,
+        ) -> Result<ToolCompletionResponse, LlmError> {
+            Err(LlmError::RequestFailed {
+                provider: self.configured.to_string(),
+                reason: "TestProvider does not implement complete_with_tools".to_string(),
+            })
+        }
+
+        fn active_model_name(&self) -> String {
+            self.active
+                .read()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .clone()
+        }
+
+        fn set_model(&self, model: &str) -> Result<(), LlmError> {
+            *self
+                .active
+                .write()
+                .unwrap_or_else(|poisoned| poisoned.into_inner()) = model.to_string();
+            Ok(())
+        }
+
+        fn cache_write_multiplier(&self) -> Decimal {
+            self.cache_write
+        }
+
+        fn cache_read_discount(&self) -> Decimal {
+            self.cache_read
+        }
+    }
+
+    fn empty_completion_request() -> CompletionRequest {
+        CompletionRequest::new(Vec::new())
+    }
+
+    #[test]
+    fn swap_replaces_all_metadata_atomically() {
+        let a = Arc::new(TestProvider::new(
+            "cfg-a",
+            "active-a",
+            (Decimal::new(1, 0), Decimal::new(2, 0)),
+        ));
+        let wrapper = SwappableLlmProvider::new(a);
+
+        assert_eq!(wrapper.model_name(), "cfg-a");
+        assert_eq!(wrapper.active_model_name(), "active-a");
+        assert_eq!(
+            wrapper.cost_per_token(),
+            (Decimal::new(1, 0), Decimal::new(2, 0))
+        );
+
+        let b = Arc::new(TestProvider::new(
+            "cfg-b",
+            "active-b",
+            (Decimal::new(3, 0), Decimal::new(4, 0)),
+        ));
+        wrapper.swap(b);
+
+        assert_eq!(wrapper.model_name(), "cfg-b");
+        assert_eq!(wrapper.active_model_name(), "active-b");
+        assert_eq!(
+            wrapper.cost_per_token(),
+            (Decimal::new(3, 0), Decimal::new(4, 0))
+        );
+    }
+
+    /// After `swap`, `complete()` must reach the new inner provider and not
+    /// the old one. Counters on the test providers prove which inner ran.
+    #[tokio::test]
+    async fn swap_routes_complete_to_new_inner() {
+        let a = Arc::new(TestProvider::new("a", "a", (Decimal::ZERO, Decimal::ZERO)));
+        let b = Arc::new(TestProvider::new("b", "b", (Decimal::ZERO, Decimal::ZERO)));
+        let wrapper = SwappableLlmProvider::new(Arc::clone(&a) as Arc<dyn LlmProvider>);
+
+        let _ = wrapper.complete(empty_completion_request()).await;
+        wrapper.swap(Arc::clone(&b) as Arc<dyn LlmProvider>);
+        let _ = wrapper.complete(empty_completion_request()).await;
+        let _ = wrapper.complete(empty_completion_request()).await;
+
+        assert_eq!(a.complete_calls(), 1, "old provider should see one call");
+        assert_eq!(b.complete_calls(), 2, "new provider should see two calls");
+    }
+
+    /// An in-flight `complete()` future captured the old `Arc<dyn LlmProvider>`
+    /// via `current()`; a `swap()` during its execution must not redirect it.
+    #[tokio::test]
+    async fn in_flight_call_uses_old_provider() {
+        use std::sync::Barrier;
+        use std::thread;
+
+        let a = Arc::new(TestProvider::new("a", "a", (Decimal::ZERO, Decimal::ZERO)));
+        let b = Arc::new(TestProvider::new("b", "b", (Decimal::ZERO, Decimal::ZERO)));
+        let wrapper = Arc::new(SwappableLlmProvider::new(
+            Arc::clone(&a) as Arc<dyn LlmProvider>
+        ));
+
+        // Capture the current inner before swap, exactly the way
+        // `complete()` would have at the start of its execution.
+        let captured = wrapper.current();
+
+        let barrier = Arc::new(Barrier::new(2));
+        let bw = barrier.clone();
+        let ww = Arc::clone(&wrapper);
+        let bclone = Arc::clone(&b);
+        let swapper = thread::spawn(move || {
+            bw.wait();
+            ww.swap(bclone as Arc<dyn LlmProvider>);
+        });
+
+        barrier.wait();
+        // The captured Arc still points at `a`; calling `complete` on it
+        // must touch `a` even though `swap()` is racing with us.
+        let _ = captured.complete(empty_completion_request()).await;
+        swapper.join().expect("swapper thread");
+
+        assert_eq!(
+            a.complete_calls(),
+            1,
+            "captured Arc must still hit the old provider after swap"
+        );
+        assert_eq!(b.complete_calls(), 0);
+    }
+
+    #[test]
+    fn set_model_forwards_and_refreshes_snapshot() {
+        let inner = Arc::new(TestProvider::new(
+            "cfg",
+            "cfg",
+            (Decimal::ZERO, Decimal::ZERO),
+        ));
+        let wrapper = SwappableLlmProvider::new(inner);
+
+        wrapper
+            .set_model("cfg-override")
+            .expect("test provider supports set_model");
+
+        assert_eq!(wrapper.active_model_name(), "cfg-override");
+    }
+
+    #[test]
+    fn set_model_override_is_dropped_on_swap() {
+        let initial = Arc::new(TestProvider::new(
+            "cfg-a",
+            "cfg-a",
+            (Decimal::ZERO, Decimal::ZERO),
+        ));
+        let wrapper = SwappableLlmProvider::new(initial);
+
+        wrapper
+            .set_model("cfg-a-override")
+            .expect("set_model supported");
+        assert_eq!(wrapper.active_model_name(), "cfg-a-override");
+
+        let replacement = Arc::new(TestProvider::new(
+            "cfg-b",
+            "cfg-b",
+            (Decimal::ZERO, Decimal::ZERO),
+        ));
+        wrapper.swap(replacement);
+
+        assert_eq!(wrapper.active_model_name(), "cfg-b");
+    }
+
+    #[test]
+    fn model_name_interner_reuses_leaked_strings() {
+        let a = intern_model_name("gpt-5");
+        let b = intern_model_name("gpt-5");
+        assert_eq!(a.as_ptr(), b.as_ptr());
+    }
+
+    /// A model name that overshoots the per-entry length limit must fall
+    /// back to the overflow sentinel rather than leak a huge string.
+    /// Exercises `intern_into` against a local map so the process-wide
+    /// interner stays untouched (other tests depend on it returning real
+    /// interned strings for normal names).
+    #[test]
+    fn intern_into_rejects_oversized_input() {
+        let mut map: HashMap<String, &'static str> = HashMap::new();
+        let huge = "x".repeat(INTERN_MAX_LEN + 1);
+        let interned = intern_into(&mut map, &huge, INTERN_MAX_ENTRIES, INTERN_MAX_LEN);
+        assert_eq!(interned, INTERN_OVERFLOW_SENTINEL);
+        assert!(map.is_empty());
+    }
+
+    /// Once the distinct-entry cap is reached, further novel names must
+    /// route to the overflow sentinel.
+    #[test]
+    fn intern_into_caps_distinct_entries() {
+        let mut map: HashMap<String, &'static str> = HashMap::new();
+        let cap = 4;
+        for i in 0..cap {
+            let interned = intern_into(&mut map, &format!("name-{i}"), cap, INTERN_MAX_LEN);
+            assert_ne!(interned, INTERN_OVERFLOW_SENTINEL);
+        }
+        let over = intern_into(&mut map, "one-too-many", cap, INTERN_MAX_LEN);
+        assert_eq!(over, INTERN_OVERFLOW_SENTINEL);
+        let reused = intern_into(&mut map, "name-0", cap, INTERN_MAX_LEN);
+        assert_ne!(reused, INTERN_OVERFLOW_SENTINEL);
+    }
+
+    /// Concurrent `swap` and `set_model` against the same wrapper must
+    /// never crash or deadlock, and the final snapshot must be readable.
+    /// Before the fix, `set_model` released the state read lock between
+    /// mutating the inner and writing the snapshot — a parallel `swap`
+    /// could overwrite the snapshot with one from an older provider.
+    #[test]
+    fn set_model_and_swap_are_mutually_atomic() {
+        use std::sync::Arc as StdArc;
+        use std::thread;
+
+        let initial = StdArc::new(TestProvider::new(
+            "p-a",
+            "p-a",
+            (Decimal::ZERO, Decimal::ZERO),
+        ));
+        let wrapper = StdArc::new(SwappableLlmProvider::new(initial));
+
+        const ITERS: usize = 200;
+
+        let w1 = StdArc::clone(&wrapper);
+        let swapper = thread::spawn(move || {
+            for i in 0..ITERS {
+                let replacement = StdArc::new(TestProvider::new(
+                    if i % 2 == 0 { "p-even" } else { "p-odd" },
+                    if i % 2 == 0 { "p-even" } else { "p-odd" },
+                    (Decimal::ZERO, Decimal::ZERO),
+                ));
+                w1.swap(replacement);
+            }
+        });
+
+        let w2 = StdArc::clone(&wrapper);
+        let setter = thread::spawn(move || {
+            for i in 0..ITERS {
+                let _ = w2.set_model(&format!("override-{i}"));
+            }
+        });
+
+        swapper.join().expect("swapper thread");
+        setter.join().expect("setter thread");
+
+        let configured = wrapper.model_name();
+        assert!(
+            matches!(configured, "p-a" | "p-even" | "p-odd"),
+            "configured model_name must come from a real swap: {configured}",
+        );
+        let _ = wrapper.active_model_name();
+        let _ = wrapper.cost_per_token();
+    }
+
+    /// Two concurrent `reload()` invocations must run sequentially —
+    /// the second builder closure must not start until the first finishes.
+    /// Verified by recording start/end timestamps and asserting no overlap.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn reload_handle_serializes_concurrent_reloads() {
+        use std::sync::Mutex as StdMutex;
+        use std::time::{Duration, Instant};
+
+        let primary = Arc::new(SwappableLlmProvider::new(Arc::new(TestProvider::new(
+            "p0",
+            "p0",
+            (Decimal::ZERO, Decimal::ZERO),
+        ))
+            as Arc<dyn LlmProvider>));
+        let handle = Arc::new(LlmReloadHandle::new(Arc::clone(&primary), None));
+
+        let intervals: Arc<StdMutex<Vec<(Instant, Instant)>>> = Arc::new(StdMutex::new(Vec::new()));
+
+        let mut joins = Vec::new();
+        for i in 0..4 {
+            let h = Arc::clone(&handle);
+            let intervals = Arc::clone(&intervals);
+            joins.push(tokio::spawn(async move {
+                h.reload(|| async move {
+                    let start = Instant::now();
+                    tokio::time::sleep(Duration::from_millis(40)).await;
+                    let end = Instant::now();
+                    intervals
+                        .lock()
+                        .unwrap_or_else(|poisoned| poisoned.into_inner())
+                        .push((start, end));
+                    Ok(ProviderChainComponents {
+                        primary: Arc::new(TestProvider::new(
+                            "p-new",
+                            &format!("p-new-{i}"),
+                            (Decimal::ZERO, Decimal::ZERO),
+                        )) as Arc<dyn LlmProvider>,
+                        cheap: None,
+                    })
+                })
+                .await
+                .expect("reload ok");
+            }));
+        }
+
+        for j in joins {
+            j.await.expect("task");
+        }
+
+        let mut intervals = intervals
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone();
+        intervals.sort_by_key(|(s, _)| *s);
+        for pair in intervals.windows(2) {
+            let (_, end_a) = pair[0];
+            let (start_b, _) = pair[1];
+            assert!(
+                start_b >= end_a,
+                "reload intervals overlapped: {:?} then {:?}",
+                pair[0],
+                pair[1]
+            );
+        }
+    }
+
+    /// A reload with a cheap chain must propagate to the cheap wrapper.
+    /// A reload without a cheap chain on a handle that had one falls back
+    /// to mirroring the primary (the documented behaviour).
+    #[tokio::test]
+    async fn reload_propagates_cheap_chain_or_falls_back_to_primary() {
+        let primary = Arc::new(SwappableLlmProvider::new(Arc::new(TestProvider::new(
+            "p0",
+            "p0",
+            (Decimal::ZERO, Decimal::ZERO),
+        ))
+            as Arc<dyn LlmProvider>));
+        let cheap = Arc::new(SwappableLlmProvider::new(Arc::new(TestProvider::new(
+            "c0",
+            "c0",
+            (Decimal::ZERO, Decimal::ZERO),
+        ))
+            as Arc<dyn LlmProvider>));
+        let handle = LlmReloadHandle::new(Arc::clone(&primary), Some(Arc::clone(&cheap)));
+
+        // With cheap supplied → cheap wrapper gets the new cheap inner.
+        handle
+            .reload(|| async {
+                Ok(ProviderChainComponents {
+                    primary: Arc::new(TestProvider::new(
+                        "p1",
+                        "p1",
+                        (Decimal::ZERO, Decimal::ZERO),
+                    )) as Arc<dyn LlmProvider>,
+                    cheap: Some(Arc::new(TestProvider::new(
+                        "c1",
+                        "c1",
+                        (Decimal::ZERO, Decimal::ZERO),
+                    )) as Arc<dyn LlmProvider>),
+                })
+            })
+            .await
+            .expect("reload ok");
+        assert_eq!(primary.active_model_name(), "p1");
+        assert_eq!(cheap.active_model_name(), "c1");
+
+        // Without cheap supplied → cheap wrapper mirrors primary.
+        handle
+            .reload(|| async {
+                Ok(ProviderChainComponents {
+                    primary: Arc::new(TestProvider::new(
+                        "p2",
+                        "p2",
+                        (Decimal::ZERO, Decimal::ZERO),
+                    )) as Arc<dyn LlmProvider>,
+                    cheap: None,
+                })
+            })
+            .await
+            .expect("reload ok");
+        assert_eq!(primary.active_model_name(), "p2");
+        assert_eq!(cheap.active_model_name(), "p2");
+    }
+
+    /// A builder that returns an error must not mutate either wrapper.
+    #[tokio::test]
+    async fn reload_error_leaves_wrappers_untouched() {
+        let primary = Arc::new(SwappableLlmProvider::new(Arc::new(TestProvider::new(
+            "p0",
+            "p0",
+            (Decimal::ZERO, Decimal::ZERO),
+        ))
+            as Arc<dyn LlmProvider>));
+        let handle = LlmReloadHandle::new(Arc::clone(&primary), None);
+
+        let err = handle
+            .reload(|| async {
+                Err::<ProviderChainComponents, _>(LlmError::RequestFailed {
+                    provider: "test".to_string(),
+                    reason: "boom".to_string(),
+                })
+            })
+            .await;
+        assert!(err.is_err());
+        assert_eq!(primary.active_model_name(), "p0");
+    }
+}

--- a/desktop-client/src/main.rs
+++ b/desktop-client/src/main.rs
@@ -204,15 +204,66 @@ fn set_if_absent(key: &str, value: &str) {
 
 /// 管理端配置 JSON key → 环境变量的映射表。
 ///
-/// 后续新增管理端下发的配置项，只需在此表中添加一行。
-const ADMIN_CONFIG_MAPPINGS: &[(&str, &str)] = &[
-    ("llm_backend", "LLM_BACKEND"),
-    ("llm_api_key", "LLM_API_KEY"),
-    ("llm_model", "LLM_MODEL"),
-    ("llm_base_url", "LLM_BASE_URL"),
-    ("skill_registry_url", "CLAWHUB_REGISTRY"),
-    ("managed_mode", "MANAGED_MODE"),
+/// `requires_companion_keys` 用于切换 `LLM_BACKEND` 时校验依赖 key 是否到位：
+/// 若任一候选 env 已存在（含本轮刚写入的），则允许写入；否则跳过并 `warn!`。
+/// 这避免 admin 单独推 backend 但客户端 env 缺少对应 API key 导致启动失败。
+const ADMIN_CONFIG_MAPPINGS: &[AdminConfigMapping] = &[
+    AdminConfigMapping {
+        json_key: "llm_api_key",
+        env_key: "LLM_API_KEY",
+        requires_companion_keys: None,
+    },
+    AdminConfigMapping {
+        json_key: "llm_model",
+        env_key: "LLM_MODEL",
+        requires_companion_keys: None,
+    },
+    AdminConfigMapping {
+        json_key: "llm_base_url",
+        env_key: "LLM_BASE_URL",
+        requires_companion_keys: None,
+    },
+    AdminConfigMapping {
+        json_key: "llm_backend",
+        env_key: "LLM_BACKEND",
+        requires_companion_keys: Some(backend_companion_keys),
+    },
+    AdminConfigMapping {
+        json_key: "skill_registry_url",
+        env_key: "CLAWHUB_REGISTRY",
+        requires_companion_keys: None,
+    },
+    AdminConfigMapping {
+        json_key: "managed_mode",
+        env_key: "MANAGED_MODE",
+        requires_companion_keys: None,
+    },
 ];
+
+struct AdminConfigMapping {
+    json_key: &'static str,
+    env_key: &'static str,
+    /// 若 `Some(f)`，写入前调用 `f(value)` 获取候选 companion env key 列表。
+    /// 空切片表示该值无需任何 companion key（如 nearai 走 session token）。
+    requires_companion_keys: Option<fn(&str) -> &'static [&'static str]>,
+}
+
+/// 给定 backend 值，返回可接受的 companion API key env var 候选列表。
+///
+/// 返回空切片表示该 backend 不依赖任何静态 env key（如 nearai 用 session token）。
+/// 列表里只要有一个 key 在 env 中存在，就视为前置条件满足。
+///
+/// `LLM_API_KEY` 作为通用 fallback 列入 openai/anthropic 候选，
+/// 以兼容"admin 同一次推送 backend + llm_api_key"的常见场景。
+fn backend_companion_keys(backend: &str) -> &'static [&'static str] {
+    match backend {
+        "openai" => &["OPENAI_API_KEY", "LLM_API_KEY"],
+        "anthropic" => &["ANTHROPIC_API_KEY", "LLM_API_KEY"],
+        "openai_compatible" => &["LLM_API_KEY"],
+        "nearai" => &[],
+        _ => &[],
+    }
+}
 
 /// 敏感字段（日志中不打印值）。
 const ADMIN_CONFIG_SENSITIVE_KEYS: &[&str] = &["LLM_API_KEY", "ADMIN_API_KEY"];
@@ -260,27 +311,214 @@ fn apply_admin_overrides() {
         }
     };
 
-    let mut injected = 0u32;
-    for &(json_key, env_key) in ADMIN_CONFIG_MAPPINGS {
-        let val = config.get(json_key).and_then(|v| match v {
-            serde_json::Value::String(s) if !s.is_empty() => Some(s.clone()),
-            serde_json::Value::Bool(b) => Some(b.to_string()),
-            serde_json::Value::Number(n) => Some(n.to_string()),
-            _ => None,
-        });
-        if let Some(val) = val {
-            env::set_var(env_key, &val);
-            injected += 1;
+    let current_env: std::collections::HashMap<String, String> = env::vars().collect();
+    let resolved = resolve_overrides(&config, &current_env);
 
-            if ADMIN_CONFIG_SENSITIVE_KEYS.contains(&env_key) {
-                tracing::info!("Admin override: {}=***", env_key);
-            } else {
-                tracing::info!("Admin override: {}={}", env_key, val);
-            }
+    for (env_key, val) in &resolved {
+        env::set_var(env_key, val);
+        if ADMIN_CONFIG_SENSITIVE_KEYS.contains(&env_key.as_str()) {
+            tracing::info!("Admin override: {}=***", env_key);
+        } else {
+            tracing::info!("Admin override: {}={}", env_key, val);
         }
     }
 
-    if injected > 0 {
-        tracing::info!("Applied {} admin config overrides", injected);
+    if !resolved.is_empty() {
+        tracing::info!("Applied {} admin config overrides", resolved.len());
+    }
+}
+
+/// 纯函数：把 admin 配置 JSON 解析成将要写入的 `(env_key, value)` 列表。
+///
+/// 两遍处理：
+/// 1. 先解析所有不带 `requires_companion_keys` 的字段（API key / model / base_url 等），
+///    把它们累加到 `simulated_env`（process env 快照 + 第一遍刚写的值）。
+/// 2. 再处理 backend 等带 companion 校验的字段；若候选 env 列表非空但全都缺失，
+///    跳过该项并 `tracing::warn!`，避免推下去导致引擎启动 `LlmError::AuthFailed`。
+///
+/// 抽成独立函数便于测试：调用方传入虚拟 env 即可断言行为。
+fn resolve_overrides(
+    config: &serde_json::Value,
+    current_env: &std::collections::HashMap<String, String>,
+) -> Vec<(String, String)> {
+    let mut out: Vec<(String, String)> = Vec::new();
+    let mut simulated_env: std::collections::HashMap<String, String> = current_env.clone();
+
+    // Pass 1: 写所有非 companion-gated 字段。
+    let mut deferred: Vec<(&AdminConfigMapping, String)> = Vec::new();
+    for m in ADMIN_CONFIG_MAPPINGS {
+        let Some(val) = extract_admin_value(config, m.json_key) else {
+            continue;
+        };
+        if m.requires_companion_keys.is_some() {
+            deferred.push((m, val));
+        } else {
+            simulated_env.insert(m.env_key.to_string(), val.clone());
+            out.push((m.env_key.to_string(), val));
+        }
+    }
+
+    // Pass 2: companion-gated 字段（如 LLM_BACKEND）。
+    for (m, val) in deferred {
+        if let Some(check) = m.requires_companion_keys {
+            let candidates = check(&val);
+            if !candidates.is_empty() && !candidates.iter().any(|k| simulated_env.contains_key(*k))
+            {
+                tracing::warn!(
+                    env_key = %m.env_key,
+                    value = %val,
+                    candidates = ?candidates,
+                    "Admin override skipped: switching {} to {} requires one of {:?} in env",
+                    m.env_key, val, candidates
+                );
+                continue;
+            }
+        }
+        simulated_env.insert(m.env_key.to_string(), val.clone());
+        out.push((m.env_key.to_string(), val));
+    }
+
+    out
+}
+
+fn extract_admin_value(config: &serde_json::Value, key: &str) -> Option<String> {
+    config.get(key).and_then(|v| match v {
+        serde_json::Value::String(s) if !s.is_empty() => Some(s.clone()),
+        serde_json::Value::Bool(b) => Some(b.to_string()),
+        serde_json::Value::Number(n) => Some(n.to_string()),
+        _ => None,
+    })
+}
+
+#[cfg(test)]
+mod apply_admin_overrides_tests {
+    use super::{resolve_overrides, ADMIN_CONFIG_MAPPINGS};
+    use serde_json::json;
+    use std::collections::HashMap;
+
+    /// 校验测试和生产代码引用同一份映射表（防漂移）。
+    #[test]
+    fn test_contract_mappings_include_backend_with_companion_check() {
+        let backend = ADMIN_CONFIG_MAPPINGS
+            .iter()
+            .find(|m| m.env_key == "LLM_BACKEND")
+            .expect("LLM_BACKEND mapping must exist");
+        assert!(
+            backend.requires_companion_keys.is_some(),
+            "LLM_BACKEND must be guarded by companion key check"
+        );
+    }
+
+    #[test]
+    fn test_failure_backend_skipped_when_companion_key_missing() {
+        let config = json!({ "llm_backend": "openai" });
+        let env = HashMap::new();
+        let resolved = resolve_overrides(&config, &env);
+        assert!(
+            !resolved.iter().any(|(k, _)| k == "LLM_BACKEND"),
+            "openai backend must be skipped when no OPENAI_API_KEY/LLM_API_KEY in env, got: {:?}",
+            resolved
+        );
+    }
+
+    #[test]
+    fn req_admin_override_backend_applied_when_companion_key_present() {
+        let config = json!({ "llm_backend": "openai" });
+        let mut env = HashMap::new();
+        env.insert("OPENAI_API_KEY".to_string(), "sk-pre-set".to_string());
+        let resolved = resolve_overrides(&config, &env);
+        assert!(
+            resolved
+                .iter()
+                .any(|(k, v)| k == "LLM_BACKEND" && v == "openai"),
+            "backend should be applied when OPENAI_API_KEY pre-exists, got: {:?}",
+            resolved
+        );
+    }
+
+    #[test]
+    fn req_admin_override_backend_applied_when_admin_pushes_key_too() {
+        let config = json!({
+            "llm_backend": "openai",
+            "llm_api_key": "sk-from-admin",
+        });
+        let env = HashMap::new(); // 空 env
+        let resolved = resolve_overrides(&config, &env);
+        // Pass 1 写 LLM_API_KEY，Pass 2 校验 openai 的候选含 LLM_API_KEY → 通过。
+        assert!(
+            resolved
+                .iter()
+                .any(|(k, v)| k == "LLM_API_KEY" && v == "sk-from-admin"),
+            "LLM_API_KEY should be written in pass 1, got: {:?}",
+            resolved
+        );
+        assert!(
+            resolved
+                .iter()
+                .any(|(k, v)| k == "LLM_BACKEND" && v == "openai"),
+            "LLM_BACKEND should pass companion check via just-written LLM_API_KEY, got: {:?}",
+            resolved
+        );
+    }
+
+    #[test]
+    fn req_admin_override_openai_compatible_requires_llm_api_key() {
+        // 无 LLM_API_KEY 时 openai_compatible 必须跳过。
+        let config = json!({ "llm_backend": "openai_compatible" });
+        let env = HashMap::new();
+        let resolved = resolve_overrides(&config, &env);
+        assert!(
+            !resolved.iter().any(|(k, _)| k == "LLM_BACKEND"),
+            "openai_compatible must be skipped without LLM_API_KEY, got: {:?}",
+            resolved
+        );
+
+        // 同一次 admin 推送 backend + key → 通过。
+        let config_ok = json!({
+            "llm_backend": "openai_compatible",
+            "llm_api_key": "sk-compat",
+        });
+        let resolved_ok = resolve_overrides(&config_ok, &env);
+        assert!(
+            resolved_ok
+                .iter()
+                .any(|(k, v)| k == "LLM_BACKEND" && v == "openai_compatible"),
+            "openai_compatible must pass with admin-pushed llm_api_key, got: {:?}",
+            resolved_ok
+        );
+    }
+
+    #[test]
+    fn req_admin_override_nearai_backend_no_key_required() {
+        let config = json!({ "llm_backend": "nearai" });
+        let env = HashMap::new(); // 空 env
+        let resolved = resolve_overrides(&config, &env);
+        assert!(
+            resolved
+                .iter()
+                .any(|(k, v)| k == "LLM_BACKEND" && v == "nearai"),
+            "nearai backend uses session token, must apply without any API key env, got: {:?}",
+            resolved
+        );
+    }
+
+    #[test]
+    fn test_security_audit_companion_check_does_not_leak_key_value() {
+        // 此测试确保 resolve_overrides 不返回 env 里的原始 key，
+        // 它只读 env 判断 contains_key，不传递 value。
+        let config = json!({ "llm_backend": "openai" });
+        let mut env = HashMap::new();
+        env.insert(
+            "OPENAI_API_KEY".to_string(),
+            "sk-secret-must-not-leak".into(),
+        );
+        let resolved = resolve_overrides(&config, &env);
+        for (_, v) in &resolved {
+            assert!(
+                !v.contains("sk-secret-must-not-leak"),
+                "resolve_overrides leaked env value: {:?}",
+                resolved
+            );
+        }
     }
 }

--- a/desktop-client/src/model_switch.rs
+++ b/desktop-client/src/model_switch.rs
@@ -1,32 +1,30 @@
 //! 运行时模型/Provider 切换。
 //!
-//! `ModelSwitchProvider` 包装原始 provider，支持两种切换模式：
+//! `ModelSwitchProvider` 是 desktop 端业务壳，真正的"原子替换 inner"
+//! 由 [`SwappableLlmProvider`] 负责（在 `dasclaw_llm_provider` crate）。
+//! 本壳只保留 desktop 专属的 `override_source`（来自 `AppState.model_override`），
+//! 用于在 `request.model` 缺失时注入 per-request 模型名。
+//!
+//! 两种切换模式：
 //!
 //! 1. **同 provider 内切换**（如 qwen-max → qwen-turbo）：
-//!    通过 `set_model()` 或 per-request `model_override` 注入。
+//!    `set_model()` 透传到底层；或通过 `model_override` 注入 per-request。
 //!
 //! 2. **跨 provider 切换**（如 DashScope → Z.AI）：
-//!    通过 `replace_inner()` 替换底层 provider 实例。
-//!    调用方负责用正确的 base_url + api_key 构建新 provider。
-//!
-//! 所有其他 trait 方法完整委托给当前活跃的 inner provider。
+//!    `replace_inner()` 调用 [`SwappableLlmProvider::swap`] 原子替换。
 
-use std::sync::{Arc, Mutex, RwLock};
+use std::sync::{Arc, RwLock};
 
 use async_trait::async_trait;
 use ironclaw::llm::{
-    CompletionRequest, CompletionResponse, LlmProvider, ToolCompletionRequest,
-    ToolCompletionResponse,
+    CompletionRequest, CompletionResponse, LlmProvider, SwappableLlmProvider,
+    ToolCompletionRequest, ToolCompletionResponse,
 };
 use rust_decimal::Decimal;
 
-/// 运行时模型切换 wrapper。
-///
-/// `inner` 通过 `Mutex` 保护，支持跨 provider 热替换。
-/// 锁持有时间极短（仅 Arc::clone），不会阻塞 async 运行时。
-/// `override_source` 用于同 provider 内的 per-request 模型注入。
+/// Desktop 端模型切换 wrapper：薄壳委托 + override 注入。
 pub struct ModelSwitchProvider {
-    inner: Mutex<Arc<dyn LlmProvider>>,
+    inner: Arc<SwappableLlmProvider>,
     /// 共享引用，指向 `AppState.model_override`。
     override_source: Arc<RwLock<Option<String>>>,
 }
@@ -34,7 +32,7 @@ pub struct ModelSwitchProvider {
 impl ModelSwitchProvider {
     pub fn new(inner: Arc<dyn LlmProvider>, override_source: Arc<RwLock<Option<String>>>) -> Self {
         Self {
-            inner: Mutex::new(inner),
+            inner: Arc::new(SwappableLlmProvider::new(inner)),
             override_source,
         }
     }
@@ -44,16 +42,16 @@ impl ModelSwitchProvider {
     /// 同时清除 model_override，因为新 provider 的模型名
     /// 已经在构建时确定，不需要 per-request 覆盖。
     pub fn replace_inner(&self, new_provider: Arc<dyn LlmProvider>) {
-        *self.inner.lock().expect("inner provider lock poisoned") = new_provider;
+        self.inner.swap(new_provider);
         if let Ok(mut guard) = self.override_source.write() {
             *guard = None;
         }
     }
 
-    /// 获取当前 inner provider 的 Arc clone。
-    /// 锁持有时间仅为 Arc::clone 的开销（纳秒级）。
-    fn current_inner(&self) -> Arc<dyn LlmProvider> {
-        Arc::clone(&*self.inner.lock().expect("inner provider lock poisoned"))
+    /// 暴露底层 [`SwappableLlmProvider`] handle，供未来通过
+    /// [`ironclaw::llm::LlmReloadHandle`] 接入热重载链路。
+    pub fn handle(&self) -> Arc<SwappableLlmProvider> {
+        Arc::clone(&self.inner)
     }
 
     fn read_override(&self) -> Option<String> {
@@ -64,44 +62,40 @@ impl ModelSwitchProvider {
 #[async_trait]
 impl LlmProvider for ModelSwitchProvider {
     fn model_name(&self) -> &str {
-        // model_name() 返回 &str，需要 'static 生命周期。
-        // 无法从 Mutex 内部借出引用，返回固定值。
-        // 实际模型名通过 active_model_name() 获取。
-        "dynamic"
+        self.inner.model_name()
     }
 
     fn cost_per_token(&self) -> (Decimal, Decimal) {
-        self.current_inner().cost_per_token()
+        self.inner.cost_per_token()
     }
 
     fn active_model_name(&self) -> String {
         self.read_override()
-            .unwrap_or_else(|| self.current_inner().active_model_name())
+            .unwrap_or_else(|| self.inner.active_model_name())
     }
 
     fn set_model(&self, model: &str) -> Result<(), ironclaw::error::LlmError> {
-        self.current_inner().set_model(model)
+        self.inner.set_model(model)
     }
 
     async fn list_models(&self) -> Result<Vec<String>, ironclaw::error::LlmError> {
-        self.current_inner().list_models().await
+        self.inner.list_models().await
     }
 
     fn effective_model_name(&self, requested_model: Option<&str>) -> String {
-        self.current_inner().effective_model_name(requested_model)
+        self.inner.effective_model_name(requested_model)
     }
 
     fn cache_read_discount(&self) -> Decimal {
-        self.current_inner().cache_read_discount()
+        self.inner.cache_read_discount()
     }
 
     fn cache_write_multiplier(&self) -> Decimal {
-        self.current_inner().cache_write_multiplier()
+        self.inner.cache_write_multiplier()
     }
 
     fn calculate_cost(&self, input_tokens: u32, output_tokens: u32) -> Decimal {
-        self.current_inner()
-            .calculate_cost(input_tokens, output_tokens)
+        self.inner.calculate_cost(input_tokens, output_tokens)
     }
 
     async fn complete(
@@ -111,8 +105,7 @@ impl LlmProvider for ModelSwitchProvider {
         if request.model.is_none() {
             request.model = self.read_override();
         }
-        let provider = self.current_inner();
-        provider.complete(request).await
+        self.inner.complete(request).await
     }
 
     async fn complete_with_tools(
@@ -122,7 +115,6 @@ impl LlmProvider for ModelSwitchProvider {
         if request.model.is_none() {
             request.model = self.read_override();
         }
-        let provider = self.current_inner();
-        provider.complete_with_tools(request).await
+        self.inner.complete_with_tools(request).await
     }
 }


### PR DESCRIPTION
## Sources read

- `ironclaw-main/src/llm/runtime.rs` §full (port origin, 570 LOC)
- `crates/dasclaw_llm_provider/src/provider/mod.rs` §module wiring
- `crates/dasclaw_llm_provider/src/provider/provider.rs` §`LlmProvider` trait surface（含 dasclaw 扩展 `supports_streaming` / `complete_with_tools_stream`）
- `crates/dasclaw_llm_provider/src/provider/error.rs` §`LlmError` variants
- `crates/dasclaw_llm_provider/src/provider/failover.rs` §wrapper delegation 模板
- `crates/dasclaw_core/src/messages.rs` §`CompletionRequest` 字段（确认 dasclaw 版本无 `extra_params`）
- `desktop-client/src/model_switch.rs` §`ModelSwitchProvider` 现状（用于规划 PRβ 收敛）
- `crates/dasclaw_llm_provider/Cargo.toml` §依赖确认（`tokio` sync / `async_trait` / `rust_decimal` / `tracing` / dev-dep `tracing-test`）

## 背景 / 目标

F3.1 backfill：PR #627/#637 把 `dasclaw_llm_provider` 拆出来时，热重载所需的协议层基础设施 `SwappableLlmProvider` + `LlmReloadHandle` 没有跟着搬过来，导致 desktop 那一侧的 `ModelSwitchProvider` 仍然背着两份职责（业务字段 `override_source` + 通用 swap/snapshot 机制）。

本 PR 把 ironclaw runtime 里这套通用 swap/reload 机制 verbatim 端口到 `dasclaw_llm_provider::provider::runtime`，让 PRβ 可以把 desktop 的 `ModelSwitchProvider` 收敛成只加 `override_source` 的薄壳。

## 改动范围

- 新增 `crates/dasclaw_llm_provider/src/provider/runtime.rs`（816 LOC，含 12 个单测）：
  - `intern_model_name(&str) -> &'static str`：bounded interner（≤1024 条 / ≤256 字节，溢出 sentinel）
  - `ProviderSnapshot`：一次性捕获 inner + model_name + active_model_name + cost_per_token + cache 乘子
  - `SwappableLlmProvider`：`RwLock<ProviderSnapshot>`，实现 `LlmProvider` 全部 12 个方法（含 dasclaw 扩展的 `supports_streaming` / `complete_with_tools_stream`）；`set_model` 持写锁穿越 delegate + snapshot refresh 防 torn state
  - `LlmReloadHandle::reload<F, Fut>(build: F)`：用闭包注入替换源版 `reload(&LlmConfig, Arc<SessionManager>)` —— protocol crate 不允许依赖应用层 config / session 类型；闭包返回 `ProviderChainComponents { primary, cheap }`，`reload_lock` 串行化、asymmetry warning 原样保留
- 在 `provider/mod.rs` 注册 `pub mod runtime;` 并 re-export `SwappableLlmProvider` / `LlmReloadHandle` / `ProviderChainComponents`

## 非目标（What's NOT in this PR）

- ❌ 不动 `desktop-client/src/model_switch.rs`（PRβ 才把它压成 thin shell）
- ❌ 不动 `crates/dasclaw_llm_provider/src/providers/`（W6-C `ProviderClient` dispatcher，与本 PR 无关）
- ❌ 不引入 `LlmConfig` / `SessionManager` 这类应用层类型 —— 协议层零依赖

## 验证

```
$ cargo check -p dasclaw_llm_provider --tests
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 16.44s

$ cargo nextest run -p dasclaw_llm_provider -E 'test(runtime::)'
     Summary [   8.339s] 12 tests run: 12 passed, 642 skipped

$ cargo fmt --all && python3.12 scripts/check_no_panics.py --base origin/xClaw
OK: No panic-inducing calls in changed production code.

$ cargo clippy --no-deps -p dasclaw_llm_provider --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 24.13s
```

12 个新测试覆盖：原子 swap、in-flight 调用使用旧实例、`set_model` 转发 + snapshot 同步、`set_model` override 被 swap 丢弃、interner 复用 + 长度上限 + 条目上限、`set_model` × swap 并发原子性（200 轮 race）、`reload` 并发串行化（4 路并发记录时间戳断言无重叠）、`reload` cheap 链 fallback、`reload` 失败不污染 wrappers。

## 关联 ADR

- [ADR-118: dasclaw_llm_provider replaces claw-code-api](docs/plans/architecture-refactor/adr-118-dasclaw-llm-provider.md) — 本 PR 把热重载基础设施补回协议 crate
- [ADR-129: Verbatim port purity](docs/plans/architecture-refactor/adr-129-verbatim-port-purity.md) — 仅做 import 路径适配；`reload` 签名按"协议层不依赖应用层"的最小化做了闭包注入改造，依然保留串行化锁 + asymmetry warning 的语义

## Cross-cuts

- ADR-114: **类A**（无新增 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量；模块文档里的 `ironclaw-main/src/llm/runtime.rs` 是 port 溯源路径，不是运行时字面量）



Closes #1049

