### PR TITLE
test(desktop-client): cover jobs IPC helpers for #1025

### DIFF
--- a/desktop-client/src/ipc/jobs.rs
+++ b/desktop-client/src/ipc/jobs.rs
@@ -9,7 +9,9 @@ use uuid::Uuid;
 
 use crate::state::EngineState;
 use crate::vercel_ui_protocol::VercelUIStream;
-use dasclaw_runtime::JobState;
+use dasclaw_runtime::{context::JobContext, JobState};
+use ironclaw::channels::IncomingMessage;
+use ironclaw::history::{AgentJobRecord, JobEventRecord};
 
 // ─── 数据类型 ────────────────────────────────────────────────────────
 
@@ -120,7 +122,7 @@ fn emit_job_status(app_handle: &AppHandle, job_id: Uuid, title: &str, status: &s
     let _ = crate::tauri_channel::emit_chat_stream(app_handle, None, &event);
 }
 
-fn restart_job_title(job: &dasclaw_runtime::context::JobContext, failure_reason: &str) -> String {
+fn restart_job_title(job: &JobContext, failure_reason: &str) -> String {
     if failure_reason.is_empty() || matches!(job.state, JobState::Cancelled) {
         return job.title.clone();
     }
@@ -129,6 +131,68 @@ fn restart_job_title(job: &dasclaw_runtime::context::JobContext, failure_reason:
         "Previous attempt failed: {}. Retry: {}",
         failure_reason, job.title
     )
+}
+
+fn job_record_to_info(job: AgentJobRecord, conversation_id: Option<Uuid>) -> JobInfoResponse {
+    JobInfoResponse {
+        id: job.id.to_string(),
+        title: job.title,
+        status: job.status,
+        created_at: job.created_at.to_rfc3339(),
+        started_at: job.started_at.map(|time| time.to_rfc3339()),
+        completed_at: job.completed_at.map(|time| time.to_rfc3339()),
+        conversation_id: conversation_id.map(|id| id.to_string()),
+    }
+}
+
+fn job_event_to_response(event: JobEventRecord) -> JobEvent {
+    JobEvent {
+        id: event.id,
+        event_type: event.event_type,
+        data: event.data,
+        created_at: event.created_at.to_rfc3339(),
+    }
+}
+
+fn job_events_response(job_id: String, events: Vec<JobEventRecord>) -> JobEventsResponse {
+    JobEventsResponse {
+        job_id,
+        events: events.into_iter().map(job_event_to_response).collect(),
+    }
+}
+
+fn job_detail_to_response(
+    job_id: String,
+    ctx: JobContext,
+    failure_reason: Option<String>,
+    events: Vec<JobEventRecord>,
+) -> JobDetailResponse {
+    JobDetailResponse {
+        id: job_id,
+        title: ctx.title,
+        description: ctx.description,
+        status: ctx.state.to_string(),
+        source: "direct".to_string(),
+        created_at: ctx.created_at.to_rfc3339(),
+        started_at: ctx.started_at.map(|time| time.to_rfc3339()),
+        completed_at: ctx.completed_at.map(|time| time.to_rfc3339()),
+        conversation_id: ctx.conversation_id.map(|id| id.to_string()),
+        failure_reason,
+        total_tokens_used: (ctx.total_tokens_used > 0).then_some(ctx.total_tokens_used),
+        events: events.into_iter().map(job_event_to_response).collect(),
+    }
+}
+
+fn build_job_prompt_message(scope_id: &str, job_id: Uuid, content: &str) -> IncomingMessage {
+    let prompt_content = format!("!prompt {} {}", job_id, content);
+    IncomingMessage::new("tauri", scope_id, prompt_content).with_owner_id(scope_id)
+}
+
+fn job_prompt_response(job_id: String) -> JobPromptResponse {
+    JobPromptResponse {
+        status: "sent".to_string(),
+        job_id,
+    }
 }
 
 // ─── Tauri Commands ──────────────────────────────────────────────────
@@ -153,20 +217,8 @@ pub async fn ic_list_jobs(state: State<'_, EngineState>) -> Result<Vec<JobInfoRe
                 .await
                 .ok()
                 .flatten()
-                .and_then(|ctx| ctx.conversation_id)
-                .map(|id| id.to_string());
-            (
-                idx,
-                JobInfoResponse {
-                    id: j.id.to_string(),
-                    title: j.title,
-                    status: j.status,
-                    created_at: j.created_at.to_rfc3339(),
-                    started_at: j.started_at.map(|t| t.to_rfc3339()),
-                    completed_at: j.completed_at.map(|t| t.to_rfc3339()),
-                    conversation_id,
-                },
-            )
+                .and_then(|ctx| ctx.conversation_id);
+            (idx, job_record_to_info(j, conversation_id))
         });
     }
 
