### PR TITLE
feat: 完成 #1054 的 Plan/Fork 主循环验证

### DIFF
--- a/desktop-client/ironclaw/src/agent/agent_loop.rs
+++ b/desktop-client/ironclaw/src/agent/agent_loop.rs
@@ -1753,11 +1753,150 @@ impl Agent {
 #[cfg(test)]
 mod tests {
     use super::{
-        chat_tool_execution_metadata, is_single_message_repl, resolve_routine_notification_user,
-        should_fallback_routine_notification, truncate_for_preview,
+        Agent, AgentDeps, chat_tool_execution_metadata, is_single_message_repl,
+        resolve_routine_notification_user, should_fallback_routine_notification,
+        truncate_for_preview,
     };
     use crate::channels::IncomingMessage;
+    use crate::config::{AgentConfig, SafetyConfig, SkillsConfig};
     use crate::error::ChannelError;
+    use crate::llm::{
+        CompletionRequest, CompletionResponse, FinishReason, LlmProvider, ToolCompletionRequest,
+        ToolCompletionResponse,
+    };
+    use crate::safety::SafetyLayer;
+    use crate::tools::ToolRegistry;
+    use async_trait::async_trait;
+    use dasclaw_hooks::HookRegistry;
+    use dasclaw_runtime::context::ContextManager;
+    use rust_decimal::Decimal;
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    struct StaticLlmProvider;
+
+    #[async_trait]
+    impl LlmProvider for StaticLlmProvider {
+        fn model_name(&self) -> &str {
+            "static-mock"
+        }
+
+        fn cost_per_token(&self) -> (Decimal, Decimal) {
+            (Decimal::ZERO, Decimal::ZERO)
+        }
+
+        async fn complete(
+            &self,
+            _request: CompletionRequest,
+        ) -> Result<CompletionResponse, crate::error::LlmError> {
+            Ok(CompletionResponse {
+                content: "ok".to_string(),
+                input_tokens: 0,
+                output_tokens: 0,
+                finish_reason: FinishReason::Stop,
+                cache_read_input_tokens: 0,
+                cache_creation_input_tokens: 0,
+            })
+        }
+
+        async fn complete_with_tools(
+            &self,
+            _request: ToolCompletionRequest,
+        ) -> Result<ToolCompletionResponse, crate::error::LlmError> {
+            Ok(ToolCompletionResponse {
+                content: Some("ok".to_string()),
+                tool_calls: Vec::new(),
+                input_tokens: 0,
+                output_tokens: 0,
+                finish_reason: FinishReason::Stop,
+                cache_read_input_tokens: 0,
+                cache_creation_input_tokens: 0,
+            })
+        }
+    }
+
+    fn test_agent_config() -> AgentConfig {
+        AgentConfig {
+            name: "test-agent".to_string(),
+            max_parallel_jobs: 1,
+            job_timeout: Duration::from_secs(60),
+            stuck_threshold: Duration::from_secs(60),
+            repair_check_interval: Duration::from_secs(30),
+            max_repair_attempts: 1,
+            use_planning: false,
+            session_idle_timeout: Duration::from_secs(300),
+            allow_local_tools: false,
+            max_cost_per_day_cents: None,
+            max_actions_per_hour: None,
+            max_cost_per_user_per_day_cents: None,
+            max_tool_iterations: 50,
+            auto_approve_tools: false,
+            default_timezone: "UTC".to_string(),
+            max_jobs_per_user: None,
+            max_tokens_per_job: 0,
+            multi_tenant: false,
+            max_llm_concurrent_per_user: None,
+            max_jobs_concurrent_per_user: None,
+        }
+    }
+
+    fn make_test_agent() -> Agent {
+        let deps = AgentDeps {
+            owner_id: "owner-scope".to_string(),
+            store: None,
+            llm: Arc::new(StaticLlmProvider),
+            cheap_llm: None,
+            safety: Arc::new(SafetyLayer::new(&SafetyConfig {
+                max_output_length: 100_000,
+                injection_check_enabled: false,
+            })),
+            tools: Arc::new(ToolRegistry::new()),
+            workspace: None,
+            extension_manager: None,
+            skill_registry: None,
+            skill_catalog: None,
+            skills_config: SkillsConfig::default(),
+            hooks: Arc::new(HookRegistry::new()),
+            cost_guard: Arc::new(crate::agent::cost_guard::CostGuard::new(
+                crate::agent::cost_guard::CostGuardConfig::default(),
+            )),
+            sse_tx: None,
+            job_event_sink: None,
+            channels_for_jobs: None,
+            http_interceptor: None,
+            transcription: None,
+            document_extraction: None,
+            sandbox_readiness: crate::agent::routine_engine::SandboxReadiness::DisabledByConfig,
+            builder: None,
+            llm_backend: "nearai".to_string(),
+            tenant_rates: Arc::new(crate::tenant::TenantRateRegistry::new(4, 3)),
+            cache_monitor: None,
+        };
+
+        Agent::new(
+            test_agent_config(),
+            deps,
+            Arc::new(crate::channels::ChannelManager::new()),
+            None,
+            None,
+            None,
+            Some(Arc::new(ContextManager::new(1))),
+            None,
+        )
+    }
+
+    async fn resolve_test_thread(
+        agent: &Agent,
+        external_thread_id: &str,
+    ) -> (
+        Arc<tokio::sync::Mutex<crate::agent::session::Session>>,
+        uuid::Uuid,
+    ) {
+        agent
+            .session_manager
+            .resolve_thread("owner-scope", "tauri", Some(external_thread_id))
+            .await
+    }
 
     #[test]
     fn test_truncate_short_input() {
@@ -1927,6 +2066,80 @@ mod tests {
         assert!(is_single_message_repl(&repl)); // safety: test-only assertion
         assert!(!is_single_message_repl(&gateway)); // safety: test-only assertion
         assert!(!is_single_message_repl(&plain_repl)); // safety: test-only assertion
+    }
+
+    #[tokio::test]
+    async fn req_1054_plan_mode_message_loop_updates_thread_state() {
+        let agent = make_test_agent();
+        let external_thread_id = "thread-plan-mode";
+        let (session, thread_id) = resolve_test_thread(&agent, external_thread_id).await;
+
+        let message = IncomingMessage::new("tauri", "owner-scope", "/plan-mode")
+            .with_thread(external_thread_id);
+        let response = agent
+            .handle_message(&message)
+            .await
+            .expect("plan-mode message should be handled");
+
+        assert_eq!(response.as_deref(), Some("Plan mode enabled."));
+        let sess = session.lock().await;
+        let thread = sess
+            .threads
+            .get(&thread_id)
+            .expect("thread remains registered after plan toggle");
+        assert!(thread.is_plan_mode());
+        assert_eq!(thread.state, crate::agent::session::ThreadState::Planning);
+    }
+
+    #[tokio::test]
+    async fn req_1054_fork_message_loop_creates_registered_thread() {
+        let agent = make_test_agent();
+        let external_thread_id = "thread-fork-source";
+        let (session, source_thread_id) = resolve_test_thread(&agent, external_thread_id).await;
+        {
+            let mut sess = session.lock().await;
+            let source = sess
+                .threads
+                .get_mut(&source_thread_id)
+                .expect("source thread should exist");
+            source.start_turn("first turn");
+            source.complete_turn("first response");
+            source.start_turn("second turn");
+            source.complete_turn("second response");
+        }
+
+        let message =
+            IncomingMessage::new("tauri", "owner-scope", "/fork 1").with_thread(external_thread_id);
+        let response = agent
+            .handle_message(&message)
+            .await
+            .expect("fork message should be handled")
+            .expect("fork command should return an acknowledgement");
+        let forked_thread_id = response
+            .strip_prefix("Forked thread: ")
+            .and_then(|id| uuid::Uuid::parse_str(id).ok())
+            .expect("acknowledgement should include the new thread id");
+
+        let sess = session.lock().await;
+        assert_eq!(sess.active_thread, Some(forked_thread_id));
+        let forked = sess
+            .threads
+            .get(&forked_thread_id)
+            .expect("forked thread should be stored in the session");
+        assert_eq!(forked.forked_from, Some(source_thread_id));
+        assert_eq!(forked.fork_point, Some(1));
+        assert_eq!(forked.turns.len(), 1);
+        assert_eq!(
+            forked.turns[0].user_input, "first turn",
+            "fork should copy history only up to the requested turn"
+        );
+        drop(sess);
+
+        let (_, resolved_fork_id) = agent
+            .session_manager
+            .resolve_thread("owner-scope", "tauri", Some(&forked_thread_id.to_string()))
+            .await;
+        assert_eq!(resolved_fork_id, forked_thread_id);
     }
 
     // ── IPC 接缝契约测试 ────────────────────────────────────────

--- a/docs/plans/architecture-refactor/41-desktop-host-runtime-boundary.md
+++ b/docs/plans/architecture-refactor/41-desktop-host-runtime-boundary.md
@@ -1,0 +1,74 @@
+# 41 — Desktop Client / IronClaw Host / Runtime Boundary
+
+> Issue: [#1054](https://github.com/Linnanli/xClaw/issues/1054)  
+> Date: 2026-06-04  
+> Scope: clarify when desktop IPC should enter the reusable agent loop, and add execution-level Plan/Fork verification.
+
+## 1. Decision
+
+Desktop chat/tool turns keep the three-layer path:
+
+```text
+desktop-client IPC/UI
+  -> desktop-client/ironclaw host
+  -> dasclaw_runtime::AgenticLoop
+```
+
+Platform diagnostics and configuration sync stay outside `AgenticLoop`. They may call shared crates directly, but they should not be forced through the LLM turn loop only to look more uniform.
+
+Plan/Fork controls sit in the middle: they enter the IronClaw host message loop so they share thread resolution, session ownership, and channel routing, but they stop at `SubmissionParser` + `thread_ops` unless the specific command intentionally asks the LLM to revise a plan.
+
+## 2. Boundary Matrix
+
+| Capability | Entry point | Stops at | Rationale |
+|---|---|---|---|
+| Chat/tool turn | `send_chat_message` / `IncomingMessage` | `dasclaw_runtime::AgenticLoop` | Needs LLM sampling, tool dispatch, hooks, cancellation, and response streaming. |
+| Plan mode toggle | `ic_toggle_plan_mode` -> `/plan-mode` | IronClaw host `thread_ops` | Mutates thread state; no LLM sampling needed. |
+| Plan approval | `ic_approve_plan` -> `/approve-plan` | IronClaw host `thread_ops` | Consumes a pending plan and switches execution state; no new model turn by itself. |
+| Plan revision | `ic_revise_plan` -> `/revise-plan` | IronClaw host, then user-input path | Validates pending plan first; then re-enters normal user-input processing to ask the model for a revised plan. |
+| Session fork | `ic_fork_thread` -> `/fork <turn>` | IronClaw host `thread_ops` + `dasclaw_core::Session` | Copies thread history and registers the new thread; no tool dispatch or model call. |
+| Sandbox status/smoke | `desktop-client/src/ipc/sandbox.rs` | `dasclaw_sandbox` / platform service | Health check of platform capability, not an agent turn. |
+| DLP/admin sync | `admin_sync.rs` / `enterprise_policy_sync.rs` | `SafetyBridge` / `dasclaw_safety` / sync service | Policy vocabulary and admin transport concern; must remain deterministic and fail-safe. |
+| Model connection probe | provider/config IPC | provider connectivity layer | Probe validates credentials/config availability; it should not create conversation state. |
+
+## 3. Layer Responsibilities
+
+`desktop-client` owns UI-facing IPC contracts, response shapes, Tauri command registration, desktop startup state, and direct platform probes.
+
+`desktop-client/ironclaw` acts as the host adapter. It owns channel routing, session/thread resolution, `SubmissionParser` handling, host-specific hooks, tool registry composition, desktop safety/context wiring, and the bridge into `dasclaw_runtime`.
+
+`dasclaw_runtime` owns reusable LLM turn orchestration: responder calls, tool dispatch iteration, cancellation, loop outcomes, and hook application that is independent of Tauri or desktop-only services.
+
+`dasclaw_core` owns stable vocabulary and state models that are safe to share across hosts: `Submission`, `Session`, `Thread`, `PendingPlan`, `SessionManager`, and agent loop config/types.
+
+## 4. Migration Guidance
+
+Good extraction candidates:
+
+| Candidate | Current evidence | Direction |
+|---|---|---|
+| `SubmissionParser` / `Submission` | Already in `crates/dasclaw_core/src/submission.rs` and re-exported by IronClaw | Keep as shared command vocabulary. |
+| `Session` / `Thread` / `SessionManager` | Already in `crates/dasclaw_core/src/session.rs` and `session_manager.rs` | Keep shared; add tests at host boundary when commands mutate it. |
+| Agent loop contracts | `crates/dasclaw_core/src/agentic_loop.rs` and `dasclaw_runtime::AgenticLoop` | Keep reusable; host provides responder/dispatcher/context. |
+
+Do not migrate in this slice:
+
+| Item | Reason |
+|---|---|
+| Tauri command registration and frontend response DTOs | Desktop UI contract, not runtime vocabulary. |
+| Desktop startup state and Tauri `EngineState` | Tauri lifecycle concern. |
+| Admin HTTP, policy sync, and DLP bridge transport | Product/admin integration; deterministic service path is safer. |
+| Sandbox smoke/status IPC | Platform readiness check; direct shared-crate call is clearer. |
+| Model connection probe IPC | Provider/config health check, not conversation execution. |
+
+## 5. Verification Notes
+
+Three-layer verification performed before writing this boundary:
+
+| Level | Evidence |
+|---|---|
+| Semantic | `code-review-graph` Python API found Plan/Fork IPC in `desktop-client/src/ipc/plan_mode.rs`, session state in `crates/dasclaw_core/src/session.rs`, and the reusable loop in `crates/dasclaw_core/src/agentic_loop.rs` / `crates/dasclaw_runtime`. |
+| Symbol/usage | The execution path is `IncomingMessage` -> `SubmissionParser::parse` -> `Agent::handle_message` -> `process_toggle_plan_mode` / `process_fork_thread` -> `Session` mutation and `SessionManager::register_thread`. |
+| Literal | `rg "plan-mode|approve-plan|revise-plan|/fork|fork_thread|toggle_plan_mode"` confirms the concrete IPC, parser, host handler, session, and existing parity tests. |
+
+The new execution-level tests live in `desktop-client/ironclaw/src/agent/agent_loop.rs` and cover the host message loop, not only the IPC enqueue contract from `desktop-client/src/ipc/plan_mode.rs`.

--- a/docs/plans/architecture-refactor/README.md
+++ b/docs/plans/architecture-refactor/README.md
@@ -26,6 +26,7 @@
 | 36 | [36-claw-code-capability-inventory.md](36-claw-code-capability-inventory.md) | claw-code 全量盘点（治理 6 件套 / mock-anthropic 27 场景） | v1 |
 | 37 | [37-ironclaw-main-capability-inventory.md](37-ironclaw-main-capability-inventory.md) | ironclaw-main 上游 v0.26 全量盘点（464,222 LOC） | v1 |
 | 38 | [38-desktop-client-ironclaw-fork-inventory.md](38-desktop-client-ironclaw-fork-inventory.md) | desktop-client/ironclaw fork 全量盘点（295,658 LOC） | v1 || 39 | [39-fork-private-cargo-inventory.md](39-fork-private-cargo-inventory.md) | **fork 私货迁移地图**：49 独家文件 / 93 修改文件 / ≈14,800 LOC + W6+ 删 fork 前置 checklist | **v1** |
+| 41 | [41-desktop-host-runtime-boundary.md](41-desktop-host-runtime-boundary.md) | #1054：desktop IPC / IronClaw host / dasclaw runtime 分层边界 + Plan/Fork 执行级验证 | v1 |
 ### 📝 架构评审
 
 | 文档 | 内容 |


### PR DESCRIPTION
## 背景
Fixes #1054。

## 改动范围
- 在 `desktop-client/ironclaw/src/agent/agent_loop.rs` 增加执行级测试，覆盖 message loop 对 Plan/Fork 命令的行为：
  - `/plan-mode`：更新线程状态为 plan mode 并返回预期文案
  - `/fork <n>`：完成 fork 后注册线程、切换 active thread，并校验 `forked_from`、`fork_point`、`turns`
- 新增架构边界文档：`docs/plans/architecture-refactor/41-desktop-host-runtime-boundary.md`
- 更新执行计划索引：`docs/plans/architecture-refactor/README.md`

## 非目标
- 不包含 runtime 主循环大迁移
- 不包含 Tauri 命令注册/签名变化
- 不包含 DLP / sandbox / 网络安全策略同步链路改造

## 验证
- `cargo check -p dasclaw --tests`
- `cargo nextest run -p dasclaw --lib -E 'test(req_1054)'`
- `cargo nextest run -p dasclaw --lib -E 'test(resolve_routine_notification_user) | test(chat_tool_execution_metadata)'`
- `cargo clippy --no-deps -p dasclaw --all-targets -- -D warnings`
- `cargo fmt -p dasclaw -- --check`
- `python3.12 scripts/check_no_panics.py --base origin/xClaw`
- `code-review-graph build --repo /Users/nallylin/Documents/code/x-claw/desktop-client/ironclaw`

## 变更边界与 ADR-114
- Cross-cuts：不涉及（无新增 `.ironclaw` 字面量与 `IRONCLAW_BASE_DIR` 字样）

## 风险/后续
- 当前新增为主循环行为回归测试，未触发大范围重构；建议 CI 通过后可按需补充更多 plan/ fork 集成与契约场景。
