### PR TITLE
test(e2e): enable approval approve branch

### DIFF
--- a/desktop-client/docs/e2e-webdriver-test-plan.md
+++ b/desktop-client/docs/e2e-webdriver-test-plan.md
@@ -14,11 +14,10 @@
 > - **可直接照抄执行**：§0 的启动命令 + WebDriver 会话样板、§1–§7 七个场景的操作步骤与
 >   断言、§14.4-C 的"经 IPC 自查日志比顺序"示例——这些是具体到命令/代码片段、可手动或
 >   脚本化跑起来的，属于"现在就能执行"的部分。
-> - **已落地但有边界**：§12 I-1~I-5 已由 #1053 覆盖；§15.3 A-1~A-5 已由 #1055
+> - **已落地但有边界**：§4 approve 分支已由 #1056 覆盖；§12 I-1~I-5 已由 #1053 覆盖；§15.3 A-1~A-5 已由 #1055
 >   覆盖；§14.5 的 DLP / 审批 / hook / sandbox 不变量也有代码级测试，但其中 DLP、hook、
 >   sandbox 仍保留更强断言缺口（见 §14.5 的 2026-06-02 状态表）。
-> - **仍待落地为代码**：§4 approve 分支当前 skip（#1056）；§14.4-C WebDriver 日志序
->   断言（#1058）；完整 `send_chat_message` blocked 零副作用测试（#1059）；真实 hook
+> - **仍待落地为代码**：§14.4-C WebDriver 日志序断言（#1058）；完整 `send_chat_message` blocked 零副作用测试（#1059）；真实 hook
 >   生命周期顺序（#1057）；sandbox 真实逃逸/绕过样本（#1060）；以及 §15.3 A-6 的 E2E
 >   冒烟仍为可选补测。
 > - **结论 / 知识沉淀**：§10–§16 的缺口、适用性、日志分层等是判断与建议，供决策与后续排期，
@@ -160,7 +159,7 @@ Tauri WebDriver"误报成产品失败。
 | §1 引擎就绪与刷新韧性 | 已落地 | WebDriver + `get_engine_status` |
 | §2 Agent 基础执行 | 已落地但依赖 LLM 可达 | #998 |
 | §3 工具注册 / list_dir | 已落地但依赖 LLM 选中只读工具 | #1000 / #1009 |
-| §4 审批 fail-safe | card + deny 已落地；approve 分支 skip | #1001 / #1009；approve 补测 #1056 |
+| §4 审批 fail-safe | card + deny + approve 已落地；approve 探针文件自动清理 | #1001 / #1009 / #1056 |
 | §5 DLP 出站脱敏 | 已落地 | 仍需日志序增强 #1058、完整零副作用 #1059 |
 | §6 会话持久化 | 已落地；核心断言看用户 marker 回放 | 发送路径仍受模型/后端可用性影响 |
 | §7 提示注入安全 | 已落地 | 纯自然语言 jailbreak 硬阻断仍看 #1021 |
@@ -335,14 +334,13 @@ assert denied, "拒绝后未出现 data-approved=false 横幅"
 - ✅ 写操作触发审批卡片且不自动执行；拒绝→`data-approved=false`，批准→`data-approved=true`。
 - ❌ Fail-Open：写文件未弹审批直接执行。
 
-**2026-06-02 落地状态**：
+**2026-06-03 落地状态**：
 
 - `test_write_tool_triggers_approval_card` 与 `test_deny_yields_approved_false` 已落地，覆盖
   "需审批工具必须弹卡"与"拒绝后 `data-approved=false`"。