@@ -206,33 +258,9 @@ pub async fn ic_get_job_detail(
         None
     };
 
-    let events = db
-        .list_job_events(uuid, None)
-        .await
-        .unwrap_or_default()
-        .into_iter()
-        .map(|e| JobEvent {
-            id: e.id,
-            event_type: e.event_type,
-            data: e.data,
-            created_at: e.created_at.to_rfc3339(),
-        })
-        .collect();
+    let events = db.list_job_events(uuid, None).await.unwrap_or_default();
 
-    Ok(JobDetailResponse {
-        id: job_id,
-        title: ctx.title,
-        description: ctx.description,
-        status: ctx.state.to_string(),
-        source: "direct".to_string(),
-        created_at: ctx.created_at.to_rfc3339(),
-        started_at: ctx.started_at.map(|t| t.to_rfc3339()),
-        completed_at: ctx.completed_at.map(|t| t.to_rfc3339()),
-        conversation_id: ctx.conversation_id.map(|id| id.to_string()),
-        failure_reason,
-        total_tokens_used: (ctx.total_tokens_used > 0).then_some(ctx.total_tokens_used),
-        events,
-    })
+    Ok(job_detail_to_response(job_id, ctx, failure_reason, events))
 }
 
 /// 获取任务事件历史。
@@ -253,22 +281,11 @@ pub async fn ic_job_events(
         .await
         .map_err(|e| format!("Failed to load job events: {}", e))?;
 
-    let items: Vec<JobEvent> = events
-        .into_iter()
-        .map(|e| JobEvent {
-            id: e.id,
-            event_type: e.event_type,
-            data: e.data,
-            created_at: e.created_at.to_rfc3339(),
-        })
-        .collect();
+    let response = job_events_response(job_id, events);
 
-    tracing::debug!(job_id = %job_id, count = items.len(), "Job events loaded");
+    tracing::debug!(job_id = %response.job_id, count = response.events.len(), "Job events loaded");
 
-    Ok(JobEventsResponse {
-        job_id,
-        events: items,
-    })
+    Ok(response)
 }
 
 /// 向运行中的任务发送后续提示。
