### PR TITLE
feat: default dasclaw app-server integration for client-gui

### DIFF
--- a/client-gui/electron-builder.yml
+++ b/client-gui/electron-builder.yml
@@ -71,6 +71,8 @@ win:
   extraResources:
     - from: .bundle-resources/mcp
       to: mcp
+    - from: .bundle-resources/dasclaw-app-server
+      to: dasclaw-app-server
     - from: resources/node/win32-x64
       to: node
     - from: resources/node/win32-x64/node_modules/npm
@@ -99,6 +101,8 @@ mac:
   extraResources:
     - from: .bundle-resources/mcp
       to: mcp
+    - from: .bundle-resources/dasclaw-app-server
+      to: dasclaw-app-server
     - from: resources/node/darwin-${arch}
       to: node
     - from: resources/node/darwin-${arch}/lib/node_modules/npm
@@ -124,6 +128,8 @@ linux:
   extraResources:
     - from: .bundle-resources/mcp
       to: mcp
+    - from: .bundle-resources/dasclaw-app-server
+      to: dasclaw-app-server
     - from: resources/node/linux-x64
       to: node
     - from: resources/node/linux-x64/lib/node_modules/npm

--- a/client-gui/package.json
+++ b/client-gui/package.json
@@ -39,7 +39,7 @@
   "scripts": {
     "dev": "npm run download:node && npm run build:wsl-agent && npm run build:lima-agent && npm run build:mcp && vite",
     "dev:with-python": "npm run download:node && npm run prepare:python && npm run build:wsl-agent && npm run build:lima-agent && npm run build:mcp && vite",
-    "build": "npm run download:node && npm run prepare:gui-tools && npm run prepare:python:all && npm run build:wsl-agent && npm run build:lima-agent && npm run build:mcp && tsc && vite build && node scripts/pre-build-check.js && electron-builder",
+    "build": "npm run download:node && npm run prepare:gui-tools && npm run prepare:python:all && npm run build:wsl-agent && npm run build:lima-agent && npm run build:mcp && npm run build:dasclaw-app-server && tsc && vite build && node scripts/pre-build-check.js && electron-builder",
     "build:win": "node scripts/build-windows.js",
     "build:wsl-agent": "tsc -p src/main/sandbox/wsl-agent/tsconfig.json",
     "build:lima-agent": "tsc -p src/main/sandbox/lima-agent/tsconfig.json",
@@ -63,7 +63,8 @@
     "typecheck": "tsc --noEmit",
     "pre-build-check": "node scripts/pre-build-check.js",
     "clean": "rimraf dist dist-electron dist-mcp dist-wsl-agent dist-lima-agent .bundle-resources release",
-    "deploy:local": "bash scripts/deploy-local.sh"
+    "deploy:local": "bash scripts/deploy-local.sh",
+    "build:dasclaw-app-server": "node scripts/build-dasclaw-app-server.mjs"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.39.0",

--- a/client-gui/scripts/build-dasclaw-app-server.mjs
+++ b/client-gui/scripts/build-dasclaw-app-server.mjs
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process';
+import { chmodSync, copyFileSync, mkdirSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const PROJECT_ROOT = path.resolve(SCRIPT_DIR, '..');
+const REPO_ROOT = process.env.DASCLAW_REPO_ROOT || path.resolve(PROJECT_ROOT, '..');
+const PROFILE = process.env.DASCLAW_APP_SERVER_BUILD_PROFILE || 'release';
+const BINARY_NAME = process.platform === 'win32' ? 'dasclaw-app-server.exe' : 'dasclaw-app-server';
+const OUT_DIR = path.join(PROJECT_ROOT, '.bundle-resources', 'dasclaw-app-server');
+
+if (PROFILE !== 'release' && PROFILE !== 'debug') {
+  throw new Error('DASCLAW_APP_SERVER_BUILD_PROFILE must be release or debug');
+}
+
+const cargoArgs = ['build', '-p', 'dasclaw_app_server', '--bin', 'dasclaw-app-server'];
+if (PROFILE === 'release') {
+  cargoArgs.push('--release');
+}
+
+console.log(`[build-dasclaw-app-server] cargo ${cargoArgs.join(' ')}`);
+const cargo = spawnSync('cargo', cargoArgs, {
+  cwd: REPO_ROOT,
+  stdio: 'inherit',
+  env: process.env,
+});
+
+if (cargo.status !== 0) {
+  process.exit(cargo.status ?? 1);
+}
+
+const targetRoot = process.env.CARGO_TARGET_DIR
+  ? path.resolve(REPO_ROOT, process.env.CARGO_TARGET_DIR)
+  : path.join(REPO_ROOT, 'target');
+const sourceBinary = path.join(targetRoot, PROFILE, BINARY_NAME);
+const targetBinary = path.join(OUT_DIR, BINARY_NAME);
+
+mkdirSync(OUT_DIR, { recursive: true });
+copyFileSync(sourceBinary, targetBinary);
+if (process.platform !== 'win32') {
+  chmodSync(targetBinary, 0o755);
+}
+
+console.log(`[build-dasclaw-app-server] bundled ${targetBinary}`);

--- a/client-gui/scripts/dasclaw-app-server-smoke.mjs
+++ b/client-gui/scripts/dasclaw-app-server-smoke.mjs
@@ -80,8 +80,11 @@ async function main() {
   if (!result.electronAPI) {
     throw new Error('renderer did not expose window.electronAPI');
   }
-  if (!result.afterConfigured) {
-    throw new Error('temporary config did not satisfy app credential guard');
+  if (result.afterConfigured) {
+    throw new Error('smoke user data should remain without legacy provider credentials');
+  }
+  if (result.hitLegacyCredentialGuard) {
+    throw new Error('dasclaw default app-server path was blocked by legacy credential guard');
   }
   if (!result.threadId) {
     throw new Error('session did not bind to a dasclaw thread id');
@@ -112,11 +115,15 @@ async function main() {
 function buildElectronEnv() {
   const env = {
     ...process.env,
-    OPEN_COWORK_AGENT_RUNNER: 'dasclaw',
     DASCLAW_APP_SERVER_RUNTIME: 'echo',
     DASCLAW_REPO_ROOT: REPO_ROOT,
     VITE_DEV_SERVER_URL: `http://${HOST}:${PREVIEW_PORT}/`,
   };
+  if (process.env.DASCLAW_SMOKE_AGENT_RUNNER) {
+    env.OPEN_COWORK_AGENT_RUNNER = process.env.DASCLAW_SMOKE_AGENT_RUNNER;
+  } else {
+    delete env.OPEN_COWORK_AGENT_RUNNER;
+  }
 
   for (const key of [
     'ANTHROPIC_API_KEY',
@@ -347,16 +354,6 @@ function rendererSmokeExpression() {
   const off = window.electronAPI.on((event) => events.push(event));
   await sleep(500);
   const before = await window.electronAPI.config.get();
-  await window.electronAPI.config.save({
-    provider: 'openai',
-    activeProfileKey: 'openai',
-    apiKey: 'sk-dasclaw-smoke',
-    baseUrl: 'https://api.openai.com/v1',
-    model: 'gpt-5.4',
-    sandboxEnabled: false,
-    memoryEnabled: false
-  });
-  await sleep(500);
   const after = await window.electronAPI.config.get();
   const session = await window.electronAPI.invoke({
     type: 'session.start',
@@ -369,6 +366,18 @@ function rendererSmokeExpression() {
       memoryEnabled: false
     }
   });
+  if (!session) {
+    await sleep(500);
+    off?.();
+    const errorEvents = events.filter((event) => event.type === 'error');
+    return {
+      electronAPI: !!window.electronAPI,
+      beforeConfigured: !!before?.isConfigured,
+      afterConfigured: !!after?.isConfigured,
+      errorEvents,
+      hitLegacyCredentialGuard: errorEvents.some((event) => event.payload?.code === 'CONFIG_REQUIRED_ACTIVE_SET')
+    };
+  }
 
   const deadline = Date.now() + 30000;
   while (Date.now() < deadline) {
@@ -385,6 +394,7 @@ function rendererSmokeExpression() {
 
   const partials = events.filter((event) => event.type === 'stream.partial' && event.payload?.sessionId === session.id);
   const statusEvents = events.filter((event) => event.type === 'session.status' && event.payload?.sessionId === session.id);
+  const errorEvents = events.filter((event) => event.type === 'error');
   return {
     electronAPI: !!window.electronAPI,
     beforeConfigured: !!before?.isConfigured,
@@ -394,6 +404,8 @@ function rendererSmokeExpression() {
     partialCount: partials.length,
     partials,
     statusEvents,
+    errorEvents,
+    hitLegacyCredentialGuard: errorEvents.some((event) => event.payload?.code === 'CONFIG_REQUIRED_ACTIVE_SET'),
     hasEchoDelta: partials.some((event) => String(event.payload?.delta || '').includes(${JSON.stringify(EXPECTED_DELTA)})),
     hasIdle: statusEvents.some((event) => event.payload?.status === 'idle')
   };

--- a/client-gui/scripts/pre-build-check.js
+++ b/client-gui/scripts/pre-build-check.js
@@ -32,6 +32,9 @@ const RESET = '\x1b[0m';
  * @returns {CheckSpec[]}
  */
 function buildCheckList(platform, arch) {
+  const appServerBinary =
+    platform === 'win32' ? 'dasclaw-app-server.exe' : 'dasclaw-app-server';
+
   /** @type {CheckSpec[]} */
   const checks = [
     // Common checks (all platforms, FATAL)
@@ -63,6 +66,12 @@ function buildCheckList(platform, arch) {
       label: 'Built-in skills directory (.claude/skills/)',
       relPath: '.claude/skills',
       type: 'dir',
+      severity: 'fatal',
+    },
+    {
+      label: 'Dasclaw app-server binary',
+      relPath: `.bundle-resources/dasclaw-app-server/${appServerBinary}`,
+      type: 'file',
       severity: 'fatal',
     },
   ];

--- a/client-gui/src/main/dasclaw/app-server-rpc.ts
+++ b/client-gui/src/main/dasclaw/app-server-rpc.ts
@@ -1,5 +1,6 @@
 import { spawn, type ChildProcessWithoutNullStreams } from 'child_process';
 import { EventEmitter } from 'events';
+import { existsSync } from 'fs';
 import { join, resolve } from 'path';
 import { app } from 'electron';
 import { log, logError, logWarn } from '../utils/logger';
@@ -44,6 +45,7 @@ type PendingRequest = {
 export type AppServerProcessFactory = () => ChildProcessWithoutNullStreams;
 
 const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
+const BUNDLED_APP_SERVER_DIR = 'dasclaw-app-server';
 
 export class StdioAppServerRpc implements AppServerRpc {
   private readonly child: ChildProcessWithoutNullStreams;
@@ -192,7 +194,7 @@ export class StdioAppServerRpc implements AppServerRpc {
   }
 }
 
-function spawnDefaultAppServer(): ChildProcessWithoutNullStreams {
+export function spawnDefaultAppServer(): ChildProcessWithoutNullStreams {
   const explicitBinary = process.env.DASCLAW_APP_SERVER_BIN;
   const env = { ...process.env };
   if (explicitBinary) {
@@ -201,7 +203,18 @@ function spawnDefaultAppServer(): ChildProcessWithoutNullStreams {
   }
 
   if (app.isPackaged) {
-    throw new Error('Packaged dasclaw app-server requires DASCLAW_APP_SERVER_BIN');
+    const bundledBinary = resolveBundledAppServerBinary(process.resourcesPath, process.platform);
+    if (bundledBinary) {
+      log('[DasclawAppServer] Spawning bundled binary:', bundledBinary);
+      return spawn(bundledBinary, [], { stdio: 'pipe', env });
+    }
+
+    throw new Error(
+      `Packaged dasclaw app-server binary was not found under ${join(
+        process.resourcesPath,
+        BUNDLED_APP_SERVER_DIR
+      )}; set DASCLAW_APP_SERVER_BIN to override`
+    );
   }
 
   const repoRoot = resolveDasclawRepoRoot();
@@ -215,6 +228,18 @@ function spawnDefaultAppServer(): ChildProcessWithoutNullStreams {
       env,
     }
   );
+}
+
+export function resolveBundledAppServerBinary(
+  resourcesPath: string,
+  platform: NodeJS.Platform = process.platform
+): string | null {
+  const binaryName = platform === 'win32' ? 'dasclaw-app-server.exe' : 'dasclaw-app-server';
+  const candidates = [
+    join(resourcesPath, BUNDLED_APP_SERVER_DIR, binaryName),
+    join(resourcesPath, BUNDLED_APP_SERVER_DIR, 'bin', binaryName),
+  ];
+  return candidates.find((candidate) => existsSync(candidate)) ?? null;
 }
 
 function resolveDasclawRepoRoot(): string {

--- a/client-gui/src/main/dasclaw/app-server-session-bridge.ts
+++ b/client-gui/src/main/dasclaw/app-server-session-bridge.ts
@@ -7,6 +7,12 @@ import { StdioAppServerRpc, type AppServerRpc, type JsonRpcNotification } from '
 
 type AppServerRpcFactory = () => AppServerRpc;
 
+interface CodexTextOnlyUserInput {
+  type: 'text';
+  text: string;
+  text_elements: [];
+}
+
 interface ThreadStartResponse {
   threadId: string;
 }
@@ -266,7 +272,7 @@ export class DasclawAppServerSessionBridge {
     try {
       response = await rpc.request<TurnStartResponse>('turn/start', {
         threadId,
-        input,
+        input: codexTextOnlyInput(input),
       });
     } catch (error) {
       if (binding.terminalTurnIds.size === terminalTurnCount && !this.isSessionInError(sessionId)) {
@@ -482,6 +488,10 @@ export class DasclawAppServerSessionBridge {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function codexTextOnlyInput(text: string): CodexTextOnlyUserInput[] {
+  return [{ type: 'text', text, text_elements: [] }];
 }
 
 function stringField(value: Record<string, unknown>, key: string): string | undefined {

--- a/client-gui/src/main/index.ts
+++ b/client-gui/src/main/index.ts
@@ -2665,7 +2665,13 @@ ipcMain.handle('sandbox.retrySetup', async () => {
 });
 
 async function handleClientEvent(event: ClientEvent): Promise<unknown> {
-  // Check if configured before starting sessions
+  if (shouldUseDasclawAppServerBridge()) {
+    const bridged = await handleDasclawSessionEvent(event);
+    if (bridged.handled) {
+      return bridged.result;
+    }
+  }
+
   if (event.type === 'session.start' && !configStore.hasUsableCredentialsForActiveSet()) {
     sendToRenderer({
       type: 'error',
@@ -2678,13 +2684,6 @@ async function handleClientEvent(event: ClientEvent): Promise<unknown> {
     return null;
   }
 
-  if (shouldUseDasclawAppServerBridge()) {
-    const bridged = await handleDasclawSessionEvent(event);
-    if (bridged.handled) {
-      return bridged.result;
-    }
-  }
-
   if (eventRequiresSessionManager(event) && !sessionManager) {
     throw new Error('Session manager not initialized');
   }
@@ -2694,11 +2693,12 @@ async function handleClientEvent(event: ClientEvent): Promise<unknown> {
 
   switch (event.type) {
     case 'session.start':
-      if (getWorkspacePathUnsupportedReason(event.payload.cwd)) {
+      const unsupportedReason = getWorkspacePathUnsupportedReason(event.payload.cwd);
+      if (unsupportedReason) {
         sendToRenderer({
           type: 'error',
           payload: {
-            message: getWorkspacePathUnsupportedReason(event.payload.cwd)!,
+            message: unsupportedReason,
           },
         });
         return null;
@@ -2867,5 +2867,20 @@ async function handleDasclawSessionEvent(
 }
 
 function shouldUseDasclawAppServerBridge(): boolean {
-  return process.env.OPEN_COWORK_AGENT_RUNNER === 'dasclaw';
+  return resolveAgentRunnerMode(process.env.OPEN_COWORK_AGENT_RUNNER) === 'dasclaw';
+}
+
+function resolveAgentRunnerMode(runner: string | undefined): 'dasclaw' | 'legacy' {
+  const normalizedRunner = runner?.trim().toLowerCase();
+  if (!normalizedRunner || normalizedRunner === 'dasclaw') {
+    return 'dasclaw';
+  }
+  if (normalizedRunner === 'legacy' || normalizedRunner === 'session-manager') {
+    return 'legacy';
+  }
+
+  logWarn(
+    `[AgentRunner] Unknown OPEN_COWORK_AGENT_RUNNER="${runner}", using legacy session-manager path`
+  );
+  return 'legacy';
 }

--- a/client-gui/tests/dasclaw-app-server-rpc.test.ts
+++ b/client-gui/tests/dasclaw-app-server-rpc.test.ts
@@ -1,0 +1,120 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const electronApp = vi.hoisted(() => ({
+  isPackaged: false,
+}));
+const spawnMock = vi.hoisted(() => vi.fn(() => ({ pid: 1234 })));
+
+vi.mock('electron', () => ({
+  app: electronApp,
+}));
+
+vi.mock('child_process', () => ({
+  spawn: spawnMock,
+}));
+
+import {
+  resolveBundledAppServerBinary,
+  spawnDefaultAppServer,
+} from '../src/main/dasclaw/app-server-rpc';
+
+const tempDirs: string[] = [];
+const originalResourcesPath = process.resourcesPath;
+const originalExplicitBinary = process.env.DASCLAW_APP_SERVER_BIN;
+
+afterEach(() => {
+  electronApp.isPackaged = false;
+  spawnMock.mockClear();
+  if (originalResourcesPath === undefined) {
+    delete process.resourcesPath;
+  } else {
+    Object.defineProperty(process, 'resourcesPath', {
+      configurable: true,
+      value: originalResourcesPath,
+    });
+  }
+  if (originalExplicitBinary === undefined) {
+    delete process.env.DASCLAW_APP_SERVER_BIN;
+  } else {
+    process.env.DASCLAW_APP_SERVER_BIN = originalExplicitBinary;
+  }
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function tempResourcesDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'dasclaw-app-server-rpc-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function createBundledBinary(resourcesPath: string, platform: NodeJS.Platform): string {
+  const bundleDir = join(resourcesPath, 'dasclaw-app-server');
+  const binaryName = platform === 'win32' ? 'dasclaw-app-server.exe' : 'dasclaw-app-server';
+  mkdirSync(bundleDir, { recursive: true });
+  const binary = join(bundleDir, binaryName);
+  writeFileSync(binary, 'binary');
+  return binary;
+}
+
+describe('resolveBundledAppServerBinary', () => {
+  it('discovers the packaged dasclaw app-server resource for the host platform', () => {
+    const resourcesPath = tempResourcesDir();
+    const binary = createBundledBinary(resourcesPath, 'darwin');
+
+    expect(resolveBundledAppServerBinary(resourcesPath, 'darwin')).toBe(binary);
+  });
+
+  it('uses the Windows executable name when resolving packaged resources', () => {
+    const resourcesPath = tempResourcesDir();
+    const binary = createBundledBinary(resourcesPath, 'win32');
+
+    expect(resolveBundledAppServerBinary(resourcesPath, 'win32')).toBe(binary);
+  });
+
+  it('does not fall back to cargo paths in packaged resource resolution', () => {
+    const resourcesPath = tempResourcesDir();
+
+    expect(resolveBundledAppServerBinary(resourcesPath, 'linux')).toBeNull();
+  });
+});
+
+describe('spawnDefaultAppServer', () => {
+  it('spawns the bundled binary in packaged mode without requiring DASCLAW_APP_SERVER_BIN', () => {
+    const resourcesPath = tempResourcesDir();
+    const binary = createBundledBinary(resourcesPath, process.platform);
+    delete process.env.DASCLAW_APP_SERVER_BIN;
+    electronApp.isPackaged = true;
+    Object.defineProperty(process, 'resourcesPath', {
+      configurable: true,
+      value: resourcesPath,
+    });
+
+    const child = spawnDefaultAppServer();
+
+    expect(child).toEqual({ pid: 1234 });
+    expect(spawnMock).toHaveBeenCalledWith(binary, [], {
+      stdio: 'pipe',
+      env: expect.objectContaining({}),
+    });
+  });
+
+  it('fails explicitly in packaged mode when the bundled binary is missing', () => {
+    const resourcesPath = tempResourcesDir();
+    delete process.env.DASCLAW_APP_SERVER_BIN;
+    electronApp.isPackaged = true;
+    Object.defineProperty(process, 'resourcesPath', {
+      configurable: true,
+      value: resourcesPath,
+    });
+
+    expect(() => spawnDefaultAppServer()).toThrow(
+      'Packaged dasclaw app-server binary was not found'
+    );
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+});

--- a/client-gui/tests/dasclaw-app-server-session-bridge.test.ts
+++ b/client-gui/tests/dasclaw-app-server-session-bridge.test.ts
@@ -40,6 +40,10 @@ class FakeRpc implements AppServerRpc {
       if (!threadId || !this.threads.has(threadId)) {
         throw new Error(`unknown thread id: ${threadId ?? '<missing>'}`);
       }
+      const prompt = codexTextInputParam(params);
+      if (!prompt) {
+        throw new Error('turn/start must use Codex UserInput text array params');
+      }
       const turnId = `turn_${this.nextTurnNumber++}`;
       return { turnId, status: 'pending' } as T;
     }
@@ -86,6 +90,20 @@ function stringParam(params: unknown, key: string): string | undefined {
   if (!params || typeof params !== 'object' || Array.isArray(params)) return undefined;
   const value = (params as Record<string, unknown>)[key];
   return typeof value === 'string' ? value : undefined;
+}
+
+function codexTextInputParam(params: unknown): string | undefined {
+  if (!params || typeof params !== 'object' || Array.isArray(params)) return undefined;
+  const input = (params as Record<string, unknown>).input;
+  if (!Array.isArray(input) || input.length !== 1) return undefined;
+  const [item] = input;
+  if (!item || typeof item !== 'object' || Array.isArray(item)) return undefined;
+  const record = item as Record<string, unknown>;
+  return record.type === 'text' &&
+    typeof record.text === 'string' &&
+    Array.isArray(record.text_elements)
+    ? record.text
+    : undefined;
 }
 
 function createDb(): DatabaseInstance {
@@ -149,7 +167,7 @@ describe('DasclawAppServerSessionBridge', () => {
     ]);
     expect(rpc.requests[2].params).toMatchObject({
       threadId: 'thread_1',
-      input: 'hello',
+      input: [{ type: 'text', text: 'hello', text_elements: [] }],
     });
     expect(db.sessions.get(session.id)?.claude_session_id).toBe('thread_1');
     expect(db.messages.getBySessionId(session.id)).toHaveLength(1);
@@ -160,6 +178,13 @@ describe('DasclawAppServerSessionBridge', () => {
       itemId: 'item_1',
       delta: 'hel',
     });
+    rpc.emit('item/completed', {
+      threadId: 'thread_1',
+      turnId: 'turn_1',
+      itemId: 'item_1',
+      status: 'completed',
+    });
+    expect(events.filter((event) => event.type === 'stream.message')).toHaveLength(0);
     rpc.emit('turn/completed', {
       threadId: 'thread_1',
       turnId: 'turn_1',
@@ -381,7 +406,7 @@ describe('DasclawAppServerSessionBridge', () => {
     ]);
     expect(rpcs[1].requests[2].params).toMatchObject({
       threadId: 'thread_1',
-      input: 'again',
+      input: [{ type: 'text', text: 'again', text_elements: [] }],
     });
     expect(db.sessions.get(session.id)?.claude_session_id).toBe('thread_1');
     expect(events).toContainEqual({

--- a/client-gui/tests/dev-script-guard.test.ts
+++ b/client-gui/tests/dev-script-guard.test.ts
@@ -31,12 +31,26 @@ describe('dev script guard', () => {
       'utf-8'
     );
 
-    expect(smokeScript).toContain("OPEN_COWORK_AGENT_RUNNER: 'dasclaw'");
+    expect(smokeScript).not.toContain("OPEN_COWORK_AGENT_RUNNER: 'dasclaw'");
+    expect(smokeScript).toContain('DASCLAW_SMOKE_AGENT_RUNNER');
     expect(smokeScript).toContain("DASCLAW_APP_SERVER_RUNTIME: 'echo'");
     expect(smokeScript).toContain('DASCLAW_SMOKE_SKIP_BUILD');
     expect(smokeScript).toContain('--user-data-dir=');
     expect(smokeScript).toContain('window.__getNavStatus');
     expect(smokeScript).toContain('result.partialCount !== 1');
     expect(smokeScript).toContain('CDP request timed out');
+  });
+
+  it('packages dasclaw app-server as a bundled default runtime resource', () => {
+    const packageJson = readPackageJson();
+    const builderConfig = readFileSync(resolve(__dirname, '../electron-builder.yml'), 'utf-8');
+    const preBuildCheck = readFileSync(resolve(__dirname, '../scripts/pre-build-check.js'), 'utf-8');
+
+    expect(packageJson.scripts?.['build:dasclaw-app-server']).toBe(
+      'node scripts/build-dasclaw-app-server.mjs'
+    );
+    expect(packageJson.scripts?.build).toContain('npm run build:dasclaw-app-server');
+    expect(builderConfig.match(/to: dasclaw-app-server/g)).toHaveLength(3);
+    expect(preBuildCheck).toContain('.bundle-resources/dasclaw-app-server/${appServerBinary}');
   });
 });

--- a/client-gui/tests/index-config-window-behavior.test.ts
+++ b/client-gui/tests/index-config-window-behavior.test.ts
@@ -15,13 +15,42 @@ describe('Main process window/config behavior', () => {
     expect(secondInstanceBlock).toContain('No existing window found');
   });
 
-  it('session.start blocked by active set emits structured error without forcing config.status', () => {
+  it('keeps credential guard on the legacy session-manager path only', () => {
     const source = fs.readFileSync(indexPath, 'utf8');
-    const sessionStartGuard = source.match(/if \(event\.type === 'session\.start'[\s\S]*?return null;\n  }/)?.[0] || '';
+    const bridgePathIndex = source.indexOf('if (shouldUseDasclawAppServerBridge())');
+    const credentialGuardIndex = source.indexOf(
+      "event.type === 'session.start' && !configStore.hasUsableCredentialsForActiveSet()"
+    );
+    const sessionStartGuard =
+      source.match(
+        /if \(event\.type === 'session\.start' && !configStore\.hasUsableCredentialsForActiveSet\(\)\) \{[\s\S]*?return null;\n  \}/
+      )?.[0] || '';
 
+    expect(bridgePathIndex).toBeGreaterThanOrEqual(0);
+    expect(credentialGuardIndex).toBeGreaterThanOrEqual(0);
+    expect(bridgePathIndex).toBeLessThan(credentialGuardIndex);
     expect(sessionStartGuard).toContain('hasUsableCredentialsForActiveSet');
     expect(sessionStartGuard).toContain("code: 'CONFIG_REQUIRED_ACTIVE_SET'");
     expect(sessionStartGuard).toContain("action: 'open_api_settings'");
     expect(sessionStartGuard).not.toContain("type: 'config.status'");
+  });
+
+  it('uses dasclaw app-server by default unless the runner explicitly selects legacy', () => {
+    const source = fs.readFileSync(indexPath, 'utf8');
+    const selector =
+      source.match(/function shouldUseDasclawAppServerBridge\(\)[\s\S]*?function resolveAgentRunnerMode/)?.[0] ||
+      '';
+    const runnerModeResolver =
+      source.match(/function resolveAgentRunnerMode\([\s\S]*?\n}/)?.[0] || '';
+
+    expect(selector).toContain(
+      "resolveAgentRunnerMode(process.env.OPEN_COWORK_AGENT_RUNNER) === 'dasclaw'"
+    );
+    expect(runnerModeResolver).toContain("normalizedRunner === 'dasclaw'");
+    expect(runnerModeResolver).toContain("normalizedRunner === 'legacy'");
+    expect(runnerModeResolver).toContain("normalizedRunner === 'session-manager'");
+    expect(runnerModeResolver).toContain('Unknown OPEN_COWORK_AGENT_RUNNER');
+    expect(runnerModeResolver).toContain("return 'legacy'");
+    expect(selector).not.toContain("OPEN_COWORK_AGENT_RUNNER === 'dasclaw'");
   });
 });

--- a/crates/dasclaw_app_server/src/lib.rs
+++ b/crates/dasclaw_app_server/src/lib.rs
@@ -3820,7 +3820,7 @@ mod tests {
 
         let response = server
             .handle_json_rpc(&format!(
-                r#"{{"jsonrpc":"2.0","id":"turn","method":"turn/start","params":{{"threadId":"{}","input":"hello input"}}}}"#,
+                r#"{{"jsonrpc":"2.0","id":"turn","method":"turn/start","params":{{"threadId":"{}","input":[{{"type":"text","text":"hello input","text_elements":[]}}]}}}}"#,
                 thread.thread_id
             ))
             .expect("turn/start should return a JSON-RPC response");
@@ -3848,7 +3848,7 @@ mod tests {
 
         let turn_response = server
             .handle_json_rpc(&format!(
-                r#"{{"jsonrpc":"2.0","id":"turn","method":"turn/start","params":{{"threadId":"{thread_id}","input":"hello"}}}}"#
+                r#"{{"jsonrpc":"2.0","id":"turn","method":"turn/start","params":{{"threadId":"{thread_id}","input":[{{"type":"text","text":"hello","text_elements":[]}}]}}}}"#
             ))
             .expect("turn/start should return a JSON-RPC response");
         let turn: Value = serde_json::from_str(&turn_response).expect("turn response JSON");

--- a/crates/dasclaw_app_server/src/main.rs
+++ b/crates/dasclaw_app_server/src/main.rs
@@ -441,7 +441,7 @@ mod tests {
         let initialize = r#"{"jsonrpc":"2.0","id":"init","method":"initialize","params":{"client":{"name":"codex","version":"2.0.0","transport":"stdio"},"protocolVersion":{"major":0,"minor":1,"patch":0},"requestedCapabilities":["codex_app_server_v2"]}}"#;
         let thread_start =
             r#"{"jsonrpc":"2.0","id":"thread","method":"thread/start","params":{"title":"Draft"}}"#;
-        let turn_start = r#"{"jsonrpc":"2.0","id":"turn","method":"turn/start","params":{"threadId":"thread_1","input":"hello"}}"#;
+        let turn_start = r#"{"jsonrpc":"2.0","id":"turn","method":"turn/start","params":{"threadId":"thread_1","input":[{"type":"text","text":"hello","text_elements":[]}]}}"#;
         let mut output = Vec::new();
         let bridge = Arc::new(CompletingRuntimeBridge::default());
         let server = dasclaw_app_server::AppServer::with_runtime_bridge(bridge);
@@ -505,7 +505,7 @@ mod tests {
         let initialize = r#"{"jsonrpc":"2.0","id":"init","method":"initialize","params":{"client":{"name":"open-cowork","version":"0.0.0","transport":"stdio"},"protocolVersion":{"major":0,"minor":1,"patch":0},"requestedCapabilities":["codex_app_server_v2"]}}"#;
         let thread_start =
             r#"{"jsonrpc":"2.0","id":"thread","method":"thread/start","params":{"title":"Draft"}}"#;
-        let turn_start = r#"{"jsonrpc":"2.0","id":"turn","method":"turn/start","params":{"threadId":"thread_1","input":"hello echo"}}"#;
+        let turn_start = r#"{"jsonrpc":"2.0","id":"turn","method":"turn/start","params":{"threadId":"thread_1","input":[{"type":"text","text":"hello echo","text_elements":[]}]}}"#;
         let mut output = Vec::new();
         let server = app_server_for_runtime_mode(Some("echo")).expect("echo mode should build");
 
@@ -541,7 +541,7 @@ mod tests {
         let initialize = r#"{"jsonrpc":"2.0","id":"init","method":"initialize","params":{"client":{"name":"codex","version":"2.0.0","transport":"stdio"},"protocolVersion":{"major":0,"minor":1,"patch":0},"requestedCapabilities":["codex_app_server_v2"]}}"#;
         let thread_start =
             r#"{"jsonrpc":"2.0","id":"thread","method":"thread/start","params":{"title":"Draft"}}"#;
-        let turn_start = r#"{"jsonrpc":"2.0","id":"turn","method":"turn/start","params":{"threadId":"thread_1","input":"hello"}}"#;
+        let turn_start = r#"{"jsonrpc":"2.0","id":"turn","method":"turn/start","params":{"threadId":"thread_1","input":[{"type":"text","text":"hello","text_elements":[]}]}}"#;
         let mut output = Vec::new();
         let bridge = Arc::new(FailingRuntimeBridge);
         let server = dasclaw_app_server::AppServer::with_runtime_bridge(bridge);
@@ -587,7 +587,7 @@ mod tests {
         let initialize = r#"{"jsonrpc":"2.0","id":"init","method":"initialize","params":{"client":{"name":"codex","version":"2.0.0","transport":"stdio"},"protocolVersion":{"major":0,"minor":1,"patch":0},"requestedCapabilities":["codex_app_server_v2"]}}"#;
         let thread_start =
             r#"{"jsonrpc":"2.0","id":"thread","method":"thread/start","params":{"title":"Draft"}}"#;
-        let turn_start = r#"{"jsonrpc":"2.0","id":"turn","method":"turn/start","params":{"threadId":"thread_1","input":"hello"}}"#;
+        let turn_start = r#"{"jsonrpc":"2.0","id":"turn","method":"turn/start","params":{"threadId":"thread_1","input":[{"type":"text","text":"hello","text_elements":[]}]}}"#;
         let interrupt = r#"{"jsonrpc":"2.0","id":"interrupt","method":"turn/interrupt","params":{"threadId":"thread_1","turnId":"turn_1"}}"#;
         let mut output = Vec::new();
 
@@ -617,6 +617,11 @@ mod tests {
         assert!(values.iter().any(|value| {
             value["id"] == "interrupt" && value["result"] == serde_json::json!({})
         }));
+        assert!(
+            !values
+                .iter()
+                .any(|value| value["method"] == "turn/completed")
+        );
         let item_completed_position = values
             .iter()
             .position(|value| value["method"] == "item/completed")

--- a/crates/dasclaw_app_server_protocol/src/lib.rs
+++ b/crates/dasclaw_app_server_protocol/src/lib.rs
@@ -947,6 +947,9 @@ pub struct ThreadReadResponse {
 #[serde(rename_all = "camelCase")]
 pub struct TurnStartParams {
     pub thread_id: String,
+    /// Phase-one compatibility boundary: canonical Codex `input` arrays are
+    /// accepted only for text UserInput items and normalized into the legacy
+    /// prompt string consumed by the current runtime.
     pub prompt: String,
 }
 
@@ -972,11 +975,15 @@ impl<'de> Deserialize<'de> for TurnStartParams {
             #[serde(default)]
             prompt: Option<String>,
             #[serde(default)]
-            input: Option<String>,
+            input: Option<serde_json::Value>,
         }
 
         let raw = RawTurnStartParams::deserialize(deserializer)?;
-        let prompt = match (raw.prompt, raw.input) {
+        let input_prompt = raw
+            .input
+            .map(codex_turn_input_to_prompt::<D::Error>)
+            .transpose()?;
+        let prompt = match (raw.prompt, input_prompt) {
             (Some(prompt), Some(input)) if prompt != input => {
                 return Err(de::Error::custom(
                     "turn/start prompt and input must match when both are provided",
@@ -993,6 +1000,55 @@ impl<'de> Deserialize<'de> for TurnStartParams {
             prompt,
         })
     }
+}
+
+fn codex_turn_input_to_prompt<E>(input: serde_json::Value) -> Result<String, E>
+where
+    E: de::Error,
+{
+    match input {
+        serde_json::Value::String(prompt) => Ok(prompt),
+        serde_json::Value::Array(items) => codex_text_only_items_to_prompt::<E>(items),
+        _ => Err(de::Error::custom(
+            "turn/start input must be a string or an array of Codex UserInput text items",
+        )),
+    }
+}
+
+fn codex_text_only_items_to_prompt<E>(items: Vec<serde_json::Value>) -> Result<String, E>
+where
+    E: de::Error,
+{
+    if items.is_empty() {
+        return Err(de::Error::custom(
+            "turn/start text-only input array must contain at least one text item",
+        ));
+    }
+
+    let mut text_parts = Vec::new();
+    for item in items {
+        let object = item.as_object().ok_or_else(|| {
+            de::Error::custom("turn/start text-only input items must be Codex UserInput objects")
+        })?;
+        let item_type = object
+            .get("type")
+            .and_then(serde_json::Value::as_str)
+            .ok_or_else(|| de::Error::custom("turn/start text-only input item is missing type"))?;
+
+        if item_type != "text" {
+            return Err(de::Error::custom(format!(
+                "unsupported turn/start text-only input item type: {item_type}"
+            )));
+        }
+
+        let text = object
+            .get("text")
+            .and_then(serde_json::Value::as_str)
+            .ok_or_else(|| de::Error::custom("turn/start text-only input item is missing text"))?;
+        text_parts.push(text.to_string());
+    }
+
+    Ok(text_parts.join("\n"))
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -1695,7 +1751,7 @@ mod tests {
     }
 
     #[test]
-    fn turn_start_params_accept_codex_v2_input_alias_without_changing_legacy_shape() {
+    fn turn_start_params_accept_string_input_and_prompt_aliases_without_changing_legacy_shape() {
         let from_input: TurnStartParams = serde_json::from_value(serde_json::json!({
             "threadId": "thread_1",
             "input": "hello from input"
@@ -1720,6 +1776,55 @@ mod tests {
             serde_json::to_value(TurnStartParams::from_input("thread_1", "hello"))
                 .expect("turn/start params should serialize"),
             serde_json::json!({"threadId": "thread_1", "prompt": "hello"})
+        );
+    }
+
+    #[test]
+    fn turn_start_params_accept_codex_v2_user_input_text_array() {
+        let from_array: TurnStartParams = serde_json::from_value(serde_json::json!({
+            "threadId": "thread_1",
+            "input": [
+                {"type": "text", "text": "hello", "text_elements": []},
+                {"type": "text", "text": "world", "text_elements": []}
+            ]
+        }))
+        .expect("turn/start should accept Codex v2 UserInput text arrays");
+        let matching_prompt: TurnStartParams = serde_json::from_value(serde_json::json!({
+            "threadId": "thread_1",
+            "prompt": "hello\nworld",
+            "input": [
+                {"type": "text", "text": "hello", "text_elements": []},
+                {"type": "text", "text": "world", "text_elements": []}
+            ]
+        }))
+        .expect("matching prompt and Codex input array should deserialize");
+
+        assert_eq!(from_array.prompt, "hello\nworld");
+        assert_eq!(matching_prompt.prompt, "hello\nworld");
+    }
+
+    #[test]
+    fn turn_start_params_reject_unsupported_codex_user_input_items() {
+        let unsupported = serde_json::from_value::<TurnStartParams>(serde_json::json!({
+            "threadId": "thread_1",
+            "input": [{"type": "image", "url": "file:///tmp/image.png"}]
+        }))
+        .expect_err("non-text Codex input variants are not silently dropped");
+        let empty = serde_json::from_value::<TurnStartParams>(serde_json::json!({
+            "threadId": "thread_1",
+            "input": []
+        }))
+        .expect_err("empty Codex input arrays should not produce an empty prompt");
+
+        assert!(
+            unsupported
+                .to_string()
+                .contains("unsupported turn/start text-only input item type: image")
+        );
+        assert!(
+            empty
+                .to_string()
+                .contains("text-only input array must contain at least one text item")
         );
     }
 
@@ -1752,7 +1857,10 @@ mod tests {
                 jsonrpc: JSON_RPC_VERSION.to_string(),
                 id: Some(serde_json::json!("turn")),
                 method: method::TURN_START.to_string(),
-                params: Some(serde_json::json!({"threadId": "thread_1", "input": "hello"})),
+                params: Some(serde_json::json!({
+                    "threadId": "thread_1",
+                    "input": [{"type": "text", "text": "hello", "text_elements": []}]
+                })),
             },
             JsonRpcRequest {
                 jsonrpc: JSON_RPC_VERSION.to_string(),

--- a/docs/plans/architecture-refactor/31-target-architecture.md
+++ b/docs/plans/architecture-refactor/31-target-architecture.md
@@ -342,6 +342,9 @@ v2.4 §3 只列了 ADR-101 ~ ADR-110。W3 ~ W6 期间又落了约 45 个 ADR（�
 | `crates/dasclaw_apply_patch` | codex port | Lark 语法 patch 协议 |
 | `crates/dasclaw_project_docs` | codex/claw 合并 | AGENTS.md / CLAUDE.md 多层加载 |
 | `crates/dasclaw_pty` | codex/exec-server port | portable-pty 信号转发 + resize |
+| `crates/dasclaw_app_server` | codex app-server 协议接入与服务端骨架 | agent 会话生命周期（thread/turn）与事件流转发 |
+| `crates/dasclaw_app_server_client` | codex app-server 协议 client 客户端 | JSON-RPC 客户端调用封装 |
+| `crates/dasclaw_app_server_protocol` | codex protocol 语义向下投射 | `turn/start` / `thread` / 通知事件协议类型定义 |
 
 ### 4.2 新建（P1 推荐，7 个） — v2.4 补 3
 


### PR DESCRIPTION
## 背景 / 目标
- 将 `client-gui` 默认对接 `dasclaw-app-server`，支持基于 codex-cli app-server 协议的 agent 能力调用。
- 轨迹优先采用 codex-compat，不做 UI 重构（no-ui-redesign），并保证交互轨迹 method/顺序/终态/错误路径/interrupt 语义一致。

## 改动范围
- 服务器协议层：
  - `crates/dasclaw_app_server_protocol/src/lib.rs`
    - `TurnStartParams` 支持 codex canonical `input: Vec<UserInput>` text-only 反序列化，兼容 `input`/`prompt` alias。
  - 错误路径增强（空数组、非法 item、非 text item 直接返回错误）。
- 服务端行为：
  - `crates/dasclaw_app_server/src/lib.rs` / `src/main.rs`
    - turn/start/stdout transcript 使用 canonical codex array；补齐 interrupt 与终态断言。
- 客户端主路由/桥接：
  - `client-gui/src/main/index.ts`
    - 默认选择 dasclaw 路径，保留 legacy 分支与未知模式 warning + 回退。
  - `client-gui/src/main/dasclaw/app-server-session-bridge.ts`
    - `startTurn` 改为发送 `input: [{type:"text", text, text_elements: []}]`。
  - `client-gui/src/main/dasclaw/app-server-rpc.ts`
    - 支持 packaged binary 发现与 spawn fallback，并导出 `resolveBundledAppServerBinary`。
- 打包/脚本：
  - `client-gui/scripts/build-dasclaw-app-server.mjs`（新增）
  - `client-gui/package.json`
  - `client-gui/electron-builder.yml`
  - `client-gui/scripts/pre-build-check.js`
  - `client-gui/scripts/dasclaw-app-server-smoke.mjs`
- 测试：
  - `client-gui/tests/dasclaw-app-server-session-bridge.test.ts`（已有）
  - `client-gui/tests/dasclaw-app-server-rpc.test.ts`（新增）
  - `client-gui/tests/dev-script-guard.test.ts`
  - `client-gui/tests/index-config-window-behavior.test.ts`

## 非目标
- 未实现完整跨平台发布脚本的端到端资源打包验证（本轮仅补齐资源接线与行为检查）。
- 未在该 PR 内做 UI 交互改造。

## 验证
- `cargo fmt --all` ✅
- `python3.12 scripts/check_no_panics.py --base origin/xClaw && git diff --check` ✅
- `cargo check -p dasclaw_app_server_protocol --tests` ✅
- `cargo check -p dasclaw_app_server --tests` ✅
- `cargo nextest run -p dasclaw_app_server_protocol -p dasclaw_app_server -E 'test(turn_start_params) | test(codex_v2_contract_fixtures_use_json_rpc_and_item_event_shapes) | test(stdio_loop_supports_codex_v2_chat_subset_transcript) | test(echo_runtime_mode_streams_real_runtime_completion_over_stdio) | test(stdio_loop_emits_codex_v2_interrupt_item_terminal_events) | test(json_rpc_turn_start_accepts_codex_v2_input_alias) | test(json_rpc_accepts_codex_v2_thread_start_and_turn_interrupt_aliases)'` ✅
- `cargo clippy --no-deps -p dasclaw_app_server_protocol -p dasclaw_app_server --all-targets -- -D warnings` ✅
- `cd client-gui && npm test -- --run tests/dasclaw-app-server-session-bridge.test.ts tests/dasclaw-app-server-rpc.test.ts tests/index-config-window-behavior.test.ts tests/dev-script-guard.test.ts` ✅
- `cd client-gui && npm run typecheck` ✅
- `cd client-gui && DASCLAW_APP_SERVER_BUILD_PROFILE=debug npm run build:dasclaw-app-server` ✅
- `cd client-gui && npm run smoke:dasclaw-app-server` ✅（本机环境通过）

## 风险 / 后续
- `pre-build-check` 当前仍依赖 `node`/`lima`/部分 MCP 资源与 Python 工具路径，这些在本地环境缺失会导致 check 失败，但与本功能实现无直接阻断关系。建议补齐该资源并补做一次完整 release 打包验证。

## Cross-cuts（ADR-114）
- 类A（无新增 `.ironclaw` / `IRONCLAW_BASE_DIR` 字面量）

## 复用与透明度
- 已检查并确认该实现与 codex 协议能力对齐（canonical text `UserInput[]`），不涉及新增同类功能重复建设。
- 已检查 X 是否已有，结论：已对比现有 codex-cli app-server 路径与轨迹语义，确认需要并已补齐客户端-服务端兼容桥接。
