### PR TITLE
test(desktop-client): cover memory ipc helpers for #1025

### DIFF
--- a/desktop-client/docs/e2e-webdriver-test-plan.md
+++ b/desktop-client/docs/e2e-webdriver-test-plan.md
@@ -605,7 +605,7 @@ L5 LLM·通道·持久化 / L6 基础设施。E2E（WebDriver）是**自顶向�
 | 模型配置 | `get_available_models`/`*_custom_model`/`test_model_connection` | ✅ 附 + I-5 |
 | Plan/Fork | `ic_toggle_plan_mode`/`ic_approve_plan`/`ic_revise_plan`/`ic_fork_thread` | ✅ I-1 |
 | Sandbox | `ic_sandbox_smoke_test`/`ic_sandbox_status` | ✅ I-2 |
-| 记忆 | `ic_memory_list`/`read`/`write`/`delete`/`search` | ⬜ 待补 |
+| 记忆 | `ic_memory_list`/`read`/`write`/`delete`/`search` | 🟨 Rust helper 覆盖 DTO 映射 / 默认值；仍缺真实 AppState + Workspace 回环 |
 | 技能 | `ic_list_skills`/`search`/`install`/`uninstall`/`enable`/`disable` | ⬜ 待补 |
 | 扩展 | `ic_list_extensions`/`install`/`setup`/`setup_submit`/… | ⬜ 待补 |
 | 任务 | `ic_list_jobs`/`ic_job_events`/`ic_job_prompt`/`ic_cancel_job`/`ic_restart_job` | ⬜ 待补 |
@@ -616,7 +616,8 @@ L5 LLM·通道·持久化 / L6 基础设施。E2E（WebDriver）是**自顶向�
 | 应用/认证 | `get_auth_token`/`get_app_version`/`check_for_updates`/`submit_approval_ticket`/`get_watermark_config` | ⬜ 待补 |
 
 > **粗略覆盖度**：~80 命令中本计划直接/间接命中约 40%（聊天·线程·审批·DLP·模型·
-> Plan/Fork·Sandbox）。记忆/技能/扩展/任务/日程/日志/工作区/文件/认证 9 个段尚未覆盖。
+> Plan/Fork·Sandbox）。记忆已补 Rust helper 级 DTO 映射 / 默认值覆盖，但仍缺真实
+> AppState + Workspace 回环；技能/扩展/任务/日程/日志/工作区/文件/认证 8 个段尚未覆盖。
 > 若要补到 ~80%，按 §12 分层原则：CRUD 类（记忆/技能/扩展/日程/日志）用**命令级
 > 集成测试**批量覆盖，UI 强交互类（任务流式、文件 Undo）保留少量 E2E。
 
@@ -959,13 +960,12 @@ loop 的入口唯一**：
 
 ### 16.2 GA 缺口分类
 
-#### A. 功能维度（IPC 命令族覆盖 ~40%，待补 9 族）
+#### A. 功能维度（IPC 命令族覆盖 ~40%，待补 8 族 + 1 族需真实状态夹具）
 
 **已覆盖**（§13 表 ✅ 段）：聊天（6）/ 线程（3）/ 工具审批（2）/ DLP（7）/ 模型（3）/ Plan/Fork（4）/ Sandbox（2）。**小计** ~31 命令 / ~80 总数 ≈ 40%。
 
 **完全未覆盖**（§13 表 ⬜ 段）：
 
-- **记忆**（5）：`ic_memory_list` / `read` / `write` / `delete` / `search`
 - **技能**（6）：`ic_list_skills` / `search` / `install` / `uninstall` / `enable` / `disable`
 - **扩展**（6+）：`ic_list_extensions` / `install` / `setup` / `setup_submit` / ...
 - **任务**（5）：`ic_list_jobs` / `ic_job_events` / `ic_job_prompt` / `ic_cancel_job` / `ic_restart_job`
