### PR TITLE
test: add workspace import round-trip coverage

### DIFF
--- a/desktop-client/src/ipc/workspace.rs
+++ b/desktop-client/src/ipc/workspace.rs
@@ -7,7 +7,7 @@ use serde::Serialize;
 use tauri::State;
 use uuid::Uuid;
 
-use crate::state::EngineState;
+use crate::state::{AppState, EngineState};
 
 /// 活跃的 LSP/MCP 服务器。
 #[derive(Debug, Clone, Serialize)]
@@ -94,14 +94,21 @@ pub async fn ic_import_workspace(
     thread_id: String,
     path: String,
 ) -> Result<String, String> {
-    let state = state.get()?;
+    import_workspace_from_state(state.get()?, &thread_id, &path).await
+}
+
+pub(crate) async fn import_workspace_from_state(
+    state: &AppState,
+    thread_id: &str,
+    path: &str,
+) -> Result<String, String> {
     let db = state.db.as_ref().ok_or("Database not available")?;
 
     let tid: Uuid = thread_id
         .parse()
         .map_err(|_| format!("Invalid thread_id: {thread_id}"))?;
 
-    let canonical = crate::workspace_dir::validate_import_path(&path)
+    let canonical = crate::workspace_dir::validate_import_path(path)
         .map_err(|e| format!("Invalid workspace path: {e}"))?;
     let canonical_str = canonical.to_string_lossy().to_string();
 
@@ -119,7 +126,13 @@ pub async fn ic_get_thread_workspace(
     state: State<'_, EngineState>,
     thread_id: String,
 ) -> Result<Option<String>, String> {
-    let state = state.get()?;
+    get_thread_workspace_from_state(state.get()?, &thread_id).await
+}
+
+pub(crate) async fn get_thread_workspace_from_state(
+    state: &AppState,
+    thread_id: &str,
+) -> Result<Option<String>, String> {
     let db = state.db.as_ref().ok_or("Database not available")?;
 
     let tid: Uuid = thread_id
@@ -179,7 +192,126 @@ pub struct SandboxWorkspace {
 
 #[cfg(test)]
 mod tests {
-    use super::{git_status_result, ActiveServer, SandboxWorkspace};
+    use std::collections::HashSet;
+    use std::sync::Arc;
+
+    use dasclaw_runtime::context::ContextManager;
+    use tokio::sync::mpsc;
+
+    use super::{
+        get_thread_workspace_from_state, git_status_result, import_workspace_from_state,
+        ActiveServer, SandboxWorkspace,
+    };
+    use crate::state::AppState;
+
+    struct StubLlmProvider;
+
+    #[async_trait::async_trait]
+    impl ironclaw::llm::LlmProvider for StubLlmProvider {
+        fn model_name(&self) -> &str {
+            "stub-model"
+        }
+
+        fn cost_per_token(&self) -> (rust_decimal::Decimal, rust_decimal::Decimal) {
+            (rust_decimal::Decimal::ZERO, rust_decimal::Decimal::ZERO)
+        }
+
+        async fn complete(
+            &self,
+            _req: ironclaw::llm::CompletionRequest,
+        ) -> Result<ironclaw::llm::CompletionResponse, ironclaw::error::LlmError> {
+            Err(ironclaw::error::LlmError::RequestFailed {
+                provider: "stub".into(),
+                reason: "not implemented".into(),
+            })
+        }
+
+        async fn complete_with_tools(
+            &self,
+            _req: ironclaw::llm::ToolCompletionRequest,
+        ) -> Result<ironclaw::llm::ToolCompletionResponse, ironclaw::error::LlmError> {
+            Err(ironclaw::error::LlmError::RequestFailed {
+                provider: "stub".into(),
+                reason: "not implemented".into(),
+            })
+        }
+    }
+
+    async fn test_db(tempdir: &tempfile::TempDir) -> Arc<dyn ironclaw::db::Database> {
+        let db_path = tempdir.path().join("workspace-state.db");
+        let backend = ironclaw::db::libsql::LibSqlBackend::new_local(&db_path)
+            .await
+            .expect("file-backed libsql backend should initialize");
+        <ironclaw::db::libsql::LibSqlBackend as ironclaw::db::Database>::run_migrations(&backend)
+            .await
+            .expect("migrations should run");
+        Arc::new(backend)
+    }
+
+    async fn test_app_state_with_db() -> (AppState, tempfile::TempDir) {
+        let tempdir = tempfile::tempdir().expect("tempdir should be created");
+        let db = test_db(&tempdir).await;
+        let (tx, _rx) = mpsc::channel(1);
+
+        let safety_config = ironclaw::safety::SafetyConfig {
+            max_output_length: 100_000,
+            injection_check_enabled: true,
+        };
+        let safety = Arc::new(ironclaw::safety::SafetyLayer::new(&safety_config));
+        let safety_bridge = Arc::new(crate::safety_bridge::SafetyBridge::new(
+            Arc::clone(&safety),
+            None,
+            None,
+        ));
+        let egress: Arc<dyn dasclaw_core::EgressGate> = Arc::new(
+            dasclaw_safety::egress_gate::IronclawEgressGate::new(Arc::clone(&safety)),
+        );
+        let attachment_scanner = Arc::new(
+            crate::safety_attachment_scanner::AttachmentScanner::new(Arc::clone(&egress)),
+        );
+        let model_override = Arc::new(std::sync::RwLock::new(None));
+        let stub_llm: Arc<dyn ironclaw::llm::LlmProvider> = Arc::new(StubLlmProvider);
+        let model_switch = Arc::new(crate::model_switch::ModelSwitchProvider::new(
+            Arc::clone(&stub_llm),
+            Arc::clone(&model_override),
+        ));
+
+        let state = AppState {
+            msg_sender: tx,
+            db: Some(db),
+            workspace: None,
+            tools: Arc::new(ironclaw::tools::ToolRegistry::new()),
+            extension_manager: None,
+            skill_registry: None,
+            skill_catalog: None,
+            skills_config: ironclaw::config::SkillsConfig::default(),
+            safety,
+            safety_bridge,
+            attachment_scanner,
+            egress,
+            context_manager: Arc::new(ContextManager::new(5)),
+            conversation_tracker: Arc::new(crate::conversation_tracker::ConversationTracker::new(
+                "workspace-ipc-owner".to_string(),
+            )),
+            data_reporter: Arc::new(crate::data_reporter::DataReporter::new_for_test()),
+            scope_id: "workspace-ipc-owner".to_string(),
+            backend_user_id: Arc::new(std::sync::RwLock::new(None)),
+            llm: Arc::clone(&model_switch) as _,
+            model_override,
+            model_switch,
+            provider_base_url: std::sync::RwLock::new(String::new()),
+            initial_provider: Arc::clone(&stub_llm),
+            initial_base_url: String::new(),
+            log_broadcaster: Arc::new(ironclaw::channels::web::log_layer::LogBroadcaster::new()),
+            log_clear_offset: std::sync::atomic::AtomicUsize::new(0),
+            routine_engine_slot: Arc::new(tokio::sync::RwLock::new(None)),
+            scheduler_slot: Arc::new(tokio::sync::RwLock::new(None)),
+            disabled_skills: std::sync::RwLock::new(HashSet::new()),
+            disabled_extensions: std::sync::RwLock::new(HashSet::new()),
+        };
+
+        (state, tempdir)
+    }
 
     #[test]
     fn req_workspace_git_status_returns_stdout_on_success() {
@@ -225,5 +357,82 @@ mod tests {
 
         assert_eq!(json["name"], "thread-123");
         assert_eq!(json["path"], "/tmp/thread-123");
+    }
+
+    #[tokio::test]
+    async fn req_workspace_import_and_get_thread_workspace_state_round_trip() {
+        let (state, tempdir) = test_app_state_with_db().await;
+        let import_dir = tempdir.path().join("imported-workspace");
+        std::fs::create_dir_all(&import_dir).expect("import workspace dir should be created");
+
+        let db = state.db.as_ref().expect("db should exist");
+        let thread_id = db
+            .create_conversation_with_metadata(
+                "tauri",
+                &state.scope_id,
+                &serde_json::json!({"workspace_root": "/old/sandbox/path", "title": "Workspace"}),
+            )
+            .await
+            .expect("conversation should be created");
+        let thread_id_str = thread_id.to_string();
+
+        let imported =
+            import_workspace_from_state(&state, &thread_id_str, &import_dir.to_string_lossy())
+                .await
+                .expect("import should persist canonical workspace path");
+        let expected = import_dir
+            .canonicalize()
+            .expect("import dir should canonicalize")
+            .to_string_lossy()
+            .to_string();
+        assert_eq!(imported, expected);
+
+        let loaded = get_thread_workspace_from_state(&state, &thread_id_str)
+            .await
+            .expect("get should read metadata from real db");
+        assert_eq!(loaded.as_deref(), Some(expected.as_str()));
+
+        let metadata = db
+            .get_conversation_metadata(thread_id)
+            .await
+            .expect("metadata should be readable")
+            .expect("metadata should exist");
+        assert_eq!(metadata["workspace_root"], serde_json::json!(expected));
+        assert_eq!(
+            metadata["title"],
+            serde_json::json!("Workspace"),
+            "import should patch workspace_root without dropping existing metadata"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_workspace_import_failure_rejects_non_directory_without_metadata_write() {
+        let (state, tempdir) = test_app_state_with_db().await;
+        let file_path = tempdir.path().join("not-a-directory.txt");
+        std::fs::write(&file_path, "not a directory").expect("test file should be written");
+
+        let db = state.db.as_ref().expect("db should exist");
+        let thread_id = db
+            .create_conversation_with_metadata(
+                "tauri",
+                &state.scope_id,
+                &serde_json::json!({"workspace_root": "/old/sandbox/path"}),
+            )
+            .await
+            .expect("conversation should be created");
+        let thread_id = thread_id.to_string();
+
+        let error = import_workspace_from_state(&state, &thread_id, &file_path.to_string_lossy())
+            .await
+            .expect_err("import should reject file paths");
+        assert!(
+            error.contains("Invalid workspace path"),
+            "error should come from path validation, actual: {error}"
+        );
+
+        let loaded = get_thread_workspace_from_state(&state, &thread_id)
+            .await
+            .expect("get should still read old metadata");
+        assert_eq!(loaded.as_deref(), Some("/old/sandbox/path"));
     }
 }


### PR DESCRIPTION
Closes #1068.

## 背景 / 目标
#1068 第四片：补齐 Workspace ic_import_workspace / ic_get_thread_workspace 的真实 AppState + DB metadata 回环覆盖。

## 改动范围
- 抽出 Workspace IPC helpers，Tauri command 保持薄包装。
- 新增 file-backed libSQL + AppState fixture。
- 新增 import -> get_thread_workspace -> metadata 验证回环测试。
- 新增导入非目录失败路径，确认不会覆盖既有 workspace_root metadata。
- 新增 test-only no-proxy DataReporter 构造器，避免 AppState fixture 被 macOS system proxy 初始化干扰。

## What’s NOT in this PR
- 不改 sandbox workspace 创建逻辑。
- 不处理 jobs/routines/auth/app/files 的 #1068 后续切片。
- 不修 desktop-client 既有 clippy lint。

## 验证
- RUSTC_WRAPPER= cargo nextest run -p desktop-client -E 'test(ipc::workspace)'：6 passed（nextest 标记 1 个既有纯序列化测试 leaky，但退出码 0）
- RUSTC_WRAPPER= cargo check -p desktop-client --tests：passed
- cargo fmt -p desktop-client：passed
- python3.12 scripts/check_no_panics.py --base origin/xClaw：passed
- git diff --check：passed
- RUSTC_WRAPPER= cargo clippy --no-deps -p desktop-client --all-targets -- -D warnings：blocked by existing desktop-client lint outside this PR scope; workspace.rs 新增 lint 已修复后复跑无 workspace.rs 诊断。

## Cross-cuts
类A：无新增 .ironclaw / IRONCLAW_BASE_DIR 字面量。

## 后续 PR / 下一步
继续拆 #1068：Jobs/Routines/Auth-App 的真实 AppState/DB/HTTP 回环覆盖。
