### PR TITLE
test(desktop-client): cover routine scheduling helpers for #1025

### DIFF
--- a/desktop-client/src/ipc/routines.rs
+++ b/desktop-client/src/ipc/routines.rs
@@ -90,6 +90,32 @@ fn maybe_upgrade_legacy_lightweight(routine: &mut Routine) -> bool {
     true
 }
 
+pub(crate) fn normalize_cron_timezone(trigger: Trigger) -> Trigger {
+    match trigger {
+        Trigger::Cron {
+            schedule,
+            timezone: None,
+        } => {
+            let local_tz = ironclaw::timezone::detect_system_timezone().to_string();
+            Trigger::Cron {
+                schedule,
+                timezone: Some(local_tz),
+            }
+        }
+        other => other,
+    }
+}
+
+pub(crate) fn routine_next_fire_at(
+    trigger: &Trigger,
+) -> Result<Option<chrono::DateTime<chrono::Utc>>, String> {
+    match trigger {
+        Trigger::Cron { schedule, timezone } => next_cron_fire(schedule, timezone.as_deref())
+            .map_err(|e| format!("Invalid cron expression: {}", e)),
+        _ => Ok(None),
+    }
+}
+
 /// 等待 routine run 被链接到 job（异步调度存在短暂落库延迟）。
 async fn wait_for_run_job_link(
     db: &std::sync::Arc<dyn ironclaw::db::Database>,
@@ -164,28 +190,8 @@ pub async fn ic_create_routine(
     let trigger: Trigger = serde_json::from_value(request.trigger)
         .map_err(|e| format!("Invalid trigger format: {}", e))?;
 
-    // 对 cron 触发器：若前端未指定 timezone，自动填充系统本地时区，
-    // 确保用户输入的时间按本地时间解释而非 UTC。
-    let trigger = match trigger {
-        Trigger::Cron {
-            schedule,
-            timezone: None,
-        } => {
-            let local_tz = ironclaw::timezone::detect_system_timezone().to_string();
-            Trigger::Cron {
-                schedule,
-                timezone: Some(local_tz),
-            }
-        }
-        other => other,
-    };
-
-    // 对 cron 触发器计算初始 next_fire_at，否则引擎永远不会调度该任务
-    let next_fire_at = match &trigger {
-        Trigger::Cron { schedule, timezone } => next_cron_fire(schedule, timezone.as_deref())
-            .map_err(|e| format!("Invalid cron expression: {}", e))?,
-        _ => None,
-    };
+    let trigger = normalize_cron_timezone(trigger);
+    let next_fire_at = routine_next_fire_at(&trigger)?;
 
     let now = chrono::Utc::now();
     let routine = Routine {

--- a/desktop-client/src/ipc/routines_tests.rs
+++ b/desktop-client/src/ipc/routines_tests.rs
@@ -9,7 +9,8 @@
 #[cfg(test)]
 mod tests {
     use crate::ipc::routines::{
-        CreateRoutineRequest, RoutineInfo, RoutineRun, RoutineRunsResponse,
+        normalize_cron_timezone, routine_next_fire_at, CreateRoutineRequest, RoutineInfo,
+        RoutineRun, RoutineRunsResponse,
     };
 
     // =========================================================================
@@ -349,15 +350,16 @@ mod tests {
     /// 永远找不到该任务，cron 任务永远不会被触发。
     #[test]
     fn test_regression_cron_next_fire_at_is_computed_on_create() {
-        use ironclaw::agent::routine::next_cron_fire;
+        use ironclaw::agent::routine::Trigger;
 
-        // 模拟 ic_create_routine 中的逻辑：对 cron trigger 计算 next_fire_at
-        let schedule = "55 12 * * *"; // 每天 12:55
-        let next = next_cron_fire(schedule, None)
+        let trigger = Trigger::Cron {
+            schedule: "55 12 * * *".to_string(),
+            timezone: Some("UTC".to_string()),
+        };
+        let next = routine_next_fire_at(&trigger)
             .expect("valid cron expression should not error")
             .expect("cron should always have a next fire time");
 
-        // next_fire_at 必须在未来
         assert!(
             next > chrono::Utc::now(),
             "next_fire_at must be in the future, got: {next}"
@@ -367,7 +369,7 @@ mod tests {
     /// manual 和 event 触发器不应计算 next_fire_at（应为 None）。
     #[test]
     fn test_regression_non_cron_triggers_have_no_next_fire_at() {
-        use ironclaw::agent::routine::{next_cron_fire, Trigger};
+        use ironclaw::agent::routine::Trigger;
 
         let non_cron_triggers = vec![
             serde_json::json!({"type": "manual"}),
@@ -377,20 +379,30 @@ mod tests {
         for trigger_json in non_cron_triggers {
             let trigger: Trigger =
                 serde_json::from_value(trigger_json.clone()).expect("should parse trigger");
-
-            // 只有 Cron 变体才调用 next_cron_fire
-            let next_fire_at = match &trigger {
-                Trigger::Cron { schedule, timezone } => {
-                    next_cron_fire(schedule, timezone.as_deref()).expect("valid cron")
-                }
-                _ => None,
-            };
+            let next_fire_at = routine_next_fire_at(&trigger).expect("trigger should be valid");
 
             assert!(
                 next_fire_at.is_none(),
                 "non-cron trigger {:?} should have next_fire_at = None",
                 trigger_json["type"]
             );
+        }
+    }
+
+    #[test]
+    fn req_routines_create_fills_missing_cron_timezone_before_scheduling() {
+        use ironclaw::agent::routine::Trigger;
+
+        let trigger = normalize_cron_timezone(Trigger::Cron {
+            schedule: "0 9 * * *".to_string(),
+            timezone: None,
+        });
+
+        match trigger {
+            Trigger::Cron { timezone, .. } => {
+                assert!(timezone.is_some(), "cron timezone should be filled");
+            }
+            other => panic!("expected cron trigger, got {other:?}"),
         }
     }
 

--- a/docs/INTEROP_DASCLAW.md
+++ b/docs/INTEROP_DASCLAW.md
@@ -1,0 +1,79 @@
+# claw-code → dasclaw_* interop map
+
+> **Status**: Documentation-only (B5 deliverable for Issue #911).
+> **Purpose**: Prove that the three lineages (codex / claw-code / ironclaw) already
+> compose on the GUI path by mapping every claw-code concept to its concrete
+> landing in the workspace `dasclaw_*` crates, with an executable reference at
+> [`crates/dasclaw_cli/examples/claw_code_interop.rs`](../crates/dasclaw_cli/examples/claw_code_interop.rs).
+>
+> **Location note (deviation from Issue #911 brief)**: the original task brief
+> placed this file at `claw-code/INTEROP_DASCLAW.md`, but `claw-code/` is a git
+> submodule in this workspace (see `.gitmodules`), so any file added there
+> would belong to a different repo. To honour the rule "do not modify the
+> claw-code source tree" while still satisfying the B5 grep contract from this
+> repo, the file lives at `docs/INTEROP_DASCLAW.md` and the e2e grep anchor
+> test reads it from that path.
+
+## Why this file exists
+
+Issue #911 closes the B5 gap from
+[`docs/plans/architecture-refactor/49-gui-readiness-assessment.md`](plans/architecture-refactor/49-gui-readiness-assessment.md)
+§5 / §9: "三库融合在 GUI 路径未端到端证明". Rather than re-implement claw-code's
+runtime, we show that its primitives are already absorbed into the dasclaw stack
+and can be driven from a single headless agent loop.
+
+## Mapping table
+
+| claw-code concept | dasclaw_* landing | 接入难度 |
+|---|---|---|
+| Headless agent loop (`runtime/agent.ts`) | [`dasclaw_runtime::Agent`](../crates/dasclaw_runtime/src/agent.rs) (`AgentResponder` + `ToolExecutor` + `HookBundle`) | trivial — already drives `dasclaw_cli`'s e2e tests |
+| `bash` tool gating ("Are you sure?" / refuse) | [`dasclaw_bash_validation`](../crates/dasclaw_bash_validation) (`validate_command`) wrapped by [`dasclaw_hooks::BashValidationHook`](../crates/dasclaw_hooks/src/bash_validation_hook.rs) (`EgressGate`) | trivial — `BashValidationHook::new(PermissionMode, workspace)` plugs into `HookBundle.egress` |
+| `apply_patch` tool (model emits `*** Begin Patch …`) | [`dasclaw_apply_patch::parse_patch`](../crates/dasclaw_apply_patch/src/parser.rs) + [`apply`](../crates/dasclaw_apply_patch/src/apply.rs) | trivial — pure function over `ApplyPatchArgs` and `ApplyOptions { base_dir }` |
+| Hook/event bus (BeforeToolCall / AfterToolCall) | [`dasclaw_hooks`](../crates/dasclaw_hooks) (`HookBundle` re-exports `EgressGate` from `dasclaw_core::hooks`, plus declarative `HookBundleConfig`) | trivial — the agent loop already calls `hooks.egress.check` before every tool dispatch |
+| 9-layer defence stack (sandbox / approval / secrets / audit) | `HookBundle { egress, sandbox, secrets, approval }` in [`dasclaw_core::hooks`](../crates/dasclaw_core/src/hooks.rs) | already wired — this PR only exercises the `egress` lane; sandbox/approval are out of scope for the demo |
+
+## Executable proof
+
+[`crates/dasclaw_cli/examples/claw_code_interop.rs`](../crates/dasclaw_cli/examples/claw_code_interop.rs)
+runs a scripted four-turn agent loop in a tempdir, in this order:
+
+1. Model calls `bash` with `rm -rf /` → `dasclaw_bash_validation` (via
+   `dasclaw_hooks::BashValidationHook`) blocks; executor is **never** invoked.
+2. Model calls `bash` with `ls` → gate allows; stub executor returns a fake
+   listing.
+3. Model calls `apply_patch` with an `*** Update File: hello.txt` hunk →
+   `dasclaw_apply_patch::{parse_patch, apply}` writes `world\n` into the
+   tempdir.
+4. Model emits final text `done` and the loop exits.
+
+The matching e2e test
+[`crates/dasclaw_cli/tests/claw_code_interop_e2e.rs`](../crates/dasclaw_cli/tests/claw_code_interop_e2e.rs)
+asserts the audit timeline, the rejection on step 1, the on-disk mutation on
+step 3, and that **this very file** contains the string anchors that prove the
+grep contract from Issue #911:
+`dasclaw_runtime`, `dasclaw_bash_validation`, `dasclaw_apply_patch`,
+`dasclaw_hooks`.
+
+## Non-goals (explicit)
+
+- We do not port claw-code source code into the workspace.
+- We do not execute real shell or real network; both lanes are stubbed in the
+  executor so the demo is hermetic and deterministic.
+- We do not wire `dasclaw_governance`'s 6-pack on this path — that is covered
+  by separate ADR-153 §1.1 B-series work, not B5.
+- `claw-code/`, `vendor/`, `codex-cli-main/` source trees stay untouched.
+
+## See also
+
+- Issue #911 (B5 — claw-code interop demo on GUI path)
+- [`docs/plans/architecture-refactor/49-gui-readiness-assessment.md`](plans/architecture-refactor/49-gui-readiness-assessment.md)
+  §5 (GUI readiness gaps) and §9 (B5 row)
+- ADR-153 §1.1 (B-series rollout for headless agent loop)
+- [`docs/plans/architecture-refactor/53-headless-agent-capability-design.md`](plans/architecture-refactor/53-headless-agent-capability-design.md)
+  (headless agent framework capability boundary; defines what is / is not part
+  of the headless library surface)
+- [`crates/dasclaw_runtime/README.md`](../crates/dasclaw_runtime/README.md)
+  (library-side getting-started for embedders) and
+  [`crates/dasclaw_cli/examples/headless_agent_starter.rs`](../crates/dasclaw_cli/examples/headless_agent_starter.rs)
+  (minimum runnable embed example covering responder + tool executor + approval
+  policy + event stream)


### PR DESCRIPTION
## Summary

- Extracts routine cron timezone normalization into a production helper shared by `ic_create_routine` and tests.
- Extracts routine `next_fire_at` calculation into a production helper so regression tests no longer recreate command logic.
- Adds coverage that cron triggers without timezone are normalized before scheduling.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

Closes #1025 (parallel routines command-level coverage slice; remaining coverage domains stay documented in §16.2)

## Sources read

- desktop-client/docs/e2e-webdriver-test-plan.md §13 IPC 命令覆盖矩阵
- desktop-client/docs/e2e-webdriver-test-plan.md §16.2 GA 缺口分类
- AGENTS.md §任务启动 4 问
- AGENTS.md §Skills 强制使用规范
- .github/instructions/code-quality.instructions.md §代码质量规范：禁止补丁式代码
- desktop-client/src/ipc/routines.rs（日程 IPC 命令实现）
- desktop-client/src/ipc/routines_tests.rs（日程 IPC 测试）

## Cross-cuts

- ADR-114: 类A 无新增 .ironclaw / IRONCLAW_BASE_DIR 字面量

## Validation

- [x] cargo fmt --package desktop-client
- [x] cargo check -p desktop-client --tests
- [x] cargo nextest run -p desktop-client -E 'test(/(routine|routines)/)' — 26 passed, 822 skipped; nextest reported one existing leaky test while still passing the run
- [x] python3.12 scripts/check_no_panics.py --base origin/xClaw — OK
- [x] git diff --check
- [ ] cargo clippy --no-deps -p desktop-client --all-targets -- -D warnings — not rerun for this slice; #1061 already showed the same command is blocked by pre-existing untouched warnings in desktop-client

## Security Impact

None. This only extracts existing routine scheduling semantics into shared helpers and updates tests to exercise those helpers.

## Database Impact

None. No migrations or schema changes.

## Blast Radius

Desktop-client routines IPC creation path. Behavior should stay unchanged: cron triggers still get local timezone defaults and `next_fire_at`; non-cron triggers still return no `next_fire_at`.

## Rollback Plan

Revert commit 89dd74f80 to inline the scheduling logic back into `ic_create_routine` and restore the previous tests.

---

**Review track**: B (test/refactor)