@@ -287,11 +304,7 @@ pub async fn ic_job_prompt(
     let state = state.get()?;
     let uuid = Uuid::parse_str(&job_id).map_err(|_| format!("Invalid job ID: {}", job_id))?;
 
-    // 通过消息系统发送后续提示
-    let prompt_content = format!("!prompt {} {}", uuid, content);
-
-    let msg = ironclaw::channels::IncomingMessage::new("tauri", &state.scope_id, &prompt_content)
-        .with_owner_id(&state.scope_id);
+    let msg = build_job_prompt_message(&state.scope_id, uuid, &content);
 
     state
         .msg_sender
@@ -301,10 +314,7 @@ pub async fn ic_job_prompt(
 
     tracing::info!(job_id = %job_id, "Follow-up prompt sent");
 
-    Ok(JobPromptResponse {
-        status: "sent".to_string(),
-        job_id,
-    })
+    Ok(job_prompt_response(job_id))
 }
 
 /// 取消运行中的 agent 任务。
@@ -336,34 +346,6 @@ pub async fn ic_cancel_job(
     emit_job_status(&app_handle, uuid, &job.title, "cancelled");
     tracing::info!(job_id = %uuid, "Job cancelled");
     Ok(())
-}
-
-#[cfg(test)]
-mod cancel_tests {
-    use super::stop_active_job;
-    use dasclaw_runtime::JobState;
-    use uuid::Uuid;
-
-    #[tokio::test]
-    async fn active_job_without_scheduler_is_rejected() {
-        let error = stop_active_job(None, Uuid::nil(), JobState::InProgress)
-            .await
-            .expect_err("active jobs require scheduler stop before marking cancelled");
-
-        assert_eq!(
-            error,
-            "Failed to cancel job: active job scheduler unavailable"
-        );
-    }
-
-    #[tokio::test]
-    async fn inactive_job_without_scheduler_is_allowed() {
-        // Use a terminal state — Completed is NOT terminal in this state machine
-        // (Completed → Submitted → Accepted), so is_active() returns true for it.
-        stop_active_job(None, Uuid::nil(), JobState::Failed)
-            .await
-            .expect("inactive job should not require scheduler stop");
-    }
 }
 
 /// 重试一个已结束的 agent 任务。
@@ -415,4 +397,181 @@ pub async fn ic_restart_job(
     emit_job_status(&app_handle, new_job_id, &title, "in_progress");
     tracing::info!(old_job_id = %uuid, new_job_id = %new_job_id, "Job restarted");
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        build_job_prompt_message, job_detail_to_response, job_event_to_response,
+        job_events_response, job_prompt_response, job_record_to_info, restart_job_title,
+        stop_active_job,
+    };
+    use chrono::{TimeZone, Utc};
+    use dasclaw_runtime::{context::JobContext, JobState};
+    use ironclaw::history::{AgentJobRecord, JobEventRecord};
+    use uuid::Uuid;
+
+    fn utc_time(second: u32) -> chrono::DateTime<Utc> {
+        Utc.with_ymd_and_hms(2026, 6, 3, 10, 20, second)
+            .single()
+            .expect("test timestamp should be valid")
+    }
+
+    fn sample_event(id: i64, job_id: Uuid, event_type: &str) -> JobEventRecord {
+        JobEventRecord {
+            id,
+            job_id,
+            event_type: event_type.to_string(),
+            data: serde_json::json!({"step": id}),
+            created_at: utc_time(id as u32),
+        }
+    }
+
+    #[test]
+    fn req_jobs_list_maps_record_without_internal_owner_fields() {
+        let job_id = Uuid::nil();
+        let conversation_id = Uuid::new_v4();
+        let record = AgentJobRecord {
+            id: job_id,
+            title: "Nightly report".to_string(),
+            status: "in_progress".to_string(),
+            user_id: "owner-1".to_string(),
+            created_at: utc_time(1),
+            started_at: Some(utc_time(2)),
+            completed_at: None,
+            failure_reason: Some("hidden".to_string()),
+        };
+
+        let response = job_record_to_info(record, Some(conversation_id));
+        let json = serde_json::to_string(&response).expect("should serialize");
+
+        assert_eq!(response.id, job_id.to_string());
+        assert_eq!(response.title, "Nightly report");
+        assert_eq!(response.status, "in_progress");
+        assert_eq!(response.conversation_id, Some(conversation_id.to_string()));
+        assert!(!json.contains("owner-1"));
+        assert!(!json.contains("hidden"));
+    }
+
+    #[test]
+    fn req_jobs_events_maps_records_in_order() {
+        let job_id = Uuid::new_v4();
+        let response = job_events_response(
+            job_id.to_string(),
+            vec![
+                sample_event(1, job_id, "started"),
+                sample_event(2, job_id, "completed"),
+            ],
+        );
+
+        assert_eq!(response.job_id, job_id.to_string());
+        assert_eq!(response.events.len(), 2);
+        assert_eq!(response.events[0].event_type, "started");
+        assert_eq!(response.events[1].data, serde_json::json!({"step": 2}));
+    }
+
+    #[test]
+    fn req_jobs_detail_maps_context_failure_and_events() {
+        let job_id = Uuid::new_v4();
+        let conversation_id = Uuid::new_v4();
+        let mut context = JobContext::with_user("owner-1", "Report", "Build summary");
+        context.job_id = job_id;
+        context.state = JobState::Failed;
+        context.conversation_id = Some(conversation_id);
+        context.created_at = utc_time(3);
+        context.started_at = Some(utc_time(4));
+        context.completed_at = Some(utc_time(5));
+        context.total_tokens_used = 42;
+
+        let response = job_detail_to_response(
+            job_id.to_string(),
+            context,
+            Some("tool failed".to_string()),
+            vec![sample_event(6, job_id, "error")],
+        );
+
+        assert_eq!(response.id, job_id.to_string());
+        assert_eq!(response.title, "Report");
+        assert_eq!(response.description, "Build summary");
+        assert_eq!(response.status, "failed");
+        assert_eq!(response.source, "direct");
+        assert_eq!(response.conversation_id, Some(conversation_id.to_string()));
+        assert_eq!(response.failure_reason.as_deref(), Some("tool failed"));
+        assert_eq!(response.total_tokens_used, Some(42));
+        assert_eq!(response.events[0].event_type, "error");
+    }
+
+    #[test]
+    fn req_jobs_prompt_message_targets_scope_owner() {
+        let job_id = Uuid::nil();
+        let message = build_job_prompt_message("owner-1", job_id, "continue");
+
+        assert_eq!(message.channel, "tauri");
+        assert_eq!(message.user_id, "owner-1");
+        assert_eq!(message.owner_id, "owner-1");
+        assert_eq!(message.sender_id, "owner-1");
+        assert_eq!(message.content, format!("!prompt {} continue", job_id));
+        assert!(message.thread_id.is_none());
+    }
+
+    #[test]
+    fn req_jobs_prompt_response_reports_sent_status() {
+        let response = job_prompt_response("job-1".to_string());
+
+        assert_eq!(response.status, "sent");
+        assert_eq!(response.job_id, "job-1");
+    }
+
+    #[test]
+    fn req_jobs_restart_title_prefixes_failed_attempt_reason() {
+        let mut context = JobContext::with_user("owner-1", "Nightly report", "Build summary");
+        context.state = JobState::Failed;
+
+        let title = restart_job_title(&context, "network timeout");
+
+        assert_eq!(
+            title,
+            "Previous attempt failed: network timeout. Retry: Nightly report"
+        );
+    }
+
+    #[test]
+    fn req_jobs_restart_title_keeps_cancelled_title() {
+        let mut context = JobContext::with_user("owner-1", "Nightly report", "Build summary");
+        context.state = JobState::Cancelled;
+
+        let title = restart_job_title(&context, "user cancelled");
+
+        assert_eq!(title, "Nightly report");
+    }
+
+    #[tokio::test]
+    async fn active_job_without_scheduler_is_rejected() {
+        let error = stop_active_job(None, Uuid::nil(), JobState::InProgress)
+            .await
+            .expect_err("active jobs require scheduler stop before marking cancelled");
+
+        assert_eq!(
+            error,
+            "Failed to cancel job: active job scheduler unavailable"
+        );
+    }
+
+    #[tokio::test]
+    async fn inactive_job_without_scheduler_is_allowed() {
+        stop_active_job(None, Uuid::nil(), JobState::Failed)
+            .await
+            .expect("inactive job should not require scheduler stop");
+    }
+
+    #[test]
+    fn req_jobs_event_mapping_preserves_timestamp_and_payload() {
+        let job_id = Uuid::new_v4();
+        let response = job_event_to_response(sample_event(7, job_id, "thinking"));
+
+        assert_eq!(response.id, 7);
+        assert_eq!(response.event_type, "thinking");
+        assert_eq!(response.data, serde_json::json!({"step": 7}));
+        assert!(response.created_at.starts_with("2026-06-03T10:20:07"));
+    }
 }

