### PR TITLE
test(desktop-client): expand IPC command coverage for #1025

### DIFF
--- a/desktop-client/docs/e2e-webdriver-test-plan.md
+++ b/desktop-client/docs/e2e-webdriver-test-plan.md
@@ -610,13 +610,14 @@ L5 LLM·通道·持久化 / L6 基础设施。E2E（WebDriver）是**自顶向�
 | 扩展 | `ic_list_extensions`/`install`/`setup`/`setup_submit`/… | ⬜ 待补 |
 | 任务 | `ic_list_jobs`/`ic_job_events`/`ic_job_prompt`/`ic_cancel_job`/`ic_restart_job` | ⬜ 待补 |
 | 日程 | `ic_list_routines`/`create`/`toggle`/`delete`/`fire`/`ic_routine_runs` | ⬜ 待补 |
-| 日志 | `ic_get_logs`/`search`/`filter`/`export`/`clear` | ⬜ 待补 |
-| 工作区 | `ic_workspace_git_status`/`ic_workspace_root`/`ic_import_workspace`/`ic_active_servers` | ⬜ 待补 |
-| 文件操作 | `ic_undo_file_edit`/`ic_open_file_at_line` | ⬜ 待补 |
-| 应用/认证 | `get_auth_token`/`get_app_version`/`check_for_updates`/`submit_approval_ticket`/`get_watermark_config` | ⬜ 待补 |
+| 日志 | `ic_get_logs`/`search`/`filter`/`export`/`clear` | ✅ Rust 命令级 helper 覆盖（#1025） |
+| 工作区 | `ic_workspace_git_status`/`ic_workspace_root`/`ic_import_workspace`/`ic_active_servers` | 🟨 Rust 命令级契约覆盖（#1025，仍缺导入真实状态夹具） |
+| 文件操作 | `ic_undo_file_edit`/`ic_open_file_at_line` | ✅ Rust 命令级 helper 覆盖（#1025） |
+| 应用/认证 | `get_auth_token`/`get_app_version`/`check_for_updates`/`submit_approval_ticket`/`get_watermark_config` | 🟨 Rust 命令级 helper 覆盖（#1025，认证 token 仍靠注册/类型契约） |
 
 > **粗略覆盖度**：~80 命令中本计划直接/间接命中约 40%（聊天·线程·审批·DLP·模型·
-> Plan/Fork·Sandbox）。记忆/技能/扩展/任务/日程/日志/工作区/文件/认证 9 个段尚未覆盖。
+> Plan/Fork·Sandbox）。#1025 已补日志/文件操作的 Rust 命令级 helper 覆盖，并补工作区/
+> 应用认证的部分命令级契约覆盖；记忆/技能/扩展/任务/日程仍是主要未覆盖段。
 > 若要补到 ~80%，按 §12 分层原则：CRUD 类（记忆/技能/扩展/日程/日志）用**命令级
 > 集成测试**批量覆盖，UI 强交互类（任务流式、文件 Undo）保留少量 E2E。
 
@@ -959,9 +960,9 @@ loop 的入口唯一**：
 
 ### 16.2 GA 缺口分类
 
-#### A. 功能维度（IPC 命令族覆盖 ~40%，待补 9 族）
+#### A. 功能维度（IPC 命令族覆盖 ~40%，剩余待补 5 族 + 2 族需真实状态夹具）
 
-**已覆盖**（§13 表 ✅ 段）：聊天（6）/ 线程（3）/ 工具审批（2）/ DLP（7）/ 模型（3）/ Plan/Fork（4）/ Sandbox（2）。**小计** ~31 命令 / ~80 总数 ≈ 40%。
+**已覆盖**（§13 表 ✅ 段）：聊天（6）/ 线程（3）/ 工具审批（2）/ DLP（7）/ 模型（3）/ Plan/Fork（4）/ Sandbox（2）/ 日志（5）/ 文件操作（2）。**小计** ~38 命令 / ~80 总数 ≈ 48%。
 
 **完全未覆盖**（§13 表 ⬜ 段）：
 
@@ -970,12 +971,13 @@ loop 的入口唯一**：
 - **扩展**（6+）：`ic_list_extensions` / `install` / `setup` / `setup_submit` / ...
 - **任务**（5）：`ic_list_jobs` / `ic_job_events` / `ic_job_prompt` / `ic_cancel_job` / `ic_restart_job`
 - **日程**（6）：`ic_list_routines` / `create` / `toggle` / `delete` / `fire` / `ic_routine_runs`
-- **日志**（5）：`ic_get_logs` / `search` / `filter` / `export` / `clear`
-- **工作区**（4）：`ic_workspace_git_status` / `ic_workspace_root` / `ic_import_workspace` / `ic_active_servers`
-- **文件操作**（2）：`ic_undo_file_edit` / `ic_open_file_at_line`
-- **应用/认证**（5）：`get_auth_token` / `get_app_version` / `check_for_updates` / `submit_approval_ticket` / `get_watermark_config`
 
-**小计** ~44 命令待补。升级路线：按 §12 分层原则，CRUD 类用**命令级集成测试**批量补（I-1~I-5 已示范），UI 强交互类（任务·日程）保留少量 E2E。
+**部分覆盖，仍需真实状态夹具 / Admin Backend stub**：
+
+- **工作区**（4）：已覆盖 `ic_workspace_git_status` 输出解释、活跃服务器 DTO；仍需 `ic_import_workspace` / `ic_get_thread_workspace` 的真实 `AppState` + DB metadata 夹具。
+- **应用/认证**（5）：已覆盖版本号、更新检查 URL/响应映射、水印默认值、审批工单 payload；`get_auth_token` 和 HTTP 成功/失败路径仍需命令级集成测试。
+
+**小计** ~30 命令待补。升级路线：按 §12 分层原则，CRUD 类用**命令级集成测试**批量补（I-1~I-5 已示范），UI 强交互类（任务·日程）保留少量 E2E。
 
 #### B. UX bug 阻断（2 个高优先级）
 

--- a/desktop-client/src/commands.rs
+++ b/desktop-client/src/commands.rs
@@ -31,6 +31,53 @@ fn admin_env() -> (String, String) {
     (url, token)
 }
 