-- `test_approve_yields_approved_true` 当前显式 skip：approve 会真实写入 `e2e_probe.txt` 到
-  `desktop-client` 工作目录，造成跨用例污染。后续应先改为 sandbox/临时 cwd 或补 teardown，
-  再启用 approve 分支。跟踪 issue：#1056。
-- 因此本节现状是 **Fail-Safe 主干已覆盖，approve happy path 尚未进入自动回归**。
+- `test_approve_yields_approved_true` 已启用：approve 写入 `e2e-webdriver/.tmp/` 下的探针文件，
+  断言 `data-approved=true` 与文件内容后通过 fixture 清理探针文件和空目录。跟踪 issue：#1056。
+- 因此本节现状是 **Fail-Safe 主干与 approve happy path 均已进入自动回归**。
 
 > ⚠️ **环境变量缺口**：题目中的 `AGENT_AUTO_APPROVE_TOOLS=false` 在全仓
 > （`crates/` + `desktop-client/`）**无任何匹配**（见 §10-G3）。不能用它来断言
@@ -818,10 +816,10 @@ RUST_LOG=desktop_client=debug,ironclaw=debug,dasclaw_hooks=trace cargo tauri dev
 | 不变量 | #1055 / 当前代码状态 | 仍缺什么 | 跟踪 |
 |---|---|---|---|
 | DLP 先于派发、被拦零派发 | 已有 `req_chat_dlp_block_before_dispatch`，覆盖 `reject_blocked_scan` seam + toy sender 计数 | 尚未覆盖完整 `send_chat_message` 路径下的零副作用；WebDriver 也尚未做 `ic_search_logs` 顺序断言 | #1059 / #1058 |
-| 审批先于工具执行 | 已有 `req_approval_gate_before_tool_exec`，用 `RecordingTool` 证明首个需审批工具会中断，后续工具未执行 | WebDriver approve 分支仍 skip，未覆盖 `data-approved=true` happy path | #1056 |
+| 审批先于工具执行 | 已有 `req_approval_gate_before_tool_exec`，用 `RecordingTool` 证明首个需审批工具会中断，后续工具未执行；WebDriver approve 分支已覆盖 `data-approved=true` happy path | 仍受 LLM 选中写工具与 WebDriver 环境可达性影响 | #1056 |
 | Hook 生命周期顺序 | 已有 `req_hooks_lifecycle_order`，但它实际验证同一 `HookPoint::BeforeInbound` 内的注册顺序 | 尚未验证 `PreToolUse -> tool execution -> PostToolUse` 真实生命周期顺序 | #1057 |
 | sandbox 不可绕过 | 已有 `test_security_sandbox_no_bypass`，覆盖 enterprise gate pure decision fail-closed | 尚未覆盖真实或半真实进程级逃逸/绕过样本 | #1060 |
-| 端到端"该拦的拦/该批的批" | §4 card/deny、§5 DLP、§7 注入防御已有 WebDriver 覆盖 | approve 分支、日志序、部分场景 LLM/dev hook 依赖仍需显式管理 | #1056 / #1058 |
+| 端到端"该拦的拦/该批的批" | §4 card/deny/approve、§5 DLP、§7 注入防御已有 WebDriver 覆盖 | 日志序、部分场景 LLM/dev hook 依赖仍需显式管理 | #1058 |
 
 ### 14.6 结论
 
@@ -1015,7 +1013,6 @@ loop 的入口唯一**：
 | **P0** | 记忆 CRUD 真回环 | 待开 | 功能验证 | §13 记忆族 AppState + Workspace 命令级集成测试 |
 | **P0** | 技能安装 E2E | 待开 | 功能验证 | §13 技能族命令级集成测试 |
 | **P0** | 审批规则配置面 E2E | #608 | 功能/UX | §1-§7 扩展或命令级 + 前端联调 |
-| **P1** | WebDriver approve 分支补回归 | #1056 | 安全/UX 不变量 | sandbox/临时 cwd + `data-approved=true` 断言 |
 | **P1** | Hook 生命周期真实顺序 | #1057 | 安全不变量 | `PreToolUse -> exec -> PostToolUse` 记录器测试 |
 | **P1** | DLP 日志序审计 | #1058 | 数据/安全验证 | §14.4-C 日志序断言进 WebDriver/CI |
 | **P1** | DLP blocked 完整零副作用 | #1059 | 安全不变量 | 完整 `send_chat_message` 或等价 seam 断言 |