@@ -975,7 +975,12 @@ loop 的入口唯一**：
 - **文件操作**（2）：`ic_undo_file_edit` / `ic_open_file_at_line`
 - **应用/认证**（5）：`get_auth_token` / `get_app_version` / `check_for_updates` / `submit_approval_ticket` / `get_watermark_config`
 
-**小计** ~44 命令待补。升级路线：按 §12 分层原则，CRUD 类用**命令级集成测试**批量补（I-1~I-5 已示范），UI 强交互类（任务·日程）保留少量 E2E。
+**部分覆盖，仍需真实状态夹具 / WebDriver 回环**：
+
+- **记忆**（5）：已覆盖 `ic_memory_list` / `read` / `search` 的 DTO 映射与默认值 helper；仍需真实
+  `AppState.workspace` 夹具覆盖 `list` / `read` / `write` / `delete` / `search` 回环。
+
+**小计** ~39 命令待补，另有记忆 5 命令需从 helper 覆盖升级到真实回环。升级路线：按 §12 分层原则，CRUD 类用**命令级集成测试**批量补（I-1~I-5 已示范），UI 强交互类（任务·日程）保留少量 E2E。
 
 #### B. UX bug 阻断（2 个高优先级）
 
@@ -1009,7 +1014,7 @@ loop 的入口唯一**：
 | **P0** | 修 #1015 webview reload 延迟 | #1015 | UX bug | Tauri IPC 优化 |
 | **P0** | jailbreak 防御升级 | #1021 | 安全 | 新增分类器 OR 行为级 Rust 集成测试（方案待 ADR） |
 | **P0** | libsql 会话导出 | #955 | 数据 | 新增 `export_session` 命令 + §13 扩展 + E2E 冒烟 |
-| **P0** | 记忆 CRUD E2E | 待开 | 功能验证 | §13 记忆族命令级集成测试 |
+| **P0** | 记忆 CRUD 真回环 | 待开 | 功能验证 | §13 记忆族 AppState + Workspace 命令级集成测试 |
 | **P0** | 技能安装 E2E | 待开 | 功能验证 | §13 技能族命令级集成测试 |
 | **P0** | 审批规则配置面 E2E | #608 | 功能/UX | §1-§7 扩展或命令级 + 前端联调 |
 | **P1** | WebDriver approve 分支补回归 | #1056 | 安全/UX 不变量 | sandbox/临时 cwd + `data-approved=true` 断言 |

--- a/desktop-client/src/ipc/memory.rs
+++ b/desktop-client/src/ipc/memory.rs
@@ -7,6 +7,8 @@ use tauri::State;
 
 use crate::state::EngineState;
 