+fn client_config_url(admin_url: &str, client_token: &str) -> Result<String> {
+    let mut url = reqwest::Url::parse(admin_url)
+        .map_err(|e| Error::ConfigError(format!("Invalid ADMIN_BACKEND_URL: {e}")))?;
+    url.path_segments_mut()
+        .map_err(|_| Error::ConfigError("Invalid ADMIN_BACKEND_URL".to_string()))?
+        .extend(["api", "client-config"]);
+    if !client_token.is_empty() {
+        url.query_pairs_mut().append_pair("client_id", client_token);
+    }
+    Ok(url.to_string())
+}
+
+fn update_status_response(config: &serde_json::Value) -> serde_json::Value {
+    let needs_upgrade = config
+        .get("needs_upgrade")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+
+    serde_json::json!({
+        "needs_upgrade": needs_upgrade,
+        "current_version": env!("CARGO_PKG_VERSION"),
+    })
+}
+
+fn watermark_config_response(settings: &serde_json::Value) -> serde_json::Value {
+    serde_json::json!({
+        "watermark_enabled": settings.get("watermark_enabled").and_then(|v| v.as_bool()).unwrap_or(false),
+        "watermark_template": settings.get("watermark_template").and_then(|v| v.as_str()).unwrap_or("{username} | {datetime}"),
+        "watermark_font_size": settings.get("watermark_font_size").and_then(|v| v.as_i64()).unwrap_or(16),
+        "watermark_opacity": settings.get("watermark_opacity").and_then(|v| v.as_f64()).unwrap_or(0.1),
+        "watermark_position": settings.get("watermark_position").and_then(|v| v.as_str()).unwrap_or("diagonal"),
+        "watermark_color": settings.get("watermark_color").and_then(|v| v.as_str()).unwrap_or("#000000"),
+    })
+}
+
+fn approval_operation_name(tool_name: &str) -> String {
+    let trimmed = tool_name.trim();
+    if trimmed.is_empty() {
+        return "工具审批".to_string();
+    }
+    format!("工具审批: {trimmed}")
+}
+
+fn approval_reason(request_id: &str, thread_id: &str, content: &str) -> String {
+    format!("request_id={request_id}\nthread_id={thread_id}\n{content}")
+}
+
 fn resolve_applicant_id_value(backend_user_id: &std::sync::RwLock<Option<Uuid>>) -> Result<Uuid> {
     crate::state::require_backend_user_id_value(backend_user_id, "审批申请人身份")
         .map_err(Error::ConfigError)
@@ -87,11 +134,7 @@ pub async fn check_for_updates() -> Result<serde_json::Value> {
     let http = build_http_client(5)?;
 
     // client_id 参数让后端返回该客户端的 needs_upgrade 状态
-    let url = if client_token.is_empty() {
-        format!("{}/api/client-config", admin_url)
-    } else {
-        format!("{}/api/client-config?client_id={}", admin_url, client_token)
-    };
+    let url = client_config_url(&admin_url, &client_token)?;
 
     let config: serde_json::Value = http
         .get(&url)
@@ -103,15 +146,7 @@ pub async fn check_for_updates() -> Result<serde_json::Value> {
         .await
         .map_err(|e| Error::ConfigError(format!("Failed to parse config: {}", e)))?;
 
-    let needs_upgrade = config
-        .get("needs_upgrade")
-        .and_then(|v| v.as_bool())
-        .unwrap_or(false);
-
-    Ok(serde_json::json!({
-        "needs_upgrade": needs_upgrade,
-        "current_version": env!("CARGO_PKG_VERSION"),
-    }))
+    Ok(update_status_response(&config))
 }
 
 /// 获取水印配置（从 Admin Backend API 读取）。
@@ -133,14 +168,7 @@ pub async fn get_watermark_config() -> Result<serde_json::Value> {
         .await
         .map_err(|e| Error::ConfigError(format!("Failed to parse settings: {}", e)))?;
 
-    Ok(serde_json::json!({
-        "watermark_enabled": settings.get("watermark_enabled").and_then(|v| v.as_bool()).unwrap_or(false),
-        "watermark_template": settings.get("watermark_template").and_then(|v| v.as_str()).unwrap_or("{username} | {datetime}"),
-        "watermark_font_size": settings.get("watermark_font_size").and_then(|v| v.as_i64()).unwrap_or(16),
-        "watermark_opacity": settings.get("watermark_opacity").and_then(|v| v.as_f64()).unwrap_or(0.1),
-        "watermark_position": settings.get("watermark_position").and_then(|v| v.as_str()).unwrap_or("diagonal"),
-        "watermark_color": settings.get("watermark_color").and_then(|v| v.as_str()).unwrap_or("#000000"),
-    }))
+    Ok(watermark_config_response(&settings))
 }
 
 /// 提交审批工单并启动后台轮询任务（需求 23.10）。
@@ -184,12 +212,8 @@ pub async fn submit_approval_ticket(
 
     let applicant_id = resolve_applicant_id(state)?;
     let http = build_http_client(10)?;
-    let operation_name = if tool_name.trim().is_empty() {
-        "工具审批".to_string()
-    } else {
-        format!("工具审批: {}", tool_name.trim())
-    };
-    let reason = format!("request_id={request_id}\nthread_id={thread_id}\n{content}");
+    let operation_name = approval_operation_name(&tool_name);
+    let reason = approval_reason(&request_id, &thread_id, &content);
 
     let payload = ApprovalTicketPayload {
         applicant_id,
@@ -255,7 +279,97 @@ pub async fn submit_approval_ticket(
 }
 
 #[cfg(test)]
-mod tests {
+mod app_command_tests {
+    use super::{
+        approval_operation_name, approval_reason, client_config_url, get_app_version,
+        update_status_response, watermark_config_response,
+    };
+
+    #[test]
+    fn req_app_get_version_matches_package_version() {
+        assert_eq!(get_app_version(), env!("CARGO_PKG_VERSION"));
+    }
+
+    #[test]
+    fn req_app_check_updates_builds_client_config_url_without_token() {
+        let url = client_config_url("http://localhost:3000", "").expect("url");
+
+        assert_eq!(url, "http://localhost:3000/api/client-config");
+    }
+
+    #[test]
+    fn req_app_check_updates_url_encodes_client_token() {
+        let url = client_config_url("http://localhost:3000/base", "client token/1").expect("url");
+
+        assert_eq!(
+            url,
+            "http://localhost:3000/base/api/client-config?client_id=client+token%2F1"
+        );
+    }
+
+    #[test]
+    fn req_app_check_updates_defaults_missing_flag_to_false() {
+        let response = update_status_response(&serde_json::json!({}));
+
+        assert_eq!(response["needs_upgrade"], false);
+        assert_eq!(response["current_version"], env!("CARGO_PKG_VERSION"));
+    }
+
+    #[test]
+    fn req_app_watermark_config_applies_defaults() {
+        let response = watermark_config_response(&serde_json::json!({}));
+
+        assert_eq!(response["watermark_enabled"], false);
+        assert_eq!(response["watermark_template"], "{username} | {datetime}");
+        assert_eq!(response["watermark_font_size"], 16);
+        assert_eq!(response["watermark_position"], "diagonal");
+    }
+
+    #[test]
+    fn req_app_watermark_config_uses_backend_values() {
+        let response = watermark_config_response(&serde_json::json!({
+            "watermark_enabled": true,
+            "watermark_template": "{email}",
+            "watermark_font_size": 22,
+            "watermark_opacity": 0.25,
+            "watermark_position": "grid",
+            "watermark_color": "#123456"
+        }));
+
+        assert_eq!(response["watermark_enabled"], true);
+        assert_eq!(response["watermark_template"], "{email}");
+        assert_eq!(response["watermark_font_size"], 22);
+        assert_eq!(response["watermark_opacity"], 0.25);
+        assert_eq!(response["watermark_position"], "grid");
+        assert_eq!(response["watermark_color"], "#123456");
+    }
+
+    #[test]
+    fn req_app_submit_approval_ticket_names_blank_tool_generically() {
+        assert_eq!(approval_operation_name("  "), "工具审批");
+    }
+
+    #[test]
+    fn req_app_submit_approval_ticket_trims_tool_name() {
+        assert_eq!(
+            approval_operation_name("  write_file  "),
+            "工具审批: write_file"
+        );
+    }
+
+    #[test]
+    fn req_app_submit_approval_ticket_reason_preserves_context() {
+        let reason = approval_reason("req-1", "thread-1", "please approve");
+
+        assert_eq!(
+            reason,
+            "request_id=req-1\nthread_id=thread-1\nplease approve"
+        );
+    }
+}
+
+#[cfg(test)]
+mod applicant_id_tests {
     use super::resolve_applicant_id_value;
     use crate::Error;
     use std::sync::RwLock;

--- a/desktop-client/src/ipc/file_ops.rs
+++ b/desktop-client/src/ipc/file_ops.rs
@@ -28,8 +28,16 @@ pub async fn ic_undo_file_edit(
 ) -> Result<String, String> {
     // 确保引擎就绪（统一的前置检查）
     let _state = state.get()?;
+    undo_file_edit(&path, &old_string, &new_string, count).await
+}
 
-    let file_path = std::path::Path::new(&path);
+pub(crate) async fn undo_file_edit(
+    path: &str,
+    old_string: &str,
+    new_string: &str,
+    count: usize,
+) -> Result<String, String> {
+    let file_path = std::path::Path::new(path);
     if !file_path.exists() {
         return Err(format!("文件不存在: {}", path));
     }
@@ -46,7 +54,7 @@ pub async fn ic_undo_file_edit(
         ));
     }
 
-    let restored = replace_first_n(&content, &new_string, &old_string, count);
+    let restored = replace_first_n(&content, new_string, old_string, count);
 
     tokio::fs::write(file_path, &restored)
         .await
@@ -66,14 +74,10 @@ pub async fn ic_open_file_at_line(path: String, line: Option<u32>) -> Result<(),
         return Err(format!("文件不存在: {}", path));
     }
 
-    // 优先尝试 VS Code CLI
-    let vscode_arg = match line {
-        Some(l) => format!("--goto {}:{}", path, l),
-        None => path.clone(),
-    };
+    let vscode_args = vscode_args(&path, line);
 
     let vscode_result = tokio::process::Command::new("code")
-        .args(vscode_arg.split_whitespace())
+        .args(&vscode_args)
         .status()
         .await;
 
@@ -91,6 +95,13 @@ pub async fn ic_open_file_at_line(path: String, line: Option<u32>) -> Result<(),
     // 回退: 使用 `open` (macOS) / `xdg-open` (Linux) / `start` (Windows)
     open::that(&path).map_err(|e| format!("无法打开文件: {}", e))?;
     Ok(())
+}
+
+pub(crate) fn vscode_args(path: &str, line: Option<u32>) -> Vec<String> {
+    match line {
+        Some(line) => vec!["--goto".to_string(), format!("{}:{}", path, line)],
+        None => vec![path.to_string()],
+    }
 }
 
 /// 替换字符串中前 `n` 次出现的 `from` 为 `to`。
@@ -155,5 +166,53 @@ mod tests {
         let input = "hello";
         let result = replace_first_n(input, "", "x", 5);
         assert_eq!(result, "hello");
+    }
+
+    #[test]
+    fn req_files_open_file_at_line_preserves_paths_with_spaces() {
+        let args = vscode_args("/tmp/project with spaces/main.rs", Some(42));
+
+        assert_eq!(args, vec!["--goto", "/tmp/project with spaces/main.rs:42"]);
+    }
+
+    #[test]
+    fn req_files_open_file_without_line_uses_single_path_arg() {
+        let args = vscode_args("/tmp/project with spaces/main.rs", None);
+
+        assert_eq!(args, vec!["/tmp/project with spaces/main.rs"]);
+    }
+
+    #[tokio::test]
+    async fn req_files_undo_file_edit_roundtrip() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("sample.txt");
+        tokio::fs::write(&path, "alpha new beta new gamma")
+            .await
+            .expect("write fixture");
+
+        let message = undo_file_edit(path.to_str().expect("utf8 path"), "old", "new", 2)
+            .await
+            .expect("undo should succeed");
+        let restored = tokio::fs::read_to_string(&path)
+            .await
+            .expect("read restored");
+
+        assert_eq!(message, "已撤回 2 处替换");
+        assert_eq!(restored, "alpha old beta old gamma");
+    }
+
+    #[tokio::test]
+    async fn test_files_failure_undo_rejects_changed_content() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("sample.txt");
+        tokio::fs::write(&path, "alpha new beta")
+            .await
+            .expect("write fixture");
+
+        let err = undo_file_edit(path.to_str().expect("utf8 path"), "old", "new", 2)
+            .await
+            .expect_err("undo should reject drifted content");
+
+        assert!(err.contains("文件内容已变更"));
     }
 }

