### PR TITLE
test(desktop-client): complete #1023 layered ipc scenarios I-1~I-5

### DIFF
--- a/desktop-client/src/ipc/chat.rs
+++ b/desktop-client/src/ipc/chat.rs
@@ -406,15 +406,25 @@ async fn send_thread_control_message(
     thread_id: &str,
     content: &str,
 ) -> Result<(), String> {
-    let msg = IncomingMessage::new("tauri", &state.scope_id, content)
-        .with_thread(thread_id)
-        .with_owner_id(&state.scope_id);
-
     state
         .msg_sender
-        .send(msg)
+        .send(build_thread_control_message(
+            &state.scope_id,
+            thread_id,
+            content,
+        ))
         .await
         .map_err(|e| format!("Failed to send thread control message: {}", e))
+}
+
+pub(crate) fn build_thread_control_message(
+    scope_id: &str,
+    thread_id: &str,
+    content: &str,
+) -> IncomingMessage {
+    IncomingMessage::new("tauri", scope_id, content)
+        .with_thread(thread_id)
+        .with_owner_id(scope_id)
 }
 
 fn build_message_metadata(

--- a/desktop-client/src/ipc/chat_tests.rs
+++ b/desktop-client/src/ipc/chat_tests.rs
@@ -7,7 +7,10 @@
 
 #[cfg(test)]
 mod tests {
-    use crate::ipc::chat::{usage_report_backend_user_id, FrontendAttachment, SendMessageResponse};
+    use crate::ipc::chat::{
+        build_thread_control_message, usage_report_backend_user_id, FrontendAttachment,
+        SendMessageResponse,
+    };
     use std::sync::RwLock;
     use uuid::Uuid;
 
@@ -223,5 +226,29 @@ mod tests {
             .expect_err("poisoned backend user id lock should fail");
 
         assert_eq!(error, "后台用户身份读取失败，跳过费用上报");
+    }
+
+    #[test]
+    fn req_chat_i4_interrupt_control_message_targets_existing_thread() {
+        let msg = build_thread_control_message("owner-1", "thread-a", "/interrupt");
+
+        assert_eq!(msg.channel, "tauri");
+        assert_eq!(msg.user_id, "owner-1");
+        assert_eq!(msg.owner_id, "owner-1");
+        assert_eq!(msg.thread_id.as_deref(), Some("thread-a"));
+        assert_eq!(msg.conversation_scope(), Some("thread-a"));
+        assert_eq!(msg.content, "/interrupt");
+    }
+
+    #[test]
+    fn req_chat_i4_finalize_thread_enqueues_conversation_report() {
+        let tracker = crate::conversation_tracker::ConversationTracker::new("owner-1".to_string());
+        let reporter = crate::data_reporter::DataReporter::new(String::new(), String::new());
+
+        tracker.record_user_message("thread-a", "hello", false, &[]);
+        tracker.record_assistant_message("thread-a", "done", Some("model-a"), 3, 2);
+        tracker.finish_thread("thread-a", &reporter);
+
+        assert_eq!(reporter.queue_len(), 1);
     }
 }

--- a/desktop-client/src/ipc/dlp.rs
+++ b/desktop-client/src/ipc/dlp.rs
@@ -262,7 +262,13 @@ pub async fn do_sync_dlp_rules(safety_bridge: &SafetyBridge) -> Result<SyncDlpRe
 
     let admin_url =
         std::env::var("ADMIN_BACKEND_URL").unwrap_or_else(|_| "http://127.0.0.1:3000".to_string());
+    do_sync_dlp_rules_from_admin_url(safety_bridge, &admin_url).await
+}
 
+pub(crate) async fn do_sync_dlp_rules_from_admin_url(
+    safety_bridge: &SafetyBridge,
+    admin_url: &str,
+) -> Result<SyncDlpResult, String> {
     let client = reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(5))
         .build()

