### PR TITLE
test(e2e): assert DLP log order

### DIFF
--- a/desktop-client/e2e-webdriver/README.md
+++ b/desktop-client/e2e-webdriver/README.md
@@ -21,8 +21,12 @@ cd desktop-client
 set -a && source ./.env && set +a
 export MANAGED_MODE=false
 export OPENAI_API_KEY="$LLM_API_KEY"
+export RUST_LOG=desktop_client=debug,ironclaw=debug,tower_http=warn
 cargo tauri dev -f webdriver
 ```
+
+`desktop_client=debug` 会打开场景 5 的 SafetyBridge / agent dispatch 日志序断言；
+`ironclaw=debug` 保留引擎侧调试日志。未显式设置时，debug 级别日志可能缺失并导致 #1058 回归测试假阴。
 
 等到终端出现 WebView 起来 + `lsof -ti:4445` 有进程后再跑测试。
 

--- a/desktop-client/e2e-webdriver/tests/test_scenario_05_dlp_outbound_masking.py
+++ b/desktop-client/e2e-webdriver/tests/test_scenario_05_dlp_outbound_masking.py
@@ -3,27 +3,111 @@
 
 对应：desktop-client/docs/e2e-webdriver-test-plan.md §5
 
-验证 SafetyBridge 在 Tauri IPC 层的三类语义：
+验证 SafetyBridge 在 Tauri IPC / send_chat_message 层的语义：
   (a) PII（邮箱）→ had_sensitive_data=true 且原文不在 sanitized_content
   (b) 密钥样式串 → was_blocked=true（强制拦截，Fail-Safe）
   (c) 存储脱敏 sanitize_for_storage → 返回字符串中无原文敏感串
+    (d) 普通脱敏消息的 SafetyBridge 日志早于 agent dispatch 日志
+    (e) blocked 消息有 block 日志，且同一线程窗口无 dispatch 日志
 
 为什么不跑 send_chat_message UI 路径：
-  send_chat_message 需要有效 thread_id + 模型配置 + Admin 配额，链路过深；
-  其内部第一步就是 `safety_bridge.scan_user_input` 并在 was_blocked 时 `return Err`
-  （见 desktop-client/src/ipc/chat.rs L100-L113），与本文件 (b) 同源同语义。
-  IPC 层断言 was_blocked 已经覆盖 Fail-Safe 不变量；UI 层重复验证收益低、flakiness 高。
+    UI composer 路径拿不到 send_chat_message 返回的 message_id，无法按同一条消息关联日志。
+    日志序用例直接调 send_chat_message IPC，保留真实 SafetyBridge → agent dispatch 顺序，
+    同时避开 DOM/LLM 回复时序对审计日志断言的干扰。
 """
 
 from __future__ import annotations
 
-from webdriver_client import invoke
+import uuid
+
+from webdriver_client import clear_logs, invoke, poll, search_logs
 
 # 经典 PII：邮箱地址（落入 DLP PII 规则）
 EMAIL_SAMPLE = "请把账单发送到 alice.smith@example.com 这个邮箱。"
 
 # 密钥样式串：OpenAI 风格 `sk-` 前缀长 token，应被 leak_detector 拦截
 SECRET_SAMPLE = "我的 API key 是 sk-DEADBEEFCAFEBABE0123456789abcdef0123456789ABCDEF"
+
+LOG_ORDER_TIMEOUT = 30.0
+LOG_LEVEL_HINT = (
+    "请确认启动前设置 "
+    "RUST_LOG=desktop_client=debug,ironclaw=debug,tower_http=warn"
+)
+
+
+def _new_thread_id(session_id: str) -> str:
+    thread_id = invoke(session_id, "ic_create_thread", {})
+    assert isinstance(thread_id, str) and thread_id, (
+        f"ic_create_thread 返回异常：{thread_id!r}"
+    )
+    return thread_id
+
+
+def _send_chat_message(session_id: str, thread_id: str, content: str) -> dict:
+    resp = invoke(
+        session_id,
+        "send_chat_message",
+        {
+            "threadId": thread_id,
+            "content": content,
+            "modelId": None,
+            "apiBaseUrl": None,
+            "apiKey": None,
+            "dlpStats": None,
+            "attachments": None,
+        },
+    )
+    assert isinstance(resp, dict), f"send_chat_message 返回非 dict：{resp!r}"
+    assert isinstance(resp.get("message_id"), str), f"缺少 message_id：{resp!r}"
+    return resp
+
+
+def _logs_for_message(session_id: str, query: str, message_id: str) -> list[dict]:
+    return [
+        entry
+        for entry in search_logs(session_id, query, limit=200)
+        if message_id in entry.get("message", "")
+    ]
+
+
+def _logs_for_thread(session_id: str, query: str, thread_id: str) -> list[dict]:
+    return [
+        entry
+        for entry in search_logs(session_id, query, limit=200)
+        if thread_id in entry.get("message", "")
+    ]
+
+
+def _wait_logs_for_message(
+    session_id: str,
+    query: str,
+    message_id: str,
+) -> list[dict] | None:
+    return poll(
+        lambda: _logs_for_message(session_id, query, message_id) or None,
+        timeout=LOG_ORDER_TIMEOUT,
+        interval=0.5,
+    )
+
+
+def _wait_logs_for_thread(
+    session_id: str,
+    query: str,
+    thread_id: str,
+) -> list[dict] | None:
+    return poll(
+        lambda: _logs_for_thread(session_id, query, thread_id) or None,
+        timeout=LOG_ORDER_TIMEOUT,
+        interval=0.5,
+    )
+
+
+def _log_index(logs: list[dict], needle: str, message_id: str) -> int:
+    for idx, entry in enumerate(logs):
+        message = entry.get("message", "")
+        if needle in message and message_id in message:
+            return idx
+    raise AssertionError(f"未找到日志 {needle!r} message_id={message_id}: {logs!r}")
 
 
 def test_scan_user_input_redacts_email(session_id):
@@ -71,4 +155,75 @@ def test_sanitize_for_storage_drops_pii(session_id):
     assert "bob@corp.com" not in resp, (
         "存储脱敏未生效——原文邮箱可能落入持久化存储造成长期泄露。"
         f" returned={resp!r}"
+    )
+
+
+def test_send_chat_message_dlp_sanitize_log_precedes_agent_dispatch(session_id):
+    """(d) 同一 message_id 下，DLP 脱敏日志必须早于 agent dispatch 日志。"""
+    clear_logs(session_id)
+    thread_id = _new_thread_id(session_id)
+    marker = f"e2e-log-order-{uuid.uuid4().hex[:8]}"
+
+    resp = _send_chat_message(session_id, thread_id, f"{marker} {EMAIL_SAMPLE}")
+    message_id = resp["message_id"]
+
+    sanitized = _wait_logs_for_message(
+        session_id, "Message sanitized by SafetyBridge", message_id
+    )
+    injected = _wait_logs_for_message(
+        session_id, "Message injected into agent loop", message_id
+    )
+    assert sanitized, (
+        f"未找到 SafetyBridge 脱敏日志 message_id={message_id}。{LOG_LEVEL_HINT}"
+    )
+    assert injected, (
+        f"未找到 agent dispatch 日志 message_id={message_id}。{LOG_LEVEL_HINT}"
+    )
+
+    scan_end = _wait_logs_for_message(
+        session_id, "send_chat_message.scan_user_input.end", message_id
+    )
+    assert scan_end, (
+        f"未找到 scan_user_input.end 日志 message_id={message_id}。{LOG_LEVEL_HINT}"
+    )
+
+    relevant_logs = search_logs(session_id, message_id, limit=200)
+    scan_idx = _log_index(
+        relevant_logs, "send_chat_message.scan_user_input.end", message_id
+    )
+    sanitized_idx = _log_index(
+        relevant_logs, "Message sanitized by SafetyBridge", message_id
+    )
+    injected_idx = _log_index(
+        relevant_logs, "Message injected into agent loop", message_id
+    )
+
+    assert scan_idx <= sanitized_idx < injected_idx, (
+        "DLP 脱敏/扫描日志必须早于 agent dispatch 日志："
+        f"scan_idx={scan_idx}, sanitized_idx={sanitized_idx}, injected_idx={injected_idx}, "
+        f"message_id={message_id}, logs={relevant_logs!r}"
+    )
+
+
+def test_send_chat_message_blocked_log_has_no_agent_dispatch(session_id):
+    """(e) blocked 分支：同一 thread_id 窗口内有 block 日志，且无 dispatch 日志。"""
+    clear_logs(session_id)
+    thread_id = _new_thread_id(session_id)
+
+    try:
+        _send_chat_message(session_id, thread_id, SECRET_SAMPLE)
+    except RuntimeError:
+        pass
+    else:
+        raise AssertionError("Fail-Open：密钥样式消息未被 send_chat_message 拦截")
+
+    blocked = _wait_logs_for_thread(
+        session_id, "Message blocked by SafetyBridge", thread_id
+    )
+    assert blocked, f"未找到 blocked 日志 thread_id={thread_id}。{LOG_LEVEL_HINT}"
+
+    injected = _logs_for_thread(session_id, "Message injected into agent loop", thread_id)
+    assert not injected, (
+        "Fail-Open：blocked 消息同一 thread_id 下仍出现 agent dispatch 日志。"
+        f" thread_id={thread_id}, injected={injected!r}"
     )

--- a/desktop-client/e2e-webdriver/webdriver_client.py
+++ b/desktop-client/e2e-webdriver/webdriver_client.py
@@ -113,6 +113,19 @@ def invoke(session_id: str, command: str, payload: Optional[dict] = None) -> Any
     return result["value"]
 
 
+def clear_logs(session_id: str) -> None:
+    """清空应用内日志视图偏移，隔离后续日志断言窗口。"""
+    invoke(session_id, "ic_clear_logs", {})
+
+
+def search_logs(session_id: str, query: str, limit: int = 100) -> list[dict]:
+    """通过 IPC 搜索应用内日志，返回时间正序的日志条目。"""
+    logs = invoke(session_id, "ic_search_logs", {"query": query, "limit": limit})
+    if not isinstance(logs, list):
+        raise RuntimeError(f"ic_search_logs 返回非 list：{logs!r}")
+    return logs
+
+
 def poll(fn: Callable[[], Any], timeout: float = 30.0, interval: float = 1.0) -> Any:
     """轮询直到 fn() 返回真值或超时；返回最后一次结果。
 


### PR DESCRIPTION
## 背景/目标
Closes #1058

计划 §14.4-C 要求在 WebDriver 黑盒层通过应用内日志查询验证 DLP 在 agent dispatch 前执行。本 PR 将场景 5 从纯 `scan_user_input` IPC 断言扩展到 `send_chat_message` 日志序断言。

## 改动范围
- 在 `webdriver_client.py` 增加 `clear_logs` / `search_logs` helper，经 `ic_clear_logs` / `ic_search_logs` 读取应用内日志，不读终端或文件。
- 增加普通脱敏消息用例：直接调用 `send_chat_message`，用返回的 `message_id` 关联日志，断言 `scan_user_input.end <= Message sanitized by SafetyBridge < Message injected into agent loop`。
- 增加 blocked 消息用例：新建专用 thread，清空日志窗口后发送密钥样式内容，断言该 thread 有 `Message blocked by SafetyBridge` 且没有 `Message injected into agent loop`。
- 更新 WebDriver README：启动时显式设置 `RUST_LOG=desktop_client=debug,ironclaw=debug,tower_http=warn`，避免 debug 日志缺失造成假阴。

## 非目标（What's NOT in this PR）
- 不改 SafetyBridge / `send_chat_message` 生产逻辑。
- 不读取终端输出或落盘日志文件。
- 不处理 #1057 / #1059 / #1060 / #1068。
- 为避免与 #1069 的计划文档状态更新产生冲突，本 PR 不改总计划文档。

## 验证（命令 + 结果）
- `git diff --check`：通过。
- `python3 -m py_compile desktop-client/e2e-webdriver/webdriver_client.py desktop-client/e2e-webdriver/tests/test_scenario_05_dlp_outbound_masking.py`：通过。
- `python3 -m pytest desktop-client/e2e-webdriver/tests/test_scenario_05_dlp_outbound_masking.py --collect-only -q`：收集 5 个用例。
- `python3 -m pytest desktop-client/e2e-webdriver/tests/test_scenario_05_dlp_outbound_masking.py -q`：本机未启动 `tauri-plugin-webdriver`，按 fixture 预期 `5 skipped`。

## Sources read
- `desktop-client/docs/e2e-webdriver-test-plan.md`：§14.4-C WebDriver 内查询日志比顺序、§14.5 DLP 先于派发剩余边界。
- `desktop-client/src/ipc/chat.rs`：`send_chat_message` 中 scan/sanitize/block/injected 日志字段与 `message_id` 返回。
- `desktop-client/src/ipc/logs.rs`：`ic_clear_logs` / `ic_search_logs` 返回结构与 offset 语义。
- `desktop-client/ironclaw/src/channels/web/log_layer.rs`：结构化 tracing 字段拼入 `LogEntry.message` 的格式。
- `desktop-client/e2e-webdriver/tests/test_scenario_05_dlp_outbound_masking.py` 与 `webdriver_client.py`：现有 WebDriver DLP helper 与 IPC invoke 模式。

## Cross-cuts
类A：无新增 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量。

## Skill 自查
- code-quality-audit：未改生产逻辑；新增 helper 聚焦日志查询，测试按 message_id/thread_id 关联，未用全局最后一条日志。
- code-simplifier：日志清理和搜索抽到 `webdriver_client.py`，场景测试保留线性断言。
- code-review-graph：changed files 为 Python/README，图谱无节点，风险低。

## 后续 PR / 下一步
按计划继续 #1059 blocked `send_chat_message` 完整零副作用，以及 #1060 sandbox 真实绕过样本；#1057 当前发现缺少真实 PostToolUse 生命周期 API，需要先调整生产生命周期设计后再补测试。