--- a/desktop-client/src/ipc/logs.rs
+++ b/desktop-client/src/ipc/logs.rs
@@ -8,8 +8,9 @@
 //! `LogBroadcaster` 不支持清空，通过 `AppState.log_clear_offset` 记录
 //! 清空时的日志总数，后续查询跳过 offset 之前的条目，实现"视觉清空"。
 
-use std::sync::atomic::Ordering;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
+use ironclaw::channels::web::log_layer::{LogBroadcaster, LogEntry};
 use serde::{Deserialize, Serialize};
 use tauri::State;
 
@@ -39,19 +40,87 @@ impl From<ironclaw::channels::web::log_layer::LogEntry> for LogEntryDto {
 /// 获取清空偏移后的日志条目（最多 `limit` 条，时间正序）。
 fn entries_after_offset(state: &crate::state::AppState, limit: usize) -> Vec<LogEntryDto> {
     let offset = state.log_clear_offset.load(Ordering::Relaxed);
-    let all = state.log_broadcaster.recent_entries();
-    let sliced: Vec<_> = all.into_iter().skip(offset).collect();
-    let start = sliced.len().saturating_sub(limit);
-    sliced.into_iter().skip(start).map(Into::into).collect()
+    entries_after_offset_from(&state.log_broadcaster, offset, limit)
 }
 
 /// 从已过滤的条目中取最后 `limit` 条并转换为 DTO。
-fn take_last(
-    entries: Vec<ironclaw::channels::web::log_layer::LogEntry>,
-    limit: usize,
-) -> Vec<LogEntryDto> {
+pub(crate) fn take_last(entries: Vec<LogEntry>, limit: usize) -> Vec<LogEntryDto> {
     let start = entries.len().saturating_sub(limit);
     entries.into_iter().skip(start).map(Into::into).collect()
+}
+
+pub(crate) fn visible_limit(limit: Option<usize>) -> usize {
+    limit.unwrap_or(100).min(1000)
+}
+
+pub(crate) fn entries_after_offset_from(
+    broadcaster: &LogBroadcaster,
+    offset: usize,
+    limit: usize,
+) -> Vec<LogEntryDto> {
+    let sliced: Vec<_> = broadcaster
+        .recent_entries()
+        .into_iter()
+        .skip(offset)
+        .collect();
+    take_last(sliced, limit)
+}
+
+pub(crate) fn search_entries(
+    broadcaster: &LogBroadcaster,
+    offset: usize,
+    query: &str,
+    limit: usize,
+) -> Vec<LogEntryDto> {
+    let q = query.to_lowercase();
+    let filtered: Vec<_> = broadcaster
+        .recent_entries()
+        .into_iter()
+        .skip(offset)
+        .filter(|e| e.message.to_lowercase().contains(&q) || e.target.to_lowercase().contains(&q))
+        .collect();
+    take_last(filtered, limit)
+}
+
+pub(crate) fn filter_entries(
+    broadcaster: &LogBroadcaster,
+    offset: usize,
+    level: &str,
+    module: &str,
+    limit: usize,
+) -> Vec<LogEntryDto> {
+    let level_filter = level.to_uppercase();
+    let module_filter = module.to_lowercase();
+    let filtered: Vec<_> = broadcaster
+        .recent_entries()
+        .into_iter()
+        .skip(offset)
+        .filter(|e| {
+            let level_ok = level_filter.is_empty() || e.level.to_uppercase() == level_filter;
+            let module_ok =
+                module_filter.is_empty() || e.target.to_lowercase().contains(&module_filter);
+            level_ok && module_ok
+        })
+        .collect();
+    take_last(filtered, limit)
+}
+
+pub(crate) fn export_entries_json(
+    broadcaster: &LogBroadcaster,
+    offset: usize,
+) -> Result<String, serde_json::Error> {
+    let entries: Vec<LogEntryDto> = broadcaster
+        .recent_entries()
+        .into_iter()
+        .skip(offset)
+        .map(Into::into)
+        .collect();
+    serde_json::to_string_pretty(&entries)
+}
+
+pub(crate) fn clear_log_offset(broadcaster: &LogBroadcaster, offset: &AtomicUsize) {
+    let current_len = broadcaster.recent_entries().len();
+    offset.store(current_len, Ordering::Relaxed);
 }
 
 /// 获取最近日志（最多 `limit` 条，默认 100）。
@@ -61,7 +130,7 @@ pub async fn ic_get_logs(
     limit: Option<usize>,
 ) -> Result<Vec<LogEntryDto>, String> {
     let state = state.get()?;
-    Ok(entries_after_offset(state, limit.unwrap_or(100).min(1000)))
+    Ok(entries_after_offset(state, visible_limit(limit)))
 }
 
 /// 按关键词搜索日志（在 message 和 module 中匹配，大小写不敏感）。
@@ -72,17 +141,13 @@ pub async fn ic_search_logs(
     limit: Option<usize>,
 ) -> Result<Vec<LogEntryDto>, String> {
     let state = state.get()?;
-    let limit = limit.unwrap_or(100).min(1000);
-    let q = query.to_lowercase();
     let offset = state.log_clear_offset.load(Ordering::Relaxed);
-    let filtered: Vec<_> = state
-        .log_broadcaster
-        .recent_entries()
-        .into_iter()
-        .skip(offset)
-        .filter(|e| e.message.to_lowercase().contains(&q) || e.target.to_lowercase().contains(&q))
-        .collect();
-    Ok(take_last(filtered, limit))
+    Ok(search_entries(
+        &state.log_broadcaster,
+        offset,
+        &query,
+        visible_limit(limit),
+    ))
 }
 
 /// 按级别和模块过滤日志。
@@ -96,23 +161,14 @@ pub async fn ic_filter_logs(
     limit: Option<usize>,
 ) -> Result<Vec<LogEntryDto>, String> {
     let state = state.get()?;
-    let limit = limit.unwrap_or(100).min(1000);
-    let level_filter = level.to_uppercase();
-    let module_filter = module.to_lowercase();
     let offset = state.log_clear_offset.load(Ordering::Relaxed);
-    let filtered: Vec<_> = state
-        .log_broadcaster
-        .recent_entries()
-        .into_iter()
-        .skip(offset)
-        .filter(|e| {
-            let level_ok = level_filter.is_empty() || e.level.to_uppercase() == level_filter;
-            let module_ok =
-                module_filter.is_empty() || e.target.to_lowercase().contains(&module_filter);
-            level_ok && module_ok
-        })
-        .collect();
-    Ok(take_last(filtered, limit))
+    Ok(filter_entries(
+        &state.log_broadcaster,
+        offset,
+        &level,
+        &module,
+        visible_limit(limit),
+    ))
 }
 
 /// 导出日志为 JSON 字符串（供前端用 dialog + fs 插件保存到用户选择的路径）。
@@ -120,22 +176,15 @@ pub async fn ic_filter_logs(
 pub async fn ic_export_logs(state: State<'_, EngineState>) -> Result<String, String> {
     let state = state.get()?;
     let offset = state.log_clear_offset.load(Ordering::Relaxed);
-    let entries: Vec<LogEntryDto> = state
-        .log_broadcaster
-        .recent_entries()
-        .into_iter()
-        .skip(offset)
-        .map(Into::into)
-        .collect();
-    serde_json::to_string_pretty(&entries).map_err(|e| format!("Serialization failed: {}", e))
+    export_entries_json(&state.log_broadcaster, offset)
+        .map_err(|e| format!("Serialization failed: {}", e))
 }
 
 /// 清空日志（视觉清空：记录当前日志总数作为偏移，后续查询跳过此前条目）。
 #[tauri::command]
 pub async fn ic_clear_logs(state: State<'_, EngineState>) -> Result<(), String> {
     let state = state.get()?;
-    let current_len = state.log_broadcaster.recent_entries().len();
-    state.log_clear_offset.store(current_len, Ordering::Relaxed);
-    tracing::debug!(offset = current_len, "Log buffer visually cleared");
+    clear_log_offset(&state.log_broadcaster, &state.log_clear_offset);
+    tracing::debug!("Log buffer visually cleared");
     Ok(())
 }

--- a/desktop-client/src/ipc/logs_tests.rs
+++ b/desktop-client/src/ipc/logs_tests.rs
@@ -3,11 +3,15 @@
 //! 测试策略：直接构造 `LogBroadcaster` + `AppState` 的最小替代，
 //! 调用内部辅助逻辑，不依赖 Tauri State 注入。
 
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
 use ironclaw::channels::web::log_layer::{LogBroadcaster, LogEntry};
 
-use crate::ipc::logs::LogEntryDto;
+use crate::ipc::logs::{
+    clear_log_offset, entries_after_offset_from, export_entries_json, filter_entries,
+    search_entries, visible_limit, LogEntryDto,
+};
 
 // ── 测试辅助 ─────────────────────────────────────────────────────
 
@@ -29,60 +33,6 @@ fn broadcaster_with(entries: &[(&str, &str, &str)]) -> Arc<LogBroadcaster> {
     b
 }
 
-// ── entries_after_offset 逻辑（提取为可测试的纯函数）────────────
-
-fn entries_after_offset_pure(
-    broadcaster: &LogBroadcaster,
-    offset: usize,
-    limit: usize,
-) -> Vec<LogEntryDto> {
-    let all = broadcaster.recent_entries();
-    let sliced: Vec<_> = all.into_iter().skip(offset).collect();
-    let start = sliced.len().saturating_sub(limit);
-    sliced.into_iter().skip(start).map(Into::into).collect()
-}
-
-fn search_pure(
-    broadcaster: &LogBroadcaster,
-    offset: usize,
-    query: &str,
-    limit: usize,
-) -> Vec<LogEntryDto> {
-    let q = query.to_lowercase();
-    let filtered: Vec<_> = broadcaster
-        .recent_entries()
-        .into_iter()
-        .skip(offset)
-        .filter(|e| e.message.to_lowercase().contains(&q) || e.target.to_lowercase().contains(&q))
-        .collect();
-    let start = filtered.len().saturating_sub(limit);
-    filtered.into_iter().skip(start).map(Into::into).collect()
-}
-
-fn filter_pure(
-    broadcaster: &LogBroadcaster,
-    offset: usize,
-    level: &str,
-    module: &str,
-    limit: usize,
-) -> Vec<LogEntryDto> {
-    let level_filter = level.to_uppercase();
-    let module_filter = module.to_lowercase();
-    let filtered: Vec<_> = broadcaster
-        .recent_entries()
-        .into_iter()
-        .skip(offset)
-        .filter(|e| {
-            let level_ok = level_filter.is_empty() || e.level.to_uppercase() == level_filter;
-            let module_ok =
-                module_filter.is_empty() || e.target.to_lowercase().contains(&module_filter);
-            level_ok && module_ok
-        })
-        .collect();
-    let start = filtered.len().saturating_sub(limit);
-    filtered.into_iter().skip(start).map(Into::into).collect()
-}
-
 // ── 正常路径测试 ─────────────────────────────────────────────────
 
 #[test]
@@ -92,7 +42,7 @@ fn test_get_logs_returns_all_entries() {
         ("WARN", "mod_b", "msg 2"),
         ("ERROR", "mod_c", "msg 3"),
     ]);
-    let result = entries_after_offset_pure(&b, 0, 100);
+    let result = entries_after_offset_from(&b, 0, 100);
     assert_eq!(result.len(), 3);
     assert_eq!(result[0].message, "msg 1");
     assert_eq!(result[2].message, "msg 3");
@@ -108,7 +58,7 @@ fn test_get_logs_respects_limit() {
         ("INFO", "m", "e"),
     ]);
     // limit=3 应返回最新的 3 条（c, d, e）
-    let result = entries_after_offset_pure(&b, 0, 3);
+    let result = entries_after_offset_from(&b, 0, 3);
     assert_eq!(result.len(), 3);
     assert_eq!(result[0].message, "c");
     assert_eq!(result[2].message, "e");
@@ -117,7 +67,7 @@ fn test_get_logs_respects_limit() {
 #[test]
 fn test_get_logs_empty_broadcaster() {
     let b = Arc::new(LogBroadcaster::new());
-    let result = entries_after_offset_pure(&b, 0, 100);
+    let result = entries_after_offset_from(&b, 0, 100);
     assert!(result.is_empty());
 }
 
@@ -131,7 +81,7 @@ fn test_clear_hides_existing_entries() {
     assert_eq!(offset, 2);
 
     // 清空后查询应为空
-    let result = entries_after_offset_pure(&b, offset, 100);
+    let result = entries_after_offset_from(&b, offset, 100);
     assert!(result.is_empty());
 }
 
@@ -144,7 +94,7 @@ fn test_new_entries_visible_after_clear() {
     b.send(make_entry("INFO", "m", "new 1"));
     b.send(make_entry("INFO", "m", "new 2"));
 
-    let result = entries_after_offset_pure(&b, offset, 100);
+    let result = entries_after_offset_from(&b, offset, 100);
     assert_eq!(result.len(), 2);
     assert_eq!(result[0].message, "new 1");
     assert_eq!(result[1].message, "new 2");
@@ -154,7 +104,7 @@ fn test_new_entries_visible_after_clear() {
 fn test_clear_offset_zero_returns_all() {
     let b = broadcaster_with(&[("INFO", "m", "a"), ("INFO", "m", "b")]);
     // offset=0 等同于未清空
-    let result = entries_after_offset_pure(&b, 0, 100);
+    let result = entries_after_offset_from(&b, 0, 100);
     assert_eq!(result.len(), 2);
 }
 
@@ -167,7 +117,7 @@ fn test_search_matches_message() {
         ("INFO", "mod", "DLP rules synced"),
         ("INFO", "mod", "engine ready"),
     ]);
-    let result = search_pure(&b, 0, "engine", 100);
+    let result = search_entries(&b, 0, "engine", 100);
     assert_eq!(result.len(), 2);
     assert!(result.iter().all(|e| e.message.contains("engine")));
 }
@@ -179,21 +129,21 @@ fn test_search_matches_module() {
         ("INFO", "desktop_client::engine", "starting"),
         ("INFO", "ironclaw::agent", "ready"),
     ]);
-    let result = search_pure(&b, 0, "ironclaw", 100);
+    let result = search_entries(&b, 0, "ironclaw", 100);
     assert_eq!(result.len(), 2);
 }
 
 #[test]
 fn test_search_case_insensitive() {
     let b = broadcaster_with(&[("INFO", "mod", "Engine Started")]);
-    let result = search_pure(&b, 0, "engine", 100);
+    let result = search_entries(&b, 0, "engine", 100);
     assert_eq!(result.len(), 1);
 }
 
 #[test]
 fn test_search_no_match_returns_empty() {
     let b = broadcaster_with(&[("INFO", "mod", "hello world")]);
-    let result = search_pure(&b, 0, "xyz_not_found", 100);
+    let result = search_entries(&b, 0, "xyz_not_found", 100);
     assert!(result.is_empty());
 }
 
