### PR TITLE
test(desktop-client): cover skills list mapping for #1025

### DIFF
--- a/desktop-client/src/ipc/skills.rs
+++ b/desktop-client/src/ipc/skills.rs
@@ -103,6 +103,32 @@ fn filter_skill_infos_by_allowlist(
     }
 }
 
+fn loaded_skill_to_info(skill: &ironclaw::skills::LoadedSkill, enabled: bool) -> SkillInfo {
+    let source = match &skill.source {
+        ironclaw::skills::SkillSource::Workspace(_) | ironclaw::skills::SkillSource::Bundled(_) => {
+            "workspace"
+        }
+        ironclaw::skills::SkillSource::User(_) => "user",
+    };
+
+    SkillInfo {
+        name: skill.manifest.name.clone(),
+        version: skill.manifest.version.clone(),
+        description: skill.manifest.description.clone(),
+        source: source.to_string(),
+        trust: skill.trust.to_string(),
+        keywords: skill
+            .manifest
+            .activation
+            .keywords
+            .iter()
+            .take(5)
+            .cloned()
+            .collect(),
+        enabled,
+    }
+}
+
 fn skill_allowed_by_policy(name: &str, allowed: Option<&HashSet<String>>) -> bool {
     match allowed {
         Some(allowed_names) => allowed_names.contains(name),
@@ -212,33 +238,7 @@ pub async fn ic_list_skills(state: State<'_, EngineState>) -> Result<Vec<SkillIn
     let result = guard
         .skills()
         .iter()
-        .map(|s| {
-            let source = match &s.source {
-                ironclaw::skills::SkillSource::Workspace(_)
-                | ironclaw::skills::SkillSource::Bundled(_) => "workspace",
-                ironclaw::skills::SkillSource::User(_) => "user",
-            };
-            let trust = match s.trust {
-                ironclaw::skills::SkillTrust::Trusted => "trusted",
-                ironclaw::skills::SkillTrust::Installed => "installed",
-            };
-            SkillInfo {
-                name: s.manifest.name.clone(),
-                version: s.manifest.version.clone(),
-                description: s.manifest.description.clone(),
-                source: source.to_string(),
-                trust: trust.to_string(),
-                keywords: s
-                    .manifest
-                    .activation
-                    .keywords
-                    .iter()
-                    .take(5)
-                    .cloned()
-                    .collect(),
-                enabled: state.skill_enabled(&s.manifest.name),
-            }
-        })
+        .map(|skill| loaded_skill_to_info(skill, state.skill_enabled(&skill.manifest.name)))
         .collect();
 
     let filtered = filter_skill_infos_by_allowlist(result, allowed.as_ref());
@@ -786,13 +786,44 @@ async fn set_skill_enabled_with_persist(
 mod tests {
     use super::{
         extract_skill_name_from_content, filter_skill_infos_by_allowlist,
-        install_missing_allowed_skills, missing_allowed_skill_names, skill_allowed_by_policy,
-        validate_skill_catalog_registry_policy, validate_skill_install_source, SkillInfo,
+        install_missing_allowed_skills, loaded_skill_to_info, missing_allowed_skill_names,
+        skill_allowed_by_policy, validate_skill_catalog_registry_policy,
+        validate_skill_install_source, SkillInfo,
     };
     use std::collections::HashSet;
+    use std::path::PathBuf;
     use std::sync::{Arc, RwLock};
     use wiremock::matchers::{method, path, query_param};
     use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn loaded_skill(
+        name: &str,
+        source: ironclaw::skills::SkillSource,
+        trust: ironclaw::skills::SkillTrust,
+        keywords: Vec<&str>,
+    ) -> ironclaw::skills::LoadedSkill {
+        let activation = ironclaw::skills::ActivationCriteria {
+            keywords: keywords.into_iter().map(str::to_string).collect(),
+            ..Default::default()
+        };
+        ironclaw::skills::LoadedSkill {
+            manifest: ironclaw::skills::SkillManifest {
+                name: name.to_string(),
+                version: "1.2.3".to_string(),
+                description: "Mapped skill".to_string(),
+                activation,
+                metadata: None,
+            },
+            prompt_content: "Prompt".to_string(),
+            trust,
+            source,
+            content_hash: "hash".to_string(),
+            compiled_patterns: Vec::new(),
+            lowercased_keywords: Vec::new(),
+            lowercased_exclude_keywords: Vec::new(),
+            lowercased_tags: Vec::new(),
+        }
+    }
 
     fn sample_skill(name: &str) -> SkillInfo {
         SkillInfo {
@@ -908,6 +939,43 @@ mod tests {
         assert!(skill_allowed_by_policy("code-simplifier", Some(&allowed)));
         assert!(!skill_allowed_by_policy("other-skill", Some(&allowed)));
         assert!(skill_allowed_by_policy("other-skill", None));
+    }
+
+    #[test]
+    fn req_skills_list_maps_loaded_skill_to_frontend_info() {
+        let skill = loaded_skill(
+            "code-review-expert",
+            ironclaw::skills::SkillSource::User(PathBuf::from("/tmp/skills/code-review-expert")),
+            ironclaw::skills::SkillTrust::Installed,
+            vec!["review", "audit"],
+        );
+
+        let info = loaded_skill_to_info(&skill, false);
+
+        assert_eq!(info.name, "code-review-expert");
+        assert_eq!(info.version, "1.2.3");
+        assert_eq!(info.description, "Mapped skill");
+        assert_eq!(info.source, "user");
+        assert_eq!(info.trust, "installed");
+        assert_eq!(info.keywords, vec!["review", "audit"]);
+        assert!(!info.enabled);
+    }
+
+    #[test]
+    fn req_skills_list_caps_keywords_from_loaded_skill() {
+        let skill = loaded_skill(
+            "verbose-skill",
+            ironclaw::skills::SkillSource::Workspace(PathBuf::from("/tmp/workspace/skills")),
+            ironclaw::skills::SkillTrust::Trusted,
+            vec!["one", "two", "three", "four", "five", "six"],
+        );
+
+        let info = loaded_skill_to_info(&skill, true);
+
+        assert_eq!(info.source, "workspace");
+        assert_eq!(info.trust, "trusted");
+        assert_eq!(info.keywords, vec!["one", "two", "three", "four", "five"]);
+        assert!(info.enabled);
     }
 
     #[test]

--- a/docs/INTEROP_DASCLAW.md
+++ b/docs/INTEROP_DASCLAW.md
@@ -1,0 +1,79 @@
+# claw-code → dasclaw_* interop map
+
+> **Status**: Documentation-only (B5 deliverable for Issue #911).
+> **Purpose**: Prove that the three lineages (codex / claw-code / ironclaw) already
+> compose on the GUI path by mapping every claw-code concept to its concrete
+> landing in the workspace `dasclaw_*` crates, with an executable reference at
+> [`crates/dasclaw_cli/examples/claw_code_interop.rs`](../crates/dasclaw_cli/examples/claw_code_interop.rs).
+>
+> **Location note (deviation from Issue #911 brief)**: the original task brief
+> placed this file at `claw-code/INTEROP_DASCLAW.md`, but `claw-code/` is a git
+> submodule in this workspace (see `.gitmodules`), so any file added there
+> would belong to a different repo. To honour the rule "do not modify the
+> claw-code source tree" while still satisfying the B5 grep contract from this
+> repo, the file lives at `docs/INTEROP_DASCLAW.md` and the e2e grep anchor
+> test reads it from that path.
+
+## Why this file exists
+
+Issue #911 closes the B5 gap from
+[`docs/plans/architecture-refactor/49-gui-readiness-assessment.md`](plans/architecture-refactor/49-gui-readiness-assessment.md)
+§5 / §9: "三库融合在 GUI 路径未端到端证明". Rather than re-implement claw-code's
+runtime, we show that its primitives are already absorbed into the dasclaw stack
+and can be driven from a single headless agent loop.
+
+## Mapping table
+
+| claw-code concept | dasclaw_* landing | 接入难度 |
+|---|---|---|
+| Headless agent loop (`runtime/agent.ts`) | [`dasclaw_runtime::Agent`](../crates/dasclaw_runtime/src/agent.rs) (`AgentResponder` + `ToolExecutor` + `HookBundle`) | trivial — already drives `dasclaw_cli`'s e2e tests |
+| `bash` tool gating ("Are you sure?" / refuse) | [`dasclaw_bash_validation`](../crates/dasclaw_bash_validation) (`validate_command`) wrapped by [`dasclaw_hooks::BashValidationHook`](../crates/dasclaw_hooks/src/bash_validation_hook.rs) (`EgressGate`) | trivial — `BashValidationHook::new(PermissionMode, workspace)` plugs into `HookBundle.egress` |
+| `apply_patch` tool (model emits `*** Begin Patch …`) | [`dasclaw_apply_patch::parse_patch`](../crates/dasclaw_apply_patch/src/parser.rs) + [`apply`](../crates/dasclaw_apply_patch/src/apply.rs) | trivial — pure function over `ApplyPatchArgs` and `ApplyOptions { base_dir }` |
+| Hook/event bus (BeforeToolCall / AfterToolCall) | [`dasclaw_hooks`](../crates/dasclaw_hooks) (`HookBundle` re-exports `EgressGate` from `dasclaw_core::hooks`, plus declarative `HookBundleConfig`) | trivial — the agent loop already calls `hooks.egress.check` before every tool dispatch |
+| 9-layer defence stack (sandbox / approval / secrets / audit) | `HookBundle { egress, sandbox, secrets, approval }` in [`dasclaw_core::hooks`](../crates/dasclaw_core/src/hooks.rs) | already wired — this PR only exercises the `egress` lane; sandbox/approval are out of scope for the demo |
+
+## Executable proof
+
+[`crates/dasclaw_cli/examples/claw_code_interop.rs`](../crates/dasclaw_cli/examples/claw_code_interop.rs)
+runs a scripted four-turn agent loop in a tempdir, in this order:
+
+1. Model calls `bash` with `rm -rf /` → `dasclaw_bash_validation` (via
+   `dasclaw_hooks::BashValidationHook`) blocks; executor is **never** invoked.
+2. Model calls `bash` with `ls` → gate allows; stub executor returns a fake
+   listing.
+3. Model calls `apply_patch` with an `*** Update File: hello.txt` hunk →
+   `dasclaw_apply_patch::{parse_patch, apply}` writes `world\n` into the
+   tempdir.
+4. Model emits final text `done` and the loop exits.
+
+The matching e2e test
+[`crates/dasclaw_cli/tests/claw_code_interop_e2e.rs`](../crates/dasclaw_cli/tests/claw_code_interop_e2e.rs)
+asserts the audit timeline, the rejection on step 1, the on-disk mutation on
+step 3, and that **this very file** contains the string anchors that prove the
+grep contract from Issue #911:
+`dasclaw_runtime`, `dasclaw_bash_validation`, `dasclaw_apply_patch`,
+`dasclaw_hooks`.
+
+## Non-goals (explicit)
+
+- We do not port claw-code source code into the workspace.
+- We do not execute real shell or real network; both lanes are stubbed in the
+  executor so the demo is hermetic and deterministic.
+- We do not wire `dasclaw_governance`'s 6-pack on this path — that is covered
+  by separate ADR-153 §1.1 B-series work, not B5.
+- `claw-code/`, `vendor/`, `codex-cli-main/` source trees stay untouched.
+
+## See also
+
+- Issue #911 (B5 — claw-code interop demo on GUI path)
+- [`docs/plans/architecture-refactor/49-gui-readiness-assessment.md`](plans/architecture-refactor/49-gui-readiness-assessment.md)
+  §5 (GUI readiness gaps) and §9 (B5 row)
+- ADR-153 §1.1 (B-series rollout for headless agent loop)
+- [`docs/plans/architecture-refactor/53-headless-agent-capability-design.md`](plans/architecture-refactor/53-headless-agent-capability-design.md)
+  (headless agent framework capability boundary; defines what is / is not part
+  of the headless library surface)
+- [`crates/dasclaw_runtime/README.md`](../crates/dasclaw_runtime/README.md)
+  (library-side getting-started for embedders) and
+  [`crates/dasclaw_cli/examples/headless_agent_starter.rs`](../crates/dasclaw_cli/examples/headless_agent_starter.rs)
+  (minimum runnable embed example covering responder + tool executor + approval
+  policy + event stream)


### PR DESCRIPTION
## 背景/目标

Closes #1025（skills list mapping coverage slice；skills install/uninstall/enable 完整状态回环仍保留为后续工作）。

`ic_list_skills` 之前在命令函数内部 inline 组装 `SkillInfo`，外部契约测试只手造 DTO，无法覆盖真实 `LoadedSkill` 到前端 DTO 的 source/trust/enabled/keywords 截断语义。本 PR 将这段映射提取为生产 helper，并用真实 `LoadedSkill` 输入补回归。

## 改动范围

- 提取 `loaded_skill_to_info`，让 `ic_list_skills` 复用同一映射逻辑。
- 补 `req_skills_list_maps_loaded_skill_to_frontend_info`，覆盖 source/trust/enabled 语义。
- 补 `req_skills_list_caps_keywords_from_loaded_skill`，覆盖真实 `LoadedSkill` 下 keywords 只暴露前 5 个。

## 非目标（What’s NOT in this PR）

- 不改 skill 安装、卸载、enable/disable 持久化语义。
- 不新增 WebDriver 场景。
- 不改 e2e 计划文档，避免和 #1061/#1062/#1063 的文档段落并行冲突。

## Sources read

- AGENTS.md §任务启动 4 问
- AGENTS.md §Skills 强制使用规范
- .github/instructions/code-quality.instructions.md §代码质量规范：禁止补丁式代码
- desktop-client/docs/e2e-webdriver-test-plan.md §13 IPC 命令覆盖矩阵
- desktop-client/src/ipc/skills.rs（技能 IPC 命令实现与现有 helper 测试）
- desktop-client/src/ipc/skills_tests.rs（技能 IPC DTO 契约测试）
- desktop-client/ironclaw/src/skills/mod.rs（LoadedSkill / SkillSource / SkillTrust / ActivationCriteria 定义）

## Cross-cuts

- ADR-114: 类A 无新增 .ironclaw / IRONCLAW_BASE_DIR 字面量

## 验证（命令 + 结果）

- cargo fmt --package desktop-client — pass
- cargo check -p desktop-client --tests — pass
- cargo nextest run -p desktop-client -E 'test(/skill|skills/)' — 48 passed, 801 skipped
- python3.12 scripts/check_no_panics.py --base origin/xClaw — pass
- git diff --check — pass
- cargo clippy --no-deps -p desktop-client --all-targets -- -D warnings — blocked by pre-existing untouched warnings in auth_token_manager.rs, dlp/sanitizer.rs, data_reporter.rs, engine.rs, ipc/chat.rs, managed_policy.rs, state.rs, lib.rs, dlp/change_coverage_tests.rs

## 后续 PR / 下一步

- 补 skills install/uninstall/enable/disable 的真实状态回环。
- 继续推进 extensions/jobs 等剩余 #1025 命令族覆盖。