### PR TITLE
test(e2e): expose active thread id for scenario 6

### DIFF
--- a/desktop-client/docs/e2e-webdriver-test-plan.md
+++ b/desktop-client/docs/e2e-webdriver-test-plan.md
@@ -409,24 +409,27 @@ execjs(sid, "document.querySelector('button.aui-composer-send').click(); return 
 ```python
 sid = new_session(); poll(lambda: json.loads(execjs(sid, SNAPSHOT))["composer"] > 0, 60)
 
-# (a) 取当前 thread 列表，记录一个 thread_id
-threads = execjs(sid, "return window.__TAURI_INTERNALS__.invoke('ic_list_threads', {});")
-tid = threads[0]["id"] if threads else None
-
 execjs(sid, INJECT, ["记住这句话：E2E-MARKER-7788"])
 execjs(sid, "document.querySelector('button.aui-composer-send').click(); return true;")
 poll(lambda: json.loads(execjs(sid, SNAPSHOT))["assistantMsgs"] > 0, 60)
 
-# (b) 刷新后用 ic_get_thread_history 回读，应含 marker
+# (a) 发送后取后端最近活跃 thread，避免把 ic_list_threads()[0] 误当 UI 当前线程
+tid = invoke("ic_get_active_thread_id", {})
+hist0 = invoke("ic_get_thread_history", {"threadId": tid, "limit": 50})
+assert json.dumps(hist0, ensure_ascii=False).find("E2E-MARKER-7788") >= 0
+
+# (b) 刷新后 active thread 应保持一致，且 ic_get_thread_history 回读应含 marker
 execjs(sid, "location.reload();")
 poll(lambda: json.loads(execjs(sid, SNAPSHOT))["composer"] > 0, 30)
+assert invoke("ic_get_active_thread_id", {}) == tid
 hist = execjs(sid, "const [t]=arguments;"
     "return window.__TAURI_INTERNALS__.invoke('ic_get_thread_history',{threadId:t});", [tid])
 assert json.dumps(hist, ensure_ascii=False).find("E2E-MARKER-7788") >= 0, "刷新后历史丢失"
 ```
 
 **断言**：
-- 线程/历史命令：`ic_list_threads` / `ic_get_thread_history` / `ic_create_thread`
+- 线程/历史命令：`ic_get_active_thread_id` / `ic_list_threads` /
+  `ic_get_thread_history` / `ic_create_thread`
   （[lib.rs 线程管理段](../src/lib.rs)）。
 - 刷新后 `ThreadHistoryLoader`（`chat-runtime-history-loading`，
   [ThreadHistoryLoader.tsx:101](../ui/src/app/runtime/ThreadHistoryLoader.tsx)）重载历史。

--- a/desktop-client/e2e-webdriver/tests/test_scenario_06_session_persistence.py
+++ b/desktop-client/e2e-webdriver/tests/test_scenario_06_session_persistence.py
@@ -6,7 +6,8 @@
 验证：
   1. 发消息后通过 ic_get_thread_history 能读回内容
   2. location.reload() 后再次读 history，原 marker 仍在
-  3. ic_list_threads 在刷新前后返回相同集合（强一致）
+  3. ic_get_active_thread_id 指向真实写入的最近活跃 thread
+  4. ic_list_threads 在刷新前后返回相同集合（强一致）
 
 依赖：
   - 引擎就绪 + LLM 可达（与场景 2/3/4 相同前置）
@@ -14,7 +15,7 @@
 
 不依赖：
   - 不依赖助手回复内容（只要 user 消息被持久化即可，回复早晚都行）
-  - 不依赖具体 thread 数量（取 `ic_list_threads` 头部那个或新建）
+  - 不依赖具体 thread 数量，也不把 `ic_list_threads` 头部误当当前 thread
 """
 
 from __future__ import annotations
@@ -94,32 +95,34 @@ def test_thread_history_survives_reload(session_id):
     invoke(session_id, "ic_list_threads", {})
 
     # UI 当前的活跃 thread 不一定是 `ic_list_threads` 的第一项（实测会自动新建
-    # 一个空 thread 给 composer），所以发送前不要假定 thread_id，发送后用
-    # marker 反查。
+    # 一个空 thread 给 composer），所以发送后用后端最近活跃 thread 对账。
     type_into_composer(session_id, PROMPT_TEMPLATE.format(marker=marker))
     click_send(session_id)
     time.sleep(2)  # 给 click_send → send_chat_message 留点 IPC 启动窗口
 
-    def _find_thread_with_marker():
+    last_active_seen = None
+
+    def _active_thread_with_marker():
+        nonlocal last_active_seen
         try:
-            threads = invoke(session_id, "ic_list_threads", {})
+            tid = invoke(session_id, "ic_get_active_thread_id", {})
+            if not isinstance(tid, str) or not tid:
+                return None
+            hist = invoke(session_id, "ic_get_thread_history",
+                          {"threadId": tid, "limit": 50})
         except RuntimeError:
             return None
-        for t in threads[:10]:  # 检查最近 10 个 thread 足够
-            try:
-                hist = invoke(session_id, "ic_get_thread_history",
-                              {"threadId": t["id"], "limit": 50})
-            except RuntimeError:
-                continue
-            if any(marker in (m.get("content") or "") for m in hist):
-                return (t["id"], hist)
+        if any(marker in (m.get("content") or "") for m in hist):
+            return (tid, hist)
+        last_active_seen = {"tid": tid, "message_count": len(hist)}
         return None
 
-    found = poll(_find_thread_with_marker, timeout=SEND_TIMEOUT, interval=1.0)
-    assert found is not None, (
-        f"{SEND_TIMEOUT:.0f}s 内 marker {marker!r} 未出现在任何 thread"
+    found = poll(_active_thread_with_marker, timeout=SEND_TIMEOUT, interval=1.0)
+    assert isinstance(found, tuple), (
+        f"{SEND_TIMEOUT:.0f}s 内 active thread 未包含 marker {marker!r}"
         " ——可能：(a) send_chat_message 未成功；(b) 持久化层未写入；"
-        "(c) SafetyBridge 拦截"
+        "(c) SafetyBridge 拦截；(d) active thread 对账指向错误线程。"
+        f" last_seen={last_active_seen!r}"
     )
     tid, _ = found
 
@@ -135,6 +138,12 @@ def test_thread_history_survives_reload(session_id):
     # 90s 仍不返）；空转 10s 让后端 ThreadHistoryLoader / IPC dispatcher 重新绑定后就能
     # 1s 内返。原因未完全查清，这里用固定延迟兑现可靠性。
     time.sleep(10)
+
+    active_after = _invoke_polling(session_id, "ic_get_active_thread_id", {}, timeout=90.0)
+    assert active_after == tid, (
+        "⚠️ 持久化回归：reload 后 active thread 对账变化——"
+        f"before={tid!r} after={active_after!r}"
+    )
 
     hist_after = _invoke_polling(session_id, "ic_get_thread_history",
                                  {"threadId": tid, "limit": 200},

--- a/desktop-client/src/ipc/threads.rs
+++ b/desktop-client/src/ipc/threads.rs
@@ -89,6 +89,26 @@ pub async fn ic_list_threads(
         .collect())
 }
 
+/// 获取后端持久化层最近活跃的对话线程 ID。
+///
+/// Desktop UI 的 selectedThreadId 由前端状态持有；后端能权威提供的是按
+/// `last_activity DESC` 排序后的最近活跃 thread。E2E 用它对账发送路径写入的
+/// 真实目标线程，避免把 `ic_list_threads()[0]` 当作 UI 当前线程。
+#[tauri::command]
+pub async fn ic_get_active_thread_id(
+    state: State<'_, EngineState>,
+) -> Result<Option<String>, String> {
+    let state = state.get()?;
+    let db = state.db.as_ref().ok_or("Database not available")?;
+
+    let conversations = db
+        .list_conversations_all_channels(&state.scope_id, 1)
+        .await
+        .map_err(|e| format!("Failed to get active thread: {}", e))?;
+
+    Ok(conversations.into_iter().next().map(|c| c.id.to_string()))
+}
+
 /// 创建新对话线程。
 ///
 /// Automatically creates a sandboxed workspace directory under

--- a/desktop-client/src/ipc/threads_tests.rs
+++ b/desktop-client/src/ipc/threads_tests.rs
@@ -324,4 +324,15 @@ mod tests {
         let result = uuid::Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000");
         assert!(result.is_ok());
     }
+
+    #[test]
+    fn test_active_thread_id_contract_serializes_as_nullable_string() {
+        let active = Some("550e8400-e29b-41d4-a716-446655440000".to_string());
+        let json = serde_json::to_value(&active).unwrap();
+        assert_eq!(json, "550e8400-e29b-41d4-a716-446655440000");
+
+        let none: Option<String> = None;
+        let json = serde_json::to_value(&none).unwrap();
+        assert!(json.is_null());
+    }
 }

--- a/desktop-client/src/lib.rs
+++ b/desktop-client/src/lib.rs
@@ -96,6 +96,7 @@ macro_rules! all_tauri_commands {
             desktop_client::ipc::get_engine_status,
             // ── 线程管理 ────────────────────────────────────────
             desktop_client::ipc::ic_list_threads,
+            desktop_client::ipc::ic_get_active_thread_id,
             desktop_client::ipc::ic_create_thread,
             desktop_client::ipc::ic_get_thread_history,
             // ── 记忆/工作空间 ───────────────────────────────────

--- a/desktop-client/tests/tauri_command_contract_tests.rs
+++ b/desktop-client/tests/tauri_command_contract_tests.rs
@@ -125,6 +125,7 @@ const REGISTERED_COMMANDS: &[&str] = &[
     "unsubscribe_chat_events",
     "get_engine_status",
     "ic_list_threads",
+    "ic_get_active_thread_id",
     "ic_create_thread",
     "ic_get_thread_history",
     "ic_memory_list",


### PR DESCRIPTION
## 背景 / 目标

Closes #1026。

本 PR 先处理 #1026 的 §6 thread_id 对账改进：E2E 场景 6 不再把 `ic_list_threads()[0]` 当作当前线程，也不再通过扫描最近多个 thread 来掩盖真实写入目标不一致的问题。

## 改动范围

- 新增 Tauri IPC：`ic_get_active_thread_id`，返回后端持久化层按 `last_activity DESC` 排序的最近活跃 thread id。
- 将新命令接入 `all_tauri_commands!()` 注册表和 Tauri 命令契约列表。
- 更新 §6 E2E：发送 marker 后只对账 active thread 的 history，reload 后再次确认 active thread 不变且历史仍含 marker。
- 更新 `desktop-client/docs/e2e-webdriver-test-plan.md` §6 示例。

## 非目标（What's NOT in this PR）

- 不处理 #1026 的 §4 approve 分支恢复；该部分后续单独切片。
- 不改变前端 `selectedThreadId` 状态模型。
- 不运行本地完整 desktop-client / workspace cargo 矩阵；完整 clippy / tests 交给 PR CI。

## 验证

- `cargo fmt -p desktop-client`：通过
- `cargo check -p desktop-client --tests`：通过（本地已跑过，耗时 14m13s；后续不再扩大本地 cargo 范围）
- `cargo nextest run -p desktop-client -E 'test(test_active_thread_id_contract_serializes_as_nullable_string) | test(test_all_frontend_commands_are_registered) | test(test_no_ghost_commands_in_handler)'`：3 passed, 906 skipped
- `python3.12 scripts/check_no_panics.py --base origin/xClaw`：通过
- `python3 scripts/check_no_new_ironclaw_literal.py --base origin/xClaw`：通过
- `python3 -m py_compile desktop-client/e2e-webdriver/tests/test_scenario_06_session_persistence.py`：通过
- `git diff --check`：通过

说明：曾启动 `cargo clippy --no-deps -p desktop-client --all-targets -- -D warnings`，发现范围仍偏大，已按协作约定中止；完整 clippy 由 PR CI 承担。

## 分析 / 自查

- 已检查 active thread id 是否已有，结论：semantic_search 未命中现成 IPC；注册表/契约测试未列出 `ic_get_active_thread_id`；`rg` 仅发现前端 `selectedThreadId` / transport `currentThreadId` 状态，后端未暴露等价命令。
- `code-simplifier`：已做一处小收敛（`into_iter().next()` 替代 `mut + pop()`）。
- `adr-compliance-check`：desktop-client 改动重点检查 `.ironclaw` 字面量，未新增。
- `code-quality-audit` / `code-review-expert`：当前环境未找到对应 skill，已用手工 diff 审查补位。

## Cross-cuts

ADR-114：类A，无新增 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量。

## 后续 PR / 下一步

- 继续处理 #1026 的 §4 approve 分支恢复：使用 TMPDIR 或 teardown，避免 `e2e_probe.txt` 污染工作目录。