--- a/desktop-client/e2e-webdriver/.gitignore
+++ b/desktop-client/e2e-webdriver/.gitignore
@@ -2,3 +2,4 @@
 __pycache__/
 *.pyc
 .pytest_cache/
+.tmp/

--- a/desktop-client/e2e-webdriver/README.md
+++ b/desktop-client/e2e-webdriver/README.md
@@ -45,7 +45,7 @@ pytest desktop-client/e2e-webdriver/tests/test_scenario_01_engine_readiness.py -
 | §1 引擎就绪与刷新韧性 | ✅ 已落地 |
 | §2 Agent 基础执行 | ✅ 已落地（需 LLM 可达） |
 | §3 工具注册与发现 | ✅ 已落地（只读工具 `list_dir` 分发链路；需 LLM 可达） |
-| §4 工具分发与审批（Fail-Safe） | ✅ 已落地（写工具触发审批卡片 + deny 路径；approve 路径 skip，见用例说明） |
+| §4 工具分发与审批（Fail-Safe） | ✅ 已落地（写工具触发审批卡片 + deny / approve 路径；approve 探针文件自动清理） |
 | §5 DLP 出站脱敏与拦截（Fail-Safe） | ✅ 已落地（邮箱脱敏 + 密钥拦截 + 存储脱敏 IPC 层；UI 路径见用例说明） |
 | §6 会话持久化（刷新后历史不丢） | ✅ 已落地（IPC 层验证 ic_get_thread_history + ic_list_threads 跨 reload 一致；需 LLM 可达） |
 | §7 提示注入防护 | ✅ 已落地（注入+密钥 / 纯语义 / 多段拼接三类 IPC 层断言；契约钉子见用例说明） |

--- a/desktop-client/e2e-webdriver/tests/test_scenario_04_approval_failsafe.py
+++ b/desktop-client/e2e-webdriver/tests/test_scenario_04_approval_failsafe.py
@@ -6,22 +6,24 @@
 验证：
   1. 触发需审批的写操作 → 必须弹出审批卡片（**不能**静默执行，Fail-Safe）
   2. 点击「拒绝」→ 结果横幅 `data-approved=false`
+    3. 点击「批准」→ 结果横幅 `data-approved=true`，且探针文件被测试清理
 
 为什么不断言 `AGENT_AUTO_APPROVE_TOOLS=false` 环境变量（plan §10-G3）：
   该变量在全仓 `crates/` + `desktop-client/` 下零匹配，是文档残留的伪不变量。
   正确的 Fail-Safe 判据是 **行为级**：写操作触发审批卡片，而不是检查某个不存在的开关。
 
