### PR TITLE
test(chat): assert blocked send zero side effects

### DIFF
--- a/desktop-client/src/ipc/chat.rs
+++ b/desktop-client/src/ipc/chat.rs
@@ -77,8 +77,9 @@ pub struct FrontendAttachment {
 /// - 消息内容不写入日志（防止敏感信息泄露）
 /// - 仅记录 message_id 和 thread_id 用于追踪
 #[tauri::command]
+#[allow(clippy::too_many_arguments)]
 pub async fn send_chat_message(
-    app_handle: tauri::AppHandle,
+    app_handle: tauri::AppHandle<impl tauri::Runtime>,
     state: State<'_, EngineState>,
     thread_id: String,
     content: String,
@@ -484,8 +485,8 @@ fn build_message_metadata(
 ///
 /// 使用 ironclaw 已有的 `prefilter_skills` 函数，不修改 ironclaw 任何代码。
 /// 失败时静默跳过（skill 通知是 best-effort，不影响消息发送）。
-fn detect_and_emit_skills_activated(
-    app_handle: &tauri::AppHandle,
+fn detect_and_emit_skills_activated<R: tauri::Runtime>(
+    app_handle: &tauri::AppHandle<R>,
     state: &crate::state::AppState,
     thread_id: &str,
     content: &str,
@@ -547,7 +548,7 @@ pub async fn subscribe_chat_events(app_handle: tauri::AppHandle) -> Result<(), S
 
     if app_handle
         .try_state::<crate::state::EngineState>()
-        .map_or(false, |es| es.is_ready())
+        .is_some_and(|es| es.is_ready())
     {
         // 系统级广播：前端所有 Transport 透传
         crate::tauri_channel::emit_chat_stream(

--- a/desktop-client/src/ipc/chat_tests.rs
+++ b/desktop-client/src/ipc/chat_tests.rs
@@ -8,15 +8,151 @@
 #[cfg(test)]
 mod tests {
     use crate::ipc::chat::{
-        build_thread_control_message, reject_blocked_scan, usage_report_backend_user_id,
-        FrontendAttachment, SendMessageResponse,
+        build_thread_control_message, reject_blocked_scan, send_chat_message,
+        usage_report_backend_user_id, FrontendAttachment, SendMessageResponse,
     };
     use crate::safety_bridge::SafetyBridge;
+    use crate::state::{AppState, EngineState};
+    use dasclaw_runtime::context::ContextManager;
     use ironclaw::safety::{SafetyConfig, SafetyLayer};
+    use ironclaw::tools::ToolRegistry;
     use std::sync::Arc;
     use std::sync::RwLock;
+    use tauri::Manager;
     use tokio::sync::mpsc;
     use uuid::Uuid;
+
+    struct StubLlmProvider;
+
+    #[async_trait::async_trait]
+    impl ironclaw::llm::LlmProvider for StubLlmProvider {
+        fn model_name(&self) -> &str {
+            "stub-model"
+        }
+
+        fn cost_per_token(&self) -> (rust_decimal::Decimal, rust_decimal::Decimal) {
+            (rust_decimal::Decimal::ZERO, rust_decimal::Decimal::ZERO)
+        }
+
+        async fn complete(
+            &self,
+            _req: ironclaw::llm::CompletionRequest,
+        ) -> Result<ironclaw::llm::CompletionResponse, ironclaw::error::LlmError> {
+            Err(ironclaw::error::LlmError::RequestFailed {
+                provider: "stub".into(),
+                reason: "not implemented".into(),
+            })
+        }
+
+        async fn complete_with_tools(
+            &self,
+            _req: ironclaw::llm::ToolCompletionRequest,
+        ) -> Result<ironclaw::llm::ToolCompletionResponse, ironclaw::error::LlmError> {
+            Err(ironclaw::error::LlmError::RequestFailed {
+                provider: "stub".into(),
+                reason: "not implemented".into(),
+            })
+        }
+    }
+
+    struct TestSafetyParts {
+        safety: Arc<SafetyLayer>,
+        safety_bridge: Arc<SafetyBridge>,
+        attachment_scanner: Arc<crate::safety_attachment_scanner::AttachmentScanner>,
+        egress: Arc<dyn dasclaw_core::EgressGate>,
+    }
+
+    struct TestModelParts {
+        llm: Arc<dyn ironclaw::llm::LlmProvider>,
+        model_override: Arc<std::sync::RwLock<Option<String>>>,
+        model_switch: Arc<crate::model_switch::ModelSwitchProvider>,
+        initial_provider: Arc<dyn ironclaw::llm::LlmProvider>,
+    }
+
+    fn create_test_safety_parts() -> TestSafetyParts {
+        let safety = Arc::new(SafetyLayer::new(&SafetyConfig {
+            max_output_length: 100_000,
+            injection_check_enabled: true,
+        }));
+        let safety_bridge = Arc::new(SafetyBridge::new(Arc::clone(&safety), None, None));
+        let egress: Arc<dyn dasclaw_core::EgressGate> = Arc::new(
+            dasclaw_safety::egress_gate::IronclawEgressGate::new(Arc::clone(&safety)),
+        );
+        let attachment_scanner = Arc::new(
+            crate::safety_attachment_scanner::AttachmentScanner::new(Arc::clone(&egress)),
+        );
+
+        TestSafetyParts {
+            safety,
+            safety_bridge,
+            attachment_scanner,
+            egress,
+        }
+    }
+
+    fn create_test_model_parts() -> TestModelParts {
+        let model_override = Arc::new(std::sync::RwLock::new(None));
+        let stub_llm: Arc<dyn ironclaw::llm::LlmProvider> = Arc::new(StubLlmProvider);
+        let model_switch = Arc::new(crate::model_switch::ModelSwitchProvider::new(
+            Arc::clone(&stub_llm),
+            Arc::clone(&model_override),
+        ));
+
+        TestModelParts {
+            llm: Arc::clone(&model_switch) as _,
+            model_override,
+            model_switch,
+            initial_provider: Arc::clone(&stub_llm),
+        }
+    }
+
+    fn create_test_app_state() -> (
+        AppState,
+        mpsc::Receiver<ironclaw::channels::IncomingMessage>,
+    ) {
+        let (tx, rx) = mpsc::channel(1);
+        let safety = create_test_safety_parts();
+        let model = create_test_model_parts();
+
+        let app_state = AppState {
+            msg_sender: tx,
+            db: None,
+            workspace: None,
+            tools: Arc::new(ToolRegistry::new()),
+            extension_manager: None,
+            skill_registry: None,
+            skill_catalog: None,
+            skills_config: ironclaw::config::SkillsConfig::default(),
+            safety: safety.safety,
+            safety_bridge: safety.safety_bridge,
+            attachment_scanner: safety.attachment_scanner,
+            egress: safety.egress,
+            context_manager: Arc::new(ContextManager::new(5)),
+            conversation_tracker: Arc::new(crate::conversation_tracker::ConversationTracker::new(
+                "test-owner".to_string(),
+            )),
+            data_reporter: Arc::new(crate::data_reporter::DataReporter::new(
+                String::new(),
+                String::new(),
+            )),
+            scope_id: "test-owner".to_string(),
+            backend_user_id: Arc::new(std::sync::RwLock::new(None)),
+            llm: model.llm,
+            model_override: model.model_override,
+            model_switch: model.model_switch,
+            provider_base_url: std::sync::RwLock::new(String::new()),
+            initial_provider: model.initial_provider,
+            initial_base_url: String::new(),
+            log_broadcaster: Arc::new(ironclaw::channels::web::log_layer::LogBroadcaster::new()),
+            log_clear_offset: std::sync::atomic::AtomicUsize::new(0),
+            routine_engine_slot: Arc::new(tokio::sync::RwLock::new(None)),
+            scheduler_slot: Arc::new(tokio::sync::RwLock::new(None)),
+            disabled_skills: std::sync::RwLock::new(std::collections::HashSet::new()),
+            disabled_extensions: std::sync::RwLock::new(std::collections::HashSet::new()),
+        };
+
+        (app_state, rx)
+    }
 
     // =========================================================================
     // 单元测试 — 正常路径
@@ -258,6 +394,55 @@ mod tests {
         assert!(
             rx.try_recv().is_err(),
             "blocked scan must not enqueue a message"
+        );
+    }
+
+    #[tokio::test]
+    async fn req_chat_blocked_send_message_has_zero_side_effects() {
+        let secret = "send ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx onward";
+        let thread_id = "thread-blocked-zero".to_string();
+        let (app_state, mut rx) = create_test_app_state();
+        let tracker = Arc::clone(&app_state.conversation_tracker);
+        let reporter = Arc::clone(&app_state.data_reporter);
+
+        let engine_state = EngineState::new();
+        engine_state
+            .initialize(app_state)
+            .expect("test EngineState should initialize once");
+        let app = tauri::test::mock_builder()
+            .manage(engine_state)
+            .build(tauri::test::mock_context(tauri::test::noop_assets()))
+            .expect("mock Tauri app should build");
+
+        let error = send_chat_message(
+            app.handle().clone(),
+            app.state::<EngineState>(),
+            thread_id.clone(),
+            secret.to_string(),
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .expect_err("secret-bearing input must be blocked");
+
+        assert!(error.contains("密钥") || error.contains("secret"));
+        assert!(
+            !error.contains(secret),
+            "blocked error must not leak raw secret"
+        );
+        assert!(
+            rx.try_recv().is_err(),
+            "blocked input must not reach msg_sender"
+        );
+
+        tracker.finish_thread(&thread_id, &reporter);
+        assert_eq!(
+            reporter.queue_len(),
+            0,
+            "blocked input must not be recorded"
         );
     }
 

--- a/desktop-client/src/tauri_channel.rs
+++ b/desktop-client/src/tauri_channel.rs
@@ -176,7 +176,7 @@ impl TextSessions {
 /// Envelope 结构：在 `VercelUIStream` 序列化结果的顶层注入 `threadId` 字段。
 /// AI SDK v5 `UIMessageChunk` 不使用该字段，完全向后兼容。
 pub fn emit_chat_stream(
-    app_handle: &tauri::AppHandle,
+    app_handle: &tauri::AppHandle<impl tauri::Runtime>,
     thread_id: Option<&str>,
     event: &VercelUIStream,
 ) -> Result<(), tauri::Error> {


### PR DESCRIPTION
## 背景/目标
Closes #1059

#1055 已覆盖 `reject_blocked_scan` seam，但还没有走更接近 Tauri command 的 `send_chat_message` 路径来机械断言 blocked 输入不会继续产生后续副作用。本 PR 补上 blocked secret 输入的真实 command 路径测试。

## 改动范围
- 新增 `req_chat_blocked_send_message_has_zero_side_effects`：用 `tauri::test::mock_builder` 注入 `EngineState`，真实调用 `send_chat_message`。
- 断言 secret-bearing 输入被 SafetyBridge block，错误不泄露原始 secret。
- 断言 `msg_sender` channel 未收到消息。
- 断言 `ConversationTracker` finish 后不上报记录，即 blocked 输入未进入持久化/审计缓冲。
- 将 `send_chat_message`、`detect_and_emit_skills_activated` 和 `emit_chat_stream` 的 `AppHandle` 参数泛型化到 `tauri::Runtime`，让生产 Wry runtime 与测试 MockRuntime 共享同一路径。

## 非目标（What's NOT in this PR）
- 不改 DLP / SafetyBridge 判定逻辑。
- 不改 `send_chat_message` 正常路径行为。
- 不修复 desktop-client 既有 clippy lint。
- 不处理 #1057 / #1060 / #1068。

## 验证（命令 + 结果）
- `CARGO_TARGET_DIR=../x-claw/target cargo fmt --all`：通过。
- `CARGO_TARGET_DIR=../x-claw/target cargo check -p desktop-client --tests`：通过。
- `CARGO_TARGET_DIR=../x-claw/target cargo nextest run -p desktop-client --lib req_chat_blocked_send_message_has_zero_side_effects`：1 passed。
- `python3.12 scripts/check_no_panics.py --base origin/xClaw`：通过，`OK: No panic-inducing calls in changed production code.`
- `CARGO_TARGET_DIR=../x-claw/target cargo clippy --no-deps -p desktop-client --all-targets -- -D warnings`：失败于未触及文件的既有 lint：`auth_token_manager.rs` collapsible_str_replace、`dlp/sanitizer.rs` derivable_impls、`data_reporter.rs` too_many_arguments、`engine.rs` question_mark、`managed_policy.rs` manual_ignore_case_cmp、`state.rs` new_without_default、`lib.rs` items_after_test_module、`dlp/change_coverage_tests.rs` module_inception/len_zero 等；触及文件中的新增 lint 已处理。

## Sources read
- `desktop-client/docs/e2e-webdriver-test-plan.md`：§14.2 blocked 语义、§14.5 DLP before dispatch 剩余边界。
- `desktop-client/src/ipc/chat.rs`：`send_chat_message` scan → reject → skill detection → tracker → msg_sender 顺序。
- `desktop-client/src/ipc/chat_tests.rs`：现有 `req_chat_dlp_block_before_dispatch` seam 测试与测试组织方式。
- `desktop-client/src/conversation_tracker.rs`：`record_user_message` / `record_activated_skills` / `finish_thread` 上报缓冲语义。
- `desktop-client/src/tauri_channel.rs`：`emit_chat_stream` 使用 `AppHandle` 发出事件。
- `desktop-client/src/state.rs`：`EngineState::initialize` / `get` 的 test 注入路径。

## Cross-cuts
类A：无新增 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量。

## Skill 自查
- code-quality-audit：生产改动仅泛型化 Tauri runtime；blocked 测试覆盖失败路径、零入队、零 tracker 上报、错误不泄露原始 secret。
- code-simplifier：AppState fixture 拆成 safety/model/app 三段，避免长函数；未新增补丁式生产分支。
- code-review-graph：changed files 低风险，0 affected flows / 0 test gaps。

## 后续 PR / 下一步
按计划继续 #1060 sandbox 真实绕过样本；#1057 仍需先补真实 PostToolUse 生命周期 API，再做验证。