--- a/desktop-client/src/ipc/dlp_tests.rs
+++ b/desktop-client/src/ipc/dlp_tests.rs
@@ -10,6 +10,8 @@
 mod tests {
     use crate::ipc::dlp::*;
     use crate::safety_bridge::{BridgeScanResult, BridgeStats};
+    use ironclaw::safety::{SafetyConfig, SafetyLayer};
+    use std::sync::Arc;
 
     // ========================================================================
     // 单元测试：类型转换
@@ -360,8 +362,48 @@ mod tests {
         };
 
         let response = DlpScanResponse::from(bridge_result);
-
         assert_eq!(response.sanitized_content, "🔑 密码 العربية emoji 🎉");
+    }
+
+    #[tokio::test]
+    async fn req_dlp_i3_admin_rule_sync_updates_scan_behavior() {
+        let mut server = mockito::Server::new_async().await;
+        let _mock = server
+            .mock("GET", "/api/dlp-rules")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{
+                    "rules": [
+                        {
+                            "name": "critical-token",
+                            "pattern": "ACME-TOKEN-[0-9]+",
+                            "rule_type": "regex",
+                            "severity": "critical",
+                            "enabled": true
+                        }
+                    ]
+                }"#,
+            )
+            .create_async()
+            .await;
+
+        let safety = Arc::new(SafetyLayer::new(&SafetyConfig {
+            max_output_length: 100_000,
+            injection_check_enabled: true,
+        }));
+        let bridge = crate::safety_bridge::SafetyBridge::new(safety, None, None);
+
+        let sync = do_sync_dlp_rules_from_admin_url(&bridge, &server.url())
+            .await
+            .expect("rules sync");
+        assert!(sync.success);
+        assert_eq!(sync.rules_synced, 1);
+
+        let scan = bridge.scan_user_input("please handle ACME-TOKEN-42");
+        assert!(scan.had_sensitive_data);
+        assert!(scan.was_blocked);
+        assert!(scan.sanitized_content.is_empty());
     }
 
     #[test]

--- a/desktop-client/src/ipc/models_tests.rs
+++ b/desktop-client/src/ipc/models_tests.rs
@@ -6,6 +6,8 @@
 //! - 安全审计测试：API Key 不泄露
 
 use super::models::*;
+use wiremock::matchers::{body_json, header, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
 
 // ============================================================================
 // 单元测试 - 正常路径
@@ -231,4 +233,64 @@ fn test_audit_custom_model_debug_output_contains_key() {
         debug_output.contains("sk-secret-key-12345"),
         "Debug 输出包含 api_key（注意：不要在生产日志中使用 Debug 打印 CustomModel）"
     );
+}
+
+#[tokio::test]
+async fn req_models_i5_invalid_model_connection_returns_recoverable_error() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .and(header("authorization", "Bearer test-key"))
+        .and(body_json(serde_json::json!({
+            "model": "invalid-model",
+            "messages": [{"role": "user", "content": "hi"}],
+            "max_tokens": 5,
+        })))
+        .respond_with(ResponseTemplate::new(404).set_body_json(serde_json::json!({
+            "error": {"message": "model not found"}
+        })))
+        .mount(&server)
+        .await;
+
+    let result = test_model_connection(
+        server.uri(),
+        "test-key".to_string(),
+        "invalid-model".to_string(),
+    )
+    .await
+    .expect("HTTP error status should be returned as recoverable payload");
+
+    assert_eq!(result["success"], false);
+    assert_eq!(result["status"], 404);
+    assert!(result["message"]
+        .as_str()
+        .unwrap_or_default()
+        .contains("连接失败"));
+    assert!(result["error"]
+        .as_str()
+        .unwrap_or_default()
+        .contains("model not found"));
+}
+
+#[tokio::test]
+async fn req_models_i5_valid_model_connection_reports_success() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/chat/completions"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "choices": [{"message": {"content": "ok"}}]
+        })))
+        .mount(&server)
+        .await;
+
+    let result = test_model_connection(
+        server.uri(),
+        "test-key".to_string(),
+        "valid-model".to_string(),
+    )
+    .await
+    .expect("successful probe should return payload");
+
+    assert_eq!(result["success"], true);
+    assert_eq!(result["status"], 200);
 }

--- a/desktop-client/src/ipc/plan_mode.rs
+++ b/desktop-client/src/ipc/plan_mode.rs
@@ -5,6 +5,7 @@
 
 use serde::{Deserialize, Serialize};
 use tauri::State;
+use tokio::sync::mpsc;
 
 use ironclaw::channels::IncomingMessage;
 