@@ -201,7 +151,7 @@ fn test_search_no_match_returns_empty() {
 fn test_search_respects_offset() {
     let b = broadcaster_with(&[("INFO", "mod", "engine old"), ("INFO", "mod", "engine new")]);
     // 清空后只有第 2 条可见
-    let result = search_pure(&b, 1, "engine", 100);
+    let result = search_entries(&b, 1, "engine", 100);
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].message, "engine new");
 }
@@ -215,7 +165,7 @@ fn test_filter_by_level() {
         ("WARN", "mod", "warn msg"),
         ("ERROR", "mod", "error msg"),
     ]);
-    let result = filter_pure(&b, 0, "warn", "", 100);
+    let result = filter_entries(&b, 0, "warn", "", 100);
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].level, "WARN");
 }
@@ -224,7 +174,7 @@ fn test_filter_by_level() {
 fn test_filter_level_case_insensitive() {
     let b = broadcaster_with(&[("ERROR", "mod", "boom")]);
     // 前端传来的可能是小写
-    let result = filter_pure(&b, 0, "error", "", 100);
+    let result = filter_entries(&b, 0, "error", "", 100);
     assert_eq!(result.len(), 1);
 }
 
@@ -235,7 +185,7 @@ fn test_filter_by_module() {
         ("INFO", "desktop_client::ipc", "ipc msg"),
         ("INFO", "ironclaw::config", "config msg"),
     ]);