--- a/docs/INTEROP_DASCLAW.md
+++ b/docs/INTEROP_DASCLAW.md
@@ -1,0 +1,79 @@
+# claw-code → dasclaw_* interop map
+
+> **Status**: Documentation-only (B5 deliverable for Issue #911).
+> **Purpose**: Prove that the three lineages (codex / claw-code / ironclaw) already
+> compose on the GUI path by mapping every claw-code concept to its concrete
+> landing in the workspace `dasclaw_*` crates, with an executable reference at
+> [`crates/dasclaw_cli/examples/claw_code_interop.rs`](../crates/dasclaw_cli/examples/claw_code_interop.rs).
+>
+> **Location note (deviation from Issue #911 brief)**: the original task brief
+> placed this file at `claw-code/INTEROP_DASCLAW.md`, but `claw-code/` is a git
+> submodule in this workspace (see `.gitmodules`), so any file added there
+> would belong to a different repo. To honour the rule "do not modify the
+> claw-code source tree" while still satisfying the B5 grep contract from this
+> repo, the file lives at `docs/INTEROP_DASCLAW.md` and the e2e grep anchor
+> test reads it from that path.
+
+## Why this file exists
+
+Issue #911 closes the B5 gap from
+[`docs/plans/architecture-refactor/49-gui-readiness-assessment.md`](plans/architecture-refactor/49-gui-readiness-assessment.md)
+§5 / §9: "三库融合在 GUI 路径未端到端证明". Rather than re-implement claw-code's
+runtime, we show that its primitives are already absorbed into the dasclaw stack
+and can be driven from a single headless agent loop.
+
+## Mapping table
+
+| claw-code concept | dasclaw_* landing | 接入难度 |
+|---|---|---|
+| Headless agent loop (`runtime/agent.ts`) | [`dasclaw_runtime::Agent`](../crates/dasclaw_runtime/src/agent.rs) (`AgentResponder` + `ToolExecutor` + `HookBundle`) | trivial — already drives `dasclaw_cli`'s e2e tests |
+| `bash` tool gating ("Are you sure?" / refuse) | [`dasclaw_bash_validation`](../crates/dasclaw_bash_validation) (`validate_command`) wrapped by [`dasclaw_hooks::BashValidationHook`](../crates/dasclaw_hooks/src/bash_validation_hook.rs) (`EgressGate`) | trivial — `BashValidationHook::new(PermissionMode, workspace)` plugs into `HookBundle.egress` |
+| `apply_patch` tool (model emits `*** Begin Patch …`) | [`dasclaw_apply_patch::parse_patch`](../crates/dasclaw_apply_patch/src/parser.rs) + [`apply`](../crates/dasclaw_apply_patch/src/apply.rs) | trivial — pure function over `ApplyPatchArgs` and `ApplyOptions { base_dir }` |
+| Hook/event bus (BeforeToolCall / AfterToolCall) | [`dasclaw_hooks`](../crates/dasclaw_hooks) (`HookBundle` re-exports `EgressGate` from `dasclaw_core::hooks`, plus declarative `HookBundleConfig`) | trivial — the agent loop already calls `hooks.egress.check` before every tool dispatch |
+| 9-layer defence stack (sandbox / approval / secrets / audit) | `HookBundle { egress, sandbox, secrets, approval }` in [`dasclaw_core::hooks`](../crates/dasclaw_core/src/hooks.rs) | already wired — this PR only exercises the `egress` lane; sandbox/approval are out of scope for the demo |
+
+## Executable proof
+
+[`crates/dasclaw_cli/examples/claw_code_interop.rs`](../crates/dasclaw_cli/examples/claw_code_interop.rs)
+runs a scripted four-turn agent loop in a tempdir, in this order:
+
+1. Model calls `bash` with `rm -rf /` → `dasclaw_bash_validation` (via
+   `dasclaw_hooks::BashValidationHook`) blocks; executor is **never** invoked.
+2. Model calls `bash` with `ls` → gate allows; stub executor returns a fake
+   listing.
+3. Model calls `apply_patch` with an `*** Update File: hello.txt` hunk →
+   `dasclaw_apply_patch::{parse_patch, apply}` writes `world\n` into the
+   tempdir.
+4. Model emits final text `done` and the loop exits.
+
+The matching e2e test
+[`crates/dasclaw_cli/tests/claw_code_interop_e2e.rs`](../crates/dasclaw_cli/tests/claw_code_interop_e2e.rs)
+asserts the audit timeline, the rejection on step 1, the on-disk mutation on
+step 3, and that **this very file** contains the string anchors that prove the
+grep contract from Issue #911:
+`dasclaw_runtime`, `dasclaw_bash_validation`, `dasclaw_apply_patch`,
+`dasclaw_hooks`.
+
+## Non-goals (explicit)
+
+- We do not port claw-code source code into the workspace.
+- We do not execute real shell or real network; both lanes are stubbed in the
+  executor so the demo is hermetic and deterministic.
+- We do not wire `dasclaw_governance`'s 6-pack on this path — that is covered
+  by separate ADR-153 §1.1 B-series work, not B5.
+- `claw-code/`, `vendor/`, `codex-cli-main/` source trees stay untouched.
+
+## See also
+
+- Issue #911 (B5 — claw-code interop demo on GUI path)
+- [`docs/plans/architecture-refactor/49-gui-readiness-assessment.md`](plans/architecture-refactor/49-gui-readiness-assessment.md)
+  §5 (GUI readiness gaps) and §9 (B5 row)
+- ADR-153 §1.1 (B-series rollout for headless agent loop)
+- [`docs/plans/architecture-refactor/53-headless-agent-capability-design.md`](plans/architecture-refactor/53-headless-agent-capability-design.md)
+  (headless agent framework capability boundary; defines what is / is not part
+  of the headless library surface)
+- [`crates/dasclaw_runtime/README.md`](../crates/dasclaw_runtime/README.md)
+  (library-side getting-started for embedders) and
+  [`crates/dasclaw_cli/examples/headless_agent_starter.rs`](../crates/dasclaw_cli/examples/headless_agent_starter.rs)
+  (minimum runnable embed example covering responder + tool executor + approval
+  policy + event stream)


### PR DESCRIPTION
## 背景/目标

Closes #1025（jobs command-helper coverage slice；完整 jobs DB/AppState 真回环仍保留为后续工作）。

`ic_list_jobs`、`ic_get_job_detail`、`ic_job_events` 和 `ic_job_prompt` 之前在命令函数内 inline 组装响应 DTO / prompt message，外部 `jobs_tests` 主要手造 DTO 做序列化契约，无法覆盖真实 `AgentJobRecord` / `JobContext` / `JobEventRecord` 到 desktop-client IPC 响应的生产映射。本 PR 将这部分命令语义提取为 production helper，并补 focused tests。

## 改动范围

- 提取 `job_record_to_info`，覆盖 agent job record 到前端列表 DTO 的映射，并确保不泄露 owner/failure_reason。
- 提取 `job_event_to_response` / `job_events_response`，覆盖持久化 job event 到 IPC event 响应的顺序与 payload 映射。
- 提取 `job_detail_to_response`，覆盖 `JobContext` 的 status、conversation、failure_reason、token usage 与 event 历史映射。
- 提取 `build_job_prompt_message` / `job_prompt_response`，覆盖 `!prompt <job_id> <content>` 和 owner scope 绑定语义。
- 将原 `cancel_tests` 移到文件底部，并保留 active job 无 scheduler fail-safe 测试。

## 非目标（What’s NOT in this PR）

- 不新增 WebDriver 场景。
- 不构造完整 `Database` / `EngineState` 真回环夹具，不声称 jobs 端到端已完成。
- 不改 job 状态机、scheduler、DB 查询或前端 Jobs UI。
- 不触碰 extensions/skills/memory/routines 等其他命令族。

## Sources read

- AGENTS.md §任务启动 4 问
- AGENTS.md §Skills 强制使用规范
- .github/instructions/code-quality.instructions.md §代码质量规范：禁止补丁式代码
- desktop-client/docs/e2e-webdriver-test-plan.md §13 IPC 命令覆盖矩阵
- desktop-client/src/ipc/jobs.rs（jobs IPC 命令实现）
- desktop-client/src/ipc/jobs_tests.rs（jobs IPC DTO 契约测试）
- crates/dasclaw_runtime/src/context/state.rs（JobContext / JobState 定义）
- desktop-client/ironclaw/src/history/store.rs（AgentJobRecord / JobEventRecord 定义）
- crates/dasclaw_channels/src/channel.rs（IncomingMessage / owner scope 语义）

## Skill / graph 自查

- code-quality-audit：通过；无补丁式特判、无生产 `unwrap()` / `panic()` 新增，测试直接使用真实 runtime/history/channel 类型。
- code-simplifier：通过；helper 边界按 list/detail/events/prompt 拆分，未把不同命令语义硬合并。
- code-review-graph：`detect_changes` 风险 0.35，关键实体为 `restart_job_title` / `ic_list_jobs` / `ic_get_job_detail` / `ic_job_events` / `ic_job_prompt`；无新增 affected flow。
- `code-review-expert` skill 文件在当前仓库未找到；已用 code-review-graph change-aware review 替代本轮自审。

## Cross-cuts

- ADR-114: 类A 无新增 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量

## 验证（命令 + 结果）

- `cargo fmt -p desktop-client` — pass
- `cargo check -p desktop-client --tests` — pass
- `cargo nextest run -p desktop-client -E 'test(req_jobs) | test(active_job_without_scheduler_is_rejected) | test(inactive_job_without_scheduler_is_allowed)'` — 10 passed, 845 skipped
- `python3.12 scripts/check_no_panics.py --base origin/xClaw` — pass
- `git diff --check -- desktop-client/src/ipc/jobs.rs` — pass
- `cargo clippy --no-deps -p desktop-client --all-targets -- -D warnings` — blocked by pre-existing untouched warnings in `auth_token_manager.rs`, `dlp/sanitizer.rs`, `data_reporter.rs`, `engine.rs`, `ipc/chat.rs`, `managed_policy.rs`, `state.rs`, `lib.rs`

## 后续 PR / 下一步

- 补 jobs 的真实 DB/AppState 命令级回环。
- 继续推进 #1025 中剩余的 skills install/enable、memory CRUD、extension true roundtrip 等切片。
