### PR TITLE
test(runtime): verify tool lifecycle order

### DIFF
--- a/crates/dasclaw_runtime/src/agent.rs
+++ b/crates/dasclaw_runtime/src/agent.rs
@@ -127,6 +127,47 @@ pub trait ToolOutputSanitizer: Send + Sync {
     fn sanitize(&self, tool_name: &str, content: &str) -> String;
 }
 
+/// Lifecycle stage emitted around a real [`ToolExecutor::execute`] call.
+///
+/// This is intentionally runtime-level production API, not a test helper:
+/// hosts can attach tracing, audit, or compliance observers to the exact
+/// executor boundary the agent loop uses.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ToolLifecycleStage {
+    /// Immediately before the executor is invoked, after approval and
+    /// pre-execute egress have allowed the call.
+    PreToolUse,
+    /// Immediately after the executor returns a [`ToolResult`], before
+    /// post-execute egress and output sanitization rewrite the payload.
+    PostToolUse,
+}
+
+/// Metadata for one tool lifecycle callback.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ToolLifecycleEvent {
+    pub stage: ToolLifecycleStage,
+    pub tool_call_id: String,
+    pub tool_name: String,
+}
+
+/// Observer for production tool lifecycle callbacks.
+#[async_trait]
+pub trait ToolLifecycleObserver: Send + Sync {
+    /// Called by the runtime around real tool execution.
+    async fn observe(&self, event: ToolLifecycleEvent) -> Result<(), HostError>;
+}
+
+/// Default observer used when hosts do not need lifecycle callbacks.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct NoopToolLifecycleObserver;
+
+#[async_trait]
+impl ToolLifecycleObserver for NoopToolLifecycleObserver {
+    async fn observe(&self, _event: ToolLifecycleEvent) -> Result<(), HostError> {
+        Ok(())
+    }
+}
+
 /// Errors surfaced by [`Agent::run`].
 ///
 /// Serialized via a private adjacent-tagged wire format
@@ -322,6 +363,7 @@ pub struct Agent {
     responder: Arc<dyn AgentResponder>,
     tool_executor: Option<Arc<dyn ToolExecutor>>,
     tool_output_sanitizer: Option<Arc<dyn ToolOutputSanitizer>>,
+    tool_lifecycle_observer: Arc<dyn ToolLifecycleObserver>,
     hooks: HookBundle,
     config: AgentConfig,
     /// Optional cancellation token forwarded to
@@ -466,6 +508,7 @@ impl Agent {
                     self.approval_inbox.clone(),
                 )),
                 self.tool_output_sanitizer.clone(),
+                Arc::clone(&self.tool_lifecycle_observer),
                 event_tx.clone(),
             )) as Arc<dyn ToolDispatcher>
         });