-为什么 `approve` 分支被 skip：
-  审批通过后会真把 `e2e_probe.txt` 写到 desktop-client 工作目录（同一 cwd 持久化），
-  造成跨用例污染 + 需要清理逻辑。Deny 分支已经覆盖了完整的「卡片 → 决策 → 横幅」链路，
-  Approve 分支差异仅在 `data-approved=true` 这一布尔值，相对成本/价值不划算。
-  若后续要补，应优先重构成 sandbox 子目录或可清理的临时路径。
+approve 分支的污染控制：
+    审批通过后会真实写文件，因此用例只允许写入 e2e-webdriver/.tmp/ 下的探针文件，
+    并在测试前后清理该路径与旧版 e2e_probe.txt 探针，避免跨用例 / 跨运行污染。
 
 测试之间用 `clear_pending_approval` 在开头清掉上一条用例可能留下的挂起卡片，
 避免共享同一 WKWebView 时的串扰。
 """
 
 from __future__ import annotations
+
+from contextlib import suppress
+from pathlib import Path
 
 import pytest
 
@@ -36,9 +38,14 @@ from webdriver_client import (
     wait_composer_ready,
 )
 
+DESKTOP_CLIENT_DIR = Path(__file__).resolve().parents[2]
+PROBE_RELATIVE_PATH = "e2e-webdriver/.tmp/e2e_probe_approval.txt"
+PROBE_PATH = DESKTOP_CLIENT_DIR / PROBE_RELATIVE_PATH
+LEGACY_PROBE_PATH = DESKTOP_CLIENT_DIR / "e2e_probe.txt"
+
 # 提示词照搬 plan §4，最大概率让 LLM 选择走写文件类需审批工具。
 WRITE_PROMPT = (
-    "请立即调用 write_file 工具在当前工作目录创建文件 e2e_probe.txt，"
+    f"请立即调用 write_file 工具在当前工作目录创建文件 {PROBE_RELATIVE_PATH}，"
     "内容为字符串 hello。不要先解释，不要先用 read_file/list_dir 探查，"
     "也不要建议我用其它方式——直接调用 write_file。"
 )
@@ -48,7 +55,29 @@ WRITE_PROMPT = (
 CARD_TIMEOUT = 120.0
 
 
-def test_write_tool_triggers_approval_card(session_id):
+def cleanup_probe_files() -> None:
+    """清理本场景可能产生的探针文件。"""
+    PROBE_PATH.unlink(missing_ok=True)
+    LEGACY_PROBE_PATH.unlink(missing_ok=True)
+    with suppress(OSError):
+        PROBE_PATH.parent.rmdir()
+
+
+def prepare_probe_dir() -> None:
+    cleanup_probe_files()
+    PROBE_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+@pytest.fixture
+def probe_workspace():
+    prepare_probe_dir()
+    try:
+        yield
+    finally:
+        cleanup_probe_files()
+
+
+def test_write_tool_triggers_approval_card(session_id, probe_workspace):
     """Fail-Safe：发"新建文件"指令 → 审批卡片出现，且不点按钮。
 
     这是 plan §4 的核心 Fail-Safe 不变量——写操作**绝不能**绕过审批静默执行。
@@ -71,12 +100,13 @@ def test_write_tool_triggers_approval_card(session_id):
         f" 末态 snapshot={snapshot(session_id)}"
     )
     assert s1["approvalCard"] is True, "snapshot 自相矛盾"
+    assert not PROBE_PATH.exists(), "审批前探针文件已被写入，疑似 Fail-Open 回归"
 
     # 清掉挂起审批，避免污染后续用例
     clear_pending_approval(session_id)
 
 
