### PR TITLE
fix(desktop-client): wrap SwappableLlmProvider + guard LLM_BACKEND on companion key

### DIFF
--- a/desktop-client/src/main.rs
+++ b/desktop-client/src/main.rs
@@ -204,15 +204,66 @@ fn set_if_absent(key: &str, value: &str) {
 
 /// 管理端配置 JSON key → 环境变量的映射表。
 ///
-/// 后续新增管理端下发的配置项，只需在此表中添加一行。
-const ADMIN_CONFIG_MAPPINGS: &[(&str, &str)] = &[
-    ("llm_backend", "LLM_BACKEND"),
-    ("llm_api_key", "LLM_API_KEY"),
-    ("llm_model", "LLM_MODEL"),
-    ("llm_base_url", "LLM_BASE_URL"),
-    ("skill_registry_url", "CLAWHUB_REGISTRY"),
-    ("managed_mode", "MANAGED_MODE"),
+/// `requires_companion_keys` 用于切换 `LLM_BACKEND` 时校验依赖 key 是否到位：
+/// 若任一候选 env 已存在（含本轮刚写入的），则允许写入；否则跳过并 `warn!`。
+/// 这避免 admin 单独推 backend 但客户端 env 缺少对应 API key 导致启动失败。
+const ADMIN_CONFIG_MAPPINGS: &[AdminConfigMapping] = &[
+    AdminConfigMapping {
+        json_key: "llm_api_key",
+        env_key: "LLM_API_KEY",
+        requires_companion_keys: None,
+    },
+    AdminConfigMapping {
+        json_key: "llm_model",
+        env_key: "LLM_MODEL",
+        requires_companion_keys: None,
+    },
+    AdminConfigMapping {
+        json_key: "llm_base_url",
+        env_key: "LLM_BASE_URL",
+        requires_companion_keys: None,
+    },
+    AdminConfigMapping {
+        json_key: "llm_backend",
+        env_key: "LLM_BACKEND",
+        requires_companion_keys: Some(backend_companion_keys),
+    },
+    AdminConfigMapping {
+        json_key: "skill_registry_url",
+        env_key: "CLAWHUB_REGISTRY",
+        requires_companion_keys: None,
+    },
+    AdminConfigMapping {
+        json_key: "managed_mode",
+        env_key: "MANAGED_MODE",
+        requires_companion_keys: None,
+    },
 ];
+
+struct AdminConfigMapping {
+    json_key: &'static str,
+    env_key: &'static str,
+    /// 若 `Some(f)`，写入前调用 `f(value)` 获取候选 companion env key 列表。
+    /// 空切片表示该值无需任何 companion key（如 nearai 走 session token）。
+    requires_companion_keys: Option<fn(&str) -> &'static [&'static str]>,
+}
+
+/// 给定 backend 值，返回可接受的 companion API key env var 候选列表。
+///
+/// 返回空切片表示该 backend 不依赖任何静态 env key（如 nearai 用 session token）。
+/// 列表里只要有一个 key 在 env 中存在，就视为前置条件满足。
+///
+/// `LLM_API_KEY` 作为通用 fallback 列入 openai/anthropic 候选，
+/// 以兼容"admin 同一次推送 backend + llm_api_key"的常见场景。
+fn backend_companion_keys(backend: &str) -> &'static [&'static str] {
+    match backend {
+        "openai" => &["OPENAI_API_KEY", "LLM_API_KEY"],
+        "anthropic" => &["ANTHROPIC_API_KEY", "LLM_API_KEY"],
+        "openai_compatible" => &["LLM_API_KEY"],
+        "nearai" => &[],
+        _ => &[],
+    }
+}
 
 /// 敏感字段（日志中不打印值）。
 const ADMIN_CONFIG_SENSITIVE_KEYS: &[&str] = &["LLM_API_KEY", "ADMIN_API_KEY"];
@@ -260,27 +311,214 @@ fn apply_admin_overrides() {
         }
     };
 
