### PR TITLE
test(sandbox): cover symlink escape sample

### DIFF
--- a/crates/dasclaw_sandbox/tests/req_kernel_enforces_read_only_subpaths_macos.rs
+++ b/crates/dasclaw_sandbox/tests/req_kernel_enforces_read_only_subpaths_macos.rs
@@ -18,6 +18,7 @@
 #![cfg(target_os = "macos")]
 
 use std::fs;
+use std::os::unix::fs::symlink;
 use std::path::PathBuf;
 use std::process::Command;
 
@@ -35,14 +36,10 @@ fn make_workspace() -> (tempfile::TempDir, PathBuf) {
     (tmp, hook)
 }
 
-#[test]
-fn req_dasclaw_sandbox_kernel_blocks_git_hooks_under_workspace_write_macos() {
-    let (tmp, hook) = make_workspace();
-    let workspace_root = tmp.path().to_path_buf();
-
-    let policy = SandboxBackendConfig {
+fn workspace_write_policy(workspace_root: PathBuf) -> SandboxBackendConfig {
+    SandboxBackendConfig {
         readable_roots: vec![PathBuf::from("/")],
-        writable_roots: vec![workspace_root.clone()],
+        writable_roots: vec![workspace_root],
         read_only_subpaths: vec![],
         allow_network: false,
         allow_spawn: true,
@@ -50,17 +47,30 @@ fn req_dasclaw_sandbox_kernel_blocks_git_hooks_under_workspace_write_macos() {
         resource_limits: Default::default(),
         enterprise_mode: false,
         linux_sandbox_exe: None,
-    };
+    }
+}
+
+fn shell_redirect_to(path: &std::path::Path, content: &str) -> Command {
+    let mut cmd = Command::new("/bin/sh");
+    cmd.arg("-c").arg(format!(
+        "echo {content} > {}",
+        path.to_string_lossy().replace('\'', "'\\''")
+    ));
+    cmd
+}
+
+#[test]
+fn req_dasclaw_sandbox_kernel_blocks_git_hooks_under_workspace_write_macos() {
+    let (tmp, hook) = make_workspace();
+    let workspace_root = tmp.path().to_path_buf();
+
+    let policy = workspace_write_policy(workspace_root.clone());
 
     // Attempt to overwrite the hook from inside the sandbox. With kernel-
     // layer 洞中洞 enforcement wired (Wave-C1), sandbox-exec must reject
     // the write even though `.git/hooks/` is nominally under a writable
     // root.
-    let mut cmd = Command::new("/bin/sh");
-    cmd.arg("-c").arg(format!(
-        "echo malicious > {}",
-        hook.to_string_lossy().replace('\'', "'\\''")
-    ));
+    let mut cmd = shell_redirect_to(&hook, "malicious");
     cmd.current_dir(&workspace_root);
 
     let req = SandboxExecRequest {
@@ -92,6 +102,43 @@ fn req_dasclaw_sandbox_kernel_blocks_git_hooks_under_workspace_write_macos() {
 }
 
 #[test]
+fn req_dasclaw_sandbox_kernel_blocks_symlink_escape_to_git_hooks_macos() {
+    let (tmp, hook) = make_workspace();
+    let workspace_root = tmp.path().to_path_buf();
+    let link = workspace_root.join("hook-via-symlink");
+    symlink(&hook, &link).expect("create symlink to protected hook");
+    let policy = workspace_write_policy(workspace_root.clone());
+
+    let mut cmd = shell_redirect_to(&link, "malicious-symlink");
+    cmd.current_dir(&workspace_root);
+
+    let req = SandboxExecRequest {
+        command: cmd,
+        policy,
+        preference: SandboxablePreference::Require,
+        windows_sandbox_enabled: false,
+        windows_sandbox_level: dasclaw_protocol::config_types::WindowsSandboxLevel::Disabled,
+        network: None,
+    };
+    let out = SeatbeltSandbox::new()
+        .execute(req)
+        .expect("seatbelt should run symlink bypass sample");
+
+    assert!(
+        !out.status.success(),
+        "expected sandbox-exec to block symlink write into .git/hooks, but shell exited {:?}\nstderr={}",
+        out.status,
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let after = fs::read_to_string(&hook).expect("read back hook");
+    assert!(
+        !after.contains("malicious-symlink"),
+        "kernel-layer regression: symlink under writable root overwrote protected hook — got: {after:?}"
+    );
+}
+
+#[test]
 fn req_dasclaw_sandbox_kernel_allows_write_to_non_hole_path_macos() {
     // Sibling positive contract: writes to the writable root that are NOT
     // covered by the 洞中洞 (e.g. a regular file in the workspace root)
@@ -101,21 +148,9 @@ fn req_dasclaw_sandbox_kernel_allows_write_to_non_hole_path_macos() {
     let workspace_root = tmp.path().to_path_buf();
     let target = workspace_root.join("notes.txt");
 
-    let policy = SandboxBackendConfig {
-        readable_roots: vec![PathBuf::from("/")],
-        writable_roots: vec![workspace_root.clone()],
-        read_only_subpaths: vec![],
-        allow_network: false,
-        allow_spawn: true,
-        proxy_loopback_ports: vec![],
-        resource_limits: Default::default(),
-        enterprise_mode: false,
-        linux_sandbox_exe: None,
-    };
+    let policy = workspace_write_policy(workspace_root.clone());
 
-    let mut cmd = Command::new("/bin/sh");
-    cmd.arg("-c")
-        .arg(format!("echo ok > {}", target.to_string_lossy()));
+    let mut cmd = shell_redirect_to(&target, "ok");
     cmd.current_dir(&workspace_root);
 
     let req = SandboxExecRequest {


### PR DESCRIPTION
## 背景/目标
Closes #1060

#1055 / 现有 enterprise gate 测试覆盖 pure decision fail-closed；已有 macOS seatbelt 测试覆盖直接写 `.git/hooks` 被 kernel 拒绝。本 PR 增加一个更像真实逃逸的 symlink 样本：在可写 workspace 根下创建符号链接，目标指向受保护 `.git/hooks/pre-commit`，再通过链接写入，要求 kernel sandbox 拒绝。

## 改动范围
- 在 `req_kernel_enforces_read_only_subpaths_macos.rs` 增加 `req_dasclaw_sandbox_kernel_blocks_symlink_escape_to_git_hooks_macos`。
- 保留并复用真实 `SeatbeltSandbox::execute` 路径，不降级为 pure decision。
- 提取 `workspace_write_policy` / `shell_redirect_to`，避免三处重复构造 policy 和 shell redirect。
- 保留 sibling positive test，确认普通 workspace 文件仍可写。

## 非目标（What's NOT in this PR）
- 不改 sandbox 生产逻辑。
- 不新增 Linux helper / Windows ACL 样本；现有平台特定测试保持原样。
- 不处理 #1057 / #1068。

## 验证（命令 + 结果）
- `CARGO_TARGET_DIR=../x-claw/target cargo fmt --all`：通过。
- `CARGO_TARGET_DIR=../x-claw/target cargo check -p dasclaw_sandbox --tests`：通过。
- `CARGO_TARGET_DIR=../x-claw/target cargo nextest run -p dasclaw_sandbox --test req_kernel_enforces_read_only_subpaths_macos`：3 passed，0 skipped。
- `python3.12 scripts/check_no_panics.py --base origin/xClaw`：通过，`OK: No panic-inducing calls in changed production code.`
- `CARGO_TARGET_DIR=../x-claw/target cargo clippy --no-deps -p dasclaw_sandbox --all-targets -- -D warnings`：通过。

## Sources read
- `desktop-client/docs/e2e-webdriver-test-plan.md`：§14.5 sandbox 真实逃逸样本要求。
- `crates/dasclaw_sandbox/tests/req_check_enterprise_gate.rs`：现有 pure decision fail-closed 覆盖。
- `crates/dasclaw_sandbox/tests/req_kernel_enforces_read_only_subpaths_macos.rs`：macOS seatbelt 真实 kernel enforcement 测试。
- `crates/dasclaw_sandbox/tests/req_kernel_enforces_read_only_subpaths_linux.rs`：Linux helper 真实/skip 条件参考。
- `crates/dasclaw_sandbox/src/macos/mod.rs`：`SeatbeltSandbox::execute` 与 sbpl 委托路径。

## Cross-cuts
类A：无新增 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量。

## Skill 自查
- code-quality-audit：未改生产逻辑；新增失败路径测试真实执行 sandbox，断言 shell 非零和受保护文件未变。
- code-simplifier：抽出 policy / redirect helper，避免重复样板。
- code-review-graph：测试文件变更低风险，0 affected flows / 0 test gaps。

## 后续 PR / 下一步
按计划剩余 #1068；#1057 仍需生产侧 PostToolUse 生命周期 API 后再补真实测试。