### PR TITLE
test: add memory workspace round-trip coverage

### DIFF
--- a/desktop-client/src/ipc/memory.rs
+++ b/desktop-client/src/ipc/memory.rs
@@ -5,7 +5,7 @@
 use serde::{Deserialize, Serialize};
 use tauri::State;
 
-use crate::state::EngineState;
+use crate::state::{AppState, EngineState};
 
 const DEFAULT_MEMORY_SEARCH_LIMIT: usize = 10;
 
@@ -42,12 +42,23 @@ pub(crate) fn memory_search_limit(limit: Option<usize>) -> usize {
     limit.unwrap_or(DEFAULT_MEMORY_SEARCH_LIMIT)
 }
 
+pub(crate) fn memory_display_path(path: &str) -> String {
+    if path.is_empty() || path == "/" {
+        return "/".to_string();
+    }
+    if path.starts_with('/') {
+        path.to_string()
+    } else {
+        format!("/{path}")
+    }
+}
+
 pub(crate) fn workspace_entry_to_memory_entry(
     entry: ironclaw::workspace::WorkspaceEntry,
 ) -> MemoryEntry {
     MemoryEntry {
         name: entry.name().to_string(),
-        path: entry.path,
+        path: memory_display_path(&entry.path),
         is_directory: entry.is_directory,
         content_preview: entry.content_preview,
     }
@@ -68,22 +79,24 @@ pub(crate) fn workspace_search_result_to_memory_search_result(
     result: ironclaw::workspace::SearchResult,
 ) -> MemorySearchResult {
     MemorySearchResult {
-        path: result.document_path,
+        path: memory_display_path(&result.document_path),
         content: result.content,
         score: result.score,
     }
 }
 
-/// 列出记忆目录。
-#[tauri::command]
-pub async fn ic_memory_list(
-    state: State<'_, EngineState>,
-    path: Option<String>,
-) -> Result<Vec<MemoryEntry>, String> {
-    let state = state.get()?;
-    let ws = state.workspace.as_ref().ok_or("Workspace not available")?;
+fn app_workspace(state: &AppState) -> Result<&ironclaw::workspace::Workspace, String> {
+    state
+        .workspace
+        .as_deref()
+        .ok_or("Workspace not available".to_string())
+}
 
-    let dir = memory_list_path(path.as_deref());
+pub(crate) async fn memory_list_from_workspace(
+    ws: &ironclaw::workspace::Workspace,
+    path: Option<&str>,
+) -> Result<Vec<MemoryEntry>, String> {
+    let dir = memory_list_path(path);
     let entries = ws
         .list(dir)
         .await
@@ -95,6 +108,69 @@ pub async fn ic_memory_list(
         .collect())
 }
 
+pub(crate) async fn memory_read_from_workspace(
+    ws: &ironclaw::workspace::Workspace,
+    path: String,
+) -> Result<MemoryDocument, String> {
+    let doc = ws
+        .read(&path)
+        .await
+        .map_err(|e| format!("Failed to read memory: {}", e))?;
+
+    Ok(workspace_document_to_memory_document(path, doc))
+}
+
+pub(crate) async fn memory_write_from_workspace(
+    ws: &ironclaw::workspace::Workspace,
+    path: &str,
+    content: &str,
+) -> Result<(), String> {
+    ws.write(path, content)
+        .await
+        .map_err(|e| format!("Failed to write memory: {}", e))?;
+
+    tracing::debug!(path = %path, "Memory written");
+    Ok(())
+}
+
+pub(crate) async fn memory_delete_from_workspace(
+    ws: &ironclaw::workspace::Workspace,
+    path: &str,
+) -> Result<(), String> {
+    ws.delete(path)
+        .await
+        .map_err(|e| format!("Failed to delete memory: {}", e))?;
+
+    tracing::debug!(path = %path, "Memory deleted");
+    Ok(())
+}
+
+pub(crate) async fn memory_search_from_workspace(
+    ws: &ironclaw::workspace::Workspace,
+    query: &str,
+    limit: Option<usize>,
+) -> Result<Vec<MemorySearchResult>, String> {
+    let results = ws
+        .search(query, memory_search_limit(limit))
+        .await
+        .map_err(|e| format!("Failed to search memory: {}", e))?;
+
+    Ok(results
+        .into_iter()
+        .map(workspace_search_result_to_memory_search_result)
+        .collect())
+}
+
+/// 列出记忆目录。
+#[tauri::command]
+pub async fn ic_memory_list(
+    state: State<'_, EngineState>,
+    path: Option<String>,
+) -> Result<Vec<MemoryEntry>, String> {
+    let state = state.get()?;
+    memory_list_from_workspace(app_workspace(state)?, path.as_deref()).await
+}
+
 /// 读取记忆文档。
 #[tauri::command]
 pub async fn ic_memory_read(
@@ -102,14 +178,7 @@ pub async fn ic_memory_read(
     path: String,
 ) -> Result<MemoryDocument, String> {
     let state = state.get()?;
-    let ws = state.workspace.as_ref().ok_or("Workspace not available")?;
-
-    let doc = ws
-        .read(&path)
-        .await
-        .map_err(|e| format!("Failed to read memory: {}", e))?;
-
-    Ok(workspace_document_to_memory_document(path, doc))
+    memory_read_from_workspace(app_workspace(state)?, path).await
 }
 
 /// 写入记忆文档。
@@ -120,28 +189,14 @@ pub async fn ic_memory_write(
     content: String,
 ) -> Result<(), String> {
     let state = state.get()?;
-    let ws = state.workspace.as_ref().ok_or("Workspace not available")?;
-
-    ws.write(&path, &content)
-        .await
-        .map_err(|e| format!("Failed to write memory: {}", e))?;
-
-    tracing::debug!(path = %path, "Memory written");
-    Ok(())
+    memory_write_from_workspace(app_workspace(state)?, &path, &content).await
 }
 
 /// 删除记忆文档。
 #[tauri::command]
 pub async fn ic_memory_delete(state: State<'_, EngineState>, path: String) -> Result<(), String> {
     let state = state.get()?;
-    let ws = state.workspace.as_ref().ok_or("Workspace not available")?;
-
-    ws.delete(&path)
-        .await
-        .map_err(|e| format!("Failed to delete memory: {}", e))?;
-
-    tracing::debug!(path = %path, "Memory deleted");
-    Ok(())
+    memory_delete_from_workspace(app_workspace(state)?, &path).await
 }
 
 /// 搜索记忆。
@@ -152,15 +207,5 @@ pub async fn ic_memory_search(
     limit: Option<usize>,
 ) -> Result<Vec<MemorySearchResult>, String> {
     let state = state.get()?;
-    let ws = state.workspace.as_ref().ok_or("Workspace not available")?;
-
-    let results = ws
-        .search(&query, memory_search_limit(limit))
-        .await
-        .map_err(|e| format!("Failed to search memory: {}", e))?;
-
-    Ok(results
-        .into_iter()
-        .map(workspace_search_result_to_memory_search_result)
-        .collect())
+    memory_search_from_workspace(app_workspace(state)?, &query, limit).await
 }

--- a/desktop-client/src/ipc/memory_tests.rs
+++ b/desktop-client/src/ipc/memory_tests.rs
@@ -9,16 +9,21 @@
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use chrono::{DateTime, Utc};
+    use ironclaw::db::libsql::LibSqlBackend;
     use ironclaw::workspace::{
         MemoryDocument as WorkspaceMemoryDocument, SearchResult as WorkspaceSearchResult,
-        WorkspaceEntry,
+        Workspace, WorkspaceEntry,
     };
     use serde_json::json;
     use uuid::Uuid;
 
     use crate::ipc::memory::{
-        memory_list_path, memory_search_limit, workspace_document_to_memory_document,
+        memory_delete_from_workspace, memory_display_path, memory_list_from_workspace,
+        memory_list_path, memory_read_from_workspace, memory_search_from_workspace,
+        memory_search_limit, memory_write_from_workspace, workspace_document_to_memory_document,
         workspace_entry_to_memory_entry, workspace_search_result_to_memory_search_result,
         MemoryDocument, MemoryEntry, MemorySearchResult,
     };
@@ -53,6 +58,19 @@ mod tests {
             fts_rank: Some(1),
             vector_rank: Some(2),
         }
+    }
+
+    async fn workspace_with_memory_db() -> (Workspace, tempfile::TempDir) {
+        let temp_dir = tempfile::tempdir().expect("temporary db directory should be created");
+        let db_path = temp_dir.path().join("memory-ipc.db");
+        let backend = LibSqlBackend::new_local(&db_path)
+            .await
+            .expect("file-backed libsql backend should initialize");
+        <LibSqlBackend as ironclaw::db::Database>::run_migrations(&backend)
+            .await
+            .expect("workspace migrations should run");
+        let db: Arc<dyn ironclaw::db::Database> = Arc::new(backend);
+        (Workspace::new_with_db("memory-ipc-user", db), temp_dir)
     }
 
     // =========================================================================
@@ -140,6 +158,19 @@ mod tests {
     }
 
     #[test]
+    fn req_memory_display_path_uses_frontend_absolute_shape() {
+        assert_eq!(
+            memory_display_path("projects/alpha.md"),
+            "/projects/alpha.md"
+        );
+        assert_eq!(
+            memory_display_path("/projects/alpha.md"),
+            "/projects/alpha.md"
+        );
+        assert_eq!(memory_display_path(""), "/");
+    }
+
+    #[test]
     fn req_memory_list_maps_workspace_entries() {
         let entry = WorkspaceEntry {
             path: "/projects/alpha/README.md".into(),
@@ -175,7 +206,7 @@ mod tests {
     #[test]
     fn req_memory_search_maps_workspace_results_without_rank_ids() {
         let dto = workspace_search_result_to_memory_search_result(workspace_search_result(
-            "/docs/api.md",
+            "docs/api.md",
             "memory search hit",
         ));
         let json = serde_json::to_string(&dto).expect("dto should serialize");
@@ -187,6 +218,68 @@ mod tests {
         assert!(!json.contains("chunk_id"));
         assert!(!json.contains("fts_rank"));
         assert!(!json.contains("vector_rank"));
+    }
+
+    #[tokio::test]
+    async fn req_memory_workspace_crud_search_round_trip() {
+        let (workspace, _temp_dir) = workspace_with_memory_db().await;
+        let path = "/projects/alpha/notes.md";
+        let content = "alpha launch notes mention hermetic workspace memory";
+
+        memory_write_from_workspace(&workspace, path, content)
+            .await
+            .expect("write should hit the real workspace");
+
+        let doc = memory_read_from_workspace(&workspace, path.to_string())
+            .await
+            .expect("read should return the persisted document");
+        assert_eq!(doc.path, path);
+        assert_eq!(doc.content, content);
+        assert!(
+            doc.updated_at.is_some(),
+            "real workspace documents should carry updated_at"
+        );
+
+        let root_entries = memory_list_from_workspace(&workspace, None)
+            .await
+            .expect("root list should use the default path");
+        assert!(
+            root_entries
+                .iter()
+                .any(|entry| entry.name == "projects" && entry.is_directory),
+            "root list should expose the virtual projects directory"
+        );
+
+        let project_entries = memory_list_from_workspace(&workspace, Some("/projects/alpha"))
+            .await
+            .expect("nested list should read real workspace entries");
+        assert!(
+            project_entries
+                .iter()
+                .any(|entry| entry.name == "notes.md" && !entry.is_directory),
+            "nested list should expose the written document"
+        );
+
+        let results = memory_search_from_workspace(&workspace, "hermetic", Some(5))
+            .await
+            .expect("search should query indexed workspace chunks");
+        assert!(
+            results
+                .iter()
+                .any(|result| result.path == path && result.content.contains("hermetic")),
+            "search should find content written through the IPC path"
+        );
+
+        memory_delete_from_workspace(&workspace, path)
+            .await
+            .expect("delete should remove the workspace document");
+        let err = memory_read_from_workspace(&workspace, path.to_string())
+            .await
+            .expect_err("deleted document should no longer be readable");
+        assert!(
+            err.contains("Failed to read memory"),
+            "delete/read failure should preserve the IPC error prefix: {err}"
+        );
     }
 
     // =========================================================================


### PR DESCRIPTION
Closes #1068.

## 背景 / 目标
#1068 继续把 #1025 后剩余的 IPC 覆盖从 helper/DTO 覆盖推进到真实状态回环。本 PR 是第一片：记忆族真实 Workspace 回环。

## 改动范围
- 抽出 memory IPC 的 Workspace 调用核心，Tauri command 仍从 EngineState 获取真实 Workspace。
- 修正 memory list/search DTO path 输出，统一为前端使用的绝对路径形态（例如 /projects/a.md）。
- 新增 libSQL file-backed Workspace 回环测试，覆盖 write -> read -> list -> search -> delete -> read failure。

## 非目标
- 不覆盖技能、扩展、任务、日程、工作区导入、应用/认证 HTTP 路径；这些继续拆后续 PR。
- 不引入 UI/WebDriver 测试。
- 不处理既有 desktop-client clippy 预存 lint。

## 验证
- RUSTC_WRAPPER= cargo nextest run -p desktop-client -E 'test(req_memory_workspace_crud_search_round_trip) | test(req_memory_display_path_uses_frontend_absolute_shape)'：2 passed
- RUSTC_WRAPPER= cargo nextest run -p desktop-client -E 'test(ipc::memory_tests)'：26 passed
- RUSTC_WRAPPER= cargo check -p desktop-client --tests：passed
- python3.12 scripts/check_no_panics.py --base origin/xClaw：passed
- RUSTC_WRAPPER= cargo clippy --no-deps -p desktop-client --all-targets -- -D warnings：blocked by pre-existing unrelated lints outside this PR (auth_token_manager.rs, DLP tests, chat.rs, state.rs, etc.)

## Cross-cuts
类A：无新增 .ironclaw / IRONCLAW_BASE_DIR 字面量。

## 后续 PR
- #1068 P0：技能 install/enable/search 真实状态回环。
- #1068 P1：扩展 setup/install、工作区导入、应用/认证 HTTP 路径。
- #1068 P2：任务/日程/文件 Undo 长尾回归。
