### PR TITLE
test(registry): guard Slack embedded artifact URLs

### DIFF
--- a/desktop-client/ironclaw/src/registry/embedded.rs
+++ b/desktop-client/ironclaw/src/registry/embedded.rs
@@ -79,6 +79,15 @@ pub fn load_embedded_bundles() -> HashMap<String, BundleDefinition> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::registry::manifest::ManifestKind;
+
+    fn artifact_url(manifest: &ExtensionManifest) -> &str {
+        manifest
+            .artifacts
+            .get("wasm32-wasip2")
+            .and_then(|artifact| artifact.url.as_deref())
+            .expect("wasm32-wasip2 artifact URL should be embedded")
+    }
 
     #[test]
     fn test_load_embedded_parses() {
@@ -99,5 +108,26 @@ mod tests {
             bundles.is_empty() || bundles.contains_key("default"),
             "Expected either empty bundles or 'default' bundle"
         );
+    }
+
+    #[test]
+    fn req_registry_1205_embedded_slack_artifacts_use_kind_prefixed_urls() {
+        let manifests = load_embedded();
+
+        let slack_tool = manifests
+            .get("tools/slack-tool")
+            .expect("embedded catalog should include Slack tool by manifest name");
+        let slack_channel = manifests
+            .get("channels/slack")
+            .expect("embedded catalog should include Slack channel");
+
+        assert_eq!(slack_tool.name, "slack-tool");
+        assert_eq!(slack_tool.kind, ManifestKind::Tool);
+        assert!(artifact_url(slack_tool).contains("/tool-slack-"));
+        assert!(!artifact_url(slack_tool).contains("/slack-tool-wasm32-wasip2.tar.gz"));
+
+        assert_eq!(slack_channel.name, "slack");
+        assert_eq!(slack_channel.kind, ManifestKind::Channel);
+        assert!(artifact_url(slack_channel).contains("/channel-slack-"));
     }
 }


### PR DESCRIPTION
## Summary

- Adds a regression test for upstream Slack install issue #1205 in the embedded registry catalog path used by release binaries.
- Asserts the Slack tool is embedded as `tools/slack-tool` and uses the kind-prefixed `/tool-slack-...` artifact URL, not the stale `/slack-tool-wasm32-wasip2.tar.gz` URL.
- Also asserts the Slack channel remains embedded separately as `channels/slack` with `/channel-slack-...`, preserving the tool/channel collision fix.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies
- [x] Test

## Linked Issue

Closes nearai/ironclaw#1205

## Sources read

- Upstream issue nearai/ironclaw#1205 — issue body and comments
- Upstream PR nearai/ironclaw#1007 — summary, validation, files changed
- AGENTS.md §Skills 强制使用规范 / Rust 开发规范
- .github/instructions/code-quality.instructions.md §代码质量规范：禁止补丁式代码
- skills/code-review-graph-usage/SKILL.md §detect-changes
- desktop-client/ironclaw/skills/review-checklist/SKILL.md §Tests / Security & Data Safety

## Cross-cuts

- ADR-114: 类A 无新增 .ironclaw / IRONCLAW_BASE_DIR 字面量

## Validation

- [x] `cargo fmt -p dasclaw`
- [x] `cargo nextest run -p dasclaw --lib req_registry_1205_embedded_slack_artifacts_use_kind_prefixed_urls`
- [x] `cargo clippy --no-deps -p dasclaw --lib -- -D warnings`
- [x] `python3.12 scripts/check_no_panics.py --base origin/xClaw`
- [x] `code-review-graph detect-changes --base origin/xClaw --brief --repo desktop-client/ironclaw` → risk 0.30, 0 affected flows, 0 test gaps

## Security Impact

None. Test-only change; no permissions, network, secrets, file access, tool execution, or sandbox behavior changes.

## Database Impact

None.

## Blast Radius

Limited to registry embedded catalog unit tests in `desktop-client/ironclaw/src/registry/embedded.rs`.

## Rollback Plan

Revert the single test commit if it causes unexpected CI issues.

---

**Review track**: A (docs/tests/chore)