-def test_deny_yields_approved_false(session_id):
+def test_deny_yields_approved_false(session_id, probe_workspace):
     """完整链路：发指令 → 等卡片 → 点拒绝 → 等 `data-approved=false` 横幅。
 
     覆盖前端 `ic_deny_tool` IPC → 后端 `Submission::ExecApproval` → SDK 把工具调用
@@ -106,30 +136,33 @@ def test_deny_yields_approved_false(session_id):
         "(a) ic_deny_tool IPC 未送达；(b) 后端未把虚拟工具推进到 complete；"
         f"(c) ApprovalResultBanner 渲染失败。 末态 snapshot={snapshot(session_id)}"
     )
+    assert not PROBE_PATH.exists(), "拒绝审批后探针文件仍被写入，疑似审批 gate 失效"
 
 
-@pytest.mark.skip(
-    reason=(
-        "approve 会真把 e2e_probe.txt 写入 desktop-client 工作目录，造成跨用例污染；"
-        "deny 分支已覆盖完整链路，approve 分支差异仅 data-approved=true 这个布尔值。"
-        "若后续要补，应先把工作目录改成 sandbox 临时路径或加 teardown 清理。"
-    )
-)
-def test_approve_yields_approved_true(session_id):
-    """（保留占位）批准路径——见 skip reason。"""
+def test_approve_yields_approved_true(session_id, probe_workspace):
+    """批准路径：发指令 → 等卡片 → 点批准 → 横幅 true → 探针文件落地后清理。"""
     clear_pending_approval(session_id)
 
     s0 = wait_composer_ready(session_id, timeout=60.0)
-    assert s0 is not None
+    assert s0 is not None, "composer 未就绪"
 
     type_into_composer(session_id, WRITE_PROMPT)
     click_send(session_id)
 
     s1 = wait_approval_card(session_id, timeout=CARD_TIMEOUT)
-    assert s1 is not None
+    assert s1 is not None, (
+        f"{CARD_TIMEOUT:.0f}s 内未出现审批卡片，无法继续验证批准路径。"
+        f" 末态 snapshot={snapshot(session_id)}"
+    )
 
     click_approval(session_id, "approve")
     approved = wait_approval_decision(
         session_id, expected_approved=True, timeout=30.0
     )
-    assert approved
+    assert approved, (
+        "点 approve 后 30s 内未出现 `data-approved=true` 横幅——可能："
+        "(a) ic_approve_tool IPC 未送达；(b) 后端未执行批准后的工具调用；"
+        f"(c) ApprovalResultBanner 渲染失败。 末态 snapshot={snapshot(session_id)}"
+    )
+    assert PROBE_PATH.exists(), f"批准后探针文件未落地：{PROBE_PATH}"
+    assert PROBE_PATH.read_text(encoding="utf-8").strip() == "hello"


### PR DESCRIPTION
## 背景/目标
Closes #1056

`test_approve_yields_approved_true` 之前因为会把 `e2e_probe.txt` 写进 `desktop-client` 工作目录而被 skip。本 PR 将 approve 分支纳入 WebDriver 自动回归，同时保证测试产物可控清理。

## 改动范围
- 将场景 04 approve 分支改为真实执行，批准后断言 `data-approved=true`。
- 将写入目标收敛到 `desktop-client/e2e-webdriver/.tmp/e2e_probe_approval.txt`，并用 pytest fixture 在测试前后清理探针文件、旧版 `e2e_probe.txt` 与空目录。
- 增加 deny / 未批准前的探针文件不存在断言，防止审批 gate fail-open。
- 更新 `desktop-client/e2e-webdriver/README.md` 与 `desktop-client/docs/e2e-webdriver-test-plan.md` 中 #1056 的状态。

## 非目标（What's NOT in this PR）
- 不改客户端审批生产逻辑。
- 不新增测试侧 mock 来掩盖客户端 bug。
- 不处理 #1057 / #1058 / #1059 / #1060 / #1068。

## 验证（命令 + 结果）
- `git diff --check`：通过。
- `python3 -m py_compile desktop-client/e2e-webdriver/tests/test_scenario_04_approval_failsafe.py`：通过。
- `python3 -m pytest desktop-client/e2e-webdriver/tests/test_scenario_04_approval_failsafe.py --collect-only -q`：收集 3 个用例，approve 不再 skip。
- `python3 -m pytest desktop-client/e2e-webdriver/tests/test_scenario_04_approval_failsafe.py -q`：本机未启动 `tauri-plugin-webdriver`，按 fixture 预期 `3 skipped`。

## Sources read
- `desktop-client/docs/e2e-webdriver-test-plan.md`：§0.5 当前自动化落地状态、§4 场景 4 审批 fail-safe、§14.5 落到现有测试族、§16 GA 剩余路线。
- `desktop-client/e2e-webdriver/tests/test_scenario_04_approval_failsafe.py`：场景 04 现有 card / deny / approve 用例。
- `desktop-client/e2e-webdriver/webdriver_client.py`：审批卡片 helper 与 decision 读取 helper。

## Cross-cuts
类A：无新增 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量。

## Skill 自查
- code-quality-audit：检查范围限本 PR 修改文件；未发现补丁式生产逻辑、重复实现或超大函数；清理逻辑集中在 fixture。
- code-simplifier：将探针准备/清理抽为 fixture，避免每个用例重复 try/finally；approve 用例主体保持线性。
- code-review-graph：对本 PR changed files 查询最小上下文，Python/Markdown 文件无图节点，风险低。

## 后续 PR / 下一步
按计划顺序继续 #1057、#1058、#1059、#1060 与 #1068。