-    let result = filter_pure(&b, 0, "", "ironclaw", 100);
+    let result = filter_entries(&b, 0, "", "ironclaw", 100);
     assert_eq!(result.len(), 2);
     assert!(result.iter().all(|e| e.module.contains("ironclaw")));
 }
@@ -247,7 +197,7 @@ fn test_filter_level_and_module_combined() {
         ("WARN", "ironclaw::agent", "agent warn"),
         ("ERROR", "desktop_client", "client error"),
     ]);
-    let result = filter_pure(&b, 0, "error", "ironclaw", 100);
+    let result = filter_entries(&b, 0, "error", "ironclaw", 100);
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].message, "agent error");
 }
@@ -256,14 +206,14 @@ fn test_filter_level_and_module_combined() {
 fn test_filter_empty_strings_returns_all() {
     let b = broadcaster_with(&[("INFO", "mod_a", "a"), ("WARN", "mod_b", "b")]);
     // level="" module="" 不过滤
-    let result = filter_pure(&b, 0, "", "", 100);
+    let result = filter_entries(&b, 0, "", "", 100);
     assert_eq!(result.len(), 2);
 }
 
 #[test]
 fn test_filter_respects_offset() {
     let b = broadcaster_with(&[("ERROR", "mod", "old error"), ("ERROR", "mod", "new error")]);
-    let result = filter_pure(&b, 1, "error", "", 100);
+    let result = filter_entries(&b, 1, "error", "", 100);
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].message, "new error");
 }
