### PR TITLE
test(desktop-client): cover extension IPC helpers for #1025

### DIFF
--- a/desktop-client/src/ipc/extensions.rs
+++ b/desktop-client/src/ipc/extensions.rs
@@ -8,6 +8,8 @@ use tauri::State;
 use super::persistence::{load_string_set, persist_disabled_items};
 use crate::managed_policy::load_verified_policy_from_store;
 use crate::state::{AppState, EngineState};
+use ironclaw::channels::web::types::SetupFieldInfo;
+use ironclaw::extensions::{ConfigureResult, InstalledExtension, SearchResult};
 
 const DISABLED_EXTENSIONS_SETTING_KEY: &str = "desktop_disabled_extensions";
 const MANAGED_ALLOWED_EXTENSIONS_SETTING_KEY: &str = "desktop_managed_allowed_extensions";
@@ -48,6 +50,52 @@ fn validate_extension_install_source(managed_mode: bool, url: Option<&str>) -> R
         );
     }
     Ok(())
+}
+
+fn installed_extension_to_info(
+    extension: InstalledExtension,
+    is_soft_enabled: bool,
+) -> ExtensionInfo {
+    ExtensionInfo {
+        name: extension.name,
+        display_name: extension.display_name,
+        kind: extension.kind.to_string(),
+        installed: extension.installed,
+        active: effective_active(extension.active, is_soft_enabled),
+        authenticated: extension.authenticated,
+        tools: extension.tools,
+    }
+}
+
+fn setup_field_to_response_field(field: SetupFieldInfo) -> ExtensionSetupField {
+    ExtensionSetupField {
+        name: field.name,
+        prompt: field.prompt,
+        optional: field.optional,
+        provided: field.provided,
+        input_type: format!("{:?}", field.input_type),
+    }
+}
+
+fn setup_submit_response_from_result(result: ConfigureResult) -> ExtensionSetupSubmitResponse {
+    ExtensionSetupSubmitResponse {
+        success: result.activated || result.verification.is_some(),
+        message: result.message,
+        activated: result.activated,
+        auth_url: result.auth_url,
+    }
+}
+
+fn search_result_to_info(result: SearchResult) -> ExtensionInfo {
+    ExtensionInfo {
+        name: result.entry.name,
+        display_name: Some(result.entry.display_name),
+        kind: result.entry.kind.to_string(),
+        installed: false,
+        active: false,
+        authenticated: false,
+        tools: Vec::new(),
+    }
 }
 
 async fn ensure_extension_allowed_in_managed_mode(
@@ -100,14 +148,9 @@ pub async fn ic_list_extensions(
 
     Ok(extensions
         .into_iter()
-        .map(|e| ExtensionInfo {
-            name: e.name.clone(),
-            display_name: e.display_name.clone(),
-            kind: format!("{}", e.kind),
-            installed: e.installed,
-            active: effective_active(e.active, state.extension_enabled(&e.name)),
-            authenticated: e.authenticated,
-            tools: e.tools.clone(),
+        .map(|extension| {
+            let is_soft_enabled = state.extension_enabled(&extension.name);
+            installed_extension_to_info(extension, is_soft_enabled)
         })
         .collect())
 }
@@ -273,13 +316,7 @@ pub async fn ic_extension_setup(
     let fields: Vec<ExtensionSetupField> = secrets
         .fields
         .into_iter()
-        .map(|s| ExtensionSetupField {
-            name: s.name,
-            prompt: s.prompt,
-            optional: s.optional,
-            provided: s.provided,
-            input_type: format!("{:?}", s.input_type),
-        })
+        .map(setup_field_to_response_field)
         .collect();
 
     tracing::debug!(extension = %name, fields = fields.len(), "Extension setup schema loaded");
@@ -322,12 +359,7 @@ pub async fn ic_extension_setup_submit(
         "Extension configured"
     );
 
-    Ok(ExtensionSetupSubmitResponse {
-        success: result.activated || result.verification.is_some(),
-        message: result.message,
-        activated: result.activated,
-        auth_url: result.auth_url,
-    })
+    Ok(setup_submit_response_from_result(result))
 }
 
 /// 搜索扩展。
@@ -347,18 +379,7 @@ pub async fn ic_search_extensions(
         .await
         .map_err(|e| format!("Failed to search extensions: {}", e))?;
 
-    Ok(results
-        .into_iter()
-        .map(|r| ExtensionInfo {
-            name: r.entry.name.clone(),
-            display_name: Some(r.entry.display_name.clone()),
-            kind: format!("{}", r.entry.kind),
-            installed: false,
-            active: false,
-            authenticated: false,
-            tools: Vec::new(),
-        })
-        .collect())
+    Ok(results.into_iter().map(search_result_to_info).collect())
 }
 
 async fn ensure_extension_installed(state: &AppState, name: &str) -> Result<(), String> {
@@ -434,8 +455,9 @@ mod tests {
     use std::sync::Arc;
 
     use super::{
-        effective_active, extension_name_exists, set_extension_enabled_with_persist,
-        validate_extension_install_source,
+        effective_active, extension_name_exists, installed_extension_to_info,
+        search_result_to_info, set_extension_enabled_with_persist, setup_field_to_response_field,
+        setup_submit_response_from_result, validate_extension_install_source,
     };
     use crate::safety_bridge::SafetyBridge;
     use crate::state::AppState;
@@ -563,6 +585,110 @@ mod tests {
         assert!(!effective_active(true, false));
         assert!(!effective_active(false, true));
         assert!(!effective_active(false, false));
+    }
+
+    #[test]
+    fn req_extensions_list_mapping_combines_runtime_and_soft_enable() {
+        let extension = ironclaw::extensions::InstalledExtension {
+            name: "github".to_string(),
+            kind: ironclaw::extensions::ExtensionKind::McpServer,
+            display_name: Some("GitHub".to_string()),
+            description: Some("GitHub MCP".to_string()),
+            url: Some("https://mcp.example.com".to_string()),
+            authenticated: true,
+            active: true,
+            tools: vec!["repo_search".to_string()],
+            needs_setup: true,
+            has_auth: true,
+            installed: true,
+            activation_error: Some("transient".to_string()),
+            version: Some("1.2.3".to_string()),
+        };
+
+        let info = installed_extension_to_info(extension, false);
+
+        assert_eq!(info.name, "github");
+        assert_eq!(info.display_name.as_deref(), Some("GitHub"));
+        assert_eq!(info.kind, "mcp_server");
+        assert!(info.installed);
+        assert!(
+            !info.active,
+            "soft-disabled extensions must render inactive"
+        );
+        assert!(info.authenticated);
+        assert_eq!(info.tools, vec!["repo_search".to_string()]);
+    }
+
+    #[test]
+    fn req_extensions_search_mapping_marks_results_available_not_installed() {
+        let result = ironclaw::extensions::SearchResult {
+            entry: ironclaw::extensions::RegistryEntry {
+                name: "slack".to_string(),
+                display_name: "Slack".to_string(),
+                kind: ironclaw::extensions::ExtensionKind::ChannelRelay,
+                description: "Team messages".to_string(),
+                keywords: vec!["chat".to_string()],
+                source: ironclaw::extensions::ExtensionSource::ChannelRelay {
+                    relay_url: "https://relay.example.com".to_string(),
+                },
+                fallback_source: None,
+                auth_hint: ironclaw::extensions::AuthHint::ChannelRelayOAuth,
+                version: Some("0.3.0".to_string()),
+            },
+            source: ironclaw::extensions::ResultSource::Registry,
+            validated: true,
+        };
+
+        let info = search_result_to_info(result);
+
+        assert_eq!(info.name, "slack");
+        assert_eq!(info.display_name.as_deref(), Some("Slack"));
+        assert_eq!(info.kind, "channel_relay");
+        assert!(!info.installed);
+        assert!(!info.active);
+        assert!(!info.authenticated);
+        assert!(info.tools.is_empty());
+    }
+
+    #[test]
+    fn req_extensions_setup_field_mapping_preserves_prompt_state() {
+        let field = ironclaw::channels::web::types::SetupFieldInfo {
+            name: "api_key".to_string(),
+            prompt: "API key".to_string(),
+            optional: false,
+            provided: true,
+            input_type: ironclaw::tools::wasm::ToolSetupFieldInputType::Password,
+        };
+
+        let response_field = setup_field_to_response_field(field);
+
+        assert_eq!(response_field.name, "api_key");
+        assert_eq!(response_field.prompt, "API key");
+        assert!(!response_field.optional);
+        assert!(response_field.provided);
+        assert_eq!(response_field.input_type, "Password");
+    }
+
+    #[test]
+    fn req_extensions_setup_submit_succeeds_for_manual_verification() {
+        let result = ironclaw::extensions::ConfigureResult {
+            message: "Verification required".to_string(),
+            activated: false,
+            restart_required: false,
+            auth_url: None,
+            verification: Some(ironclaw::extensions::VerificationChallenge {
+                code: "ABC123".to_string(),
+                instructions: "Send this code".to_string(),
+                deep_link: None,
+            }),
+        };
+
+        let response = setup_submit_response_from_result(result);
+
+        assert!(response.success);
+        assert_eq!(response.message, "Verification required");
+        assert!(!response.activated);
+        assert!(response.auth_url.is_none());
     }
 
     #[tokio::test]

--- a/docs/INTEROP_DASCLAW.md
+++ b/docs/INTEROP_DASCLAW.md
@@ -1,0 +1,79 @@
+# claw-code → dasclaw_* interop map
+
+> **Status**: Documentation-only (B5 deliverable for Issue #911).
+> **Purpose**: Prove that the three lineages (codex / claw-code / ironclaw) already
+> compose on the GUI path by mapping every claw-code concept to its concrete
+> landing in the workspace `dasclaw_*` crates, with an executable reference at
+> [`crates/dasclaw_cli/examples/claw_code_interop.rs`](../crates/dasclaw_cli/examples/claw_code_interop.rs).
+>
+> **Location note (deviation from Issue #911 brief)**: the original task brief
+> placed this file at `claw-code/INTEROP_DASCLAW.md`, but `claw-code/` is a git
+> submodule in this workspace (see `.gitmodules`), so any file added there
+> would belong to a different repo. To honour the rule "do not modify the
+> claw-code source tree" while still satisfying the B5 grep contract from this
+> repo, the file lives at `docs/INTEROP_DASCLAW.md` and the e2e grep anchor
+> test reads it from that path.
+
+## Why this file exists
+
+Issue #911 closes the B5 gap from
+[`docs/plans/architecture-refactor/49-gui-readiness-assessment.md`](plans/architecture-refactor/49-gui-readiness-assessment.md)
+§5 / §9: "三库融合在 GUI 路径未端到端证明". Rather than re-implement claw-code's
+runtime, we show that its primitives are already absorbed into the dasclaw stack
+and can be driven from a single headless agent loop.
+
+## Mapping table
+
+| claw-code concept | dasclaw_* landing | 接入难度 |
+|---|---|---|
+| Headless agent loop (`runtime/agent.ts`) | [`dasclaw_runtime::Agent`](../crates/dasclaw_runtime/src/agent.rs) (`AgentResponder` + `ToolExecutor` + `HookBundle`) | trivial — already drives `dasclaw_cli`'s e2e tests |
+| `bash` tool gating ("Are you sure?" / refuse) | [`dasclaw_bash_validation`](../crates/dasclaw_bash_validation) (`validate_command`) wrapped by [`dasclaw_hooks::BashValidationHook`](../crates/dasclaw_hooks/src/bash_validation_hook.rs) (`EgressGate`) | trivial — `BashValidationHook::new(PermissionMode, workspace)` plugs into `HookBundle.egress` |
+| `apply_patch` tool (model emits `*** Begin Patch …`) | [`dasclaw_apply_patch::parse_patch`](../crates/dasclaw_apply_patch/src/parser.rs) + [`apply`](../crates/dasclaw_apply_patch/src/apply.rs) | trivial — pure function over `ApplyPatchArgs` and `ApplyOptions { base_dir }` |
+| Hook/event bus (BeforeToolCall / AfterToolCall) | [`dasclaw_hooks`](../crates/dasclaw_hooks) (`HookBundle` re-exports `EgressGate` from `dasclaw_core::hooks`, plus declarative `HookBundleConfig`) | trivial — the agent loop already calls `hooks.egress.check` before every tool dispatch |
+| 9-layer defence stack (sandbox / approval / secrets / audit) | `HookBundle { egress, sandbox, secrets, approval }` in [`dasclaw_core::hooks`](../crates/dasclaw_core/src/hooks.rs) | already wired — this PR only exercises the `egress` lane; sandbox/approval are out of scope for the demo |
+
+## Executable proof
+
+[`crates/dasclaw_cli/examples/claw_code_interop.rs`](../crates/dasclaw_cli/examples/claw_code_interop.rs)
+runs a scripted four-turn agent loop in a tempdir, in this order:
+
+1. Model calls `bash` with `rm -rf /` → `dasclaw_bash_validation` (via
+   `dasclaw_hooks::BashValidationHook`) blocks; executor is **never** invoked.
+2. Model calls `bash` with `ls` → gate allows; stub executor returns a fake
+   listing.
+3. Model calls `apply_patch` with an `*** Update File: hello.txt` hunk →
+   `dasclaw_apply_patch::{parse_patch, apply}` writes `world\n` into the
+   tempdir.
+4. Model emits final text `done` and the loop exits.
+
+The matching e2e test
+[`crates/dasclaw_cli/tests/claw_code_interop_e2e.rs`](../crates/dasclaw_cli/tests/claw_code_interop_e2e.rs)
+asserts the audit timeline, the rejection on step 1, the on-disk mutation on
+step 3, and that **this very file** contains the string anchors that prove the
+grep contract from Issue #911:
+`dasclaw_runtime`, `dasclaw_bash_validation`, `dasclaw_apply_patch`,
+`dasclaw_hooks`.
+
+## Non-goals (explicit)
+
+- We do not port claw-code source code into the workspace.
+- We do not execute real shell or real network; both lanes are stubbed in the
+  executor so the demo is hermetic and deterministic.
+- We do not wire `dasclaw_governance`'s 6-pack on this path — that is covered
+  by separate ADR-153 §1.1 B-series work, not B5.
+- `claw-code/`, `vendor/`, `codex-cli-main/` source trees stay untouched.
+
+## See also
+
+- Issue #911 (B5 — claw-code interop demo on GUI path)
+- [`docs/plans/architecture-refactor/49-gui-readiness-assessment.md`](plans/architecture-refactor/49-gui-readiness-assessment.md)
+  §5 (GUI readiness gaps) and §9 (B5 row)
+- ADR-153 §1.1 (B-series rollout for headless agent loop)
+- [`docs/plans/architecture-refactor/53-headless-agent-capability-design.md`](plans/architecture-refactor/53-headless-agent-capability-design.md)
+  (headless agent framework capability boundary; defines what is / is not part
+  of the headless library surface)
+- [`crates/dasclaw_runtime/README.md`](../crates/dasclaw_runtime/README.md)
+  (library-side getting-started for embedders) and
+  [`crates/dasclaw_cli/examples/headless_agent_starter.rs`](../crates/dasclaw_cli/examples/headless_agent_starter.rs)
+  (minimum runnable embed example covering responder + tool executor + approval
+  policy + event stream)


### PR DESCRIPTION
## 背景/目标

Closes #1025（extensions command-helper coverage slice；完整 extensions install/enable/setup 真回环仍保留为后续工作）。

`ic_list_extensions`、`ic_search_extensions`、`ic_extension_setup` 和 `ic_extension_setup_submit` 之前在命令函数内部 inline 组装前端 DTO，外部契约测试主要手造 DTO，无法覆盖真实 IronClaw 类型到 desktop-client IPC 响应的生产映射语义。本 PR 将这些映射提取为 production helper，并补确定性单元测试覆盖 active 合成、搜索结果、setup 字段和 manual verification success 判定。

## 改动范围

- 提取 `installed_extension_to_info`，让 `ic_list_extensions` 复用 runtime active + desktop soft-enable 的同一映射逻辑。
- 提取 `search_result_to_info`，让 `ic_search_extensions` 复用 registry search result 到可安装扩展 DTO 的映射。
- 提取 `setup_field_to_response_field` 与 `setup_submit_response_from_result`，覆盖 setup schema 和 verification pending 仍算 success 的命令语义。
- 在现有 `extensions.rs` 测试模块中补 `req_extensions_*` 测试，直接使用真实 `ironclaw::extensions` / `channels::web::types` 输入。

## 非目标（What’s NOT in this PR）

- 不新增 WebDriver 场景。
- 不构造完整 `ExtensionManager` / `EngineState` 真回环夹具，不声称 extension install/enable/setup 端到端已完成。
- 不触碰 jobs/skills/memory/routines 等其他命令族。
- 不更新 e2e 计划文档，避免和并行 #1025 文档切片冲突。

## Sources read

- AGENTS.md §任务启动 4 问
- AGENTS.md §Skills 强制使用规范
- .github/instructions/code-quality.instructions.md §代码质量规范：禁止补丁式代码
- desktop-client/docs/e2e-webdriver-test-plan.md §13 IPC 命令覆盖矩阵
- desktop-client/src/ipc/extensions.rs（扩展 IPC 命令实现与现有 helper 测试）
- desktop-client/src/ipc/extensions_tests.rs（扩展 IPC DTO 契约测试）
- desktop-client/ironclaw/src/extensions/mod.rs（InstalledExtension / SearchResult / ConfigureResult 定义）
- desktop-client/ironclaw/src/extensions/manager.rs（ExtensionSetupSchema 定义）
- desktop-client/ironclaw/src/channels/web/types.rs（SetupFieldInfo 定义）
- desktop-client/ironclaw/src/tools/wasm/mod.rs（ToolSetupFieldInputType re-export）

## Skill / graph 自查

- code-quality-audit：通过；无补丁式特判、无生产 `unwrap()` / `clone()` 新增，测试直接使用真实 IronClaw 类型。
- code-simplifier：通过；helper 边界清晰，未合并不同命令语义。
- code-review-graph：`detect_changes` 风险 0.50，关键实体为 `ic_list_extensions` / `ic_search_extensions` / `ic_extension_setup_submit`；无新增 affected flow。
- `code-review-expert` skill 文件在当前仓库未找到；已用 code-review-graph change-aware review 替代本轮自审。

## Cross-cuts

- ADR-114: 类A 无新增 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量

## 验证（命令 + 结果）

- `cargo fmt -p desktop-client` — pass
- `cargo check -p desktop-client --tests` — pass
- `cargo nextest run -p desktop-client -E 'test(req_extensions) | test(test_validate_extension_install_source) | test(test_disable_extension_rollback_when_persist_fails) | test(test_enable_extension_rollback_when_persist_fails)'` — 9 passed, 842 skipped
- `python3.12 scripts/check_no_panics.py --base origin/xClaw` — pass
- `git diff --check -- desktop-client/src/ipc/extensions.rs` — pass
- `cargo clippy --no-deps -p desktop-client --all-targets -- -D warnings` — blocked by pre-existing untouched warnings in `auth_token_manager.rs`, `dlp/sanitizer.rs`, `data_reporter.rs`, `engine.rs`, `ipc/chat.rs`, `managed_policy.rs`, `state.rs`, `lib.rs`

## 后续 PR / 下一步

- 补 extensions install/enable/disable/setup 的真实状态回环。
- 继续推进 jobs 等剩余 #1025 命令族覆盖。