-    let mut injected = 0u32;
-    for &(json_key, env_key) in ADMIN_CONFIG_MAPPINGS {
-        let val = config.get(json_key).and_then(|v| match v {
-            serde_json::Value::String(s) if !s.is_empty() => Some(s.clone()),
-            serde_json::Value::Bool(b) => Some(b.to_string()),
-            serde_json::Value::Number(n) => Some(n.to_string()),
-            _ => None,
-        });
-        if let Some(val) = val {
-            env::set_var(env_key, &val);
-            injected += 1;
+    let current_env: std::collections::HashMap<String, String> = env::vars().collect();
+    let resolved = resolve_overrides(&config, &current_env);
 
-            if ADMIN_CONFIG_SENSITIVE_KEYS.contains(&env_key) {
-                tracing::info!("Admin override: {}=***", env_key);
-            } else {
-                tracing::info!("Admin override: {}={}", env_key, val);
-            }
+    for (env_key, val) in &resolved {
+        env::set_var(env_key, val);
+        if ADMIN_CONFIG_SENSITIVE_KEYS.contains(&env_key.as_str()) {
+            tracing::info!("Admin override: {}=***", env_key);
+        } else {
+            tracing::info!("Admin override: {}={}", env_key, val);
         }
     }
 
-    if injected > 0 {
-        tracing::info!("Applied {} admin config overrides", injected);
+    if !resolved.is_empty() {
+        tracing::info!("Applied {} admin config overrides", resolved.len());
+    }
+}
+
+/// 纯函数：把 admin 配置 JSON 解析成将要写入的 `(env_key, value)` 列表。
+///
+/// 两遍处理：
+/// 1. 先解析所有不带 `requires_companion_keys` 的字段（API key / model / base_url 等），
+///    把它们累加到 `simulated_env`（process env 快照 + 第一遍刚写的值）。
+/// 2. 再处理 backend 等带 companion 校验的字段；若候选 env 列表非空但全都缺失，
+///    跳过该项并 `tracing::warn!`，避免推下去导致引擎启动 `LlmError::AuthFailed`。
+///
+/// 抽成独立函数便于测试：调用方传入虚拟 env 即可断言行为。
+fn resolve_overrides(
+    config: &serde_json::Value,
+    current_env: &std::collections::HashMap<String, String>,
+) -> Vec<(String, String)> {
+    let mut out: Vec<(String, String)> = Vec::new();
+    let mut simulated_env: std::collections::HashMap<String, String> = current_env.clone();
+
+    // Pass 1: 写所有非 companion-gated 字段。
+    let mut deferred: Vec<(&AdminConfigMapping, String)> = Vec::new();
+    for m in ADMIN_CONFIG_MAPPINGS {
+        let Some(val) = extract_admin_value(config, m.json_key) else {
+            continue;
+        };
+        if m.requires_companion_keys.is_some() {
+            deferred.push((m, val));
+        } else {
+            simulated_env.insert(m.env_key.to_string(), val.clone());
+            out.push((m.env_key.to_string(), val));
+        }
+    }
+
+    // Pass 2: companion-gated 字段（如 LLM_BACKEND）。
+    for (m, val) in deferred {
+        if let Some(check) = m.requires_companion_keys {
+            let candidates = check(&val);
+            if !candidates.is_empty() && !candidates.iter().any(|k| simulated_env.contains_key(*k))
+            {
+                tracing::warn!(
+                    env_key = %m.env_key,
+                    value = %val,
+                    candidates = ?candidates,
+                    "Admin override skipped: switching {} to {} requires one of {:?} in env",
+                    m.env_key, val, candidates
+                );
+                continue;
+            }
+        }
+        simulated_env.insert(m.env_key.to_string(), val.clone());
+        out.push((m.env_key.to_string(), val));
+    }
+
+    out
+}
+
+fn extract_admin_value(config: &serde_json::Value, key: &str) -> Option<String> {
+    config.get(key).and_then(|v| match v {
+        serde_json::Value::String(s) if !s.is_empty() => Some(s.clone()),
+        serde_json::Value::Bool(b) => Some(b.to_string()),
+        serde_json::Value::Number(n) => Some(n.to_string()),
+        _ => None,
+    })
+}
+
+#[cfg(test)]
+mod apply_admin_overrides_tests {
+    use super::{resolve_overrides, ADMIN_CONFIG_MAPPINGS};
+    use serde_json::json;
+    use std::collections::HashMap;
+
+    /// 校验测试和生产代码引用同一份映射表（防漂移）。
+    #[test]
+    fn test_contract_mappings_include_backend_with_companion_check() {
+        let backend = ADMIN_CONFIG_MAPPINGS
+            .iter()
+            .find(|m| m.env_key == "LLM_BACKEND")
+            .expect("LLM_BACKEND mapping must exist");
+        assert!(
+            backend.requires_companion_keys.is_some(),
+            "LLM_BACKEND must be guarded by companion key check"
+        );
+    }
+
+    #[test]
+    fn test_failure_backend_skipped_when_companion_key_missing() {
+        let config = json!({ "llm_backend": "openai" });
+        let env = HashMap::new();
+        let resolved = resolve_overrides(&config, &env);
+        assert!(
+            !resolved.iter().any(|(k, _)| k == "LLM_BACKEND"),
+            "openai backend must be skipped when no OPENAI_API_KEY/LLM_API_KEY in env, got: {:?}",
+            resolved
+        );
+    }
+
+    #[test]
+    fn req_admin_override_backend_applied_when_companion_key_present() {
+        let config = json!({ "llm_backend": "openai" });
+        let mut env = HashMap::new();
+        env.insert("OPENAI_API_KEY".to_string(), "sk-pre-set".to_string());
+        let resolved = resolve_overrides(&config, &env);
+        assert!(
+            resolved
+                .iter()
+                .any(|(k, v)| k == "LLM_BACKEND" && v == "openai"),
+            "backend should be applied when OPENAI_API_KEY pre-exists, got: {:?}",
+            resolved
+        );
+    }
+
+    #[test]
+    fn req_admin_override_backend_applied_when_admin_pushes_key_too() {
+        let config = json!({
+            "llm_backend": "openai",
+            "llm_api_key": "sk-from-admin",
+        });
+        let env = HashMap::new(); // 空 env
+        let resolved = resolve_overrides(&config, &env);
+        // Pass 1 写 LLM_API_KEY，Pass 2 校验 openai 的候选含 LLM_API_KEY → 通过。
+        assert!(
+            resolved
+                .iter()
+                .any(|(k, v)| k == "LLM_API_KEY" && v == "sk-from-admin"),
+            "LLM_API_KEY should be written in pass 1, got: {:?}",
+            resolved
+        );
+        assert!(
+            resolved
+                .iter()
+                .any(|(k, v)| k == "LLM_BACKEND" && v == "openai"),
+            "LLM_BACKEND should pass companion check via just-written LLM_API_KEY, got: {:?}",
+            resolved
+        );
+    }
+
+    #[test]
+    fn req_admin_override_openai_compatible_requires_llm_api_key() {
+        // 无 LLM_API_KEY 时 openai_compatible 必须跳过。
+        let config = json!({ "llm_backend": "openai_compatible" });
+        let env = HashMap::new();
+        let resolved = resolve_overrides(&config, &env);
+        assert!(
+            !resolved.iter().any(|(k, _)| k == "LLM_BACKEND"),
+            "openai_compatible must be skipped without LLM_API_KEY, got: {:?}",
+            resolved
+        );
+
+        // 同一次 admin 推送 backend + key → 通过。
+        let config_ok = json!({
+            "llm_backend": "openai_compatible",
+            "llm_api_key": "sk-compat",
+        });
+        let resolved_ok = resolve_overrides(&config_ok, &env);
+        assert!(
+            resolved_ok
+                .iter()
+                .any(|(k, v)| k == "LLM_BACKEND" && v == "openai_compatible"),
+            "openai_compatible must pass with admin-pushed llm_api_key, got: {:?}",
+            resolved_ok
+        );
+    }
+
+    #[test]
+    fn req_admin_override_nearai_backend_no_key_required() {
+        let config = json!({ "llm_backend": "nearai" });
+        let env = HashMap::new(); // 空 env
+        let resolved = resolve_overrides(&config, &env);
+        assert!(
+            resolved
+                .iter()
+                .any(|(k, v)| k == "LLM_BACKEND" && v == "nearai"),
+            "nearai backend uses session token, must apply without any API key env, got: {:?}",
+            resolved
+        );
+    }
+
+    #[test]
+    fn test_security_audit_companion_check_does_not_leak_key_value() {
+        // 此测试确保 resolve_overrides 不返回 env 里的原始 key，
+        // 它只读 env 判断 contains_key，不传递 value。
+        let config = json!({ "llm_backend": "openai" });
+        let mut env = HashMap::new();
+        env.insert(
+            "OPENAI_API_KEY".to_string(),
+            "sk-secret-must-not-leak".into(),
+        );
+        let resolved = resolve_overrides(&config, &env);
+        for (_, v) in &resolved {
+            assert!(
+                !v.contains("sk-secret-must-not-leak"),
+                "resolve_overrides leaked env value: {:?}",
+                resolved
+            );
+        }
     }
 }

--- a/desktop-client/src/model_switch.rs
+++ b/desktop-client/src/model_switch.rs
@@ -1,32 +1,30 @@
 //! 运行时模型/Provider 切换。
 //!
-//! `ModelSwitchProvider` 包装原始 provider，支持两种切换模式：
+//! `ModelSwitchProvider` 是 desktop 端业务壳，真正的"原子替换 inner"
+//! 由 [`SwappableLlmProvider`] 负责（在 `dasclaw_llm_provider` crate）。
+//! 本壳只保留 desktop 专属的 `override_source`（来自 `AppState.model_override`），
+//! 用于在 `request.model` 缺失时注入 per-request 模型名。
+//!
+//! 两种切换模式：
 //!
 //! 1. **同 provider 内切换**（如 qwen-max → qwen-turbo）：
-//!    通过 `set_model()` 或 per-request `model_override` 注入。
+//!    `set_model()` 透传到底层；或通过 `model_override` 注入 per-request。
 //!
 //! 2. **跨 provider 切换**（如 DashScope → Z.AI）：
-//!    通过 `replace_inner()` 替换底层 provider 实例。
-//!    调用方负责用正确的 base_url + api_key 构建新 provider。
-//!
-//! 所有其他 trait 方法完整委托给当前活跃的 inner provider。
+//!    `replace_inner()` 调用 [`SwappableLlmProvider::swap`] 原子替换。
 
-use std::sync::{Arc, Mutex, RwLock};
+use std::sync::{Arc, RwLock};
 
 use async_trait::async_trait;
 use ironclaw::llm::{
-    CompletionRequest, CompletionResponse, LlmProvider, ToolCompletionRequest,
-    ToolCompletionResponse,
+    CompletionRequest, CompletionResponse, LlmProvider, SwappableLlmProvider,
+    ToolCompletionRequest, ToolCompletionResponse,
 };
 use rust_decimal::Decimal;
 
-/// 运行时模型切换 wrapper。
-///
-/// `inner` 通过 `Mutex` 保护，支持跨 provider 热替换。
-/// 锁持有时间极短（仅 Arc::clone），不会阻塞 async 运行时。
-/// `override_source` 用于同 provider 内的 per-request 模型注入。
+/// Desktop 端模型切换 wrapper：薄壳委托 + override 注入。
 pub struct ModelSwitchProvider {
-    inner: Mutex<Arc<dyn LlmProvider>>,
+    inner: Arc<SwappableLlmProvider>,
     /// 共享引用，指向 `AppState.model_override`。
     override_source: Arc<RwLock<Option<String>>>,
 }
@@ -34,7 +32,7 @@ pub struct ModelSwitchProvider {
 impl ModelSwitchProvider {
     pub fn new(inner: Arc<dyn LlmProvider>, override_source: Arc<RwLock<Option<String>>>) -> Self {
         Self {
-            inner: Mutex::new(inner),
+            inner: Arc::new(SwappableLlmProvider::new(inner)),
             override_source,
         }
     }
@@ -44,16 +42,16 @@ impl ModelSwitchProvider {
     /// 同时清除 model_override，因为新 provider 的模型名
     /// 已经在构建时确定，不需要 per-request 覆盖。
     pub fn replace_inner(&self, new_provider: Arc<dyn LlmProvider>) {
-        *self.inner.lock().expect("inner provider lock poisoned") = new_provider;
+        self.inner.swap(new_provider);
         if let Ok(mut guard) = self.override_source.write() {
             *guard = None;
         }
     }
 
-    /// 获取当前 inner provider 的 Arc clone。
-    /// 锁持有时间仅为 Arc::clone 的开销（纳秒级）。
-    fn current_inner(&self) -> Arc<dyn LlmProvider> {
-        Arc::clone(&*self.inner.lock().expect("inner provider lock poisoned"))
+    /// 暴露底层 [`SwappableLlmProvider`] handle，供未来通过
+    /// [`ironclaw::llm::LlmReloadHandle`] 接入热重载链路。
+    pub fn handle(&self) -> Arc<SwappableLlmProvider> {
+        Arc::clone(&self.inner)
     }
 
     fn read_override(&self) -> Option<String> {
@@ -64,44 +62,40 @@ impl ModelSwitchProvider {
 #[async_trait]
 impl LlmProvider for ModelSwitchProvider {
     fn model_name(&self) -> &str {
-        // model_name() 返回 &str，需要 'static 生命周期。
-        // 无法从 Mutex 内部借出引用，返回固定值。
-        // 实际模型名通过 active_model_name() 获取。
-        "dynamic"
+        self.inner.model_name()
     }
 
     fn cost_per_token(&self) -> (Decimal, Decimal) {
-        self.current_inner().cost_per_token()
+        self.inner.cost_per_token()
     }
 
     fn active_model_name(&self) -> String {
         self.read_override()
-            .unwrap_or_else(|| self.current_inner().active_model_name())
+            .unwrap_or_else(|| self.inner.active_model_name())
     }
 
     fn set_model(&self, model: &str) -> Result<(), ironclaw::error::LlmError> {
-        self.current_inner().set_model(model)
+        self.inner.set_model(model)
     }
 
     async fn list_models(&self) -> Result<Vec<String>, ironclaw::error::LlmError> {
-        self.current_inner().list_models().await
+        self.inner.list_models().await
     }
 
     fn effective_model_name(&self, requested_model: Option<&str>) -> String {
-        self.current_inner().effective_model_name(requested_model)
+        self.inner.effective_model_name(requested_model)
     }
 
     fn cache_read_discount(&self) -> Decimal {
-        self.current_inner().cache_read_discount()
+        self.inner.cache_read_discount()
     }
 
     fn cache_write_multiplier(&self) -> Decimal {
-        self.current_inner().cache_write_multiplier()
+        self.inner.cache_write_multiplier()
     }
 
     fn calculate_cost(&self, input_tokens: u32, output_tokens: u32) -> Decimal {
-        self.current_inner()
-            .calculate_cost(input_tokens, output_tokens)
+        self.inner.calculate_cost(input_tokens, output_tokens)
     }
 
     async fn complete(
@@ -111,8 +105,7 @@ impl LlmProvider for ModelSwitchProvider {
         if request.model.is_none() {
             request.model = self.read_override();
         }
-        let provider = self.current_inner();
-        provider.complete(request).await
+        self.inner.complete(request).await
     }
 
     async fn complete_with_tools(
@@ -122,7 +115,6 @@ impl LlmProvider for ModelSwitchProvider {
         if request.model.is_none() {
             request.model = self.read_override();
         }
-        let provider = self.current_inner();
-        provider.complete_with_tools(request).await
+        self.inner.complete_with_tools(request).await
     }
 }


### PR DESCRIPTION
## Stacked on #1045 (`feat/dasclaw-llm-port-runtime`)

> **base 不是 `xClaw`**：本 PR base 为 `feat/dasclaw-llm-port-runtime`。请先 review/merge #1045，再看本 PR。
> Stacked merge 纪律（AGENTS.md）：合并 #1045 时**保留下层分支**（路径 A）；或在 squash 前把本 PR base 切到 `xClaw`（路径 B）。

## 背景 / 目标

PR #1045 把 `SwappableLlmProvider` 从 `ironclaw::runtime` 抽到独立的 `dasclaw_llm_provider` crate。desktop-client 侧仍存在两个遗留问题：

1. **`desktop-client/src/model_switch.rs`** 自己用 `Mutex<Arc<dyn LlmProvider>>` 重复实现了同一套"原子替换 inner provider"逻辑，与 `SwappableLlmProvider` 重复造轮子。
2. **`desktop-client/src/main.rs::apply_admin_overrides`** 盲目地 `env::set_var("LLM_BACKEND", admin_value)`：当 admin 推 `LLM_BACKEND=openai` 但本地 `.env` 没有 `OPENAI_API_KEY` 时，引擎启动直接 `LlmError::AuthFailed` → 前端报 `ENGINE_START_FAILED`。

## 改动范围

### `desktop-client/src/model_switch.rs`（重写约 117 行）

- `ModelSwitchProvider` 退化为薄壳：`inner: Arc<SwappableLlmProvider>` + desktop 专属 `override_source: Arc<RwLock<Option<String>>>`。
- 删除自实现的 `Mutex<Arc<dyn LlmProvider>>` 替换逻辑，统一委托 `SwappableLlmProvider::swap`。
- 新增 `handle() -> Arc<SwappableLlmProvider>`：暴露底层 handle，方便后续接入热重载（与 ADR `LlmReloadHandle` 路线对齐）。
- 公共 API 保持兼容：`new(initial, override_source) -> Self`、`replace_inner(&self, new)` 签名不变。
- `model_name()` 改为返回 inner 真实 interned 名（替代之前硬编码 `"dynamic"`）——仅影响 `ipc/models.rs:365` UI 展示，是严格改进。

### `desktop-client/src/main.rs::apply_admin_overrides`（~150 行重构）

- 引入 `AdminConfigMapping` 结构 + `ADMIN_CONFIG_MAPPINGS: &[...]` 表替代硬编码 if-else。
- `backend_companion_keys(backend)` 给出每个 backend 可接受的 companion key 候选（`OPENAI_API_KEY`/`LLM_API_KEY` 二选一即可满足 openai；`nearai` 走 session token 返回空切片）。
- 抽出**纯函数 `resolve_overrides(config, env) -> Vec<(env_key,value)>`** 便于单元测试：
  - **Pass 1**：写所有非 companion-gated 字段（`llm_api_key`/`llm_model`/`llm_base_url`/`skill_registry_url`/`managed_mode`）到 `simulated_env` + `out`。
  - **Pass 2**：处理 `llm_backend` 这类带 companion 校验的字段；候选列表非空且全都缺失 → `tracing::warn!` + 跳过，**避免推下去触发 AuthFailed**。
  - 两遍设计保证 admin 同一次推 `backend + llm_api_key` 时，pass-2 能看见 pass-1 写入的 key。
- 敏感日志路径不变：`LLM_API_KEY`/`ADMIN_API_KEY` 仍打 `***`。

### 测试（`#[cfg(test)] mod apply_admin_overrides_tests`）

7 个新测试覆盖四类维度：

| 维度 | 测试 |
|------|------|
| Contract | `test_contract_mappings_include_backend_with_companion_check` |
| Failure | `test_failure_backend_skipped_when_companion_key_missing` |
| 需求 | `req_admin_override_backend_applied_when_companion_key_present` |
| 需求（核心两遍设计） | `req_admin_override_backend_applied_when_admin_pushes_key_too` |
| 需求 | `req_admin_override_openai_compatible_requires_llm_api_key` |
| 需求 | `req_admin_override_nearai_backend_no_key_required` |
| Security Audit | `test_security_audit_companion_check_does_not_leak_key_value` |

## 非目标（What's NOT in this PR）

- ❌ 不改 `crates/dasclaw_llm_provider/` 任何文件（属于 #1045 范围）。
- ❌ 不改 `desktop-client/ironclaw/` 任何文件。
- ❌ 不接入 `LlmReloadHandle` 热重载链路（`handle()` 只是预留入口，调用方仍走 `replace_inner`）。
- ❌ 不修复 `desktop-client/src/dlp/security_tests.rs` / `desktop-client/src/safety_bridge.rs` 中**预先存在**的 clippy 错误（module_inception / unnecessary_unwrap / manual_range_contains，共 ~24 条，本 PR 未触及这些文件）。
- ❌ 不修改 admin 端推送配置的格式（仍读 `~/Library/Application Support/ironclaw-desktop/admin_config.json`）。

## 验证

```bash
# 1. 类型检查（0 错 0 警）
cargo check -p desktop-client --tests
# ✅ Finished `dev` profile

# 2. 新增 7 个 admin-override 测试
cargo nextest run -p desktop-client -E 'test(apply_admin_overrides)' --no-fail-fast
# ✅ Summary [13.118s] 7 tests run: 7 passed, 823 skipped, EXIT=0

# 3. 既有 14 个 model_switch 测试无回归
cargo nextest run -p desktop-client -E 'test(model_switch_tests)' --no-fail-fast
# ✅ Summary [27.034s] 14 tests run: 14 passed, 816 skipped

# 4. fmt + no-panics
cargo fmt --all
python3.12 scripts/check_no_panics.py --base origin/xClaw
# ✅ OK: No panic-inducing calls in changed production code.

# 5. clippy（我改动的文件 0 警告 0 错误；预先存在的 dlp/safety_bridge 噪声由 CI 决定）
cargo clippy --no-deps -p desktop-client --all-targets 2>&1 | grep -cE "(model_switch|src/main\.rs):"
# ✅ 0
```

## Sources read

- `AGENTS.md`（PR 流程 / stacked PR 路径 A/B / 本地节奏 / Skills 强制使用规范）
- `.github/copilot-instructions.md`
- `desktop-client/src/model_switch.rs`（重写前）
- `desktop-client/src/model_switch_tests.rs`（14 个既有测试）
- `desktop-client/src/main.rs`（apply_admin_overrides 旧实现）
- `desktop-client/src/engine.rs:195` 调用点（确认 `ModelSwitchProvider::new` 签名约束）
- `desktop-client/src/ipc/chat.rs:662,704` 调用点（确认 `replace_inner` 签名约束）
- `desktop-client/src/ipc/models.rs:365` 调用点（确认 `model_name()` 返回值影响范围）
- `crates/dasclaw_llm_provider/src/provider.rs`（确认 `SwappableLlmProvider::new` / `swap` / `current` 可见性）
- `desktop-client/ironclaw/src/llm/mod.rs:18`（确认 `pub use dasclaw_llm_provider::provider::*` 再导出）
- `desktop-client/ironclaw/src/setup/wizard.rs`（核对每个 backend 真实要求的 env key）

## Cross-cuts

- **ADR-114（`.ironclaw` → `.dasclaw` 命名）**：`类A` —— diff 不含任何 `.ironclaw` 或 `IRONCLAW_BASE_DIR` 新增字面量。
- **ADR-118（dasclaw crate 拆分）**：本 PR 是 `dasclaw_llm_provider` 落地后的 desktop-client 适配，符合"消费者改 use 路径 + 删除重复实现"的预期。
- **ADR-129（verbatim port 纯度）**：N/A —— 本 PR 不属于 verbatim port，是 desktop 业务层适配。

## 后续 / 下一步

- 接入 `LlmReloadHandle` 热重载（依赖 `handle()` 入口已就位）。
- admin_config.json schema 演进到带 secret reference（如 vault path），把 companion-key 校验前移到 admin 推送侧。

Closes #1047