@@ -53,16 +54,14 @@ pub async fn ic_toggle_plan_mode(
     thread_id: String,
 ) -> Result<PlanModeResponse, String> {
     let state = state.get()?;
-
-    let msg = IncomingMessage::new("tauri", &state.scope_id, "/plan-mode")
-        .with_thread(&thread_id)
-        .with_owner_id(&state.scope_id);
-
-    state
-        .msg_sender
-        .send(msg)
-        .await
-        .map_err(|e| format!("Failed to toggle plan mode: {}", e))?;
+    dispatch_control_message(
+        &state.msg_sender,
+        &state.scope_id,
+        &thread_id,
+        "/plan-mode",
+        "toggle plan mode",
+    )
+    .await?;
 
     Ok(PlanModeResponse {
         thread_id,
@@ -87,15 +86,14 @@ pub async fn ic_approve_plan(
     let state = state.get()?;
 
     let content = format!("/approve-plan {plan_id}");
-    let msg = IncomingMessage::new("tauri", &state.scope_id, &content)
-        .with_thread(&thread_id)
-        .with_owner_id(&state.scope_id);
-
-    state
-        .msg_sender
-        .send(msg)
-        .await
-        .map_err(|e| format!("Failed to approve plan: {}", e))?;
+    dispatch_control_message(
+        &state.msg_sender,
+        &state.scope_id,
+        &thread_id,
+        &content,
+        "approve plan",
+    )
+    .await?;
 
     Ok(PlanApprovalResponse {
         thread_id,
@@ -121,15 +119,14 @@ pub async fn ic_revise_plan(
     let state = state.get()?;
 
     let content = format!("/revise-plan {plan_id} {feedback}");
-    let msg = IncomingMessage::new("tauri", &state.scope_id, &content)
-        .with_thread(&thread_id)
-        .with_owner_id(&state.scope_id);
-
-    state
-        .msg_sender
-        .send(msg)
-        .await
-        .map_err(|e| format!("Failed to revise plan: {}", e))?;
+    dispatch_control_message(
+        &state.msg_sender,
+        &state.scope_id,
+        &thread_id,
+        &content,
+        "revise plan",
+    )
+    .await?;
 
     Ok(PlanApprovalResponse {
         thread_id,
@@ -156,15 +153,14 @@ pub async fn ic_fork_thread(
     let state = state.get()?;
 
     let content = format!("/fork {at_turn}");
-    let msg = IncomingMessage::new("tauri", &state.scope_id, &content)
-        .with_thread(&thread_id)
-        .with_owner_id(&state.scope_id);
-
-    state
-        .msg_sender
-        .send(msg)
-        .await
-        .map_err(|e| format!("Failed to fork thread: {}", e))?;
+    dispatch_control_message(
+        &state.msg_sender,
+        &state.scope_id,
+        &thread_id,
+        &content,
+        "fork thread",
+    )
+    .await?;
 
     // 实际的 new_thread_id 由 Agent 异步通过 chat-stream 返回
     Ok(ForkResponse {
@@ -172,4 +168,77 @@ pub async fn ic_fork_thread(
         new_thread_id: String::new(),
         at_turn,
     })
+}
+
+fn build_control_message(scope_id: &str, thread_id: &str, content: &str) -> IncomingMessage {
+    IncomingMessage::new("tauri", scope_id, content)
+        .with_thread(thread_id)
+        .with_owner_id(scope_id)
+}
+
+async fn dispatch_control_message(
+    sender: &mpsc::Sender<IncomingMessage>,
+    scope_id: &str,
+    thread_id: &str,
+    content: &str,
+    operation: &str,
+) -> Result<(), String> {
+    sender
+        .send(build_control_message(scope_id, thread_id, content))
+        .await
+        .map_err(|e| format!("Failed to {operation}: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assert_control_message(msg: IncomingMessage, content: &str) {
+        assert_eq!(msg.channel, "tauri");
+        assert_eq!(msg.user_id, "owner-1");
+        assert_eq!(msg.owner_id, "owner-1");
+        assert_eq!(msg.thread_id.as_deref(), Some("thread-a"));
+        assert_eq!(msg.conversation_scope(), Some("thread-a"));
+        assert_eq!(msg.content, content);
+    }
+
+    #[tokio::test]
+    async fn req_plan_mode_i1_control_sequence_preserves_thread_scope() {
+        let (tx, mut rx) = mpsc::channel(4);
+        for content in [
+            "/plan-mode".to_string(),
+            "/approve-plan plan-1".to_string(),
+            "/revise-plan plan-1 add more tests".to_string(),
+            "/fork 2".to_string(),
+        ] {
+            dispatch_control_message(&tx, "owner-1", "thread-a", &content, "test")
+                .await
+                .expect("control message should dispatch");
+            let msg = rx.recv().await.expect("message should be queued");
+            assert_control_message(msg, &content);
+        }
+    }
+
+    #[test]
+    fn req_plan_mode_i1_response_contracts_are_stable() {
+        let approval = PlanApprovalResponse {
+            thread_id: "thread-a".to_string(),
+            plan_id: "plan-1".to_string(),
+            status: "approved".to_string(),
+        };
+        let fork = ForkResponse {
+            source_thread_id: "thread-a".to_string(),
+            new_thread_id: String::new(),
+            at_turn: 2,
+        };
+
+        let approval_json = serde_json::to_value(approval).expect("approval serializes");
+        assert_eq!(approval_json["status"], "approved");
+        assert_eq!(approval_json["thread_id"], "thread-a");
+
+        let fork_json = serde_json::to_value(fork).expect("fork serializes");
+        assert_eq!(fork_json["source_thread_id"], "thread-a");
+        assert_eq!(fork_json["new_thread_id"], "");
+        assert_eq!(fork_json["at_turn"], 2);
+    }
 }

--- a/desktop-client/src/ipc/sandbox.rs
+++ b/desktop-client/src/ipc/sandbox.rs
@@ -248,4 +248,33 @@ mod tests {
         assert!(r.dasclaw_home.is_none());
         assert!(r.action_hint.is_none());
     }
+
+    #[tokio::test]
+    async fn req_sandbox_i2_smoke_and_status_share_backend_contract() {
+        let status = ic_sandbox_status().await.expect("status");
+        let smoke = ic_sandbox_smoke_test().await.expect("smoke");
+
+        assert!([
+            "none",
+            "macos_seatbelt",
+            "linux_seccomp",
+            "windows_restricted_token",
+            "unknown",
+        ]
+        .contains(&status.backend.as_str()));
+        assert!([
+            "none",
+            "macos_seatbelt",
+            "linux_seccomp",
+            "windows_restricted_token"
+        ]
+        .contains(&smoke.backend.as_str()));
+
+        if smoke.success {
+            assert_eq!(smoke.stdout, "dasclaw");
+            assert!(smoke.note.is_none());
+        } else {
+            assert!(smoke.note.is_some());
+        }
+    }
 }


### PR DESCRIPTION
## 背景/目标
- 关联 issue：#1023（desktop-client 分层测试场景 I-1..I-5）
- 目标：在不改动无头 `dasclaw_runtime` 边界的前提下，补齐 desktop IPC 层集成测试覆盖，并消除 DLP 测试对全局环境变量的依赖。

Closes #1023

## 改动范围
- plan/fork 控制消息路径：提炼消息构造与发送 helper，并补 I-1 契约/顺序测试。
- sandbox 状态与冒烟路径：补 I-2 后端契约一致性测试。
- DLP admin 规则同步：提炼 `do_sync_dlp_rules_from_admin_url(...)` seam，补 I-3 同步后行为生效测试。
- chat thread 控制：提炼 thread control helper，补 I-4 interrupt/finalize 两条链路测试。
- model connection：补 I-5 recoverable error + success 两条测试（wiremock）。

## 非目标（What's NOT in this PR）
- 不扩展/改造无头 agent runtime（`dasclaw_runtime`）。
- 不引入新的 WebDriver E2E 套件（本 PR 聚焦 IPC 层 Rust 测试）。
- 不处理与本 issue 无关的历史 clippy 债务。

## 验证（命令 + 结果）
- `cargo fmt --all --check`：通过。
- `cargo check -p desktop-client --tests`：通过。
- `cargo nextest run -p desktop-client -E 'test(req_plan_mode_i1) | test(req_sandbox_i2) | test(req_dlp_i3) | test(req_chat_i4) | test(req_models_i5)' --no-fail-fast`：8/8 通过。
- `cargo nextest run -p desktop-client`：840/840 通过，6 skipped，1 leaky 标记（exit code 0）。
- `python3.12 scripts/check_no_panics.py --base origin/xClaw`：通过（修改的生产代码无新增 panic/unwrap/expect）。

## Sources read
- `desktop-client/docs/e2e-webdriver-test-plan.md`：§12（分层场景 I-1..I-5 测试设计）
- `docs/plans/architecture-refactor/adr-112-compatibility-evaluation.md`：§1（背景与目标）、§3（39 Contract Test 矩阵）
- `docs/plans/architecture-refactor/adr-113-hook-engine-unification.md`：§1（Context）、§2（Decision）