@@ -534,6 +577,7 @@ pub struct AgentBuilder {
     responder: Option<Arc<dyn AgentResponder>>,
     tool_executor: Option<Arc<dyn ToolExecutor>>,
     tool_output_sanitizer: Option<Arc<dyn ToolOutputSanitizer>>,
+    tool_lifecycle_observer: Option<Arc<dyn ToolLifecycleObserver>>,
     hooks: Option<HookBundle>,
     config: AgentConfig,
     cancellation_token: Option<CancellationToken>,
@@ -587,6 +631,24 @@ impl AgentBuilder {
     #[must_use]
     pub fn tool_output_sanitizer_arc(mut self, sanitizer: Arc<dyn ToolOutputSanitizer>) -> Self {
         self.tool_output_sanitizer = Some(sanitizer);
+        self
+    }
+
+    /// Attach a production lifecycle observer around real tool execution.
+    #[must_use]
+    pub fn tool_lifecycle_observer(
+        mut self,
+        observer: impl ToolLifecycleObserver + 'static,
+    ) -> Self {
+        self.tool_lifecycle_observer = Some(Arc::new(observer));
+        self
+    }
+
+    /// Same as [`Self::tool_lifecycle_observer`] but accepts a pre-built
+    /// `Arc` so hosts can share an observer across agents.
+    #[must_use]
+    pub fn tool_lifecycle_observer_arc(mut self, observer: Arc<dyn ToolLifecycleObserver>) -> Self {
+        self.tool_lifecycle_observer = Some(observer);
         self
     }
 
@@ -661,6 +723,9 @@ impl AgentBuilder {
             responder,
             tool_executor: self.tool_executor,
             tool_output_sanitizer: self.tool_output_sanitizer,
+            tool_lifecycle_observer: self
+                .tool_lifecycle_observer
+                .unwrap_or_else(|| Arc::new(NoopToolLifecycleObserver)),
             hooks,
             config: self.config,
             cancellation_token: self.cancellation_token,
@@ -954,6 +1019,79 @@ mod tests {
             .expect("build");
         let out = agent.run("please call echo").await.expect("run");
         assert_eq!(out, "all done");
+    }
+
+    struct RecordingLifecycleObserver {
+        calls: Arc<tokio::sync::Mutex<Vec<&'static str>>>,
+    }
+
+    #[async_trait]
+    impl ToolLifecycleObserver for RecordingLifecycleObserver {
+        async fn observe(&self, event: ToolLifecycleEvent) -> Result<(), HostError> {
+            assert_eq!(event.tool_call_id, "call_1");
+            assert_eq!(event.tool_name, "echo");
+            let label = match event.stage {
+                ToolLifecycleStage::PreToolUse => "pre",
+                ToolLifecycleStage::PostToolUse => "post",
+            };
+            self.calls.lock().await.push(label);
+            Ok(())
+        }
+    }
+
+    struct RecordingOrderExecutor {
+        calls: Arc<tokio::sync::Mutex<Vec<&'static str>>>,
+    }
+
+    #[async_trait]
+    impl ToolExecutor for RecordingOrderExecutor {
+        async fn execute(&self, call: &ToolCall) -> Result<ToolResult, HostError> {
+            self.calls.lock().await.push("exec");
+            Ok(ToolResult {
+                tool_call_id: call.id.clone(),
+                name: call.name.clone(),
+                content: "echo result".to_string(),
+                is_error: false,
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn req_1057_tool_lifecycle_wraps_real_executor_order() {
+        // Regression for issue #1057: this must exercise the production
+        // Agent -> SequentialDispatcher -> ToolExecutor path. The test
+        // records lifecycle callbacks and the actual executor invocation
+        // into one log, proving the real order is:
+        //   PreToolUse -> execute -> PostToolUse
+        let calls = Arc::new(tokio::sync::Mutex::new(Vec::new()));
+        let responder = ScriptedResponder::new(vec![
+            tool_call_output_named("echo", "call_1"),
+            text_output("all done"),
+        ]);
+        let observer = Arc::new(RecordingLifecycleObserver {
+            calls: Arc::clone(&calls),
+        });
+        let executor = RecordingOrderExecutor {
+            calls: Arc::clone(&calls),
+        };
+
+        let agent = Agent::builder()
+            .responder(responder)
+            .tool_executor(executor)
+            .tool_lifecycle_observer_arc(observer)
+            .tools(vec![ToolDefinition {
+                name: "echo".into(),
+                description: "echo".into(),
+                parameters: serde_json::json!({"type": "object"}),
+            }])
+            .build()
+            .expect("build");
+
+        let out = agent.run("please call echo").await.expect("run");
+        assert_eq!(out, "all done");
+
+        let actual = calls.lock().await.clone();
+        assert_eq!(actual, vec!["pre", "exec", "post"]);
     }
 
     #[tokio::test]

--- a/crates/dasclaw_runtime/src/lib.rs
+++ b/crates/dasclaw_runtime/src/lib.rs
@@ -83,7 +83,7 @@ pub mod tool_to_executor_adapter;
 
 pub use agent::{
     Agent, AgentBuilder, AgentConfig, AgentError, AgentEvent, AgentResponder, ToolExecutor,
-    ToolOutputSanitizer,
+    ToolLifecycleEvent, ToolLifecycleObserver, ToolLifecycleStage, ToolOutputSanitizer,
 };
 pub use agentic_loop::AgenticLoop;
 // W8.0: re-export the loop control vocabulary so AgentResponder impls

--- a/crates/dasclaw_runtime/src/tool_dispatch.rs
+++ b/crates/dasclaw_runtime/src/tool_dispatch.rs
@@ -25,7 +25,10 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc;
 
 use crate::AgentEvent;
-use crate::agent::{ToolExecutor, ToolOutputSanitizer};
+use crate::agent::{
+    ToolExecutor, ToolLifecycleEvent, ToolLifecycleObserver, ToolLifecycleStage,
+    ToolOutputSanitizer,
+};
 use crate::approval::{ApprovalOutcome, Approver};
 
 /// Sentinel prefix for `LoopOutcome::Failure` strings produced when an
@@ -81,6 +84,7 @@ pub struct SequentialDispatcher {
     egress: Arc<dyn EgressGate>,
     approver: Arc<dyn Approver>,
     tool_output_sanitizer: Option<Arc<dyn ToolOutputSanitizer>>,
+    tool_lifecycle_observer: Arc<dyn ToolLifecycleObserver>,
     event_tx: Option<mpsc::Sender<AgentEvent>>,
 }
 
@@ -93,6 +97,7 @@ impl SequentialDispatcher {
         egress: Arc<dyn EgressGate>,
         approver: Arc<dyn Approver>,
         tool_output_sanitizer: Option<Arc<dyn ToolOutputSanitizer>>,
+        tool_lifecycle_observer: Arc<dyn ToolLifecycleObserver>,
         event_tx: Option<mpsc::Sender<AgentEvent>>,
     ) -> Self {
         Self {
@@ -100,6 +105,7 @@ impl SequentialDispatcher {
             egress,
             approver,
             tool_output_sanitizer,
+            tool_lifecycle_observer,
             event_tx,
         }
     }
@@ -165,7 +171,9 @@ impl ToolDispatcher for SequentialDispatcher {
                 continue;
             }
 
+            self.observe(call, ToolLifecycleStage::PreToolUse).await?;
             let result = self.executor.execute(call).await?;
+            self.observe(call, ToolLifecycleStage::PostToolUse).await?;
             let executor_is_error = result.is_error;
 
             // ADR-148 Layer B + ADR-153 §1.1 e15/A9:
@@ -213,6 +221,16 @@ impl ToolDispatcher for SequentialDispatcher {
 impl SequentialDispatcher {
     async fn emit(&self, event: AgentEvent) {
         emit_event(self.event_tx.as_ref(), event).await;
+    }
+
+    async fn observe(&self, call: &ToolCall, stage: ToolLifecycleStage) -> Result<(), HostError> {
+        self.tool_lifecycle_observer
+            .observe(ToolLifecycleEvent {
+                stage,
+                tool_call_id: call.id.clone(),
+                tool_name: call.name.clone(),
+            })
+            .await
     }
 
     async fn push_rejection(


### PR DESCRIPTION
## 背景 / 目标

Closes #1057。当前 `req_hooks_lifecycle_order` 只覆盖同一 HookPoint 内部注册顺序，不能证明真实工具执行链路中的 `PreToolUse -> execute -> PostToolUse` 顺序。

## 改动范围

- 在 `dasclaw_runtime` 增加生产级 `ToolLifecycleObserver` / `ToolLifecycleEvent` / `ToolLifecycleStage` API。
- 在 `SequentialDispatcher` 的真实 `ToolExecutor::execute` 边界前后触发 `PreToolUse` / `PostToolUse`。
- 补 `Agent -> SequentialDispatcher -> ToolExecutor` 级回归测试，断言顺序为 `pre -> exec -> post`。

## What’s NOT in this PR

- 不改 `dasclaw_hooks::HookRegistry` 的注册/执行语义。
- 不接入桌面 UI、WebDriver 或 GitHub CI watch。
- 不改变现有 tool execution 默认行为；未注入 observer 时走 no-op。

## 验证

- `cargo check -p dasclaw_runtime --tests` ✅
- `cargo nextest run -p dasclaw_runtime` ✅ 197/197 passed
- `cargo clippy --no-deps -p dasclaw_runtime --all-targets -- -D warnings` ✅
- `cargo fmt -p dasclaw_runtime` ✅
- `python3.12 scripts/check_no_panics.py --base origin/xClaw` ✅
- `git diff --check` ✅

## Cross-cuts

ADR-114：类A（无新增 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量）。

## 风险 / 后续步骤

风险较低：新增 observer 默认为 no-op，现有调用方无需迁移。后续如需要更细粒度审计，可在 host 层注入 observer 记录到 tracing / audit sink。