@@ -273,8 +223,7 @@ fn test_filter_respects_offset() {
 #[test]
 fn test_export_produces_valid_json() {
     let b = broadcaster_with(&[("INFO", "mod", "hello"), ("ERROR", "mod", "world")]);
-    let entries: Vec<LogEntryDto> = b.recent_entries().into_iter().map(Into::into).collect();
-    let json = serde_json::to_string_pretty(&entries).expect("should serialize");
+    let json = export_entries_json(&b, 0).expect("should serialize");
 
     // 验证是合法 JSON 数组
     let parsed: Vec<serde_json::Value> = serde_json::from_str(&json).expect("should parse");
@@ -286,8 +235,7 @@ fn test_export_produces_valid_json() {
 #[test]
 fn test_export_empty_is_empty_array() {
     let b = Arc::new(LogBroadcaster::new());
-    let entries: Vec<LogEntryDto> = b.recent_entries().into_iter().map(Into::into).collect();
-    let json = serde_json::to_string_pretty(&entries).expect("should serialize");
+    let json = export_entries_json(&b, 0).expect("should serialize");
     assert_eq!(json.trim(), "[]");
 }
 // ── LogEntryDto From 转换测试 ─────────────────────────────────────
@@ -307,8 +255,7 @@ fn test_log_entry_dto_field_mapping() {
 #[test]
 fn test_export_logs_json_is_valid_and_contains_all_entries() {
     let b = broadcaster_with(&[("INFO", "mod", "hello"), ("ERROR", "mod", "world")]);
-    let entries: Vec<LogEntryDto> = b.recent_entries().into_iter().map(Into::into).collect();
-    let json = serde_json::to_string_pretty(&entries).expect("should serialize");
+    let json = export_entries_json(&b, 0).expect("should serialize");
 
     let parsed: Vec<serde_json::Value> = serde_json::from_str(&json).expect("should parse");
     assert_eq!(parsed.len(), 2);
@@ -320,13 +267,7 @@ fn test_export_logs_json_is_valid_and_contains_all_entries() {
 fn test_export_logs_respects_clear_offset() {
     let b = broadcaster_with(&[("INFO", "mod", "old"), ("INFO", "mod", "new")]);
     let offset = 1; // 清空后只有第 2 条可见
-    let entries: Vec<LogEntryDto> = b
-        .recent_entries()
-        .into_iter()
-        .skip(offset)
-        .map(Into::into)
-        .collect();
-    let json = serde_json::to_string_pretty(&entries).expect("should serialize");
+    let json = export_entries_json(&b, offset).expect("should serialize");
     let parsed: Vec<serde_json::Value> = serde_json::from_str(&json).expect("should parse");
     assert_eq!(parsed.len(), 1);
     assert_eq!(parsed[0]["message"], "new");
@@ -335,8 +276,7 @@ fn test_export_logs_respects_clear_offset() {
 #[test]
 fn test_export_logs_writes_to_temp_dir() {
     let b = broadcaster_with(&[("INFO", "mod", "test entry")]);
-    let entries: Vec<LogEntryDto> = b.recent_entries().into_iter().map(Into::into).collect();
-    let json = serde_json::to_string_pretty(&entries).expect("should serialize");
+    let json = export_entries_json(&b, 0).expect("should serialize");
 
     // 模拟写文件逻辑
     let dir = std::env::temp_dir();
@@ -349,4 +289,25 @@ fn test_export_logs_writes_to_temp_dir() {
 
     // 清理
     let _ = std::fs::remove_file(&path);
+}
+
+#[test]
+fn req_logs_clear_command_records_current_buffer_len() {
+    let b = broadcaster_with(&[("INFO", "mod", "old 1"), ("INFO", "mod", "old 2")]);
+    let offset = AtomicUsize::new(0);
+
+    clear_log_offset(&b, &offset);
+    b.send(make_entry("INFO", "mod", "new"));
+
+    assert_eq!(offset.load(Ordering::Relaxed), 2);
+    let visible = entries_after_offset_from(&b, offset.load(Ordering::Relaxed), 100);
+    assert_eq!(visible.len(), 1);
+    assert_eq!(visible[0].message, "new");
+}
+
+#[test]
+fn req_logs_limit_defaults_and_caps_to_one_thousand() {
+    assert_eq!(visible_limit(None), 100);
+    assert_eq!(visible_limit(Some(5)), 5);
+    assert_eq!(visible_limit(Some(5_000)), 1_000);
 }

--- a/desktop-client/src/ipc/workspace.rs
+++ b/desktop-client/src/ipc/workspace.rs
@@ -28,12 +28,20 @@ pub async fn ic_workspace_git_status(state: State<'_, EngineState>) -> Result<St
         .await
         .map_err(|e| format!("Failed to run git: {e}"))?;
 
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
+    git_status_result(output.status.success(), &output.stdout, &output.stderr)
+}
+
+pub(crate) fn git_status_result(
+    success: bool,
+    stdout: &[u8],
+    stderr: &[u8],
+) -> Result<String, String> {
+    if !success {
+        let stderr = String::from_utf8_lossy(stderr);
         return Err(format!("git status failed: {stderr}"));
     }
 
-    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+    Ok(String::from_utf8_lossy(stdout).into_owned())
 }
 
 /// 返回当前工作目录路径。
@@ -167,4 +175,55 @@ pub async fn ic_list_sandbox_workspaces() -> Result<Vec<SandboxWorkspace>, Strin
 pub struct SandboxWorkspace {
     pub name: String,
     pub path: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{git_status_result, ActiveServer, SandboxWorkspace};
+
+    #[test]
+    fn req_workspace_git_status_returns_stdout_on_success() {
+        let stdout = b"On branch xClaw\nnothing to commit, working tree clean\n";
+
+        let result = git_status_result(true, stdout, b"").expect("status should succeed");
+
+        assert!(result.contains("On branch xClaw"));
+        assert!(result.contains("working tree clean"));
+    }
+
+    #[test]
+    fn test_workspace_failure_git_status_surfaces_stderr() {
+        let err = git_status_result(false, b"", b"fatal: not a git repository")
+            .expect_err("status should fail");
+
+        assert!(err.contains("git status failed"));
+        assert!(err.contains("not a git repository"));
+    }
+
+    #[test]
+    fn req_workspace_active_server_contract_renames_type_field() {
+        let server = ActiveServer {
+            name: "filesystem".to_string(),
+            server_type: "mcp".to_string(),
+        };
+
+        let json = serde_json::to_value(&server).expect("serialize active server");
+
+        assert_eq!(json["name"], "filesystem");
+        assert_eq!(json["type"], "mcp");
+        assert!(json.get("server_type").is_none());
+    }
+
+    #[test]
+    fn req_workspace_sandbox_workspace_contract_matches_frontend() {
+        let workspace = SandboxWorkspace {
+            name: "thread-123".to_string(),
+            path: "/tmp/thread-123".to_string(),
+        };
+
+        let json = serde_json::to_value(&workspace).expect("serialize workspace");
+
+        assert_eq!(json["name"], "thread-123");
+        assert_eq!(json["path"], "/tmp/thread-123");
+    }
 }

--- a/docs/INTEROP_DASCLAW.md
+++ b/docs/INTEROP_DASCLAW.md
@@ -1,0 +1,79 @@
+# claw-code → dasclaw_* interop map
+
+> **Status**: Documentation-only (B5 deliverable for Issue #911).
+> **Purpose**: Prove that the three lineages (codex / claw-code / ironclaw) already
+> compose on the GUI path by mapping every claw-code concept to its concrete
+> landing in the workspace `dasclaw_*` crates, with an executable reference at
+> [`crates/dasclaw_cli/examples/claw_code_interop.rs`](../crates/dasclaw_cli/examples/claw_code_interop.rs).
+>
+> **Location note (deviation from Issue #911 brief)**: the original task brief
+> placed this file at `claw-code/INTEROP_DASCLAW.md`, but `claw-code/` is a git
+> submodule in this workspace (see `.gitmodules`), so any file added there
+> would belong to a different repo. To honour the rule "do not modify the
+> claw-code source tree" while still satisfying the B5 grep contract from this
+> repo, the file lives at `docs/INTEROP_DASCLAW.md` and the e2e grep anchor
+> test reads it from that path.
+
+## Why this file exists
+
+Issue #911 closes the B5 gap from
+[`docs/plans/architecture-refactor/49-gui-readiness-assessment.md`](plans/architecture-refactor/49-gui-readiness-assessment.md)
+§5 / §9: "三库融合在 GUI 路径未端到端证明". Rather than re-implement claw-code's
+runtime, we show that its primitives are already absorbed into the dasclaw stack
+and can be driven from a single headless agent loop.
+
+## Mapping table
+
+| claw-code concept | dasclaw_* landing | 接入难度 |
+|---|---|---|
+| Headless agent loop (`runtime/agent.ts`) | [`dasclaw_runtime::Agent`](../crates/dasclaw_runtime/src/agent.rs) (`AgentResponder` + `ToolExecutor` + `HookBundle`) | trivial — already drives `dasclaw_cli`'s e2e tests |
+| `bash` tool gating ("Are you sure?" / refuse) | [`dasclaw_bash_validation`](../crates/dasclaw_bash_validation) (`validate_command`) wrapped by [`dasclaw_hooks::BashValidationHook`](../crates/dasclaw_hooks/src/bash_validation_hook.rs) (`EgressGate`) | trivial — `BashValidationHook::new(PermissionMode, workspace)` plugs into `HookBundle.egress` |
+| `apply_patch` tool (model emits `*** Begin Patch …`) | [`dasclaw_apply_patch::parse_patch`](../crates/dasclaw_apply_patch/src/parser.rs) + [`apply`](../crates/dasclaw_apply_patch/src/apply.rs) | trivial — pure function over `ApplyPatchArgs` and `ApplyOptions { base_dir }` |
+| Hook/event bus (BeforeToolCall / AfterToolCall) | [`dasclaw_hooks`](../crates/dasclaw_hooks) (`HookBundle` re-exports `EgressGate` from `dasclaw_core::hooks`, plus declarative `HookBundleConfig`) | trivial — the agent loop already calls `hooks.egress.check` before every tool dispatch |
+| 9-layer defence stack (sandbox / approval / secrets / audit) | `HookBundle { egress, sandbox, secrets, approval }` in [`dasclaw_core::hooks`](../crates/dasclaw_core/src/hooks.rs) | already wired — this PR only exercises the `egress` lane; sandbox/approval are out of scope for the demo |
+
+## Executable proof
+
+[`crates/dasclaw_cli/examples/claw_code_interop.rs`](../crates/dasclaw_cli/examples/claw_code_interop.rs)
+runs a scripted four-turn agent loop in a tempdir, in this order:
+
+1. Model calls `bash` with `rm -rf /` → `dasclaw_bash_validation` (via
+   `dasclaw_hooks::BashValidationHook`) blocks; executor is **never** invoked.
+2. Model calls `bash` with `ls` → gate allows; stub executor returns a fake
+   listing.
+3. Model calls `apply_patch` with an `*** Update File: hello.txt` hunk →
+   `dasclaw_apply_patch::{parse_patch, apply}` writes `world\n` into the
+   tempdir.
+4. Model emits final text `done` and the loop exits.
+
+The matching e2e test
+[`crates/dasclaw_cli/tests/claw_code_interop_e2e.rs`](../crates/dasclaw_cli/tests/claw_code_interop_e2e.rs)
+asserts the audit timeline, the rejection on step 1, the on-disk mutation on
+step 3, and that **this very file** contains the string anchors that prove the
+grep contract from Issue #911:
+`dasclaw_runtime`, `dasclaw_bash_validation`, `dasclaw_apply_patch`,
+`dasclaw_hooks`.
+
+## Non-goals (explicit)
+
+- We do not port claw-code source code into the workspace.
+- We do not execute real shell or real network; both lanes are stubbed in the
+  executor so the demo is hermetic and deterministic.
+- We do not wire `dasclaw_governance`'s 6-pack on this path — that is covered
+  by separate ADR-153 §1.1 B-series work, not B5.
+- `claw-code/`, `vendor/`, `codex-cli-main/` source trees stay untouched.
+
+## See also
+
+- Issue #911 (B5 — claw-code interop demo on GUI path)
+- [`docs/plans/architecture-refactor/49-gui-readiness-assessment.md`](plans/architecture-refactor/49-gui-readiness-assessment.md)
+  §5 (GUI readiness gaps) and §9 (B5 row)
+- ADR-153 §1.1 (B-series rollout for headless agent loop)
+- [`docs/plans/architecture-refactor/53-headless-agent-capability-design.md`](plans/architecture-refactor/53-headless-agent-capability-design.md)
+  (headless agent framework capability boundary; defines what is / is not part
+  of the headless library surface)
+- [`crates/dasclaw_runtime/README.md`](../crates/dasclaw_runtime/README.md)
+  (library-side getting-started for embedders) and
+  [`crates/dasclaw_cli/examples/headless_agent_starter.rs`](../crates/dasclaw_cli/examples/headless_agent_starter.rs)
+  (minimum runnable embed example covering responder + tool executor + approval
+  policy + event stream)


### PR DESCRIPTION
## Summary

- Refactors logs IPC command behavior into production helpers and points tests at the same helpers instead of duplicated test-side logic.
- Adds focused command-helper coverage for file undo/open semantics, workspace git-status/DTO contracts, and app/auth response mapping.
- Fixes VS Code open arguments for paths containing spaces by passing structured args instead of splitting a command string.
- Updates the #1025 coverage plan to distinguish Rust command-level coverage from remaining WebDriver/state-fixture gaps.

## Change Type

- [x] Bug fix
- [ ] New feature
- [x] Refactor
- [x] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

Closes #1025 (command-level coverage slice; remaining domains are documented in §16.2)

## Sources read

- desktop-client/docs/e2e-webdriver-test-plan.md §13 IPC 命令覆盖矩阵
- desktop-client/docs/e2e-webdriver-test-plan.md §16.2 GA 缺口分类
- AGENTS.md §任务启动 4 问
- AGENTS.md §Skills 强制使用规范
- .github/instructions/code-quality.instructions.md §代码质量规范：禁止补丁式代码
- desktop-client/src/ipc/logs.rs（日志 IPC 命令实现）
- desktop-client/src/ipc/logs_tests.rs（日志 IPC 测试）
- desktop-client/src/ipc/file_ops.rs（文件操作 IPC 命令实现）
- desktop-client/src/ipc/workspace.rs（工作区 IPC 命令实现）
- desktop-client/src/commands.rs（应用/认证命令实现）

## Cross-cuts

- ADR-114: 类A 无新增 .ironclaw / IRONCLAW_BASE_DIR 字面量

## Validation

- [x] cargo fmt --package desktop-client
- [x] cargo check -p desktop-client --tests
- [x] cargo nextest run -p desktop-client -E 'test(/(req_logs|test_export|test_search|test_filter|req_files|test_files|req_workspace|test_workspace|req_app|test_resolve_applicant)/)' — 39 passed, 827 skipped
- [x] python3.12 scripts/check_no_panics.py --base origin/xClaw — OK
- [ ] cargo clippy --no-deps -p desktop-client --all-targets -- -D warnings — blocked by pre-existing warnings in untouched files: auth_token_manager.rs, dlp/sanitizer.rs, data_reporter.rs, engine.rs, ipc/chat.rs, managed_policy.rs, state.rs, lib.rs
- [x] git diff --check

## Security Impact

Touches file-operation command helpers but does not broaden path permissions or bypass existing engine readiness checks. The open-file change only fixes argument construction so paths with spaces remain a single file argument.

## Database Impact

None. No migrations or schema changes.

## Blast Radius

Desktop-client IPC command surfaces for logs, file operations, workspace status mapping, and app/auth helper mapping. Main risk is command response formatting; focused Rust tests cover the changed semantics.

## Rollback Plan

Revert commit f5143b7bf to restore prior IPC helper structure and plan text.

---

**Review track**: B (tests/refactor + small runtime bug fix)