+const DEFAULT_MEMORY_SEARCH_LIMIT: usize = 10;
+
 /// 记忆条目（目录列表用）。
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MemoryEntry {
@@ -32,6 +34,46 @@ pub struct MemorySearchResult {
     pub score: f32,
 }
 
+pub(crate) fn memory_list_path(path: Option<&str>) -> &str {
+    path.unwrap_or("/")
+}
+
+pub(crate) fn memory_search_limit(limit: Option<usize>) -> usize {
+    limit.unwrap_or(DEFAULT_MEMORY_SEARCH_LIMIT)
+}
+
+pub(crate) fn workspace_entry_to_memory_entry(
+    entry: ironclaw::workspace::WorkspaceEntry,
+) -> MemoryEntry {
+    MemoryEntry {
+        name: entry.name().to_string(),
+        path: entry.path,
+        is_directory: entry.is_directory,
+        content_preview: entry.content_preview,
+    }
+}
+
+pub(crate) fn workspace_document_to_memory_document(
+    path: String,
+    document: ironclaw::workspace::MemoryDocument,
+) -> MemoryDocument {
+    MemoryDocument {
+        path,
+        content: document.content,
+        updated_at: Some(document.updated_at.to_rfc3339()),
+    }
+}
+
+pub(crate) fn workspace_search_result_to_memory_search_result(
+    result: ironclaw::workspace::SearchResult,
+) -> MemorySearchResult {
+    MemorySearchResult {
+        path: result.document_path,
+        content: result.content,
+        score: result.score,
+    }
+}
+
 /// 列出记忆目录。
 #[tauri::command]
 pub async fn ic_memory_list(
@@ -41,7 +83,7 @@ pub async fn ic_memory_list(
     let state = state.get()?;
     let ws = state.workspace.as_ref().ok_or("Workspace not available")?;
 
-    let dir = path.as_deref().unwrap_or("/");
+    let dir = memory_list_path(path.as_deref());
     let entries = ws
         .list(dir)
         .await
@@ -49,12 +91,7 @@ pub async fn ic_memory_list(
 
     Ok(entries
         .into_iter()
-        .map(|e| MemoryEntry {
-            name: e.name().to_string(),
-            path: e.path.clone(),
-            is_directory: e.is_directory,
-            content_preview: e.content_preview.clone(),
-        })
+        .map(workspace_entry_to_memory_entry)
         .collect())
 }
 
@@ -72,11 +109,7 @@ pub async fn ic_memory_read(
         .await
         .map_err(|e| format!("Failed to read memory: {}", e))?;
 
-    Ok(MemoryDocument {
-        path,
-        content: doc.content,
-        updated_at: Some(doc.updated_at.to_rfc3339()),
-    })
+    Ok(workspace_document_to_memory_document(path, doc))
 }
 
 /// 写入记忆文档。
@@ -122,16 +155,12 @@ pub async fn ic_memory_search(
     let ws = state.workspace.as_ref().ok_or("Workspace not available")?;
 
     let results = ws
-        .search(&query, limit.unwrap_or(10))
+        .search(&query, memory_search_limit(limit))
         .await
         .map_err(|e| format!("Failed to search memory: {}", e))?;
 
     Ok(results
         .into_iter()
-        .map(|r| MemorySearchResult {
-            path: r.document_path,
-            content: r.content,
-            score: r.score,
-        })
+        .map(workspace_search_result_to_memory_search_result)
         .collect())
 }

--- a/desktop-client/src/ipc/memory_tests.rs
+++ b/desktop-client/src/ipc/memory_tests.rs
@@ -9,7 +9,51 @@
 
 #[cfg(test)]
 mod tests {
-    use crate::ipc::memory::{MemoryDocument, MemoryEntry, MemorySearchResult};
+    use chrono::{DateTime, Utc};
+    use ironclaw::workspace::{
+        MemoryDocument as WorkspaceMemoryDocument, SearchResult as WorkspaceSearchResult,
+        WorkspaceEntry,
+    };
+    use serde_json::json;
+    use uuid::Uuid;
+
+    use crate::ipc::memory::{
+        memory_list_path, memory_search_limit, workspace_document_to_memory_document,
+        workspace_entry_to_memory_entry, workspace_search_result_to_memory_search_result,
+        MemoryDocument, MemoryEntry, MemorySearchResult,
+    };
+
+    fn fixed_time() -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339("2026-06-03T10:11:12Z")
+            .expect("fixed timestamp should parse")
+            .with_timezone(&Utc)
+    }
+
+    fn workspace_document(path: &str, content: &str) -> WorkspaceMemoryDocument {
+        let timestamp = fixed_time();
+        WorkspaceMemoryDocument {
+            id: Uuid::new_v4(),
+            user_id: "user-1".into(),
+            agent_id: Some(Uuid::new_v4()),
+            path: path.into(),
+            content: content.into(),
+            created_at: timestamp,
+            updated_at: timestamp,
+            metadata: json!({"private": true}),
+        }
+    }
+
+    fn workspace_search_result(path: &str, content: &str) -> WorkspaceSearchResult {
+        WorkspaceSearchResult {
+            document_id: Uuid::new_v4(),
+            document_path: path.into(),
+            chunk_id: Uuid::new_v4(),
+            content: content.into(),
+            score: 0.75,
+            fts_rank: Some(1),
+            vector_rank: Some(2),
+        }
+    }
 
     // =========================================================================
     // 单元测试 — 正常路径
@@ -80,6 +124,69 @@ mod tests {
         let entry: MemoryEntry = serde_json::from_str(json).unwrap();
         assert_eq!(entry.name, "config.toml");
         assert!(entry.content_preview.is_none());
+    }
+
+    #[test]
+    fn req_memory_list_defaults_to_root_path() {
+        assert_eq!(memory_list_path(None), "/");
+        assert_eq!(memory_list_path(Some("/projects")), "/projects");
+    }
+
+    #[test]
+    fn req_memory_search_uses_default_limit() {
+        assert_eq!(memory_search_limit(None), 10);
+        assert_eq!(memory_search_limit(Some(3)), 3);
+        assert_eq!(memory_search_limit(Some(0)), 0);
+    }
+
+    #[test]
+    fn req_memory_list_maps_workspace_entries() {
+        let entry = WorkspaceEntry {
+            path: "/projects/alpha/README.md".into(),
+            is_directory: false,
+            updated_at: Some(fixed_time()),
+            content_preview: Some("# Alpha".into()),
+        };
+
+        let dto = workspace_entry_to_memory_entry(entry);
+
+        assert_eq!(dto.name, "README.md");
+        assert_eq!(dto.path, "/projects/alpha/README.md");
+        assert!(!dto.is_directory);
+        assert_eq!(dto.content_preview.as_deref(), Some("# Alpha"));
+    }
+
+    #[test]
+    fn req_memory_read_maps_workspace_document_without_internal_ids() {
+        let dto = workspace_document_to_memory_document(
+            "/notes/todo.md".into(),
+            workspace_document("/storage/internal.md", "ship memory coverage"),
+        );
+        let json = serde_json::to_string(&dto).expect("dto should serialize");
+
+        assert_eq!(dto.path, "/notes/todo.md");
+        assert_eq!(dto.content, "ship memory coverage");
+        assert_eq!(dto.updated_at.as_deref(), Some("2026-06-03T10:11:12+00:00"));
+        assert!(!json.contains("user_id"));
+        assert!(!json.contains("agent_id"));
+        assert!(!json.contains("metadata"));
+    }
+
+    #[test]
+    fn req_memory_search_maps_workspace_results_without_rank_ids() {
+        let dto = workspace_search_result_to_memory_search_result(workspace_search_result(
+            "/docs/api.md",
+            "memory search hit",
+        ));
+        let json = serde_json::to_string(&dto).expect("dto should serialize");
+
+        assert_eq!(dto.path, "/docs/api.md");
+        assert_eq!(dto.content, "memory search hit");
+        assert!((dto.score - 0.75).abs() < f32::EPSILON);
+        assert!(!json.contains("document_id"));
+        assert!(!json.contains("chunk_id"));
+        assert!(!json.contains("fts_rank"));
+        assert!(!json.contains("vector_rank"));
     }
 
     // =========================================================================

--- a/docs/INTEROP_DASCLAW.md
+++ b/docs/INTEROP_DASCLAW.md
@@ -1,0 +1,79 @@
+# claw-code → dasclaw_* interop map
+
+> **Status**: Documentation-only (B5 deliverable for Issue #911).
+> **Purpose**: Prove that the three lineages (codex / claw-code / ironclaw) already
+> compose on the GUI path by mapping every claw-code concept to its concrete
+> landing in the workspace `dasclaw_*` crates, with an executable reference at
+> [`crates/dasclaw_cli/examples/claw_code_interop.rs`](../crates/dasclaw_cli/examples/claw_code_interop.rs).
+>
+> **Location note (deviation from Issue #911 brief)**: the original task brief
+> placed this file at `claw-code/INTEROP_DASCLAW.md`, but `claw-code/` is a git
+> submodule in this workspace (see `.gitmodules`), so any file added there
+> would belong to a different repo. To honour the rule "do not modify the
+> claw-code source tree" while still satisfying the B5 grep contract from this
+> repo, the file lives at `docs/INTEROP_DASCLAW.md` and the e2e grep anchor
+> test reads it from that path.
+
+## Why this file exists
+
+Issue #911 closes the B5 gap from
+[`docs/plans/architecture-refactor/49-gui-readiness-assessment.md`](plans/architecture-refactor/49-gui-readiness-assessment.md)
+§5 / §9: "三库融合在 GUI 路径未端到端证明". Rather than re-implement claw-code's
+runtime, we show that its primitives are already absorbed into the dasclaw stack
+and can be driven from a single headless agent loop.
+
+## Mapping table
+
+| claw-code concept | dasclaw_* landing | 接入难度 |
+|---|---|---|
+| Headless agent loop (`runtime/agent.ts`) | [`dasclaw_runtime::Agent`](../crates/dasclaw_runtime/src/agent.rs) (`AgentResponder` + `ToolExecutor` + `HookBundle`) | trivial — already drives `dasclaw_cli`'s e2e tests |
+| `bash` tool gating ("Are you sure?" / refuse) | [`dasclaw_bash_validation`](../crates/dasclaw_bash_validation) (`validate_command`) wrapped by [`dasclaw_hooks::BashValidationHook`](../crates/dasclaw_hooks/src/bash_validation_hook.rs) (`EgressGate`) | trivial — `BashValidationHook::new(PermissionMode, workspace)` plugs into `HookBundle.egress` |
+| `apply_patch` tool (model emits `*** Begin Patch …`) | [`dasclaw_apply_patch::parse_patch`](../crates/dasclaw_apply_patch/src/parser.rs) + [`apply`](../crates/dasclaw_apply_patch/src/apply.rs) | trivial — pure function over `ApplyPatchArgs` and `ApplyOptions { base_dir }` |
+| Hook/event bus (BeforeToolCall / AfterToolCall) | [`dasclaw_hooks`](../crates/dasclaw_hooks) (`HookBundle` re-exports `EgressGate` from `dasclaw_core::hooks`, plus declarative `HookBundleConfig`) | trivial — the agent loop already calls `hooks.egress.check` before every tool dispatch |
+| 9-layer defence stack (sandbox / approval / secrets / audit) | `HookBundle { egress, sandbox, secrets, approval }` in [`dasclaw_core::hooks`](../crates/dasclaw_core/src/hooks.rs) | already wired — this PR only exercises the `egress` lane; sandbox/approval are out of scope for the demo |
+
+## Executable proof
+
+[`crates/dasclaw_cli/examples/claw_code_interop.rs`](../crates/dasclaw_cli/examples/claw_code_interop.rs)
+runs a scripted four-turn agent loop in a tempdir, in this order:
+
+1. Model calls `bash` with `rm -rf /` → `dasclaw_bash_validation` (via
+   `dasclaw_hooks::BashValidationHook`) blocks; executor is **never** invoked.
+2. Model calls `bash` with `ls` → gate allows; stub executor returns a fake
+   listing.
+3. Model calls `apply_patch` with an `*** Update File: hello.txt` hunk →
+   `dasclaw_apply_patch::{parse_patch, apply}` writes `world\n` into the
+   tempdir.
+4. Model emits final text `done` and the loop exits.
+
+The matching e2e test
+[`crates/dasclaw_cli/tests/claw_code_interop_e2e.rs`](../crates/dasclaw_cli/tests/claw_code_interop_e2e.rs)
+asserts the audit timeline, the rejection on step 1, the on-disk mutation on
+step 3, and that **this very file** contains the string anchors that prove the
+grep contract from Issue #911:
+`dasclaw_runtime`, `dasclaw_bash_validation`, `dasclaw_apply_patch`,
+`dasclaw_hooks`.
+
+## Non-goals (explicit)
+
+- We do not port claw-code source code into the workspace.
+- We do not execute real shell or real network; both lanes are stubbed in the
+  executor so the demo is hermetic and deterministic.
+- We do not wire `dasclaw_governance`'s 6-pack on this path — that is covered
+  by separate ADR-153 §1.1 B-series work, not B5.
+- `claw-code/`, `vendor/`, `codex-cli-main/` source trees stay untouched.
+
+## See also
+
+- Issue #911 (B5 — claw-code interop demo on GUI path)
+- [`docs/plans/architecture-refactor/49-gui-readiness-assessment.md`](plans/architecture-refactor/49-gui-readiness-assessment.md)
+  §5 (GUI readiness gaps) and §9 (B5 row)
+- ADR-153 §1.1 (B-series rollout for headless agent loop)
+- [`docs/plans/architecture-refactor/53-headless-agent-capability-design.md`](plans/architecture-refactor/53-headless-agent-capability-design.md)
+  (headless agent framework capability boundary; defines what is / is not part
+  of the headless library surface)
+- [`crates/dasclaw_runtime/README.md`](../crates/dasclaw_runtime/README.md)
+  (library-side getting-started for embedders) and
+  [`crates/dasclaw_cli/examples/headless_agent_starter.rs`](../crates/dasclaw_cli/examples/headless_agent_starter.rs)
+  (minimum runnable embed example covering responder + tool executor + approval
+  policy + event stream)


### PR DESCRIPTION
## 背景/目标

Closes #1025（memory command-helper coverage slice；完整 memory CRUD 真回环仍保留为后续工作）。

基于 desktop-client/docs/e2e-webdriver-test-plan.md §13 / §16.2，记忆命令族仍缺 IPC 覆盖。本 PR 先补确定性高、无需 WebDriver/真实 LLM 的 memory IPC helper 语义：默认目录、默认 search limit，以及 Workspace 返回类型到前端 DTO 的映射与内部字段不泄露。

## 改动范围

- 将 memory IPC 的 list/read/search DTO 映射与默认 limit 提取为生产 helper，命令路径复用同一套 helper。
- 在现有 memory_tests 中补 req_memory_* 测试，直接使用 ironclaw::workspace 的真实返回类型构造输入。
- 更新 e2e-webdriver-test-plan.md，将 memory 状态从“完全待补”调整为“helper 覆盖已补，真实 AppState + Workspace 回环仍待补”。

## 非目标（What’s NOT in this PR）

- 不新增真实 Tauri WebDriver 场景。
- 不构造完整 EngineState/AppState.workspace 夹具，不声称 memory CRUD 真回环已完成。
- 不触碰 skills/extensions/jobs/routines 等其他命令族。

## Sources read

- AGENTS.md §任务启动 4 问
- AGENTS.md §Skills 强制使用规范
- .github/instructions/code-quality.instructions.md §代码质量规范：禁止补丁式代码
- desktop-client/docs/e2e-webdriver-test-plan.md §13 IPC 命令覆盖矩阵
- desktop-client/docs/e2e-webdriver-test-plan.md §16.2 GA 缺口分类
- desktop-client/src/ipc/memory.rs（记忆 IPC 命令实现）
- desktop-client/src/ipc/memory_tests.rs（记忆 IPC 现有测试）
- desktop-client/ironclaw/src/workspace/mod.rs（Workspace list/read/search 返回类型）
- crates/dasclaw_workspace_cap/src/document.rs（MemoryDocument / WorkspaceEntry 字段）
- crates/dasclaw_workspace_cap/src/search.rs（SearchResult 字段）

## Cross-cuts

- ADR-114: 类A 无新增 .ironclaw / IRONCLAW_BASE_DIR 字面量

## 验证（命令 + 结果）

- cargo fmt --package desktop-client — pass
- cargo check -p desktop-client --tests — pass
- cargo nextest run -p desktop-client -E 'test(/memory/)' — 31 passed, 821 skipped
- python3.12 scripts/check_no_panics.py --base origin/xClaw — pass
- git diff --check — pass
- cargo clippy --no-deps -p desktop-client --all-targets -- -D warnings — blocked by pre-existing untouched warnings in auth_token_manager.rs, dlp/sanitizer.rs, data_reporter.rs, engine.rs, ipc/chat.rs, managed_policy.rs, state.rs, lib.rs

## 后续 PR / 下一步

- 补 memory CRUD 的真实 AppState + Workspace 命令级回环。
- 继续推进 skills/extensions/jobs 等剩余 #1025 命令族覆盖。